### PR TITLE
pacvim: init at 2018-05-16

### DIFF
--- a/pkgs/games/pacvim/default.nix
+++ b/pkgs/games/pacvim/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "pacvim-${version}";
+  version = "2018-05-16";
+  src = fetchFromGitHub {
+    owner = "jmoon018";
+    repo = "PacVim";
+    rev = "ca7c8833c22c5fe97974ba5247ef1fcc00cedb8e";
+    sha256 = "1kq6j7xmsl5qfl1246lyglkb2rs9mnb2rhsdrp18965dpbj2mhx2";
+  };
+
+  buildInputs = [ ncurses ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jmoon018/PacVim";
+    description = "PacVim is a game that teaches you vim commands.";
+    maintainers = with maintainers; [ infinisil ];
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19340,6 +19340,8 @@ with pkgs;
 
   orthorobot = callPackage ../games/orthorobot { love = love_0_7; };
 
+  pacvim = callPackage ../games/pacvim { };
+
   performous = callPackage ../games/performous { };
 
   pingus = callPackage ../games/pingus {};


### PR DESCRIPTION
###### Motivation for this change
Seen [on reddit](https://www.reddit.com/r/programming/comments/8jq5sl/a_cli_game_to_learn_vim/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

