### PR TITLE
cura: fix invisible sidebar and install missing materials

### DIFF
--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -11,6 +11,13 @@ mkDerivation rec {
     sha256 = "0yaya0ww92qjm7g31q85m5f95nwdapldjx1kdf1ar4yzwh4r15rp";
   };
 
+  materials = fetchFromGitHub {
+    owner = "Ultimaker";
+    repo = "fdm_materials";
+    rev = "3.2.1";
+    sha256 = "1kr9ga727x0kazw2ypac9bi6g6lddbsx80qw8fbn0514kg2mr9n3";
+  };
+
   buildInputs = [ qtbase qtquickcontrols2 ];
   propagatedBuildInputs = with python3.pkgs; [ uranium zeroconf pyserial numpy-stl ];
   nativeBuildInputs = [ cmake python3.pkgs.wrapPython ];
@@ -20,6 +27,11 @@ mkDerivation rec {
   postPatch = ''
     sed -i 's,/python''${PYTHON_VERSION_MAJOR}/dist-packages,/python''${PYTHON_VERSION_MAJOR}.''${PYTHON_VERSION_MINOR}/site-packages,g' CMakeLists.txt
     sed -i 's, executable_name = .*, executable_name = "${curaengine}/bin/CuraEngine",' plugins/CuraEngineBackend/CuraEngineBackend.py
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/cura/resources/materials
+    cp ${materials}/*.fdm_material $out/share/cura/resources/materials/
   '';
 
   postFixup = ''

--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, python3, qtbase, qtquickcontrols, curaengine }:
+{ mkDerivation, lib, fetchFromGitHub, cmake, python3, qtbase, qtquickcontrols2, curaengine }:
 
 mkDerivation rec {
   name = "cura-${version}";
@@ -11,7 +11,7 @@ mkDerivation rec {
     sha256 = "0yaya0ww92qjm7g31q85m5f95nwdapldjx1kdf1ar4yzwh4r15rp";
   };
 
-  buildInputs = [ qtbase qtquickcontrols ];
+  buildInputs = [ qtbase qtquickcontrols2 ];
   propagatedBuildInputs = with python3.pkgs; [ uranium zeroconf pyserial numpy-stl ];
   nativeBuildInputs = [ cmake python3.pkgs.wrapPython ];
 


### PR DESCRIPTION
###### Motivation for this change

The sidebar is invisible (cf. Ultimaker/Cura#3370) due to a wrong dependency and Cura is unable to create new materials without one to base it upon.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @abbradar
