### PR TITLE
libb2: 0.97 -> 0.98 and fix build on ARM

### DIFF
--- a/pkgs/development/libraries/libb2/default.nix
+++ b/pkgs/development/libraries/libb2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, libtool }:
+{ stdenv, hostPlatform, fetchurl, autoconf, automake, libtool }:
 
 stdenv.mkDerivation rec {
   name = "libb2-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  configureFlags = [ "--enable-fat=yes" ];
+  configureFlags = stdenv.lib.optional hostPlatform.isx86 "--enable-fat=yes";
 
   nativeBuildInputs = [ autoconf automake libtool ];
 

--- a/pkgs/development/libraries/libb2/default.nix
+++ b/pkgs/development/libraries/libb2/default.nix
@@ -1,17 +1,26 @@
-{stdenv, fetchurl}:
-with stdenv; with lib;
-mkDerivation rec {
-  name = "libb2-${meta.version}";
+{ stdenv, fetchurl, autoconf, automake, libtool }:
+
+stdenv.mkDerivation rec {
+  name = "libb2-${version}";
+  version = "0.98";
 
   src = fetchurl {
     url = "https://blake2.net/${name}.tar.gz";
-    sha256 = "7829c7309347650239c76af7f15d9391af2587b38f0a65c250104a2efef99051";
+    sha256 = "1852gh8wwnsghdb9zhxdhw0173plpqzk684npxbl4bzk1hhzisal";
   };
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    ./autogen.sh
+  '';
 
   configureFlags = [ "--enable-fat=yes" ];
 
-  meta = {
-    version = "0.97";
+  nativeBuildInputs = [ autoconf automake libtool ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
     description = "The BLAKE2 family of cryptographic hash functions";
     platforms = platforms.all;
     maintainers = with maintainers; [ dfoxfranke ];


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/job/nixpkgs/trunk/libb2.aarch64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dfoxfranke @dezgeg 