### PR TITLE
wine: Enable on macOS

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -6,8 +6,6 @@
   buildScript ? null, configureFlags ? ""
 }:
 
-assert stdenv.cc.cc.isGNU or false;
-
 with import ./util.nix { inherit lib; };
 
 stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
@@ -54,9 +52,14 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
   ++ lib.optionals xmlSupport    [ pkgs.libxml2 pkgs.libxslt ]
   ++ lib.optionals tlsSupport    [ pkgs.openssl pkgs.gnutls ]
   ++ lib.optionals openglSupport [ pkgs.libGLU_combined pkgs.mesa_noglu.osmesa pkgs.libdrm ]
-  ++ (with pkgs.xorg; [
-    libX11  libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext
-  ])));
+  ++ lib.optionals stdenv.isDarwin (with pkgs.buildPackages.darwin.apple_sdk.frameworks; [
+     CoreServices Foundation ForceFeedback AppKit OpenGL IOKit DiskArbitration Security
+     ApplicationServices AudioToolbox CoreAudio AudioUnit CoreMIDI OpenAL OpenCL Cocoa Carbon
+  ])
+  ++ lib.optionals stdenv.isLinux  (with pkgs.xorg; [
+     libXi libXcursor libXrandr libXrender libXxf86vm libXcomposite libXext
+  ])
+  ++ [ pkgs.xorg.libX11 ]));
 
   # Wine locates a lot of libraries dynamically through dlopen().  Add
   # them to the RPATH so that the user doesn't have to set them in
@@ -105,7 +108,8 @@ stdenv.mkDerivation ((lib.optionalAttrs (! isNull buildScript) {
 
   # https://bugs.winehq.org/show_bug.cgi?id=43530
   # https://github.com/NixOS/nixpkgs/issues/31989
-  hardeningDisable = [ "bindnow" ];
+  hardeningDisable = [ "bindnow" ]
+    ++ lib.optional (stdenv.hostPlatform.isDarwin) "fortify";
 
   passthru = { inherit pkgArches; };
   meta = {

--- a/pkgs/misc/emulators/wine/packages.nix
+++ b/pkgs/misc/emulators/wine/packages.nix
@@ -20,7 +20,7 @@ in with src; {
     geckos = [ gecko64 ];
     monos =  [ mono ];
     configureFlags = [ "--enable-win64" ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
   wineWow = callPackage ./base.nix {
     name = "wine-wow-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

