### PR TITLE
fontconfig, misc A/V packages: No crossAttrs

### DIFF
--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -12,9 +12,13 @@ let
       sha256 = "03s1zsprz5p6gjgwwqcf7b6cvzwwid6l8k7bamx9i0f1iwkgdm0j";
     };
     
+    configurePlatforms = [];
     configureFlags = [
-      "--arch=arm"
+      "--arch=${hostPlatform.parsed.cpu.name}"
+    ] ++ stdenv.lib.optionals stdenv.hostPlatform.isAarch32 [
+      # TODO be better with condition
       "--cpu=arm1176jzf-s"
+    ] ++ [
       "--disable-muxers"
       "--enable-muxer=spdif"
       "--enable-muxer=adts"
@@ -42,19 +46,14 @@ let
       "--enable-hardcoded-tables"
       "--disable-runtime-cpudetect"
       "--disable-debug"
+      "--arch=${hostPlatform.parsed.cpu.name}"
+      "--target_os=${hostPlatform.parsed.kernel.name}"
+    ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--cross-prefix=${stdenv.cc.targetPrefix}"
+      "--enable-cross-compile"
     ];
 
     enableParallelBuilding = true;
-      
-    crossAttrs = {
-      configurePlatforms = [];
-      configureFlags = configureFlags ++ [
-        "--cross-prefix=${stdenv.cc.targetPrefix}"
-        "--enable-cross-compile"
-        "--target_os=linux"
-        "--arch=${hostPlatform.parsed.cpu.name}"
-        ];
-    };
 
     meta = {
       homepage = http://www.ffmpeg.org/;
@@ -83,5 +82,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/huceke/omxplayer;
     description = "Commandline OMX player for the Raspberry Pi";
     license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.arm;
   };
 }

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -249,7 +249,10 @@ stdenv.mkDerivation rec {
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
   '';
 
+  configurePlatforms = [];
   configureFlags = [
+    "--target_os=${hostPlatform.parsed.kernel.name}"
+    "--arch=${hostPlatform.parsed.cpu.name}"
     /*
      *  Licensing flags
      */
@@ -371,8 +374,6 @@ stdenv.mkDerivation rec {
     #(enableFeature quvi "libquvi")
     (enableFeature (rtmpdump != null) "librtmp")
     #(enableFeature (schroedinger != null) "libschroedinger")
-    #(enableFeature (shine != null) "libshine")
-    (enableFeature (samba != null && gplLicensing && version3Licensing) "libsmbclient")
     (enableFeature (SDL2 != null) "sdl2")
     (enableFeature (soxr != null) "libsoxr")
     (enableFeature (speex != null) "libspeex")
@@ -396,6 +397,9 @@ stdenv.mkDerivation rec {
     (enableFeature optimizationsDeveloper "optimizations")
     (enableFeature extraWarningsDeveloper "extra-warnings")
     (enableFeature strippingDeveloper "stripping")
+  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--cross-prefix=${stdenv.cc.targetPrefix}"
+    "--enable-cross-compile"
   ];
 
   nativeBuildInputs = [ perl pkgconfig texinfo yasm ];
@@ -432,20 +436,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-
   enableParallelBuilding = true;
-
-  /* Cross-compilation is untested, consider this an outline, more work
-     needs to be done to portions of the build to get it to work correctly */
-  crossAttrs = {
-    configurePlatforms = [];
-    configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cc.targetPrefix}"
-      "--enable-cross-compile"
-      "--target_os=${hostPlatform.parsed.kernel.name}"
-      "--arch=${hostPlatform.parsed.cpu.name}"
-    ];
-  };
 
   meta = with stdenv.lib; {
     description = "A complete, cross-platform solution to record, convert and stream audio and video";

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -79,7 +79,10 @@ stdenv.mkDerivation rec {
     ++ optional (reqMin "1.0") "doc" ; # just dev-doc
   setOutputFlags = false; # doesn't accept all and stores configureFlags in libs!
 
+  configurePlatforms = [];
   configureFlags = [
+      "--arch=${hostPlatform.parsed.cpu.name}"
+      "--target_os=${hostPlatform.parsed.kernel.name}"
     # License
       "--enable-gpl"
       "--enable-version3"
@@ -145,6 +148,9 @@ stdenv.mkDerivation rec {
       "--disable-stripping"
     # Disable mmx support for 0.6.90
       (verFix null "0.6.90" "--disable-mmx")
+  ] ++ optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+      "--cross-prefix=${stdenv.cc.targetPrefix}"
+      "--enable-cross-compile"
   ] ++ optional stdenv.cc.isClang "--cc=clang";
 
   nativeBuildInputs = [ perl pkgconfig texinfo yasm ];
@@ -167,18 +173,6 @@ stdenv.mkDerivation rec {
     moveToOutput bin "$bin"
     moveToOutput share/ffmpeg/examples "$doc"
   '';
-
-  /* Cross-compilation is untested, consider this an outline, more work
-     needs to be done to portions of the build to get it to work correctly */
-  crossAttrs = {
-    configurePlatforms = [];
-    configureFlags = configureFlags ++ [
-      "--cross-prefix=${stdenv.cc.targetPrefix}"
-      "--enable-cross-compile"
-      "--target_os=${hostPlatform.parsed.kernel.name}"
-      "--arch=${hostPlatform.parsed.cpu.name}"
-    ];
-  };
 
   installFlags = [ "install-man" ];
 

--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -17,22 +17,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ expat ];
 
   configureFlags = [
+    "--with-arch=${hostPlatform.parsed.cpu.name}"
     "--sysconfdir=/etc"
     "--with-cache-dir=/var/cache/fontconfig"
     "--disable-docs"
     "--with-default-fonts="
   ];
-
-  # We should find a better way to access the arch reliably.
-  crossArch = if stdenv.hostPlatform != stdenv.buildPlatform
-    then hostPlatform.parsed.cpu.name
-    else null;
-
-  preConfigure = ''
-    if test -n "$crossConfig"; then
-      configureFlags="$configureFlags --with-arch=$crossArch";
-    fi
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -40,22 +40,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ expat ];
 
   configureFlags = [
+    "--with-arch=${hostPlatform.parsed.cpu.name}"
     "--with-cache-dir=/var/cache/fontconfig" # otherwise the fallback is in $out/
     "--disable-docs"
     # just <1MB; this is what you get when loading config fails for some reason
     "--with-default-fonts=${dejavu_fonts.minimal}"
   ];
-
-  # We should find a better way to access the arch reliably.
-  crossArch = if stdenv.hostPlatform != stdenv.buildPlatform
-    then hostPlatform.parsed.cpu.name
-    else null;
-
-  preConfigure = ''
-    if test -n "$crossConfig"; then
-      configureFlags="$configureFlags --with-arch=$crossArch";
-    fi
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -18,7 +18,7 @@
 
 assert faacSupport -> enableUnfree;
 
-let inherit (stdenv.lib) optional optionals hasPrefix; in
+let inherit (stdenv.lib) optional optionals hasPrefix enableFeature; in
 
 /* ToDo:
     - more deps, inspiration: http://packages.ubuntu.com/raring/libav-tools
@@ -51,29 +51,35 @@ let
       substituteInPlace ./configure --replace "#! /bin/sh" "#!${bash}/bin/sh"
     '';
 
-    configureFlags =
-      assert stdenv.lib.all (x: x!=null) buildInputs;
-    [
+    configurePlatforms = [];
+    configureFlags = assert stdenv.lib.all (x: x!=null) buildInputs; [
+      "--arch=${hostPlatform.parsed.cpu.name}"
+      "--target_os=${hostPlatform.parsed.kernel.name}"
       #"--enable-postproc" # it's now a separate package in upstream
       "--disable-avserver" # upstream says it's in a bad state
       "--enable-avplay"
       "--enable-shared"
       "--enable-runtime-cpudetect"
       "--cc=cc"
-    ]
-      ++ optionals enableGPL [ "--enable-gpl" "--enable-swscale" ]
-      ++ optional mp3Support "--enable-libmp3lame"
-      ++ optional speexSupport "--enable-libspeex"
-      ++ optional theoraSupport "--enable-libtheora"
-      ++ optional vorbisSupport "--enable-libvorbis"
-      ++ optional vpxSupport "--enable-libvpx"
-      ++ optional x264Support "--enable-libx264"
-      ++ optional xvidSupport "--enable-libxvid"
-      ++ optional faacSupport "--enable-libfaac --enable-nonfree"
-      ++ optional vaapiSupport "--enable-vaapi"
-      ++ optional vdpauSupport "--enable-vdpau"
-      ++ optional freetypeSupport "--enable-libfreetype"
-      ;
+      (enableFeature enableGPL "gpl")
+      (enableFeature enableGPL "swscale")
+      (enableFeature mp3Support "libmp3lame")
+      (enableFeature mp3Support "libmp3lame")
+      (enableFeature speexSupport "libspeex")
+      (enableFeature theoraSupport "libtheora")
+      (enableFeature vorbisSupport "libvorbis")
+      (enableFeature vpxSupport "libvpx")
+      (enableFeature x264Support "libx264")
+      (enableFeature xvidSupport "libxvid")
+      (enableFeature faacSupport "libfaac")
+      (enableFeature faacSupport "nonfree")
+      (enableFeature vaapiSupport "vaapi")
+      (enableFeature vdpauSupport "vdpau")
+      (enableFeature freetypeSupport "libfreetype")
+    ] ++ optional (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "--cross-prefix=${stdenv.cc.targetPrefix}"
+      "--enable-cross-compile"
+    ];
 
   nativeBuildInputs = [ pkgconfig perl ];
     buildInputs = [ lame yasm zlib bzip2 SDL bash ]
@@ -111,16 +117,6 @@ let
 
     doInstallCheck = false; # fails randomly
     installCheckTarget = "check"; # tests need to be run *after* installation
-
-    crossAttrs = {
-      configurePlatforms = [];
-      configureFlags = configureFlags ++ [
-        "--cross-prefix=${stdenv.cc.targetPrefix}"
-        "--enable-cross-compile"
-        "--target_os=linux"
-        "--arch=${hostPlatform.parsed.cpu.name}"
-        ];
-    };
 
     passthru = { inherit vdpauSupport; };
 


### PR DESCRIPTION
###### Motivation for this change

Progress towards #33302

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

