### PR TITLE
bashplotlib: init at 2017-10-11

### DIFF
--- a/pkgs/tools/misc/bashplotlib/default.nix
+++ b/pkgs/tools/misc/bashplotlib/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "bashplotlib-${version}";
+  version = "2017-10-11";
+
+  src = fetchFromGitHub {
+    owner = "glamp";
+    repo = "bashplotlib";
+    rev = "fdc52be2c1fed13753692eced328143ab1db6f3d";
+    sha256 = "1ycql6j65zywyav2n3c0x1i5cm9w6glzqc3v0cgdvv1bdg4wi0gf";
+  };
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/glamp/bashplotlib;
+    description = "Plotting in the terminal";
+    maintainers = with maintainers; [ dtzWill ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -784,6 +784,8 @@ with pkgs;
 
   basex = callPackage ../tools/text/xml/basex { };
 
+  bashplotlib = callPackage ../tools/misc/bashplotlib { };
+
   babeld = callPackage ../tools/networking/babeld { };
 
   badvpn = callPackage ../tools/networking/badvpn {};


### PR DESCRIPTION
"Plotting in the terminal"


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---