### PR TITLE
MinGW, Hurd: Clean ups and crossConfig removal

### DIFF
--- a/pkgs/os-specific/gnu/hurd/default.nix
+++ b/pkgs/os-specific/gnu/hurd/default.nix
@@ -75,25 +75,16 @@ stdenv.mkDerivation ({
 
 //
 
-(if !headersOnly && buildTarget != null
- then assert installTarget != null; {
-   # Use the default `buildPhase' and `installPhase' so that the usual hooks
-   # can still be used.
-   buildFlags = buildTarget;
-   installTargets = installTarget;
- }
- else {})
+stdenv.lib.optionalAttrs (!headersOnly && buildTarget != null) {
+  # Use the default `buildPhase' and `installPhase' so that the usual hooks
+  # can still be used.
+  buildFlags = buildTarget;
+  installTargets = assert installTarget != null; installTarget;
+}
 
 //
 
-(if headersOnly
- then { dontBuild = true; installPhase = "make install-headers"; }
- else (if (cross != null)
-       then {
-         crossConfig = cross.config;
-
-         # The `configure' script wants to build executables so tell it where
-         # to find `crt1.o' et al.
-         LDFLAGS = "-B${glibcCross}/lib";
-       }
-       else { })))
+stdenv.lib.optionalAttrs headersOnly {
+  dontBuild = true;
+  installPhase = "make install-headers";
+})

