### PR TITLE
libinput: 1.10.0 -> 1.10.6

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -16,11 +16,11 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libinput-${version}";
-  version = "1.10.0";
+  version = "1.10.6";
 
   src = fetchurl {
     url = "http://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "0mrzsf0349d1g68lizkzxw7vaw459fl8xhl7v0s8njb31hp2riy2";
+    sha256 = "4207742c96980584112b19090413f2d390c6acaaf51c4aac1df9edbbcdfb9b39";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change
UX improvements esp. for trackpoints and touchpads

Note: `nix-shell -p --run "nox-review-wip"` locked up my computer for a while (walked away) and then **failed**, gist at https://gist.github.com/jcrben/b16aefebafd3921dd27a44eb3c72362c - I wonder if the lockup might've caused an issue ('GC Warning: Repeated allocation of very large block (appr. size 217088): May lead to memory leak and poor performance')

Technically I built 1.10.5 from scratch and that succeeded. 1.10.6 just has some tweaks for hardware I don't have, but I will build it to be safe esp given this nox-review.

Background:
* Commits are at https://github.com/wayland-project/libinput/commits/1.10-branch
* Announcements and various discussion at https://lists.freedesktop.org/archives/wayland-devel/ - also left some comments pointing to interesting outstanding bugs at https://github.com/NixOS/nixos-hardware/issues/56 for those interested in digging into hysteresis and acceleration profiles.

This seems better for my thinkpad t460s altho still not as good as my macbook running darwin. Did not test on any other hardware.

cc @codyopel @wkennington @ryantm

PS: noticed the last update was semi-automated, curious about how that works

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

