### PR TITLE
nixos: fix some types

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xterm.nix
+++ b/nixos/modules/services/x11/desktop-managers/xterm.nix
@@ -12,6 +12,7 @@ in
   options = {
 
     services.xserver.desktopManager.xterm.enable = mkOption {
+      type = types.bool;
       default = true;
       description = "Enable a xterm terminal as a desktop manager.";
     };

--- a/nixos/modules/system/boot/systemd-unit-options.nix
+++ b/nixos/modules/system/boot/systemd-unit-options.nix
@@ -217,7 +217,7 @@ in rec {
 
     environment = mkOption {
       default = {};
-      type = with types; attrsOf (nullOr (either str package));
+      type = with types; attrsOf (nullOr (either str (either path package)));
       example = { PATH = "/foo/bar/bin"; LANG = "nl_NL.UTF-8"; };
       description = "Environment variables passed to the service's processes.";
     };


### PR DESCRIPTION
xterm thing is OCD. Without the systemd patch some modules fail to evaluate after e9fc2558f95152020e8b588f92563d6664f4c3c3.