### PR TITLE
avocode: init at 2.26.0

### DIFF
--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -1,0 +1,97 @@
+{ stdenv, lib, makeDesktopItem, fetchurl, unzip
+, gdk_pixbuf, glib, gtk2, atk, pango, cairo, freetype, fontconfig, dbus, nss, nspr, alsaLib, cups, expat, udev, gnome2
+, xorg, mozjpeg
+}:
+
+stdenv.mkDerivation rec {
+  name = "avocode-${version}";
+  version = "2.26.0";
+
+  src = fetchurl {
+    url = "https://media.avocode.com/download/avocode-app/${version}/avocode-${version}-linux.zip";
+    sha256 = "11d3nlshyzh5aqf5vsvnjwhr9qn8a2kd848x0ylv91y9p9njgsl5";
+  };
+
+  libPath = stdenv.lib.makeLibraryPath (with xorg; with gnome2; [
+    stdenv.cc.cc.lib
+    gdk_pixbuf
+    glib
+    gtk2
+    atk
+    pango
+    cairo
+    freetype
+    fontconfig
+    dbus
+    nss
+    nspr
+    alsaLib
+    cups
+    expat
+    udev
+    GConf
+    libX11
+    libxcb
+    libXi
+    libXcursor
+    libXdamage
+    libXrandr
+    libXcomposite
+    libXext
+    libXfixes
+    libXrender
+    libXtst
+    libXScrnSaver
+  ]);
+
+  desktopItem = makeDesktopItem {
+    name = "Avocode";
+    exec = "avocode";
+    icon = "avocode";
+    desktopName = "Avocode";
+    genericName = "Design Inspector";
+    categories = "Application;Development;";
+    comment = "The bridge between designers and developers";
+  };
+
+  buildInputs = [ unzip ];
+
+  unpackCmd = ''
+    mkdir out
+    unzip $curSrc -d out
+  '';
+
+  installPhase = ''
+    substituteInPlace avocode.desktop.in \
+      --replace /path/to/avocode-dir/Avocode $out/bin/avocode \
+      --replace /path/to/avocode-dir/avocode.png avocode
+
+    mkdir -p share/applications share/pixmaps
+    mv avocode.desktop.in share/applications/avocode.desktop
+    mv avocode.png share/pixmaps/
+
+    rm resources/cjpeg
+    cp -av . $out
+
+    mkdir $out/bin
+    ln -s $out/avocode $out/bin/avocode
+    ln -s ${mozjpeg}/bin/cjpeg $out/resources/cjpeg
+  '';
+
+  postFixup = ''
+    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/avocode
+        patchelf --set-rpath ${libPath}:$out/ $file
+    done
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://avocode.com/;
+    description = "The bridge between designers and developers";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ megheaiulian ];
+  };
+}

--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ unzip ];
 
+  # src is producing multiple folder on unzip so we must
+  # override unpackCmd to extract it into newly created folder
   unpackCmd = ''
     mkdir out
     unzip $curSrc -d out

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14880,6 +14880,8 @@ with pkgs;
 
   autotrace = callPackage ../applications/graphics/autotrace {};
 
+  avocode = callPackage ../applications/graphics/avocode {};
+
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
   schismtracker = callPackage ../applications/audio/schismtracker { };


### PR DESCRIPTION
###### Motivation for this change
Add avocode package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

