### PR TITLE
[RFC] pythonPackages.libnl: init+bump at 3.4.0 

### DIFF
--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, bison, flex, pkgconfig }:
 
-let version = "3.3.0"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "libnl-${version}";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     repo = "libnl";
     owner = "thom311";
     rev = "libnl${lib.replaceStrings ["."] ["_"] version}";
-    sha256 = "1796kyq2lkhz2802v9kp32vlxf8ynlyqgyw9nhmry3qh5d0ahcsv";
+    sha256 = "1bqf1f5glwf285sa98k5pkj9gg79lliixk1jk85j63v5510fbagp";
   };
 
   outputs = [ "bin" "dev" "out" "man" ];

--- a/pkgs/os-specific/linux/libnl/default.nix
+++ b/pkgs/os-specific/linux/libnl/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, bison, flex, pkgconfig }:
+{ stdenv, file, lib, fetchFromGitHub, fetchpatch, autoreconfHook, bison, flex, pkgconfig
+, pythonSupport ? true, swig ? null, python}:
 
 stdenv.mkDerivation rec {
   name = "libnl-${version}";
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1bqf1f5glwf285sa98k5pkj9gg79lliixk1jk85j63v5510fbagp";
   };
 
-  outputs = [ "bin" "dev" "out" "man" ];
+  outputs = [ "bin" "dev" "out" "man" ] ++ lib.optional pythonSupport "py";
 
   patches = stdenv.lib.optional stdenv.hostPlatform.isMusl
     (fetchpatch {
@@ -21,7 +22,22 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook bison flex pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook bison flex pkgconfig file ]
+    ++ lib.optional pythonSupport swig;
+
+  postBuild = lib.optionalString (pythonSupport) ''
+      cd python
+      ${python}/bin/python setup.py install --prefix=../pythonlib
+      cd -
+  '';
+
+  postFixup = lib.optionalString pythonSupport ''
+    mv "pythonlib/" "$py"
+  '';
+
+  passthru = {
+    inherit pythonSupport;
+  };
 
   meta = with lib; {
     inherit version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6951,6 +6951,9 @@ in {
 
   pylru = callPackage ../development/python-modules/pylru { };
 
+  libnl-python = disabledIf isPy3k
+    (toPythonModule (pkgs.libnl.override{pythonSupport=true; inherit python; })).py;
+
   lark-parser = callPackage ../development/python-modules/lark-parser { };
 
   lazy-object-proxy = buildPythonPackage rec {


### PR DESCRIPTION
Netlink is the userspace <-> kernelspace coomunication protocol.

###### Motivation for this change
I need it
Note: I don't know if it's because netlink examples are outdated or because of my packaging but 
`import netlink.genl.capi`, one would need to do `import netlink.genl._capi`. Maybe I should rename _capi.so to capi.so ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

