### PR TITLE
pythonPackages.cx_oracle: fix dlopen, patchelf and fix library path for oracle-instantclient binaries

### DIFF
--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -86,6 +86,6 @@ in stdenv.mkDerivation rec {
     '';
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ pesterhazy ];
+    maintainers = with maintainers; [ pesterhazy flokli ];
   };
 }

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -34,8 +34,10 @@ in stdenv.mkDerivation rec {
   srcSqlplus = (requireSource version "1" "sqlplus" "303e82820a10f78e401e2b07d4eebf98b25029454d79f06c46e5f9a302ce5552");
   srcOdbc = optionalString odbcSupport (requireSource version "2" "odbc" "e870c84d2d4be6f77c0760083b82b7ffbb15a4bf5c93c4e6c84f36d6ed4dfdf1");
 
-  buildInputs = [ glibc patchelf rpmextract ] ++
+  buildInputs = [ glibc ] ++
     optional odbcSupport unixODBC;
+
+  nativeBuildInputs = [ rpmextract patchelf ];
 
   buildCommand = ''
     mkdir -p "${name}"

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, requireFile, libelf, gcc, glibc, patchelf, unzip, rpmextract, libaio
-, odbcSupport ? false, unixODBC
-}:
+{ stdenv, requireFile, glibc, patchelf, rpmextract, libaio, odbcSupport ? false, unixODBC }:
 
 assert odbcSupport -> unixODBC != null;
 

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, glibc, patchelf, rpmextract, libaio, odbcSupport ? false, unixODBC }:
+{ stdenv, requireFile, glibc, patchelf, rpmextract, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
 
 assert odbcSupport -> unixODBC != null;
 
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ glibc ] ++
     optional odbcSupport unixODBC;
 
-  nativeBuildInputs = [ rpmextract patchelf ];
+  nativeBuildInputs = [ rpmextract patchelf makeWrapper ];
 
   buildCommand = ''
     mkdir -p "${name}"
