### PR TITLE
mattermost: 4.8.0 -> 4.10.0

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,49 +1,61 @@
-{ stdenv, fetchurl, fetchFromGitHub, buildGoPackage }:
+{ stdenv, fetchurl, fetchFromGitHub, buildGoPackage, buildEnv }:
 
 let
-  version = "4.8.0";
-  goPackagePath = "github.com/mattermost/mattermost-server";
-  buildFlags = "-ldflags \"-X '${goPackagePath}/model.BuildNumber=nixpkgs-${version}'\"";
+  version = "4.10.0";
+
+  mattermost-server = buildGoPackage rec {
+    name = "mattermost-server-${version}";
+
+    src = fetchFromGitHub {
+      owner = "mattermost";
+      repo = "mattermost-server";
+      rev = "v${version}";
+      sha256 = "02isw8qapp35pgriy4w1ar1ppvgc5a10j550hjbc1mylnhzkg1jf";
+    };
+
+    goPackagePath = "github.com/mattermost/mattermost-server";
+
+    buildFlagsArray = ''
+      -ldflags=
+        -X ${goPackagePath}/model.BuildNumber=nixpkgs-${version}
+    '';
+
+    postInstall = ''
+      ln -s $bin/bin/mattermost-server $bin/bin/platform
+      ln -s $bin/bin/mattermost-server $bin/bin/mattermost-platform
+    '';
+
+  };
+
+  mattermost-webapp = stdenv.mkDerivation {
+    name = "mattermost-webapp-${version}";
+
+    src = fetchurl {
+      url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
+      sha256 = "0pfj2dxl4qrv4w6yj0385nw0fa4flcg95kkahs0arwhan5bgifl5";
+    };
+
+    installPhase = ''
+      mkdir -p $out
+      tar --strip 1 --directory $out -xf $src \
+        mattermost/client \
+        mattermost/i18n \
+        mattermost/fonts \
+        mattermost/templates \
+        mattermost/config
+    '';
+  };
+
 in
+  buildEnv {
+    name = "mattermost-${version}";
+    paths = [ mattermost-server mattermost-webapp ];
 
-buildGoPackage rec {
-  name = "mattermost-${version}";
-
-  src = fetchFromGitHub {
-    owner = "mattermost";
-    repo = "mattermost-server";
-    rev = "v${version}";
-    sha256 = "16yf4p0n3klgh0zw2ikbahj9cy1wcxbwg86pld0yz63cfvfz5ns4";
-  };
-
-  webApp = fetchurl {
-    url = "https://releases.mattermost.com/${version}/mattermost-team-${version}-linux-amd64.tar.gz";
-    sha256 = "0ykp9apsv2514bircgay0xi0jigiai65cnb8q77v1qxjzdyx8s75";
-  };
-
-  inherit goPackagePath;
-
-  buildPhase = ''
-    runHook preBuild
-    cd go/src/${goPackagePath}/cmd/platform
-    go install ${buildFlags}
-    runHook postBuild
-  '';
-
-  preInstall = ''
-    mkdir -p $bin
-    tar --strip 1 -C $bin -xf $webApp
-  '';
-
-  postInstall = ''
-    ln -s $bin/bin/platform $bin/bin/mattermost-platform
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Open-source, self-hosted Slack-alternative";
-    homepage = https://www.mattermost.org;
-    license = with licenses; [ agpl3 asl20 ];
-    maintainers = with maintainers; [ fpletz ryantm ];
-    platforms = platforms.unix;
-  };
-}
+    meta = with stdenv.lib; {
+      description = "Open-source, self-hosted Slack-alternative";
+      homepage = https://www.mattermost.org;
+      license = with licenses; [ agpl3 asl20 ];
+      maintainers = with maintainers; [ fpletz ryantm ];
+      platforms = platforms.unix;
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change

1. new version
2. We were compiling the server and then overwriting it with a binary from the binary distribution. See https://github.com/NixOS/nixpkgs/pull/39876 for details.

In the future, we should figure out how to build the webapp instead of using the binary distribution. I attempted this and opened this issue regarding building the webapp:

https://github.com/mattermost/mattermost-server/issues/8806

cc @Mic92 for review

###### Things done

- [x] rewrote derivation as two separate derivations combined with buildEnv
- [x] tested NixOS service

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

