### PR TITLE
m32edit and x32edit: init at 3.2

### DIFF
--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, lib, libX11, libXext, alsaLib, freetype, brand, type, version, homepage, sha256, ... }:
+stdenv.mkDerivation rec {
+  inherit type;
+  baseName = "${type}-Edit";
+  name = "${baseName}-${version}";
+
+  src = fetchurl {
+    url = "http://downloads.music-group.com/software/behringer/${type}/${type}-Edit_LINUX_64bit_${version}.tar.gz";
+    inherit sha256;
+  };
+
+  sourceRoot = ".";
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${baseName} $out/bin
+  '';
+  preFixup = let
+    # we prepare our library path in the let clause to avoid it become part of the input of mkDerivation
+    libPath = lib.makeLibraryPath [
+      libX11           # libX11.so.6
+      libXext          # libXext.so.6
+      alsaLib          # libasound.so.2
+      freetype         # libfreetype.so.6
+      stdenv.cc.cc.lib # libstdc++.so.6
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/bin/${baseName}
+  '';
+
+  meta = with stdenv.lib; {
+    inherit homepage;
+    description = "Editor for the ${brand} ${type} digital mixer";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.magnetophon ];
+  };
+}

--- a/pkgs/applications/audio/midas/m32edit.nix
+++ b/pkgs/applications/audio/midas/m32edit.nix
@@ -1,0 +1,9 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // {
+  brand = "Midas";
+  type = "M32";
+  version = "3.2";
+  sha256 = "1cds6qinz37086l6pmmgrzrxadygjr2z96sjjyznnai2wz4z2nrd";
+  homepage = http://www.musictri.be/Categories/Midas/Mixers/Digital/M32/p/P0B3I/downloads;
+})

--- a/pkgs/applications/audio/midas/x32edit.nix
+++ b/pkgs/applications/audio/midas/x32edit.nix
@@ -1,0 +1,9 @@
+{ callPackage, ... } @ args:
+
+callPackage ./generic.nix (args // {
+  brand = "Behringer";
+  type = "X32";
+  version = "3.2";
+  sha256 = "1lzmhd0sqnlzc0khpwm82sfi48qhv7rg153a57qjih7hhhy41mzk";
+  homepage = http://www.musictri.be/Categories/Behringer/Mixers/Digital/X32/p/P0ASF/downloads;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16144,6 +16144,8 @@ with pkgs;
 
   linssid = libsForQt5.callPackage ../applications/networking/linssid { };
 
+  m32edit = callPackage ../applications/audio/midas/m32edit.nix {};
+
   manuskript = callPackage ../applications/editors/manuskript { };
 
   manul = callPackage ../development/tools/manul { };
@@ -18741,6 +18743,8 @@ with pkgs;
   x2goclient = libsForQt5.callPackage ../applications/networking/remote/x2goclient { };
 
   x2vnc = callPackage ../tools/X11/x2vnc { };
+
+  x32edit = callPackage ../applications/audio/midas/x32edit.nix {};
 
   x42-plugins = callPackage ../applications/audio/x42-plugins { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

