### PR TITLE
nim: 0.17.2 -> 0.18.0

### DIFF
--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, makeWrapper, nodejs, openssl, pcre, readline, sqlite, boehmgc, sfml }:
+# based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
+
+{ stdenv, lib, fetchurl, makeWrapper, nodejs, openssl, pcre, readline, sqlite, boehmgc, sfml, tzdata }:
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
@@ -19,9 +21,6 @@ stdenv.mkDerivation rec {
     "-lreadline"
     "-lsqlite3"
     "-lgc"
-#    "-lsfml-graphics"
-#    "-lsfml-window"
-#    "-lsfml-system"
   ];
 
   # 1. nodejs is only needed for tests
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
   #    as part of building it, so it cannot be read-only
 
   buildInputs = [
-    makeWrapper nodejs
+    makeWrapper nodejs tzdata
     openssl pcre readline sqlite boehmgc sfml
   ];
 
@@ -55,6 +54,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace ./tests/async/tioselectors.nim --replace "/bin/sleep" "sleep"
     substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin/" "/run/current-system/sw/bin/"
+    substituteInPlace ./tests/stdlib/ttimes.nim --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 
   checkPhase = ''

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
-  version = "0.17.2";
+  version = "0.18.0";
 
   src = fetchurl {
     url = "https://nim-lang.org/download/${name}.tar.xz";
-    sha256 = "1gc2xk3ygmz9y4pm75pligssgw995a7gvnfpy445fjpw4d81pzxa";
+    sha256 = "45c74adb35f08dfa9add1112ae17330e5d902ebb4a36e7046caee8b79e6f3bd0";
   };
 
   doCheck = true;

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,6 +1,6 @@
 # based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
 
-{ stdenv, lib, fetchurl, makeWrapper, nodejs, openssl, pcre, readline, sqlite, boehmgc, sfml, tzdata, coreutils }:
+{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-8_x, openssl, pcre, readline, sqlite, boehmgc, sfml, tzdata, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   #    as part of building it, so it cannot be read-only
 
   buildInputs = [
-    makeWrapper nodejs tzdata coreutils
+    makeWrapper nodejs-slim-8_x tzdata coreutils
     openssl pcre readline sqlite boehmgc sfml
   ];
 

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,6 +1,6 @@
 # based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
 
-{ stdenv, lib, fetchurl, makeWrapper, nodejs, openssl, pcre, readline, sqlite, boehmgc, sfml, tzdata }:
+{ stdenv, lib, fetchurl, makeWrapper, nodejs, openssl, pcre, readline, sqlite, boehmgc, sfml, tzdata, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   #    as part of building it, so it cannot be read-only
 
   buildInputs = [
-    makeWrapper nodejs tzdata
+    makeWrapper nodejs tzdata coreutils
     openssl pcre readline sqlite boehmgc sfml
   ];
 
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./tests/async/tioselectors.nim --replace "/bin/sleep" "sleep"
-    substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin/" "/run/current-system/sw/bin/"
+    substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin" "${coreutils}/bin"
     substituteInPlace ./tests/stdlib/ttimes.nim --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Update the version of Nim to the current release, 0.18.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I haven't had time to test this at all as I'm new to Nix, but this is a releatively minor change that should hopefully just work.
