### PR TITLE
nixos/kubernetes: Update kube-dns and kube-dashbashboard docker image…

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/dashboard.nix
+++ b/nixos/modules/services/cluster/kubernetes/dashboard.nix
@@ -10,8 +10,9 @@ let
 
   image = pkgs.dockerTools.pullImage {
     imageName = name;
-    imageTag = version;
+    finalImageTag = version;
     sha256 = "11h0fz3wxp0f10fsyqaxjm7l2qg7xws50dv5iwlck5gb1fjmajad";
+    imageDigest = "sha256:e7984d10351601080bbc146635d51f0cfbea31ca6f0df323cf7a58cf2f6a68df";
   };
 in {
   options.services.kubernetes.addons.dashboard = {

--- a/nixos/modules/services/cluster/kubernetes/dns.nix
+++ b/nixos/modules/services/cluster/kubernetes/dns.nix
@@ -7,20 +7,23 @@ let
 
   k8s-dns-kube-dns = pkgs.dockerTools.pullImage {
     imageName = "gcr.io/google_containers/k8s-dns-kube-dns-amd64";
-    imageTag = version;
+    finalImageTag = version;
     sha256 = "0q97xfqrigrfjl2a9cxl5in619py0zv44gch09jm8gqjkxl80imp";
+    imageDigest = "sha256:40790881bbe9ef4ae4ff7fe8b892498eecb7fe6dcc22661402f271e03f7de344";
   };
 
   k8s-dns-dnsmasq-nanny = pkgs.dockerTools.pullImage {
     imageName = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64";
-    imageTag = version;
+    finalImageTag = version;
     sha256 = "051w5ca4qb88mwva4hbnh9xzlsvv7k1mbk3wz50lmig2mqrqqx6c";
+    imageDigest = "sha256:aeeb994acbc505eabc7415187cd9edb38cbb5364dc1c2fc748154576464b3dc2";
   };
 
   k8s-dns-sidecar = pkgs.dockerTools.pullImage {
     imageName = "gcr.io/google_containers/k8s-dns-sidecar-amd64";
-    imageTag = version;
+    finalImageTag = version;
     sha256 = "1z0d129bcm8i2cqq36x5jhnrv9hirj8c6kjrmdav8vgf7py78vsm";
+    imageDigest = "sha256:97074c951046e37d3cbb98b82ae85ed15704a290cce66a8314e7f846404edde9";
   };
 
   cfg = config.services.kubernetes.addons.dns;


### PR DESCRIPTION
… derivations to new pullImage function signature

###### Motivation for this change
Hi,
I tried to run kubernetes on my nixos/unstable system.  Unfortunately nix refused to build kube-dns and kube-dashboard.  It looks like this is caused by a change in the function signature of `pkgs/build-tools/docker/default.nix:pullImage`.  This patch tries to fix that.

~~I tested the module on my local system, but unfortunately the nixos tests for kubernetes are not "working" for other reasons I do not understand quite right.  However, the build failure does not occur anymore with this patch and the problems arise for me at runtime and seem -- as far as I understand -- not related to the thing this patch tries fix.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

