### PR TITLE
top-level: build winePackages on Hydra

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21209,54 +21209,7 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
-  winePackages = recurseIntoAttrs rec {
-    minimal = callPackage ../misc/emulators/wine {
-      wineRelease = config.wine.release or "stable";
-      wineBuild = config.wine.build or "wine32";
-    };
-
-    base = minimal.override {
-      pngSupport = true;
-      jpegSupport = true;
-      tiffSupport = true;
-      gettextSupport = true;
-      fontconfigSupport = true;
-      alsaSupport = true;
-      openglSupport = true;
-      vulkanSupport = stdenv.isLinux;
-      tlsSupport = true;
-      cupsSupport = true;
-      dbusSupport = true;
-      cairoSupport = true;
-      cursesSupport = true;
-      saneSupport = true;
-      pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
-      udevSupport = true;
-      xineramaSupport = true;
-      xmlSupport = true;
-    };
-
-    full = base.override {
-      gtkSupport = true;
-      gstreamerSupport = true;
-      colorManagementSupport = true;
-      mpg123Support = true;
-      openalSupport = true;
-      openclSupport = true;
-      odbcSupport = true;
-      netapiSupport = true;
-      vaSupport = true;
-      pcapSupport = true;
-      v4lSupport = true;
-      gsmSupport = true;
-      gphoto2Support = true;
-      ldapSupport = true;
-    };
-
-    stable = base.override { wineRelease = "stable"; };
-    unstable = base.override { wineRelease = "unstable"; };
-    staging = base.override { wineRelease = "staging"; };
-  };
+  winePackages = recurseIntoAttrs (callPackage ./wine-packages.nix { });
 
   wine = winePackages.full;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21209,7 +21209,7 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
-  winePackages = rec {
+  winePackages = recurseIntoAttrs rec {
     minimal = callPackage ../misc/emulators/wine {
       wineRelease = config.wine.release or "stable";
       wineBuild = config.wine.build or "wine32";

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -1,0 +1,50 @@
+{ stdenv, config, callPackage }:
+
+rec {
+  minimal = callPackage ../misc/emulators/wine {
+    wineRelease = config.wine.release or "stable";
+    wineBuild = config.wine.build or "wine32";
+  };
+
+  base = minimal.override {
+    pngSupport = true;
+    jpegSupport = true;
+    tiffSupport = true;
+    gettextSupport = true;
+    fontconfigSupport = true;
+    alsaSupport = true;
+    openglSupport = true;
+    vulkanSupport = stdenv.isLinux;
+    tlsSupport = true;
+    cupsSupport = true;
+    dbusSupport = true;
+    cairoSupport = true;
+    cursesSupport = true;
+    saneSupport = true;
+    pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
+    udevSupport = true;
+    xineramaSupport = true;
+    xmlSupport = true;
+  };
+
+  full = base.override {
+    gtkSupport = true;
+    gstreamerSupport = true;
+    colorManagementSupport = true;
+    mpg123Support = true;
+    openalSupport = true;
+    openclSupport = true;
+    odbcSupport = true;
+    netapiSupport = true;
+    vaSupport = true;
+    pcapSupport = true;
+    v4lSupport = true;
+    gsmSupport = true;
+    gphoto2Support = true;
+    ldapSupport = true;
+  };
+
+  stable = base.override { wineRelease = "stable"; };
+  unstable = base.override { wineRelease = "unstable"; };
+  staging = base.override { wineRelease = "staging"; };
+}


### PR DESCRIPTION
Use case: I would like to work around https://bugs.winehq.org/show_bug.cgi?id=41930, and that requires Wine build with `openglSupport = false;`. That currently means I have to build Wine. It would be neat to be able to use `winePackages.minimal` from cache.

The same concern largely applies to `wineUnstable`, which is the latest development release of Wine without experimental staging patches on top of it. Staging breaks many apps (which is why those patches aren't merged upstream), but some crucial fix might have been merged recently and is not in stable yet. (This, for example, applies to The Sims 4).