### PR TITLE
astroid: 0.10.2 -> 0.11.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchFromGitHub, scons, pkgconfig, gnome3, gmime3, webkitgtk24x-gtk3
-, libsass, notmuch, boost, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, webkitgtk24x-gtk3
+, libsass, notmuch, boost, wrapGAppsHook, glib-networking }:
 
 stdenv.mkDerivation rec {
   name = "astroid-${version}";
-  version = "0.10.2";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "astroidmail";
     repo = "astroid";
     rev = "v${version}";
-    sha256 = "0y1i40xbjjvnylqpdkvj0m9fl6f5k9zk1z4pqg3vhj8x1ys8am1c";
+    sha256 = "1z48rvlzwi7bq7j55rnb0gg1a4k486yj910z2cxz1p46lxk332j1";
   };
 
-  nativeBuildInputs = [ scons pkgconfig wrapGAppsHook ];
+  nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook ];
 
   buildInputs = [ gnome3.gtkmm gmime3 webkitgtk24x-gtk3 libsass gnome3.libpeas
-                  notmuch boost gnome3.gsettings-desktop-schemas ];
-
-  buildPhase = "scons --propagate-environment --prefix=$out build";
-  installPhase = "scons --propagate-environment --prefix=$out install";
+                  notmuch boost gnome3.gsettings-desktop-schemas
+                  glib-networking ];
 
   meta = with stdenv.lib; {
     homepage = https://astroidmail.github.io/;


### PR DESCRIPTION
###### Motivation for this change

Version bump.
`glib-networking` dependancy added to fix image requests via TLS.
Build system changed to cmake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

