### PR TITLE
nixos: stumpwm: switch from package marked as broken to working quick…

### DIFF
--- a/nixos/modules/services/x11/window-managers/stumpwm.nix
+++ b/nixos/modules/services/x11/window-managers/stumpwm.nix
@@ -15,10 +15,10 @@ in
     services.xserver.windowManager.session = singleton {
       name = "stumpwm";
       start = ''
-        ${pkgs.stumpwm}/bin/stumpwm &
+        ${pkgs.lispPackages.stumpwm}/bin/stumpwm &
         waitPID=$!
       '';
     };
-    environment.systemPackages = [ pkgs.stumpwm ];
+    environment.systemPackages = [ pkgs.lispPackages.stumpwm ];
   };
 }


### PR DESCRIPTION
nixos: stumpwm: switch from package marked as broken to working quicklisp package

###### Motivation for this change

`services.xserver.windowManager.stumpwm.enable` is currently not working as it uses a stumpwm package explicitly marked as broken (`pkgs.stumpwm`). This pull request simply switches to an alternative stumpwm package (`pkgs.lispPackages.stumpwm`) already in NixPkgs, and which is not broken. Furthermore, this package has been built using quicklisp and, arguably, should be the preferred option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

