### PR TITLE
nixos/tests/mysqlbackup: fix non-deterministic failure

### DIFF
--- a/nixos/tests/mysql-backup.nix
+++ b/nixos/tests/mysql-backup.nix
@@ -23,17 +23,25 @@ import ./make-test.nix ({ pkgs, ... } : {
   testScript =
     '' startAll;
 
+       # Delete backup file that may be left over from a previous test run.
+       # This is not needed on Hydra but useful for repeated local test runs.
+       $master->execute("rm -f /var/backup/mysql/testdb.gz");
+
        # Need to have mysql started so that it can be populated with data.
        $master->waitForUnit("mysql.service");
 
-       # Wait for testdb to be populated.
-       $master->sleep(10);
+       # Wait for testdb to be fully populated (5 rows).
+       $master->waitUntilSucceeds("mysql -u root -D testdb -N -B -e 'select count(id) from tests' | grep -q 5");
 
-       # Do a backup and wait for it to finish.
+       # Do a backup and wait for it to start
        $master->startJob("mysql-backup.service");
        $master->waitForJob("mysql-backup.service");
 
-       # Check that data appears in backup
+       # wait for backup to fail, because of database 'doesnotexist'
+       $master->waitUntilFails("systemctl is-active -q mysql-backup.service");
+
+       # wait for backup file and check that data appears in backup
+       $master->waitForFile("/var/backup/mysql/testdb.gz");
        $master->succeed("${pkgs.gzip}/bin/zcat /var/backup/mysql/testdb.gz | grep hello");
 
        # Check that a failed backup is logged


### PR DESCRIPTION
###### Motivation for this change

Test sometimes [failed on Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.mysqlBackup.x86_64-linux) as it looked for a backup file that was not yet created.

Fixed by  waiting for backup to finish and backup file to appear.