### PR TITLE
Unbreak gv (fixes #34841)

### DIFF
--- a/pkgs/applications/misc/gv/default.nix
+++ b/pkgs/applications/misc/gv/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation {
     Xaw3d
     ghostscriptX
     perl
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
     pkgconfig
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
     libiconv
   ];
 


### PR DESCRIPTION
It appears that without pkgconfig, the build process misdetects some features, resulting in gv to segfault immediately on startup.

The fix was adopted from https://github.com/Homebrew/legacy-homebrew/issues/18555#issuecomment-15074618. I don't claim to know the proper background of this error; but I can confirm that with this change, gv works as it should.

###### Motivation for this change

In current NixOS unstable, gv builds, but immediately segfaults on startup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

