### PR TITLE
DataDog Agent v6

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -407,6 +407,7 @@
   ./services/monitoring/cadvisor.nix
   ./services/monitoring/collectd.nix
   ./services/monitoring/das_watchdog.nix
+  ./services/monitoring/datadog-agent.nix
   ./services/monitoring/dd-agent/dd-agent.nix
   ./services/monitoring/fusion-inventory.nix
   ./services/monitoring/grafana.nix

--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -1,0 +1,201 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.datadog-agent;
+
+  ddConf = {
+    dd_url              = "https://app.datadoghq.com";
+    skip_ssl_validation = "no";
+    api_key             = "";
+    confd_path          = "/etc/datadog-agent/conf.d";
+    additional_checksd  = "/etc/datadog-agent/checks.d";
+    use_dogstatsd       = "yes";
+  }
+  // optionalAttrs (cfg.logLevel != null) { log_level = cfg.logLevel; }
+  // optionalAttrs (cfg.hostname != null) { inherit (cfg) hostname; }
+  // optionalAttrs (cfg.tags != null ) { tags = concatStringsSep ", " cfg.tags; }
+  // cfg.extraConfig;
+
+  makeConfigDir = entries: mapAttrsToList (name: conf: {
+    source = pkgs.writeText (baseNameOf name) (builtins.toJSON conf);
+    target = "datadog-agent/" + name;
+  }) (filterAttrs (name: conf: conf != null) entries);
+
+  etcfiles = makeConfigDir
+    { "datadog.yaml" = ddConf;
+      "conf.d/disk.yaml" = cfg.diskConfig;
+      "conf.d/network.yaml" = cfg.networkConfig;
+      "conf.d/postgres.d/conf.yaml" = cfg.postgresqlConfig;
+      "conf.d/nginx.d/conf.yaml" = cfg.nginxConfig;
+      "conf.d/mongo.d/conf.yaml" = cfg.mongoConfig;
+      "conf.d/process.yaml" = cfg.processConfig;
+      "conf.d/jmx.yaml" = cfg.jmxConfig;
+    };
+
+in {
+  options.services.datadog-agent = {
+    enable = mkOption {
+      description = ''
+        Whether to enable the datadog-agent v6 monitoring service
+      '';
+      default = false;
+      type = types.bool;
+    };
+
+    package = mkOption {
+      default = pkgs.datadog-agent;
+      defaultText = "pkgs.datadog-agent";
+      description = ''
+        Which DataDog v6 agent package to use.
+        Override the <literal>pythonPackages</literal> argument
+        of this derivation to include more checks.
+      '';
+      type = types.package;
+    };
+
+    apiKeyFile = mkOption {
+      description = ''
+        Path to a file containing the Datadog API key to associate the
+        agent with your account.
+      '';
+      example = "/run/keys/datadog_api_key";
+      type = types.path;
+    };
+
+    tags = mkOption {
+      description = "The tags to mark this Datadog agent";
+      example = [ "test" "service" ];
+      default = null;
+      type = types.nullOr (types.listOf types.str);
+    };
+
+    hostname = mkOption {
+      description = "The hostname to show in the Datadog dashboard (optional)";
+      default = null;
+      example = "mymachine.mydomain";
+      type = types.uniq (types.nullOr types.string);
+    };
+
+    logLevel = mkOption {
+      description = "Logging verbosity.";
+      default = null;
+      type = types.nullOr (types.enum ["DEBUG" "INFO" "WARN" "ERROR"]);
+    };
+
+    extraConfig = mkOption {
+      default = {};
+      type = types.attrs;
+      description = ''
+        Extra configuration options that will be merged into the
+        main config file <filename>datadog.yaml</filename>.
+      '';
+     };
+
+    diskConfig = mkOption {
+      description = "Disk check config";
+      type = types.attrs;
+      default = {
+        init_config = {};
+        instances = [ { use-mount = "no"; } ];
+      };
+     };
+
+    networkConfig = mkOption {
+      description = "Network check config";
+      type = types.attrs;
+      default = {
+        init_config = {};
+        # Network check only supports one configured instance
+        instances = [ { collect_connection_state = false;
+                        excluded_interfaces = [ "lo" "lo0" ]; } ];
+      };
+    };
+
+    postgresqlConfig = mkOption {
+      description = "Datadog PostgreSQL integration configuration";
+      default = null;
+      type = types.nullOr types.attrs;
+    };
+
+    nginxConfig = mkOption {
+      description = "Datadog nginx integration configuration";
+      default = null;
+      type = types.nullOr types.attrs;
+    };
+
+    mongoConfig = mkOption {
+      description = "MongoDB integration configuration";
+      default = null;
+      type = types.nullOr types.attrs;
+    };
+
+    jmxConfig = mkOption {
+      description = "JMX integration configuration";
+      default = null;
+      type = types.nullOr types.attrs;
+    };
+
+    processConfig = mkOption {
+      description = ''
+        Process integration configuration
+
+        See http://docs.datadoghq.com/integrations/process/
+      '';
+      default = null;
+      type = types.nullOr types.attrs;
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package pkgs.sysstat pkgs.procps ];
+
+    users.extraUsers.datadog = {
+      description = "Datadog Agent User";
+      uid = config.ids.uids.datadog;
+      group = "datadog";
+      home = "/var/log/datadog/";
+      createHome = true;
+    };
+
+    users.extraGroups.datadog.gid = config.ids.gids.datadog;
+
+    systemd.services = let
+      makeService = attrs: recursiveUpdate {
+        path = [ cfg.package pkgs.python pkgs.sysstat pkgs.procps ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User = "datadog";
+          Group = "datadog";
+          Restart = "always";
+          RestartSec = 2;
+          PrivateTmp = true;
+        };
+        restartTriggers = [ cfg.package ] ++ map (etc: etc.source) etcfiles;
+      } attrs;
+    in {
+      datadog-agent = makeService {
+        description = "Datadog agent monitor";
+        preStart = ''
+          chown -R datadog: /etc/datadog-agent
+          rm -f /etc/datadog-agent/auth_token
+        '';
+        script = ''
+          export DD_API_KEY=$(head -n1 ${cfg.apiKeyFile})
+          exec ${cfg.package}/bin/agent start -c /etc/datadog-agent/datadog.yaml
+        '';
+        serviceConfig.PermissionsStartOnly = true;
+      };
+
+      dd-jmxfetch = lib.mkIf (cfg.jmxConfig != null) (makeService {
+        description = "Datadog JMX Fetcher";
+        path = [ cfg.package pkgs.python pkgs.sysstat pkgs.procps pkgs.jdk ];
+        serviceConfig.ExecStart = "${cfg.package}/bin/dd-jmxfetch";
+      });
+    };
+
+    environment.etc = etcfiles;
+  };
+}

