### PR TITLE
pythonPackages.asyncssh: init at 1.13.0

### DIFF
--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, cryptography
+, bcrypt, gssapi, libnacl, libsodium, nettle, pyopenssl }:
+
+buildPythonPackage rec {
+  pname = "asyncssh";
+  version = "1.12.2";
+  disabled = pythonOlder "3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "154zgl527dach974w8fad0aw326rnhxsrx79svad8vz7wn4dycv9";
+  };
+
+  propagatedBuildInputs = [ 
+    bcrypt
+    cryptography
+    gssapi
+    libnacl
+    libsodium
+    nettle
+    pyopenssl
+  ];
+
+  # Disables windows specific test (specifically the GSSAPI wrapper for Windows)
+  postPatch = ''
+    rm ./tests/sspi_stub.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Provides an asynchronous client and server implementation of the SSHv2 protocol on top of the Python asyncio framework";
+    homepage = https://pypi.python.org/pypi/asyncssh;
+    license = licenses.epl10;
+    maintainers = with maintainers; [ worldofpeace ];
+  };
+}

--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -4,12 +4,12 @@
 
 buildPythonPackage rec {
   pname = "asyncssh";
-  version = "1.12.2";
+  version = "1.13.0";
   disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "154zgl527dach974w8fad0aw326rnhxsrx79svad8vz7wn4dycv9";
+    sha256 = "1n75z4dvhzymd4n610dpwlq7wl8cyz1gxx9m7iq92pzhss5vgpfd";
   };
 
   propagatedBuildInputs = [ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -539,6 +539,8 @@ in {
 
   asyncio = callPackage ../development/python-modules/asyncio {};
 
+  asyncssh = callPackage ../development/python-modules/asyncssh { };
+
   python-fontconfig = callPackage ../development/python-modules/python-fontconfig { };
 
   funcsigs = callPackage ../development/python-modules/funcsigs { };


### PR DESCRIPTION
###### Motivation for this change
I needed this

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

