### PR TITLE
elfutils: add patch that fixes compilation under gcc8

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs }:
+{ lib, stdenv, fetchurl, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs, fetchpatch }:
 
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
@@ -10,7 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "0rp0r54z44is49c594qy7hr211nhb00aa5y7z74vsybbaxslg10z";
   };
 
-  patches = ./debug-info-from-env.patch;
+  patches = [
+    ./debug-info-from-env.patch
+    (fetchpatch {
+      name = "0001-Ensure-that-packed-structs-follow-the-gcc-memory-lay.patch";
+      url = http://git.openembedded.org/openembedded-core/plain/meta/recipes-devtools/elfutils/files/0001-Ensure-that-packed-structs-follow-the-gcc-memory-lay.patch?id=49aae1d75ff1c6a9643c30a8cc5776a2ffa83dd3;
+      sha256 = "09y4x1yaqm84w7cy1sf57a6g8ah49b0349dsj2a81wy4flw8ih5j";
+    })
+    ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs, fetchpatch }:
+{ lib, stdenv, fetchurl, m4, zlib, bzip2, bison, flex, gettext, xz, setupDebugInfoDirs }:
 
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
@@ -12,12 +12,14 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./debug-info-from-env.patch
-    (fetchpatch {
-      name = "0001-Ensure-that-packed-structs-follow-the-gcc-memory-lay.patch";
+
+    /* For gcc8. Fixes -Werror=packed-not-aligned errors.
+    incorporated in upstream, so can probably be removed at next update */
+    (fetchurl {
       url = http://git.openembedded.org/openembedded-core/plain/meta/recipes-devtools/elfutils/files/0001-Ensure-that-packed-structs-follow-the-gcc-memory-lay.patch?id=49aae1d75ff1c6a9643c30a8cc5776a2ffa83dd3;
-      sha256 = "09y4x1yaqm84w7cy1sf57a6g8ah49b0349dsj2a81wy4flw8ih5j";
+      sha256 = "11sg2dn3vjvgq2fb9n8pgw1ajvs3gliks7djg1794wxlfg0rvifb";
     })
-    ];
+  ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change

Was failing: https://hydra.nixos.org/build/73828348/nixlog/2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