--- a/pkgs/development/python-modules/uuid/default.nix
+++ b/pkgs/development/python-modules/uuid/default.nix
@@ -1,0 +1,16 @@
+{ lib, stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "uuid";
+  version = "1.30";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gqrjsm85nnkxkmd1vk8350wqj2cigjflnvcydk084n5980cr1qz";
+  };
+
+  meta = with lib; {
+    description = "UUID object and generation functions (Python 2.3 or higher)";
+    homepage = http://zesty.ca/python/;
+  };
+}

--- a/pkgs/tools/networking/dd-agent/5.nix
+++ b/pkgs/tools/networking/dd-agent/5.nix
@@ -89,7 +89,10 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Event collector for the DataDog analysis service";
+    description = ''
+      Event collector for the DataDog analysis service
+      -- v5 Python implementation
+    '';
     homepage    = https://www.datadoghq.com;
     license     = stdenv.lib.licenses.bsd3;
     platforms   = stdenv.lib.platforms.all;

--- a/pkgs/tools/networking/dd-agent/6.nix
+++ b/pkgs/tools/networking/dd-agent/6.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchFromGitHub, buildGoPackage, makeWrapper, pythonPackages, pkgconfig }:
 
 let
-  inherit (pythonPackages) python;
-
   # keep this in sync with github.com/DataDog/agent-payload dependency
   payloadVersion = "4.7";
 
@@ -26,6 +24,9 @@ in buildGoPackage rec {
   ];
   goDeps = ./deps.nix;
   goPackagePath = "github.com/${owner}/${repo}";
+
+  # Explicitly set this here to allow it to be overridden.
+  python = pythonPackages.python;
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
   PKG_CONFIG_PATH = "${python}/lib/pkgconfig";

