### PR TITLE
truffleHog: init at 2.0.91

### DIFF
--- a/pkgs/development/python-modules/GitPython/default.nix
+++ b/pkgs/development/python-modules/GitPython/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, gitdb2, mock, nose, ddt }:
+
+buildPythonPackage rec {
+  version = "2.1.9";
+  pname = "GitPython";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0a9in1jfv9ssxhckl6sasw45bhm762y2r5ikgb2pk2g8yqdc6z64";
+  };
+
+  checkInputs = [ mock nose ddt ];
+  propagatedBuildInputs = [ gitdb2 ];
+
+  # Tests require a git repo
+  doCheck = false;
+
+  meta = {
+    description = "Python Git Library";
+    maintainers = [ ];
+    homepage = https://github.com/gitpython-developers/GitPython;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/gitdb/default.nix
+++ b/pkgs/development/python-modules/gitdb/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, smmap }:
+
+buildPythonPackage rec {
+  pname = "gitdb";
+  version = "0.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n4n2c7rxph9vs2l6xlafyda5x1mdr8xy16r9s3jwnh3pqkvrsx3";
+  };
+
+  propagatedBuildInputs = [ smmap ];
+
+  # Bunch of tests fail because they need an actual git repo
+  doCheck = false;
+
+  meta = {
+    description = "Git Object Database";
+    maintainers = [ ];
+    homepage = https://github.com/gitpython-developers/gitdb;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/gitdb2/default.nix
+++ b/pkgs/development/python-modules/gitdb2/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, smmap2 }:
+
+buildPythonPackage rec {
+  pname = "gitdb2";
+  version = "2.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02azg62mr99b7cllyjrly77np3vw32y8nrxpa2xjapiyaga2j3mn";
+  };
+
+  propagatedBuildInputs = [ smmap2 ];
+
+  # Bunch of tests fail because they need an actual git repo
+  doCheck = false;
+
+  meta = {
+    description = "Git Object Database";
+    maintainers = [ ];
+    homepage = https://github.com/gitpython-developers/gitdb;
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/smmap/default.nix
+++ b/pkgs/development/python-modules/smmap/default.nix
@@ -1,0 +1,19 @@
+{ lib, fetchPypi, buildPythonPackage, nosexcover }:
+
+buildPythonPackage rec {
+  pname = "smmap";
+  version = "0.9.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qlx25f6n2n9ff37w9gg62f217fzj16xlbh0pkz0lpxxjys64aqf";
+  };
+
+  checkInputs = [ nosexcover ];
+
+  meta = {
+    description = "A pure python implementation of a sliding window memory map manager";
+    homepage = https://github.com/gitpython-developers/smmap;
+    maintainers = [ ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/smmap2/default.nix
+++ b/pkgs/development/python-modules/smmap2/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchPypi, buildPythonPackage, nosexcover }:
+
+buildPythonPackage rec {
+  pname = "smmap2";
+  version = "2.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hvn28p3zvxa98sbi9lrqvv2ps4q284j4jq9a619zw0m7yv0sly7";
+  };
+
+  checkInputs = [ nosexcover ];
+
+  meta = {
+    description = "A pure python implementation of a sliding window memory map manager";
+    homepage = https://pypi.org/project/smmap2;
+    maintainers = [ ];
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/tools/security/trufflehog/default.nix
+++ b/pkgs/tools/security/trufflehog/default.nix
@@ -1,0 +1,38 @@
+{ lib, pythonPackages }:
+
+let
+  truffleHogRegexes = pythonPackages.buildPythonPackage rec {
+    pname = "truffleHogRegexes";
+    version = "0.0.4";
+    src = pythonPackages.fetchPypi {
+      inherit pname version;
+      sha256 = "09vrscbb4h4w01gmamlzghxx6cvrqdscylrbdcnbjsd05xl7zh4z";
+    };
+  };
+in
+  pythonPackages.buildPythonApplication rec {
+    pname = "truffleHog";
+    version = "2.0.91";
+
+    src = pythonPackages.fetchPypi {
+      inherit pname version;
+      sha256 = "0r4c9ihy6wjh5cwli7lb6cr2yfvxrh7r6cgznql1src5gzlnkymx";
+    };
+
+    # Relax overly restricted version constraint
+    postPatch = ''
+      substituteInPlace setup.py --replace "GitPython ==" "GitPython >= "
+    '';
+
+    propagatedBuildInputs = [ pythonPackages.GitPython truffleHogRegexes ];
+
+    # Test cases run git clone and require network access
+    doCheck = false;
+
+    meta = {
+      homepage = https://github.com/dxa4481/truffleHog;
+      description = "Searches through git repositories for high entropy strings and secrets, digging deep into commit history";
+      license = with lib.licenses; [ gpl2 ];
+      maintainers = with lib.maintainers; [ bhipple ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21119,6 +21119,8 @@ with pkgs;
 
   tup = callPackage ../development/tools/build-managers/tup { };
 
+  trufflehog = callPackage ../tools/security/trufflehog { };
+
   tvheadend = callPackage ../servers/tvheadend { };
 
   ums = callPackage ../servers/ums { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2820,31 +2820,9 @@ in {
 
   gpy = callPackage ../development/python-modules/gpy { };
 
-  gitdb = buildPythonPackage rec {
-    name = "gitdb-0.6.4";
+  gitdb = callPackage ../development/python-modules/gitdb { };
 
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/g/gitdb/${name}.tar.gz";
-      sha256 = "0n4n2c7rxph9vs2l6xlafyda5x1mdr8xy16r9s3jwnh3pqkvrsx3";
-    };
-
-    buildInputs = with self; [ nose ];
-    propagatedBuildInputs = with self; [ smmap ];
-
-    checkPhase = ''
-      nosetests
-    '';
-
-    doCheck = false; # Bunch of tests fail because they need an actual git repo
-
-    meta = {
-      description = "Git Object Database";
-      maintainers = with maintainers; [ ];
-      homepage = https://github.com/gitpython-developers/gitdb;
-      license = licenses.bsd3;
-    };
-
-  };
+  gitdb2 = callPackage ../development/python-modules/gitdb2 { };
 
   GitPython = buildPythonPackage rec {
     version = "2.0.8";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2824,30 +2824,7 @@ in {
 
   gitdb2 = callPackage ../development/python-modules/gitdb2 { };
 
-  GitPython = buildPythonPackage rec {
-    version = "2.0.8";
-    name = "GitPython-${version}";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/G/GitPython/GitPython-${version}.tar.gz";
-      sha256 = "7c03d1130f903aafba6ae5b89ccf8eb433a995cd3120cbb781370e53fc4eb222";
-    };
-
-    buildInputs = with self; [ mock nose ];
-    propagatedBuildInputs = with self; [ gitdb ];
-
-    # All tests error with
-    # InvalidGitRepositoryError: /tmp/nix-build-python2.7-GitPython-1.0.1.drv-0/GitPython-1.0.1
-    # Maybe due to being in a chroot?
-    doCheck = false;
-
-    meta = {
-      description = "Python Git Library";
-      maintainers = with maintainers; [ ];
-      homepage = https://github.com/gitpython-developers/GitPython;
-      license = licenses.bsd3;
-    };
-  };
+  GitPython = callPackage ../development/python-modules/GitPython { };
 
   git-annex-adapter = callPackage ../development/python-modules/git-annex-adapter {
     inherit (pkgs.gitAndTools) git-annex;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14241,18 +14241,9 @@ in {
 
   tqdm = callPackage ../development/python-modules/tqdm { };
 
-  smmap = buildPythonPackage rec {
-    name = "smmap-0.9.0";
-    disabled = isPyPy;  # This fails the tests if built with pypy
-    meta.maintainers = with maintainers; [ ];
+  smmap = callPackage ../development/python-modules/smmap { };
 
-    buildInputs = with self; [ nosexcover ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/smmap/${name}.tar.gz";
-      sha256 = "0qlx25f6n2n9ff37w9gg62f217fzj16xlbh0pkz0lpxxjys64aqf";
-    };
-  };
+  smmap2 = callPackage ../development/python-modules/smmap2 { };
 
   traits = buildPythonPackage rec {
     name = "traits-${version}";


### PR DESCRIPTION
This commit adds the python3 application truffleHog, which is a stand-alone tool
that scans a git repo for unencrypted passwords.

This depends on a newer GitPython, which depends on a new major version of
gitdb, which depends on a new major version of smmap2, so I've packaged those
as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

