### PR TITLE
nginx service: add nested locations support

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -680,6 +680,12 @@ rec {
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
+    # Break documentation recursion in infinitely nested submodules.
+    hideSubTree = elemType: elemType // {
+      getSubOptions = prefix: {};
+      getSubModules = null;
+    };
+
   };
 };
 

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -352,6 +352,7 @@ let
       ${optionalString (config.root != null) "root ${config.root};"}
       ${optionalString (config.alias != null) "alias ${config.alias};"}
       ${optionalString (config.return != null) "return ${config.return};"}
+      ${mkLocations config.locations}
       ${config.extraConfig}
       ${optionalString (config.proxyPass != null && cfg.recommendedProxySettings) "include ${recommendedProxyConfig};"}
       ${mkBasicAuth "sublocation" config}

--- a/nixos/modules/services/web-servers/nginx/location-options.nix
+++ b/nixos/modules/services/web-servers/nginx/location-options.nix
@@ -7,6 +7,7 @@
 
 with lib;
 
+let self =
 {
   options = {
     basicAuth = mkOption {
@@ -111,6 +112,21 @@ with lib;
       '';
     };
 
+    locations = mkOption {
+      type = types.attrsOf (types.hideSubTree (types.submodule self));
+      default = {};
+      example = literalExpression ''
+        {
+          "/" = {
+            proxyPass = "http://localhost:3000";
+          };
+        };
+      '';
+      description = ''
+        Sub-locations configuration.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -129,4 +145,6 @@ with lib;
       '';
     };
   };
-}
+};
+
+in self


### PR DESCRIPTION
###### Motivation for this change

Copy locations from vhost-options.nix so can be nested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

