### PR TITLE
home-assistant: 0.68.1 -> 0.69.0

### DIFF
--- a/pkgs/development/python-modules/deluge-client/default.nix
+++ b/pkgs/development/python-modules/deluge-client/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "deluge-client";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "27a7f4c6da8f057e03171a493f17340f39f288199a21beb3226a188ab3c02cea";
+    sha256 = "86979ebcb9f1f991554308e88c7a57469cbf339958b44c71cbdcba128291b043";
   };
 
   # it will try to connect to a running instance

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.68.1";
+  version = "0.69.0";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -165,6 +165,7 @@
     "lock.sesame" = ps: with ps; [  ];
     "lutron" = ps: with ps; [  ];
     "lutron_caseta" = ps: with ps; [  ];
+    "matrix" = ps: with ps; [ matrix-client ];
     "maxcube" = ps: with ps; [  ];
     "media_extractor" = ps: with ps; [  ];
     "media_player.anthemav" = ps: with ps; [  ];
@@ -239,7 +240,6 @@
     "notify.lametric" = ps: with ps; [  ];
     "notify.mailgun" = ps: with ps; [  ];
     "notify.mastodon" = ps: with ps; [  ];
-    "notify.matrix" = ps: with ps; [ matrix-client ];
     "notify.message_bird" = ps: with ps; [  ];
     "notify.pushbullet" = ps: with ps; [ pushbullet ];
     "notify.pushetta" = ps: with ps; [  ];
@@ -261,6 +261,7 @@
     "qwikswitch" = ps: with ps; [  ];
     "rainbird" = ps: with ps; [  ];
     "raincloud" = ps: with ps; [  ];
+    "rainmachine" = ps: with ps; [  ];
     "raspihats" = ps: with ps; [  ];
     "recorder" = ps: with ps; [ sqlalchemy ];
     "remember_the_milk" = ps: with ps; [ httplib2 ];
@@ -299,6 +300,7 @@
     "sensor.dsmr" = ps: with ps; [  ];
     "sensor.dweet" = ps: with ps; [  ];
     "sensor.eddystone_temperature" = ps: with ps; [ construct ];
+    "sensor.eliqonline" = ps: with ps; [  ];
     "sensor.envirophat" = ps: with ps; [  ];
     "sensor.etherscan" = ps: with ps; [  ];
     "sensor.fastdotcom" = ps: with ps; [  ];
@@ -333,6 +335,7 @@
     "sensor.mfi" = ps: with ps; [  ];
     "sensor.mhz19" = ps: with ps; [  ];
     "sensor.miflora" = ps: with ps; [  ];
+    "sensor.mitemp_bt" = ps: with ps; [  ];
     "sensor.modem_callerid" = ps: with ps; [  ];
     "sensor.mopar" = ps: with ps; [  ];
     "sensor.mvglive" = ps: with ps; [ PyMVGLive ];
@@ -345,6 +348,7 @@
     "sensor.plex" = ps: with ps; [  ];
     "sensor.pocketcasts" = ps: with ps; [  ];
     "sensor.pollen" = ps: with ps; [  ];
+    "sensor.postnl" = ps: with ps; [  ];
     "sensor.pushbullet" = ps: with ps; [ pushbullet ];
     "sensor.qnap" = ps: with ps; [  ];
     "sensor.ripple" = ps: with ps; [  ];
@@ -360,6 +364,7 @@
     "sensor.sma" = ps: with ps; [  ];
     "sensor.snmp" = ps: with ps; [ pysnmp ];
     "sensor.sochain" = ps: with ps; [  ];
+    "sensor.socialblade" = ps: with ps; [  ];
     "sensor.speedtest" = ps: with ps; [  ];
     "sensor.spotcrime" = ps: with ps; [  ];
     "sensor.sql" = ps: with ps; [ sqlalchemy ];
@@ -412,7 +417,6 @@
     "switch.netio" = ps: with ps; [  ];
     "switch.orvibo" = ps: with ps; [  ];
     "switch.rachio" = ps: with ps; [  ];
-    "switch.rainmachine" = ps: with ps; [  ];
     "switch.rpi_rf" = ps: with ps; [  ];
     "switch.snmp" = ps: with ps; [ pysnmp ];
     "switch.thinkingcleaner" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -28,11 +28,18 @@ let
           sha256 = "af7315c9fa99e0bfd195a21106c82c81619b42f0bd9b6e287b797c6b6b6a9918";
         };
       });
-      astral = super.astral.overridePythonAttrs (oldAttrs: rec {
-        version = "1.6";
+      attrs = super.attrs.overridePythonAttrs (oldAttrs: rec {
+        version = "18.1.0";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "874b397ddbf0a4c1d8d644b21c2481e8a96b61343f820ad52d8a322d61a15083";
+          sha256 = "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b";
+        };
+      });
+      astral = super.astral.overridePythonAttrs (oldAttrs: rec {
+        version = "1.6.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "ab0c08f2467d35fcaeb7bad15274743d3ac1ad18b5391f64a0058a9cd192d37d";
         };
       });
       async-timeout = super.async-timeout.overridePythonAttrs (oldAttrs: rec {
@@ -40,6 +47,15 @@ let
         src = oldAttrs.src.override {
           inherit version;
           sha256 = "00cff4d2dce744607335cba84e9929c3165632da2d27970dbc55802a0c7873d0";
+        };
+      });
+      # used by check_config script
+      # can be unpinned once https://github.com/home-assistant/home-assistant/issues/11917 is resolved
+      colorlog = super.colorlog.overridePythonAttrs (oldAttrs: rec {
+        version = "3.1.4";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "418db638c9577f37f0fae4914074f395847a728158a011be2a193ac491b9779d";
         };
       });
       hass-frontend = super.callPackage ./frontend.nix { };
@@ -58,7 +74,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.68.1";
+  hassVersion = "0.69.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -73,7 +89,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "103py7hfdanr8zk3cl93rm7ngjz0n95kwjbphq7iy8l8hqpzs1m8";
+    sha256 = "05hagifi1338law2mwwik2gjjw1ckjdjh0lg9l8ldsz999dkc2zz";
   };
 
   propagatedBuildInputs = [
@@ -91,8 +107,7 @@ in with py.pkgs; buildPythonApplication rec {
     # The components' dependencies are not included, so they cannot be tested
     py.test --ignore tests/components
     # Some basic components should be tested however
-    # test_not_log_password fails because nothing is logged at all
-    py.test -k "not test_not_log_password" \
+    py.test \
       tests/components/{group,http} \
       tests/components/test_{api,configurator,demo,discovery,frontend,init,introduction,logger,script,shell_command,system_log,websocket_api}.py
   '';

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180426.0";
+  version = "20180509.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "60ff4e0b0c4538fa0be0db9407f95333546940e119a8d3edb9b0d7e1c86b1f3b";
+    sha256 = "11d9c4a07565358e6ee001f5c57c8393b4aaadac0d993a0a39a0387a33644fba";
   };
 
   propagatedBuildInputs = [ user-agents ];


### PR DESCRIPTION
###### Motivation for this change
https://www.home-assistant.io/blog/2018/05/11/release-69

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg 