### PR TITLE
enlightenment: add xkeyboard-config dependency

### DIFF
--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -35,15 +35,44 @@ stdenv.mkDerivation rec {
     gdbm
     pcre
     mesa_noglu
+    xkeyboard_config
   ] ++
     stdenv.lib.optionals stdenv.isLinux [ libcap ];
 
-  # Instead of setting owner to root and permissions to setuid/setgid
-  # (which is not allowed for files in /nix/store) of some
-  # enlightenment programs, the file $out/e-wrappers.nix is created,
-  # containing the needed configuration for that purpose. It can be
-  # used in the enlightenment module.
-  patches = [ ./enlightenment.suid-exes.patch ];
+  patches = [
+    # Some programs installed by enlightenment (to set the cpu frequency,
+    # for instance) need root ownership and setuid/setgid permissions, which
+    # are not allowed for files in /nix/store. Instead of allowing the
+    # installer to try to do this, the file $out/e-wrappers.nix is created,
+    # containing the needed configuration for wrapping those programs. It
+    # can be used in the enlightenment module. The idea is:
+    # 
+    #  1) rename the original binary adding the extension .orig
+    #  2) wrap the renamed binary at /run/wrappers/bin/
+    #  3) create a new symbolic link using the original binary name (in the
+    #     original directory where enlightenment wants it) pointing to the
+    #     wrapper
+
+    ./enlightenment.suid-exes.patch
+  ];
+
+  postPatch = ''
+    # In order to get the available keyboard layouts Enlightenment looks for
+    # the file xorg.lst, that should be provided by xkeyboard-config (when
+    # configured with option --with-xkb-rules-symlink=xorg). Currently
+    # xkeyboard-config is not configured with this option in
+    # NixOS. Therefore it is needed to add base.lst (which xorg.lst would be
+    # a symbolic link to) explicitly as an alternative.
+
+    sed "/#ifdef XKB_BASE/a XKB_BASE \"\/rules\/base.lst\"," \
+      -i src/modules/wizard/page_011.c src/modules/xkbswitch/e_mod_parse.c
+
+    # edge_cc is a binary provided by efl and cannot be found at the directory
+    # given by e_prefix_bin_get(), which is $out/bin
+
+    substituteInPlace src/bin/e_import_config_dialog.c \
+      --replace "e_prefix_bin_get()" "\"${efl}/bin\""
+  '';
 
   mesonFlags = [ "-Dsystemdunitdir=lib/systemd/user" ];
 


### PR DESCRIPTION
###### Motivation for this change

- Add runtime dependence on xkeyboard-config

- Add base.lst from xkeyboard-config to the list of keyboard layout
files. Something similar to this has been removed in a previous patch
by mistake.

- Fix location of binary edge_cc. This has been removed in a previous
patch by mastake.

- Make the explanation for the wrapping of some binaries more clear.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).