### PR TITLE
guile: Backport cross fixes

### DIFF
--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -1,15 +1,16 @@
-{ fetchurl, stdenv, libtool, readline, gmp
-, gawk, makeWrapper }:
+{ stdenv, buildPackages
+, buildPlatform, hostPlatform
+, fetchurl, makeWrapper, gawk, pkgconfig
+, libtool, readline, gmp
+}:
 
 stdenv.mkDerivation rec {
   name = "guile-1.8.8";
 
   src = fetchurl {
-    url = "mirror://gnu/guile/" + name + ".tar.gz";
+    url = "mirror://gnu/guile/${name}.tar.gz";
     sha256 = "0l200a0v7h8bh0cwz6v7hc13ds39cgqsmfrks55b1rbj5vniyiy3";
   };
-
-  patches = [ ./cpp-4.5.patch ];
 
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
@@ -17,9 +18,16 @@ stdenv.mkDerivation rec {
   # GCC 4.6 raises a number of set-but-unused warnings.
   configureFlags = [ "--disable-error-on-warning" ];
 
-  nativeBuildInputs = [ makeWrapper gawk ];
-  propagatedBuildInputs = [ readline gmp libtool ];
-  selfNativeBuildInput = true;
+  depsBuildBuild = [ buildPackages.stdenv.cc ]
+    ++ stdenv.lib.optional (hostPlatform != buildPlatform)
+                           buildPackages.buildPackages.guile_1_8;
+  nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
+  buildInputs = [ readline libtool ];
+
+  propagatedBuildInputs = [ gmp ];
+
+  patches = [ ./cpp-4.5.patch ];
+
 
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"
@@ -46,17 +54,16 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   meta = {
-    description = "GNU Guile, an embeddable Scheme interpreter";
+    description = "Embeddable Scheme implementation";
+    homepage    = http://www.gnu.org/software/guile/;
+    license     = stdenv.lib.licenses.lgpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.ludo ];
+    platforms   = stdenv.lib.platforms.unix;
+
     longDescription = ''
       GNU Guile is an interpreter for the Scheme programming language,
       packaged as a library that can be embedded into programs to make
       them extensible.  It supports many SRFIs.
     '';
-
-    homepage = http://www.gnu.org/software/guile/;
-    license = stdenv.lib.licenses.lgpl2Plus;
-
-    maintainers = [ stdenv.lib.maintainers.ludo ];
-    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -27,12 +27,15 @@
   nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
   buildInputs = [ readline libtool libunistring libffi ];
 
-  propagatedBuildInputs = [ gmp boehmgc ]
-    # XXX: These ones aren't normally needed here, but since
-    # `libguile-2.0.la' reads `-lltdl -lunistring', adding them here will add
+  propagatedBuildInputs = [
+    gmp boehmgc
+
+    # XXX: These ones aren't normally needed here, but `libguile*.la' has '-l'
+    # flags for them without corresponding '-L' flags. Adding them here will add
     # the needed `-L' flags.  As for why the `.la' file lacks the `-L' flags,
     # see below.
-    ++ [ libtool libunistring ];
+    libtool libunistring
+  ];
 
   enableParallelBuilding = true;
 
@@ -70,11 +73,12 @@
 
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"
-
+  ''
     # XXX: See http://thread.gmane.org/gmane.comp.lib.gnulib.bugs/18903 for
     # why `--with-libunistring-prefix' and similar options coming from
     # `AC_LIB_LINKFLAGS_BODY' don't work on NixOS/x86_64.
-    sed -i "$out/lib/pkgconfig/guile-2.0.pc"    \
+  + ''
+    sed -i "$out/lib/pkgconfig/guile"-*.pc    \
         -e "s|-lunistring|-L${libunistring}/lib -lunistring|g ;
             s|^Cflags:\(.*\)$|Cflags: -I${libunistring}/include \1|g ;
             s|-lltdl|-L${libtool.lib}/lib -lltdl|g ;

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -92,15 +92,6 @@
 
   setupHook = ./setup-hook-2.0.sh;
 
-  crossAttrs.preConfigure =
-    stdenv.lib.optionalString (hostPlatform.isHurd)
-       # On GNU, libgc depends on libpthread, but the cross linker doesn't
-       # know where to find libpthread, which leads to erroneous test failures
-       # in `configure', where `-pthread' and `-lpthread' aren't explicitly
-       # passed.  So it needs some help (XXX).
-       "export LDFLAGS=-Wl,-rpath-link=${gnu.libpthreadCross}/lib";
-
-
   meta = {
     description = "Embeddable Scheme implementation";
     homepage    = http://www.gnu.org/software/guile/;

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -1,6 +1,8 @@
-{ fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
-, libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
-, hostPlatform, buildPackages
+{ stdenv, buildPackages
+, buildPlatform, hostPlatform
+, fetchpatch, fetchurl, makeWrapper, gawk, pkgconfig
+, libffi, libtool, readline, gmp, boehmgc, libunistring
+, coverageAnalysis ? null, gnu ? null
 }:
 
 # Do either a coverage analysis build or a standard build.
@@ -19,12 +21,13 @@
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
 
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ makeWrapper gawk pkgconfig ] ++
-    stdenv.lib.optional stdenv.isCross buildPackages.buildPackages.guile_2_0;
+  depsBuildBuild = [ buildPackages.stdenv.cc ]
+    ++ stdenv.lib.optional (hostPlatform != buildPlatform)
+                           buildPackages.buildPackages.guile_2_0;
+  nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
   buildInputs = [ readline libtool libunistring libffi ];
-  propagatedBuildInputs = [ gmp boehmgc ]
 
+  propagatedBuildInputs = [ gmp boehmgc ]
     # XXX: These ones aren't normally needed here, but since
     # `libguile-2.0.la' reads `-lltdl -lunistring', adding them here will add
     # the needed `-L' flags.  As for why the `.la' file lacks the `-L' flags,

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
 , libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
-, hostPlatform
+, hostPlatform, buildPackages
 }:
 
 # Do either a coverage analysis build or a standard build.
@@ -19,7 +19,9 @@
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
 
-  nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ makeWrapper gawk pkgconfig ] ++
+    stdenv.lib.optional stdenv.isCross buildPackages.buildPackages.guile_2_0;
   buildInputs = [ readline libtool libunistring libffi ];
   propagatedBuildInputs = [ gmp boehmgc ]
 
@@ -29,9 +31,6 @@
     # see below.
     ++ [ libtool libunistring ];
 
-  # A native Guile 2.0 is needed to cross-build Guile.
-  selfNativeBuildInput = true;
-
   enableParallelBuilding = true;
 
   patches = [ ./disable-gc-sensitive-tests.patch ./eai_system.patch ./clang.patch
@@ -40,6 +39,7 @@
       url = "http://git.savannah.gnu.org/cgit/guile.git/patch/?id=2fbde7f02adb8c6585e9baf6e293ee49cd23d4c4";
       sha256 = "0p6c1lmw1iniq03z7x5m65kg3lq543kgvdb4nrxsaxjqf3zhl77v";
     })
