### PR TITLE
gcc,gcc8: {revert gcc to gcc7, mark gcc8 as broken} on Darwin

### DIFF
--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -439,6 +439,9 @@ stdenv.mkDerivation ({
       stdenv.lib.platforms.linux ++
       stdenv.lib.platforms.freebsd ++
       stdenv.lib.platforms.darwin;
+
+    # See #40038
+    broken = stdenv.isDarwin;
   };
 }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6072,7 +6072,8 @@ with pkgs;
   gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { };
 
   gccFun = callPackage ../development/compilers/gcc/7;
-  gcc = gcc8;
+  # Temporary solution until #40038 is fixed
+  gcc = if hostPlatform.isDarwin then gcc7 else gcc8;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6073,7 +6073,7 @@ with pkgs;
 
   gccFun = callPackage ../development/compilers/gcc/7;
   # Temporary solution until #40038 is fixed
-  gcc = if hostPlatform.isDarwin then gcc7 else gcc8;
+  gcc = if stdenv.isDarwin then gcc7 else gcc8;
   gcc-unwrapped = gcc.cc;
 
   gccStdenv = if stdenv.cc.isGNU then stdenv else stdenv.override {

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -110,7 +110,10 @@ let
               jobs.tests.cc-wrapper-gcc7.x86_64-linux
               jobs.tests.cc-wrapper-gcc7.x86_64-darwin
               jobs.tests.cc-wrapper-gcc8.x86_64-linux
+
+              # broken see issue #40038
               # jobs.tests.cc-wrapper-gcc8.x86_64-darwin
+
               jobs.tests.cc-wrapper-clang.x86_64-linux
               jobs.tests.cc-wrapper-clang.x86_64-darwin
               jobs.tests.cc-wrapper-libcxx.x86_64-linux

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -110,7 +110,7 @@ let
               jobs.tests.cc-wrapper-gcc7.x86_64-linux
               jobs.tests.cc-wrapper-gcc7.x86_64-darwin
               jobs.tests.cc-wrapper-gcc8.x86_64-linux
-              jobs.tests.cc-wrapper-gcc8.x86_64-darwin
+              # jobs.tests.cc-wrapper-gcc8.x86_64-darwin
               jobs.tests.cc-wrapper-clang.x86_64-linux
               jobs.tests.cc-wrapper-clang.x86_64-darwin
               jobs.tests.cc-wrapper-libcxx.x86_64-linux


### PR DESCRIPTION
###### Motivation for this change

See #40038.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

