### PR TITLE
nixos cups: support for socket activation [WIP]

### DIFF
--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -35,12 +35,11 @@ import ./make-test.nix ({pkgs, ... }: {
       startAll;
 
       # Make sure that cups is up on both sides.
-      $server->waitForUnit("cups.service");
-      $client->waitForUnit("cups.service");
-      $client->sleep(10); # wait until cups is fully initialized
+      $server->waitForUnit("sockets.target");
+      $client->waitForUnit("sockets.target");
       $client->succeed("lpstat -r") =~ /scheduler is running/ or die;
       # Test that UNIX socket is used for connections.
-      $client->succeed("lpstat -H") =~ "/var/run/cups/cups.sock" or die;
+      $client->succeed("lpstat -H") =~ "/run/cups/cups.sock" or die;
       # Test that HTTP server is available too.
       $client->succeed("curl --fail http://localhost:631/");
       $client->succeed("curl --fail http://server:631/");


### PR DESCRIPTION
###### Motivation for this change

With printing enabled, the cups services would start eagerly on boot despite only being needed when printing.

With this PR, cups only start when needed so it takes a few seconds for the print dialog to show.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

