### PR TITLE
haskell generic-builder: add doHpack (defaults to false)

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -44,6 +44,7 @@ in
 , maintainers ? []
 , doCoverage ? false
 , doHaddock ? !(ghc.isHaLVM or false)
+, doHpack ? false
 , passthru ? {}
 , pkgconfigDepends ? [], libraryPkgconfigDepends ? [], executablePkgconfigDepends ? [], testPkgconfigDepends ? [], benchmarkPkgconfigDepends ? []
 , testDepends ? [], testHaskellDepends ? [], testSystemDepends ? []
@@ -302,7 +303,7 @@ stdenv.mkDerivation ({
       echo >&2 "*** abort because of serious configure-time warning from Cabal"
       exit 1
     fi
-
+    ${optionalString doHpack "${buildHaskellPackages.hpack}/bin/hpack"}
     export GHC_PACKAGE_PATH="$packageConfDir:"
 
     runHook postConfigure

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -185,6 +185,8 @@ rec {
 
   disableHardening = drv: flags: overrideCabal drv (drv: { hardeningDisable = flags; });
 
+  doHpack = drv: overrideCabal drv (drv: { doHpack = true; });
+
   /* Let Nix strip the binary files.
    * This removes debugging symbols.
    */


### PR DESCRIPTION
Follow up on https://github.com/NixOS/nixpkgs/issues/25010

I've verified that `nix-build -A haskellPackages.mtl` is a noop with this change.