+    ./riscv.patch
   ] ++
     (stdenv.lib.optional (coverageAnalysis != null) ./gcov-file-name.patch);
 

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -28,12 +28,15 @@
   nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
   buildInputs = [ readline libtool libunistring libffi ];
 
-  propagatedBuildInputs = [ gmp boehmgc ]
-    # XXX: These ones aren't normally needed here, but since
-    # `libguile-2.0.la' reads `-lltdl -lunistring', adding them here will add
+  propagatedBuildInputs = [
+    gmp boehmgc
+
+    # XXX: These ones aren't normally needed here, but `libguile*.la' has '-l'
+    # flags for them without corresponding '-L' flags. Adding them here will add
     # the needed `-L' flags.  As for why the `.la' file lacks the `-L' flags,
     # see below.
-    ++ [ libtool libunistring ];
+    libtool libunistring
+  ];
 
   enableParallelBuilding = true;
 
@@ -66,11 +69,12 @@
 
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"
-
+  ''
     # XXX: See http://thread.gmane.org/gmane.comp.lib.gnulib.bugs/18903 for
     # why `--with-libunistring-prefix' and similar options coming from
     # `AC_LIB_LINKFLAGS_BODY' don't work on NixOS/x86_64.
-    sed -i "$out/lib/pkgconfig/guile-2.2.pc"    \
+  + ''
+    sed -i "$out/lib/pkgconfig/guile"-*.pc    \
         -e "s|-lunistring|-L${libunistring}/lib -lunistring|g ;
             s|^Cflags:\(.*\)$|Cflags: -I${libunistring}/include \1|g ;
             s|-lltdl|-L${libtool.lib}/lib -lltdl|g ;

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -88,15 +88,6 @@
 
   setupHook = ./setup-hook-2.2.sh;
 
