### PR TITLE
systemd: suppress certain warnings to compile under gcc8

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -17,6 +17,7 @@ let
   pythonLxmlEnv = buildPackages.python3Packages.python.withPackages ( ps: with ps; [ python3Packages.lxml ]);
 
 in stdenv.mkDerivation rec {
+  # To whoever updates this to 239: check the todo on line 173.
   version = "238";
   name = "systemd-${version}";
 
@@ -166,6 +167,12 @@ in stdenv.mkDerivation rec {
       "-USYSTEMD_CGROUP_AGENT_PATH" "-DSYSTEMD_CGROUP_AGENT_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
 
       "-USYSTEMD_BINARY_PATH" "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
+
+
+      # Temporary flags to get this to compile under GCC8.
+      # TODO when updating (to systemd 239): remove this.
+      "-Wno-maybe-uninitialized"
+      "-Wno-error=format-truncation"
     ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

systemd didn't build under gcc8. This suppresses the warnings, my prediction is that this is only needed for this systemd release and that the next release will have fixed this. I have left a note to the next person updating systemd to check this.

[This was failing on Hydra (linux-x86_64) due to memory shortage](https://hydra.nixos.org/build/73841671), here's the (linux-aarch64) log:
https://hydra.nixos.org/build/73809444/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

