### PR TITLE
cmake: Fix build and setup hook

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -82,6 +82,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--docdir=share/doc/${name}"
+  ] ++ (if useSharedLibraries then [ "--no-system-jsoncpp" "--system-libs" ] else [ "--no-system-libs" ]) # FIXME: cleanup
+    ++ optional (useQt4 || withQt5) "--qt-gui"
+    ++ [
+    "--"
     # We should set the proper `CMAKE_SYSTEM_NAME`.
     # http://www.cmake.org/Wiki/CMake_Cross_Compiling
     #
@@ -93,10 +97,7 @@ stdenv.mkDerivation rec {
     "-DCMAKE_AR=${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
     "-DCMAKE_RANLIB=${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
     "-DCMAKE_STRIP=${getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}strip"
-   ] ++ (if useSharedLibraries then [ "--no-system-jsoncpp" "--system-libs" ] else [ "--no-system-libs" ]) # FIXME: cleanup
-     ++ optional (useQt4 || withQt5) "--qt-gui"
-     ++ ["--"]
-     ++ optionals (!useNcurses) [ "-DBUILD_CursesDialog=OFF" ];
+  ] ++ optionals (!useNcurses) [ "-DBUILD_CursesDialog=OFF" ];
 
   dontUseCmakeConfigure = true;
   enableParallelBuilding = true;

--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -38,7 +38,7 @@ cmakeConfigurePhase() {
     cmakeFlags="-DCMAKE_CXX_COMPILER=$CXX $cmakeFlags"
     cmakeFlags="-DCMAKE_C_COMPILER=$CC $cmakeFlags"
     cmakeFlags="-DCMAKE_AR=$(command -v $AR) $cmakeFlags"
-    cmakeFlags="-DCMAKE_RANLIB=$(command -v $RANLAB) $cmakeFlags"
+    cmakeFlags="-DCMAKE_RANLIB=$(command -v $RANLIB) $cmakeFlags"
     cmakeFlags="-DCMAKE_STRIP=$(command -v $STRIP) $cmakeFlags"
 
     # This installs shared libraries with a fully-specified install


### PR DESCRIPTION
###### Motivation for this change

I screwed this up in 330ca731e88ec015181c43d92ae8f7c77cf0226a / https://github.com/NixOS/nixpkgs/pull/40529. I'm sorry.

###### Things done

Testing building Darwin stdenv (includes CMake).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

