### PR TITLE
avocode: 2.26.0 -> 2.26.1

### DIFF
--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "avocode-${version}";
-  version = "2.26.0";
+  version = "2.26.1";
 
   src = fetchurl {
     url = "https://media.avocode.com/download/avocode-app/${version}/avocode-${version}-linux.zip";
-    sha256 = "11d3nlshyzh5aqf5vsvnjwhr9qn8a2kd848x0ylv91y9p9njgsl5";
+    sha256 = "0npwwz5m4klswc32fs82icpqqfx9v4786sksiwykj75dsznyv3x8";
   };
 
   libPath = stdenv.lib.makeLibraryPath (with xorg; with gnome2; [
@@ -81,9 +81,9 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/avocode
     for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/avocode
-        patchelf --set-rpath ${libPath}:$out/ $file
+      patchelf --set-rpath ${libPath}:$out/ $file
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade avocode from 2.26.0 to 2.26.1 and cleanup `postFixup`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

