### PR TITLE
googleearth: init at 7.1.8.3036

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -103,12 +103,6 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
    </listitem>
    <listitem>
     <para>
-     <literal>googleearth</literal> has been removed from Nixpkgs. Google does not provide
-     a stable URL for Nixpkgs to use to package this proprietary software.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      <literal>gnucash</literal> has changed from version 2.4 to 3.x.
      If you've been using <literal>gnucash</literal> (version 2.4) instead of
      <literal>gnucash26</literal> (version 2.6) you must open your Gnucash 

--- a/pkgs/applications/misc/googleearth/default.nix
+++ b/pkgs/applications/misc/googleearth/default.nix
@@ -1,0 +1,97 @@
+{ stdenv, fetchurl, glibc, libGLU_combined, freetype, glib, libSM, libICE, libXi, libXv
+, libXrender, libXrandr, libXfixes, libXcursor, libXinerama, libXext, libX11, qt4
+, zlib, fontconfig, dpkg, libproxy, libxml2, gstreamer, gst_all_1, dbus }:
+
+let
+  arch =
+    if stdenv.system == "x86_64-linux" then "amd64"
+    else if stdenv.system == "i686-linux" then "i386"
+    else throw "Unsupported system ${stdenv.system}";
+  sha256 =
+    if arch == "amd64"
+    then "0dwnppn5snl5bwkdrgj4cyylnhngi0g66fn2k41j3dvis83x24k6"
+    else "0gndbxrj3kgc2dhjqwjifr3cl85hgpm695z0wi01wvwzhrjqs0l2";
+  version = "7.1.8.3036";
+  fullPath = stdenv.lib.makeLibraryPath [
+    glibc
+    glib
+    stdenv.cc.cc
+    libSM
+    libICE
+    libXi
+    libXv
+    libGLU_combined
+    libXrender
+    libXrandr
+    libXfixes
+    libXcursor
+    libXinerama
+    freetype
+    libXext
+    libX11
+    zlib
+    fontconfig
+    libproxy
+    libxml2
+    gstreamer
+    dbus
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+in
+stdenv.mkDerivation rec {
+  name = "googleearth-${version}";
+  src = fetchurl {
+    url = "https://dl.google.com/linux/earth/deb/pool/main/g/google-earth-stable/google-earth-stable_${version}-r0_${arch}.deb";
+    inherit sha256;
+  };
+
+  phases = [ "unpackPhase" "installPhase" "checkPhase" ];
+
+  doCheck = true;
+
+  buildInputs = [ dpkg ];
+
+  unpackPhase = ''
+    dpkg-deb -x ${src} ./
+  '';
+
+  installPhase =''
+    mkdir $out
+    mv usr/* $out/
+    rmdir usr
+    mv * $out/
+    rm $out/bin/google-earth $out/opt/google/earth/free/googleearth
+
+    # patch and link googleearth binary
+    ln -s $out/opt/google/earth/free/googleearth-bin $out/bin/googleearth
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${fullPath}:\$ORIGIN" \
+      $out/opt/google/earth/free/googleearth-bin
+
+    # patch and link gpsbabel binary
+    ln -s $out/opt/google/earth/free/gpsbabel $out/bin/gpsbabel
+    patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${fullPath}:\$ORIGIN" \
+      $out/opt/google/earth/free/gpsbabel
+
+    # patch libraries
+    for a in $out/opt/google/earth/free/*.so* ; do
+      patchelf --set-rpath "${fullPath}:\$ORIGIN" $a
+    done
+  '';
+
+  checkPhase = ''
+    $out/bin/gpsbabel -V > /dev/null
+  '';
+
+  dontPatchELF = true;
+
+  meta = with stdenv.lib; {
+    description = "A world sphere viewer";
+    homepage = http://earth.google.com;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ markus1189 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16181,6 +16181,8 @@ with pkgs;
 
   gollum = callPackage ../applications/misc/gollum { };
 
+  googleearth = callPackage ../applications/misc/googleearth { };
+
   google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };


### PR DESCRIPTION
Wanted to play with google earth and found #39426.  I took the URL from the AUR PKGBUILD, so it seems like the moving link problem is gone.

I tested it locally and it worked without problems, maybe somebody can test whether it works for them too.

/cc @matthewbauer @woffs as you were involved in the issue to remove the package