### PR TITLE
nixopsUnstable: 1.6pre2276_9203440 -> 1.6.1pre2622_f10999a

### DIFF
--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -5,9 +5,9 @@
 # Then copy the URL to the tarball.
 
 callPackage ./generic.nix (rec {
-  version = "1.6pre2276_9203440";
+  version = "1.6.1pre2622_f10999a";
   src = fetchurl {
-    url = "https://hydra.nixos.org/build/64518294/download/2/nixops-${version}.tar.bz2";
-    sha256 = "1cl0869nl67fr5xk0jl9cvqbmma7d4vz5xbg56jpl7casrr3i51x";
+    url = "https://hydra.nixos.org/build/73716350/download/2/nixops-${version}.tar.bz2";
+    sha256 = "08886b6vxhjc3cp0ikxp920zap7wp6r92763fp785rvxrmb00rbd";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

The current `nixopsUnstable` is broken with current `nixpkgs` versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

