### PR TITLE
m-cli: init at 0.2.5

### DIFF
--- a/pkgs/os-specific/darwin/m-cli/default.nix
+++ b/pkgs/os-specific/darwin/m-cli/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "m-cli-${version}";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "rgcr";
+    repo = "m-cli";
+    rev = "v${version}";
+    sha512 = "0mkcx7jq91pbfs8327qc8434gj73fvjgdfdsrza0lyd9wns6jhsqsf0585klzl68aqscvksgzi2asdnim4va35cdkp2fdzl0g3sm4kd";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    local MPATH="$out/share/m"
+
+    gawk -i inplace '{
+      gsub(/^\[ -L.*|^\s+\|\| pushd.*|^popd.*/, "");
+      gsub(/MPATH=.*/, "MPATH='$MPATH'");
+      gsub(/(update|uninstall)_mcli \&\&.*/, "echo NOOP \\&\\& exit 0");
+      print
+    }' m
+
+    install -Dt "$MPATH/plugins" -m755 plugins/*
+
+    install -Dm755 m $out/bin/m
+
+    install -Dt "$out/share/bash-completion/completions/" -m444 completion/bash/m
+    install -Dt "$out/share/fish/vendor_completions.d/" -m444 completion/fish/m.fish
+    install -Dt "$out/share/zsh/site-functions/" -m444 completion/zsh/_m
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Swiss Army Knife for macOS";
+    inherit (src.meta) homepage;
+    repositories.git = git://github.com/rgcr/m-cli.git;
+
+    license = licenses.mit;
+
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ yurrriq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -683,6 +683,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
 
+  m-cli = callPackage ../os-specific/darwin/m-cli { };
+
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace {};
 
   skhd = callPackage ../os-specific/darwin/skhd {
@@ -3163,7 +3165,7 @@ with pkgs;
   jing-trang = callPackage ../tools/text/xml/jing-trang { };
 
   jira-cli = callPackage ../development/tools/jira_cli { };
- 
+
   jl = haskellPackages.callPackage ../development/tools/jl { };
 
   jmespath = callPackage ../development/tools/jmespath { };


### PR DESCRIPTION
###### Motivation for this change

Package the self-described [Swiss Army Knife for macOS](https://github.com/rgcr/m-cli).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
