### PR TITLE
ncurses: use a different mirror / archive

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -17,14 +17,8 @@ stdenv.mkDerivation rec {
   name = "ncurses-${version}" + lib.optionalString (abiVersion == "5") "-abi5-compat";
 
   src = fetchurl {
-    urls = [
-      # Remove this mirror on next upgrade, it's only needed because upstream took ncurses-6.0-20171125.tgz down!
-      "http://bld1.alpinelinux.org/distfiles/v3.5/ncurses-${version}.tgz"
-
-      "ftp://ftp.invisible-island.net/ncurses/current/ncurses-${version}.tgz"
-      "https://invisible-mirror.net/archives/ncurses/current/ncurses-${version}.tgz"
-    ];
-    sha256 = "11adzj0k82nlgpfrflabvqn2m7fmhp2y6pd7ivmapynxqb9vvb92";
+    url = https://github.com/mirror/ncurses/archive/8d3ea9021573747ecd129228ba7782a03243f62c.tar.gz;
+    sha256 = "0pn5zksizs2h127zfxnf48f7f9ac4lgi6h8jhr1h8hl994s3bp32";
   };
 
   patches = lib.optional (!stdenv.cc.isClang) ./clang.patch;


### PR DESCRIPTION
The ncurses version we use was taken down by upstream. Another mirror
that was added is now also unavailable.

This commit points to a new mirror on GitHub. The hash is however
different.

https://github.com/NixOS/nixpkgs/issues/35264

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

