### PR TITLE
pythonPackages.mail-parser: init at 3.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3021,6 +3021,11 @@
     email = "philipp@xndr.de";
     name = "Philipp Steinpaß";
   };
+  psyanticy = {
+    email = "iuns@outlook.fr";
+    github = "Assassinkin";
+    name = "Psyanticy";
+  };
   puffnfresh = {
     email = "brian@brianmckenna.org";
     github = "puffnfresh";

--- a/pkgs/development/python-modules/mail-parser/default.nix
+++ b/pkgs/development/python-modules/mail-parser/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildPythonPackage, python, pythonOlder, glibcLocales, fetchFromGitHub, ipaddress, six, simplejson }:
+
+buildPythonPackage rec {
+  pname = "mail-parser";
+  version = "3.3.1";
+
+  # no tests in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "SpamScope";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1b1v61zwgdx2xjzds3hp6bv53yq424hhlrhf445n4faj1l0c4lkg";
+  };
+
+  LC_ALL = "en_US.utf-8";
+
+  # ipaddress is part of the standard library of Python 3.3+
+  prePatch = lib.optionalString (!pythonOlder "3.3") ''
+    substituteInPlace requirements.txt \
+      --replace "ipaddress" ""
+  '';
+
+  nativeBuildInputs = [ glibcLocales ];
+  propagatedBuildInputs = [ simplejson six ] ++ lib.optional (pythonOlder "3.3") ipaddress;
+
+  # Taken from .travis.yml
+  checkPhase = ''
+    ${python.interpreter} tests/test_main.py
+    ${python.interpreter} -m mailparser -v
+    ${python.interpreter} -m mailparser -h
+    ${python.interpreter} -m mailparser -f tests/mails/mail_malformed_3 -j
+    cat tests/mails/mail_malformed_3 | ${python.interpreter} -m mailparser -k -j
+  '';
+
+  meta = with lib; {
+    description = "A mail parser for python 2 and 3";
+    homepage = https://github.com/SpamScope/mail-parser;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -277,6 +277,8 @@ in {
 
   logster = callPackage ../development/python-modules/logster { };
 
+  mail-parser = callPackage ../development/python-modules/mail-parser {  };
+
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;
   };


### PR DESCRIPTION
###### Motivation for this change

mail-parser is not only a wrapper for email Python Standard Library. It gives an easy way to pass from raw mail to Python object.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

