### PR TITLE
pypy: 5.10.0 -> 6.0.0

### DIFF
--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -10,19 +10,16 @@
 assert zlibSupport -> zlib != null;
 
 let
-  majorVersion = "6.0";
-  minorVersion = "0";
-  minorVersionSuffix = "";
+  version = "6.0.0";
   pythonVersion = "2.7";
-  version = "${majorVersion}.${minorVersion}${minorVersionSuffix}";
-  libPrefix = "pypy${majorVersion}";
+  libPrefix = "pypy${pythonVersion}";
   sitePackages = "site-packages";
 
   pythonForPypy = python.withPackages (ppkgs: [ ppkgs.pycparser ]);
 
 in stdenv.mkDerivation rec {
   name = "pypy-${version}";
-  inherit majorVersion version pythonVersion;
+  inherit version pythonVersion;
 
   src = fetchurl {
     url = "https://bitbucket.org/pypy/pypy/get/release-pypy${pythonVersion}-v${version}.tar.bz2";

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -116,6 +116,8 @@ in stdenv.mkDerivation rec {
     inherit zlibSupport libPrefix sitePackages;
     executable = "pypy";
     isPypy = true;
+    isPy2 = true;
+    isPy27 = true;
     buildEnv = callPackage ../../wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
     interpreter = "${self}/bin/${executable}";
     withPackages = import ../../with-packages.nix { inherit buildEnv pythonPackages;};

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -79,9 +79,7 @@ in stdenv.mkDerivation rec {
     # disable shutils because it assumes gid 0 exists
     # disable socket because it has two actual network tests that fail
     # disable test_urllib2net, test_urllib2_localnet, and test_urllibnet because they require networking (example.com)
-    # disable test_ssl because no shared cipher' not found in '[Errno 1] error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
-    # disable test_zipfile64 because it causes ENOSPACE
-    ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_ssl or test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil or test_zipfile64 )' lib-python
+    ./pypy-c ./pypy/test_all.py --pypy=./pypy-c -k 'not ( test_urllib2net or test_urllibnet or test_urllib2_localnet or test_socket or test_shutil )' lib-python
   '';
 
   installPhase = ''

--- a/pkgs/development/interpreters/python/pypy/2.7/default.nix
+++ b/pkgs/development/interpreters/python/pypy/2.7/default.nix
@@ -66,12 +66,7 @@ in stdenv.mkDerivation rec {
     ${pythonForPypy.interpreter} rpython/bin/rpython \
       --make-jobs="$NIX_BUILD_CORES" \
       -Ojit \
-      --batch pypy/goal/targetpypystandalone.py \
-      --withmod-_minimal_curses \
-      --withmod-unicodedata \
-      --withmod-thread \
-      --withmod-bz2 \
-      --withmod-_multiprocessing
+      --batch pypy/goal/targetpypystandalone.py
   '';
 
   setupHook = python-setup-hook sitePackages;


### PR DESCRIPTION
###### Motivation for this change

Upgrade pypy from 5.10.0 to 6.0.0. This also includes the improvements from #34066 (but without the addition of pypy3).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

