### PR TITLE
treewide: remove lib.meta.enableIfAvailable

### DIFF
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -86,6 +86,4 @@ rec {
         then { system = elem; }
         else { parsed = elem; };
     in lib.matchAttrs pattern platform;
-
-  enableIfAvailable = p: if p.meta.available or true then [ p ] else [];
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, fetchpatch, pkgconfig, intltool, gperf, libcap, kmod
 , zlib, xz, pam, acl, cryptsetup, libuuid, m4, utillinux, libffi
 , glib, kbd, libxslt, coreutils, libgcrypt, libgpgerror, libidn2, libapparmor
-, audit, lz4, bzip2, kexectools, libmicrohttpd
+, audit, lz4, bzip2, libmicrohttpd
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
-, libseccomp, iptables, gnu-efi
+, iptables, gnu-efi
 , autoreconfHook, gettext, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_45
 , ninja, meson, python3Packages, glibcLocales
 , patchelf
@@ -11,6 +11,8 @@
 , hostPlatform
 , buildPackages
 , withSelinux ? false, libselinux
+, withLibseccomp ? libseccomp.meta.available, libseccomp
+, withKexectools ? kexectools.meta.available, kexectools
 }:
 
 let
@@ -42,13 +44,13 @@ in stdenv.mkDerivation rec {
     [ linuxHeaders libcap kmod xz pam acl
       /* cryptsetup */ libuuid glib libgcrypt libgpgerror libidn2
       libmicrohttpd ] ++
-      stdenv.lib.meta.enableIfAvailable kexectools ++
-      stdenv.lib.meta.enableIfAvailable libseccomp ++
+      stdenv.lib.optional withKexectools kexectools ++
+      stdenv.lib.optional withLibseccomp libseccomp ++
     [ libffi audit lz4 bzip2 libapparmor
       iptables gnu-efi
       # This is actually native, but we already pull it from buildPackages
       pythonLxmlEnv
-    ] ++ stdenv.lib.optionals withSelinux [ libselinux ];
+    ] ++ stdenv.lib.optional withSelinux libselinux;
 
   #dontAddPrefix = true;
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -1,11 +1,12 @@
 { lib, stdenv, fetchurl, fetchFromGitHub, perl, curl, bzip2, sqlite, openssl ? null, xz
 , pkgconfig, boehmgc, perlPackages, libsodium, aws-sdk-cpp, brotli, boost
 , autoreconfHook, autoconf-archive, bison, flex, libxml2, libxslt, docbook5, docbook5_xsl
-, libseccomp, busybox-sandbox-shell
+, busybox-sandbox-shell
 , hostPlatform, buildPlatform
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
 , confDir ? "/etc"
+, withLibseccomp ? libseccomp.meta.available, libseccomp
 }:
 
 let
@@ -30,7 +31,7 @@ let
     buildInputs = [ curl openssl sqlite xz bzip2 ]
       ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
       ++ lib.optionals is20 [ brotli ] # Since 1.12
-      ++ lib.meta.enableIfAvailable libseccomp
+      ++ lib.optional withLibseccomp libseccomp
       ++ lib.optional ((stdenv.isLinux || stdenv.isDarwin) && is20)
           (aws-sdk-cpp.override {
             apis = ["s3"];


### PR DESCRIPTION
###### Motivation for this change

This seems like a better approach than "enableIfAvailable" to me. The issue with "enableIfAvailable" is it combines two concepts: optional dependencies (usually configured by a flag) and availability, that are better left separate. This may seem convenient but it gives users less control over what packages are being built. For both packages (Nix & Systemd) using "enableIfAvailable" right now, it's pretty clear that they are being used as we normally use optional dependencies. Both "libseccomp" & "kexectools" can be left out and they will run correctly, whether each is broken or not. So, it makes more sense to make these configurable with a flag. We can still provide ```libseccomp.meta.available``` & ```kexectools.meta.available``` as defaults.

I don't know if anyone has strong feelings in favor of enableIfAvailable. I definitely think it's an overloaded concept that shouldn't be used extensively in Nixpkgs. If necessary packages can always define their own version of enableIfAvailable, but I definitely don't think it should be included in lib.
