### PR TITLE
kdeApplications.konquest: init at 2.4

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -127,6 +127,7 @@ let
       konsole = callPackage ./konsole.nix {};
       kontact = callPackage ./kontact.nix {};
       kontactinterface = callPackage ./kontactinterface.nix {};
+      konquest = callPackage ./konquest.nix {};
       korganizer = callPackage ./korganizer.nix {};
       kpimtextedit = callPackage ./kpimtextedit.nix {};
       ksmtp = callPackage ./ksmtp {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -140,6 +140,7 @@ let
       libgravatar = callPackage ./libgravatar.nix {};
       libkcddb = callPackage ./libkcddb.nix {};
       libkdcraw = callPackage ./libkdcraw.nix {};
+      libkdegames = callPackage ./libkdegames.nix {};
       libkdepim = callPackage ./libkdepim.nix {};
       libkexiv2 = callPackage ./libkexiv2.nix {};
       libkgapi = callPackage ./libkgapi.nix {};

--- a/pkgs/applications/kde/konquest.nix
+++ b/pkgs/applications/kde/konquest.nix
@@ -1,0 +1,18 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules
+, kdoctools
+, kdelibs4support
+, libkdegames
+, qtquickcontrols
+}:
+
+mkDerivation {
+  name = "konquest";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [ kdelibs4support libkdegames qtquickcontrols ];
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ lheckemann ];
+  };
+}

--- a/pkgs/applications/kde/libkdegames.nix
+++ b/pkgs/applications/kde/libkdegames.nix
@@ -1,0 +1,26 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules
+, kdoctools
+, kdelibs4support
+, qtdeclarative
+, kdeclarative
+, kdnssd
+, knewstuff
+, openal
+, libsndfile
+, qtquickcontrols
+}:
+
+mkDerivation {
+  name = "libkdegames";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kdelibs4support qtdeclarative kdeclarative kdnssd knewstuff openal libsndfile
+    qtquickcontrols
+  ];
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ lheckemann ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
Conquering the galaxy!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

