### PR TITLE
nixos-manual: Fixes build

### DIFF
--- a/nixos/doc/manual/configuration/linux-kernel.xml
+++ b/nixos/doc/manual/configuration/linux-kernel.xml
@@ -50,9 +50,9 @@ nixpkgs.config.packageOverrides = pkgs:
 <xref linkend="opt-boot.kernelModules"/> = [ "fuse" "kvm-intel" "coretemp" ];
 </programlisting>
   If the module is required early during the boot (e.g. to mount the root file
-  system), you can use <xref linkend="opt-boot.initrd.extraKernelModules"/>:
+  system), you can use <xref linkend="opt-boot.initrd.kernelModules"/>:
 <programlisting>
-<xref linkend="opt-boot.initrd.extraKernelModules"/> = [ "cifs" ];
+<xref linkend="opt-boot.initrd.kernelModules"/> = [ "cifs" ];
 </programlisting>
   This causes the specified modules and their dependencies to be added to the
   initial ramdisk.


### PR DESCRIPTION
Building the manual crashed with the following error:
```
manual-combined.xml:2917: element xref: validity error : IDREF attribute linkend references an unknown ID "opt-boot.initrd.extraKernelModules"
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

