### PR TITLE
fix ghc bootstrap on non-nixos nonstd-storepath

### DIFF
--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     # Some scripts used during the build need to have their shebangs patched
     ''
       patchShebangs ghc-${version}/utils/
+      patchShebangs ghc-${version}/configure
     '' +
 
     # Strip is harmful, see also below. It's important that this happens


### PR DESCRIPTION
Something goes amiss in the configurePhase and binaries start picking up
system libraries and everything falls apart. Patch the configure script
to use a bourne shell out of the store, and things are happier.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

