### PR TITLE
xkeyboard-config: enable xkb rules symlink

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2476,6 +2476,7 @@ let
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ libX11 xproto ];
+    configureFlags = [ "--with-xkb-rules-symlink=xorg" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit libX11 xproto ;};
 


### PR DESCRIPTION
###### Motivation for this change

The `xorg.lst` file is needed by the Enlightenment desktop environment in order to set keyboard layouts. `xkeyboard-config` should be configured with the flag `--with-xkb-rules-symlink=xorg` in order to provide it.

Fedora, Arch and Gentoo linux all use this configuration currently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).