### PR TITLE
[18.03] graylog: 2.4.3 -> 2.4.4

### DIFF
--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, makeWrapper, jre_headless }:
 
 stdenv.mkDerivation rec {
   version = "2.4.4";
@@ -12,9 +12,13 @@ stdenv.mkDerivation rec {
   dontBuild = true;
   dontStrip = true;
 
+  buildInputs = [ makeWrapper ];
+  makeWrapperArgs = [ "--prefix" "PATH" ":" "${jre_headless}/bin" ];
+
   installPhase = ''
     mkdir -p $out
     cp -r {graylog.jar,lib,bin,plugin,data} $out
+    wrapProgram $out/bin/graylogctl $makeWrapperArgs
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/graylog/default.nix
+++ b/pkgs/tools/misc/graylog/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "2.4.3";
+  version = "2.4.4";
   name = "graylog-${version}";
 
   src = fetchurl {
     url = "https://packages.graylog2.org/releases/graylog/graylog-${version}.tgz";
-    sha256 = "0kwgg9m9sqzl4y2ri69fpi7w9961psbmfdq3avjsbgbs60ly1hn6";
+    sha256 = "0wiqwwsy306hr7zn57f5hvh8wvcc2q46x0hdlabi0n9m44wk993i";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change
Graylog 2.4.4 release contains a security fix, we should have the fixed version available in 18.03.

The 2nd commit ( 2693d6b98323a5a65e84a293942c38298a7e7c50 ) is not strictly necessary but it keeps 18.03 in sync with master and fixes graylogctl complaining when using it outside of the NixOS module.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] YOLOed it in production without noticing any issues
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

