### PR TITLE
lib: Add more configure flag helpers

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -51,11 +51,11 @@ let
     # back-compat aliases
     platforms = systems.forMeta;
 
-    inherit (builtins) add addErrorContext attrNames
-      concatLists deepSeq elem elemAt filter genericClosure genList
-      getAttr hasAttr head isAttrs isBool isInt isList
-      isString length lessThan listToAttrs pathExists readFile
-      replaceStrings seq stringLength sub substring tail;
+    inherit (builtins) add addErrorContext attrNames concatLists
+      deepSeq elem elemAt filter genericClosure genList getAttr
+      hasAttr head isAttrs isBool isInt isList isString length
+      lessThan listToAttrs pathExists readFile replaceStrings seq
+      stringLength sub substring tail;
     inherit (trivial) id const concat or and boolToString mergeAttrs
       flip mapNullable inNixShell min max importJSON warn info
       nixpkgsVersion version mod compare splitByAndCompare
@@ -74,30 +74,32 @@ let
     inherit (lists) singleton foldr fold foldl foldl' imap0 imap1
       concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range partition zipListsWith zipLists
-      reverseList listDfs toposort sort naturalSort compareLists take drop sublist
-      last init crossLists unique intersectLists subtractLists
-      mutuallyExclusive;
+      reverseList listDfs toposort sort naturalSort compareLists take
+      drop sublist last init crossLists unique intersectLists
+      subtractLists mutuallyExclusive;
     inherit (strings) concatStrings concatMapStrings concatImapStrings
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath makePerlPath optionalString
       hasPrefix hasSuffix stringToCharacters stringAsChars escape
-      escapeShellArg escapeShellArgs replaceChars lowerChars upperChars
-      toLower toUpper addContextFrom splitString removePrefix
-      removeSuffix versionOlder versionAtLeast getVersion nameFromURL
-      enableFeature fixedWidthString fixedWidthNumber isStorePath
+      escapeShellArg escapeShellArgs replaceChars lowerChars
+      upperChars toLower toUpper addContextFrom splitString
+      removePrefix removeSuffix versionOlder versionAtLeast getVersion
+      nameFromURL enableFeature enableFeatureAs withFeature
+      withFeatureAs fixedWidthString fixedWidthNumber isStorePath
       toInt readPathsFromFile fileContents;
     inherit (stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
     inherit (customisation) overrideDerivation makeOverridable
-      callPackageWith callPackagesWith extendDerivation
-      hydraJob makeScope;
+      callPackageWith callPackagesWith extendDerivation hydraJob
+      makeScope;
     inherit (meta) addMetaAttrs dontDistribute setName updateName
       appendToName mapDerivationAttrset lowPrio lowPrioSet hiPrio
       hiPrioSet;
     inherit (sources) pathType pathIsDirectory cleanSourceFilter
       cleanSource sourceByRegex sourceFilesBySuffices
-      commitIdFromGitRepo cleanSourceWith pathHasContext canCleanSource;
+      commitIdFromGitRepo cleanSourceWith pathHasContext
+      canCleanSource;
     inherit (modules) evalModules closeModules unifyModuleSyntax
       applyIfFunction unpackSubmodule packSubmodule mergeModules
       mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions
@@ -119,8 +121,7 @@ let
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal
       traceShowValMarked showVal traceCall traceCall2 traceCall3
-      traceValIfNot runTests testAllTrue traceCallXml
-      attrNamesToStr;
+      traceValIfNot runTests testAllTrue traceCallXml attrNamesToStr;
     inherit (misc) maybeEnv defaultMergeArg defaultMerge foldArgs
       defaultOverridableDelayableArgs composedArgsAndFun
       maybeAttrNullable maybeAttr ifEnable checkFlag getValue
@@ -129,7 +130,7 @@ let
       closePropagation mapAttrsFlatten nvs setAttr setAttrMerge
       mergeAttrsWithFunc mergeAttrsConcatenateValues
       mergeAttrsNoOverride mergeAttrByFunc mergeAttrsByFuncDefaults
-      mergeAttrsByFuncDefaultsClean mergeAttrBy
-      prepareDerivationArgs nixType imap overridableDelayableArgs;
+      mergeAttrsByFuncDefaultsClean mergeAttrBy prepareDerivationArgs
+      nixType imap overridableDelayableArgs;
   });
 in lib

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -414,6 +414,39 @@ rec {
   */
   enableFeature = enable: feat: "--${if enable then "enable" else "disable"}-${feat}";
 
+  /* Create an --{enable-<feat>=<value>,disable-<feat>} string that can be passed to
+     standard GNU Autoconf scripts.
+
+     Example:
+       enableFeature true "shared" "foo"
+       => "--enable-shared=foo"
+       enableFeature false "shared" (throw "ignored")
+       => "--disable-shared"
+  */
+  enableFeatureAs = enable: feat: value: enableFeature enable feat + optionalString enable "=${value}";
+
+  /* Create an --{with,without}-<feat> string that can be passed to
+     standard GNU Autoconf scripts.
+
+     Example:
+       withFeature true "shared"
+       => "--with-shared"
+       withFeature false "shared"
+       => "--without-shared"
+  */
+  withFeature = with_: feat: "--${if with_ then "with" else "without"}-${feat}";
+
+  /* Create an --{with-<feat>=<value>,without-<feat>} string that can be passed to
+     standard GNU Autoconf scripts.
+
+     Example:
+       with_Feature true "shared" "foo"
+       => "--with-shared=foo"
+       with_Feature false "shared" (throw "ignored")
+       => "--without-shared"
+  */
+  withFeatureAs = with_: feat: value: withFeature with_ feat + optionalString with_ "=${value}";
+
   /* Create a fixed width string with additional prefix to match
      required width.
 


### PR DESCRIPTION
###### Motivation for this change

Add with/without to match enable/disable, and add `--{enable,with}-key=value` versions of both.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

