### PR TITLE
nixos: security.pam: Rename enableU2F and add opts

### DIFF
--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -250,6 +250,9 @@ with lib;
     (mkRenamedOptionModule [ "programs" "info" "enable" ] [ "documentation" "info" "enable" ])
     (mkRenamedOptionModule [ "programs" "man"  "enable" ] [ "documentation" "man"  "enable" ])
 
+    # PAM
+    (mkRenamedOptionModule [ "security" "pam" "enableU2F" ] [ "security" "pam" "u2f" "enable" ])
+
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"
                    "snmpExporter" "unifiExporter" "varnishExporter" ]

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -36,13 +36,21 @@ let
         '';
       };
 
-      u2fAuth = mkOption {
-        default = config.security.pam.enableU2F;
+      u2f.enable = mkOption {
+        default = config.security.pam.u2f.enable;
         type = types.bool;
         description = ''
           If set, users listed in
           <filename>~/.config/Yubico/u2f_keys</filename> are able to log in
           with the associated U2F key.
+        '';
+      };
+
+      u2f.options = mkOption {
+        default = config.security.pam.u2f.options;
+        type = types.str;
+        description = ''
+          Options provided to the U2F PAM module.
         '';
       };
 
@@ -290,8 +298,8 @@ let
               "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u"}
           ${optionalString cfg.fprintAuth
               "auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so"}
-          ${optionalString cfg.u2fAuth
-              "auth sufficient ${pkgs.pam_u2f}/lib/security/pam_u2f.so"}
+          ${optionalString cfg.u2f.enable
+              "auth sufficient ${pkgs.pam_u2f}/lib/security/pam_u2f.so ${cfg.u2f.options}"}
           ${optionalString cfg.usbAuth
               "auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so"}
           ${let oath = config.security.pam.oath; in optionalString cfg.oathAuth
@@ -493,10 +501,19 @@ in
       '';
     };
 
-    security.pam.enableU2F = mkOption {
+    security.pam.u2f.enable = mkOption {
       default = false;
       description = ''
         Enable the U2F PAM module.
+      '';
+    };
+
+    security.pam.u2f.options = mkOption {
+      type = types.str;
+      default = "";
+      example = "authfile=/etc/u2f_mappings cue";
+      description = ''
+        Parameters to supply to the U2F PAM module.
       '';
     };
 
@@ -529,7 +546,7 @@ in
       ++ optionals config.krb5.enable [pam_krb5 pam_ccreds]
       ++ optionals config.security.pam.enableOTPW [ pkgs.otpw ]
       ++ optionals config.security.pam.oath.enable [ pkgs.oathToolkit ]
-      ++ optionals config.security.pam.enableU2F [ pkgs.pam_u2f ];
+      ++ optionals config.security.pam.u2f.enable [ pkgs.pam_u2f ];
 
     boot.supportedFilesystems = optionals config.security.pam.enableEcryptfs [ "ecryptfs" ];
 


### PR DESCRIPTION
Renamed security.pam.enableU2F to security.pam.u2f.enable
Added security.pam.u2f.options

###### Motivation for this change
The old setup makes it impossible to provide options to the U2F PAM module, even though these options provide a lot of extra possibilities in using the module (to hardcode U2F keys in /etc/, for example).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

