### PR TITLE
[RDY] cmake: don't override cmakeDir when set

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/cmake/setup-hook.sh
@@ -22,7 +22,7 @@ cmakeConfigurePhase() {
     if [ -z "$dontUseCmakeBuildDir" ]; then
         mkdir -p build
         cd build
-        cmakeDir=..
+        cmakeDir=${cmakeDir:-..}
     fi
 
     if [ -z "$dontAddPrefix" ]; then


### PR DESCRIPTION
When dontUseCmakeBuildDir is true (aka the default), it overrides
cmakeDir regardless of the package configuration.

While packaging netbee, I needed to both keep dontUseCmakeBuildDir to
true (some hardcoded paths expect the build folder) and set cmakeDir
(since CMakeList.txt was in a subfolder) which proved impossible.
Here is the fix.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

