### PR TITLE
dyncall: install cmake modules, man pages, use upstream's preferred URL

### DIFF
--- a/pkgs/development/libraries/dyncall/default.nix
+++ b/pkgs/development/libraries/dyncall/default.nix
@@ -10,12 +10,26 @@ stdenv.mkDerivation rec {
     sha256 = "d1b6d9753d67dcd4d9ea0708ed4a3018fb5bfc1eca5f37537fba2bc4f90748f2";
   };
 
-  doCheck = true;
-  checkTarget = "run-tests";
+  # XXX: broken tests, failures masked, lets avoid crashing a bunch for now :)
+  doCheck = false;
+
+  # install bits not automatically installed
+  postInstall = ''
+    # install cmake modules to make using dyncall easier
+    # This is essentially what -DINSTALL_CMAKE_MODULES=ON if using cmake build
+    # We don't use the cmake-based build since it installs different set of headers
+    # (mostly fewer headers, but installs dyncall_alloc_wx.h "instead" dyncall_alloc.h)
+    # and we'd have to patch the cmake module installation to not use CMAKE_ROOT anyway :).
+    install -D -t $out/lib/cmake ./buildsys/cmake/Modules/Find*.cmake
+
+    # manpages are nice, install them
+    # doing this is in the project's "ToDo", so check this when updating!
+    install -D -t $out/share/man/man3 ./*/*.3
+  '';
 
   meta = with stdenv.lib; {
     description = "Highly dynamic multi-platform foreign function call interface library";
-    homepage = http://dyncall.org;
+    homepage = http://www.dyncall.org;
     license = licenses.isc;
     maintainers = with maintainers; [ dtzWill ];
   };


### PR DESCRIPTION
Various minor improvements for folks wanting to dev against dyncall.

Disabling tests in favor of crashing and pretending things work ;).
Spent too much time trying to fix the test suite,
but it has multiple problems that convince me
that it's not intended for our use. Yet!


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---