### PR TITLE
aircrack-ng: 1.2-rc4 -> 1.2

### DIFF
--- a/pkgs/tools/networking/aircrack-ng/default.nix
+++ b/pkgs/tools/networking/aircrack-ng/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchurl, libpcap, openssl, zlib, wirelesstools
-, iw, ethtool, pciutils, libnl, pkgconfig, makeWrapper }:
+, iw, ethtool, pciutils, libnl, pkgconfig, makeWrapper
+, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "aircrack-ng-1.2-rc4";
+  name = "aircrack-ng-1.2";
 
   src = fetchurl {
     url = "http://download.aircrack-ng.org/${name}.tar.gz";
-    sha256 = "0dpzx9kddxpgzmgvdpl3rxn0jdaqhm5wxxndp1xd7d75mmmc2fnr";
+    sha256 = "0z7sl1ihgrnc98bpqa1mmkh51w26fnsanvj6ydwcnd8g83azwkvr";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
+  nativeBuildInputs = [ pkgconfig makeWrapper autoreconfHook ];
   buildInputs = [ libpcap openssl zlib libnl iw ethtool pciutils ];
 
   patchPhase = ''
-    sed -e 's@^prefix.*@prefix = '$out@ -i common.mak
     sed -e 's@/usr/local/bin@'${wirelesstools}@ -i src/osdep/linux.c
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Fix "illegal instruction" on non-AVX machines (see 
https://bugs.archlinux.org/task/48287)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

