### PR TITLE
minor improvement to nix installation instructions

### DIFF
--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -47,7 +47,7 @@
     Short version:
    </para>
 <screen>
-$ curl https://nixos.org/nix/install | bash
+$ curl https://nixos.org/nix/install | sh
 $ . $HOME/.nix-profile/etc/profile.d/nix.sh # …or open a fresh shell</screen>
    <para>
     More details in the

--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -47,7 +47,7 @@
     Short version:
    </para>
 <screen>
-$ bash &lt;(curl https://nixos.org/nix/install)
+$ curl https://nixos.org/nix/install | bash
 $ . $HOME/.nix-profile/etc/profile.d/nix.sh # …or open a fresh shell</screen>
    <para>
     More details in the


### PR DESCRIPTION
in the command

	$ bash <(curl https://nixos.org/nix/install)

<(..) is a bashism.  The documentation now show a command that does
not require to be executed by bash.

###### Motivation for this change

Trying to install nix in an environment you have control over (think some cloud provider) fail if the 
default shell is not bash.  This change make a minor improvement in the documentation.

---

