### PR TITLE
tio: init at 1.30

### DIFF
--- a/pkgs/tools/misc/tio/default.nix
+++ b/pkgs/tools/misc/tio/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchzip, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "tio-${version}";
+  version = "1.30";
+
+  src = fetchzip {
+    url = "https://github.com/tio/tio/archive/v${version}.tar.gz";
+    sha256 = "1cyjy1jg2s32h1jkb99qb79sxkxh92niiyig0vysr14m4xnw01mr";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    description = "Serial console TTY";
+    homepage = https://tio.github.io/;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5203,6 +5203,8 @@ with pkgs;
 
   tiny8086 = callPackage ../applications/virtualization/8086tiny { };
 
+  tio = callPackage ../tools/misc/tio { };
+
   tldr = callPackage ../tools/misc/tldr { };
 
   tldr-hs = haskellPackages.tldr;


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

