### PR TITLE
docs: fix broken link to staging policy

### DIFF
--- a/doc/submitting-changes.xml
+++ b/doc/submitting-changes.xml
@@ -476,7 +476,7 @@ Additional information.
      <para>
       It's only for non-breaking mass-rebuild commits. That means it's not to
       be used for testing, and changes must have been well tested already.
-      <link xlink:href="http://comments.gmane.org/gmane.linux.distributions.nixos/13447">Read
+      <link xlink:href="https://web.archive.org/web/20160528180406/http://comments.gmane.org/gmane.linux.distributions.nixos/13447">Read
       policy here</link>.
      </para>
     </listitem>


### PR DESCRIPTION
###### Motivation for this change
Important policy

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

