### PR TITLE
treewide: Get rid of `*Platform.arch`

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -11,22 +11,19 @@ rec {
 
   sheevaplug = rec {
     config = "armv5tel-unknown-linux-gnueabi";
-    arch = "armv5tel";
     float = "soft";
     platform = platforms.sheevaplug;
   };
 
   raspberryPi = rec {
     config = "armv6l-unknown-linux-gnueabihf";
-    arch = "armv6l";
     float = "hard";
     fpu = "vfp";
     platform = platforms.raspberrypi;
   };
 
   armv7l-hf-multiplatform = rec {
-    config = "arm-unknown-linux-gnueabihf";
-    arch = "armv7-a";
+    config = "armv7a-unknown-linux-gnueabihf";
     float = "hard";
     fpu = "vfpv3-d16";
     platform = platforms.armv7l-hf-multiplatform;
@@ -34,13 +31,11 @@ rec {
 
   aarch64-multiplatform = rec {
     config = "aarch64-unknown-linux-gnu";
-    arch = "aarch64";
     platform = platforms.aarch64-multiplatform;
   };
 
   aarch64-android-prebuilt = rec {
     config = "aarch64-unknown-linux-android";
-    arch = "aarch64";
     platform = platforms.aarch64-multiplatform;
     useAndroidPrebuilt = true;
   };
@@ -51,7 +46,6 @@ rec {
   };
 
   pogoplug4 = rec {
-    arch = "armv5tel";
     config = "armv5tel-unknown-linux-gnueabi";
     float = "soft";
     platform = platforms.pogoplug4;
@@ -59,7 +53,6 @@ rec {
 
   ben-nanonote = rec {
     config = "mipsel-unknown-linux-uclibc";
-    arch = "mips";
     float = "soft";
     platform = {
       name = "ben_nanonote";
@@ -73,7 +66,6 @@ rec {
 
   fuloongminipc = rec {
     config = "mipsel-unknown-linux-gnu";
-    arch = "mips";
     float = "hard";
     platform = platforms.fuloong2f_n32;
   };
@@ -122,7 +114,6 @@ rec {
   # 32 bit mingw-w64
   mingw32 = {
     config = "i686-pc-mingw32";
-    arch = "x86"; # Irrelevant
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
     platform = {};
   };
@@ -131,7 +122,6 @@ rec {
   mingwW64 = {
     # That's the triplet they use in the mingw-w64 docs.
     config = "x86_64-pc-mingw32";
-    arch = "x86_64"; # Irrelevant
     libc = "msvcrt"; # This distinguishes the mingw (non posix) toolchain
     platform = {};
   };

--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -52,7 +52,7 @@ let
         "--cross-prefix=${stdenv.cc.targetPrefix}"
         "--enable-cross-compile"
         "--target_os=linux"
-        "--arch=${hostPlatform.arch}"
+        "--arch=${hostPlatform.parsed.cpu.name}"
         ];
     };
 

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -442,7 +442,7 @@ stdenv.mkDerivation rec {
       "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
       "--target_os=${hostPlatform.parsed.kernel.name}"
-      "--arch=${hostPlatform.arch}"
+      "--arch=${hostPlatform.parsed.cpu.name}"
     ];
   };
 

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -176,7 +176,7 @@ stdenv.mkDerivation rec {
       "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
       "--target_os=${hostPlatform.parsed.kernel.name}"
-      "--arch=${hostPlatform.arch}"
+      "--arch=${hostPlatform.parsed.cpu.name}"
     ];
   };
 

--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation rec {
   ];
 
   # We should find a better way to access the arch reliably.
-  crossArch = hostPlatform.arch or null;
+  crossArch = if stdenv.hostPlatform != stdenv.buildPlatform
+    then hostPlatform.parsed.cpu.name
+    else null;
 
   preConfigure = ''
     if test -n "$crossConfig"; then

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -56,7 +56,9 @@ stdenv.mkDerivation rec {
   ];
 
   # We should find a better way to access the arch reliably.
-  crossArch = hostPlatform.arch or null;
+  crossArch = if stdenv.hostPlatform != stdenv.buildPlatform
+    then hostPlatform.parsed.cpu.name
+    else null;
 
   preConfigure = ''
     if test -n "$crossConfig"; then

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -113,7 +113,7 @@ let
         "--cross-prefix=${stdenv.cc.targetPrefix}"
         "--enable-cross-compile"
         "--target_os=linux"
-        "--arch=${hostPlatform.arch}"
+        "--arch=${hostPlatform.parsed.cpu.name}"
         ];
     };
 


### PR DESCRIPTION
###### Motivation for this change

Use `parsed.cpu.name` or `platform.gcc.arch` instead.

Back-port of https://github.com/NixOS/nixpkgs/pull/40270

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

