### PR TITLE
kernel: drop tuxOnIce patch

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -1,26 +1,6 @@
 { stdenv, fetchurl, fetchpatch, pkgs }:
 
-let
-
-  makeTuxonicePatch = { version, kernelVersion, sha256,
-    url ? "http://tuxonice.nigelcunningham.com.au/downloads/all/tuxonice-for-linux-${kernelVersion}-${version}.patch.bz2" }:
-    { name = "tuxonice-${kernelVersion}";
-      patch = stdenv.mkDerivation {
-        name = "tuxonice-${version}-for-${kernelVersion}.patch";
-        src = fetchurl {
-          inherit url sha256;
-        };
-        phases = [ "installPhase" ];
-        installPhase = ''
-          source $stdenv/setup
-          bunzip2 -c $src > $out
-        '';
-      };
-    };
-in
-
 rec {
-
   bridge_stp_helper =
     { name = "bridge-stp-helper";
       patch = ./bridge-stp-helper.patch;


### PR DESCRIPTION
Hasn't been updated since 3.14, abandoned by its author, not actually used despite being inside a let binding.