### PR TITLE
hostapd: remove assertion (allow 5GHz channels)

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -151,11 +151,6 @@ in
 
   config = mkIf cfg.enable {
 
-    assertions = [
-      { assertion = (cfg.channel >= 1 && cfg.channel <= 13);
-        message = "channel must be between 1 and 13";
-      }];
-
     environment.systemPackages =  [ pkgs.hostapd ];
 
     systemd.services.hostapd =


### PR DESCRIPTION
5Ghz channels go at least as high as 165.