### PR TITLE
sasview: fix build

### DIFF
--- a/pkgs/applications/science/misc/sasview/default.nix
+++ b/pkgs/applications/science/misc/sasview/default.nix
@@ -1,7 +1,8 @@
-{lib, fetchgit, gcc, python}:
+{ lib, fetchFromGitHub, gcc, python }:
 
 let
-  xhtml2pdf = import ./xhtml2pdf.nix { inherit lib;
+  xhtml2pdf = import ./xhtml2pdf.nix {
+    inherit lib;
     fetchPypi = python.pkgs.fetchPypi;
     buildPythonPackage = python.pkgs.buildPythonPackage;
     html5lib = python.pkgs.html5lib;
@@ -10,17 +11,29 @@ let
     pillow = python.pkgs.pillow;
     pypdf2 = python.pkgs.pypdf2;
     reportlab = python.pkgs.reportlab;
-};
+  };
 
 in
 
 python.pkgs.buildPythonApplication rec {
   pname = "sasview";
-  version = "4.1.2";
+  version = "unstable-2018-05-05";
 
-  buildInputs = with python.pkgs; [
+  checkInputs = with python.pkgs; [
     pytest
-    unittest-xml-reporting];
+    unittest-xml-reporting
+  ];
+
+  checkPhase = ''
+    # fix the following error:
+    # imported module 'sas.sascalc.data_util.uncertainty' has this __file__ attribute:
+    #   /build/source/build/lib.linux-x86_64-2.7/sas/sascalc/data_util/uncertainty.py
+    # which is not the same as the test file we want to collect:
+    #   /build/source/dist/tmpbuild/sasview/sas/sascalc/data_util/uncertainty.py
+    rm -r dist/tmpbuild
+
+    HOME=$(mktemp -d) py.test
+  '';
 
   propagatedBuildInputs = with python.pkgs; [
     bumps
@@ -41,20 +54,22 @@ python.pkgs.buildPythonApplication rec {
     six
     sphinx
     wxPython
-    xhtml2pdf];
+    xhtml2pdf
+  ];
 
-  src = fetchgit {
-    url = "https://github.com/SasView/sasview.git";
-    rev = "v${version}";
-    sha256 ="05la54wwzzlkhmj8vkr0bvzagyib6z6mgwqbddzjs5y1wd48vpcx";
+  src = fetchFromGitHub {
+    owner = "SasView";
+    repo = "sasview";
+    rev = "de431924d0ddf73cfb952df88bd6661181947019";
+    sha256 = "01bk0i0g65yzyq16n1a61rgjna8rrc2i51x2ndf1z7khb1fl16vg";
   };
 
-  patches = [./pyparsing-fix.patch ./local_config.patch];
+  patches = [ ./pyparsing-fix.patch ./local_config.patch ];
 
-  meta = {
+  meta = with lib; {
     homepage = https://www.sasview.org;
     description = "Fitting and data analysis for small angle scattering data";
-    maintainers = with lib.maintainers; [ rprospero ];
-    license = lib.licenses.bsd3;
+    maintainers = with maintainers; [ rprospero ];
+    license = licenses.bsd3;
   };
 }

--- a/pkgs/applications/science/misc/sasview/local_config.patch
+++ b/pkgs/applications/science/misc/sasview/local_config.patch
@@ -1,10 +1,22 @@
+diff --git a/src/sas/_config.py b/src/sas/_config.py
+index ece08fd4c..926768593 100644
 --- a/src/sas/_config.py
 +++ b/src/sas/_config.py
-@@ -70,2 +70,2 @@
+@@ -67,8 +67,8 @@ def load_local_config(app_dir):
+         logger.info("GuiManager loaded %s", path)
+         return module
+     except Exception as exc:
 -        logger.critical("Error loading %s: %s", path, exc)
 -        sys.exit()
 +        import sas.sasview.local_config
 +        return sas.sasview.local_config
--- 
-2.15.0
-
+ 
+ def make_custom_config_path(user_dir):
+     """
+@@ -116,4 +116,4 @@ def load_custom_config(path):
+ 
+     from sas.sasview import custom_config
+     logger.info("GuiManager custom_config defaults to sas.sasview.custom_config")
+-    return custom_config
+\ No newline at end of file
++    return custom_config

--- a/pkgs/applications/science/misc/sasview/pyparsing-fix.patch
+++ b/pkgs/applications/science/misc/sasview/pyparsing-fix.patch
@@ -1,8 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 866ab7e36..78727b276 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -5,1 +5,1 @@
--    'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing<2.0.0',
+@@ -401,7 +401,7 @@ package_data['sas.sasview'] = ['images/*',
+ packages.append("sas.sasview")
+ 
+ required = [
+-    'bumps>=0.7.5.9', 'periodictable>=1.5.0', 'pyparsing>=2.0.0',
 +    'bumps>=0.7.5.9', 'periodictable>=1.5.0',
--- 
-2.15.0
-
+ 
+     # 'lxml>=2.2.2',
+     'lxml', 'h5py',


### PR DESCRIPTION
###### Motivation for this change

The package breaks currently breaks with the following message:

```
fixed-output derivation produced path '/nix/store/5dh1mdj027ad8sprk12fqa5h5bpdxs5n-sasview' with sha256 hash '12k1w4yq1mzjxcp2cqb562c7cbwzhi54rsbmgi0fax0i1660q167' instead of the expected hash '05la54wwzzlkhmj8vkr0bvzagyib6z6mgwqbddzjs5y1wd48vpcx'
```

To fix the build the following changes were applied:

* Switched to latest master for now as the older releases have a broken
  `py.test` configuration and altering hashes.

* Added `checkPhase` which invokes `py.test` directly and drops
  duplicated files from `dist/tmpbuild`.

* Rebased the patches `pyparsing-fix.patch` and `local_config.patch` for
  the latest master revision.

Additionally refer to the discussion in #40381 for further reference.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

