### PR TITLE
emacsPackages.emacs-libvterm: init at unstable-2017-11-24

### DIFF
--- a/pkgs/applications/editors/emacs-modes/emacs-libvterm/default.nix
+++ b/pkgs/applications/editors/emacs-modes/emacs-libvterm/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, emacs, neovim-libvterm }:
+
+let
+  emacsSources = stdenv.mkDerivation {
+    name = emacs.name + "-sources";
+    src = emacs.src;
+
+    configurePhase = ":";
+    dontBuild = true;
+    doCheck = false;
+    fixupPhase = ":";
+
+    installPhase = ''
+      mkdir -p $out
+      cp -a * $out
+    '';
+
+  };
+
+in stdenv.mkDerivation rec {
+  name = "emacs-libvterm-${version}";
+  version = "unstable-2017-11-24";
+
+  src = fetchFromGitHub {
+    owner = "akermu";
+    repo = "emacs-libvterm";
+    rev = "829ae86f60c3a54048804997edffa161c77a2f4b";
+    sha256 = "1xb24kpvypvskh4vr3b45nl2m2vsczcr9rnsr2sjzf32mnapyjnp";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ emacs neovim-libvterm ];
+
+  cmakeFlags = [ "-DEMACS_SOURCE=${emacsSources}" ];
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install ../*.el $out/share/emacs/site-lisp
+    install ../*.so $out/share/emacs/site-lisp
+  '';
+}

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,41 +1,13 @@
 { stdenv, fetchFromGitHub, cmake, gettext, libmsgpack, libtermkey
 , libtool, libuv, luaPackages, ncurses, perl, pkgconfig
 , unibilium, vimUtils, xsel, gperf, callPackage
+, libvterm-neovim
 , withJemalloc ? true, jemalloc
 }:
 
 with stdenv.lib;
 
 let
-
-  # Note: this is NOT the libvterm already in nixpkgs, but some NIH silliness:
-  neovimLibvterm = stdenv.mkDerivation rec {
-    name = "neovim-libvterm-${version}";
-    version = "2017-11-05";
-
-    src = fetchFromGitHub {
-      owner = "neovim";
-      repo = "libvterm";
-      rev = "4ca7ebf7d25856e90bc9d9cc49412e80be7c4ea8";
-      sha256 = "05kyvvz8af90mvig11ya5xd8f4mbvapwyclyrihm9lwas706lzf6";
-    };
-
-    buildInputs = [ perl ];
-    nativeBuildInputs = [ libtool ];
-
-    makeFlags = [ "PREFIX=$(out)" ]
-      ++ stdenv.lib.optional stdenv.isDarwin "LIBTOOL=${libtool}/bin/libtool";
-
-    enableParallelBuilding = true;
-
-    meta = {
-      description = "VT220/xterm/ECMA-48 terminal emulator library";
-      homepage = http://www.leonerd.org.uk/code/libvterm/;
-      license = licenses.mit;
-      maintainers = with maintainers; [ garbas ];
-      platforms = platforms.unix;
-    };
-  };
 
   neovim = stdenv.mkDerivation rec {
     name = "neovim-unwrapped-${version}";
@@ -55,7 +27,7 @@ let
       libuv
       libmsgpack
       ncurses
-      neovimLibvterm
+      libvterm-neovim
       unibilium
       luaPackages.lua
       gperf

--- a/pkgs/development/libraries/libvterm-neovim/default.nix
+++ b/pkgs/development/libraries/libvterm-neovim/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub
+, perl
+, libtool
+}:
+
+stdenv.mkDerivation rec {
+  name = "neovim-libvterm-${version}";
+  version = "2017-11-05";
+
+  src = fetchFromGitHub {
+    owner = "neovim";
+    repo = "libvterm";
+    rev = "4ca7ebf7d25856e90bc9d9cc49412e80be7c4ea8";
+    sha256 = "05kyvvz8af90mvig11ya5xd8f4mbvapwyclyrihm9lwas706lzf6";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ libtool ];
+
+  makeFlags = [ "PREFIX=$(out)" ]
+    ++ stdenv.lib.optional stdenv.isDarwin "LIBTOOL=${libtool}/bin/libtool";
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "VT220/xterm/ECMA-48 terminal emulator library";
+    homepage = http://www.leonerd.org.uk/code/libvterm/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ garbas ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10529,6 +10529,7 @@ with pkgs;
   libvpx-git = callPackage ../development/libraries/libvpx/git.nix { };
 
   libvterm = callPackage ../development/libraries/libvterm { };
+  libvterm-neovim = callPackage ../development/libraries/libvterm-neovim { };
 
   libvorbis = callPackage ../development/libraries/libvorbis { };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -178,6 +178,8 @@ let
     };
   };
 
+  emacs-libvterm = callPackage ../applications/editors/emacs-modes/emacs-libvterm { };
+
   evil-jumper = melpaBuild rec {
     pname   = "evil-jumper";
     version = "20151017";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/akermu/emacs-libvterm is a full terminal emulator for emacs using https://github.com/neovim/libvterm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I broke out libvterm from the neovim package, otherwise the derivation is unchanged.
cc @garbas