### PR TITLE
hack-font: 3.002 -> 3.003

### DIFF
--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.002";
+  version = "3.003";
 in fetchzip rec {
   name = "hack-font-${version}";
 
@@ -12,7 +12,7 @@ in fetchzip rec {
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/hack
   '';
 
-  sha256 = "11f3hl4nvxq6pvsmwr1c1r5wrxhrp7ixr5bshrz2dmqn7l8bxa63";
+  sha256 = "1l6ih6v7dqali5c7zh6z2xnbf9h2wz0ag6fdgszmqd5lnhw39v6s";
 
   meta = with stdenv.lib; {
     description = "A typeface designed for source code";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

