### PR TITLE
check-{ups,nwc}-health: update to release versions

### DIFF
--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -1,25 +1,24 @@
-{ stdenv, fetchFromGitHub, buildPerlPackage, autoreconfHook, makeWrapper
+{ stdenv, fetchFromGitHub, fetchurl, buildPerlPackage, autoreconfHook, makeWrapper
 , perl, NetSNMP, coreutils, gnused, gnugrep }:
 
 let
-  owner = "lausser";
-
   glplugin = fetchFromGitHub {
+    owner = "lausser";
     repo   = "GLPlugin";
-    rev    = "b92a261ca4bf84e5b20d3025cc9a31ade03c474b";
-    sha256 = "0kflnmpjmklq8fy2vf2h8qyvaiznymdi09z2h5qscrfi51xc9gmh";
-    inherit owner;
+    rev    = "e8e1a2907a54435c932b3e6c584ba1d679754849";
+    sha256 = "0wb55a9pmgbilfffx0wkiikg9830qd66j635ypczqp4basslpq5b";
   };
 
-  generic = { pname, version, rev, sha256, description, ... } @ attrs:
+  generic = { pname, version, sha256, description, ... } @ attrs:
   let
     attrs' = builtins.removeAttrs attrs [ "pname" "version" "rev" "sha256"];
+    name' = "${stdenv.lib.replaceStrings [ "-" ] [ "_" ] "${pname}"}-${version}";
   in perl.stdenv.mkDerivation rec {
-    name = stdenv.lib.replaceStrings [ "-" ] [ "_" ] "${pname}-${version}";
+    name = "${pname}-${version}";
 
-    src = fetchFromGitHub {
-      repo   = pname;
-      inherit owner rev sha256;
+    src = fetchurl {
+      url = "https://labs.consol.de/assets/downloads/nagios/${name'}.tar.gz";
+      inherit sha256;
     };
 
     buildInputs = [ perl NetSNMP ];
@@ -27,7 +26,8 @@ let
     nativeBuildInputs = [ autoreconfHook makeWrapper ];
 
     prePatch = with stdenv.lib; ''
-      ln -s ${glplugin}/* GLPlugin
+      rm -rf GLPlugin
+      ln -s ${glplugin} GLPlugin
       substituteInPlace plugins-scripts/Makefile.am \
         --replace /bin/cat  ${getBin coreutils}/bin/cat \
         --replace /bin/echo ${getBin coreutils}/bin/echo \
@@ -56,17 +56,15 @@ let
 in {
   check-nwc-health = generic {
     pname       = "check_nwc_health";
-    version     = "20170804";
-    rev         = "e959b412b5cf027c82a446668e026214fdcf8df3";
-    sha256      = "11l74xw62g15rqrbf9ff2bfd5iw159gwhhgbkxwdqi8sp9j6navk";
+    version     = "7.0.1.3";
+    sha256      = "0rgd6zgd7kplx3z72n8zbzwkh8vnd83361sk9ibh6ng78sds1sl5";
     description = "Check plugin for network equipment.";
   };
 
   check-ups-health = generic {
     pname       = "check_ups_health";
-    version     = "20170804";
-    rev         = "32a8a359ea46ec0d6f3b7aea19ddedaad63b04b9";
-    sha256      = "05na48dxfxrg0i9185j1ck2795p0rw1zwcs8ra0f14cm0qw0lp4l";
+    version     = "2.8.2.2";
+    sha256      = "1gc2wjsymay2vk5ywc1jj9cvrbhs0fs851x8l4nc75df2g75v521";
     description = "Check plugin for UPSs.";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

We were pulling random git commits - use released versions instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

