### PR TITLE
thin-provisioning-tools: 0.7.5 -> 0.7.6, fix w/musl, enable parallel

### DIFF
--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
       block-cache/io_engine.h unit-tests/io_engine_t.cc
   '';
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
     homepage = https://github.com/jthornber/thin-provisioning-tools/;
     description = "A suite of tools for manipulating the metadata of the dm-thin device-mapper target";

--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "thin-provisioning-tools-${version}";
-  version = "0.7.5";
+  version = "0.7.6";
 
   src = fetchFromGitHub {
     owner = "jthornber";
     repo = "thin-provisioning-tools";
     rev = "v${version}";
-    sha256 = "1ibg5wxrbqg4pr3f6aacqm42fxpwn5q00j8ldy9mw4an3ck41cwa";
+    sha256 = "175mk3krfdmn43cjw378s32hs62gq8fmq549rjmyc651sz6jnj0g";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ expat libaio boost ];
 
+  postPatch = stdenv.lib.optional stdenv.hostPlatform.isMusl ''
+    sed -i -e '/PAGE_SIZE/d' -e '1i#include <limits.h>' \
+      block-cache/io_engine.h unit-tests/io_engine_t.cc
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://github.com/jthornber/thin-provisioning-tools/;
     description = "A suite of tools for manipulating the metadata of the dm-thin device-mapper target";


### PR DESCRIPTION
Fix with musl, update and enable parallel building while visiting.

Recent musl touches up how/when `PAGE_SIZE`/`PAGESIZE` are exported[1][2][3],
but unfortunately that doesn't fix compilation here.

This fixes build by using PAGE_SIZE from limits.h explicitly,
instead of defining local version.
Unlikely to change but might as well use what libc exports
in case it has a different value.

[1] https://git.musl-libc.org/cgit/musl/commit/?id=8e1381be44642523b5cbd1bba4d7ca20ee920b85
[2] https://git.musl-libc.org/cgit/musl/commit/?id=6ecb9c14c429cc73ace937fd7459f58f0b7a8e6e
[3] https://git.musl-libc.org/cgit/musl/commit/?id=c9c2cd3e6955cb1d57b8be01d4b072bf44058762



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---