### PR TITLE
llvm: fix cross compiling for v4, v5, v6.

### DIFF
--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
 , libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
-, darwin
+, darwin, hostLLVM
 }:
 
 let
@@ -23,7 +23,7 @@ let
     drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
   llvm = callPackage ./llvm.nix {
-    inherit compiler-rt_src stdenv;
+    inherit compiler-rt_src stdenv hostLLVM;
   };
 
   clang-unwrapped = callPackage ./clang {

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -17,6 +17,7 @@
 , enableManpages ? false
 , enableSharedLibraries ? true
 , darwin
+, hostLLVM
 }:
 
 let
@@ -40,7 +41,8 @@ in stdenv.mkDerivation (rec {
     ++ stdenv.lib.optional enableSharedLibraries "lib";
 
   nativeBuildInputs = [ cmake python ]
-    ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    ++ stdenv.lib.optional enableManpages python.pkgs.sphinx
+    ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) hostLLVM;
 
   buildInputs = [ libxml2 libffi ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
@@ -122,6 +124,10 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
     "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+  ]
+  ++ stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "-DCMAKE_CROSSCOMPILING=True"
+    "-DLLVM_TABLEGEN=${hostLLVM}/bin/llvm-tblgen"
   ];
 
   postBuild = ''

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
 , libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
-, darwin
+, darwin, hostLLVM
 }:
 
 let
@@ -23,7 +23,7 @@ let
     drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
   llvm = callPackage ./llvm.nix {
-    inherit compiler-rt_src stdenv;
+    inherit compiler-rt_src stdenv hostLLVM;
   };
 
   clang-unwrapped = callPackage ./clang {

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,6 +1,6 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
 , libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
-, darwin
+, darwin, hostLLVM
 }:
 
 let
@@ -23,7 +23,7 @@ let
     drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
   llvm = callPackage ./llvm.nix {
-    inherit compiler-rt_src stdenv;
+    inherit compiler-rt_src stdenv hostLLVM;
   };
 
   clang-unwrapped = callPackage ./clang {

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -18,6 +18,7 @@
 , enableSharedLibraries ? true
 , enableWasm ? true
 , darwin
+, hostLLVM
 }:
 
 let
@@ -41,7 +42,8 @@ in stdenv.mkDerivation (rec {
     ++ stdenv.lib.optional enableSharedLibraries "lib";
 
   nativeBuildInputs = [ cmake python ]
-    ++ stdenv.lib.optional enableManpages python.pkgs.sphinx;
+    ++ stdenv.lib.optional enableManpages python.pkgs.sphinx
+    ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) hostLLVM;
 
   buildInputs = [ libxml2 libffi ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi ];
@@ -114,8 +116,13 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
     "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
-  ] ++ stdenv.lib.optional enableWasm
-   "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
+  ]
+  ++ stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)[
+    "-DCMAKE_CROSSCOMPILING=True"
+    "-DLLVM_TABLEGEN=${hostLLVM}/bin/llvm-tblgen"
+  ]
+  ++ stdenv.lib.optional enableWasm
+    "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
   ;
 
   postBuild = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6708,12 +6708,14 @@ with pkgs;
 
   llvmPackages_4 = callPackage ../development/compilers/llvm/4 ({
     inherit (stdenvAdapters) overrideCC;
+    hostLLVM = buildPackages.llvmPackages_4.llvm;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6;
   });
 
   llvmPackages_5 = callPackage ../development/compilers/llvm/5 ({
     inherit (stdenvAdapters) overrideCC;
+    hostLLVM = buildPackages.llvmPackages_5.llvm;
   } // stdenv.lib.optionalAttrs stdenv.isDarwin {
     cmake = cmake.override {
       isBootstrap = true;
@@ -6727,6 +6729,7 @@ with pkgs;
 
   llvmPackages_6 = callPackage ../development/compilers/llvm/6 ({
     inherit (stdenvAdapters) overrideCC;
+    hostLLVM = buildPackages.llvmPackages_6.llvm;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });


### PR DESCRIPTION
###### Motivation for this change
Allows LLVM versions 4, 5, and 6 to be cross-compiled by relying on `${buildPackages.llvmPackages.llvm}/bin/llvm-tblgen` when cross-compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

