### PR TITLE
theme-jade1: init at 3.2

### DIFF
--- a/pkgs/misc/themes/jade1/default.nix
+++ b/pkgs/misc/themes/jade1/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "theme-jade1-${version}";
+  version = "3.2";
+
+  src = fetchFromGitHub {
+    owner = "madmaxms";
+    repo = "theme-jade-1";
+    rev = "v${version}";
+    sha256 = "0lf8cawn2s2x1b9af0cznhqzx3dsr8h18srcwjz7af3y5daxf311";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -a Jade-1 $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A fork of the original Linux Mint theme with dark menus, more intensive green and some other modifications";
+    homepage = https://github.com/madmaxms/theme-jade-1;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19806,9 +19806,11 @@ with pkgs;
 
   numix-sx-gtk-theme = callPackage ../misc/themes/numix-sx { };
 
-  theme-obsidian2 = callPackage ../misc/themes/obsidian2 { };
-
   onestepback = callPackage ../misc/themes/onestepback { };
+
+  theme-jade1 = callPackage ../misc/themes/jade1 { };
+
+  theme-obsidian2 = callPackage ../misc/themes/obsidian2 { };
 
   theme-vertex = callPackage ../misc/themes/vertex { };
 


### PR DESCRIPTION
###### Motivation for this change

Add [theme-jade-1](https://github.com/madmaxms/theme-jade-1), a fork of the original Linux Mint theme with dark menus, more intensive green and some other modifications. 

![screenshot](https://user-images.githubusercontent.com/1217934/39884858-86be89c8-5461-11e8-820f-aebd83c12ac1.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).