### PR TITLE
staruml: 2.6.0 -> 2.8.1, fix internal node binary

### DIFF
--- a/pkgs/tools/misc/staruml/default.nix
+++ b/pkgs/tools/misc/staruml/default.nix
@@ -8,16 +8,16 @@ let
     [ glib gtk2 gdk_pixbuf alsaLib nss nspr GConf cups libgcrypt dbus ];
 in
 stdenv.mkDerivation rec {
-  version = "2.6.0";
+  version = "2.8.1";
   name = "staruml-${version}";
 
   src =
     if stdenv.system == "i686-linux" then fetchurl {
       url = "http://staruml.io/download/release/v${version}/StarUML-v${version}-32-bit.deb";
-      sha256 = "684d7ce7827a98af5bf17bf68d18f934fd970f13a2112a121b1f1f76d6387849";
+      sha256 = "0vb3k9m3l6pmsid4shlk0xdjsriq3gxzm8q7l04didsppg0vvq1n";
     } else fetchurl {
       url = "http://staruml.io/download/release/v${version}/StarUML-v${version}-64-bit.deb";
-      sha256 = "36e0bdc1bb57b7d808a007a3fafb1b38662d5b0793424d5ad4f51a3a6a9a636d";
+      sha256 = "05gzrnlssjkhyh0wv019d4r7p40lxnsa1sghazll6f233yrqmxb0";
     };
 
   buildInputs = [ dpkg ];

--- a/pkgs/tools/misc/staruml/default.nix
+++ b/pkgs/tools/misc/staruml/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, makeWrapper
 , dpkg, patchelf
-, gtk2, glib, gdk_pixbuf, alsaLib, nss, nspr, GConf, cups, libgcrypt, dbus, systemd }:
+, gtk2, glib, gdk_pixbuf, alsaLib, nss, nspr, GConf, cups, libgcrypt, dbus, systemd
+, libXdamage }:
 
 let
   inherit (stdenv) lib;
   LD_LIBRARY_PATH = lib.makeLibraryPath
-    [ glib gtk2 gdk_pixbuf alsaLib nss nspr GConf cups libgcrypt dbus ];
+    [ glib gtk2 gdk_pixbuf alsaLib nss nspr GConf cups libgcrypt dbus libXdamage ];
 in
 stdenv.mkDerivation rec {
   version = "2.8.1";
@@ -34,17 +35,17 @@ stdenv.mkDerivation rec {
     mkdir $out
     mv opt/staruml $out/bin
 
-    ${patchelf}/bin/patchelf \
-      --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      $out/bin/StarUML
-
     mkdir -p $out/lib
-
     ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
     ln -s ${systemd.lib}/lib/libudev.so.1 $out/lib/libudev.so.0
 
-    wrapProgram $out/bin/StarUML \
-      --prefix LD_LIBRARY_PATH : $out/lib:${LD_LIBRARY_PATH}
+    for binary in StarUML Brackets-node; do
+      ${patchelf}/bin/patchelf \
+        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        $out/bin/$binary
+      wrapProgram $out/bin/$binary \
+        --prefix LD_LIBRARY_PATH : $out/lib:${LD_LIBRARY_PATH}
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes #40503 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

