### PR TITLE
firefox: fix build on aarch64 with version >= 60

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -28,7 +28,9 @@
 # WARNING: NEVER set any of the options below to `true` by default.
 # Set to `privacySupport` or `false`.
 
-, webrtcSupport ? !privacySupport
+# webrtcSupport breaks the aarch64 build on version >= 60.
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1434589
+, webrtcSupport ? (if lib.versionAtLeast version "60" && stdenv.isAarch64 then false else !privacySupport)
 , geolocationSupport ? !privacySupport
 , googleAPISupport ? geolocationSupport
 , crashreporterSupport ? false

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -12,6 +12,12 @@ let
     ./fix-pa-context-connect-retval.patch
   ];
 
+  firefox60_aarch64_skia_patch = fetchpatch {
+      name = "aarch64-skia.patch";
+      url = https://src.fedoraproject.org/rpms/firefox/raw/8cff86d95da3190272d1beddd45b41de3148f8ef/f/build-aarch64-skia.patch;
+      sha256 = "11acb0ms4jrswp7268nm2p8g8l4lv8zc666a5bqjbb09x9k6b78k";
+  };
+
 in
 
 rec {
@@ -26,7 +32,7 @@ rec {
 
     patches = nixpkgsPatches ++ [
       ./no-buildconfig.patch
-    ];
+    ] ++ lib.optional stdenv.isAarch64 firefox60_aarch64_skia_patch;
 
     meta = {
       description = "A web browser built from Firefox source tree";
@@ -77,7 +83,7 @@ rec {
 
     patches = nixpkgsPatches ++ [
       ./no-buildconfig.patch
-    ];
+    ] ++ lib.optional stdenv.isAarch64 firefox60_aarch64_skia_patch;
 
     meta = firefox.meta // {
       description = "A web browser built from Firefox Extended Support Release source tree";


### PR DESCRIPTION

###### Motivation for this change

The firefox build fails with an error referring to ssse2 which doesn't
exist on aarch64.

Additionally the skia code needs some patching since it tries to access functions which aren't declared on aarch64.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

