### PR TITLE
xbmcPlugins.osmc-skin: init at 17.0.4

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -338,4 +338,26 @@ rec {
 
     extraBuildInputs = [ zlib ];
   };
+
+  osmc-skin = mkKodiPlugin rec {
+
+    plugin = "osmc-skin";
+    namespace = "skin.osmc";
+    version = "17.0.4";
+
+    src = fetchFromGitHub {
+      owner = "osmc";
+      repo = namespace;
+      rev = "a9268937f49286bab9fb49de430b8aafd7a60a9e";
+      sha256 = "1b3fm02annsq58pcfc985glrmh21rmqksdj3q8wn6gyza06jdf3v";
+    };
+
+    meta = with stdenv.lib; {
+      homepage = https://github.com/omsc/skin.osmc;
+      description = "The default skin for OSMC";
+      platforms = platforms.all;
+      maintainers = with maintainers; [ worldofpeace ];
+      license = licenses.cc-by-nc-sa-30;
+    };
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18620,6 +18620,7 @@ with pkgs;
       ++ optionals (config.kodi.enableHyperLauncher or false)
            (with hyper-launcher; [ plugin service pdfreader ])
       ++ optional (config.kodi.enableJoystick or false) joystick
+      ++ optional (config.kodi.enableOSMCskin or false) osmc-skin
       ++ optional (config.kodi.enableSVTPlay or false) svtplay
       ++ optional (config.kodi.enableSteamController or false) steam-controller
       ++ optional (config.kodi.enableSteamLauncher or false) steam-launcher


### PR DESCRIPTION
###### Motivation for this change
This is a very nice skin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---

###### Notes on the version number

The source repo has no tags, but the version of the plugin can be seen at the [addon.xml](https://github.com/osmc/skin.osmc/blob/a9268937f49286bab9fb49de430b8aafd7a60a9e/addon.xml#L4).

