### PR TITLE
libressl: init at 2.7, change url to https

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -26,7 +26,7 @@ let
 
     meta = with lib; {
       description = "Free TLS/SSL implementation";
-      homepage    = "http://www.libressl.org";
+      homepage    = "https://www.libressl.org";
       platforms   = platforms.all;
       maintainers = with maintainers; [ thoughtpolice wkennington fpletz globin ];
     };

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -43,4 +43,9 @@ in {
     version = "2.6.4";
     sha256 = "07yi37a2ghsgj2b4w30q1s4d2inqnix7ika1m21y57p9z71212k3";
   };
+
+  libressl_2_7 = generic {
+    version = "2.7.3";
+    sha256 = "1597kj9jy3jyw52ys19sd4blg2gkam5q0rqdxbnrnvnyw67hviqn";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10947,7 +10947,8 @@ with pkgs;
 
   inherit (callPackages ../development/libraries/libressl { })
     libressl_2_5
-    libressl_2_6;
+    libressl_2_6
+    libressl_2_7;
 
   libressl = libressl_2_5;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10950,7 +10950,7 @@ with pkgs;
     libressl_2_6
     libressl_2_7;
 
-  libressl = libressl_2_5;
+  libressl = libressl_2_7;
 
   boringssl = callPackage ../development/libraries/boringssl { };
 


### PR DESCRIPTION
###### Motivation for this change

[LibreSSL 2.7 has been released in March](https://www.libressl.org/releases.html). Since 2.6.4, a memory leak, null check, and `tls_config_clear_keys()` bug have been fixed, apart from other improvements.

The releases page states:

> LibreSSL transitions to a new stable release branch every 6 months in coordination with the OpenBSD development schedule. LibreSSL stable branches are updated for 1 year after their corresponding OpenBSD branch is tagged for release.

If I understand correctly, this means that 2.5 is no longer supported, as 2.5.3 was tagged for OpenBSD 6.1 on April 11th, 2017, and OpenBSD 6.2 included LibreSSL 2.6.3. However, previous release notes of 2.6.3 and 2.5.3 also include “LibreSSL 2.4.x support has also ended” and “LibreSSL 2.3.x support has also ended”. The release notes of 2.7.2 (that goes with OpenBSD 6.3) did not include such a statement. I am not sure whether this is intentional, or an oversight in the release notes. In any case, it would probably be a good idea to update the default `libressl` to a newer version in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The contributing guidelines say to also update the `license` field, but the situation for LibreSSL is complicated, I am not really sure what to put there.