### PR TITLE
lib, nixos: fix module aliases in presence of defaults

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -667,22 +667,26 @@ rec {
   };
 
   doRename = { from, to, visible, warn, use }:
+    { config, options, ... }:
     let
+      fromOpt = getAttrFromPath from options;
+      toOpt = getAttrFromPath to options;
       toOf = attrByPath to
         (abort "Renaming error: option `${showOption to}' does not exist.");
     in
-      { config, options, ... }:
-      { options = setAttrByPath from (mkOption {
-          inherit visible;
-          description = "Alias of <option>${showOption to}</option>.";
-          apply = x: use (toOf config);
-        });
-        config = {
-          warnings =
-            let opt = getAttrFromPath from options; in
-            optional (warn && opt.isDefined)
-              "The option `${showOption from}' defined in ${showFiles opt.files} has been renamed to `${showOption to}'.";
-        } // setAttrByPath to (mkAliasDefinitions (getAttrFromPath from options));
-      };
+    {
+      options = setAttrByPath from (mkOption {
+        inherit visible;
+        description = "Alias of <option>${showOption to}</option>.";
+        apply = x: use (toOf config);
+      });
+      config = mkMerge [
+        {
+          warnings = optional (warn && fromOpt.isDefined)
+            "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
+        }
+        (mkAliasAndWrapDefinitions (setAttrByPath to) fromOpt)
+      ];
+    };
 
 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -532,9 +532,7 @@ rec {
   #
   mkAliasDefinitions = mkAliasAndWrapDefinitions id;
   mkAliasAndWrapDefinitions = wrap: option:
-    mkMerge
-      (optional (isOption option && option.isDefined)
-        (wrap (mkMerge option.definitions)));
+    mkIf (isOption option && option.isDefined) (wrap (mkMerge option.definitions));
 
 
   /* Compatibility. */


### PR DESCRIPTION
Before this change `mkRenamedOptionModule` would override option defaults
even when the old option name is left unused. For instance

```nix
{
  optios = {
    services.name.new = mkOption {
      default = { one = {}; };
    };
  };
  imports = [
    (mkRenamedOptionModule [ "services" "name" "old" ] [ "services" "name" "new" "two" ])
  ];
  config = {};
}
```

would evaluate to

`{ config.services.name.new = { two = {}; }; }`

when you'd expect it to evaluate to

`{ config.services.name.new = { one = {}; }; }`.

- [X] All my configs build.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Really /cc @edolstra and @nbp, since this touches the core.