### PR TITLE
enlightenment: remove bashism from patch

### DIFF
--- a/pkgs/desktops/enlightenment/enlightenment.suid-exes.patch
+++ b/pkgs/desktops/enlightenment/enlightenment.suid-exes.patch
@@ -14,9 +14,9 @@
  for x in "$@" ; do
 -	chown root "$DESTDIR/$x"
 -	chmod a=rx,u+xs "$DESTDIR/$x"
-+	f="$DESTDIR/$x";
++	f="$DESTDIR$x";
 +	b=$(basename "$f".orig)
-+	mv -v "$f"{,.orig}
++	mv -v "$f" "$f".orig
 +	ln -sv /run/wrappers/bin/"$b" "$f"
 +	echo "    \"$b\".source = \"$f.orig\";" >> $w
  done


### PR DESCRIPTION
###### Motivation for this change

The `mv -v "$f"{,.orig}` command is not working in the machine where the binary cache is built.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).