### PR TITLE
s2png: init at 0.7.2

### DIFF
--- a/pkgs/tools/graphics/s2png/default.nix
+++ b/pkgs/tools/graphics/s2png/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, diffutils, gd, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "s2png-${version}";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "dbohdan";
+    repo = "s2png";
+    rev = "v${version}";
+    sha256 = "0y3crfm0jqprgxamlly713cka2x1bp6z63p1lw9wh4wc37kpira6";
+  };
+
+  buildInputs = [ diffutils gd pkgconfig ];
+  installFlags = [ "prefix=" "DESTDIR=$(out)" ];
+
+  meta = {
+    homepage = https://github.com/dbohdan/s2png/;
+    description = "Store any data in PNG images";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.dbohdan ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1385,6 +1385,8 @@ with pkgs;
 
   parallel-rust = callPackage ../tools/misc/parallel-rust { };
 
+  s2png = callPackage ../tools/graphics/s2png { };
+
   socklog = callPackage ../tools/system/socklog { };
 
   staccato = callPackage ../tools/text/staccato { };


### PR DESCRIPTION
"Store any data in PNG images"

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---