### PR TITLE
lib/systems: Prohibit "gnu" ABI (*-gnu) with 32-bit ARM

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -50,5 +50,12 @@ rec {
     } // mapAttrs (n: v: v final.parsed) inspect.predicates
       // args;
   in assert final.useAndroidPrebuilt -> final.isAndroid;
+     assert lib.foldl
+       (pass: { assertion, message }:
+         if assertion final
+         then pass
+         else throw message)
+       true
+       (final.parsed.abi.assertions or []);
     final;
 }

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -192,7 +192,15 @@ rec {
   abis = setTypes types.openAbi {
     android = {};
     cygnus = {};
-    gnu = {};
+    gnu = {
+      assertions = [
+        { assertion = platform: !platform.isAarch32;
+          message = ''
+            The "gnu" ABI is ambiguous on 32-bit ARM. Use "gnueabi" or "gnueabihf" instead.
+          '';
+        }
+      ];
+    };
     msvc = {};
     eabi = {};
     androideabi = {};
@@ -270,7 +278,7 @@ rec {
       kernel = getKernel args.kernel;
       abi =
         /**/ if args ? abi       then getAbi args.abi
-        else if isLinux   parsed then abis.gnu
+        else if isLinux   parsed then (if isAarch32 parsed then abis.gnueabi else abis.gnu)
         else if isWindows parsed then abis.gnu
         else                     abis.unknown;
     };


### PR DESCRIPTION
###### Motivation for this change

It is ambiguous, and therefore banned within GCC.

@dezgeg doing this separately since it is eval-only, and I can therefore test it myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

