### PR TITLE
lib/systems: Sort platforms, and space CPUs

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -47,15 +47,7 @@ rec {
 
   ben-nanonote = rec {
     config = "mipsel-unknown-linux-uclibc";
-    platform = {
-      name = "ben_nanonote";
-      kernelMajor = "2.6";
-      kernelArch = "mips";
-      gcc = {
-        arch = "mips32";
-        float = "soft";
-      };
-    };
+    platform = platforms.ben_nanonote;
   };
 
   fuloongminipc = rec {

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -79,15 +79,20 @@ rec {
     armv8r   = { bits = 32; significantByte = littleEndian; family = "arm"; };
     armv8m   = { bits = 32; significantByte = littleEndian; family = "arm"; };
     aarch64  = { bits = 64; significantByte = littleEndian; family = "arm"; };
+
     i686     = { bits = 32; significantByte = littleEndian; family = "x86"; };
     x86_64   = { bits = 64; significantByte = littleEndian; family = "x86"; };
+
     mips     = { bits = 32; significantByte = bigEndian;    family = "mips"; };
     mipsel   = { bits = 32; significantByte = littleEndian; family = "mips"; };
     mips64   = { bits = 64; significantByte = bigEndian;    family = "mips"; };
     mips64el = { bits = 64; significantByte = littleEndian; family = "mips"; };
+
     powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
+
     riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; };
     riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };
+
     wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
     wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
   };

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -20,6 +20,10 @@ rec {
     kernelAutoModules = false;
   };
 
+  ##
+  ## ARM
+  ##
+
   pogoplug4 = {
     name = "pogoplug4";
 
@@ -372,84 +376,6 @@ rec {
     kernelBaseConfig = "guruplug_defconfig";
   };
 
-  fuloong2f_n32 = {
-    name = "fuloong2f_n32";
-    kernelMajor = "2.6";
-    kernelBaseConfig = "lemote2f_defconfig";
-    kernelArch = "mips";
-    kernelAutoModules = false;
-    kernelExtraConfig = ''
-      MIGRATION n
-      COMPACTION n
-
-      # nixos mounts some cgroup
-      CGROUPS y
-
-      BLK_DEV_RAM y
-      BLK_DEV_INITRD y
-      BLK_DEV_CRYPTOLOOP m
-      BLK_DEV_DM m
-      DM_CRYPT m
-      MD y
-      REISERFS_FS m
-      EXT4_FS m
-      USB_STORAGE_CYPRESS_ATACB m
-
-      IP_PNP y
-      IP_PNP_DHCP y
-      IP_PNP_BOOTP y
-      NFS_FS y
-      ROOT_NFS y
-      TUN m
-      NFS_V4 y
-      NFS_V4_1 y
-      NFS_FSCACHE y
-      NFSD m
-      NFSD_V2_ACL y
-      NFSD_V3 y
-      NFSD_V3_ACL y
-      NFSD_V4 y
-
-      # Fail to build
-      DRM n
-      SCSI_ADVANSYS n
-      USB_ISP1362_HCD n
-      SND_SOC n
-      SND_ALI5451 n
-      FB_SAVAGE n
-      SCSI_NSP32 n
-      ATA_SFF n
-      SUNGEM n
-      IRDA n
-      ATM_HE n
-      SCSI_ACARD n
-      BLK_DEV_CMD640_ENHANCED n
-
-      FUSE_FS m
-
-      # Needed for udev >= 150
-      SYSFS_DEPRECATED_V2 n
-
-      VGA_CONSOLE n
-      VT_HW_CONSOLE_BINDING y
-      SERIAL_8250_CONSOLE y
-      FRAMEBUFFER_CONSOLE y
-      EXT2_FS y
-      EXT3_FS y
-      REISERFS_FS y
-      MAGIC_SYSRQ y
-
-      # The kernel doesn't boot at all, with FTRACE
-      FTRACE n
-    '';
-    kernelTarget = "vmlinux";
-    gcc = {
-      arch = "loongson2f";
-      float = "hard";
-      abi = "n32";
-    };
-  };
-
   beaglebone = armv7l-hf-multiplatform // {
     name = "beaglebone";
     kernelBaseConfig = "bb.org_defconfig";
@@ -536,6 +462,102 @@ rec {
       arch = "armv8-a";
     };
   };
+
+  ##
+  ## MIPS
+  ##
+
+  ben_nanonote = {
+    name = "ben_nanonote";
+    kernelMajor = "2.6";
+    kernelArch = "mips";
+    gcc = {
+      arch = "mips32";
+      float = "soft";
+    };
+  };
+
+  fuloong2f_n32 = {
+    name = "fuloong2f_n32";
+    kernelMajor = "2.6";
+    kernelBaseConfig = "lemote2f_defconfig";
+    kernelArch = "mips";
+    kernelAutoModules = false;
+    kernelExtraConfig = ''
+      MIGRATION n
+      COMPACTION n
+
+      # nixos mounts some cgroup
+      CGROUPS y
+
+      BLK_DEV_RAM y
+      BLK_DEV_INITRD y
+      BLK_DEV_CRYPTOLOOP m
+      BLK_DEV_DM m
+      DM_CRYPT m
+      MD y
+      REISERFS_FS m
+      EXT4_FS m
+      USB_STORAGE_CYPRESS_ATACB m
+
+      IP_PNP y
+      IP_PNP_DHCP y
+      IP_PNP_BOOTP y
+      NFS_FS y
+      ROOT_NFS y
+      TUN m
+      NFS_V4 y
+      NFS_V4_1 y
+      NFS_FSCACHE y
+      NFSD m
+      NFSD_V2_ACL y
+      NFSD_V3 y
+      NFSD_V3_ACL y
+      NFSD_V4 y
+
+      # Fail to build
+      DRM n
+      SCSI_ADVANSYS n
+      USB_ISP1362_HCD n
+      SND_SOC n
+      SND_ALI5451 n
+      FB_SAVAGE n
+      SCSI_NSP32 n
+      ATA_SFF n
+      SUNGEM n
+      IRDA n
+      ATM_HE n
+      SCSI_ACARD n
+      BLK_DEV_CMD640_ENHANCED n
+
+      FUSE_FS m
+
+      # Needed for udev >= 150
+      SYSFS_DEPRECATED_V2 n
+
+      VGA_CONSOLE n
+      VT_HW_CONSOLE_BINDING y
+      SERIAL_8250_CONSOLE y
+      FRAMEBUFFER_CONSOLE y
+      EXT2_FS y
+      EXT3_FS y
+      REISERFS_FS y
+      MAGIC_SYSRQ y
+
+      # The kernel doesn't boot at all, with FTRACE
+      FTRACE n
+    '';
+    kernelTarget = "vmlinux";
+    gcc = {
+      arch = "loongson2f";
+      float = "hard";
+      abi = "n32";
+    };
+  };
+
+  ##
+  ## Other
+  ##
 
   riscv-multiplatform = bits: {
     name = "riscv-multiplatform";


### PR DESCRIPTION
###### Motivation for this change

General cleanliness.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

