### PR TITLE
flent: init at 1.2.2

### DIFF
--- a/pkgs/applications/networking/flent/default.nix
+++ b/pkgs/applications/networking/flent/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub, matplotlib, netperf, procps, pyqt5 }:
+
+buildPythonApplication rec {
+  pname = "flent";
+  version = "1.2.2";
+  src = fetchFromGitHub {
+    owner = "tohojo";
+    repo = "flent";
+    rev = version;
+    sha256 = "0rl4ahynl6ymw7r04vpg9p90pplrxc41rjlzvm0swxsvpw40yvkm";
+  };
+
+  buildInputs = [ netperf ];
+  propagatedBuildInputs = [
+    matplotlib
+    procps
+    pyqt5
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The FLExible Network Tester";
+    homepage = https://flent.org;
+    license = licenses.gpl3;
+
+    maintainers = [ maintainers.mmlb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2332,6 +2332,8 @@ with pkgs;
 
   flashrom = callPackage ../tools/misc/flashrom { };
 
+  flent = python3Packages.callPackage ../applications/networking/flent { };
+
   flpsed = callPackage ../applications/editors/flpsed { };
 
   fluentd = callPackage ../tools/misc/fluentd { };


### PR DESCRIPTION
###### Motivation for this change
Add new package, flent for network testing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

