### PR TITLE
kde-gtk-config: Set path for GSettings schemas

### DIFF
--- a/pkgs/desktops/plasma-5/kde-gtk-config/default.nix
+++ b/pkgs/desktops/plasma-5/kde-gtk-config/default.nix
@@ -1,21 +1,25 @@
 {
   mkDerivation,
-  extra-cmake-modules,
+  extra-cmake-modules, wrapGAppsHook,
   glib, gtk2, gtk3, karchive, kcmutils, kconfigwidgets, ki18n, kiconthemes, kio,
   knewstuff, gsettings-desktop-schemas
 }:
 
 mkDerivation {
   name = "kde-gtk-config";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules wrapGAppsHook ];
+  dontWrapGApps = true;  # There is nothing to wrap
   buildInputs = [
     ki18n kio glib gtk2 gtk3 karchive kcmutils kconfigwidgets kiconthemes
     knewstuff gsettings-desktop-schemas
   ];
-  patches = [ ./0001-follow-symlinks.patch ];
+  patches = [ ./patches/follow-symlinks.patch ./patches/gsettings.patch ];
   cmakeFlags = [
     "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
     "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
     "-DGLIB_SCHEMAS_DIR=${gsettings-desktop-schemas.out}/"
   ];
+  preConfigure = ''
+    NIX_CFLAGS_COMPILE+=" -DGSETTINGS_SCHEMAS_PATH=\"$GSETTINGS_SCHEMAS_PATH\""
+  '';
 }

--- a/pkgs/desktops/plasma-5/kde-gtk-config/patches/follow-symlinks.patch
+++ b/pkgs/desktops/plasma-5/kde-gtk-config/patches/follow-symlinks.patch
@@ -8,11 +8,11 @@ Subject: [PATCH] follow symlinks
  src/iconthemesmodel.cpp | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/src/appearancegtk2.cpp b/src/appearancegtk2.cpp
-index b1e0b52..095cddc 100644
---- a/src/appearancegtk2.cpp
-+++ b/src/appearancegtk2.cpp
-@@ -73,7 +73,7 @@ QString AppearanceGTK2::themesGtkrcFile(const QString& themeName) const
+Index: kde-gtk-config-5.12.4/src/appearancegtk2.cpp
+===================================================================
+--- kde-gtk-config-5.12.4.orig/src/appearancegtk2.cpp
++++ kde-gtk-config-5.12.4/src/appearancegtk2.cpp
+@@ -69,7 +69,7 @@ QString AppearanceGTK2::themesGtkrcFile(
      QStringList themes=installedThemes();
      themes=themes.filter(QRegExp("/"+themeName+"/?$"));
      if(themes.size()==1) {
@@ -21,12 +21,12 @@ index b1e0b52..095cddc 100644
          while(it.hasNext()) {
              it.next();
              if(it.fileName()=="gtkrc") {
-diff --git a/src/iconthemesmodel.cpp b/src/iconthemesmodel.cpp
-index 07c7ad7..b04d978 100644
---- a/src/iconthemesmodel.cpp
-+++ b/src/iconthemesmodel.cpp
-@@ -46,7 +46,7 @@ QList<QDir> IconThemesModel::installedThemesPaths()
-     
+Index: kde-gtk-config-5.12.4/src/iconthemesmodel.cpp
+===================================================================
+--- kde-gtk-config-5.12.4.orig/src/iconthemesmodel.cpp
++++ kde-gtk-config-5.12.4/src/iconthemesmodel.cpp
+@@ -47,7 +47,7 @@ QList<QDir> IconThemesModel::installedTh
+ 
      foreach(const QString& dir, dirs) {
          QDir userIconsDir(dir);
 -        QDirIterator it(userIconsDir.path(), QDir::NoDotAndDotDot|QDir::AllDirs|QDir::NoSymLinks);
@@ -34,14 +34,11 @@ index 07c7ad7..b04d978 100644
          while(it.hasNext()) {
              QString currentPath = it.next();
              QDir dir(currentPath);
--- 
-2.6.2
-
-diff --git a/src/cursorthemesmodel.cpp b/src/cursorthemesmodel.cpp
-index 926a666..85b10f8 100644
---- a/src/cursorthemesmodel.cpp
-+++ b/src/cursorthemesmodel.cpp
-@@ -47,7 +47,7 @@ QList<QDir> CursorThemesModel::installedThemesPaths()
+Index: kde-gtk-config-5.12.4/src/cursorthemesmodel.cpp
+===================================================================
+--- kde-gtk-config-5.12.4.orig/src/cursorthemesmodel.cpp
++++ kde-gtk-config-5.12.4/src/cursorthemesmodel.cpp
+@@ -47,7 +47,7 @@ QList<QDir> CursorThemesModel::installed
  
      foreach(const QString& dir, dirs) {
          QDir userIconsDir(dir);

--- a/pkgs/desktops/plasma-5/kde-gtk-config/patches/gsettings.patch
+++ b/pkgs/desktops/plasma-5/kde-gtk-config/patches/gsettings.patch
@@ -1,0 +1,21 @@
+Index: kde-gtk-config-5.12.4/src/gtkconfigkcmodule.cpp
+===================================================================
+--- kde-gtk-config-5.12.4.orig/src/gtkconfigkcmodule.cpp
++++ kde-gtk-config-5.12.4/src/gtkconfigkcmodule.cpp
+@@ -78,6 +78,16 @@ GTKConfigKCModule::GTKConfigKCModule(QWi
+     m_iconsModel = new IconThemesModel(false, this);
+     ui->cb_icon->setModel(m_iconsModel);
+     ui->cb_icon_fallback->setModel(m_iconsModel);
++
++    // Add GSETTINGS_SCHEMAS_PATH to the front of XDG_DATA_DIRS.
++    // Normally this would be done by wrapGAppsHook, but this plugin
++    // (shared object) cannot be wrapped.
++    QByteArray xdgdata = qgetenv("XDG_DATA_DIRS");
++    if (!xdgdata.isEmpty()) {
++        xdgdata.push_front(":");
++    }
++    xdgdata.push_front(QByteArray(GSETTINGS_SCHEMAS_PATH));
++    qputenv("XDG_DATA_DIRS", xdgdata);
+     
+     m_tempGtk2Preview = QStandardPaths::writableLocation(QStandardPaths::TempLocation)+ "/gtkrc-2.0";
+     m_tempGtk3Preview = QStandardPaths::writableLocation(QStandardPaths::TempLocation)+ "/.config/gtk-3.0/settings.ini";

--- a/pkgs/desktops/plasma-5/kde-gtk-config/patches/series
+++ b/pkgs/desktops/plasma-5/kde-gtk-config/patches/series
@@ -1,0 +1,2 @@
+follow-symlinks.patch
+gsettings.patch


### PR DESCRIPTION
Fixes: #38919

The KCModule is patched to set the appropriate environment variables in
the parent process when it is initialized.

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

