### PR TITLE
faust2: fix build with llvm 5.0.2 [18.03] 

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -73,6 +73,13 @@ let
       sed '52iLLVM_VERSION=${stdenv.lib.getVersion llvm}' -i compiler/Makefile.unix
     '';
 
+    postPatch = ''
+      # fix build with llvm 5.0.2 by adding it to the list of known versions
+      # TODO: check if still needed on next update
+      substituteInPlace compiler/Makefile.unix \
+        --replace "5.0.0 5.0.1" "5.0.0 5.0.1 5.0.2"
+    '';
+
     # Remove most faust2appl scripts since they won't run properly
     # without additional paths setup. See faust.wrap,
     # faust.wrapWithBuildEnv.
@@ -192,6 +199,7 @@ let
       buildInputs = [ makeWrapper ];
 
       propagatedBuildInputs = [ faust ] ++ propagatedBuildInputs;
+
 
       postFixup = ''
 


### PR DESCRIPTION
###### Motivation for this change

Build was broken by  llvm: 5.0.1 -> 5.0.2 (#39979)  - error "unknown llvm version".
Fixed by adding 5.0.2 to the list of known llvm versions.
Opened upstream issue https://github.com/grame-cncm/faust/issues/181.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---