### PR TITLE
giac: remove liblapackWithAtlas dependency

### DIFF
--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, texlive, bison, flex
-, gmp, mpfr, pari, ntl, gsl, blas, mpfi, liblapackWithAtlas
+, gmp, mpfr, pari, ntl, gsl, blas, mpfi
 , readline, gettext, libpng, libao, gfortran, perl
 , enableGUI ? false, libGLU_combined ? null, xorg ? null, fltk ? null
 }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   # perl is only needed for patchShebangs fixup.
   buildInputs = [
-    gmp mpfr pari ntl gsl blas mpfi liblapackWithAtlas
+    gmp mpfr pari ntl gsl blas mpfi
     readline gettext libpng libao perl
     # gfortran.cc default output contains static libraries compiled without -fPIC
     # we want libgfortran.so.3 instead


### PR DESCRIPTION
###### Motivation for this change

`atlas` takes ages to build, is optimized for the build machine and doesn't currently build on aarch.

I tried to figure out why the `liblapackWithAtlas` dependency is needed for giac and I couldn't find a reason. [gentoo](https://github.com/cschwan/sage-on-gentoo/blob/d598cc29686636fd4fc53f358dc84aeae8f3f6d5/sci-mathematics/giac/giac-1.2.3.57.ebuild) (at least in its sage overlay, I couldn't find another package) and [debian](https://salsa.debian.org/science-team/giac/blob/master/debian/control) don't have a dependency on giac. I couldn't find any mention of it on giacs [homepage](https://www-fourier.ujf-grenoble.fr/~parisse/giac.html) either.

Nothing besides sage depends on giac, so I couldn't use that as a test either. So unless the maintainer @symphorien remembers the original reason to include that dependency, I propose we remove it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

