### PR TITLE
vala-panel-appmenu: init at 0.6.94

### DIFF
--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -97,6 +97,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   #### PANEL PLUGINS
 
+  xfce4-vala-panel-appmenu-plugin = callPackage ./panel-plugins/xfce4-vala-panel-appmenu-plugin { };
+
   xfce4-battery-plugin = callPackage ./panel-plugins/xfce4-battery-plugin.nix { };
 
   xfce4-clipman-plugin = callPackage ./panel-plugins/xfce4-clipman-plugin.nix { };

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/appmenu-gtk-module.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/appmenu-gtk-module.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, substituteAll, cmake, vala, glib, gtk2, gtk3 }:
+stdenv.mkDerivation rec {
+  name = "vala-panel-appmenu-xfce-${version}";
+  version = "0.6.94";
+
+  src = "${fetchFromGitHub {
+    owner = "rilian-la-te";
+    repo = "vala-panel-appmenu";
+    rev = version;
+    fetchSubmodules = true;
+
+    sha256 = "0xxn3zs60a9nfix8wrdp056wviq281cm1031hznzf1l38lp3wr5p";
+  }}/subprojects/appmenu-gtk-module";
+
+  nativeBuildInputs = [ cmake vala ];
+  buildInputs = [ glib gtk2 gtk3 ];
+
+  configurePhase = ''
+    cmake . -DGTK3_INCLUDE_GDK=
+  '';
+  installPhase = ''
+    make DESTDIR=output install
+    cp -r output/var/empty/* "$out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Port of the Unity GTK+ Module";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ jD91mZM2 ];
+  };
+}

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, substituteAll, callPackage, pkgconfig, cmake, vala, libxml2,
+  glib, pcre, gtk2, gtk3, xorg, libxkbcommon, epoxy, at-spi2-core, dbus-glib, bamf,
+  xfce, libwnck3, libdbusmenu-glib, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "xfce4-vala-panel-appmenu-plugin-${version}";
+  version = "0.6.94";
+
+  src = fetchFromGitHub {
+    owner = "rilian-la-te";
+    repo = "vala-panel-appmenu";
+    rev = version;
+    fetchSubmodules = true;
+
+    sha256 = "0xxn3zs60a9nfix8wrdp056wviq281cm1031hznzf1l38lp3wr5p";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake vala libxml2.bin ];
+  buildInputs = [ (callPackage ./appmenu-gtk-module.nix {})
+                  glib pcre gtk2 gtk3 xorg.libpthreadstubs xorg.libXdmcp libxkbcommon epoxy
+                  at-spi2-core dbus-glib bamf xfce.xfce4panel_gtk3 xfce.libxfce4util xfce.xfconf
+                  libwnck3 libdbusmenu-glib gobjectIntrospection ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-bamf-dependency.patch;
+      bamf = bamf;
+    })
+  ];
+
+  cmakeFlags = [
+      "-DENABLE_XFCE=ON"
+      "-DENABLE_BUDGIE=OFF"
+      "-DENABLE_VALAPANEL=OFF"
+      "-DENABLE_MATE=OFF"
+      "-DENABLE_JAYATANA=OFF"
+      "-DENABLE_APPMENU_GTK_MODULE=OFF"
+  ];
+
+  preConfigure = ''
+    mv cmake/FallbackVersion.cmake.in cmake/FallbackVersion.cmake
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Global Menu applet for XFCE4";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ jD91mZM2 ];
+  };
+}

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/fix-bamf-dependency.patch
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-vala-panel-appmenu-plugin/fix-bamf-dependency.patch
@@ -1,0 +1,12 @@
++++ source/cmake/FindBAMF.cmake	2018-05-11 17:03:44.385917811 +0200
+@@ -80,9 +80,7 @@
+ 
+ find_program(BAMF_DAEMON_EXECUTABLE
+ 	bamfdaemon
+-	HINTS ${CMAKE_INSTALL_FULL_LIBDIR}
+-		  ${CMAKE_INSTALL_FULL_LIBEXECDIR}
+-		  ${BAMF_LIBDIR}
++	HINTS "@bamf@/libexec/bamf/"
+ 	PATH_SUFFIXES bamf
+ )
+ 


### PR DESCRIPTION
Adds a plugin for Global Menus to xfce4-panel, [vala-panel-appmenu](https://github.com/rilian-la-te/vala-panel-appmenu) :D

Note: Requires xfce4-panel GTK+3. The default GTK+2 version won't work.

I'm not completely sure it works, I can only get it to display the Desktop window.
But it compiles at least, and that's a start ¯\\\_(ツ)_/¯