### PR TITLE
gcc7: Enable arm erratum 843419 on aarch64

### DIFF
--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -381,6 +381,7 @@ stdenv.mkDerivation ({
       "--with-gnu-as" "--without-gnu-ld"
     ]
     ++ optional (targetPlatform == hostPlatform && targetPlatform.libc == "musl") "--disable-libsanitizer"
+    ++ optional (targetPlatform.isAarch64) "--enable-fix-cortex-a53-843419"
   ;
 
   targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;


### PR DESCRIPTION
This fix is required for the raspherry pi 3 with glibc 2.27,
otherwise the kernel panics in initrd with:
```
<<< NixOS Stage 1 >>>

loading module dm_mod...
running udev...
kbd_mode: KDSKBMODE: Inappropriate ioctl for device
Gstarting device mapper and LVM...
[    1.969164] Kernel panic - not syncing: Attempted to kill init!
exitcode=0x0000000b
[    1.969164]
[    1.978476] CPU: 0 PID: 1 Comm: init Not tainted 4.16.8 #1-NixOS
[    1.984580] Hardware name: Raspberry Pi 3 Model B (DT)
[    1.989801] Call trace:
[    1.992301]  dump_backtrace+0x0/0x1c8
[    1.996025]  show_stack+0x24/0x30
[    1.999396]  dump_stack+0x9c/0xc0
[    2.002766]  panic+0x124/0x294
[    2.005872]  complete_and_exit+0x0/0x30
[    2.009771]  do_group_exit+0x40/0xa8
[    2.013406]  get_signal+0x280/0x5b0
[    2.016954]  do_signal+0x88/0x240
[    2.020325]  do_notify_resume+0xd8/0x130
[    2.024311]  work_pending+0x8/0x10
[    2.027774] SMP: stopping secondary CPUs
[    2.031763] Kernel Offset: disabled
[    2.035308] CPU features: 0x0802004
[    2.038850] Memory Limit: none
[    2.041963] ---[ end Kernel panic - not syncing: Attempted to kill
init! exitcode=0x0000000b
[    2.041963]
[    2.865264] random: crng init done
```
Suse has done the same to circumvent crashes with hostname resolving in
glibc 2.27 on aarch64.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

