### PR TITLE
Fix small typo in configuration documentation

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -416,7 +416,7 @@ cp ${myProfile} $out/etc/profile.d/my-profile.sh
         nox
         silver-searcher
       ];
-      pathsToLink = [ "/share/man" "/share/doc" /bin" "/etc" ];
+      pathsToLink = [ "/share/man" "/share/doc" "/bin" "/etc" ];
       extraOutputsToInstall = [ "man" "doc" ];
     };
   };

--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -378,7 +378,7 @@
     myPackages = pkgs.buildEnv {
       name = "my-packages";
       paths = [ aspell bc coreutils ffmpeg nixUnstable emscripten jq nox silver-searcher ];
-      pathsToLink = [ "/share/man" "/share/doc" /bin" ];
+      pathsToLink = [ "/share/man" "/share/doc" "/bin" ];
       extraOutputsToInstall = [ "man" "doc" ];
     };
   };


### PR DESCRIPTION
Noticed this small typo while reading through the docs. Let me know if there is a more appropriate commit message for a documentation-only change and I will amend.

###### Motivation for this change
- Syntax highlighting makes the error a bit more glaring than it would without.
- Easy copy-pasta

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

**DOCUMENTATION ONLY CHANGE**
