### PR TITLE
plano-theme: 3.24-3 -> 3.28-1

### DIFF
--- a/pkgs/misc/themes/plano/default.nix
+++ b/pkgs/misc/themes/plano/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "plano-theme-${version}";
-  version = "3.24-3";
+  version = "3.28-1";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "plano-theme";
     rev = "v${version}";
-    sha256 = "079gj3kgsim01r7yb9dcxvrci3my1y0zkn86igdlspxcnjzmxkq0";
+    sha256 = "1862nx7c8786vfa0qdg4aqa13whsk3j5n93v9m91wpccv19n0ryn";
   };
 
   buildInputs = [ gdk_pixbuf gtk_engines ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [3.28-1](https://github.com/lassekongo83/plano-theme/releases/tag/v3.28-1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).