--- a/pkgs/tools/networking/dd-agent/6.nix
+++ b/pkgs/tools/networking/dd-agent/6.nix
@@ -1,0 +1,76 @@
+{ stdenv, fetchFromGitHub, buildGoPackage, makeWrapper, pythonPackages, pkgconfig }:
+
+let
+  inherit (pythonPackages) python;
+
+  # keep this in sync with github.com/DataDog/agent-payload dependency
+  payloadVersion = "4.7";
+
+in buildGoPackage rec {
+  name = "datadog-agent-${version}";
+  version = "6.1.4";
+  owner   = "DataDog";
+  repo    = "datadog-agent";
+
+  src = fetchFromGitHub {
+    inherit owner repo;
+    rev    = "a8ee76deb11fa334470d9b8f2356214999980894";
+    sha256 = "06grcwwbfvcw1k1d4nqrasrf76qkpik1gsw60zwafllfd9ffhl1v";
+  };
+
+  subPackages = [
+    "cmd/agent"
+    "cmd/dogstatsd"
+    "cmd/py-launcher"
+    "cmd/cluster-agent"
+  ];
+  goDeps = ./deps.nix;
+  goPackagePath = "github.com/${owner}/${repo}";
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  PKG_CONFIG_PATH = "${python}/lib/pkgconfig";
+
+  buildFlagsArray = let
+    ldFlags = stdenv.lib.concatStringsSep " " [
+      "-X ${goPackagePath}/pkg/version.Commit=${src.rev}"
+      "-X ${goPackagePath}/pkg/version.AgentVersion=${version}"
+      "-X ${goPackagePath}/pkg/serializer.AgentPayloadVersion=${payloadVersion}"
+      "-X ${goPackagePath}/pkg/collector/py.pythonHome=${python}"
+      "-r ${python}/lib"
+    ];
+  in [
+    "-ldflags=${ldFlags}"
+  ];
+  buildFlags = "-tags cpython";
+
+  # DataDog use paths relative to the agent binary, so fix these.
+  postPatch = ''
+    sed -e "s|PyChecksPath =.*|PyChecksPath = \"$bin/${python.sitePackages}\"|" \
+        -e "s|distPath =.*|distPath = \"$bin/share/datadog-agent\"|" \
+        -i cmd/agent/common/common_nix.go
+  '';
+
+  # Install the config files and python modules from the "dist" dir
+  # into standard paths.
+  postInstall = ''
+    mkdir -p $bin/${python.sitePackages} $bin/share/datadog-agent
+    cp -R $src/cmd/agent/dist/{conf.d,trace-agent.conf} $bin/share/datadog-agent
+    cp -R $src/cmd/agent/dist/{checks,utils,config.py} $bin/${python.sitePackages}
+
+    cp -R $src/pkg/status/dist/templates $bin/share/datadog-agent
+
+    wrapProgram "$bin/bin/agent" \
+        --set PYTHONPATH "$bin/${python.sitePackages}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      Event collector for the DataDog analysis service
+      -- v6 new golang implementation.
+    '';
+    homepage    = https://www.datadoghq.com;
+    license     = licenses.bsd3;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ thoughtpolice domenkozar rvl ];
+  };
+}

