### PR TITLE
inkscape: disable parallelBuilding to avoid non-deterministic failure

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -51,7 +51,9 @@ stdenv.mkDerivation rec {
     libvisio libcdr libexif potrace python2Env icu
   ];
 
-  enableParallelBuilding = true;
+  # To avoid non-deterministic build failure using make.
+  # When switching back to cmake turn parallel back on, see #40046.
+  enableParallelBuilding = false;
 
   preConfigure = ''
     intltoolize -f


### PR DESCRIPTION
###### Motivation for this change

Try to avoid non-deterministic build failure with make, until #40046 is fixed and we can switch back to cmake. Inkscape is currently holding back nixos-unstable.

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

