### PR TITLE
linuxPackages.bcc: make it useable as a python library

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchFromGitHub, fetchpatch, makeWrapper, cmake, llvmPackages, kernel
-, flex, bison, elfutils, python, pythonPackages, luajit, netperf, iperf, libelf
+, flex, bison, elfutils, python, luajit, netperf, iperf, libelf
 , systemtap
 }:
 
-stdenv.mkDerivation rec {
+python.pkgs.buildPythonApplication rec {
   version = "0.5.0";
   name = "bcc-${version}";
 
@@ -14,9 +14,11 @@ stdenv.mkDerivation rec {
     sha256 = "0bb3244xll5sqx0lvrchg71qy2zg0yj6r5h4v5fvrg1fjhaldys9";
   };
 
+  format = "other";
+
   buildInputs = [
     llvmPackages.llvm llvmPackages.clang-unwrapped kernel
-    elfutils python pythonPackages.netaddr luajit netperf iperf
+    elfutils luajit netperf iperf
     systemtap.stapBuild
   ];
 
@@ -26,18 +28,31 @@ stdenv.mkDerivation rec {
       url = "https://github.com/iovisor/bcc/commit/bd7fa55bb39b8978dafd0b299e35616061e0a368.patch";
       sha256 = "1sgxhsq174iihyk1x08py73q8fh78d7y3c90k5nh8vcw2pf1xbnf";
     })
+
+    # This is needed until we fix
+    # https://github.com/NixOS/nixpkgs/issues/40427
+    ./fix-deadlock-detector-import.patch
   ];
 
   nativeBuildInputs = [ makeWrapper cmake flex bison ]
     # libelf is incompatible with elfutils-libelf
     ++ stdenv.lib.filter (x: x != libelf) kernel.moduleBuildDependencies;
 
-  cmakeFlags =
-    [ "-DBCC_KERNEL_MODULES_DIR=${kernel.dev}/lib/modules"
-      "-DREVISION=${version}"
-      "-DENABLE_USDT=ON"
-      "-DENABLE_CPP_API=ON"
-    ];
+  cmakeFlags = [
+    "-DBCC_KERNEL_MODULES_DIR=${kernel.dev}/lib/modules"
+    "-DREVISION=${version}"
+    "-DENABLE_USDT=ON"
+    "-DENABLE_CPP_API=ON"
+  ];
+
+  postPatch = ''
+    substituteAll ${./libbcc-path.patch} ./libbcc-path.patch
+    patch -p1 < libbcc-path.patch
+  '';
+
+  propagatedBuildInputs = [
+    python.pkgs.netaddr
+  ];
 
   postInstall = ''
     mkdir -p $out/bin $out/share
@@ -47,12 +62,17 @@ stdenv.mkDerivation rec {
 
     find $out/share/bcc/tools -type f -executable -print0 | \
     while IFS= read -r -d ''$'\0' f; do
-      pythonLibs="$out/lib/python2.7/site-packages:${pythonPackages.netaddr}/lib/${python.libPrefix}/site-packages"
-      rm -f $out/bin/$(basename $f)
-      makeWrapper $f $out/bin/$(basename $f) \
-        --prefix LD_LIBRARY_PATH : $out/lib \
-        --prefix PYTHONPATH : "$pythonLibs"
+      bin=$out/bin/$(basename $f)
+      if [ ! -e $bin ]; then
+        ln -s $f $bin
+      fi
     done
+
+    sed -i -e "s!lib=.*!lib=$out/bin!" $out/bin/{java,ruby,node,python}gc
+  '';
+
+  postFixup = ''
+    wrapPythonProgramsIn "$out/share/bcc/tools" "$out $pythonPath"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/bcc/fix-deadlock-detector-import.patch
+++ b/pkgs/os-specific/linux/bcc/fix-deadlock-detector-import.patch
@@ -1,0 +1,14 @@
+--- source.org/tools/deadlock_detector.py	1980-01-02 00:00:00.000000000 +0000
++++ source/tools/deadlock_detector.py	2018-05-29 13:57:11.807126673 +0100
+@@ -44,9 +44,8 @@
+ #
+ # 01-Feb-2017   Kenny Yu   Created this.
+ 
+-from __future__ import (
+-    absolute_import, division, unicode_literals, print_function
+-)
++from __future__ import absolute_import, division, unicode_literals, print_function
++
+ from bcc import BPF
+ from collections import defaultdict
+ import argparse

--- a/pkgs/os-specific/linux/bcc/libbcc-path.patch
+++ b/pkgs/os-specific/linux/bcc/libbcc-path.patch
@@ -1,0 +1,11 @@
+--- source.org/src/python/bcc/libbcc.py	2018-05-13 08:35:06.850522883 +0100
++++ source/src/python/bcc/libbcc.py	2018-05-13 08:36:24.602733151 +0100
+@@ -14,7 +14,7 @@
+ 
+ import ctypes as ct
+ 
+-lib = ct.CDLL("libbcc.so.0", use_errno=True)
++lib = ct.CDLL("@out@/lib/libbcc.so.0", use_errno=True)
+ 
+ # keep in sync with bpf_common.h
+ lib.bpf_module_create_b.restype = ct.c_void_p

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13548,7 +13548,9 @@ with pkgs;
 
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
-    bcc = callPackage ../os-specific/linux/bcc { };
+    bcc = callPackage ../os-specific/linux/bcc {
+      python = python3;
+    };
 
     bbswitch = callPackage ../os-specific/linux/bbswitch {};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