--- a/pkgs/os-specific/gnu/libpthread/default.nix
+++ b/pkgs/os-specific/gnu/libpthread/default.nix
@@ -55,8 +55,6 @@ stdenv.mkDerivation ({
 
 (if cross != null
  then {
-   crossConfig = cross.config;
-
    # Tell gcc where to find `crt1.o' et al.  This is specified in two
    # different ways: one for gcc as run from `configure', and one for linking
    # libpthread.so (by default `libtool --mode=link' swallows `-B', hence

--- a/pkgs/os-specific/windows/mingwrt/common.nix
+++ b/pkgs/os-specific/windows/mingwrt/common.nix
@@ -1,0 +1,12 @@
+{ lib, fetchurl }:
+
+rec {
+  name = "mingwrt-3.20";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mingw/MinGW/Base/mingw-rt/${name}-mingw32-src.tar.gz";
+    sha256 = "02pydg1m8y35nxb4k34nlb5c341y2waq76z42mgdzlcf661r91pi";
+  };
+
+  meta.platforms = [ lib.systems.inspect.isMinGW ];
+}

--- a/pkgs/os-specific/windows/mingwrt/default.nix
+++ b/pkgs/os-specific/windows/mingwrt/default.nix
@@ -1,29 +1,7 @@
-{stdenv, fetchurl, binutils ? null, gccCross ? null, onlyHeaders ? false}:
+{ stdenv, callPackage }:
 
-let
-  name = "mingwrt-3.20";
-in
-stdenv.mkDerivation (rec {
-  inherit name;
-
-  src = fetchurl {
-    url = "mirror://sourceforge/mingw/MinGW/Base/mingw-rt/${name}-mingw32-src.tar.gz";
-    sha256 = "02pydg1m8y35nxb4k34nlb5c341y2waq76z42mgdzlcf661r91pi";
-  };
-
-} //
-(if onlyHeaders then {
-  name = name + "-headers";
-  phases = [ "unpackPhase" "installPhase" ];
-  installPhase = ''
-    mkdir -p $out
-    cp -R include $out
-  '';
-} else {
-  buildInputs = [ gccCross binutils ];
-
-  crossConfig = gccCross.crossConfig;
-
+stdenv.mkDerivation {
+  inherit (callPackage ./common.nix {}) name src meta;
   dontStrip = true;
-})
-)
+  hardeningDisable = [ "stackprotector" "fortify" ];
+}

--- a/pkgs/os-specific/windows/mingwrt/headers.nix
+++ b/pkgs/os-specific/windows/mingwrt/headers.nix
@@ -1,0 +1,17 @@
+{ stdenvNoCC, callPackage }:
+
+let
+  inherit (callPackage ./common.nix {}) name src meta;
+
+in stdenvNoCC.mkDerivation {
+  name = name + "-headers";
+
+  inherit src meta;
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R include $out
+  '';
+}

--- a/pkgs/os-specific/windows/w32api/common.nix
+++ b/pkgs/os-specific/windows/w32api/common.nix
@@ -1,0 +1,14 @@
+{ fetchurl, xz }:
+
+rec {
+  name = "w32api-3.17-2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/mingw/MinGW/Base/w32api/w32api-3.17/${name}-mingw32-src.tar.lzma";
+    sha256 = "09rhnl6zikmdyb960im55jck0rdy5z9nlg3akx68ixn7khf3j8wb";
+  };
+
+  nativeBuildInputs = [ xz ];
+
+  meta.platforms = [ lib.systems.inspect.isMinGW ];
+}

--- a/pkgs/os-specific/windows/w32api/default.nix
+++ b/pkgs/os-specific/windows/w32api/default.nix
@@ -1,32 +1,6 @@
-{ stdenv, fetchurl, xz, binutils ? null
-, gccCross ? null, onlyHeaders ? false }:
+{ stdenv, callPackage }:
 
-let
-  name = "w32api-3.17-2";
-in
-stdenv.mkDerivation ({
-  inherit name;
-
-  src = fetchurl {
-    url = "mirror://sourceforge/mingw/MinGW/Base/w32api/w32api-3.17/${name}-mingw32-src.tar.lzma";
-    sha256 = "09rhnl6zikmdyb960im55jck0rdy5z9nlg3akx68ixn7khf3j8wb";
-  };
-
-  nativeBuildInputs = [ xz ];
-
-} //
-(if onlyHeaders then {
-  name = name + "-headers";
-  phases = [ "unpackPhase" "installPhase" ];
-  installPhase = ''
-    mkdir -p $out
-    cp -R include $out
-  '';
-} else {
-  buildInputs = [ gccCross binutils ];
-
-  crossConfig = gccCross.crossConfig;
-
+stdenv.mkDerivation {
+  inherit (callPackage ./common.nix {}) name src nativeBuildInputs meta;
   dontStrip = true;
-})
-)
+}

--- a/pkgs/os-specific/windows/w32api/headers.nix
+++ b/pkgs/os-specific/windows/w32api/headers.nix
@@ -1,0 +1,17 @@
+{ stdenvNoCC, callPackage }:
+
+let
+  inherit (callPackage ./common.nix {}) name src meta;
+
+in stdenvNoCC.mkDerivation {
+  name = name + "-headers";
+
+  inherit src nativeBuildInputs meta;
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R include $out
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13868,23 +13868,13 @@ with pkgs;
 
     jom = callPackage ../os-specific/windows/jom { };
 
-    w32api = callPackage ../os-specific/windows/w32api {
-      gccCross = gccCrossStageStatic;
-      binutils = binutils;
-    };
+    w32api = callPackage ../os-specific/windows/w32api { };
 
-    w32api_headers = w32api.override {
-      onlyHeaders = true;
-    };
+    w32api_headers = callPackage ../os-specific/windows/w32api/headers { };
 
-    mingw_runtime = callPackage ../os-specific/windows/mingwrt {
-      gccCross = gccCrossMingw2;
-      binutils = binutils;
-    };
+    mingw_runtime = callPackage ../os-specific/windows/mingwrt { };
 
-    mingw_runtime_headers = mingw_runtime.override {
-      onlyHeaders = true;
-    };
+    mingw_runtime_headers = callPackage ../os-specific/windows/mingwrt/headers.nix { };
 
     mingw_headers1 = buildEnv {
       name = "mingw-headers-1";


### PR DESCRIPTION
###### Motivation for this change

Backport of #40530. The mingw changes might actually be useful for stable. The Hurd changes certainly aren't, but are useful for other refactors which are staging relevant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

