### PR TITLE
lighttpd: add option to enable WebDAV

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -2,11 +2,14 @@
 , openssl, enableMagnet ? false, lua5_1 ? null
 , enableMysql ? false, mysql ? null
 , enableLdap ? false, openldap ? null
+, enableWebDAV ? true, sqlite ? null, libuuid ? null
 }:
 
 assert enableMagnet -> lua5_1 != null;
 assert enableMysql -> mysql != null;
 assert enableLdap -> openldap != null;
+assert enableWebDAV -> sqlite != null;
+assert enableWebDAV -> libuuid != null;
 
 stdenv.mkDerivation rec {
   name = "lighttpd-1.4.49";
@@ -20,12 +23,16 @@ stdenv.mkDerivation rec {
   buildInputs = [ pcre libxml2 zlib attr bzip2 which file openssl ]
              ++ stdenv.lib.optional enableMagnet lua5_1
              ++ stdenv.lib.optional enableMysql mysql.connector-c
-             ++ stdenv.lib.optional enableLdap openldap;
+             ++ stdenv.lib.optional enableLdap openldap
+             ++ stdenv.lib.optional enableWebDAV sqlite
+             ++ stdenv.lib.optional enableWebDAV libuuid;
 
   configureFlags = [ "--with-openssl" ]
                 ++ stdenv.lib.optional enableMagnet "--with-lua"
                 ++ stdenv.lib.optional enableMysql "--with-mysql"
-                ++ stdenv.lib.optional enableLdap "--with-ldap";
+                ++ stdenv.lib.optional enableLdap "--with-ldap"
+                ++ stdenv.lib.optional enableWebDAV "--with-webdav-props"
+                ++ stdenv.lib.optional enableWebDAV "--with-webdav-locks";
 
   preConfigure = ''
     sed -i "s:/usr/bin/file:${file}/bin/file:g" configure


### PR DESCRIPTION
###### Motivation for this change
lighttpd supports WebDAV, but the Nix package does not enable it, so add an option to enable WebDAV.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

