### PR TITLE
zuki-themes: 3.26-1 -> 3.28-1

### DIFF
--- a/pkgs/misc/themes/zuki/default.nix
+++ b/pkgs/misc/themes/zuki/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "zuki-themes-${version}";
-  version = "3.26-1";
+  version = "3.28-1";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "zuki-themes";
     rev = "v${version}";
-    sha256 = "17p75h1i3hbpshhhliliq0mm88amvfnxq8659vabqd17ccgzwzns";
+    sha256 = "1if39k8vgk4cpshl625vdf8lz6jgicgybd5nilycj66sf1k5jgb9";
   };
 
   buildInputs = [ gdk_pixbuf gtk_engines ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [3.28-1](https://github.com/lassekongo83/zuki-themes/releases/tag/v3.28-1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).