### PR TITLE
urn: init at 0.7.1

### DIFF
--- a/pkgs/development/compilers/urn/default.nix
+++ b/pkgs/development/compilers/urn/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchFromGitLab, buildEnv, makeWrapper, lua, luajit, readline
+, useLuaJit ? false
+, extraLibraries ? []
+}:
+
+let
+  version = "0.7.1";
+  # Build a sort of "union package" with all the native dependencies we
+  # have: Lua (or LuaJIT), readline, etc. Then, we can depend on this
+  # and refer to ${urn-rt} instead of ${lua}, ${readline}, etc.
+  urn-rt = buildEnv {
+    name = "urn-rt-${version}";
+    ignoreCollisions = true;
+    paths = if useLuaJit then
+              [ luajit readline ]
+            else
+              [ lua ];
+  };
+
+  inherit (stdenv.lib) optionalString concatMapStringsSep;
+in
+
+stdenv.mkDerivation rec {
+  name = "urn-${optionalString (extraLibraries != []) "with-libraries-"}${version}";
+
+  src = fetchFromGitLab {
+    owner = "urn";
+    repo = "urn";
+    rev = "v${version}";
+    sha256 = "1vw0sljrczbwl7fl5d3frbpklb0larzyp7s7mwwprkb07b027sd5";
+  };
+
+  buildInputs = [ makeWrapper ];
+  # Any packages that depend on the compiler have a transitive
+  # dependency on the Urn runtime support.
+  propagatedBuildInputs = [ urn-rt ];
+
+  makeFlags = ["-B"];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    install -m 0755 bin/urn.lua $out/bin/urn
+    cp -r lib $out/lib/urn
+    wrapProgram $out/bin/urn \
+      --add-flags "-i $out/lib/urn --prelude $out/lib/urn/prelude.lisp" \
+      --add-flags "${concatMapStringsSep " " (x: "-i ${x.libraryPath}") extraLibraries}" \
+      --prefix PATH : ${urn-rt}/bin/ \
+      --prefix LD_LIBRARY_PATH : ${urn-rt}/lib/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://urn-lang.com;
+    description = "Yet another Lisp variant which compiles to Lua";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ CrazedProgrammer ];
+  };
+
+  passthru = {
+    inherit urn-rt;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6969,6 +6969,8 @@ with pkgs;
 
   bupc = callPackage ../development/compilers/bupc { };
 
+  urn = callPackage ../development/compilers/urn { };
+
   urweb = callPackage ../development/compilers/urweb { };
 
   inherit (callPackage ../development/compilers/vala { })


### PR DESCRIPTION
###### Motivation for this change

Adds [Urn](https://urn-lang.com/), a powerful Lisp dialect which compiles to Lua.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