--- a/pkgs/tools/networking/dd-agent/deps.nix
+++ b/pkgs/tools/networking/dd-agent/deps.nix
@@ -1,0 +1,353 @@
+[
+  {
+    goPackagePath = "github.com/DataDog/agent-payload";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/agent-payload";
+      rev = "3b793015ecfa5b829e8a466bd7cce836891502cc";
+      sha256 = "0lg7c1whmvk4a13mrivdjfzfxqan07kvs2calgylncy7yf4szdp6";
+    };
+  }
+  {
+    goPackagePath = "github.com/DataDog/gohai";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/gohai";
+      rev = "d80d0f562a71fa2380fbeccc93ba5a2e325606e4";
+      sha256 = "1frslms7f5i8dc8n0v9pb64mf4zdj3q2c005qxajl8j8i9nhj7yb";
+    };
+  }
+  {
+    goPackagePath = "github.com/DataDog/mmh3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/mmh3";
+      rev = "2cfb68475274527a10701355c739f31dd404718c";
+      sha256 = "09jgzxi08pkxllxk3f5qwipz96jxrw5v035fj2bkid1d4akn8y0b";
+    };
+  }
+  {
+    goPackagePath = "github.com/beevik/ntp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beevik/ntp";
+      rev = "cb3dae3a7588ae35829eb5724df611cd75152fba";
+      sha256 = "0nc6f7d0xw23y18z9qxrmm8kvnywihassyk706mn9v4makmhalnz";
+    };
+  }
+  {
+    goPackagePath = "github.com/cihub/seelog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cihub/seelog";
+      rev = "f561c5e57575bb1e0a2167028b7339b3a8d16fb4";
+      sha256 = "0r3228hvgljgpaggj6b9mvxfsizfw25q2c1761wsvcif8gz49cvl";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/docker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/docker";
+      rev = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363";
+      sha256 = "0l9kjibnpwcgk844sibxk9ppyqniw9r0np1mzp95f8f461jb0iar";
+    };
+  }
+  {
+    goPackagePath = "github.com/dsnet/compress";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dsnet/compress";
+      rev = "cc9eb1d7ad760af14e8f918698f745e80377af4f";
+      sha256 = "159liclywmyb6zx88ga5gn42hfl4cpk1660zss87fkx31hdq9fgx";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "507f6050b8568533fb3f5504de8e5205fa62a114";
+      sha256 = "0k1v9dkhrxiqhg48yqkwzpd7x40xx38gv2pgknswbsy4r8w644i7";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "bda519ae5f4cbc60d391ff8610711627a08b86ae";
+      sha256 = "05vcc3ssxyrk8g3sr4gs888vllgjqfq11na63qz2pvaiy7m0rqrs";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "1ef32a8b9fc3f8ec940126907cedb5998f6318e4";
+      sha256 = "0zk2n0n35ksskr5cd83k5k8wg21ckrcggjy88bym2s21ngj5w4fh";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "553a641470496b2327abcac10b36396bd98e45c9";
+      sha256 = "0kssxnih1l722hx9219c7javganjqkqhvl3i0hp0hif6xm6chvqk";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev = "ded0c29b24f96f46cf349e6701b099db601cf8ec";
+      sha256 = "125dxfxs7his95fd2r28bn1rpb78pldfgm3lmw84ha1c0v5gfh33";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168";
+      sha256 = "1qalfsc31fra7hcw2lc3s20aj7al62fq3j5fn5kga3mg99b82nyr";
+    };
+  }
+  {
+    goPackagePath = "github.com/kardianos/osext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kardianos/osext";
+      rev = "ae77be60afb1dcacde03767a8c37337fad28ac14";
+      sha256 = "056dkgxrqjj5r18bnc3knlpgdz5p3yvp12y4y978hnsfhwaqvbjz";
+    };
+  }
+  {
+    goPackagePath = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev = "2c9e9502788518c97fe44e8955cd069417ee89df";
+      sha256 = "1w0rl9rla61m0qbha75jg48yiq1vs91sfy96rgqa6nags9v9b1rl";
+    };
+  }
+  {
+    goPackagePath = "github.com/mholt/archiver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mholt/archiver";
+      rev = "e4ef56d48eb029648b0e895bb0b6a393ef0829c3";
+      sha256 = "1krxyh6iq0s0rwhz7gg6dn795j9qq64rsgq9nivav7fhrqpgr6hb";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "00c29f56e2386353d58c599509e8dc3801b0d716";
+      sha256 = "1vw8fvhax0d567amgvxr7glcl12lvzg2sbzs007q5k5bbwn1szyb";
+    };
+  }
+  {
+    goPackagePath = "github.com/nwaples/rardecode";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nwaples/rardecode";
+      rev = "e06696f847aeda6f39a8f0b7cdff193b7690aef6";
+      sha256 = "1aj7l8ii7hxnn3q4wzxlx3f92b1aspck6ncyqgb4h2g228phcibw";
+    };
+  }
+  {
+    goPackagePath = "github.com/patrickmn/go-cache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/patrickmn/go-cache";
+      rev = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0";
+      sha256 = "10020inkzrm931r4bixf8wqr9n39wcrb78vfyxmbvjavvw4zybgs";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev = "66540cf1fcd2c3aee6f6787dfa32a6ae9a870f12";
+      sha256 = "1n8na0yg90gm0rpifmzrby5r385vvd62cdam3ls7ssy02bjvfw15";
+    };
+  }
+  {
+    goPackagePath = "github.com/pierrec/lz4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/lz4";
+      rev = "ed8d4cc3b461464e69798080a0092bd028910298";
+      sha256 = "0flsn2ka108lb63gkxfzl90bkhndh1znnscv4v1k6j5h2s3zksls";
+    };
+  }
+  {
+    goPackagePath = "github.com/pierrec/xxHash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pierrec/xxHash";
+      rev = "a0006b13c722f7f12368c00a3d3c2ae8a999a0c6";
+      sha256 = "1hf7hqrqx0cbgx0alfwnqs0mrxg9rnwsijn5d0lv06w6vzqbvnzj";
+    };
+  }
+  {
+    goPackagePath = "github.com/shirou/gopsutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shirou/gopsutil";
+      rev = "57f370e13068146efe1cb7129f79e5d51da8a242";
+      sha256 = "1ij0bbnfjj65afin8vhccr3cxvg6r0awmvcvb2ilza5wbbsslggb";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev = "63644898a8da0bc22138abf860edaf5277b6102e";
+      sha256 = "13piahaq4vw1y1sklq5scrsflqx0a8hzmdqfz1fy4871kf2gl8qw";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev = "8965335b8c7107321228e3e3702cab9832751bac";
+      sha256 = "177bk7lq40jbgv9p9r80aydpaccfk8ja3a7jjhfwiwk9r1pa4rr2";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "ef82de70bb3f60c65fb8eebacbb2d122ef517385";
+      sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394";
+      sha256 = "132p84i20b9s5r6fs597lsa6648vd415ch7c0d018vm8smzqpd0h";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "583c0c0531f06d5278b7d917446061adc344b5cd";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev = "8dc2790b029dc41e2b8ff772c63c26adbb1db70d";
+      sha256 = "147zq6v34pgb79r4m0m2mwm8739jxwawxs8mpqvvhq7gxwvhng40";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "c679ae2cc0cb27ec3293fea7e254e47386f05d69";
+      sha256 = "1rrdn7k83j492rzhqwkh6956sj8m2nbk44d7r1xa9nsn3hfwj691";
+    };
+  }
+  {
+    goPackagePath = "github.com/ulikunitz/xz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ulikunitz/xz";
+      rev = "0c6b41e72360850ca4f98dc341fd999726ea007f";
+      sha256 = "0a6l7sp67ipxim093qh6fvw8knbxj24l7bj5lykcddi5gwfi78n3";
+    };
+  }
+  {
+    goPackagePath = "github.com/urfave/negroni";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/negroni";
+      rev = "22c5532ea862c34fdad414e90f8cc00b4f6f4cab";
+      sha256 = "0jxd10cr3imm96xa01mdgyad4nq6mc7yr49z830fv3vywfr7bac8";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "640f4622ab692b87c2f3a94265e6f579fe38263d";
+      sha256 = "097m4qhcljhp180171j5fjhq4740iirfkkajfd7yrxqhp4s9hljx";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "6f686a352de66814cdd080d970febae7767857a3";
+      sha256 = "1z3pwvxlzq8kghjdsd9xmf184iiz13h8h66ipp626k4rc7kydr03";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "7922cc490dd5a7dbaa7fd5d6196b49db59ac042f";
+      sha256 = "06sicjc24hv7v9p1l6psaq87w4lycx3mjixd6gsd1wnd4jhqvlnr";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath = "github.com/sbinet/go-python";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sbinet/go-python";
+      rev = "6d13f941744b9332d6ed00dc2cd2722acd79a47e";
+      sha256 = "0x5q4nyv6gck9q33g54gy2ajmyjksxjmzh0jfqqn97jpgf4qfaym";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/reflectwalk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/reflectwalk";
+      rev = "63d60e9d0dbc60cf9164e6510889b0db6683d98c";
+      sha256 = "1hpq6sjr6l1h25x68mz13q7sd52dv1mjfxbl5p7m3j7cv85khnvc";
+    };
+  }
+]

