### PR TITLE
nixos/statsd: refactor test

### DIFF
--- a/nixos/tests/statsd.nix
+++ b/nixos/tests/statsd.nix
@@ -8,7 +8,7 @@ with lib;
     maintainers = [ ma27 ];
   };
 
-  nodes.statsd1 = {
+  machine = {
     services.statsd.enable = true;
     services.statsd.backends = [ "statsd-influxdb-backend" "console" ];
     services.statsd.extraConfig = ''
@@ -33,8 +33,19 @@ with lib;
   };
 
   testScript = ''
-    $statsd1->start();
-    $statsd1->waitForUnit("statsd.service");
-    $statsd1->waitUntilSucceeds("nc -z 127.0.0.1 8126");
+    $machine->start();
+    $machine->waitForUnit("statsd.service");
+    $machine->waitForOpenPort(8126);
+
+    # check state of the `statsd` server
+    $machine->succeed('[ "health: up" = "$(echo health | nc 127.0.0.1 8126 -w 120 -N)" ];');
+
+    # confirm basic examples for metrics derived from docs:
+    # https://github.com/etsy/statsd/blob/v0.8.0/README.md#usage and
+    # https://github.com/etsy/statsd/blob/v0.8.0/docs/admin_interface.md
+    $machine->succeed("echo 'foo:1|c' | nc -u -w 0  127.0.0.1 8125");
+    $machine->succeed("echo counters | nc -w 120 127.0.0.1 8126 -N | grep foo");
+    $machine->succeed("echo 'delcounters foo' | nc -w 120 127.0.0.1 8126 -N");
+    $machine->fail("echo counters | nc -w 120 127.0.0.1 8126 -N | grep foo");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

`statsd` is a daemon written in `node` to gather statistics over UDP.
The current test ensures that a port is open, but the basic
functionality isn't sufficiently tested.

This patch contains the following changes:

* Simplified port scanning (`waitForOpenPort` rather than `netcat` magic).

* Issue a TCP command to check the health of the `statsd` server.

* Simple script to check if `statsd` receives data over UDP and confirms
  the basic functionality of the TCP interface on `8126` for admin
  purposes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