-  crossAttrs.preConfigure =
-    stdenv.lib.optionalString (hostPlatform.isHurd)
-       # On GNU, libgc depends on libpthread, but the cross linker doesn't
-       # know where to find libpthread, which leads to erroneous test failures
-       # in `configure', where `-pthread' and `-lpthread' aren't explicitly
-       # passed.  So it needs some help (XXX).
-       "export LDFLAGS=-Wl,-rpath-link=${gnu.libpthreadCross}/lib";
-
-
   meta = {
     description = "Embeddable Scheme implementation";
     homepage    = http://www.gnu.org/software/guile/;

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
 , libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
-, hostPlatform
+, hostPlatform, buildPackages
 }:
 
 # Do either a coverage analysis build or a standard build.
@@ -20,7 +20,9 @@
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
 
-  nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ makeWrapper gawk pkgconfig ] ++
+    stdenv.lib.optional stdenv.isCross buildPackages.buildPackages.guile;
   buildInputs = [ readline libtool libunistring libffi ];
 
   propagatedBuildInputs = [ gmp boehmgc ]
@@ -30,13 +32,11 @@
     # see below.
     ++ [ libtool libunistring ];
 
-  # A native Guile 2.0 is needed to cross-build Guile.
-  selfNativeBuildInput = true;
-
   enableParallelBuilding = true;
 
   patches = [
     ./eai_system.patch
+    ./riscv.patch
   ] ++
     (stdenv.lib.optional (coverageAnalysis != null) ./gcov-file-name.patch);
 

--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -1,6 +1,8 @@
-{ fetchurl, stdenv, libtool, readline, gmp, pkgconfig, boehmgc, libunistring
-, libffi, gawk, makeWrapper, fetchpatch, coverageAnalysis ? null, gnu ? null
-, hostPlatform, buildPackages
+{ stdenv, buildPackages
+, buildPlatform, hostPlatform
+, fetchurl, makeWrapper, gawk, pkgconfig
+, libffi, libtool, readline, gmp, boehmgc, libunistring
+, coverageAnalysis ? null, gnu ? null
 }:
 
 # Do either a coverage analysis build or a standard build.
@@ -20,9 +22,10 @@
   outputs = [ "out" "dev" "info" ];
   setOutputFlags = false; # $dev gets into the library otherwise
 
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
-  nativeBuildInputs = [ makeWrapper gawk pkgconfig ] ++
-    stdenv.lib.optional stdenv.isCross buildPackages.buildPackages.guile;
+  depsBuildBuild = [ buildPackages.stdenv.cc ]
+    ++ stdenv.lib.optional (hostPlatform != buildPlatform)
+                           buildPackages.buildPackages.guile;
+  nativeBuildInputs = [ makeWrapper gawk pkgconfig ];
   buildInputs = [ readline libtool libunistring libffi ];
 
   propagatedBuildInputs = [ gmp boehmgc ]

--- a/pkgs/development/interpreters/guile/riscv.patch
+++ b/pkgs/development/interpreters/guile/riscv.patch
@@ -1,0 +1,13 @@
+diff --git a/module/system/base/target.scm b/module/system/base/target.scm
+index 95ab8d8c9..93616f4a3 100644
+--- a/module/system/base/target.scm
++++ b/module/system/base/target.scm
+@@ -86,6 +86,8 @@
+              (endianness big))
+             ((string=? "aarch64" cpu)
+              (endianness little))
++            ((string-match "riscv[1-9][0-9]*" cpu)
++             (endianness little))
+             (else
+              (error "unknown CPU endianness" cpu)))))
+ 


### PR DESCRIPTION
###### Motivation for this change

Where noninvasive, I like to port cross fixes back to the 18.03. Also I have some further changes for both which depend on these.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

