### PR TITLE
doc: Fixes documented default option for `<name>` for submodules.

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -372,7 +372,13 @@ rec {
             # This is mandatory as some option declaration might use the
             # "name" attribute given as argument of the submodule and use it
             # as the default of option declarations.
-            args.name = "&lt;name&gt;";
+            #
+            # Using lookalike unicode single angle quotation marks because
+            # of the docbook transformation the options receive. In all uses
+            # &gt; and &lt; wouldn't be encoded correctly so the encoded values
+            # would be used, and use of `<` and `>` would break the XML document.
+            # It shouldn't cause an issue since this is cosmetic for the manual.
+            args.name = "‹name›";
           }).options;
         getSubModules = opts';
         substSubModules = m: submodule m;


### PR DESCRIPTION
Fixes #40463

This is related to change 1d56d0c8a79334cd7149fd580512046558eaac78

###### Motivation for this change

Example from the man page:

```
       security.acme.certs.<name>.domain
           Domain to fetch certificate for (defaults to the entry name)
           Type: string
           Default: "‹name›"
           Declared by:
               <nixpkgs/nixos/modules/security/acme.nix>

```

Example from the (local) manual:

![20180513204100](https://user-images.githubusercontent.com/132835/39973444-037bbb78-56ee-11e8-9b78-22a1b4e16ae9.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ❌ macOS
   - ❌ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).