### PR TITLE
python: introduce `config.pythonPackageOverrides` for proper overrides

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -18,8 +18,6 @@
 , python-setup-hook
 # Some proprietary libs assume UCS2 unicode, especially on darwin :(
 , ucsEncoding ? 4
-# For the Python package set
-, pkgs, packageOverrides ? (self: super: {})
 }:
 
 assert x11Support -> tcl != null
@@ -227,7 +225,7 @@ in stdenv.mkDerivation {
       '';
 
     passthru = let
-      pythonPackages = callPackage ../../../../../top-level/python-packages.nix {python=self; overrides=packageOverrides;};
+      pythonPackages = callPackage ../../../../../top-level/python-packages.nix { python=self; };
     in rec {
       inherit libPrefix sitePackages x11Support hasDistutilsCxxPatch ucsEncoding;
       executable = libPrefix;

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -14,8 +14,6 @@
 , self
 , CF, configd
 , python-setup-hook
-# For the Python package set
-, pkgs, packageOverrides ? (self: super: {})
 }:
 
 assert x11Support -> tcl != null
@@ -161,7 +159,7 @@ in stdenv.mkDerivation {
   '';
 
   passthru = let
-    pythonPackages = callPackage ../../../../../top-level/python-packages.nix {python=self; overrides=packageOverrides;};
+    pythonPackages = callPackage ../../../../../top-level/python-packages.nix { python=self; };
   in rec {
     inherit libPrefix sitePackages x11Support;
     executable = "${libPrefix}m";

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -14,8 +14,6 @@
 , self
 , CF, configd
 , python-setup-hook
-# For the Python package set
-, pkgs, packageOverrides ? (self: super: {})
 }:
 
 assert x11Support -> tcl != null
@@ -155,7 +153,7 @@ in stdenv.mkDerivation {
   '';
 
   passthru = let
-    pythonPackages = callPackage ../../../../../top-level/python-packages.nix {python=self; overrides=packageOverrides;};
+    pythonPackages = callPackage ../../../../../top-level/python-packages.nix { python=self; };
   in rec {
     inherit libPrefix sitePackages x11Support;
     executable = "${libPrefix}m";

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -15,8 +15,6 @@
 , self
 , CF, configd
 , python-setup-hook
-# For the Python package set
-, pkgs, packageOverrides ? (self: super: {})
 }:
 
 assert x11Support -> tcl != null
@@ -178,7 +176,7 @@ in stdenv.mkDerivation {
   '';
 
   passthru = let
-    pythonPackages = callPackage ../../../../../top-level/python-packages.nix {python=self; overrides=packageOverrides;};
+    pythonPackages = callPackage ../../../../../top-level/python-packages.nix { python=self; };
   in rec {
     inherit libPrefix sitePackages x11Support;
     executable = "${libPrefix}m";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6,10 +6,11 @@
 #
 # For more details, please see the Python section in the Nixpkgs manual.
 
-{ pkgs
+{ config
+, pkgs
 , stdenv
 , python
-, overrides ? (self: super: {})
+, overrides ? config.pythonPackageOverrides or (self: super: {})
 }:
 
 with pkgs.lib;


### PR DESCRIPTION
The way it was done before didn't even really work because it inherited
top-level `packageOverrides` into `python-packages.nix` and top-level
`packageOverrides` has a different type.

This patch copies the way Haskell and R do the same thing.

- [X] Now it works.
- [X] Nothing changes if you don't use any overrides.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).