--- a/pkgs/tools/networking/dd-agent/integrations-core.nix
+++ b/pkgs/tools/networking/dd-agent/integrations-core.nix
@@ -1,0 +1,66 @@
+{ pkgs
+, python
+, overrides ? (self: super: {})
+}:
+
+with pkgs.lib;
+
+let
+  src = pkgs.fetchFromGitHub {
+    owner = "DataDog";
+    repo = "integrations-core";
+    rev = "7be76e73969a8b9c993903681b300e1dd32f4b4d";
+    sha256 = "1qsqzm5iswgv9jrflh5mvbz9a7js7jf42cb28lzdzsp45iwfs2aa";
+  };
+  version = "git-2018-05-27";
+
+  buildIntegration = { pname, ... }@args: python.pkgs.buildPythonPackage (args // {
+    inherit src version;
+    name = "datadog-integration-${pname}-${version}";
+
+    postPatch = ''
+      # jailbreak install_requires
+      sed -i 's/==.*//' requirements.in
+      cp requirements.in requirements.txt
+    '';
+    sourceRoot = "source/${args.sourceRoot or pname}";
+    doCheck = false;
+  });
+
+  packages = (self: {
+    python = python.withPackages (ps: with self; [ disk network postgres nginx mongo ]);
+
+    datadog_checks_base = buildIntegration {
+      pname = "checks-base";
+      sourceRoot = "datadog_checks_base";
+      propagatedBuildInputs = with self; with python.pkgs; [ requests protobuf prometheus_client uuid simplejson uptime ];
+    };
+
+    disk = buildIntegration {
+      pname = "disk";
+      propagatedBuildInputs = with self; with python.pkgs; [ datadog_checks_base psutil ];
+    };
+
+    network = buildIntegration {
+      pname = "network";
+      propagatedBuildInputs = with self; with python.pkgs; [ datadog_checks_base psutil ];
+    };
+
+    postgres = buildIntegration {
+      pname = "postgres";
+      propagatedBuildInputs = with self; with python.pkgs; [ datadog_checks_base pg8000 psycopg2 ];
+    };
+
+    nginx = buildIntegration {
+      pname = "nginx";
+      propagatedBuildInputs = with self; with python.pkgs; [ datadog_checks_base ];
+    };
+
+    mongo = buildIntegration {
+      pname = "mongo";
+      propagatedBuildInputs = with self; with python.pkgs; [ datadog_checks_base pymongo ];
+    };
+
+  });
+
+in fix' (extends overrides packages)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15672,7 +15672,8 @@ with pkgs;
 
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
 
