### PR TITLE
materia-theme: unset $name in install script

### DIFF
--- a/pkgs/misc/themes/materia-theme/default.nix
+++ b/pkgs/misc/themes/materia-theme/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gnome3.glib libxml2 bc ];
 
-  buildInputs = [ gnome3.gnome-themes-standard gdk_pixbuf librsvg ];
+  buildInputs = [ gnome3.gnome-themes-extra gdk_pixbuf librsvg ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
       -e "s|if .*which gnome-shell.*;|if true;|" \
       -e "s|CURRENT_GS_VERSION=.*$|CURRENT_GS_VERSION=${gnome3.version}|"
     mkdir -p $out/share/themes
-    ./install.sh --dest $out/share/themes
+    # name is used internally by the package installation script
+    name= ./install.sh --dest $out/share/themes
     rm $out/share/themes/*/COPYING
   '';
 


### PR DESCRIPTION
###### Motivation for this change

- `install.sh` uses a global environment variable called `name`, if defined,
to name the theme. This is an issue because nix sets this variable to
the package name.

- Replace `gnome-themes-standard` with `gnome-themes-extra`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).