### PR TITLE
linux: add CONFIG_KEY_DH_OPERATIONS

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -636,6 +636,11 @@ with stdenv.lib;
     X86_X2APIC y
     IRQ_REMAP y
   ''}
+  
+  # needed for iwd WPS support (wpa_supplicant replacement)
+  ${optionalString (versionAtLeast version "4.7") ''
+    CONFIG_KEY_DH_OPERATIONS y
+  ''}
 
   # Disable the firmware helper fallback, udev doesn't implement it any more
   FW_LOADER_USER_HELPER_FALLBACK? n

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -639,7 +639,7 @@ with stdenv.lib;
   
   # needed for iwd WPS support (wpa_supplicant replacement)
   ${optionalString (versionAtLeast version "4.7") ''
-    CONFIG_KEY_DH_OPERATIONS y
+    KEY_DH_OPERATIONS y
   ''}
 
   # Disable the firmware helper fallback, udev doesn't implement it any more


### PR DESCRIPTION
###### Motivation for this change

Intel has been working on a [wpa_supplicant replacement that's simpler](https://git.kernel.org/pub/scm/network/wireless/iwd.git/about/) (just released v0.3). It offloads most crypto to the kernel. For some of this (WPS support), CONFIG_KEY_DH_OPERATIONS has to be enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