-  dd-agent = callPackage ../tools/networking/dd-agent { };
+  dd-agent = callPackage ../tools/networking/dd-agent/5.nix { };
+  datadog-agent = callPackage ../tools/networking/dd-agent/6.nix { };
 
   ddgr = callPackage ../applications/misc/ddgr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15673,7 +15673,12 @@ with pkgs;
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
 
   dd-agent = callPackage ../tools/networking/dd-agent/5.nix { };
-  datadog-agent = callPackage ../tools/networking/dd-agent/6.nix { };
+  datadog-agent = callPackage ../tools/networking/dd-agent/6.nix {
+    pythonPackages = datadog-integrations-core;
+  };
+  datadog-integrations-core = callPackage ../tools/networking/dd-agent/integrations-core.nix {
+    python = python27;
+  };
 
   ddgr = callPackage ../applications/misc/ddgr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15674,10 +15674,11 @@ with pkgs;
 
   dd-agent = callPackage ../tools/networking/dd-agent/5.nix { };
   datadog-agent = callPackage ../tools/networking/dd-agent/6.nix {
-    pythonPackages = datadog-integrations-core;
+    pythonPackages = datadog-integrations-core {};
   };
-  datadog-integrations-core = callPackage ../tools/networking/dd-agent/integrations-core.nix {
+  datadog-integrations-core = extras: callPackage ../tools/networking/dd-agent/integrations-core.nix {
     python = python27;
+    extraIntegrations = extras;
   };
 
   ddgr = callPackage ../applications/misc/ddgr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17309,6 +17309,8 @@ EOF
 
   uranium = callPackage ../development/python-modules/uranium { };
 
+  uuid = callPackage ../development/python-modules/uuid { };
+
   versioneer = callPackage ../development/python-modules/versioneer { };
 
   vine = callPackage ../development/python-modules/vine { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to store the `api_key` setting in a file, saw that datadog-agent v6 supports using an environment variable, then foolishly attempted packaging datadog-agent v6.

They decided to rewrite most parts of the agent in Go. The new version is here: https://github.com/DataDog/datadog-agent

The NixOS module supports both versions using the `service.dd-agent.package` option.

###### Things done

It's hard to automatically test this because it depends on a proprietary service.
I have tested a basic setup using a nixops VM and a DataDog trial account and this works.
If someone could help test more elaborate configs, that would help.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @thoughtpolice @domenkozar @mbbx6spp @Fuuzetsu @bflyblue @coretemp
