### PR TITLE
nixos/auto-patchelf: Various fixes

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -11,16 +11,13 @@ isExecutable() {
 }
 
 findElfs() {
-    find "$1" -type f -exec "$SHELL" -c '
-        while [ -n "$1" ]; do
-            mimeType="$(file -b -N --mime-type "$1")"
-            if [ "$mimeType" = application/x-executable \
-              -o "$mimeType" = application/x-sharedlib ]; then
-                echo "$1"
-            fi
-            shift
-        done
-    ' -- {} +
+    find "$1" -type f | while IFS='' read -r file; do
+        mimeType="$(file -b -N --mime-type "$file")"
+        if [ "$mimeType" = application/x-executable \
+            -o "${mimeType}" = application/x-sharedlib ]; then
+            echo "${file}"
+        fi
+    done
 }
 
 # We cache dependencies so that we don't need to search through all of them on

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -103,11 +103,6 @@ autoPatchelfFile() {
     local interpreter="$(< "$NIX_CC/nix-support/dynamic-linker")"
     if isExecutable "$toPatch"; then
         patchelf --set-interpreter "$interpreter" "$toPatch"
-        if [ -n "$runtimeDependencies" ]; then
-            for dep in $runtimeDependencies; do
-                rpath="$rpath${rpath:+:}$dep/lib"
-            done
-        fi
     fi
 
     echo "searching for dependencies of $toPatch" >&2
@@ -156,6 +151,14 @@ autoPatchelf() {
     cachedDependencies+=(
         $(find "$prefix" \! -type d \( -name '*.so' -o -name '*.so.*' \))
     )
+    # Also add all runtime dependencies
+    if [ -n "$runtimeDependencies" ]; then
+        for dep in $runtimeDependencies; do
+            cachedDependencies+=(
+                $(find "$dep/lib" \! -type d \( -name '*.so' -o -name '*.so.*' \))
+            )
+        done
+    fi
     local elffile
 
     # Here we actually have a subshell, which also means that


### PR DESCRIPTION
###### Motivation for this change

Maybe I'm just using the tool wrong, but it seems it has two issues (see each individual commit message for more details).

The first thing fixed are shell errors from the `findElfs` function.
The other thing is the discovery of runtime dependencies, the commit message really explains that more clearly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

