### PR TITLE
matomo: 3.4.0 -> 3.5.0

### DIFF
--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "matomo-${version}";
-  version = "3.4.0";
+  version = "3.5.0";
 
   src = fetchurl {
     # TODO: As soon as the tarballs are renamed as well on future releases, this should be enabled again
     # url = "https://builds.matomo.org/${name}.tar.gz";
     url = "https://builds.matomo.org/piwik-${version}.tar.gz";
-    sha256 = "1hnja8mvjvlbqgw7maa76lxd5hxxg7d5ggq9wyrff25mapj398wc";
+    sha256 = "1l656b194h7z3k52ywl7sfa2h6sxa5gf22wcfrp0pp07v9p6pc5f";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
   #   unix socket authentication only works with localhost,
   #   but password-based SQL authentication works with both.
   # TODO: is upstream interested in this?
+  # -> discussion at https://github.com/matomo-org/matomo/issues/12646
   patches = [ ./make-localhost-default-database-host.patch ];
 
   # this bootstrap.php adds support for getting PIWIK_USER_PATH


### PR DESCRIPTION
###### Motivation for this change
The new matomo release brings new features required for compyling with GDPR, which will get in effect on May 25th. See [the release announcement](https://matomo.org/changelog/matomo-3-5-0/) for more information.

Maintainer of matomo here, this should be backported this to stable. I see only a minimal risk for breakage, while those new features are strictly required for operating Matomo when targeting EU visitors as soon as GPDR is binding.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

