### PR TITLE
nixpkgs module: Fix defaulting of `localSystem` and `system`

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -1,9 +1,10 @@
-{ config, lib, pkgs, ... }:
+{ config, options, lib, pkgs, ... }:
 
 with lib;
 
 let
   cfg = config.nixpkgs;
+  opts = options.nixpgs;
 
   isConfig = x:
     builtins.isAttrs x || lib.isFunction x;
@@ -62,12 +63,11 @@ in
     pkgs = mkOption {
       defaultText = literalExample
         ''import "''${nixos}/.." {
-            inherit (config.nixpkgs) config overlays localSystem crossSystem;
+            inherit (cfg) config overlays localSystem crossSystem;
           }
         '';
       default = import ../../.. {
-        localSystem = { inherit (cfg) system; } // cfg.localSystem;
-        inherit (cfg) config overlays crossSystem;
+        inherit (cfg) config overlays localSystem crossSystem;
       };
       type = pkgsType;
       example = literalExample ''import <nixpkgs> {}'';
@@ -140,7 +140,7 @@ in
 
     localSystem = mkOption {
       type = types.attrs; # TODO utilize lib.systems.parsedPlatform
-      default = { system = builtins.currentSystem; };
+      default = { system = cfg.system or builtins.currentSystem; };
       example = { system = "aarch64-linux"; config = "aarch64-unknown-linux-gnu"; };
       defaultText = literalExample
         ''(import "''${nixos}/../lib").lib.systems.examples.aarch64-multiplatform'';
@@ -179,6 +179,8 @@ in
 
     system = mkOption {
       type = types.str;
+      default = cfg.localSystem.system
+        or opts.localSystem.default.system;
       example = "i686-linux";
       description = ''
         Specifies the Nix platform type on which NixOS should be built.
@@ -196,6 +198,7 @@ in
         </programlisting>
         See <code>nixpkgs.localSystem</code> for more information.
 
+        Ignored when <code>nixpkgs.localSystem</code> is set.
         Ignored when <code>nixpkgs.pkgs</code> is set.
       '';
     };


### PR DESCRIPTION
###### Motivation for this change

My c6f7d4367894047592cc412740f0c1f5b2ca2b59 made the mistake of not
having enough defaults. Now both variables are default as the *explicit*
value of the other, or a fallback. The fallback of `system` is the
default of `localSystem.system`. The fallback of `localSystem` is not
the other default (projected), as that would cause a cycle, but `{
system = builtins.currentTime; }` just as nixpkgs itself does it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ElvishJerricco 