### PR TITLE
pants: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/tools/build-managers/pants/default.nix
+++ b/pkgs/development/tools/build-managers/pants/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 with pythonPackages;
 
 let
-  version = "1.5.0";
+  version = "1.6.0";
 in buildPythonApplication rec {
   inherit version;
   pname = "pantsbuild.pants";
@@ -12,7 +12,7 @@ in buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7c0a1206594c615fce0a7f6daa4ea1028645bc20afa5599c2cf0ad7c06223fa7";
+    sha256 = "0ahvcj33xribypgyh515mb3ack1djr0cq27nlyk0qhwgwv6acfnj";
   };
 
   prePatch = ''
@@ -27,7 +27,7 @@ in buildPythonApplication rec {
     twitter-common-collections setproctitle ansicolors packaging pathspec
     scandir twitter-common-dirutil psutil requests pystache pex docutils
     markdown pygments twitter-common-confluence fasteners pywatchman
-    futures cffi subprocess32 contextlib2 faulthandler pyopenssl
+    futures cffi subprocess32 contextlib2 faulthandler pyopenssl wheel
   ];
 
   meta = {


### PR DESCRIPTION
Also fixing the missing dependency (wheel). Not sure when this
got broken, but 1.5.0 did not work either.

###### Motivation for this change
Update pantsbuild to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

