### PR TITLE
nixos/tests/acme: fix on i686, improve timing

### DIFF
--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -54,9 +54,11 @@ in import ./make-test.nix {
   };
 
   testScript = ''
+    $letsencrypt->waitForUnit("default.target");
     $letsencrypt->waitForUnit("boulder.service");
-    startAll;
+    $webserver->waitForUnit("default.target");
     $webserver->waitForUnit("acme-certificates.target");
+    $client->waitForUnit("default.target");
     $client->succeed('curl https://example.com/ | grep -qF "hello world"');
   '';
 }

--- a/nixos/tests/common/letsencrypt.nix
+++ b/nixos/tests/common/letsencrypt.nix
@@ -386,6 +386,10 @@ in {
 
     services.nginx.enable = true;
     services.nginx.recommendedProxySettings = true;
+    # This fixes the test on i686
+    services.nginx.commonHttpConfig = ''
+      server_names_hash_bucket_size 64;
+    '';
     services.nginx.virtualHosts.${wfeDomain} = {
       onlySSL = true;
       enableACME = false;


### PR DESCRIPTION
###### Motivation for this change

Test failed consistently for i686.
Fix it and improve timing to prevent non-deterministic failures under high load on Hydra.
