### PR TITLE
haskell: fix build of base-compat-batteries

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -505,6 +505,6 @@ self: super: builtins.intersectAttrs super {
 
   # cabal2nix generates a dependency on base-compat, which is the wrong version
   base-compat-batteries = super.base-compat-batteries.override {
-    base-compat = pkgs.haskellPackages.base-compat_0_10_1;
+    base-compat = super.base-compat_0_10_1;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

@peti `base-compat-batteries` fails to build with compilers other than the one from `haskellPackages`. This commit fixes that.

CC @endgame.

###### Things done

Tested using:

```
$ nix-build -A haskell.packages.ghc842.base-compat-batteries
```

and

```
$ nix-build -A haskellPackages.base-compat-batteries
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

