### PR TITLE
manual: Clarify that limits.conf doesn't apply to systemd services.

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -449,6 +449,10 @@ in
           <varname>item</varname>, and <varname>value</varname>
           attribute.  The syntax and semantics of these attributes
           must be that described in the limits.conf(5) man page.
+
+          Note that these limits do not apply to systemd services,
+          whose limits can be changed via <option>systemd.extraConfig</option>
+          instead.
        '';
     };
 

--- a/nixos/modules/system/boot/coredump.nix
+++ b/nixos/modules/system/boot/coredump.nix
@@ -15,8 +15,11 @@ with lib;
           Enables storing core dumps in systemd.
           Note that this alone is not enough to enable core dumps. The maximum
           file size for core dumps must be specified in limits.conf as well. See
-          <option>security.pam.loginLimits</option> as well as the limits.conf(5)
-          man page.
+          <option>security.pam.loginLimits</option> and the limits.conf(5)
+          man page (these specify the core dump limits for user login sessions)
+          and <option>systemd.extraConfig</option> (where e.g.
+          <literal>DefaultLimitCORE=1000000</literal> can be specified to set
+          the core dump limit for systemd system-level services).
         '';
       };
 


### PR DESCRIPTION
Say how systemd services can be set instead.

Sources:

* https://bugzilla.redhat.com/show_bug.cgi?id=754285
* https://ro-che.info/articles/2017-03-26-increase-open-files-limit

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [X] Tested that the statements are true on NixOS

---

