### PR TITLE
ries: init at 2018-04-11

### DIFF
--- a/pkgs/applications/science/math/ries/default.nix
+++ b/pkgs/applications/science/math/ries/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchzip }:
+stdenv.mkDerivation {
+  name = "ries-2018-04-11";
+
+  # upstream does not provide a stable link
+  src = fetchzip {
+    url = "https://salsa.debian.org/debian/ries/-/archive/debian/2018.04.11-1/ries-debian-2018.04.11-1.zip";
+    sha256 = "1h2wvd4k7f0l0i1vm9niz453xdbcs3nxccmri50qyrzzzc1b0842";
+  };
+
+  makeFlags = "PREFIX=$(out)";
+
+  meta = with stdenv.lib; {
+    homepage = https://mrob.com/pub/ries/;
+    description = "Tool to produce a list of equations that approximately solve to a given number";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ symphorien ];
+    license = licenses.gpl3Plus;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17244,6 +17244,8 @@ with pkgs;
 
   ricochet = libsForQt5.callPackage ../applications/networking/instant-messengers/ricochet { };
 
+  ries = callPackage ../applications/science/math/ries { };
+
   ripser = callPackage ../applications/science/math/ripser { };
 
   rkt = callPackage ../applications/virtualization/rkt { };


### PR DESCRIPTION
###### Motivation for this change

https://xkcd.com/1047/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

