### PR TITLE
nasm: set -Wno-error=attributes for gcc8

### DIFF
--- a/pkgs/development/compilers/nasm/default.nix
+++ b/pkgs/development/compilers/nasm/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     make golden && make test
   '';
 
+  NIX_CFLAGS_COMPILE="-Wno-error=attributes";
+
   meta = with stdenv.lib; {
     homepage = http://www.nasm.us/;
     description = "An 80x86 and x86-64 assembler designed for portability and modularity";


### PR DESCRIPTION
###### Motivation for this change

It was broken without: https://nix-cache.s3.amazonaws.com/log/q1ll3km6l5crfz1sjb8ixfpwd8v5iq6m-nasm-2.13.03.drv

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

