### PR TITLE
haskellPackages.developPackage: Add a defaulted provideShellEnv argument

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -176,6 +176,7 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     #   , source-overrides : Defaulted (Either Path VersionNumber)
     #   , overrides : Defaulted (HaskellPackageOverrideSet)
     #   , modifier : Defaulted
+    #   , returnShellEnv : Defaulted
     #   } -> NixShellAwareDerivation
     # Given a path to a haskell package directory whose cabal file is
     # named the same as the directory name, an optional set of
@@ -183,11 +184,19 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     # function, an optional set of arbitrary overrides, and an optional
     # haskell package modifier,  return a derivation appropriate
     # for nix-build or nix-shell to build that package.
-    developPackage = { root, source-overrides ? {}, overrides ? self: super: {}, modifier ? drv: drv }:
-      let name = builtins.baseNameOf root;
-          drv =
-            (extensible-self.extend (pkgs.lib.composeExtensions (self.packageSourceOverrides source-overrides) overrides)).callCabal2nix name root {};
-      in if pkgs.lib.inNixShell then (modifier drv).env else modifier drv;
+    developPackage =
+      { root
+      , source-overrides ? {}
+      , overrides ? self: super: {}
+      , modifier ? drv: drv
+      , returnShellEnv ? pkgs.lib.inNixShell }:
+      let drv =
+        (extensible-self.extend
+           (pkgs.lib.composeExtensions
+              (self.packageSourceOverrides source-overrides)
+              overrides))
+        .callCabal2nix (builtins.baseNameOf root) root {};
+      in if returnShellEnv then (modifier drv).env else modifier drv;
 
     ghcWithPackages = selectFrom: withPackages (selectFrom self);
 


### PR DESCRIPTION
###### Motivation for this change

This will allow for greater flexbility when building custom scripting and tooling, by getting access to the core derivation constructed by `developPackage`, even while evaluating an invocation of `nix-shell`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---