### PR TITLE
nixos/tests/graphite: fix test

### DIFF
--- a/nixos/tests/graphite.nix
+++ b/nixos/tests/graphite.nix
@@ -4,6 +4,7 @@ import ./make-test.nix ({ pkgs, ...} :
   nodes = {
     one =
       { config, pkgs, ... }: {
+        virtualisation.memorySize = 1024;
         time.timeZone = "UTC";
         services.graphite = {
           web.enable = true;
@@ -21,12 +22,17 @@ import ./make-test.nix ({ pkgs, ...} :
   testScript = ''
     startAll;
     $one->waitForUnit("default.target");
-    $one->requireActiveUnit("graphiteWeb.service");
-    $one->requireActiveUnit("graphiteApi.service");
-    $one->requireActiveUnit("graphitePager.service");
-    $one->requireActiveUnit("carbonCache.service");
-    $one->requireActiveUnit("seyren.service");
-    $one->succeed("echo \"foo 1 `date +%s`\" | nc -q0 localhost 2003");
-    $one->waitUntilSucceeds("curl 'http://localhost:8080/metrics/find/?query=foo&format=treejson' --silent | grep foo")
+    $one->waitForUnit("graphiteWeb.service");
+    $one->waitForUnit("graphiteApi.service");
+    $one->waitForUnit("graphitePager.service");
+    $one->waitForUnit("carbonCache.service");
+    $one->waitForUnit("seyren.service");
+    # The services above are of type "simple". systemd considers them active immediately
+    # even if they're still in preStart (which takes quite long for graphiteWeb).
+    # Wait for ports to open so we're sure the services are up and listening.
+    $one->waitForOpenPort(8080);
+    $one->waitForOpenPort(2003);
+    $one->succeed("echo \"foo 1 `date +%s`\" | nc -N localhost 2003");
+    $one->waitUntilSucceeds("curl 'http://localhost:8080/metrics/find/?query=foo&format=treejson' --silent | grep foo >&2");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Test [failed on Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.graphite.x86_64-linux) for different reasons:

- failed deterministically since netcat was switched to libressl version (non-existing option)
- failed non-deterministically before that due to improper timing of the test