### PR TITLE
minimap2: init at 2.10

### DIFF
--- a/pkgs/applications/science/biology/minimap2/default.nix
+++ b/pkgs/applications/science/biology/minimap2/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "minimap2";
+  version = "2.10";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "lh3";
+    rev = "v${version}";
+    sha256 = "0b35w14j9h2q9qbh3sxc518mcx0ifsvwqr1nv70rv6mgy1cqqkw0";
+  };
+
+  buildInputs = [ zlib ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp minimap2 $out/bin
+    mkdir -p $out/share/man/man1
+    cp minimap2.1 $out/share/man/man1
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "A versatile pairwise aligner for genomic and spliced nucleotide sequences";
+    homepage = https://lh3.github.io/minimap2;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.arcadio ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19927,6 +19927,8 @@ with pkgs;
     inherit (perlPackages) GetoptTabular MNI-Perllib;
   };
 
+  minimap2 = callPackage ../applications/science/biology/minimap2 { };
+
   ncbi_tools = callPackage ../applications/science/biology/ncbi-tools { };
 
   paml = callPackage ../applications/science/biology/paml { };


### PR DESCRIPTION
###### Motivation for this change

Add a new derivation for minimap2, an increasingly popular aligner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

