### PR TITLE
taskwarrior: install zsh completion

### DIFF
--- a/pkgs/applications/misc/taskwarrior/default.nix
+++ b/pkgs/applications/misc/taskwarrior/default.nix
@@ -4,10 +4,8 @@ stdenv.mkDerivation rec {
   name = "taskwarrior-${version}";
   version = "2.5.1";
 
-  enableParallelBuilding = true;
-
   src = fetchurl {
-    url = "http://www.taskwarrior.org/download/task-${version}.tar.gz";
+    url = "https://taskwarrior.org/download/task-${version}.tar.gz";
     sha256 = "059a9yc58wcicc6xxsjh1ph7k2yrag0spsahp1wqmsq6h7jwwyyq";
   };
 
@@ -20,11 +18,13 @@ stdenv.mkDerivation rec {
     ln -s "../../doc/task/scripts/bash/task.sh" "$out/share/bash-completion/completions/task.bash"
     mkdir -p "$out/share/fish/vendor_completions.d"
     ln -s "../../../share/doc/task/scripts/fish/task.fish" "$out/share/fish/vendor_completions.d/"
+    mkdir -p "$out/share/zsh/site-functions"
+    ln -s "../../../share/doc/task/scripts/zsh/_task" "$out/share/zsh/site-functions/"
   '';
 
   meta = with stdenv.lib; {
     description = "Highly flexible command-line tool to manage TODO lists";
-    homepage = http://taskwarrior.org;
+    homepage = https://taskwarrior.org;
     license = licenses.mit;
     maintainers = with maintainers; [ marcweber jgeerds ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
###### Motivation for this change

Upstream provides a zsh completion file which needs to be linked to the correct location.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @marcweber @jgeerds