### PR TITLE
android cross: Support 32-bit too

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -31,18 +31,21 @@ rec {
 
   armv5te-android-prebuilt = rec {
     config = "armv5tel-unknown-linux-androideabi";
+    sdkVer = "21";
     platform = platforms.armv5te-android;
     useAndroidPrebuilt = true;
   };
 
   armv7a-android-prebuilt = rec {
     config = "armv7a-unknown-linux-androideabi";
+    sdkVer = "21";
     platform = platforms.armv7a-android;
     useAndroidPrebuilt = true;
   };
 
   aarch64-android-prebuilt = rec {
     config = "aarch64-unknown-linux-android";
+    sdkVer = "21";
     platform = platforms.aarch64-multiplatform;
     useAndroidPrebuilt = true;
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -3,6 +3,9 @@ with import ./parse.nix { inherit lib; };
 with lib.attrsets;
 with lib.lists;
 
+let abis_ = abis; in
+let abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) abis_; in
+
 rec {
   patterns = rec {
     isi686         = { cpu = cpuTypes.i686; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -199,8 +199,16 @@ rec {
     msvc         = {};
     eabi         = {};
 
-    androideabi  = {};
-    android      = {};
+    androideabi  = { float = "hard"; };
+    android      = {
+      assertions = [
+        { assertion = platform: !platform.isAarch32;
+          message = ''
+            The "android" ABI is not for 32-bit ARM. Use "androideabi" instead.
+          '';
+        }
+      ];
+    };
 
     gnueabi      = { float = "soft"; };
     gnueabihf    = { float = "hard"; };

--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -15,7 +15,12 @@ let
     "x86_64-unknown-linux-gnu" = {
       double = "linux-x86_64";
     };
-    "arm-unknown-linux-androideabi" = {
+   "armv5tel-unknown-linux-androideabi" = {
+      arch = "arm";
+      triple = "arm-linux-androideabi";
+      gccVer = "4.8";
+    };
+   "armv7a-unknown-linux-androideabi" = {
       arch = "arm";
       triple = "arm-linux-androideabi";
       gccVer = "4.8";
@@ -59,9 +64,29 @@ rec {
     cc = binaries;
     bintools = binutils;
     libc = targetAndroidndkPkgs.libraries;
-    extraBuildCommands =
+    extraBuildCommands = lib.optionalString targetPlatform.isAarch32 (let
+        p = targetPlatform.platform.gcc or {};
+        float = p.float or (targetPlatform.parsed.abi.float or null);
+        flags = lib.concatLists [
+          (lib.optional (p ? arch) "-march=${p.arch}")
+          (lib.optional (p ? cpu) "-mcpu=${p.cpu}")
+          (lib.optional (p ? abi) "-mabi=${p.abi}")
+          (lib.optional (p ? fpu) "-mfpu=${p.fpu}")
+          (lib.optional (float != null) "-mfloat=${float}")
+          (lib.optional (p ? float-abi) "-mfloat-abi=${p.float-abi}")
+          (lib.optional (p ? mode) "-mmode=${p.mode}")
+        ];
+      in ''
+        sed -E -i \
+          $out/bin/${targetPlatform.config}-cc \
+          $out/bin/${targetPlatform.config}-c++ \
+          $out/bin/${targetPlatform.config}-gcc \
+          $out/bin/${targetPlatform.config}-g++ \
+          -e '130i    extraBefore+=(-Wl,--fix-cortex-a8)' \
+          -e 's|^(extraBefore=)\(\)$|\1(${builtins.toString flags})|'
+      '')
       # GCC 4.9 is the first relase with "-fstack-protector"
-      lib.optionalString (lib.versionOlder targetInfo.gccVer "4.9") ''
+      + lib.optionalString (lib.versionOlder targetInfo.gccVer "4.9") ''
         sed -E \
         -i $out/nix-support/add-hardening.sh \
         -e 's|(-fstack-protector)-strong|\1|g'
@@ -76,7 +101,7 @@ rec {
   libraries = {
     name = "bionic-prebuilt";
     type = "derivation";
-    outPath = "${buildAndroidndk}/libexec/${buildAndroidndk.name}/platforms/android-21/arch-${hostInfo.arch}/usr/";
+    outPath = "${buildAndroidndk}/libexec/${buildAndroidndk.name}/platforms/android-${hostPlatform.sdkVer}/arch-${hostInfo.arch}/usr/";
     drvPath = throw "fake derivation, build ${buildAndroidndk} to use";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I didn't do this initially because there were a few things I wanted to research/clean. That is all done now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