@@ -70,6 +70,7 @@ in stdenv.mkDerivation rec {
       patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
                --force-rpath --set-rpath "$out/lib:${libaio}/lib" \
                $exe
+      wrapProgram $exe --prefix LD_LIBRARY_PATH ":" $out/lib
     done
   '';
 

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -56,5 +56,6 @@ in stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ pesterhazy flokli ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, requireFile, glibc, patchelf, rpmextract, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
+{ stdenv, requireFile, autoPatchelfHook, rpmextract, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
 
 assert odbcSupport -> unixODBC != null;
-
-with stdenv.lib;
 
 let
     baseVersion = "12.2";
@@ -27,55 +25,26 @@ in stdenv.mkDerivation rec {
   version = "${baseVersion}.0.1.0";
   name = "oracle-instantclient-${version}";
 
-  srcBase = (requireSource version "1" "basic" "43c4bfa938af741ae0f9964a656f36a0700849f5780a2887c8e9f1be14fe8b66");
-  srcDevel = (requireSource version "1" "devel" "4c7ad8d977f9f908e47c5e71ce56c2a40c7dc83cec8a5c106b9ff06d45bb3442");
-  srcSqlplus = (requireSource version "1" "sqlplus" "303e82820a10f78e401e2b07d4eebf98b25029454d79f06c46e5f9a302ce5552");
-  srcOdbc = optionalString odbcSupport (requireSource version "2" "odbc" "e870c84d2d4be6f77c0760083b82b7ffbb15a4bf5c93c4e6c84f36d6ed4dfdf1");
+  buildInputs = [ libaio stdenv.cc.cc.lib ] ++ stdenv.lib.optional odbcSupport unixODBC;
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper rpmextract ];
 
-  buildInputs = [ glibc ] ++
-    optional odbcSupport unixODBC;
+  srcs = [
+    (requireSource version "1" "basic" "43c4bfa938af741ae0f9964a656f36a0700849f5780a2887c8e9f1be14fe8b66")
+    (requireSource version "1" "devel" "4c7ad8d977f9f908e47c5e71ce56c2a40c7dc83cec8a5c106b9ff06d45bb3442")
+    (requireSource version "1" "sqlplus" "303e82820a10f78e401e2b07d4eebf98b25029454d79f06c46e5f9a302ce5552")
+  ] ++ stdenv.lib.optional odbcSupport (requireSource version "2" "odbc" "e870c84d2d4be6f77c0760083b82b7ffbb15a4bf5c93c4e6c84f36d6ed4dfdf1");
 
-  nativeBuildInputs = [ rpmextract patchelf makeWrapper ];
+  unpackCmd = "rpmextract $curSrc";
 
-  buildCommand = ''
-    mkdir -p "${name}"
-    cd "${name}"
-    ${rpmextract}/bin/rpmextract "${srcBase}"
-    ${rpmextract}/bin/rpmextract "${srcDevel}"
-    ${rpmextract}/bin/rpmextract "${srcSqlplus}"
-    '' + optionalString odbcSupport ''${rpmextract}/bin/rpmextract ${srcOdbc}
-    '' + ''
+  installPhase = ''
     mkdir -p "$out/"{bin,include,lib,"share/${name}/demo/"}
-    mv "usr/share/oracle/${baseVersion}/client64/demo/"* "$out/share/${name}/demo/"
-    mv "usr/include/oracle/${baseVersion}/client64/"* "$out/include/"
-    mv "usr/lib/oracle/${baseVersion}/client64/lib/"* "$out/lib/"
-    mv "usr/lib/oracle/${baseVersion}/client64/bin/"* "$out/bin/"
-    ln -s "$out/bin/sqlplus" "$out/bin/sqlplus64"
 
-    for lib in $out/lib/lib*.so; do
-      test -f $lib || continue
-      chmod +x $lib
-      patchelf --force-rpath --set-rpath "$out/lib:${libaio}/lib" \
-               $lib
-    done
-
-    for lib in $out/lib/libsqora*; do
-      test -f $lib || continue
-      chmod +x $lib
-      patchelf --force-rpath --set-rpath "$out/lib:${unixODBC}/lib" \
-               $lib
-    done
-
-    for exe in $out/bin/{adrci,genezi,sqlplus}; do
-      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-               --force-rpath --set-rpath "$out/lib:${libaio}/lib" \
-               $exe
-      wrapProgram $exe --prefix LD_LIBRARY_PATH ":" $out/lib
-    done
+    install -Dm755 lib/oracle/${baseVersion}/client64/bin/* $out/bin
+    ln -s $out/bin/sqlplus $out/bin/sqlplus64
+    install -Dm644 lib/oracle/${baseVersion}/client64/lib/* $out/lib
+    install -Dm644 include/oracle/${baseVersion}/client64/* $out/include
+    install -Dm644 share/oracle/${baseVersion}/client64/demo/* $out/share/${name}/demo
   '';
-
-  dontStrip = true;
-  dontPatchELF = true;
 
   meta = with stdenv.lib; {
     description = "Oracle instant client libraries and sqlplus CLI";

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -66,7 +66,7 @@ in stdenv.mkDerivation rec {
                $lib
     done
 
-    for exe in $out/bin/sqlplus; do
+    for exe in $out/bin/{adrci,genezi,sqlplus}; do
       patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
                --force-rpath --set-rpath "$out/lib:${libaio}/lib" \
                $exe

--- a/pkgs/development/python-modules/cx_oracle/0001-odpi-src-dpiOci.c-nixify-libclntsh.so-dlopen.patch
+++ b/pkgs/development/python-modules/cx_oracle/0001-odpi-src-dpiOci.c-nixify-libclntsh.so-dlopen.patch
@@ -1,0 +1,27 @@
+From 355b9d812efdfbd041e14b365258b69c81689981 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Thu, 17 May 2018 18:37:40 +0200
+Subject: [PATCH] odpi/src/dpiOci.c: nixify libclntsh.so dlopen
+
+---
+ odpi/src/dpiOci.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/odpi/src/dpiOci.c b/odpi/src/dpiOci.c
+index 76b9867..22c2987 100644
+--- a/odpi/src/dpiOci.c
++++ b/odpi/src/dpiOci.c
+@@ -1575,6 +1575,10 @@ static int dpiOci__loadLib(dpiError *error)
+             }
+         }
+     }
++    if(!dpiOciLibHandle) {
++        dpiOciLibHandle = dlopen("@libclntsh@", RTLD_LAZY);
++    }
++
+ #endif
+ 
+     if (!dpiOciLibHandle) {
+-- 
+2.16.3
+

--- a/pkgs/development/python-modules/cx_oracle/default.nix
+++ b/pkgs/development/python-modules/cx_oracle/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "cx_Oracle";
-  version = "6.1";
+  version = "6.2.1";
 
   buildInputs = [
     oracle-instantclient
@@ -10,7 +10,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "80545fc7acbdda917dd2b1604c938141256bdfed3ad464a44586c9c2f09c3004";
+    sha256 = "01970bc843b3c699a7fd98af19e0401fe69abfbd2acdf464e0bf2ae06ea372b9";
   };
 
   # Check need an Oracle database to run  

--- a/pkgs/development/python-modules/cx_oracle/default.nix
+++ b/pkgs/development/python-modules/cx_oracle/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, oracle-instantclient }:
+
+buildPythonPackage rec {
+  pname = "cx_Oracle";
+  version = "6.1";
+
+  buildInputs = [
+    oracle-instantclient
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "80545fc7acbdda917dd2b1604c938141256bdfed3ad464a44586c9c2f09c3004";
+  };
+
+  # Check need an Oracle database to run  
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python interface to Oracle";
+    homepage = "https://oracle.github.io/python-cx_Oracle";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ y0no ];
+  };
+}

--- a/pkgs/development/python-modules/cx_oracle/default.nix
+++ b/pkgs/development/python-modules/cx_oracle/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "cx_Oracle";
-  version = "6.2.1";
+  version = "6.3.1";
 
   buildInputs = [
     oracle-instantclient
@@ -10,10 +10,10 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "01970bc843b3c699a7fd98af19e0401fe69abfbd2acdf464e0bf2ae06ea372b9";
+    sha256 = "0200j6jh80rpgzxmvgcxmkshaj4zadq32g2i97nlwiq3f7q374l7";
   };
 
-  # Check need an Oracle database to run  
+  # Check need an Oracle database to run
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/cx_oracle/default.nix
+++ b/pkgs/development/python-modules/cx_oracle/default.nix
@@ -13,6 +13,12 @@ buildPythonPackage rec {
     sha256 = "0200j6jh80rpgzxmvgcxmkshaj4zadq32g2i97nlwiq3f7q374l7";
   };
 
+  patches = [ ./0001-odpi-src-dpiOci.c-nixify-libclntsh.so-dlopen.patch ];
+
+  postPatch = ''
+    substituteInPlace odpi/src/dpiOci.c --replace @libclntsh@ "${oracle-instantclient}/lib/libclntsh.so";
+  '';
+
   # Check need an Oracle database to run
   doCheck = false;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1498,6 +1498,8 @@ in {
 
   cx_Freeze = callPackage ../development/python-modules/cx_freeze {};
 
+  cx_oracle = callPackage ../development/python-modules/cx_oracle {};
+
   cvxopt = buildPythonPackage rec {
     name = "${pname}-${version}";
     pname = "cvxopt";


### PR DESCRIPTION
###### Motivation for this change

Backport of #40688 to release-18.03.

This PR:
 - cleans up the oracle-instantclient expression
 - prefixes `LD_LIBRARY_PATH` for binaries in there
 - `patchelf`s some previously missed binaries
 - bumps pythonPackages.cx_oracle package
 - patches the `odpi` library, so it can find the oracle-instantclient libraries without having to set `ORACLE_HOME`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

