### PR TITLE
sqlar: init at 2018-01-07

### DIFF
--- a/pkgs/development/libraries/sqlite/sqlar.nix
+++ b/pkgs/development/libraries/sqlite/sqlar.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, fuse, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "sqlar-${version}";
+  version = "2018-01-07";
+
+  src = fetchurl {
+    url = "https://www.sqlite.org/sqlar/tarball/4824e73896/sqlar-src-4824e73896.tar.gz";
+    sha256 = "09pikkbp93gqypn3da9zi0dzc47jyypkwc9vnmfzhmw7kpyv8nm9";
+  };
+
+  buildInputs = [ fuse zlib ];
+
+  buildFlags = [ "sqlar" "sqlarfs" ];
+
+  installPhase = ''
+    install -D -t $out/bin sqlar sqlarfs
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://sqlite.org/sqlar;
+    description = "SQLite Archive utilities";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11650,6 +11650,8 @@ with pkgs;
 
   sqlite3_analyzer = lowPrio (callPackage ../development/libraries/sqlite/sqlite3_analyzer.nix { });
 
+  sqlar = callPackage ../development/libraries/sqlite/sqlar.nix { };
+
   sqlite-interactive = appendToName "interactive" (sqlite.override { interactive = true; }).bin;
 
   sqlite-jdbc = callPackage ../servers/sql/sqlite/jdbc { };


### PR DESCRIPTION
Dedicated utility (vs `sqlite3 -A` in recent versions)
and minimal support for mounting via FUSE!



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---