### PR TITLE
nms: init at 0.3.3

### DIFF
--- a/pkgs/tools/misc/nms/default.nix
+++ b/pkgs/tools/misc/nms/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nms-${version}";
+  version = "0.3.3";
+
+  src = fetchFromGitHub {
+    owner = "bartobri";
+    repo = "no-more-secrets";
+    rev = "v${version}";
+    sha256 = "1zfv4qabikf8w9winsr4brxrdvs3f0d7xvydksyx8bydadsm2v2h";
+  };
+
+  buildFlags = [ "nms" "sneakers" ];
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/bartobri/no-more-secrets";
+    description = ''
+      A command line tool that recreates the famous data decryption
+      effect seen in the 1992 movie Sneakers.
+    '';
+    license = licenses.gpl3;
+    maintainers = [ maintainers.infinisil ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3161,7 +3161,7 @@ with pkgs;
   jing-trang = callPackage ../tools/text/xml/jing-trang { };
 
   jira-cli = callPackage ../development/tools/jira_cli { };
- 
+
   jl = haskellPackages.callPackage ../development/tools/jl { };
 
   jmespath = callPackage ../development/tools/jmespath { };
@@ -4009,6 +4009,8 @@ with pkgs;
   nilfs_utils = nilfs-utils;
 
   nitrogen = callPackage ../tools/X11/nitrogen {};
+
+  nms = callPackage ../tools/misc/nms { };
 
   notify-desktop = callPackage ../tools/misc/notify-desktop {};
 


### PR DESCRIPTION
###### Motivation for this change
Saw this one on reddit too, pretty cool tool :)

Edit: https://github.com/bartobri/no-more-secrets

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
