### PR TITLE
git-cola: port to qt5

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, makeWrapper, gettext, git }:
 
 let
-  inherit (pythonPackages) buildPythonApplication pyqt4 sip pyinotify python mock;
+  inherit (pythonPackages) buildPythonApplication pyqt5 sip pyinotify python mock;
 in buildPythonApplication rec {
   name = "git-cola-${version}";
   version = "3.1";
@@ -14,7 +14,7 @@ in buildPythonApplication rec {
   };
 
   buildInputs = [ git gettext ];
-  propagatedBuildInputs = [ pyqt4 sip pyinotify ];
+  propagatedBuildInputs = [ pyqt5 sip pyinotify ];
 
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change

`git-cola` is a simple GUI `git` wrapper based on QT. Since 2.7
(namely https://github.com/git-cola/git-cola/commit/293364b45c4cbf3faff3fd7aba79b474d0abc845)
it supports QT5 which provides a nicer inteface.

See #33248

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

