### PR TITLE
Add support for SSL in ocamlPackage.conduit.

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,5 +1,5 @@
 { stdenv, ocaml, findlib, jbuilder, conduit-lwt
-, logs, ppx_sexp_conv
+, logs, ppx_sexp_conv, lwt_ssl
 }:
 
 if !stdenv.lib.versionAtLeast conduit-lwt.version "1.0"
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
 	buildInputs = [ ocaml findlib jbuilder ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ conduit-lwt logs ];
+	propagatedBuildInputs = [ conduit-lwt logs lwt_ssl ];
 
 	buildPhase = "jbuilder build -p conduit-lwt-unix";
 }


### PR DESCRIPTION
###### Motivation for this change

This makes it possible to run the example given at https://github.com/mirage/ocaml-cohttp#client-tutorial

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

