### PR TITLE
tomcat service: fix webapps default option

### DIFF
--- a/nixos/modules/services/web-servers/tomcat.nix
+++ b/nixos/modules/services/web-servers/tomcat.nix
@@ -109,8 +109,8 @@ in
 
       webapps = mkOption {
         type = types.listOf types.package;
-        default = [ tomcat.webapps ];
-        defaultText = "[ tomcat.webapps ]";
+        default = [ tomcat85.webapps ];
+        defaultText = "[ tomcat85.webapps ]";
         description = "List containing WAR files or directories with WAR files which are web applications to be deployed on Tomcat";
       };
 


### PR DESCRIPTION
The package referenced in the old default value does not exist in nixpkgs.
If accepted this should also be applied to release-18.03 branch.

###### Motivation for this change
Users were confused

/cc @armin1402 
