### PR TITLE
treewide: Remove uses of crossConfig and add strictDeps

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -186,6 +186,7 @@ stdenv.mkDerivation {
       else throw "unknown emulation for platform: " + targetPlatform.config;
     in targetPlatform.platform.bfdEmulation or (fmt + sep + arch);
 
+  strictDeps = true;
   depsTargetTargetPropagated = extraPackages;
 
   setupHook = ./setup-hook.sh;

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -8,7 +8,7 @@ set -u
 # native compile.
 #
 # TODO(@Ericson2314): No native exception
-[[ -z ${crossConfig-} ]] || (( "$hostOffset" < 0 )) || return 0
+[[ -z ${strictDeps-} ]] || (( "$hostOffset" < 0 )) || return 0
 
 bintoolsWrapper_addLDVars () {
     case $depHostOffset in

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -201,6 +201,7 @@ stdenv.mkDerivation {
       ln -s $ccPath/${targetPrefix}ghdl $out/bin/${targetPrefix}ghdl
     '';
 
+  strictDeps = true;
   propagatedBuildInputs = [ bintools ];
   depsTargetTargetPropagated = extraPackages;
 

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -60,7 +60,7 @@ set -u
 # native compile.
 #
 # TODO(@Ericson2314): No native exception
-[[ -z ${crossConfig-} ]] || (( "$hostOffset" < 0 )) || return 0
+[[ -z ${strictDeps-} ]] || (( "$hostOffset" < 0 )) || return 0
 
 # It's fine that any other cc-wrapper will redefine this. Bash functions close
 # over no state, and there's no @-substitutions within, so any redefined

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -129,10 +129,8 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
-  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
-  # compatability. This will be replaced with something clearer in a future
-  # masss-rebuild.
-  crossConfig = true;
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [
     ghc perl libxml2 libxslt docbook_xsl docbook_xml_dtd_45 docbook_xml_dtd_42 hscolour

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -128,10 +128,8 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
-  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
-  # compatability. This will be replaced with something clearer in a future
-  # masss-rebuild.
-  crossConfig = true;
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [ ghc perl hscolour sphinx ];
 

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -145,10 +145,8 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
-  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
-  # compatability. This will be replaced with something clearer in a future
-  # masss-rebuild.
-  crossConfig = true;
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [ alex autoconf autoreconfHook automake ghc happy hscolour perl python3 sphinx ];
 

--- a/pkgs/development/compilers/ghc/8.4.1.nix
+++ b/pkgs/development/compilers/ghc/8.4.1.nix
@@ -144,10 +144,8 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
-  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
-  # compatability. This will be replaced with something clearer in a future
-  # masss-rebuild.
-  crossConfig = true;
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -134,10 +134,8 @@ stdenv.mkDerivation rec {
     "--disable-large-address-space"
   ];
 
-  # Hack to make sure we never to the relaxation `$PATH` and hooks support for
-  # compatability. This will be replaced with something clearer in a future
-  # masss-rebuild.
-  crossConfig = true;
+  # Make sure we never relax`$PATH` and hooks support for compatability.
+  strictDeps = true;
 
   nativeBuildInputs = [ ghc perl autoconf automake happy alex python3 ];
 

--- a/pkgs/development/libraries/fontconfig/2.10.nix
+++ b/pkgs/development/libraries/fontconfig/2.10.nix
@@ -21,18 +21,9 @@ stdenv.mkDerivation rec {
     "--with-cache-dir=/var/cache/fontconfig"
     "--disable-docs"
     "--with-default-fonts="
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--with-arch=${hostPlatform.parsed.cpu.name}"
   ];
-
-  # We should find a better way to access the arch reliably.
-  crossArch = if stdenv.hostPlatform != stdenv.buildPlatform
-    then hostPlatform.parsed.cpu.name
-    else null;
-
-  preConfigure = ''
-    if test -n "$crossConfig"; then
-      configureFlags="$configureFlags --with-arch=$crossArch";
-    fi
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -53,18 +53,9 @@ stdenv.mkDerivation rec {
     "--disable-docs"
     # just <1MB; this is what you get when loading config fails for some reason
     "--with-default-fonts=${dejavu_fonts.minimal}"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--with-arch=${hostPlatform.parsed.cpu.name}"
   ];
-
-  # We should find a better way to access the arch reliably.
-  crossArch = if stdenv.hostPlatform != stdenv.buildPlatform
-    then hostPlatform.parsed.cpu.name
-    else null;
-
-  preConfigure = ''
-    if test -n "$crossConfig"; then
-      configureFlags="$configureFlags --with-arch=$crossArch";
-    fi
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -16,12 +16,19 @@ stdenv.mkDerivation rec {
 
   LDFLAGS = if stdenv.isSunOS then "-lm -lmd -lmp -luutil -lnvpair -lnsl -lidmap -lavl -lsec" else "";
 
-  configureFlags = [ "--disable-csharp" "--with-xz" ]
+  configureFlags = [
+     "--disable-csharp" "--with-xz"
      # avoid retaining reference to CF during stdenv bootstrap
-     ++ lib.optionals stdenv.isDarwin [
-            "gt_cv_func_CFPreferencesCopyAppValue=no"
-            "gt_cv_func_CFLocaleCopyCurrent=no"
-        ];
+  ] ++ lib.optionals stdenv.isDarwin [
+    "gt_cv_func_CFPreferencesCopyAppValue=no"
+    "gt_cv_func_CFLocaleCopyCurrent=no"
+  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    # On cross building, gettext supposes that the wchar.h from libc
+    # does not fulfill gettext needs, so it tries to work with its
+    # own wchar.h file, which does not cope well with the system's
+    # wchar.h and stddef.h (gcc-4.3 - glibc-2.9)
+    "gl_cv_func_wcwidth_works=yes"
+  ];
 
   postPatch = ''
    substituteAllInPlace gettext-runtime/src/gettext.sh.in
@@ -31,17 +38,6 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString hostPlatform.isCygwin ''
     sed -i -e "s/\(cldr_plurals_LDADD = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" gettext-tools/src/Makefile.in
     sed -i -e "s/\(libgettextsrc_la_LDFLAGS = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" gettext-tools/src/Makefile.in
-  '';
-
-  # On cross building, gettext supposes that the wchar.h from libc
-  # does not fulfill gettext needs, so it tries to work with its
-  # own wchar.h file, which does not cope well with the system's
-  # wchar.h and stddef.h (gcc-4.3 - glibc-2.9)
-  preConfigure = ''
-    if test -n "$crossConfig"; then
-      echo gl_cv_func_wcwidth_works=yes > cachefile
-      configureFlags="$configureFlags --cache-file=`pwd`/cachefile"
-    fi
   '';
 
   nativeBuildInputs = [ xz xz.bin ];

--- a/pkgs/development/libraries/glibc/2.27.nix
+++ b/pkgs/development/libraries/glibc/2.27.nix
@@ -71,14 +71,15 @@ callPackage ./common-2.27.nix { inherit stdenv; } {
 
       # Get rid of more unnecessary stuff.
       rm -rf $out/var $bin/bin/sln
-
+    ''
       # For some reason these aren't stripped otherwise and retain reference
       # to bootstrap-tools; on cross-arm this stripping would break objects.
-      if [ -z "$crossConfig" ]; then
-        for i in "$out"/lib/*.a; do
-            [ "$i" = "$out/lib/libm.a" ] || strip -S "$i"
-        done
-      fi
+    + stdenv.lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+
+      for i in "$out"/lib/*.a; do
+          [ "$i" = "$out/lib/libm.a" ] || $STRIP -S "$i"
+      done
+    '' + ''
 
       # Put libraries for static linking in a separate output.  Note
       # that libc_nonshared.a and libpthread_nonshared.a are required

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -71,14 +71,15 @@ callPackage ./common.nix { inherit stdenv; } {
 
       # Get rid of more unnecessary stuff.
       rm -rf $out/var $bin/bin/sln
-
+    ''
       # For some reason these aren't stripped otherwise and retain reference
       # to bootstrap-tools; on cross-arm this stripping would break objects.
-      if [ -z "$crossConfig" ]; then
-        for i in "$out"/lib/*.a; do
-            [ "$i" = "$out/lib/libm.a" ] || strip -S "$i"
-        done
-      fi
+    + stdenv.lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+
+      for i in "$out"/lib/*.a; do
+          [ "$i" = "$out/lib/libm.a" ] || $STRIP -S "$i"
+      done
+    '' + ''
 
       # Put libraries for static linking in a separate output.  Note
       # that libc_nonshared.a and libpthread_nonshared.a are required

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -29,20 +29,17 @@ cmakeConfigurePhase() {
         cmakeFlags="-DCMAKE_INSTALL_PREFIX=$prefix $cmakeFlags"
     fi
 
-    if [ -n "$crossConfig" ]; then
-        # By now it supports linux builds only. We should set the proper
-        # CMAKE_SYSTEM_NAME otherwise.
-        # http://www.cmake.org/Wiki/CMake_Cross_Compiling
-        #
-        # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
-        # strip. Otherwise they are taken to be relative to the source root of
-        # the package being built.
-        cmakeFlags="-DCMAKE_CXX_COMPILER=$crossConfig-c++ $cmakeFlags"
-        cmakeFlags="-DCMAKE_C_COMPILER=$crossConfig-cc $cmakeFlags"
-        cmakeFlags="-DCMAKE_AR=$(command -v $crossConfig-ar) $cmakeFlags"
-        cmakeFlags="-DCMAKE_RANLIB=$(command -v $crossConfig-ranlib) $cmakeFlags"
-        cmakeFlags="-DCMAKE_STRIP=$(command -v $crossConfig-strip) $cmakeFlags"
-    fi
+    # We should set the proper `CMAKE_SYSTEM_NAME`.
+    # http://www.cmake.org/Wiki/CMake_Cross_Compiling
+    #
+    # Unfortunately cmake seems to expect absolute paths for ar, ranlib, and
+    # strip. Otherwise they are taken to be relative to the source root of the
+    # package being built.
+    cmakeFlags="-DCMAKE_CXX_COMPILER=$CXX $cmakeFlags"
+    cmakeFlags="-DCMAKE_C_COMPILER=$CC $cmakeFlags"
+    cmakeFlags="-DCMAKE_AR=$(command -v $AR) $cmakeFlags"
+    cmakeFlags="-DCMAKE_RANLIB=$(command -v $RANLAB) $cmakeFlags"
+    cmakeFlags="-DCMAKE_STRIP=$(command -v $STRIP) $cmakeFlags"
 
     # This installs shared libraries with a fully-specified install
     # name. By default, cmake installs shared libraries with just the

--- a/pkgs/misc/uboot/nanonote.nix
+++ b/pkgs/misc/uboot/nanonote.nix
@@ -1,8 +1,5 @@
 {stdenv, fetchurl, fetchgit}:
 
-# We should enable this check once we have the cross target system information
-# assert stdenv.system == "armv5tel-linux" || crossConfig == "armv5tel-linux";
-
 # All this file is made for the Marvell Sheevaplug
    
 stdenv.mkDerivation {
@@ -30,21 +27,19 @@ stdenv.mkDerivation {
     sed -i -e 's/0x200000;bootm/0x400000;bootm/' include/configs/qi_lb60.h
   '';
 
-  # Remove the cross compiler prefix, and add reiserfs support
+  makeFlags = [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
+
+  # Add reiserfs support
   configurePhase = ''
     make mrproper
     make qi_lb60_config
-    sed -i /CROSS_COMPILE/d include/config.mk
   '';
 
-  buildPhase = ''
+  preBuild= ''
     # A variable named 'src' used to affect the build in some uboot...
-    unset src
-    if test -z "$crossConfig"; then
-        make clean all
-    else
-        make clean all ARCH=mips CROSS_COMPILE=$crossConfig-
-    fi
+    unset -v src
   '';
 
   dontStrip = true;
@@ -59,6 +54,6 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    platforms = [ "mipsel-linux" ];
+    platforms = stdenv.lib.platforms.mips;
   };
 }

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -5,11 +5,9 @@ let
   inherit (stdenv) lib isDarwin;
   inherit (lib) overrideDerivation;
 
-  setMalloc0ReturnsNullCrossCompiling = ''
-    if test -n "$crossConfig"; then
-      configureFlags="$configureFlags --enable-malloc0returnsnull";
-    fi
-  '';
+  malloc0ReturnsNullCrossFlag = stdenv.lib.optional
+    (stdenv.hostPlatform != stdenv.buildPlatform)
+    "--enable-malloc0returnsnull";
 
   gitRelease = { libName, version, rev, sha256 } : attrs : attrs // {
     name = libName + "-" + version;
@@ -101,7 +99,9 @@ in
 
   libX11 = attrs: attrs // {
     outputs = [ "out" "dev" "man" ];
-    preConfigure = setMalloc0ReturnsNullCrossCompiling + ''
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
+    preConfigure = ''
       sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure
     '';
     postInstall =
@@ -138,16 +138,19 @@ in
 
   libXxf86vm = attrs: attrs // {
     outputs = [ "out" "dev" ];
-    preConfigure = setMalloc0ReturnsNullCrossCompiling;
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
   };
 
   # Propagate some build inputs because of header file dependencies.
   # Note: most of these are in Requires.private, so maybe builder.sh
   # should propagate them automatically.
   libXt = attrs: attrs // {
-    preConfigure = setMalloc0ReturnsNullCrossCompiling + ''
+    preConfigure = ''
       sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure
     '';
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
     propagatedBuildInputs = [ xorg.libSM ];
     CPP = stdenv.lib.optionalString stdenv.isDarwin "clang -E -";
     outputs = [ "out" "dev" "devdoc" ];
@@ -188,7 +191,8 @@ in
   libXft = attrs: attrs // {
     outputs = [ "out" "dev" ];
     propagatedBuildInputs = [ xorg.libXrender args.freetype args.fontconfig ];
-    preConfigure = setMalloc0ReturnsNullCrossCompiling;
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
     # the include files need ft2build.h, and Requires.private isn't enough for us
     postInstall = ''
       sed "/^Requires:/s/$/, freetype2/" -i "$dev/lib/pkgconfig/xft.pc"
@@ -198,7 +202,8 @@ in
   libXext = attrs: attrs // {
     outputs = [ "out" "dev" "man" "doc" ];
     propagatedBuildInputs = [ xorg.xproto xorg.libXau ];
-    preConfigure = setMalloc0ReturnsNullCrossCompiling;
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
   };
 
   libXfixes = attrs: attrs // {
@@ -221,7 +226,8 @@ in
 
   libXrandr = attrs: attrs // {
     outputs = [ "out" "dev" ];
-    preConfigure = setMalloc0ReturnsNullCrossCompiling;
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
     propagatedBuildInputs = [xorg.libXrender];
   };
 
@@ -232,8 +238,9 @@ in
 
   libXrender = attrs: attrs // {
     outputs = [ "out" "dev" "doc" ];
+    configureFlags = attrs.configureFlags or []
+      ++ malloc0ReturnsNullCrossFlag;
     propagatedBuildInputs = [ xorg.renderproto ];
-    preConfigure = setMalloc0ReturnsNullCrossCompiling;
   };
 
   libXres = attrs: attrs // {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -52,7 +52,8 @@ rec {
     # InstallCheck phase
     , doInstallCheck ? false
 
-    , crossConfig ? null
+    , # TODO(@Ericson2314): Make always true and remove
+      strictDeps ? stdenv.hostPlatform != stdenv.buildPlatform
     , meta ? {}
     , passthru ? {}
     , pos ? # position used in error messages and for meta.position
@@ -155,6 +156,8 @@ rec {
           inherit (stdenv) system;
           userHook = config.stdenv.userHook or null;
           __ignoreNulls = true;
+
+          inherit strictDeps;
 
           depsBuildBuild              = lib.elemAt (lib.elemAt dependencies 0) 0;
           nativeBuildInputs           = lib.elemAt (lib.elemAt dependencies 0) 1;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -501,7 +501,7 @@ activatePackage() {
     # the transition, we do include everything in thatcase.
     #
     # TODO(@Ericson2314): Don't special-case native compilation
-    if [[ ( -z "${crossConfig-}" ||  "$hostOffset" -le -1 ) && -d "$pkg/bin" ]]; then
+    if [[ ( -z "${strictDeps-}" ||  "$hostOffset" -le -1 ) && -d "$pkg/bin" ]]; then
         addToSearchPath _PATH "$pkg/bin"
     fi
 
@@ -551,7 +551,7 @@ _addToEnv() {
         for depTargetOffset in "${allPlatOffsets[@]}"; do
             (( "$depHostOffset" <= "$depTargetOffset" )) || continue
             local hookRef="${hookVar}[$depTargetOffset - $depHostOffset]"
-            if [[ -z "${crossConfig-}" ]]; then
+            if [[ -z "${strictDeps-}" ]]; then
                 # Apply environment hooks to all packages during native
                 # compilation to ease the transition.
                 #

--- a/pkgs/tools/misc/bc/default.nix
+++ b/pkgs/tools/misc/bc/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   # Hack to make sure we never to the relaxation `$PATH` and hooks support for
   # compatability. This will be replaced with something clearer in a future
   # masss-rebuild.
-  crossConfig = true;
+  strictDeps = true;
 
   meta = {
     description = "GNU software calculator";


### PR DESCRIPTION
Backport of #40529

I carefully kept the *definition* of `crossConfig` in the stdenv adapter, as removing it would be a breaking change. 

###### Motivation for this change

Besides the general idea of back-porting simple cross fixes, `strictDeps` is needed to make some large Haskell apps build. Yes, this can already be accomplished with `crossConfig = true`, but that is awful to teach and not really a public interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @srhb @TravisWhitaker