### PR TITLE
Don't let Qt require a minimum kernel of 3.17+ (even if we're building against headers satisfying that requirement)

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -327,6 +327,10 @@ stdenv.mkDerivation {
         ]
         ++ lib.optional withGtk3 "-gtk"
         ++ lib.optional (compareVersion "5.9.0" >= 0) "-inotify"
+        ++ lib.optionals (compareVersion "5.10.0" >= 0) [
+          "-no-feature-renameat2"
+          "-no-feature-getentropy"
+        ]
     );
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Fixes #38832.

Fixes use of qt 5.10 on many distributions not shipping 3.17 or newer.

I believe even kernels with these features --if such exist-- won't work since
the check is specifically for version and not for the features in question.

This is especially "unfortunate" since libraries requiring versions newer
than what is available are silently overlooked during searches,
resulting in messages indicating that "libFoo.so" cannot be found
(instead of "libFoo.so found but requires kernel X.Y, you're running A.B" or whatever).

As indicated in the commit, someone checking this situation would be appreciated :).
And to be completely clear, this compatibility is achieved by disabling use of
the `renameat2` and `getentropy` syscalls (even if they are supported);
this does not seem problematic to me but is something to be considered.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---