### PR TITLE
slang: 2.3.1a -> 2.3.2

### DIFF
--- a/pkgs/development/libraries/slang/default.nix
+++ b/pkgs/development/libraries/slang/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, ncurses, pcre, libpng, zlib, readline, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "slang-2.3.1a";
+  name = "slang-2.3.2";
   src = fetchurl {
     url = "http://www.jedsoft.org/releases/slang/${name}.tar.bz2";
-    sha256 = "0dlcy0hn0j6cj9qj5x6hpb0axifnvzzmv5jqq0wq14fygw0c7w2l";
+    sha256 = "06p379fqn6w38rdpqi98irxi2bf4llb0rja3dlgkqz7nqh7kp7pw";
   };
 
   outputs = [ "out" "dev" "man" "doc" ];
@@ -16,9 +16,22 @@ stdenv.mkDerivation rec {
     sed -i -e "s|/bin/ln|ln|" src/Makefile.in
     sed -i -e "s|-ltermcap|-lncurses|" ./configure
   '';
-  configureFlags = "--with-png=${libpng.dev} --with-z=${zlib.dev} --with-pcre=${pcre.dev} --with-readline=${readline.dev}";
-  buildInputs = [ pcre libpng zlib readline ] ++ stdenv.lib.optionals (stdenv.isDarwin) [ libiconv ];
+
+  configureFlags = [
+    "--with-png=${libpng.dev}"
+    "--with-z=${zlib.dev}"
+    "--with-pcre=${pcre.dev}"
+    "--with-readline=${readline.dev}"
+  ];
+
+  buildInputs = [
+    pcre libpng zlib readline
+  ] ++ stdenv.lib.optionals (stdenv.isDarwin) [ libiconv ];
+
   propagatedBuildInputs = [ ncurses ];
+
+  # slang 2.3.2 does not support parallel building
+  enableParallelBuilding = false;
 
   postInstall = ''
     find "$out"/lib/ -name '*.so' -exec chmod +x "{}" \;
@@ -29,7 +42,7 @@ stdenv.mkDerivation rec {
     description = "A multi-platform programmer's library designed to allow a developer to create robust software";
     homepage = http://www.jedsoft.org/slang/;
     license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fuuzetsu ];
     platforms = platforms.unix;
-    maintainers = [ maintainers.fuuzetsu ];
   };
 }

--- a/pkgs/tools/misc/mc/default.nix
+++ b/pkgs/tools/misc/mc/default.nix
@@ -11,8 +11,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ perl glib slang zip unzip file gettext libX11 libICE
-    libssh2 openssl ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ e2fsprogs gpm ];
+
+  buildInputs = [
+    perl glib slang zip unzip file gettext libX11 libICE libssh2 openssl
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [ e2fsprogs gpm ];
+
+  enableParallelBuilding = true;
 
   configureFlags = [ "--enable-vfs-smb" ];
 


### PR DESCRIPTION
###### Motivation for this change

```ncurses``` was updated in edf201583d6 to 6.1 which caused slang to break on 256 color terminals. One example is ```mc```:

```
~ $ mc  
Unknown terminal: screen-256color
Check the TERM environment variable.
Also make sure that the terminal is defined in the terminfo database.
Alternatively, set the TERMCAP environment variable to the desired
termcap entry.
```

This fixes it (at least for mc but presumable others). The mc change here is super tiny - I thought if we were going to rebuild it anyway due to slang, we might as well clean it up all little.

Cc: @Fuuzetsu @svanderburg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

