### PR TITLE
Install shell completions for beets, borg, exa, youtube-dl

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -174,6 +174,11 @@ in pythonPackages.buildPythonApplication rec {
       test/test_replaygain.py
   '';
 
+  postInstall = ''
+    mkdir -p $out/share/zsh/site-functions
+    cp extra/_beet $out/share/zsh/site-functions/
+  '';
+
   doCheck = true;
 
   preCheck = ''
@@ -222,7 +227,7 @@ in pythonPackages.buildPythonApplication rec {
 
   meta = {
     description = "Music tagger and library organizer";
-    homepage = http://beets.radbox.org;
+    homepage = http://beets.io;
     license = licenses.mit;
     maintainers = with maintainers; [ aszlig domenkozar pjones ];
     platforms = platforms.linux;

--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -44,11 +44,20 @@ python3Packages.buildPythonApplication rec {
     make -C docs man
     mkdir -p $out/share/man
     cp -R docs/_build/man $out/share/man/man1
+
+    mkdir -p $out/share/bash-completion/completions
+    cp scripts/shell_completions/bash/borg $out/share/bash-completion/completions/
+
+    mkdir -p $out/share/fish/vendor_completions.d
+    cp scripts/shell_completions/fish/borg.fish $out/share/fish/vendor_completions.d/
+
+    mkdir -p $out/share/zsh/site-functions
+    cp scripts/shell_completions/zsh/_borg $out/share/zsh/site-functions/
   '';
 
   meta = with stdenv.lib; {
     description = "A deduplicating backup program (attic fork)";
-    homepage = https://borgbackup.github.io/;
+    homepage = https://www.borgbackup.org;
     license = licenses.bsd3;
     platforms = platforms.unix; # Darwin and FreeBSD mentioned on homepage
     maintainers = with maintainers; [ flokli ];

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -23,6 +23,20 @@ buildRustPackage rec {
     libiconv darwin.apple_sdk.frameworks.Security ]
   ;
 
+  postInstall = ''
+    mkdir -p $out/share/man/man1
+    cp contrib/man/exa.1 $out/share/man/man1/
+
+    mkdir -p $out/share/bash-completion/completions
+    cp contrib/completions.bash $out/share/bash-completion/completions/exa
+
+    mkdir -p $out/share/fish/vendor_completions.d
+    cp contrib/completions.fish $out/share/fish/vendor_completions.d/exa.fish
+
+    mkdir -p $out/share/zsh/site-functions
+    cp contrib/completions.zsh $out/share/zsh/site-functions/_exa
+  '';
+
   # Some tests fail, but Travis ensures a proper build
   doCheck = false;
 

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -38,11 +38,16 @@ buildPythonApplication rec {
         ++ optional phantomjsSupport phantomjs2;
     in [ ''--prefix PATH : "${makeBinPath packagesToBinPath}"'' ];
 
+  postInstall = ''
+    mkdir -p $out/share/zsh/site-functions
+    cp youtube-dl.zsh $out/share/zsh/site-functions/_youtube-dl
+  '';
+
   # Requires network
   doCheck = false;
 
   meta = {
-    homepage = http://rg3.github.io/youtube-dl/;
+    homepage = https://rg3.github.io/youtube-dl/;
     repositories.git = https://github.com/rg3/youtube-dl.git;
     description = "Command-line tool to download videos from YouTube.com and other sites";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change

Missing shell completions and in the case of `exa` also a missing man page.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
