### PR TITLE
Pijul 0.8.0 -> 0.10.0

### DIFF
--- a/pkgs/applications/version-management/pijul/default.nix
+++ b/pkgs/applications/version-management/pijul/default.nix
@@ -1,24 +1,25 @@
-{ stdenv, fetchurl, rustPlatform, darwin }:
+{ stdenv, fetchurl, rustPlatform, darwin, libsodium, openssl, pkgconfig }:
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "pijul-${version}";
-  version = "0.8.0";
+  version = "0.10.0";
 
   src = fetchurl {
     url = "https://pijul.org/releases/${name}.tar.gz";
-    sha256 = "00pi03yp2bgnjpsz2hgaapxfw2i4idbjqc88cagpvn4yr1612wqx";
+    sha256 = "1lkipcp83rfsj9yqddvb46dmqdf2ch9njwvjv8f3g91rmfjcngys";
   };
 
-  sourceRoot = "${name}/pijul";
+  nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin
-    (with darwin.apple_sdk.frameworks; [ Security ]);
+  buildInputs = [ libsodium openssl ] ++
+    stdenv.lib.optionals stdenv.isDarwin
+      (with darwin.apple_sdk.frameworks; [ Security ]);
 
   doCheck = false;
 
-  cargoSha256 = "1cnr08qbpia3336l37k1jli20d7kwnrw2gys8s9mg271cb4vdx03";
+  cargoSha256 = "1419mlxa4p53hm5qzfd1yi2k0n1bcv8kaslls1nyx661vknhfamw";
 
   meta = with stdenv.lib; {
     description = "A distributed version control system";


### PR DESCRIPTION
###### Motivation for this change
__This is a non-trivial verision bump.__

Had to make quite a few changes:

- `sourceRoot` was removed because `target/release` is now located the root directory not in `${name}/pijul`
- added `pkgconfig`, `libsodium`, and `openssl`

__Requires additional testing.__

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

