### PR TITLE
nexus: fix setup and nixos test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -345,6 +345,7 @@ in rec {
   tests.networking.scripted = callSubTests tests/networking.nix { networkd = false; };
   # TODO: put in networking.nix after the test becomes more complete
   tests.networkingProxy = callTest tests/networking-proxy.nix {};
+  tests.nexus = callTest tests/nexus.nix { };
   tests.nfs3 = callTest tests/nfs.nix { version = 3; };
   tests.nfs4 = callTest tests/nfs.nix { version = 4; };
   tests.nginx = callTest tests/nginx.nix { };

--- a/nixos/tests/nexus.nix
+++ b/nixos/tests/nexus.nix
@@ -1,12 +1,12 @@
 # verifies:
 #   1. nexus service starts on server
-#   2. nexus user can be extended on server
-#   3. nexus service not can startup on server (creating database and all other initial stuff)
+#   2. nexus service can startup on server (creating database and all other initial stuff)
+#   3. the web application is reachable via HTTP
 
 import ./make-test.nix ({ pkgs, ...} : {
   name = "nexus";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ ironpinguin ];
+    maintainers = [ ironpinguin ma27 ];
   };
 
   nodes = {
@@ -14,21 +14,19 @@ import ./make-test.nix ({ pkgs, ...} : {
     server =
       { config, pkgs, ... }:
       { virtualisation.memorySize = 2048;
+        virtualisation.diskSize = 2048;
 
         services.nexus.enable = true;
-
-        users.extraUsers.nexus.extraGroups = [ "users" ];
       };
+
   };
 
   testScript = ''
     startAll;
 
     $server->waitForUnit("nexus");
-
-    print $server->execute("sudo -u nexus groups");
-    $server->mustSucceed("sudo -u nexus groups | grep nexus | grep users");
-
     $server->waitForOpenPort(8081);
+
+    $server->succeed("curl -f 127.0.0.1:8081");
   '';
 })

--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchurl, makeWrapper, jre, gawk }:
+
 stdenv.mkDerivation rec {
   name = "nexus-${version}";
-  version = "3.5.1-02";
+  version = "3.11.0-01";
 
   src = fetchurl {
     url = "https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-${version}-mac.tgz";
-    sha256 = "5ef3512c2bbdd45ef35921c1a0ba109b45bd9dad88311750196aa689262258b6";
+    sha256 = "1h5nfzb1sqhzb5j7w2dpmdi7vnnc9g6zx43a44f3zjvlxh1s0vim";
   };
 
   sourceRoot = name;
 
   nativeBuildInputs = [ makeWrapper ];
 
-  patches = [ ./nexus-bin.patch ];
+  patches = [ ./nexus-bin.patch ./nexus-vm-opts.patch ];
 
   postPatch = ''
     substituteInPlace bin/nexus.vmoptions \
-      --replace ../sonatype-work/nexus3 /run/sonatype-work/nexus3 \
       --replace etc/karaf $out/etc/karaf \
       --replace =. =$out
   '';
@@ -28,14 +28,12 @@ stdenv.mkDerivation rec {
     cp -rfv * .install4j $out
     rm -fv $out/bin/nexus.bat
 
-    runHook postInstall
-  '';
-
-  postInstall = ''
     wrapProgram $out/bin/nexus \
       --set JAVA_HOME ${jre} \
       --set ALTERNATIVE_NAME "nexus" \
       --prefix PATH "${stdenv.lib.makeBinPath [ gawk ]}"
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
@@ -43,6 +41,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.sonatype.org/nexus;
     license = licenses.epl10;
     platforms = platforms.all;
-    maintainers = with maintainers; [ aespinosa ironpinguin ];
+    maintainers = with maintainers; [ aespinosa ironpinguin ma27 ];
   };
 }

--- a/pkgs/development/tools/repository-managers/nexus/nexus-vm-opts.patch
+++ b/pkgs/development/tools/repository-managers/nexus/nexus-vm-opts.patch
@@ -1,0 +1,14 @@
+diff --git a/bin/nexus b/bin/nexus
+index e7ed3fb..8db766b 100755
+--- a/bin/nexus
++++ b/bin/nexus
+@@ -440,7 +440,8 @@ add_class_path "$app_home/lib/boot/org.apache.karaf.diagnostic.boot-4.0.9.jar"
+ add_class_path "$app_home/lib/boot/org.apache.karaf.jaas.boot-4.0.9.jar"
+ 
+ vmoptions_val=""
+-read_vmoptions "$prg_dir/$progname.vmoptions"
++VM_OPTS=${VM_OPTS_FILE:-"$prg_dir/$progname.vmoptions"}
++read_vmoptions "$VM_OPTS"
+ INSTALL4J_ADD_VM_PARAMS="$INSTALL4J_ADD_VM_PARAMS $vmoptions_val"
+ 
+ 


### PR DESCRIPTION
###### Motivation for this change

The original `nexus` derivation required `/run/sonatype-work/nexus3`
which explicitly depended on the NixOS path structure.

This would break `nexus` for everyone using `nixpkgs` on a non-NixOS
system, additionally the module never created `/run/sonatype-work`, so
the systemd unit created in `services.nexus` fails as well. The issue
wasn't actively known as the `nixos/nexus` test wasn't registered in
Hydra (see #40257).

This patch contains the following changes:

* Adds `tests.nexus` to `release.nix` to run the test on Hydra.

* Makes JVM parameters configurable: by default all JVM options were located
  in `result/bin/nexus.vmoptions` which made it quite hard to patch
  these parameters. Now it's possible to override all parameters by
  running `VM_OPTS_FILE=custom-nexus.vmoptions ./result/bin/nexus run`
  (after patching the `nexus` shell script), additionally it's possible
  to override these parameters with `services.nexus.vmoptions`.

* Bumped Nexus from 3.5.1 to 3.11.0

* Run the `nexus` test on Hydra with `callTest` in `nixos/release.nix`,
  furthermore the test checks if the UI is available on the specified
  port.

* Added myself as maintainer for the NixOS test and the package to have
  some more people in case of further breakage.

* Added sufficient disk space to the `nexus` test, otherwise the service
  fails with the following errors:

  ```
  com.orientechnologies.orient.core.exception.ODatabaseException: Cannot create database 'accesslog'
  com.orientechnologies.orient.core.exception.OLowDiskSpaceException: Error occurred while executing
    a write operation to database 'accesslog' due to limited free space on the disk (242 MB). The database
    is now working in read-only mode. Please close the database (or stop OrientDB), make room on your hard
    drive and then reopen the database. The minimal required space is 256 MB. Required space is now set to
    256MB (you can change it by setting parameter storage.diskCache.diskFreeSpaceLimit) .
  ```

/cc @ironpinguin @xeji

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

