### PR TITLE
nixos/tests: add jbake

### DIFF
--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/jbake --set JAVA_HOME "${jre}"
   '';
 
+  checkPhase = ''
+    export JAVA_HOME=${jre}
+    bin/jbake | grep -q "${version}" || (echo "jbake did not return correct version"; exit 1)
+  '';
+  doCheck = true;
+
   meta = with stdenv.lib; {
     description = "JBake is a Java based, open source, static site/blog generator for developers & designers";
     homepage = "https://jbake.org/";


### PR DESCRIPTION
###### Motivation for this change

Adding test to prevent bot upgrades from causing issues.

###### Things done

tested with `nix-build nixos/tests/jbake.nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

