### PR TITLE
qiskit: init at 0.4.15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2928,6 +2928,11 @@
     github = "panaeon";
     name = "Vitalii Voloshyn";
   };
+  pandaman = {
+    email = "kointosudesuyo@infoseek.jp";
+    github = "pandaman64";
+    name = "pandaman";
+  };
   paperdigits = {
     email = "mica@silentumbrella.com";
     github = "paperdigits";

--- a/pkgs/development/python-modules/ibmquantumexperience/default.nix
+++ b/pkgs/development/python-modules/ibmquantumexperience/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+, requests_ntlm
+}:
+
+buildPythonPackage rec {
+  pname = "IBMQuantumExperience";
+  version = "1.9.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "480cce2ca285368432b7d00b9cd702a4f8a1c9d69914ba6f65e08099e151e407";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    requests_ntlm
+  ];
+
+  # test requires an API token
+  doCheck = false;
+
+  meta = {
+    description = "A Python library for the Quantum Experience API";
+    homepage    = https://github.com/QISKit/qiskit-api-py;
+    license     = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      pandaman
+    ];
+  };
+}

--- a/pkgs/development/python-modules/qasm2image/default.nix
+++ b/pkgs/development/python-modules/qasm2image/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cairocffi
+, cairosvg
+, cffi
+, qiskit
+, svgwrite
+, colorama
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "qasm2image";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "nelimeee";
+    repo = "qasm2image";
+    rev = "7f3c3e4d1701b8b284ef0352aa3a47722ebbbcaa";
+    sha256 = "129xlpwp36h2czzw1wcl8df2864zg3if2gaad1v18ah1cf68b0f3";
+  };
+
+  propagatedBuildInputs = [
+    cairocffi
+    cairosvg
+    cffi
+    qiskit
+    svgwrite
+  ];
+
+  checkInputs = [
+    colorama
+  ];
+  checkPhase = ''
+    ${python.interpreter} tests/launch_tests.py
+  '';
+
+  meta = {
+    description = "A Python module to visualise quantum circuit";
+    homepage    = https://github.com/nelimeee/qasm2image;
+    license     = lib.licenses.cecill-b;
+    maintainers = with lib.maintainers; [
+      pandaman
+    ];
+  };
+}

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, isPy3k
+, buildPythonPackage
+, fetchPypi
+, fetchurl
+, python
+, numpy
+, scipy
+, sympy
+, matplotlib
+, networkx
+, ply
+, pillow
+, cffi
+, requests
+, requests_ntlm
+, IBMQuantumExperience
+, cmake
+, llvmPackages 
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit";
+  version = "0.4.15";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bd126a35189f8303df41cb7b7f26b0d06e1fabf61f4fd567b8ec356d31170141";
+  };
+
+  buildInputs = [ cmake ]
+    ++ stdenv.lib.optional stdenv.isDarwin llvmPackages.openmp;
+
+  propagatedBuildInputs = [
+    numpy
+    matplotlib
+    networkx
+    ply
+    scipy
+    sympy
+    pillow
+    cffi
+    requests
+    requests_ntlm
+    IBMQuantumExperience
+  ];
+
+  # Pypi's tarball doesn't contain tests
+  doCheck = false;
+
+  patches = [
+    ./setup.py.patch
+  ];
+
+  meta = {
+    description = "Quantum Software Development Kit for writing quantum computing experiments, programs, and applications";
+    homepage    = https://github.com/QISKit/qiskit-sdk-py;
+    license     = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [
+      pandaman
+    ];
+  };
+}

--- a/pkgs/development/python-modules/qiskit/setup.py.patch
+++ b/pkgs/development/python-modules/qiskit/setup.py.patch
@@ -1,0 +1,19 @@
+--- a/setup.py
++++ b/setup.py
+@@ -28,11 +28,11 @@ from setuptools.dist import Distribution
+ 
+ requirements = [
+     "IBMQuantumExperience>=1.8.29",
+-    "matplotlib>=2.1,<2.2",
+-    "networkx>=2.0,<2.1",
+-    "numpy>=1.13,<1.15",
+-    "ply==3.10",
+-    "scipy>=0.19,<1.1",
++    "matplotlib>=2.1",
++    "networkx>=2.0",
++    "numpy>=1.13",
++    "ply>=3.10",
++    "scipy>=0.19",
+     "sympy>=1.0",
+     "pillow>=4.2.1"
+ ]

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18203,6 +18203,8 @@ EOF
   gast = callPackage ../development/python-modules/gast { };
 
   IBMQuantumExperience = callPackage ../development/python-modules/ibmquantumexperience { };
+
+  qiskit = callPackage ../development/python-modules/qiskit { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18205,6 +18205,8 @@ EOF
   IBMQuantumExperience = callPackage ../development/python-modules/ibmquantumexperience { };
 
   qiskit = callPackage ../development/python-modules/qiskit { };
+
+  qasm2image = callPackage ../development/python-modules/qasm2image { };
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18202,6 +18202,7 @@ EOF
 
   gast = callPackage ../development/python-modules/gast { };
 
+  IBMQuantumExperience = callPackage ../development/python-modules/ibmquantumexperience { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
IBMQuantumExperience: init at 1.9.1
qiskit: init at 0.4.15
qasm2image: init at 0.5.0

This pull request introduces several python libraries for creating quantum programs.
IBMQuantumExperience is an API for IBM Q, IBM's quantum processors.
QISKit is an SDK for developing quantum programs with Python.
qasm2image visualizes quantum programs.

QISKit depends on IBMQuantumExperience and qasm2image on QISKit. So I put them in a single pull request.

Some QISKit's dependencies have a different version from the upstream, so I copied their `default.nix` into QISKit's directory and changed to the appropriate versions.
I'm not sure this is a good workaround.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

