### PR TITLE
Fix some GHC dependencies on iOS

### DIFF
--- a/pkgs/development/node-packages/default-v6.nix
+++ b/pkgs/development/node-packages/default-v6.nix
@@ -59,6 +59,7 @@ nodePackages // {
 
   ios-deploy = nodePackages.ios-deploy.override (oldAttrs: {
     preRebuild = ''
+      LD=$CC
       tmp=$(mktemp -d)
       ln -s /usr/bin/xcodebuild $tmp
       export PATH="$PATH:$tmp"

--- a/pkgs/development/node-packages/default-v8.nix
+++ b/pkgs/development/node-packages/default-v8.nix
@@ -59,6 +59,7 @@ nodePackages // {
 
   ios-deploy = nodePackages.ios-deploy.override (oldAttrs: {
     preRebuild = ''
+      LD=$CC
       tmp=$(mktemp -d)
       ln -s /usr/bin/xcodebuild $tmp
       export PATH="$PATH:$tmp"

--- a/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libiconv/default.nix
@@ -1,14 +1,18 @@
 { stdenv, appleDerivation }:
 
 appleDerivation {
-  preConfigure = "cd libiconv";
+  preConfigure = "cd libiconv"
+    + stdenv.lib.optionalString stdenv.hostPlatform.isiOS ''
+
+      sed -i 's/darwin\*/ios\*/g' configure libcharset/configure
+    '';
 
   postInstall = ''
     mv $out/lib/libiconv.dylib $out/lib/libiconv-nocharset.dylib
-    install_name_tool -id $out/lib/libiconv-nocharset.dylib $out/lib/libiconv-nocharset.dylib
+    ${stdenv.cc.bintools.targetPrefix}install_name_tool -id $out/lib/libiconv-nocharset.dylib $out/lib/libiconv-nocharset.dylib
 
     # re-export one useless symbol; ld will reject a dylib that only reexports other dylibs
-    echo 'void dont_use_this(){}' | clang -dynamiclib -x c - -current_version 2.4.0 \
+    echo 'void dont_use_this(){}' | ${stdenv.cc.bintools.targetPrefix}clang -dynamiclib -x c - -current_version 2.4.0 \
       -compatibility_version 7.0.0 -current_version 7.0.0 -o $out/lib/libiconv.dylib \
       -Wl,-reexport_library -Wl,$out/lib/libiconv-nocharset.dylib \
       -Wl,-reexport_library -Wl,$out/lib/libcharset.dylib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10790,7 +10790,7 @@ with pkgs;
   ncurses6 = callPackage ../development/libraries/ncurses {
     abiVersion = "6";
   };
-  ncurses = ncurses6;
+  ncurses = if hostPlatform.useiOSPrebuilt then null else ncurses6;
 
   neardal = callPackage ../development/libraries/neardal { };
 


### PR DESCRIPTION
###### Motivation for this change

This fixes a few iOS related packages, particularly with the goal of fixing GHC dependencies. GHC itself does not quite build yet, but its dependencies do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @ryantrinkle @Ericson2314 