### PR TITLE
[RDY] neovim: fix gperf error on dev-version

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -75,6 +75,7 @@ let
 
     cmakeFlags = [
       "-DLUA_PRG=${luaPackages.lua}/bin/lua"
+      "-DGPERF_PRG=${gperf}/bin/gperf"
     ];
 
     # triggers on buffer overflow bug while running tests


### PR DESCRIPTION
while trying to fix some bugs in neovim, I found out this problem which didn't happen before

```
[ 50%] Generating auto/api/private/dispatch_wrappers.c.generated.h, ../../include/api/private/dispatch_wrappers.h.generated.h
[ 50%] Generating auto/funcs.generated.h, ../../funcs_data.mpack
/nix/store/xn5gv3lpfy91yvfy9b0i7klfcxh9xskz-bash-4.4-p19/bin/bash: ../../../.deps/usr/bin/gperf: No such file or directory
```
gperf was already a buildInput but the path was not given to cmake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

