### PR TITLE
Ghcjs 8.2 & 8.4

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/8.2/dep-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.2/dep-overrides.nix
@@ -1,0 +1,6 @@
+{ haskellLib }:
+
+let inherit (haskellLib) dontHaddock;
+in self: super: {
+  ghcjs = dontHaddock super.ghcjs;
+}

--- a/pkgs/development/compilers/ghcjs-ng/8.2/dep-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.2/dep-overrides.nix
@@ -1,6 +1,0 @@
-{ haskellLib }:
-
-let inherit (haskellLib) dontHaddock;
-in self: super: {
-  ghcjs = dontHaddock super.ghcjs;
-}

--- a/pkgs/development/compilers/ghcjs-ng/8.2/git.json
+++ b/pkgs/development/compilers/ghcjs-ng/8.2/git.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/ghcjs/ghcjs",
+  "rev": "0cff73c3ee13b464adba90f308b77751c75b9f26",
+  "sha256": "1shg34zi6ryaihar62qdkkalv8dsrsqbv58jzkhk9in38sdfkjxv",
+  "fetchSubmodules": true
+}

--- a/pkgs/development/compilers/ghcjs-ng/8.2/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.2/stage0.nix
@@ -1,0 +1,168 @@
+{ callPackage, configuredSrc }:
+
+{
+
+  ghcjs = callPackage
+    ({ mkDerivation, aeson, array, attoparsec, base, base16-bytestring
+    , base64-bytestring, binary, bytestring, Cabal, containers
+    , cryptohash, data-default, deepseq, directory, executable-path
+    , filepath, ghc-api-ghcjs, ghc-boot, ghc-paths, ghci-ghcjs
+    , ghcjs-th, haddock-api-ghcjs, hashable, haskell-src-exts
+    , haskell-src-meta, http-types, HUnit, lens, lifted-base, mtl
+    , network, optparse-applicative, parallel, parsec, process, random
+    , regex-posix, safe, shelly, split, stdenv, stringsearch, syb
+    , system-fileio, system-filepath, tar, template-haskell
+    , template-haskell-ghcjs, terminfo, test-framework
+    , test-framework-hunit, text, time, transformers
+    , transformers-compat, unix, unix-compat, unordered-containers
+    , vector, wai, wai-app-static, wai-extra, wai-websockets, warp
+    , webdriver, websockets, wl-pprint-text, yaml
+    }:
+    mkDerivation {
+      pname = "ghcjs";
+      version = "8.2.0.1";
+      src = configuredSrc + /.;
+      isLibrary = true;
+      isExecutable = true;
+      enableSeparateDataOutput = true;
+      setupHaskellDepends = [
+        base Cabal containers directory filepath process template-haskell
+        transformers
+      ];
+      libraryHaskellDepends = [
+        aeson array attoparsec base base16-bytestring base64-bytestring
+        binary bytestring Cabal containers cryptohash data-default deepseq
+        directory filepath ghc-api-ghcjs ghc-boot ghc-paths ghci-ghcjs
+        ghcjs-th hashable haskell-src-exts haskell-src-meta lens mtl
+        optparse-applicative parallel parsec process regex-posix safe split
+        stringsearch syb template-haskell template-haskell-ghcjs text time
+        transformers unordered-containers vector wl-pprint-text yaml
+      ];
+      executableHaskellDepends = [
+        aeson base binary bytestring Cabal containers directory
+        executable-path filepath ghc-api-ghcjs ghc-boot haddock-api-ghcjs
+        lens mtl optparse-applicative process shelly system-fileio
+        system-filepath tar terminfo text time transformers
+        transformers-compat unix unix-compat unordered-containers vector
+        yaml
+      ];
+      testHaskellDepends = [
+        aeson base bytestring data-default deepseq directory http-types
+        HUnit lens lifted-base network optparse-applicative process random
+        shelly system-fileio system-filepath test-framework
+        test-framework-hunit text time transformers unordered-containers
+        wai wai-app-static wai-extra wai-websockets warp webdriver
+        websockets yaml
+      ];
+      description = "Haskell to JavaScript compiler";
+      license = stdenv.lib.licenses.mit;
+    }) {};
+
+  ghc-api-ghcjs = callPackage
+    ({ mkDerivation, array, base, binary, bytestring, containers
+    , deepseq, directory, filepath, ghc-boot, ghc-boot-th, ghci-ghcjs
+    , hoopl, hpc, process, stdenv, template-haskell-ghcjs, terminfo
+    , time, transformers, unix
+    }:
+    mkDerivation {
+      pname = "ghc-api-ghcjs";
+      version = "8.2.2";
+      src = configuredSrc + /lib/ghc-api-ghcjs;
+      libraryHaskellDepends = [
+        array base binary bytestring containers deepseq directory filepath
+        ghc-boot ghc-boot-th ghci-ghcjs hoopl hpc process
+        template-haskell-ghcjs terminfo time transformers unix
+      ];
+      homepage = "http://www.haskell.org/ghc/";
+      description = "The GHC API (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  ghci-ghcjs = callPackage
+    ({ mkDerivation, array, base, binary, bytestring, containers
+    , deepseq, filepath, ghc-boot, ghc-boot-th, stdenv
+    , template-haskell-ghcjs, transformers, unix
+    }:
+    mkDerivation {
+      pname = "ghci-ghcjs";
+      version = "8.2.2";
+      src = configuredSrc + /lib/ghci-ghcjs;
+      libraryHaskellDepends = [
+        array base binary bytestring containers deepseq filepath ghc-boot
+        ghc-boot-th template-haskell-ghcjs transformers unix
+      ];
+      description = "The library supporting GHC's interactive interpreter (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  ghcjs-th = callPackage
+    ({ mkDerivation, base, binary, bytestring, containers, ghc-prim
+    , ghci-ghcjs, stdenv, template-haskell-ghcjs
+    }:
+    mkDerivation {
+      pname = "ghcjs-th";
+      version = "0.1.0.0";
+      src = configuredSrc + /lib/ghcjs-th;
+      libraryHaskellDepends = [
+        base binary bytestring containers ghc-prim ghci-ghcjs
+        template-haskell-ghcjs
+      ];
+      homepage = "http://github.com/ghcjs";
+      license = stdenv.lib.licenses.mit;
+    }) {};
+
+  haddock-api-ghcjs = callPackage
+    ({ mkDerivation, array, base, bytestring, Cabal, containers, deepseq
+    , directory, filepath, ghc-api-ghcjs, ghc-boot, ghc-paths
+    , haddock-library-ghcjs, hspec, hspec-discover, QuickCheck, stdenv
+    , transformers, xhtml
+    }:
+    mkDerivation {
+      pname = "haddock-api-ghcjs";
+      version = "2.18.1";
+      src = configuredSrc + /lib/haddock-api-ghcjs;
+      enableSeparateDataOutput = true;
+      libraryHaskellDepends = [
+        array base bytestring Cabal containers deepseq directory filepath
+        ghc-api-ghcjs ghc-boot ghc-paths haddock-library-ghcjs transformers
+        xhtml
+      ];
+      testHaskellDepends = [
+        base containers ghc-api-ghcjs hspec QuickCheck
+      ];
+      testToolDepends = [ hspec-discover ];
+      homepage = "http://www.haskell.org/haddock/";
+      description = "A documentation-generation tool for Haskell libraries (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  haddock-library-ghcjs = callPackage
+    ({ mkDerivation, base, base-compat, bytestring, deepseq, hspec
+    , hspec-discover, QuickCheck, stdenv, transformers
+    }:
+    mkDerivation {
+      pname = "haddock-library-ghcjs";
+      version = "1.4.4";
+      src = configuredSrc + /lib/haddock-library-ghcjs;
+      libraryHaskellDepends = [ base bytestring deepseq transformers ];
+      testHaskellDepends = [
+        base base-compat bytestring deepseq hspec QuickCheck transformers
+      ];
+      testToolDepends = [ hspec-discover ];
+      homepage = "http://www.haskell.org/haddock/";
+      description = "Library exposing some functionality of Haddock";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  template-haskell-ghcjs = callPackage
+    ({ mkDerivation, base, ghc-boot-th, pretty, stdenv }:
+    mkDerivation {
+      pname = "template-haskell-ghcjs";
+      version = "2.12.0.0";
+      src = configuredSrc + /lib/template-haskell-ghcjs;
+      libraryHaskellDepends = [ base ghc-boot-th pretty ];
+      description = "Support library for Template Haskell (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+}

--- a/pkgs/development/compilers/ghcjs-ng/8.4/dep-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/dep-overrides.nix
@@ -1,0 +1,7 @@
+{ haskellLib }:
+
+let inherit (haskellLib) dontCheck doJailbreak;
+in self: super: {
+  haddock-library-ghcjs = dontCheck super.haddock-library-ghcjs;
+  haddock-api-ghcjs = doJailbreak super.haddock-api-ghcjs;
+}

--- a/pkgs/development/compilers/ghcjs-ng/8.4/git.json
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/git.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/ghcjs/ghcjs",
+  "rev": "c494a598d1e5b6d70ddcb97177dc4b6cc71f5bd0",
+  "sha256": "1gpn1y3m2gk2x4anfh11p4cp49blabj761wicawvkw0w9bfhcfhn",
+  "fetchSubmodules": true
+}

--- a/pkgs/development/compilers/ghcjs-ng/8.4/git.json
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/git.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/ghcjs/ghcjs",
-  "rev": "6770fa38621f55b7a947fc11c69f81b8ce8502cf",
-  "sha256": "0c0x0yylx14mrvzmbvkw6zbprriizk73hvz8iija8i8hwpff79vm",
+  "rev": "d20da90a4819faad1c6309a06363b34edac0374c",
+  "sha256": "0jmxgfm1zwg6xscjcaycfam7zss8ik4ql4ii5lpryh4h6cdhvkbr",
   "fetchSubmodules": true
 }

--- a/pkgs/development/compilers/ghcjs-ng/8.4/git.json
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/git.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/ghcjs/ghcjs",
-  "rev": "c494a598d1e5b6d70ddcb97177dc4b6cc71f5bd0",
-  "sha256": "1gpn1y3m2gk2x4anfh11p4cp49blabj761wicawvkw0w9bfhcfhn",
+  "rev": "6770fa38621f55b7a947fc11c69f81b8ce8502cf",
+  "sha256": "0c0x0yylx14mrvzmbvkw6zbprriizk73hvz8iija8i8hwpff79vm",
   "fetchSubmodules": true
 }

--- a/pkgs/development/compilers/ghcjs-ng/8.4/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/stage0.nix
@@ -1,0 +1,175 @@
+{ callPackage, configuredSrc }:
+
+{
+
+  ghcjs = callPackage
+    ({ mkDerivation, aeson, array, attoparsec, base, base16-bytestring
+    , base64-bytestring, binary, bytestring, Cabal, containers
+    , cryptohash, data-default, deepseq, directory, executable-path
+    , filepath, ghc-api-ghcjs, ghc-boot, ghc-paths, ghci-ghcjs
+    , ghcjs-th, haddock-api-ghcjs, hashable, haskell-src-exts
+    , haskell-src-meta, http-types, HUnit, lens, lifted-base, mtl
+    , network, optparse-applicative, parallel, parsec, process, random
+    , regex-posix, safe, shelly, split, stdenv, stringsearch, syb
+    , system-fileio, system-filepath, tar, template-haskell
+    , template-haskell-ghcjs, terminfo, test-framework
+    , test-framework-hunit, text, time, transformers
+    , transformers-compat, unix, unix-compat, unordered-containers
+    , vector, wai, wai-app-static, wai-extra, wai-websockets, warp
+    , webdriver, websockets, wl-pprint-text, yaml
+    }:
+    mkDerivation {
+      pname = "ghcjs";
+      version = "8.4.0.1";
+      src = configuredSrc + /.;
+      isLibrary = true;
+      isExecutable = true;
+      enableSeparateDataOutput = true;
+      setupHaskellDepends = [
+        base Cabal containers directory filepath process template-haskell
+        transformers
+      ];
+      libraryHaskellDepends = [
+        aeson array attoparsec base base16-bytestring base64-bytestring
+        binary bytestring Cabal containers cryptohash data-default deepseq
+        directory filepath ghc-api-ghcjs ghc-boot ghc-paths ghci-ghcjs
+        ghcjs-th hashable haskell-src-exts haskell-src-meta lens mtl
+        optparse-applicative parallel parsec process regex-posix safe split
+        stringsearch syb template-haskell template-haskell-ghcjs text time
+        transformers unordered-containers vector wl-pprint-text yaml
+      ];
+      executableHaskellDepends = [
+        aeson base binary bytestring Cabal containers directory
+        executable-path filepath ghc-api-ghcjs ghc-boot haddock-api-ghcjs
+        lens mtl optparse-applicative process shelly system-fileio
+        system-filepath tar terminfo text time transformers
+        transformers-compat unix unix-compat unordered-containers vector
+        yaml
+      ];
+      testHaskellDepends = [
+        aeson base bytestring data-default deepseq directory http-types
+        HUnit lens lifted-base network optparse-applicative process random
+        shelly system-fileio system-filepath test-framework
+        test-framework-hunit text time transformers unordered-containers
+        wai wai-app-static wai-extra wai-websockets warp webdriver
+        websockets yaml
+      ];
+      description = "Haskell to JavaScript compiler";
+      license = stdenv.lib.licenses.mit;
+    }) {};
+
+  ghc-api-ghcjs = callPackage
+    ({ mkDerivation, array, base, binary, bytestring, containers
+    , deepseq, directory, filepath, ghc-boot, ghc-boot-th, ghci-ghcjs
+    , hpc, process, stdenv, template-haskell-ghcjs, terminfo, time
+    , transformers, unix
+    }:
+    mkDerivation {
+      pname = "ghc-api-ghcjs";
+      version = "8.4.0";
+      src = configuredSrc + /lib/ghc-api-ghcjs;
+      libraryHaskellDepends = [
+        array base binary bytestring containers deepseq directory filepath
+        ghc-boot ghc-boot-th ghci-ghcjs hpc process template-haskell-ghcjs
+        terminfo time transformers unix
+      ];
+      homepage = "http://www.haskell.org/ghc/";
+      description = "The GHC API (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  ghci-ghcjs = callPackage
+    ({ mkDerivation, array, base, binary, bytestring, containers
+    , deepseq, filepath, ghc-boot, ghc-boot-th, stdenv
+    , template-haskell-ghcjs, transformers, unix
+    }:
+    mkDerivation {
+      pname = "ghci-ghcjs";
+      version = "8.4.0";
+      src = configuredSrc + /lib/ghci-ghcjs;
+      libraryHaskellDepends = [
+        array base binary bytestring containers deepseq filepath ghc-boot
+        ghc-boot-th template-haskell-ghcjs transformers unix
+      ];
+      description = "The library supporting GHC's interactive interpreter (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  ghcjs-th = callPackage
+    ({ mkDerivation, base, binary, bytestring, containers, ghc-prim
+    , ghci-ghcjs, stdenv, template-haskell-ghcjs
+    }:
+    mkDerivation {
+      pname = "ghcjs-th";
+      version = "0.1.0.0";
+      src = configuredSrc + /lib/ghcjs-th;
+      libraryHaskellDepends = [
+        base binary bytestring containers ghc-prim ghci-ghcjs
+        template-haskell-ghcjs
+      ];
+      homepage = "http://github.com/ghcjs";
+      license = stdenv.lib.licenses.mit;
+    }) {};
+
+  haddock-api-ghcjs = callPackage
+    ({ mkDerivation, array, base, bytestring, Cabal, containers, deepseq
+    , directory, filepath, ghc-api-ghcjs, ghc-boot, ghc-paths
+    , haddock-library-ghcjs, hspec, hspec-discover, QuickCheck, stdenv
+    , transformers, xhtml
+    }:
+    mkDerivation {
+      pname = "haddock-api-ghcjs";
+      version = "2.20.0";
+      src = configuredSrc + /lib/haddock-api-ghcjs;
+      enableSeparateDataOutput = true;
+      libraryHaskellDepends = [
+        array base bytestring Cabal containers deepseq directory filepath
+        ghc-api-ghcjs ghc-boot ghc-paths haddock-library-ghcjs transformers
+        xhtml
+      ];
+      testHaskellDepends = [
+        array base bytestring Cabal containers deepseq directory filepath
+        ghc-api-ghcjs ghc-boot ghc-paths haddock-library-ghcjs hspec
+        QuickCheck transformers xhtml
+      ];
+      testToolDepends = [ hspec-discover ];
+      homepage = "http://www.haskell.org/haddock/";
+      description = "A documentation-generation tool for Haskell libraries";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  haddock-library-ghcjs = callPackage
+    ({ mkDerivation, base, base-compat, bytestring, containers, deepseq
+    , directory, filepath, haddock-library, hspec, hspec-discover
+    , optparse-applicative, QuickCheck, stdenv, transformers, tree-diff
+    }:
+    mkDerivation {
+      pname = "haddock-library-ghcjs";
+      version = "1.6.0";
+      src = configuredSrc + /lib/haddock-library-ghcjs;
+      libraryHaskellDepends = [
+        base bytestring containers deepseq transformers
+      ];
+      testHaskellDepends = [
+        base base-compat bytestring containers deepseq directory filepath
+        haddock-library hspec optparse-applicative QuickCheck transformers
+        tree-diff
+      ];
+      testToolDepends = [ hspec-discover ];
+      homepage = "http://www.haskell.org/haddock/";
+      description = "Library exposing some functionality of Haddock";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+  template-haskell-ghcjs = callPackage
+    ({ mkDerivation, base, ghc-boot-th, pretty, stdenv }:
+    mkDerivation {
+      pname = "template-haskell-ghcjs";
+      version = "2.13.0.0";
+      src = configuredSrc + /lib/template-haskell-ghcjs;
+      libraryHaskellDepends = [ base ghc-boot-th pretty ];
+      description = "Support library for Template Haskell (customized for GHCJS)";
+      license = stdenv.lib.licenses.bsd3;
+    }) {};
+
+}

--- a/pkgs/development/compilers/ghcjs-ng/README.md
+++ b/pkgs/development/compilers/ghcjs-ng/README.md
@@ -1,0 +1,20 @@
+New build system for GHCJS 8.2
+---
+
+`ghcjs-8.2` reworked the build system, and now comes with its own
+small package set of dependencies. This involves autogenerating
+several sources and cabal files, based on a GHC
+checkout. `callCabal2nix` is off limits, since we don't like "import
+from derivation" in nixpkgs. So there is a derivation that builds the
+nix expression that should be checked in whenever GHCJS is updated.
+
+Updating
+---
+
+```
+$ nix-prefetch-git https://github.com/ghcjs/ghcjs --rev refs/heads/ghc-8.2 \
+  | jq '{ url, rev, fetchSubmodules, sha256 }' \
+  > 8.2/git.json
+$ cat $(nix-build ../../../.. -A haskell.compiler.ghcjs82.genStage0 --no-out-link) > 8.2/stage0.nix
+```
+

--- a/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
@@ -1,0 +1,8 @@
+{ haskellLib, alex, happy }:
+
+let inherit (haskellLib) addBuildTools appendConfigureFlag dontHaddock doJailbreak;
+in self: super: {
+  ghc-api-ghcjs = addBuildTools super.ghc-api-ghcjs [alex happy];
+  ghcjs = appendConfigureFlag (doJailbreak super.ghcjs) "-fno-wrapper-install";
+  haddock-library-ghcjs = dontHaddock super.haddock-library-ghcjs;
+}

--- a/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
@@ -3,6 +3,6 @@
 let inherit (haskellLib) addBuildTools appendConfigureFlag dontHaddock doJailbreak;
 in self: super: {
   ghc-api-ghcjs = addBuildTools super.ghc-api-ghcjs [alex happy];
-  ghcjs = appendConfigureFlag (doJailbreak super.ghcjs) "-fno-wrapper-install";
+  ghcjs = dontHaddock (appendConfigureFlag (doJailbreak super.ghcjs) "-fno-wrapper-install");
   haddock-library-ghcjs = dontHaddock super.haddock-library-ghcjs;
 }

--- a/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
+++ b/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
@@ -1,0 +1,44 @@
+{ perl
+, autoconf
+, automake
+, python3
+, gcc
+, cabal-install
+, gmp
+, runCommand
+
+, ghc
+, happy
+, alex
+
+, ghcjsSrc
+}:
+
+runCommand "configured-ghcjs-src" {
+  buildInputs = [
+    perl
+    autoconf
+    automake
+    python3
+    ghc
+    happy
+    alex
+    cabal-install
+  ];
+  inherit ghcjsSrc;
+} ''
+  export HOME=$(pwd)
+  cp -r "$ghcjsSrc" "$out"
+  chmod -R +w "$out"
+  cd "$out"
+
+  # TODO: Find a better way to avoid impure version numbers
+  sed -i 's/RELEASE=NO/RELEASE=YES/' ghc/configure.ac
+
+  # TODO: How to actually fix this?
+  # Seems to work fine and produce the right files.
+  touch ghc/includes/ghcautoconf.h
+
+  patchShebangs .
+  ./utils/makePackages.sh copy
+''

--- a/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
+++ b/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
@@ -20,6 +20,7 @@ runCommand "configured-ghcjs-src" {
     autoconf
     automake
     python3
+    gcc
     ghc
     happy
     alex

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -1,0 +1,77 @@
+{ stdenv
+, callPackage
+, fetchgit
+, ghcjsSrcJson ? null
+, ghcjsSrc ? fetchgit (builtins.fromJSON (builtins.readFile ghcjsSrcJson))
+, bootPkgs
+, alex
+, happy
+, stage0
+, haskellLib
+, cabal-install
+, nodejs
+, makeWrapper
+, xorg
+, gmp
+, lib
+, ghcjsDepOverrides ? (_:_:{})
+}:
+
+let
+  passthru = {
+    configuredSrc = callPackage ./configured-ghcjs-src.nix {
+      inherit ghcjsSrc alex happy;
+      inherit (bootPkgs) ghc;
+    };
+    genStage0 = callPackage ./mk-stage0.nix { inherit (passthru) configuredSrc; };
+    bootPkgs = bootPkgs.extend (lib.foldr lib.composeExtensions (_:_:{}) [
+      (self: _: import stage0 {
+        inherit (passthru) configuredSrc;
+        inherit (self) callPackage;
+      })
+
+      (callPackage ./common-overrides.nix { inherit haskellLib alex happy; })
+      ghcjsDepOverrides
+    ]);
+
+    targetPrefix = "";
+    inherit (passthru.bootPkgs.ghcjs) version;
+    isGhcjs = true;
+
+    # Relics of the old GHCJS build system
+    stage1Packages = [];
+    mkStage2 = _: {};
+  };
+
+  libexec =
+    if builtins.compareVersions passthru.bootPkgs.ghcjs.version "8.3" <= 0
+      then "${passthru.bootPkgs.ghcjs}/bin"
+      else "${passthru.bootPkgs.ghcjs}/libexec/${stdenv.system}-${passthru.bootPkgs.ghc.name}/${passthru.bootPkgs.ghcjs.name}";
+
+in stdenv.mkDerivation {
+    name = "ghcjs";
+    src = passthru.configuredSrc;
+    nativeBuildInputs = [passthru.bootPkgs.ghcjs passthru.bootPkgs.ghc cabal-install nodejs makeWrapper xorg.lndir gmp];
+    phases = ["unpackPhase" "buildPhase"];
+    buildPhase = ''
+      export HOME=$TMP
+      cd lib/boot
+
+      mkdir -p $out/bin
+      mkdir -p $out/libexec
+      lndir ${libexec} $out/bin
+
+      wrapProgram $out/bin/ghcjs --add-flags "-B$out/libexec"
+      wrapProgram $out/bin/haddock-ghcjs --add-flags "-B$out/libexec"
+      wrapProgram $out/bin/ghcjs-pkg --add-flags "--global-package-db=$out/libexec/package.conf.d"
+
+      env PATH=$out/bin:$PATH $out/bin/ghcjs-boot -j $NIX_BUILD_CORES --with-ghcjs-bin $out/bin
+    '';
+
+    enableParallelBuilding = true;
+
+    inherit passthru;
+
+    meta.platforms = passthru.bootPkgs.ghc.meta.platforms;
+  }
+

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -73,7 +73,7 @@ in stdenv.mkDerivation {
       mkdir -p $out/libexec
       lndir ${libexec} $out/bin
 
-      wrapProgram $out/bin/ghcjs --add-flags "-B$out/libexec -dcore-lint"
+      wrapProgram $out/bin/ghcjs --add-flags "-B$out/libexec"
       wrapProgram $out/bin/haddock-ghcjs --add-flags "-B$out/libexec"
       wrapProgram $out/bin/ghcjs-pkg --add-flags "--global-package-db=$out/libexec/package.conf.d"
 

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -36,6 +36,7 @@ let
     ]);
 
     targetPrefix = "";
+    inherit bootGhcjs;
     inherit (bootGhcjs) version;
     isGhcjs = true;
 

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -77,10 +77,12 @@ in stdenv.mkDerivation {
       wrapProgram $out/bin/haddock-ghcjs --add-flags "-B$out/libexec"
       wrapProgram $out/bin/ghcjs-pkg --add-flags "--global-package-db=$out/libexec/package.conf.d"
 
-      env PATH=$out/bin:$PATH $out/bin/ghcjs-boot -j $NIX_BUILD_CORES --with-ghcjs-bin $out/bin
+      env PATH=$out/bin:$PATH $out/bin/ghcjs-boot -j1 --with-ghcjs-bin $out/bin
     '';
 
-    enableParallelBuilding = true;
+    # We hard code -j1 as a temporary workaround for
+    # https://github.com/ghcjs/ghcjs/issues/654
+    # enableParallelBuilding = true;
 
     inherit passthru;
 

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -13,6 +13,7 @@
 , makeWrapper
 , xorg
 , gmp
+, pkgconfig
 , lib
 , ghcjsDepOverrides ? (_:_:{})
 }:
@@ -60,6 +61,7 @@ in stdenv.mkDerivation {
       makeWrapper
       xorg.lndir
       gmp
+      pkgconfig
     ];
     phases = ["unpackPhase" "buildPhase"];
     buildPhase = ''

--- a/pkgs/development/compilers/ghcjs-ng/mk-stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/mk-stage0.nix
@@ -1,0 +1,25 @@
+{ configuredSrc
+, runCommand
+, cabal2nix
+, yq
+}:
+
+runCommand "stage0.nix" {
+  buildInputs = [cabal2nix yq];
+} ''
+  (
+    printf '{ callPackage, configuredSrc }:\n\n{\n\n'
+    yq '.packages | .[]' ${configuredSrc}/stack.yaml -r | sed 's|^\.$|./.|' | sed 's|^\.||' | while read f; do
+      printf '  %s = callPackage\n' \
+        "$(find ${configuredSrc}/$f -name "*.cabal" -maxdepth 1 \
+          | xargs basename \
+          | sed 's/.cabal$//')"
+      printf '(%s) {};' \
+        "$(cabal2nix ${configuredSrc}/$f \
+          | sed 's|${configuredSrc}/|configuredSrc + |g')" \
+        | sed 's/^/    /'
+      printf '\n\n'
+    done
+    printf '}\n'
+  ) > $out
+''

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -105,6 +105,9 @@ self: super: {
   ## hspec-discover ==2.4.8
   hspec-discover = super.hspec-discover_2_5_0;
 
+  # https://github.com/jcristovao/enclosed-exceptions/issues/12
+  enclosed-exceptions = dontCheck super.enclosed-exceptions;
+
   ## On Hackage:
 
   ## Upstreamed, awaiting a Hackage release
@@ -450,7 +453,7 @@ self: super: {
   matrix = self.matrix_0_3_6_1;
   pandoc = self.pandoc_2_2;
   pandoc-types = self.pandoc-types_1_17_4_2;
-  wl-pprint-text = self.wl-pprint-text_1_1_1_1;
+  wl-pprint-text = self.wl-pprint-text_1_2_0_0;
   base-compat = self.base-compat_0_10_1;
 
   # https://github.com/xmonad/xmonad/issues/155

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -10,7 +10,10 @@ let
     "ghc821Binary"
     "ghcCross"
     "ghcjs"
-    "ghcjsHEAD"
+    "ghcjs710"
+    "ghcjs80"
+    "ghcjs82"
+    "ghcjs84"
     "integer-simple"
   ];
 
@@ -76,13 +79,21 @@ in rec {
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
     };
-    ghcjs = packages.ghc7103.callPackage ../development/compilers/ghcjs {
+    ghcjs = compiler.ghcjs82;
+    ghcjs710 = packages.ghc7103.callPackage ../development/compilers/ghcjs {
       bootPkgs = packages.ghc7103;
       inherit (pkgs) cabal-install;
     };
-    ghcjsHEAD = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
+    ghcjs80 = packages.ghc802.callPackage ../development/compilers/ghcjs/head.nix {
       bootPkgs = packages.ghc802;
       inherit (pkgs) cabal-install;
+    };
+    ghcjs82 = callPackage ../development/compilers/ghcjs-ng rec {
+      bootPkgs = packages.ghc822;
+      inherit (bootPkgs) alex happy;
+      ghcjsSrcJson = ../development/compilers/ghcjs-ng/8.2/git.json;
+      stage0 = ../development/compilers/ghcjs-ng/8.2/stage0.nix;
+      ghcjsDepOverrides = callPackage ../development/compilers/ghcjs-ng/8.2/dep-overrides.nix {};
     };
 
     # The integer-simple attribute set contains all the GHC compilers
@@ -139,16 +150,23 @@ in rec {
       ghc = bh.compiler.ghcHEAD;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-head.nix { };
     };
-    ghcjs = callPackage ../development/haskell-modules rec {
+    ghcjs = packages.ghcjs82;
+    ghcjs710 = callPackage ../development/haskell-modules rec {
       buildHaskellPackages = ghc.bootPkgs;
       ghc = bh.compiler.ghcjs;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-7.10.x.nix { };
       packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
     };
-    ghcjsHEAD = callPackage ../development/haskell-modules rec {
+    ghcjs80 = callPackage ../development/haskell-modules rec {
       buildHaskellPackages = ghc.bootPkgs;
       ghc = bh.compiler.ghcjsHEAD;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.0.x.nix { };
+      packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
+    };
+    ghcjs82 = callPackage ../development/haskell-modules rec {
+      buildHaskellPackages = ghc.bootPkgs;
+      ghc = bh.compiler.ghcjs82;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
       packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
     };
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -95,6 +95,13 @@ in rec {
       stage0 = ../development/compilers/ghcjs-ng/8.2/stage0.nix;
       ghcjsDepOverrides = callPackage ../development/compilers/ghcjs-ng/8.2/dep-overrides.nix {};
     };
+    ghcjs84 = callPackage ../development/compilers/ghcjs-ng rec {
+      bootPkgs = packages.ghc842;
+      inherit (bootPkgs) alex happy;
+      ghcjsSrcJson = ../development/compilers/ghcjs-ng/8.4/git.json;
+      stage0 = ../development/compilers/ghcjs-ng/8.4/stage0.nix;
+      ghcjsDepOverrides = callPackage ../development/compilers/ghcjs-ng/8.4/dep-overrides.nix {};
+    };
 
     # The integer-simple attribute set contains all the GHC compilers
     # build with integer-simple instead of integer-gmp.
@@ -167,6 +174,12 @@ in rec {
       buildHaskellPackages = ghc.bootPkgs;
       ghc = bh.compiler.ghcjs82;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
+      packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
+    };
+    ghcjs84 = callPackage ../development/haskell-modules rec {
+      buildHaskellPackages = ghc.bootPkgs;
+      ghc = bh.compiler.ghcjs84;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.4.x.nix { };
       packageSetConfig = callPackage ../development/haskell-modules/configuration-ghcjs.nix { };
     };
 

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -93,7 +93,6 @@ in rec {
       inherit (bootPkgs) alex happy;
       ghcjsSrcJson = ../development/compilers/ghcjs-ng/8.2/git.json;
       stage0 = ../development/compilers/ghcjs-ng/8.2/stage0.nix;
-      ghcjsDepOverrides = callPackage ../development/compilers/ghcjs-ng/8.2/dep-overrides.nix {};
     };
     ghcjs84 = callPackage ../development/compilers/ghcjs-ng rec {
       bootPkgs = packages.ghc842;


### PR DESCRIPTION
###### Motivation for this change

Adds GHCJS 8.2 and GHCJS 8.4.

These builds are currently blocked on ghcjs/ghcjs#654. It's important that these builds be checked more than once until that bug is fixed, as it is an intermittent failure.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

