### PR TITLE
nixos/mesos: fix non-deterministic service and test failure

### DIFF
--- a/nixos/modules/services/misc/mesos-slave.nix
+++ b/nixos/modules/services/misc/mesos-slave.nix
@@ -187,7 +187,7 @@ in {
     systemd.services.mesos-slave = {
       description = "Mesos Slave";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+      after = [ "network.target" ] ++ optionals cfg.withDocker [ "docker.service" ] ;
       path = [ pkgs.runtimeShellPackage ];
       serviceConfig = {
         ExecStart = ''

--- a/nixos/tests/mesos.nix
+++ b/nixos/tests/mesos.nix
@@ -66,9 +66,11 @@ import ./make-test.nix ({ pkgs, ...} : rec {
   testScript =
     ''
       startAll;
+      $master->waitForUnit("zookeeper.service");
       $master->waitForUnit("mesos-master.service");
+      $slave->waitForUnit("docker.service");
       $slave->waitForUnit("mesos-slave.service");
-
+      $master->waitForOpenPort(2181);
       $master->waitForOpenPort(5050);
       $slave->waitForOpenPort(5051);
 


### PR DESCRIPTION
###### Motivation for this change

`nixos/tests/mesos` [failed most of the time on Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.mesos.x86_64-linux/all ). This was caused by two different issues:

1. `mesos-slave.service` failed if `docker.service` wasn't ready due to a missing  `After=` dependency.
2. The nixos test didn't wait for all relevant services and ports to be available before sending requests.