### PR TITLE
perlPackages.Paranoid: init at 2.05

### DIFF
--- a/pkgs/development/perl-modules/Paranoid-blessed-path.patch
+++ b/pkgs/development/perl-modules/Paranoid-blessed-path.patch
@@ -1,0 +1,23 @@
+diff -ru Paranoid-2.05/lib/Paranoid.pm /tmp/Paranoid-2.05/lib/Paranoid.pm
+--- Paranoid-2.05/lib/Paranoid.pm	2017-02-06 05:48:57.000000000 -0500
++++ /tmp/Paranoid-2.05/lib/Paranoid.pm	2018-05-10 06:40:35.286313299 -0400
+@@ -61,7 +61,7 @@
+ 
+     my $path = shift;
+ 
+-    $path = '/bin:/usr/bin' unless defined $path;
++    $path = '__BLESSED_PATH__' unless defined $path;
+ 
+     delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
+     $ENV{PATH} = $path;
+Binary files Paranoid-2.05/lib/.Paranoid.pm.swp and /tmp/Paranoid-2.05/lib/.Paranoid.pm.swp differ
+diff -ru Paranoid-2.05/t/01_init_core.t /tmp/Paranoid-2.05/t/01_init_core.t
+--- Paranoid-2.05/t/01_init_core.t	2016-07-12 04:49:33.000000000 -0400
++++ /tmp/Paranoid-2.05/t/01_init_core.t	2018-05-10 06:43:41.323183381 -0400
+@@ -35,5 +35,5 @@
+ ok( psecureEnv('/bin:/sbin'), 'psecureEnv 1' );
+ is( $ENV{PATH}, '/bin:/sbin', 'Validated PATH' );
+ ok( psecureEnv(), 'psecureEnv 2' );
+-is( $ENV{PATH}, '/bin:/usr/bin', 'Validated PATH' );
++is( $ENV{PATH}, '__BLESSED_PATH__', 'Validated PATH' );
+ 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11954,6 +11954,25 @@ let self = _self // overrides; _self = with self; {
      };
   };
 
+  Paranoid = buildPerlPackage rec {
+    name = "Paranoid-2.05";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/C/CO/CORLISS/Paranoid/${name}.tar.gz";
+      sha256 = "583dfa0279733531f360795ad1cf4aa652d537b2b0bbd3c6925d0c8d75cbb3df";
+    };
+    patches = [ ../development/perl-modules/Paranoid-blessed-path.patch ];
+    preConfigure = ''
+      # Capture the path used when compiling this module as the "blessed"
+      # system path, analogous to the module's own use of '/bin:/sbin'.
+      sed -i "s#__BLESSED_PATH__#$PATH#" lib/Paranoid.pm t/01_init_core.t
+    '';
+    meta = {
+      description = "General function library for safer, more secure programming";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+      maintainers = [ maintainers.limeytexan ];
+    };
+  };
+
   PARDist = buildPerlPackage {
     name = "PAR-Dist-0.49";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11964,7 +11964,7 @@ let self = _self // overrides; _self = with self; {
     preConfigure = ''
       # Capture the path used when compiling this module as the "blessed"
       # system path, analogous to the module's own use of '/bin:/sbin'.
-      sed -i "s#__BLESSED_PATH__#$PATH#" lib/Paranoid.pm t/01_init_core.t
+      sed -i "s#__BLESSED_PATH__#${pkgs.coreutils}/bin#" lib/Paranoid.pm t/01_init_core.t
     '';
     meta = {
       description = "General function library for safer, more secure programming";


### PR DESCRIPTION
###### Motivation for this change
Add Paranoid module from CPAN.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

