### PR TITLE
 firefox, firefox-bin: 60.0 -> 60.0.1,  firefox-esr: 60.0esr -> 60.0.1esr 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "60.0";
+  version = "60.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ach/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ach/firefox-60.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "1e7d2419e488a14eed5af7f2aec9a0092f830cea256f69cf654b2bbf783b192ead4512538fe3b2566dd55061cccaced91a7aa54732fc0987a4b24f676b9cabd9";
+      sha512 = "ca1638e32f121b1f366d89934e5516ee23cbe249596a7600f5ba1986fcb014d9125d24d3d7a38f251aa9fb527d368001ccc0af80063a7f3abb02a2a920bc7fd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/af/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/af/firefox-60.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "5714025668a2a9856571c743870f3401f0bfba66bb216936df7fbc977d9a935ae8b66fcb3042e45a934584a2571289fdac4f8fe8af2ec6a52c93d6fbf21484fd";
+      sha512 = "f693b42ee4380fa6c0505fb7971984dcb466ef2a1ce90c09e8088e758f1aef5d3ee790ac578737523ba93f2866dcc92722852579cf4cc5898e66adf28ce17495";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/an/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/an/firefox-60.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "678a060be20453e11fa2e8dc92db8a510789082d026a768dfb6cb3ac6a77924a1f6a9cce4e8c83e19a4aa6702b1e7e0b17846c52d2de2719dc5f8141a95d1c47";
+      sha512 = "4858341f974d45c982a9c3c8285de2932db81c8dbdd124272e7aaafc0e4712f613aec5e4929ad0182c1801850fc394ebeda38f08a40e71e29ce111c17abbfc7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ar/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ar/firefox-60.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "0c8e9cff9d7a349dfb18e3c5924efb068e1f9f145347b08feb158521b3ebf331ee01b035052ddb889d09b728745465fb6b7ba79c3608719c6f14a36e1da061c5";
+      sha512 = "dcbe81e9b0910c44530f9b8f33876c8e2df6ca314172f268c9b5cc53010f5f4024b37929a726d4c138033596d904596a6040b6770e796d20a9a8999ff3e84ecc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/as/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/as/firefox-60.0.1.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "0ec81546fa30b6ff5fd8b66df5b97eff25b359ea0ff258cd24aeab63cc87ecec3deb5f4173d9da46efbf82f70a3fd1579aff819de4e299a464abe289e7c77890";
+      sha512 = "4420f102bc6d665ddb568d3a27001cb91ddd76ac20ebe65c4c6fe58d92b2b9406a47c492c2f5ed4da42a48355e30a982c81da2b756826d239d443179bd6deec1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ast/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ast/firefox-60.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "ca9eceb89df3d618756618d961be5115846c1c6426f7f145379c2a127c807ba17c4796e9a16395e6f2d05b5638366b7f0a77ca19a75f89bbdf6a2a2f93269c74";
+      sha512 = "5294a33939e40bc868041952830593fafb27f7be2eb7fc163571a6d08c7ccf19443f177bd73e4a3bed96d73103d2fb696810982648abfe300973c7ca7c6677d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/az/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/az/firefox-60.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "e99295b469fb85cba099424700267f875e7d4ad9c3e8398c7ed8bd4427a3d173feec957edec2847ade3735df77a7313ca99a98b66b67c158b33bd17e39fe98df";
+      sha512 = "272fe5c3c276e9f3cc9554ebada40a90762af24cf6652a5fb9541f41aad964358471f2c19f94b3c1ad59eaf93a4ee507617f4ec299d4601c41d72a6620d0cd3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/be/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/be/firefox-60.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "ce80aa81c5b04da5f0f89d9e527b8e1d7ebc287ddb05d2ecc08994c0e31ea8860b68316af5e00f59e1ba85a4abb29e1e9403cedde40faa294af6b130be2a4ef1";
+      sha512 = "75689bbdb2f678ed36b265696d21d6f9becd7658001e15bbd8bd306e683b69d4762ac1cb27ddbb12638f7e626927e36fc0a16cc7b98479c5f2e21769dcd9cd06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/bg/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/bg/firefox-60.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "5a5f0fa8745c9c649dc26e8d235729bcdcbc397c4deb56bc0d8bff954ec64c2acd9f4d9fbeab9b0484d3fe91ed3717f8e37d5602f139fb5bc4fb22d0a372b926";
+      sha512 = "33b7aa767bb6c234dcb8406eb7eee3160424192dc1a76b9c1c7beee1de42d1c623ad009ab714e60c62e07bbb087cc1b08feec7628361739380a767bb7b43a020";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/bn-BD/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/bn-BD/firefox-60.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "62989d16accef0717ec9360d66cd169d89847701cab64f06fae6290b9be6d67acb0dd6c5d7f0e0c79107301512f57b44da04ce66096232291c5947a903e446e7";
+      sha512 = "3c6fdfe39d61fd681fa3d30a4ea1c1ef7988a1345912592a79b9622f18d1106ab96e099fe56b428568467c0c63b56e2cc09bc5fe2a9705478f458d5de0f36433";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/bn-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/bn-IN/firefox-60.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "fd75cfe4d3e9e7534d4b99452c05e4ee8bb45ddeb0b6cbac979b65db0a783f342b346204428c9b0787ab4e1bcccf4d4f056f4043a906dee41e7753ab8e53fc9a";
+      sha512 = "d9c67926f2df8faae64a6d9848a3823bd4968cafa1caaaf8b2713db2656c0a6c82dfc16eca9741c274994178ea46a7325b5f72a11ecafddacd8cf4df45683a89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/br/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/br/firefox-60.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "5c17a47e0fcc7231e6d1a9fb632f5f55c6dcb4dbfdf02ca6607ddcc54db3e198d563b0247fd4e95226ca29dfda25bf092e1b427d1b532b6544c2f2c5c498ee02";
+      sha512 = "a0ad58a34f85b254d5985a1bc6a2a0003a91773ba43408a45998098b98fe104b9f09e4d4e9bc9ab7ec9cd378692beb6e9f7aa4d2e55b49630c807bf0f9d158dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/bs/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/bs/firefox-60.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "290f57558d2d0b6abee4e6220047e0e6082f328bf3c1c7ba02474d7885ad3bbe77ead7875ec2726ae5ab4db25bf9659147c5abe9fea771a54acd4a9cefa18c8a";
+      sha512 = "3c24cba1629f4458832d09df121c897fa08c6c3a02ddb42d4e232207086525ff0dd01adc8e133c4ed2b6fc909907efd87f985cf0bc1d27fed18055ec566403f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ca/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ca/firefox-60.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "cfd5654a3ac3a50885621bc4be9918f5e71dd8150e4fe4e54acf35685a42ea82d6115e8a50593866e186860c7d5de5408c5a0e7325050b1bc39d6964e828a3e7";
+      sha512 = "75d63bd285257a1f8a6dd97981914fbe0886d77abebc237f08abb498a34bd1f129e38afd6fdbdce3da3d7dab5a7138e1da883ffad0ca31f954da68fc3d273ed4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/cak/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/cak/firefox-60.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "479d713253b99a19c6ec305e7986062b3a1ee476afb8968dfa2f57c52f22b734df82661bf487ad1fe7e706dfb581a99b247ea4128e89c9105b719b96f37e1cc2";
+      sha512 = "d79aaa1c8833f2fa9c9612efb8e5b7a02805c37f1fc45db6f7fc2f6288c48f75880ff46b9ddd96be7f05b674a8201f3c1bcbd36d0deafd9072aee5dce8f18ab1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/cs/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/cs/firefox-60.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "5139f4a2820ee921bd3c02acca7f57c5c2cc510c0e364129ecc07f17843cf92c565770fd0829515bfae94f96f6c9c68e8eb05c87fe5800da0be64f2400bf876a";
+      sha512 = "8b01b051a92320457c9364ab0f28761a7dc574b35777098bb773c9b0ec64d8947a76a2bf3c58b3b4a073e392f7d07b4f804994854c6f625a9e9dc51cad9bf914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/cy/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/cy/firefox-60.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "d26fa97dae91eaaf0b09a580880ff0bb70f67c473cd8dd804d835823ac6cd97306b0bfab9b8fabd45b35330ddbef72e779dd09b47580b0347d4d857dd04182e5";
+      sha512 = "9f0e601b41e8f698de134d17d84f1b43d8f91d3319041482fe698fce34c8bcaa0da31e1e113fde72e1760bd93dc11dded02fbc917d69cf1ab008518e54c491dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/da/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/da/firefox-60.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "66a187b067f2e71f8ef43e3eed3eb12d02b407a230692e653111407c2dec82dce552eb5f9716733b0b3112d2d07ba6d917e4166e9bdac030dc0569a8630b566e";
+      sha512 = "dc4280c4e4f7e51befe4adc002d6875f9bdc7d4cb592335134d5b0df18462b6fe54817dbfa2815375e8947bf76d81ab9ccec31b7b36f07ca2b11ec04b3bbf728";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/de/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/de/firefox-60.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "aab4cfcf1c47d99c01cc93b0e26babecb4619b67df65a2400259249a870aa765152b7e4be625a9708e3e44b90f5a20b77f282b6939f2d092cc0bd180d8167c0d";
+      sha512 = "f9c7e6f1b83616883c74ba8fca5d21b793a811868e15e40611c93312f76ca8d8c37c4222454a8a71bce47d1d30e8596ed5907eb9300c3b5a957ae49249808c7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/dsb/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/dsb/firefox-60.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "8726bd887b610e74b8b7073b8e797a98e009150594f2dd5e0f301f375b7bd6af02b5c8915c444145fadc6ae3e77f494a6c39632858d172b6324a2e4c84c0d6f0";
+      sha512 = "fc41281038372262d135de8004a1d7b03a3c8047fc20ab0e6856b696eee3260328a64b59212a809eb03cad7efd58fadda422e44153e7c8e33415d0efe5321c63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/el/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/el/firefox-60.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "f67a778f0aa15bac7450a210287f8e1e29cb9f4abc0f9e3c037d15a0f9341cdfff80b38a936724e5d18b5ceb373233fd8d038579e3a044c177887e05f5834310";
+      sha512 = "5a5f2d3f2f83e8c3a4bf358cc9611f1279fbf218f24c4e5aff69efcbe4b27ae08b955bafafe3a73ae1caa05914bd4ad739f1292344d9434f1f486f5e615645dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/en-GB/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/en-GB/firefox-60.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "fecd277c434cf3d4509371a5abf09fad81aba3fc7807470fcb91975939fef0d1384a97c4322411a787bb3fb27e3b043f9dd3ac182e41d35ea59824d109ff483e";
+      sha512 = "19b09722af085bdb016a12cc586ec9d32371d293f3c5be660efdb792e2d894d339600cef27325759f0489a0b3a4000123685c19db5b6d933d3f4f51244cd4f90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/en-US/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/en-US/firefox-60.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "263b6e827b8e6f8757c82a2ca24f78bd649ee07254cfde454e6d6ed879cfe816ed61c94aab3c10f3d63a38f83f391bf66bc578ae958343327298801fc30eaf3f";
+      sha512 = "2f7c14e1ef94ad4751c7382d7b012fcd36787ee1045918226cb3b0fdbb08508fa986181f54e304df12fdb8d49aadd62afc936f5855939437a7f9d8860976398c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/en-ZA/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/en-ZA/firefox-60.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "6ffa936e9f5e495309ff535fa9775200f8110bc0162d97f8d8bd00cbf3606c47b88b566114224f882a323c6e9538150ef79e1340e1e1eead8ddaf030b4ffb3fe";
+      sha512 = "04661ad52e94ad5e8967e21a460fe1e25cc08f9f0f108e9fe55633d4fdaaf23df133b1b73388146c496285d8562b57d38603100f45c4d81787ec02d4c4b6f0f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/eo/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/eo/firefox-60.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "f65bf2b40299c5260cb857c781445c9213dea8a49751d6701f43f6dd11fccec206b5850d54e96a4eba544d59b6a470f21b3e15b60116615c343d78726e7402f4";
+      sha512 = "bb1bd451569e1a4f116b458bb9d020d046b556c7335589dd6aa13f2a941b4ebbd197fa25728607f8bcfeacb610a94943d01d05b072f212346a5b74e96071f157";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/es-AR/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/es-AR/firefox-60.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "50a912c5d4cb1e73bbe5b4c6cd8a112cf88377ca78cb45a073bfe74b4b5618a39fe088c908e278eedaf50308e70e63d38c06343c4d60fdfc346684ce7042a5ef";
+      sha512 = "8b175a74a9688a50adc42a13b4ff4c137b34f09c571606d9a25080a8134640bfc8e0ef757ff88e90428153002d5c71f6dd339c54320520976669c264004a6743";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/es-CL/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/es-CL/firefox-60.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "b12f0fca0d307b280ec2a44f9dceed0073b0b9e898e05a55fdfd15623e022eac7b937e6b4ce470c7892e9ed429fd98a4d09141a5e1141fe05e3b21ab838a21d2";
+      sha512 = "7561ea580fa411d7c4a8c4cc6bed455f3287a55a843484d20431aa81f7d08b42386287e3cbf5fe7751f528945d9ed70b922cbaaa0f5cde74ff030101d897447a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/es-ES/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/es-ES/firefox-60.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "492aed6ef8fa3e51ad1604cf858dd1223ccc8a949b3cef4ec37be1596640421b057f50d3ad1827fe139230013ba4c040466682e61ebee59e7b6c168f35a14b1d";
+      sha512 = "3f7dea40f758a29ac6cdc8dc9e78ab4fde698c7f8d5369670ae31ef3a09819dd40e28296e2c05caa57e95bf4238f6c162fb81fff6d2bcb4a2ebf26eaad3a225a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/es-MX/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/es-MX/firefox-60.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "8f12520b74b0899c58f29217f9ecc6223635b627ddf525e3d36b7a0616ad2ea39e239bdb3cf3e0570ba4be03ebd93a2aa2739cb7cbfb851e84d2549970fd0bec";
+      sha512 = "2ef05c4095c02c22769098c837cabc435d2d84ec60b7ce09682c6625117c93e294bd00877379561728117e33d5991a0272cf48044a035964eb5d9df6167586d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/et/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/et/firefox-60.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "c24e822fbd147ae85a8f02dcbb070764c31b96056a07b2b344f85641517e1e8fa78fff860bc7e951675f9ba30616dcb567e279db93638f241a75632f7fd97b9f";
+      sha512 = "445158a41339640365d8101bf4473dc77df38f8c965a75f66ba8ef48172e6bd21d6813025192a7f98d451b50078faf5485f95b826af566c3e5215a10df2cbcce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/eu/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/eu/firefox-60.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "61ebe8e2e353419f7ed3ef8f944f4d8ae54d3c1c21ed7c1707212ac31e20c6f0607c00d0f3039e83c1aba832653f9c352b4976af4100b968045ad103862cee6c";
+      sha512 = "7760ad9243be37fbf1aa727afda348f8b4460eb4726d1402e2da82b3165f208eee21b786adde20e7c11aeb5567c6e379210874b0eba75a86f5c88486b4c48c2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/fa/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/fa/firefox-60.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "d47f63bedfc12a2e14eab57eeca7f946513b3067ea84b7931237a32841c40e477dfb4f3979fdd617b6b43787631f97fa4e28f996038f3eac7c2be7c82f8edfaf";
+      sha512 = "38fff9451b7fc7a027a5cf646ea6666a9519ae57f31ea77da8560777e485fcafa27e5203ce184916a725449384ce7531f41ba5f38d30a05004093c932c052ebb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ff/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ff/firefox-60.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "91fbab65d71da4416df7501ef392154844a6e5fafde529e9a9a42f01b44eb87ad248d83387b68fbda5b964b8d18b1b22b978dac8751cd73bf30c46d3cafda868";
+      sha512 = "efed066528af1466f750af19ac816f64031220618cd1c35e8c2041b6d94e0b3fe894780dda51c22e75eb49d4a0f3013c6de9557167de22b85ab4d72bb44d6729";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/fi/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/fi/firefox-60.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "483408626eaec192e753277b02de5c5bb68ca6056f35756fd7f80ff6c6ab3e6ff15f23d4cd5d1a28c8e662bc278ce7cb285513504663340451b912126e4d4fbe";
+      sha512 = "95d8c34ba47b0fbf2b112764c5f2dff684f9e207c839eef45a2443500de6f30b72ded618e116d784b6b315028df8cceb1efe11d3dc08b1af4a0466c016854c73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/fr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/fr/firefox-60.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "adb7d295ba37c0cc7b51e312ffc3f60e8ee13106bacbb833086d160535504fa2f8f859ea3c1d30eb6a823ed9c2c6efc97bb691dde8cdcf991090e29e15d5c21b";
+      sha512 = "108fa3054bec0877f35594c6c5f22d5d5bce3eaf5e74e5a1843bcb7592ff84b67160065b32962497577cf59b5375f0bcf75d4676c4e7201712589050a018e00b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/fy-NL/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/fy-NL/firefox-60.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "ff44abaf4ec57162bdeb3197c3f75f312029934a8546018dab76aee8bab44cf2411c59d04a4dee9bebd618f26b466fd074f7533d839f1202e643d255e97e8015";
+      sha512 = "9dddf9cc3be7557e495e712f542f5f3f40ef205c893b5773217ff13e93cc83d35c7d7fa3611ebd1223a9cde4308cc8b4d0d0ba8879072e9dbc1d1433b972ae15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ga-IE/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ga-IE/firefox-60.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "5d511a4dbc00b39199500b30c98ecd6bc009217644b82f58beed9fbb74699fdeca7cc31b59a046a7c56fa57c53c2aef7cc55232fedbca751b85347460c014d3b";
+      sha512 = "a2539cd2e7ec2f8898c98a27e7e70772d42a14a435279e33f2fe192189253e8c0d92814d25d3b2e5a5c66ac02ba6745b5feee1045c965398781fa86b19c68b0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/gd/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/gd/firefox-60.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "c7c893d0acb97541d9545a35c031aec967405113a4855d6833b5ade0418004fb8b6efab82abb551499c4b4f8a32010634b64a96e8c9b12f27b764dc50b33a23e";
+      sha512 = "dbfcbdd6bf0ddcf535821268d0c7fe59541387647124a7b95243babb1ba02e34dbfc3956808aea1bafe5f301a7c31382eb958e3da21a476c7961f44b4055bd4b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/gl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/gl/firefox-60.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "aadd92086094860936f1c0436bab9742170533a1b233022313439c9aa968269835b2f63bf33226c1fc52bafbcbe1e00677e8f1e04579193c474600e5dc3d94c0";
+      sha512 = "743c417dcb7bfb4027b0f56ff9c2561888bb7a66b0399e713bc65255f6283f9f33736abbfb449030cada641b085ed9d6a5a7010c60ada1002802f4cf6f3fedbf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/gn/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/gn/firefox-60.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "cf566c8adb01873712708f76bb976a92a3b729459639faabd22ab5515cf59951142af734c9eab7d67ec4eabf9590f1d7bab65787f70908dbc01aece73bf52277";
+      sha512 = "319eb86fac5e121e27a55386d3b9b79a07e4c766ac999ea387e03619f85e1c9a194dc4bc6cb56d66203ae647f6cede6bba81e65c4bace35baec986a18d79045f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/gu-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/gu-IN/firefox-60.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "ecc4afe4acebf476fb0c4bd089679d8fdfb88c06769a75dc473ca3cefae09c01c8e71f88cf3c8130f4576eac17445032223f2713327ef6386fda6a2e3f588bbd";
+      sha512 = "37a5b54f94b5532d8bbaff537642bce1ca3822697821b84df523d9ecbeecd991aa2302c65a1f31883e7a0f9519347a3bb5995bc17208e1a56d8c98897fd1d2b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/he/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/he/firefox-60.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "604048649305e7abe426b831c8b3fd0eb3cb26cabc7b055f85b7fcad8d0f9cb8bb06a431a28013ae8fd24ab4b21d8f8e68053dd7397a88546305f241adab476a";
+      sha512 = "7a9cae5f7a7aebbf25908509efae41430f6f24d91d406964f83da585762cc078caf508750a562683e1f782bd805ba24b59327d1807badf63462a19955230aef2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/hi-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/hi-IN/firefox-60.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "1f1d56c762166cd8c099f636c610c361ca94d388bd4d627ddae6d94e4424074686b5fb6a3aae5562e9250dc82576bc52abac4e1b09386dc2f81799a1804bb7c9";
+      sha512 = "99ed2ea7f0aaaf214d3d4e60ff1fefefee09c42d5aaee85690d0c4e9832cab67f23b4d3f5eff8f46a936ab91922bb32ccc801db06c1cfaee4bdea3e60df3a2b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/hr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/hr/firefox-60.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "f5968a481d92aa0b57ed6319e7bba0d11ff00e0ec8beab9c6b66e18f4a6d128979ce1efaaf6fa07d4202130698216e58b8580833c13e1420dcfadbcda925b908";
+      sha512 = "ea4814ad10720b0685713ea2d670c65713e453693b1d6ab95eb55e1ce418f398549ffdbbec172955d0141f275caa424c75bbcb326b736013dd8741511cba9488";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/hsb/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/hsb/firefox-60.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "6dee0423afa3ab5c173568aa91a2e92927cd6aae390033f34d8e63ad224d813b3f688a0287872cd8b08efad823b05804ddf54efcb57d1503bb70731391fafebf";
+      sha512 = "2e89edffaebcf69580fdb83c92830b091956d2ddd2d523885d0cbb858f3a958661c47e65e82a5f4f832751b215d568f985632a466e52cc23254ebf0b0276cdbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/hu/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/hu/firefox-60.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "688103282fbc64a541bf6b914f757ef4cdf58ac6eaa942f45bb8b20b661136913b62735b7352c2118643118c48d94dd9a7cc18dcac184c3080e078d6bafbb278";
+      sha512 = "d00f603275a624ad6ded66f71b287e38afc8c4904b194fa0c71ab4f148ce2ddeda286eadc1b2395c316a4ace7aa7ea39e6f50ae8b8177bcafd60774661295e23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/hy-AM/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/hy-AM/firefox-60.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "f836cd764ddd7f9f48295c103b4ec0c091c8eaceb756825fbc9f4a03b9dab786fc94781903975167d93c8d9ee73940a6607403ae6d0ef97a7c83b89989ec628c";
+      sha512 = "da238fd6afbb3bbd7586f9f057ccb53d5dd8068fc12ce6ced6602384ede890b71e964c0c516b776154f5de358b1bf6b06daf91526dd8fd334bc6fb8fa650bc1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ia/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ia/firefox-60.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "61ed80fa61e7e8247ac1b59dd26582b063fd1313a02bf1ab73c696389cdf5f3d8bc0c3b58a15fd9ff08ca9514e3a3b53fb16aa532758586d412a8155131fa457";
+      sha512 = "dad9d2b95fa47fc1b34aa9bd47f785e7640eaf44ee51dc0cee8df6897939e3c77977c60b7a8fd3427b23dddb10bf4d0758b3ba08d305c61f7b42dab6b490a6fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/id/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/id/firefox-60.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "a87de8f34c82d35a5bfc77ba7a5be2c5afa6b5015d79f25280d162f9563cf8e48ff54386c03b67e4743a376c0d679f1d90b7f87924126028f2a4b990e7d28182";
+      sha512 = "17f8ceee4f31a8a37684d1319f9b84685c05f3f2aa0ba3a8801c4132c2f61755ef9427eeffdb38420829e92fbbd24dcbe54906de59d89ff149f055ede61b751d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/is/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/is/firefox-60.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "3b51c777930363c3085f11f3fd54a58a3ebf63a1a35384ec8d324acd670cb35e8bf8f9d1bd3b6ba735b63b5b2f0901d064e7802c5fea6edd5b36d7cc022cfd94";
+      sha512 = "9dc8a651bcf460e48a64661dea924d56d48e37424579b369ce4bce113d3a3405fd65f542096c8d199a2a3db42463dc28964fe92c42419c8aa5020084b82059a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/it/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/it/firefox-60.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "84ab4fc30b8753fd7586239b6f7313828862793581932aba00394ba59f6070a5ce69455a102f2ad05fe19e8cdfcd78de82d488bc31918b63f4d8aa810db2be76";
+      sha512 = "49a8881a2ae10544db31aba2a8f54bce5948ad25a47f8bd221d8982f12fa66cc7caa43e8c1963cc3ed156ded31bcc331ca0b2f784655c7ef0d8af89d7fd2c271";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ja/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ja/firefox-60.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "345b9ed332637d74064064894d34d32263725af9d288da3de3b2c05d2e38ee97355bba5a871698980d772a7b6847642c19716e00514d2965900f12b8a5d7a633";
+      sha512 = "9af0675507f54ec12924c29e051fa4727ea7b380ebcbb8fac1a91481c0405585b4e593324f72b4778538f0acc0efe8878f21f16a02272c5b02acc5ba7be7245c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ka/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ka/firefox-60.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "fa3baf6c474e883c94e5d862739e2124980e3d7cb7692dee8507d13bd1aaf389c849b218ec0cde02f60db479c1ecd32e8e444afe3e09c6ebb4e7afa0b273a2a4";
+      sha512 = "c5b52b448bdb19945baab604b820d383f48cf75a3fef2b8d734f0874d7aa8ba1e3ac6493e9892d8003371fde1bec8405cb1bb0991656b8d9d537e8c0b77a062d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/kab/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/kab/firefox-60.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "a86ccc40c7a7460acf3242a8ab85fdae4146bf0efbae20ea44fb0251f18bbc803f55748348022ad5196c2347e3da7b79a03418ae281835af184d2245e4bb7635";
+      sha512 = "7f93bb78f7e57004fc22863d7dcd40f9407e32a606ff07bbc20a3e4e8d348720fff541d72d962d119eab70998925cdb81ab816086bb8d95c4724a9c02a723587";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/kk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/kk/firefox-60.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "420956435202d7166c3d29c795974034b43c758fe19d0d55dfbd207e4e1862272a55a6770294ffa54a4cb9259985eac7f17a290e13a49006661b18beb7f27a23";
+      sha512 = "fc60ad4c8c2db9252e4975534a50b373bd5b223ea8ae6e6d2a7a07bbaa4834d078ef2756b40dcbab2cc4dc1bdb5feb1def890021c1d44620a179dbb10ec2ab28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/km/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/km/firefox-60.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "cfc262238316cd3dcab2e2a11647cdf3a7ba38004d4fa18f83286d6cf1320a78534cb88727635c330e6ca8c8608aae748786a83fb68484f6d2f6ee23cff603f1";
+      sha512 = "c6a544c825f3895ec390275e823da876113d74e16fe3c61838c55afae38b9ba7abdc05e28d1b66bdd3477be0e4b0b792fa2244eb6dfa7aa4a189da438badd823";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/kn/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/kn/firefox-60.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "27c445445080f6642d4f95022d8bd07824ea81549f80da041ad1273db6d4a0eccb9e1bdcacb89e269e69dc63a33af2c131f193545624771e25444e212592c45b";
+      sha512 = "c42366e72d38cbe3301d52ec5c6e34d5b623d5f1a06e8309cdacb5ed6b6a3a356034cbe95ccc5c6a8b320dd41e8a92564b66effddab4a03476dacf00acab3fc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ko/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ko/firefox-60.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "21f8dedddbcc5da3788abbc17ae07c422b2f1476fea3c45f173376b1ba38736f1a85b7d11bfc0e50ad610d605680b3333c39b18b89e9e4990086a782f8559881";
+      sha512 = "4e05c5d8956661956581acd8bbd93eebaa84b6d5972da34b976bb6f654a06d1d0286504350b89dc43988675a3a9c57890dcec81c4a39ad87e0fbd0593a0e1d63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/lij/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/lij/firefox-60.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "706bb394d90ac405773448cd4869c8880a649569d15af420e15851131194a014b0b9f72a9b60b2f621596d4215f606b3b81e0409ea4eff5da0c04a91691bd99f";
+      sha512 = "68120d34a56f65afe99930e32c0b35660c36b38d61e5f60f7ad5da131b1c95d02e241124379c11b6287d2f8794191d27ef1fff1f5c4eed5dd3a5df6f5a2183cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/lt/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/lt/firefox-60.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "6cf1735fb80b7fd945a2b993f1963ed14c903791dd720fb9821a728251b0c006cfda12f80f55e96bb821c7988f7e73144254e7e3a3c92a4a66680be9293771cc";
+      sha512 = "149ee7cedc772534427202309ec4060e8187a847b79dd686096d5ec2c44b1a0656e8c3099606e921942e8c426d0206551fa5952dc0e9abd1d510320fee26926a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/lv/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/lv/firefox-60.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "5feccbfe1088ed569e67e3a54f9cff0f7fcac91dccb8fa447febfd96ef2a4f25a2f51b8dce2f397b2b09fd8654bfcf292339cc5d25140a1892894425f2d86e3e";
+      sha512 = "0e630d9a09895fdb06c6893d7f9f3bfe3c3832d4a1682e2f12ee89611570b6bbca695bafd8dcfa583525645db86a156bfcf97afb575c44c19f801a43edd824cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/mai/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/mai/firefox-60.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "0b75fa47591f6ed9cdab76ceda17636a7f666b6469e2fef948d29c77f559328320cb1108105590a240a0004976cc922439eaa800a5234f7064396e2d56e5a45c";
+      sha512 = "6c3dc9e2230a3f7d74390e00e661eca28306996cb8d5379ee7fde818dc09beb813ae5ccf09319510a1df84e3ebd45b7f1a8a08e776d046e39a69f724fbd79da9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/mk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/mk/firefox-60.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "bcecbd3a82a66abc1918f03ff0c5da822526f3c1a8ad72ca9a021d5c036a382734251513dacef9ca6f290b130b67edeea5a79a37606ac34f34b27528ba7cffac";
+      sha512 = "60353c437af1ed116c5d16a4e5d57a1b99016a36eeca8f8e4e8379553a5374cea543dd8a9864e448028b2f188ae16180590da7e199ef96fad604e172fa1f6e55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ml/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ml/firefox-60.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "14d844aa0c430376d17224e0172234bf028f1bdc56b931aad2455c221affb93f1048866b8bb3418dd10fe12367178e7504842762fa9fff381a21ef8599bf9f37";
+      sha512 = "6065d13e781728dcf587a1389d3893ee69e7e49b601cccb293e2c13dd5e0b5b039ddcef5de3b8b61baf30aa0e994f44eed6f29b38c94b3b24df88f102b0721fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/mr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/mr/firefox-60.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "b25b3aad52c6670c27c977084cacaf526b4c64b24c679dd7f45f4ab583a80799912b6e6b9eac195ba19c94d70dc5a1fcdac46e2c1234fac777d706fa51008221";
+      sha512 = "ddaf770f926ffcb612bef6169cbf073ed4c624635d00db6edd3ac6c6051ebd9ab926ae48f2a9b92a5816c6aa2e6b5ed33ea90827f18c70b7364bc33d6ff9174d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ms/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ms/firefox-60.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "5df8c5ca3e8dec6b84066ce0c4e2db00d12cbf7c0c51d229a88072653166359652caf4c51e7470f06151d9ddda0075f8f53eebe2bd83e25bec9920db7654a97a";
+      sha512 = "4b9f1e63cfce7b99e05d54f99b7d42255f2e2875718e2ba0e173a7aa53113ed990f1547ecafd508a8547b696f036ec88826260545ab7a6b03d4acde8afbd1fc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/my/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/my/firefox-60.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "eb35f499f6d2ad6e71eb780767abef864b2611e8cf83669e1a8a08f6fdd098ea183234e157a5ea442773c45348b13c55b2811398a2440d5e579cf57ffd1620fe";
+      sha512 = "a82103f7dc6880e8e81ec3f0f9b07af4dc13de369eb87398dc977f2935387e489c6e61ff2f5a2c883d5d69ec24cd556bc44c722592d432a3a8f82420fadf11d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/nb-NO/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/nb-NO/firefox-60.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "bf8b5d719d507faed5f2f9c34d6a78471b16f0452286ab3f79d63d516bdd6af54186cb4cd896d09400da51ec4a923f711791e4040048ed546a0d30a065dac129";
+      sha512 = "4a68aabf3a6a085a8a7abfe705ee67b724243696e63bbd5a9324a1a39c2765db0c75d1fd8b652b78982702702fa1997831945e2eb56b059efe55d64d351723d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ne-NP/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ne-NP/firefox-60.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "e389da15177b36b9f480630e88491252b37ae1c4b9874804eda96a259fd8d0dd5c53975056246dbfb1ec8b5d47c90a9eddd2dc665c19dda64d35fb1af4d1a531";
+      sha512 = "760c819b44b1b2d694ddd5841a97f586c46fe2661c18a2d9f6831ae24a1f67a90beaf5592d8dccba35868a0e608f80b0a652f9c3af8e01601dbfe771d35c38d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/nl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/nl/firefox-60.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "d4b4978889d9acd79e60c05f9e088c8850ef234e475bc05b27abe79596f74db47da748fa228b0b9706ff8f7e747b28edda36555dca8a3c8a70bb3a2ee147b8cf";
+      sha512 = "698c765c19647bbd6cf55e3812501131720ffdb485058e90e79446b5310d056ee09162253ee334535ff0eff2d544748385ea88d3bc1fb3bfa0044d4eefac8f07";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/nn-NO/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/nn-NO/firefox-60.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "7f27fefba306c82b7227889f56059d271623ac40af272ecf810c53224cdfca8a79225bdc1dbf267be8b8a4db4a5c870f5f969f0e30cb3bc6488c8ce101c43bd5";
+      sha512 = "5cd75409e8f952a681cf7485860a0c45bcb77a9b6f3d645f27b34560802772917a8d29eb465b8eca2fafdaa5db1cfd5a37ef2219cd14444296c81b1c53008375";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/oc/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/oc/firefox-60.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "f5dd23837b4c6d60a3efece4f70fa4ad2c69a0d560d2dba884ca0bf004619c26aca11348e4eaecebb0a92c46a835ea766b09a9734f7ae34dab88c4849aae5151";
+      sha512 = "765bee0da88cdf168a37521e94249e14dfc80f72248e9d6805b098af8d99801ba38b96eadd6461bfa523fc2bb9999652ca2309ae9fa9202a5e5e00d4aecb506c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/or/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/or/firefox-60.0.1.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "f3224d03f3a264498167e62fa8df8b1d4ad0cd9de07f9bfe26eb85977214a00d64daa0d3ed8ae9d2d4ba30e606bb006a0399918dcda34d6eb5b9009eb3db6dcf";
+      sha512 = "06fdff27a007b45357d17f77fb22b589bd2f0d07866e0f64f00af46a1403f7375df82cda101997d008882232ba34043f26e0e8db0f796bfe30d442eb990ddfec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/pa-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/pa-IN/firefox-60.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "47b347b899f7300a9bc9fb15f00ea5b05ed26f422b4836d24da1a795b8f35fa8cdce292fcd92b8730e54078318794cf942b27425c367ed4090f3ea9237611cb1";
+      sha512 = "8a416b28b1f2d73865d151480ff329843e53ad45dea6a1e931fa6426d1d448d47b6ef2e8cf2125d7e03c69bbed90351bf6fe65036be490dbe7688598eb01a8ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/pl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/pl/firefox-60.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "844eb1c7e46ef7bea66317220a6a57daa0cca6022457da4184550974cb9f616bc25ea01ccd8f158c3d195d39e74cab4d04f51d41406a9cbaffb423c87ea24b3c";
+      sha512 = "df635d41fc27ccab2eb30d6b73effe6ee33a44f543fa0f7cdfcb9e2ba8a70ba3a5608a914bb80bd4f450b623d3d6b05e0d9cb250a660560cbefdf98d501425b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/pt-BR/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/pt-BR/firefox-60.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "ba3418e27df6f0e037c37d1afde5e96c5415257fb0ad70f95bec98d50084f8f0aaf1a5d8752163bfaf00b390db6d0dfb88867d3afe48bb246664e7a9361b2d87";
+      sha512 = "b5e23c79428ab50ee97ceb79305331cb36b19f9f76b8473a53f83e669178eecbf06fcf79d067923147fda14863d56bdc157d1123b50cf64841ef3d8fd77f7cd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/pt-PT/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/pt-PT/firefox-60.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "6f675e939407e19ddea4962e2f8cb0fcfc7f573ff76689d1f434416b02024bf8786ad78b03fcd4150301309fbfbb91be078340a47d9fa413d2312c6b8aebdb8c";
+      sha512 = "03e3dc135b4d0d8c74ed9cd087edebdf26b256768adbf42d3a8e6745b438a9e617d717d9fa68533d9aa5e7c07c64ed42540b5005cd1b36fa04e9912b4e046090";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/rm/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/rm/firefox-60.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "d6623710addc98457977ff62337a3aaccf1953874e6df5fb6d4ecfe2d7650920d5c1d4593793f37b5397e688ee3e745ac7007f3925e0982b7ce168f5a1fd90ae";
+      sha512 = "74884aa4baf61bef8707eb94c9cd523707426ee5c5e280a2f18ddc1cb5535d15a83c7125b4734e3472c9e0ffcf2a8aa7837b9c150ecfc2b1767ee42750cd2a3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ro/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ro/firefox-60.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "38c6a14a6ac375ce700cea3853b4fa208929ab6814bf2037c2b9d03b15d85ce81833c09e889ef5a8966c61658055fc11e4d1ece2a16370e7436adb52ab321bc5";
+      sha512 = "d245c0322e0a4d94b3a837c75c8b800505c82472363202520fdc99d0db04b2830bbf522bf1cc63285d103a0fab22083b8dba93c1117df78ec8ccb6c03cb36633";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ru/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ru/firefox-60.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "730d26ce8e54b9b4e8379c475e6db9bfc293cd6bd233f566ac54ef6512f3f3bcf687b18f8a31f3869821a9fa1d26cd8e6149e3721b5950ff7633a645df4df8fb";
+      sha512 = "1ff03c04e419498d3e2ea565c02f4716f41370fc97c24166e54d6a07d92ad6f0ffb6ba13f708e4079d00a4c98fc24e36c278414c7b638e29cc7e5f2891417348";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/si/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/si/firefox-60.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "37b72c9fd02ca03087458b58080da505fd334fd7059291a7d83557212af0e30273ef002a3fdd9a8797e76f1178fba731c127a28051b1bbf74f570f13d6d8064f";
+      sha512 = "4467d0a6a69d7ce89e1849d1cfaa81f2588cf8019e50a5fac6f292a2a50c55750130e885334659f834190969636ab74a3af97d6175be5f88e45b97cb772a55e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/sk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/sk/firefox-60.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "5ad4c596575cf5ee63d7ee6c9df3f9b9dead8fe41fc66dd09c010755d069f2c6dc2a920ce4cd82f23df7a22d600aa502b3accbdb05976ad5f08f1ec19772fd51";
+      sha512 = "1060fbd4bf7f83c851d74773ce0277ebcb7f22769ef95b75775d7546b3fbad930e2a04deead17d37e5bee69f39aa978b65c41e20862235209528bb91a776550c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/sl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/sl/firefox-60.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "5c7181d319b5bc4c9c731640360fec12a862975fb8d6b59f913a9a113b88a65ab3b9db9ff759f9faef6088f25c5f59462f0f82b62a8e5115836f498289478f6c";
+      sha512 = "75f0d0a4af65fc3f3992cd859c7f7f7a9292aa4f0e1906fd4e7bb4106edad80f3cf086cd843bb526cf2958cdfd94403fd110c83d232c533b105e7a79b6b01b06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/son/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/son/firefox-60.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "f1ff760bc5516ac6a5beb251d541e38cadf0652ff51f9f1798b9677e9d3e33c844d56e6397288c898ba38c6bfc80129c7318e1e9cba3ef9ab4b9f07405dd628a";
+      sha512 = "4f5a8dbd2c60874a4158a4f78b66377a193265751c1f7629836c789ce0abb83de85ff1bee97ab8708ef86bb123d0d2ea5bbb2bb21fcdc52950e1c1164fc13684";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/sq/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/sq/firefox-60.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "d57cd7cf4669cb537d96d6b9b4bc81446d7e54d6cc294776f2155b1280352289c1afc3d0b2744973280bc980c4f6200a0cf114e449c15c339535cb30ed153766";
+      sha512 = "5b226608e43a7fe4ae8f23eced67af9f512adda9f70c4f33b81f0a4e779e78e9301bb5e95a4b4362ee79a04ac5da81c36005c5b4e903d40f6f4af84b5503c113";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/sr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/sr/firefox-60.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "2aaaa459fc730feb75428dc4af773d001bd18fd0afbe564d919925f159cd95abc22a21db9919a0c3f16f12ffdb30e8f0d91c0d3c113578804c35a1764b86af1b";
+      sha512 = "143de2c6f87385f71deb0faf6db20cfa5680c5e3f682e89456602f05494624d22db9c577b92934cda98e041f27682103d1755864b0dec5bc3b2b6d9121133532";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/sv-SE/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/sv-SE/firefox-60.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "223f00e509c53a88f102c2f9da9b75640bea329307251b59aaf2ccc759fa0246701b1877c400f3fef2337099f2c070f33ffb92c8313612a384e7f5ec7cf66ffd";
+      sha512 = "09e52958d73ec2b32331109a1f1d9798493cecae739fde6542dc4d6ba026b4d2e1d1f3816b4d2b16d71faa3a3840417329b97eb7a8c0fac2cd168b159a61eb7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ta/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ta/firefox-60.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "910ff3e81fda8c94989b3d6cefc5ade22ff0dce21a81907e84f1573d631253ca3b3f45383552193fb46875e09b770ff8e28fe945558fd897bf0b64bfb4e01004";
+      sha512 = "72b0e1a7b94eccade119f7e4b251b803f4f0c54783faeb506649b9048d663698e084e15664baccfa79ad2f6c6238a19c1bc61bcf840fbf003df94cd62ef38deb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/te/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/te/firefox-60.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "3fb89f3620d5a39a44cef228a9fdd11362bb3bff59fc64815468376221bc151e3538f929023fe634a163e0c7ec47c45c54388d4f5dc911b53a3f2565caaa6edf";
+      sha512 = "0478768a0e6b228ad924dcda9dca83fbe2d51646503db931ae4600bd107fa15c8f1bcfd4034b6201a72debf561a815c28c54396a45100dacb68d9f04c2c0a45f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/th/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/th/firefox-60.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "78a66d69b6225ee29c5c1084c9059a9f1bb867c22886ad42e628fd7e0316bc2eb8eb02522972817508557f1be5369e00ba489260b7b6882a4f12448808b9af16";
+      sha512 = "499aa56d62d5293e050bc67a50feefaf5019385291e4d3a602f35c1e8b58937acaea893a36d4d77e0e4eacacc3c406054b9e81bfe8cdb27c687b4cc6efcf1b2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/tr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/tr/firefox-60.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "afb9c372e5b1f0f69c53b4c0ea9dcd8ba73672c163bd63cf88b7d8c9bf24af3656a924b29c6b3e28f826ea710c452cde789ee68e0a80bf269b034428ca2de577";
+      sha512 = "8c3f26b9d37e47e3445fb14ca547f143961f19eab66c93ee4a560828a4bed3c773fe09d2e77c350effd76e0a0c447a0121c9ed29774a5ed93de3d707891a024e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/uk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/uk/firefox-60.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "ff3cd139b34652446807063c4d68f4a5ff8b5643bfe786527114a11a4cfe2838f64ff151d5d77ffc9c51e4b057d3f1058dee1dde521ea95bc9f17392a641c5ae";
+      sha512 = "ef7a776d6aadd6d9c70594260679810325a4cbd11002bedf5e7d58d36bfc82f72c3c2c352f0d693292992ad6bf9fc323e5947183f6c713f85c353ebe72203b7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/ur/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/ur/firefox-60.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "f075ecd1d15e9737ea6079c2dad94f7e3bda9503ae8a17f017fba27c166f1721ff9e5956c3a7a3704594d8f4154f9e11dd2df19630aa735aa7d3e533283af43f";
+      sha512 = "9096d21d134c2e55d694ea9a6e06a669e636b15fc4532bcda12b9944d38eef325e256106004e6f9fa503f5590e5077da5f72a535b8887501a53d4a8c9c0c4c55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/uz/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/uz/firefox-60.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "8c885715f9df669d79fa4c0b0bc054c4e760916ddef288deda943ce372dfc85693a2297ed591b4f540f618e4044321fd3812c9fb037561969a11a7b472dba2ca";
+      sha512 = "d856195097a7923d42a7efb257a9758ce4bb5ec3d93de798bfcea1ff20dbbe1664d71fcd8bc72dc9592bb4c4e8e45a041164fb9b9174c2c75e2c04ade968e532";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/vi/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/vi/firefox-60.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "19b398ae13e9cb74f61fbfeefe68fa8fcdf8785fdba2dece9e2674900cd9ab71b401029e1f1fb91174c9996e65522eabea975d3bf9d46de0f76c29d0ff6d3812";
+      sha512 = "7ce9b59b89c77e289b56ee8b358409aa6bca3c47b6be004a38037f7c156834213dc5704e1ffabe3fa86f1ba89243abb6efa2fba31eb5bd1f4d95e0f225d0253d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/xh/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/xh/firefox-60.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "e236beb0e0d5a7fda5c6bde0141884a0d5e09628e579ad0e31280db64d2f373946bba15fa1fc40a7c5ac7d468896d9e7af41b587378a999dd7fc1d9b89d7a11d";
+      sha512 = "7dfc5627038c97188e4875af30cb88baea359463d5bd47d11440c9f33f84ad4168d860e947e90c104ac647a09f3134892a394b8a8435639f71f7bb9edd92bcae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/zh-CN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/zh-CN/firefox-60.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "d4865b13e94ed4ecaddee1458700ad6ac3850aed5c5298761fc1dee3b483a302a60256ceae15fb0b8d2b212420aedf1e66345b951dc90e5d8368242bcdd0cebb";
+      sha512 = "75d8a96eac39c0c60814718929997e9d4a60a2fd273ceab744bead7164d6bbdbd8057a94a3310709da7b6287549cd44f6d7dabc4bba1bfe1f48f3345193cd142";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-x86_64/zh-TW/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-x86_64/zh-TW/firefox-60.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "2165c1971c390be50a8af0e7a17766952a28c62355ac6c017c0871696b4073dd164795b3a347c3db99fd6b625f02c7e1ab8dfedb48943bcd50a1fcd46aca797d";
+      sha512 = "d0465db2b3aa8a52d8e60c480605c069c31f0fcf80cc757980022bb538c0509b99563ce7fd06f2660dc8169dcd3fb6a8681859218365a3ef2ea822eebeb29e12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ach/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ach/firefox-60.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "ae783339b7f51f9e7fdddd36086fee47545b0624d42498627b65233bdc157cd30b2efd2272e27699e495b617b888c6c0a179d9026b7e22b5f96112f9cb520837";
+      sha512 = "7770772e90d57f9bfe30a5f965cd89fe367ded55c4fc146da547d150c85d0fbe906fa092c2a62ae8df3cccd5702e6a7b1b1680e0522e3164d1df20d2538993e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/af/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/af/firefox-60.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "8591da90fb08f30445457e84464219f47e685b973b118829878e5c9bda41a58296190f34959549bec9cfda400cf4dd29b2bff99b8411a3f255b04da4f67789b4";
+      sha512 = "c615df0582484ce23cb16556cda202cdd81056d197a78be02b31d3f71059644378c2e24cd42b4afcbb0b610a3f25d87aa1178671ba04437a0885cd90b0954f97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/an/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/an/firefox-60.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "f60502441cc1d58194329d9853cc5d893ef1255dbf0d07a9344d9d49ebf328473bc978a5cd8ec43de5b57751b698774e090c2ee471ce65423f5a33750262c280";
+      sha512 = "ab0fd2292c5aac5ec5e1669c49f0aa6568f0c8d0bbea8c20c18ead6a52e88ddf08e3ca44e24386a9a0102f0bd7eec12b9e2b9e6713a3958cf13bd978106f7009";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ar/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ar/firefox-60.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "c0174c009dce15fc2836d28cf80063e04ce34d12c04ce2230c5a9e01bbdcdc8073856601db45158bee68b410c4b9d9c53c78bfbe24c8293536c866b2cd13c3cf";
+      sha512 = "dac0df9a18f1a7d01c1caf05e17edbffa6029733c6d439c26fed0b12d1fa8ad325fa10ccca51cde25ada1f76e338c0e6a8792e400f0ae44771231a3a49a33a8d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/as/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/as/firefox-60.0.1.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "19f81fb36908e5959818c74c0534d4189025b061222bcd01745033891321a2931ffcfec76a893249a8e7026489ced55497c00ef0dab156416a644a9b88c72a05";
+      sha512 = "d57627a4cfad823602cf5e243c5a1c1d8e5e7fd5cbbd345cac1db7ca23947fbe0dfc8a4dad223c6af8b5059f3544a34afde8502ea29f9ed6e41623ce4d856f98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ast/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ast/firefox-60.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a9bcf4be3e09509d34f70ea2cbffd4ecbf3aeb15f535080851c63aa2cc8e473fcc9453ef76d25fd525ae79f74eb76a6269919261aff5e8637cac139587b92c95";
+      sha512 = "32bd3dcfa0a8c63605aefe54a3c96f2dea826d41edce8c71bdc4da5eaffc2b303c8f1c057ce0a4c6ce5d853d4ef55484b5dacb51f27dad5e50b96cdeaa2298c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/az/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/az/firefox-60.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "14dc7149a69e6dce184e4526cc31f1a8d2f5a833c49ffd1c0ec51d67e8746d27334fa49abf9d487b7656b9f1e71ee0f24e7ef69b9888e6da640ffeab1da12ef0";
+      sha512 = "e94f419ec6a34100242babf4afbbf23b98106748b7c2f02b83ff4b0a396bf5e003ec1bb3ed36feeeff82c79fb17c18918ee6e9ddc038ffccc0e121dcaf0eb1f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/be/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/be/firefox-60.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "38dc8e028feb9a523190346b01b9342e865af18db67eda7dd65189087ec1302085a141c708da5834339f5abb36e5eb91cf727eab1dd4feca3b4fda8035f8b423";
+      sha512 = "b23cc179f2c4c5b3d79f6009d87f4772dedba67150e014b792a5d892fd1e09a413ed405d86f82e9f74a1c2e36ab76b2a9e41bd49dc7d16483749d195b56791de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/bg/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/bg/firefox-60.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "d8f0df46d689c512996623657d3b2e893d2a465bf22be0679c1ff9204e8e773172f6a857d392fe2278c59c44e91eb588ba4b035b1dca1540ed59645a9d8708b7";
+      sha512 = "0d8abaa490719185579d4c24b02ce38971191ec13bdd1798966364c2f9fc118bf46dfa4ae0621d1c6427beeb03f487a1ebccb0a4e49d6ec93372397de56c4851";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/bn-BD/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/bn-BD/firefox-60.0.1.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "98902ccb5f3b34e3dfcf101c6f1333428a6a1579d5c5c390cfc134fcf64ae0b4fdb493094bd654c39e9e6708bcdb1ffab377003544432a73e4d80c150a17e871";
+      sha512 = "db9e15472c21880a07e1337e92fde44ec19a8f6297992b589f20bc05ec37140c41d65097f1759734b9ac13b75c806996e17c70bd5fd0bbe65e3acd6a0bb0a854";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/bn-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/bn-IN/firefox-60.0.1.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "d2582614773a08192d0ef87eba9392dc4023c15affbfd14227b642ff93bffa8339fcafad0ef0ee8428c8d5f84a4e84f67af376cbd2e14f187c37a294e710dd12";
+      sha512 = "2017273b405a8ff2b9bb1d1c1120c74679a1583ddee9f32e4643f62ef22fd3174e4e01f22e374af92b9821a550b8711d2b65987c71b44215236c161827f679b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/br/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/br/firefox-60.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "62457d015c193a77d12bfe58dff76a23c8b71e184965130699d7d97ba9dcdac47cdbbe9858e5a571185e4c56621f5aa4d8ec01a8c081f6157a98c6ef68ee90d9";
+      sha512 = "9e7648e312d78397bdc06b0a6921f76acf1916c28c8ae05aa9dc7c70c83d522898ef7e2e847cc3c0cbb19553a572ada7914b60424a46d57c0d7fc207941af3dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/bs/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/bs/firefox-60.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "5fe3bdeabe8804b4604440541565fd45854c82f421714a182b93f5b455935743ccb8f29d7b177316513a3f86bf31f549bfbda296c68f5808071dd3f74744fd4b";
+      sha512 = "6e93cd48d03f87e027e913199e0e7b99f5d66d2d81a4d7da52b8f6a38b9b1e43d5ac5ffa56a6eb46c921a695f1826c6f5b936d4622aab3501e6132da26395888";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ca/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ca/firefox-60.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "05240abcb093d8a643e636f05fc24f58cd79aebdfd9050dbea00cbec8f25bd61f521f4f85492df0bb4b7db1a69b0d73a322604a0d3741ebd88a3c961495924e8";
+      sha512 = "0e49140d11167e2b6c7d15f75f2b121ab44afffaf1af9135012314c9234af25555a5e18a7ae866d3219e6c0c6752f7ae313f66c7312959fc101c32e417feaed1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/cak/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/cak/firefox-60.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "9bd35d87ee4b3e0d867088c5c788c3871ed6c1bdfb5443d7cc4c88501a59a2cd16d58ebe38343d7e9789292ef9ba1392d7a26d86dc56ca916330cf91e7e859d2";
+      sha512 = "75c5532e9ee936aa24c5fad77c96fb8aa9e84d3531ac6d36330fd3c324c8bdf13f2e7f815d844e639fd06096c6203e4253c9d97e0c7a564b0b393543a892e56d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/cs/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/cs/firefox-60.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "643daf0dabf25827872158e746355b2cce1df12b696e03e2e1e1ee9beb70339eae1175c3eacb31bef8af45d82772310bbcda00fa4d19219421c636a79b85fd0f";
+      sha512 = "32835014bb3b7acb93d566710bf52ebb3bde52f9c17f4b4de64ec598e4a40b9ee8644a2c1866a48aa6598ace07969912eeb09a47811d67d6cb317078e8e99e99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/cy/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/cy/firefox-60.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "3742cf47692ef0a6cc3597678601c260bbbcedf1828286ecef73c55b51113b63954d8f1577050f7db647fc5c520c080fd476e2b714c1c7fc4d2a2eb7bb5ef450";
+      sha512 = "7b29c7e69a18e817828fd7cfc05faee51a9f9bd1b229a1943443cc3676b4a3e8daf4b52232633c713f0cc3ec4d9ef43a6dae0ec1dcec66caf0ab9d67b1be9467";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/da/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/da/firefox-60.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "500ac0b682d60e92a695da8b63c87414f2d86f48fea269946b978fe2e1adb79583c813764d039e2201736d367c86dd91a2ca62a555d3355d25b7c4dc96f9fea7";
+      sha512 = "41aa2e220651b92b8aef3e868d1b9080d1872841d5b82cafa7c1f2d1b0db063c487198949643d89fa0121bfa4287b7dcda99c245f8095b1f3dd86bfe960ab257";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/de/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/de/firefox-60.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "4d0e210832d9a3290271b804bcf3a64c125764c6236bb84af88988c8ffd0aa57ba7e1060985005100476f36a4a93da93469717634665a634d726a1eda372cf73";
+      sha512 = "7d25282bb59a627dcf09b39ca15777253593c4b91e61e6f9d4d2138426cf8ee16f6d8e509398824d8697e42eb301db29e6843eebfad5eaee1fdaaba5fbe7f76c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/dsb/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/dsb/firefox-60.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "39b5f2aaf2617a021d15a9da5a3bdb9ce5e56b28e8d61d7d422d5e95918fe10b5608aeb255595f9f92879fc48686337dcb93fc5b8e4a04610523156c8097f579";
+      sha512 = "1f1245297135c1c1550db1ceb110546bc0b436ceaf364bbcd531f6df4770ab694c1602de9f39bf0d9083dccdefa1d5fea21cf9f4e46925cf1357bcc5043f8926";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/el/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/el/firefox-60.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "bc8d884f1b850d0b76625d4abf1a919481d23a0632e89396ade24841d7bbc9e23eeabed768b7d937bd7d69adeb2146551e25065251d65021240459f197a6d533";
+      sha512 = "58763f729f19722446e87dc7f0e8044993f9cff5b7f707c3d1256628d00011c48973f4408a8cbca67551b621f67256a9596d91f353ecd82482e3b9278fe8b687";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/en-GB/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/en-GB/firefox-60.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "905394e0add0e530b4a0202237ce6c77bbc124543f2fada77ff6d578b52deeb90861ce4b7df907b9be0c12863b4aea9f545ad55729b83e713cdb556c7d1c4404";
+      sha512 = "d51d6942aaed323fd82eb833a84ee13e4ce8b2d7c461a5bd1f2f48b2b1ae8c9d900280bd21a2891455bf17711f01cbbe70e793f18e3a0c2e9b15cec274c3da1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/en-US/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/en-US/firefox-60.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "75d3f38d13033717486a7b9cd686cdda1dc15d2064f47311b1bc4c7cbd4c1fd783fb1b8298751360f1513e74dcd1f9eefd73967fb248dc52e26bbc92f5914b3e";
+      sha512 = "6c849a9fe358e06c9db01fcc1f811c9cce59cfc150423dcbf8f83eb1407113378b25641de67a8ce8bfeea4930937fd0ff4e919648ef80b219f84eebc3ebee546";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/en-ZA/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/en-ZA/firefox-60.0.1.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "9ce1abed9f7bc0debbd34e70c036ae48afe36d87b1cd4df108fd5ff698b3d8e8b32cdf5c8d9ba8b9bba2c7113eddaf9f7a5d015e1b908b47c98f066bff644b40";
+      sha512 = "42280dcb3627c457097887b51a2530eaf32850c4b01e25c62fde1c89e3cc8392ad29ee72ed8cdec11d78f776e4d720235e4f33b21883cef0c4c99823f26c7c10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/eo/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/eo/firefox-60.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "bf671aa74bd9f22d56864b46d12ac131255c43b2820cda77264f08c48223627e4dff88872240b39d6404a7cec2135788ce5b08506eeeee571c14e2d933d8eb35";
+      sha512 = "0ada2ad4b8ef63b0881d1249b29a39aca65bf2714614e5c074d80d8901124a54d63ec5af4301ffe1483f4e70c6cfcb62db398042b8d12005aca7d95079588065";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/es-AR/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/es-AR/firefox-60.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "b282c35954eed46ddf46ed1f0e0ad52440811f6bb0b351337716eed5bd595c519792853003a6f7a742f83beb5231abe8f11deaaa176febe2dcbf84a43eda4077";
+      sha512 = "5c548ab1b0ddbf832d0ae42ff5bc6457ff7aee08b8ac3e94ef65a0e3ab326bfdf6f85be8745fca64e66efd2b45ee992499ccfff963ae21308519fca1bc72cfb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/es-CL/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/es-CL/firefox-60.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "278245defd36da337383e6970b8afc59c37b207248638db8947a8fa970ca025620dfa8c8045ac2c0f53b4f3e8167425c2f6dc2071574931b43190560ca511ad5";
+      sha512 = "509acc1e54e03aadf6c2b1b21d0366d52fa02a51f1983107ef88a7a175226021a574bbdeccc5715bd63ad596f934fa69e1c10bc0122359409632d06bde63f14a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/es-ES/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/es-ES/firefox-60.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "f0fb467bbace051bc229fbe07f21f29db492d35f3901cfa9b488c72f303a5dcc85a7969517165980ea7182a85c45a3758a7ceedea3c51bb8a31b9e81ae197214";
+      sha512 = "e23028c9a8234744001b267ba43899b2740b63e5655ff289d1e45b1132f3fa97e28d7d800bdeaf2d016ede782432db8f7cae1dd8598eaffba3899c9f7a99ff37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/es-MX/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/es-MX/firefox-60.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "9a0bfa7ec953da8564b34d0e17efb6935bac51399f604ede83f4c0497494a93ce087ea35daa8ba0c52839e8722ce3bdbceb2e1ed17810f5816c5dbc9778bcd72";
+      sha512 = "a5974914bf0e664ee4dfc0ca2697be5971563e24249adb6b7a7528be67329ec43005fa77acf9bd51970776e9da110019d8bc353a4d6cbce3a27c122399c88cb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/et/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/et/firefox-60.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "12209ad383627aaafdc4a89b462494f23eb239c736d5f3a1f2541b0ebd5487d6348ac63ccfd4da40df9c8bb929c02a9a54563bd6c53ec5dd87edfdeaece0bb5a";
+      sha512 = "9701a3d97558c3a6946294aa3196d816ada9c721d72993a2b10be24640d48ec37c5675abe3a42df9ca986e8b92f3fffabe0649d3be335e2e557f39f63d454997";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/eu/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/eu/firefox-60.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "afc9e8e0fed835420c385f0c19e81d1711a8c99a7b02f1a8e09218ac2a30aac6380ed88040e96a36edd39a057b98581cdc3a043d6222aaf30bab92ca81669729";
+      sha512 = "119c5b59dd5520017334db3ff95511ca8ab2d674dfbc85f0cd6f77fac919bbc0e99af18c59f05fb6cdf75f6015cb83ac24d15d0cf4ae3a2b5ed7564c8bc7bf9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/fa/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/fa/firefox-60.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "6e8821bc7678a1d486693b2043031064618ff06309cd5b0dcaad0c9b712a312e43cb948bfa0e5e5af1eb54ac8e258bb6a5464b1369c9759ac72803709f5d86b3";
+      sha512 = "c45fa6ace31733812411d597362bc56f4672fb7a8bd9b127eb288d7ddd2de3e129721c2ec44a08d8adbc8c15672328ef62384e0139a1e37c6a12ba9ae35ceb7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ff/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ff/firefox-60.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "ecf9565c6d6e8442836dfb50f1ad833cf88ea9eab884dd3d2fe6f1296d6230658093f27e30e953a51c2bd6ba5d69823f1f4e3f5457cc40a4e516b14baa17d884";
+      sha512 = "cf96e6cdc941ec347036b5d737d0060a892220ebe6f72a71354a21099a7c82a0fd337bfeb6e6eba53d95af88754687888abc4dfa307348d5073315692a4f3496";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/fi/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/fi/firefox-60.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "ca10ece92ea7114a4c91bdebadbab97933232f8610719b5130e2658600b9ff7667834708a992500f31628249bca5c585f08fbced1e98ff31e318a20b68d3e27c";
+      sha512 = "0b4bc6fc0559c05b92e42bcd11513ae20d2101384189ffcff337cb017bfbc5a90151e5c4b8bfe29442ffddfb48eba552a06b3a1db24f7dbb78ff45bfc6a4b5f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/fr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/fr/firefox-60.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "2458452a4c239cdc36e744e4116791a310f2a300b913b61dee64e20349dbce8c0290e544027f0b9eca6d50dcc57561e63f4c618ef5ece9cc05815337ce639498";
+      sha512 = "0ce803471b565c8ca715b1700a54be80894205434060751c31d8696d1716f3d3b8fc19c5a0baa82e78f7ffe0df462780e479597c975d2c476b10540de1e98656";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/fy-NL/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/fy-NL/firefox-60.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "51cf096cd74d98bb081f9d397ff7eebc4624bfc4b90de8000bdf07dd739a441543d631dc783af1bb8aa3c639492aa1e402541ea979fd7837535874d8a4adb771";
+      sha512 = "3dae49cc320f46622ec92d7ad948455a1861f8986cfe9b98bc73035fa41ae44c9b150b9223c037c87c42c5d93c62bdff40784010d2e7f8ee6ee8fb7725c3ee55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ga-IE/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ga-IE/firefox-60.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "680c47e14f7c6a1abd94ac73bba738a44c0bab8745176639283efea617974c40efecf5b43538940c43599bcdb21ff6c4cb380c3c53c0c9915fc542cc647240d2";
+      sha512 = "9bc562d1e432e6e45e56de1238b61f27303fe5b475f0ab0528e44f7c15424911b6b699b08e0386dec8cc7c15df9345b7690361b24b9d467841df63d5677392f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/gd/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/gd/firefox-60.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "3702012b6a32bb9878747d85a0a66c69ee68fe2eac25be428b9e07081a90c867cafd70d2cae32b48229fb333c3f3dddc339f43212aaca29508db33f5807ee6a3";
+      sha512 = "fd343b25a8f07fd3d5f276372bdeea05bd9692b761051c9fa968beafb6518619ccc40e2d69ef00737ed4da23f092363ba575099137aec85dfb7f6a813384ca7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/gl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/gl/firefox-60.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "bbc4986b7d03bd11041e969ef8341023a95e2f4a524c6cbd2290555ced2669edaf89971bd58b30b8193dd880a068d9bc8b2c0a3b16310a678b19e3f5e60c3c65";
+      sha512 = "2be7fd719d946a96325e684a14247ea344e9c5e096378f02629f87bcc1180d01010cf46f3baa4edc2cebeb4fb99aa5e1d79c24e7b2d1c4d5da1c747ae884be3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/gn/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/gn/firefox-60.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "a27c80bd7041fc80939716b55c631796e2421a5bdd05843d411d6f0dda84a636fbd366cffa214fba133635332318af2d2e67f5e03c719b12368437dcb4341142";
+      sha512 = "d19176ca380d778ed407db04712d51098b57090487564ffefbe0d2e25c4a35596e3ba2b10b9d179e886f38a4d3a4fbdfa7454116a49ec82b6701678c3af7d8dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/gu-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/gu-IN/firefox-60.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "14edc663057b200f32f9a4437c0141d079fa5b77eeeee357d3a09342299643aa0ee5146c6dc2fe0a178285d39f530c58c456f8bf6533e7f901cba551ad84f1fd";
+      sha512 = "d219e58d9699ff8b3d87822421f032fbcb4f8c3dd7c13b928e7e8a1661d0672cc1582ea55fb348fb168641307d430d66aaa7912e32a9ac1c78091e3f46867723";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/he/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/he/firefox-60.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "ce57395416083abb353c45050b6f6fcc8c7b9affe81d6e8504b8c6264b806ce33a44bc018918df92cfcdef047d31c67640074c63447a76c65f5928fbf6b0f50a";
+      sha512 = "cf2e5f7f7da94e75f26be5fb6c9e90d089dbab94779fa026ab61f87bbbb0e6ae75e16160c65f19de809bf6527b9d8a92bb0cec97ad18657b07ebb107b88edd6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/hi-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/hi-IN/firefox-60.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "a3621b49b47f835381df92712044a1d9d4655bb0d4a8502841761a60c8d00f0fd0288b8a6574aa2baba88ab8cfbe714c866bbb493aaa1bb382f75ca069f1a97f";
+      sha512 = "08626ae0313f7227eb144bd264a6f9c7d2e041b88fce8f1ea182bfdf438496ecc1899d9caf76bf00b6ea25604fa6032807766a93de088764e17a2c8449bd548c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/hr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/hr/firefox-60.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "49cb57fc321b67e1b5c9e516b72d36025d22abfdc49bda180cca0194cdc0465be5c0e7edd9b98714eb3b1a7c0a1946bd28d8b9ae59e2ac4e9f45d48916cbfeb2";
+      sha512 = "1c9e3ae0e271ed1ed332fe1c6f820cd0ebf0cb01e86ec713b9523a7247efb8ddd4c6d5f0dd93d5522adab2e18e1bcf9ed44ed2a86be03643f1836e260b498524";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/hsb/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/hsb/firefox-60.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "c8488108906636a4a93447ca28176013e161c56e86d16b535cd73bd27dc568ce22fccff1d26a520a76578c31d870637afcf04ae9e104fc6b347701d4021eb98c";
+      sha512 = "669c3c36fc77359edabced7532e558d0f4e24fef66766b49ca71b4f32d19cc3a1856fc92b716de8507d742905fcb82d6d23f62d542f5adf151a95b99068c7195";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/hu/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/hu/firefox-60.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "69bc30e00e39f2c3ae4da333fbd48a595dcc84f7e9e2cc0691e04658ab02e48d2ac6a1e9194faba7a0c28df3637ff9d213708812436200213721136775243d91";
+      sha512 = "c84788b5f7c670e0a0afda91f47d91f51a40e4441522e049b850bed89908363c74dfea7c9023bf3d54068c1fcdb7752f327f57b6f8812e880363881434f893f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/hy-AM/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/hy-AM/firefox-60.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "155c1a34a252cb1789c85ce4d757f483cc51b62d1f8bbe6179adfe5642a9693f1d202240a1765c5966602c03f95dba5c8ae58cd9a0c98edd65da101e61593cfd";
+      sha512 = "ca81e92cc2ddf30c55dbf7124c4f11f0c2dc00466d17e8f518d2969ae57e04e2a543118756bae3e55bc72e668bc9e78ea1e11d952fb233e43941560720cfa90c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ia/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ia/firefox-60.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "7e603f5d72c0b060404d6639858051951a4aef9d61f3e1e813e8c0167896e15a4b837d6f0eae5da8b26acd8b5899c7a557e5e259a797b096a6e6d8eca2cc7177";
+      sha512 = "8914b9e45e37602eec6aa20a77ed5c9cf618b0c5d789fbe1821d13ea909148606923d1acbb79006c3fc3e38a4657e926eab02d91a1f47717a9b6f527c935c629";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/id/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/id/firefox-60.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "82179d401af39f949057153062190214bf294445964a6d1c63102da1a7f94ce3327351e6257e82bd66c4586791a73c11e2394207514cab6b8ac76fc7f4a2f147";
+      sha512 = "ccdc3eceb51e7ee33f3a49bbb752055bd000152dfe3af1bf9bd7d8a617e217c8615bea4c3ce1d8bb51ab60477956867f5ce93bad472da47fbf47404ab0db9524";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/is/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/is/firefox-60.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "20237dc74245241a289a4a51964d19ec0ae60732c2a528de412d5ae70aebc1b58c4d4ad514109c01bfb1bbd83d4be22bfcf18b89361eeff0e9024bd07acfec35";
+      sha512 = "802c8d9b77678bdf051633b19a452544028a4be76fde686240a78fad9d25dc7ed38de0c58b54fbe214bcdc46e0cd1b6f2cad5ec646a8fabe3e8c7072b84b627a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/it/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/it/firefox-60.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "d15b7b6a4e56676a45d2a0c55612de6b57a5d90558bd826d3c9047db831551893cc288771826b95a0ceb587b9bd82e5b30c914f9dc7070bb09a93073222e2bea";
+      sha512 = "44cc35fb9e6375739c5e88bc8e7489c15a80faa9d0327ffb2793916d2674cf71a4b237a41073f05477fcb142bdac8d4ada684ce2101027f551a7241eb46bb7b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ja/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ja/firefox-60.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "e47706e58a216f0f468bd6972d0373c3795a33318f811064b1c7dbf78a955bc65a62f8f27d66c656b002a4301043485abeaef8c5ef28622e65bc355cb1fa05db";
+      sha512 = "8daac42dcb02ad640a56196ce500b9528c4fbc2a562549f08d76bfd990e51dc2c938a99becd26860c659e4bdaf90465d6c9c909f6cea95030c61839adc79a4a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ka/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ka/firefox-60.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "84c141262f4c2a7ece6ae6effb47ac2ce277da9db4bf1683dfc62e78dea5a0daac52647279da7ef19e439c8622678e235fc90763a0e19dcbf156aa0e2b30d8d0";
+      sha512 = "2cd50870e0ebad8d385b5e1feffa546dbdee31c2916277c36afa9835d01f9e9dc1d7d4c0f386d4baca38eef11a6c0b1cf1657bc7588a1cd5512e894b12acb9d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/kab/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/kab/firefox-60.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "d5ca56b0d58f9acf8577cc1a69f1e0213a2d9e6c6ad70f6ef2b234d6ca87ae4b37489f69f7d8003a71a7992c6443700c8aa2739c58bafb34d3f99ecbe2b9aca3";
+      sha512 = "8c292f95480d21ad521df9e4fbbd580306c2615705a37a75ceaffc8f6ca5a24648fa1e0bc97006c34a38b6e58a523a487953c414395c1bef8f58c11b68bdf5e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/kk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/kk/firefox-60.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "8b892727929298025c9f7c212da27c6941afbea15a07b5212bae363b358c05ca5373a1fcaf487e2f4f2aa5a491ac0a244e74240b22d80125140ea563432bb7b8";
+      sha512 = "285e6bb268d6b9968d9a0d2cda10c82a790be9d0dde686ba3c0230d84029eae28943e1edf70188fb32c96a7712f13ed9087eac57d690bae222736593515e80e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/km/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/km/firefox-60.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "11326282020f7b673b78490452fd47bfd932c99ed523b87ef4d99b55a189069665d1e8cb7d39d0f45a673e1e36e0bb689b9454c9047c1f701dc1c9b18055f043";
+      sha512 = "a939d51066e185a68170bd7c3d21523c4e3c5d69189822496ddbde0bda46ffba3728211efcebb89808ca6d70d76ba12547bfdea8c8fb3420000dbe39fecb8232";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/kn/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/kn/firefox-60.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "842005f68c58fbfc6c831a7515e0ad5078697e6eabf40294fb1c0b8bf45497549f0636b6a9d53973f64d0d522d601cc0d872ce6f515c4a488c2aaa563b70da60";
+      sha512 = "2207b6883e5dc506d556f8f79bc773f304168029b3282835282296c8b2104ebee6a12e5b1f3887645d366339bc026e53021a004bbab893e3e0362ca28921c78d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ko/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ko/firefox-60.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "aa8bf2c373fe549a59f3412e3b155164c3f4953257f7adb6535c3e4cec494e1191f25dfff9475fa610cd3ab765c10c4a303c895c78b35720483677a87613923a";
+      sha512 = "02b13260a74edecb18543679e8d0f969d95b40f87dc237f39465399ddfb5cdd66293408ffda594a53a6514a83ee120c464f3827064b6a286187916109eb0cb03";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/lij/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/lij/firefox-60.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "fbcfad4fae4dcd132ccbc2fdbf7cb6f0deb49357c987c52edcf87b25d55684732b5e6a834d0263996620c2b4149e06b5e82a097807d8673a8b7df6c0cb9a0561";
+      sha512 = "2386a05577d90599c48c04083ef1305d84b7a88b6cf22eb331fcda80ef5678755f7d60f418c053dda9aa992aab5ac6ada99bc5e76afca9cec1dd0d250313d277";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/lt/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/lt/firefox-60.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "f388751a01ed0214c284ec1ef1045a7c66c7a201901ad48370d7fa3c0e06e2b66c3ecc42357c781b58f6308efcf74e6b0c3902a8db46b11d0b39435294eb5e42";
+      sha512 = "6eac885d100539167429293655033e86387d50fddc6d6702f5b9e8ee6f21758e3bf01e340c4dee702958851cdf89c3159ed940545b2d439f8d32a90bc3c272a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/lv/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/lv/firefox-60.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "f932a06b7667762f41c410e394b4ec5cd91116cf82a774899b48045143c6fe88840ba472d91c71f7088f420563857b185c99cbaee884acb2ad760ce7f83abcc4";
+      sha512 = "984840eff4cf03915d04ca12ed78ce06db9c765db069d2cb647d3b795f8fbe6927f6abfa5d8ccc1c2806f10ab45fa7d612a08f4a0aee1b129c9aa4ad31bf4613";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/mai/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/mai/firefox-60.0.1.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "34da4ab327eba8076fd9944ad1c86b6e0e300df870b5a7ce906c7666df8c8ba7c76c792da7d8776150710bf2e8098a0ee9de86c273b19f6fdeadb5978258357a";
+      sha512 = "b063a79532ec9345751d69a41a1e3542256c2b623532a524724eda4f04aba6f5174c568cb45f60e332b1224f3cc0f9a0e641e455e3668cbbb52048571715a559";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/mk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/mk/firefox-60.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "8b92fd90754604535c641286e465b720400505e86d778d554364ba6e3fea9db038607bc0638e426123760de59a4a920d21fc4522d8e3e155f47d834ef7db4cd8";
+      sha512 = "944882edf6c53dc02682733d50dd09c1df3b06c8bb32e05ee1307504936ced2d408623b7ec6588aac3a26e5c82861cf5bb4db44cd4462c9fd8d9fe62dec19743";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ml/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ml/firefox-60.0.1.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "4ce610e4b8979027e12dc07cca350f467d9f48c9c8cff1f52d08452616cab30dc8c49ce967ee49afca1c4905121d93ec00be9892b7b613736f1daced144f4347";
+      sha512 = "b206d4ceffcf460c73b31326ce2a7cc5d8fefd851a3d824a0012793d0bb0cd773b6abfda81cfcb721f11b3f6b4f38de727a04ab2a32a56f3f7ab7abde6632d3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/mr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/mr/firefox-60.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "1c1092ee47d62addc304dc81ddef6fa2987afd778ed8deb2796c862496bba584812a9acad11deb045c050fe80aec523de3b007488bbd23fc039767254b8f5918";
+      sha512 = "965c85edf69d05c96f3f23b987376c3747dfe9694af92f925c405a42544ac8a2992782c7aea60bce3fab4072db153b37e0f2873a4f42e564e821731eefd05400";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ms/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ms/firefox-60.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "d0e4257f953e907c2ebdeafb7c60e3407906f908a9724ce6674842a2c87692963d0d932ba16e92ab0506cb91461ad07712178914f38feeb0662cde7b0fe035c8";
+      sha512 = "ae5938803a9acc6871577d6629579c0bd5ac4d7404e87cfe373876b94204d5af1110425400f9a7642b13bf2a68f32f2c485c8b9e3565f4d3c49ffd967a8e6df0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/my/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/my/firefox-60.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "d77bce209f0b333abf132f9d8220b5d808e7aa45930f509278b9666c4f0bf03d09cd9a38752af7924a66f3c1171260a92ffee2ed550c75c304065e413d9d25ac";
+      sha512 = "4fb3ac47fcd3b7b36bb66fa24ac82bf9ade26fbadf8eea125b78fced6222ae0f2c3c45638b3511b630b50e27fce70739733fbb357744ba89febd16544703b356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/nb-NO/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/nb-NO/firefox-60.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "a1d86b6859599df2680e68e166e411590eda852923117051e28c14832c061a975dd535b11439639e44b1ea85bc4b409aada94e01bbda8847d4ca5239268306f3";
+      sha512 = "c469e49346a29b8b2bb87b6d3be37f72be7db18977a9085240184a66cced8da5c8a62d09c84424985418e106d8cc1a2359ce8778e515430188ff6921d403b42f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ne-NP/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ne-NP/firefox-60.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "5cd668f8c4295bffd14d769557f0be86b643ade50990497d72f15f5da15e1b4e82cb9b671045f445e87987f13fc97d05d04970d9fb559db1edc0122bf08871e1";
+      sha512 = "5374a889f9ae7934c4138b4742dfe50c360858e460b7e348be5ba7196f001453466c84b8bb55e8c1178a194e9500831684f50866c13ccfdd6228a8fb4d17e607";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/nl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/nl/firefox-60.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "a0aac7fda38ac8f85ba341a11b1e90bb21dd5827e5201c782adc854a5b159a5555eaacc8df78bd6ccfe6945fa4502711b655688e61bf1d24748872da7830f522";
+      sha512 = "f937a25191c60c973b0676cc9ad993c07c221dbdc3c3f794c8cfbb2981ebe4d85b0450702b5c7270f47f6daa7b55bb4fb617e113686bc7b496811f5304ae8053";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/nn-NO/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/nn-NO/firefox-60.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "e40c0bab77e5437c77a2db272444d0fe6874b9e153f84033f0bbc21a3d987562d77b5e37da82accc1e996682b8cdfc8eb67c104134191414e6a86f755130aac0";
+      sha512 = "d95de4ef017c0fb951fcf8c90488acc63f5fa82ec7c72bc87f02aa4f2f4f75c2f4cf1a805958fadacd65759e68fef1be21181ad8511c6d1158bbf331c72b97d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/oc/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/oc/firefox-60.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "86a2193d5d442dad54fa55d83f0788d3e30b278370ef6b5836ad06e36307b599155ce2bef6760e6c73c56f4badfb1ad63073d3348395c598e13be73b2fef762d";
+      sha512 = "d4757d7a79b953a9aa92363c7fc40a7545fd7dcfa5ed03ee45af2b48b71b74a0fcbb841fd580244e6ddcc392c6fd105fbaaa03e42256522e2b51e6b18f433fb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/or/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/or/firefox-60.0.1.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "b10a8f799764a2933d6a3843848028bbd8f6cc7fbe2566550426c2f066699158f654bb6913e57585fd695bd775efa29c054c5b7992efd1110d3e7135723ce206";
+      sha512 = "e5d6ec46f23bb31fd32ec5bf58049d7d948fb7632a198fdac34c004c23b58d2bb08c163e4b53e789529d1f6232fd050142a0c84d7d43d1d334ad3b66857a747e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/pa-IN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/pa-IN/firefox-60.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "5b0e9b50dd17472919cbcbc04dd8edcdde706d08421723e7afeb978fb31422e49751a4377a414b330ee81a6ad0e6ecb508db28d9a6a9fddd6e915819c1895fe5";
+      sha512 = "bc2d7ef61b866fae30e6b2fe6c542e206e879d4d0edeff4764a635c9927430cd763e6e907d8676914a5dc95d7a670958f332a62d09517446cfa1a32ebbc858df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/pl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/pl/firefox-60.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "49f9ff7f27dd04ff0c05b82b82d9f3864b3fa10cc27fe86099773e4984f6ae8d6ab8be964d345801a4bbf84b5fd28e794eb850d67f5e82d8a1a693ad77e8f396";
+      sha512 = "c8ee365012576e66468c848d232af3d28796fc7bb8a2971e953ae0f4783b3eee06bd4c1da5725732ee5bd964c2447d1d3cd11041f5d56d88877fc36a6a568dab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/pt-BR/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/pt-BR/firefox-60.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "e4e6a6b5017297faff42ea399519c414530b2a281a9e8d20858c10b464e06d989f145b78b955e653fa5f11895a2b375d549bf8bad01b10fb4b8c88e7b5aab2e1";
+      sha512 = "e708e25ba08c0ba92981c0abd27b170086fd7e54be5604ba5b6c4be47012d4cc467f5ee81e5a50ee1ccf413d5e4e3fa29fafca0ce84d4b35001e59e46afa796b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/pt-PT/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/pt-PT/firefox-60.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "6acb042f4e22f67afb66a2a34f7c3865b77fa59dee2e163594f87c0aff0e409d3f252ffdb1986a4f7d776ece974ccb8701c90e72ee4782ea774298f801782271";
+      sha512 = "5a227d1954a93f35d83b7f89b48d6fef10f1ce09c239eb84a3fbf76b2c93f03ecb0890a9c18bc2d2edb01fece405aeafe16ced0420ef8b8ff90efb232d13569b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/rm/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/rm/firefox-60.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "822ca52c4be4a5ac19fd1c0436603d587816b3771f39ba1c6bb9e2e047b8e5fce8d8b4ae5109a07c79cbe35ece397cbd9644a45b4a8dd3d79d0e5162bdc6f68d";
+      sha512 = "9f2caae925cebb42c49c4c2b139dcfd961174aa8a4dd4d323b65d84b6acbef5beb1e5c844f09454d6fa3af882758137d452ba1cbad5cf017a8b54766f4967ba1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ro/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ro/firefox-60.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "0c85d51248e95ba3a6a871b99e97dad557af06686949616990aca8ff939fdc1e4fa3414f91c03f7c9f6b8b1a90d13d8b080bc1a04af40daf57b01681efb8ff46";
+      sha512 = "a24ffa5fb4f05bb700025df13384ca5f57183eb94d9826fa82560dc45d50a05c3f96c7c58fb1f609e1efdf3b9d3b86bd720a044d5c5c0ae8886e1d4218189635";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ru/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ru/firefox-60.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "cf2b8f766237534342c31f6227e653fbe171222caeb4ba8a234dd23389ac5fd4e1ff7a75cb9fa66d25a3022e73c148cce9872f976cc9e0f8b275c828cb30fd5a";
+      sha512 = "e256695c13cdce7fbd0650561c2e68ca7b3c6eafef5c451b54db67ebd6dc0c14f1c84622cc2550a573932b4ef1ffe20d1608a2d36d3fe0033ec18399ca80448d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/si/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/si/firefox-60.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "4b480cec371499a48f01455a908b1acc90525b8f92a7cc0e0a4dbb7f81daac6ee60b96ef2c8439dd3e8b38d721317b07928afd59ac329ec80575e10d16579f67";
+      sha512 = "b42ffbb1c3948555320d89e7732c145061b91453ed6f70a7d334754264ede63759201ff36bf94b1e33814c0d171541e450f8eb53ef95e8c5320d0e408475ba5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/sk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/sk/firefox-60.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "415a8231ef4303fabe66b9e4f3e34ec8fbabd1d56feb5a2f7e9c63dd30907786255992f56ce340609fdfccec6eb88583c00473fdc52245456aa16078cfe6a834";
+      sha512 = "d224b3ae2edeea852e2d26314b3f8d22d7c048eebd540107281b2863c23dd7c7caeab9ec814c90434da515e912acfea35d5331beede5b9e6bc74ec77ca8e8781";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/sl/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/sl/firefox-60.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "e3f4374669d2ef1cb029695ac2945147f7a47d6b97a711f99a0e622aa6919dc30505f19879018f6df4c1f3086937c5317ad85945770ff3cfd7d86e89bbd22886";
+      sha512 = "c3c1ae0ce8858d1dfeba2e56d9b92769ab06585c86519f754f3ac97a527816bbf7c56df6e8055c04e7b06370c1b9c397ca522991c5f23371ef4e76fb3811cd23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/son/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/son/firefox-60.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "0ca8209e1ca51d4529b6dc20b7c7d15f8e5307a4b4b292a6c6eaabf4919d91c35a6d35694031eac5889ea17ef691f34683210de3590c9bc768bcc5f444b6a0c4";
+      sha512 = "7622a3c211e34c48185e5756168378d60bbfb52784cb9b4e1b37d9e985d92d3d88ba6b29b750578136db9beb5f2123cb1b7c9f47d4b8139b0441b92884620c4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/sq/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/sq/firefox-60.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "27613a71060a22665d6332b2f8e5e3c91c98a8cd3207b94a67ebfd08b8604c7bad834e4cc2bfab10f9f0897696925e19addee42eb45eaca9b358fe15136c09a9";
+      sha512 = "8f4f30bd858bba7c2e90655821395522f6a96e38ff169334b034f182162294af8ca2d00da375e03c3e18e1c96c113333ec4f7d41ac01d385a12a7acb3e188653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/sr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/sr/firefox-60.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "6234e96196069614a25ddf751f820f5787e77f75d0adf91c9a479749471c75cef114d4a3816b4d63227344c4ae9915756c81e862aca3282d467f86fd42faee99";
+      sha512 = "00b4b3ef5d8217d7acfb2504c86338ca729f9ca3b69f2a0616def97ca88bcf61f2669f1a4e4acf4ccf5473db08de53c4308a342cc3ce944634743fdc1b8e5a11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/sv-SE/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/sv-SE/firefox-60.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "3b5f8c85ffd4037aea0f8de95c77ac29f227e6ea02cbd8fdebbfc50ef6a03c6b7d31f695c7e0eb54dbd4d1d5471edf0c4793bf39e78b846c287f35ffc5a01aab";
+      sha512 = "287ae1efdc8ec6a34165bd4588b51c0f81203685d47ed59c01922e87d7d9aae9ab23b1351a7297a493d45645635c2da7458b245ef56991e7ec928fe264576e57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ta/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ta/firefox-60.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "e965954447ea2b47b949b74c06857c75b31edf724987559fc13ec25c4eb2766811da9929f0430297d4c7354ffe8bc9ee2b8ef7274bc47d1a07af3ed3f0ceaf61";
+      sha512 = "fde55160176bf7f5c016d7d780e8a78e556ba6d04e1703e6fd6e90ffa278b23822855e8e26a7b86ff38cf006dad3042ea9cd7d4f75b810efa5f543ac28126f6a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/te/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/te/firefox-60.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "05b795c817f46fdbb1b15055203f4622fc231d5344993d96db81c98466724b72e99f8293cab8d560e9c297f7b4197e3cc0449e037096455c480020817aa24a0f";
+      sha512 = "5cd75ab1ed134ceae22c0020d753cae351caabf513a025dfe30ab3b146f5c693cdf202f5cb4f48a00fafdfe6584ff693d383a5a3f973e307e9ef056e61bcc43e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/th/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/th/firefox-60.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "6e10c20163819045bafd07216f7d29ef4d737bf60c9f38e4981871fda4c19112b19aa628ede00f45b71c7b549b2611c2cf74044a1d153fb9fab9b9014184bf84";
+      sha512 = "037b7e200bb6246e3d95983f5cd9451a10c54be0fcbbf30ec35ddc115395cf8fda3274a212285bbb1dcadd69f3efaab60606345765ed3f69471c5ea2d47c467e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/tr/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/tr/firefox-60.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "1ed74dc5b302c70c9d980f6c19dcda00b399879034f6d49368b0a859434d5ba3097360e15de8d47b136dccd3567d60dbef1f0ac20cdcea3ca8757b2dc189a19c";
+      sha512 = "d2cd7b818c64a6529387d5bf540174aee44b5e863479978b15aac20fe62d102f231d2f1367454c5ddf9f3009776e6176fca8d96eeb221730a477c4fced4b45d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/uk/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/uk/firefox-60.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "be15de40cc87999b145178e5009e144aa1a68d6c7c422dd3f7c1669bdf8c200787ffe650670d29b2ab8230dd25a3ece9bdf9dc5b93331da96df6f28bb2388b1a";
+      sha512 = "4f8ed8dbd4f7bc8184ee4c128382a5ccc5dd6b93840199657a6a2ce5e6ffa5b192d7e17d50ea4a4631f2ef0a5fa225506de953a03e92b4f51e731c436d4d2b11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/ur/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/ur/firefox-60.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "c4d853ce32374513df113fc95e28c26c2dfdd4e7d2f4771cd23fbad78f29068cd003fd2aad657ea582a5229ee217d3c05c2acc0ee248c10b1630c0bd8b521625";
+      sha512 = "4c8db3bf7affc403705bcb5c4da7685a43cc6119e02f3efe8fa499bc22da18a6f43f7d720fe07c32d226d97e6f92ea1611f153d85f7ebd25c038e938acaa3da8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/uz/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/uz/firefox-60.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "9912cef59e3f2457126a6623f0e3913248335b29d5c5412b6ddd451aa32e455cf3d4a752f975c6b06a9a4dcbb2511cff6cb918b0bf3564c8e8c37a06f79e862d";
+      sha512 = "933c279629ce254da1f7886825a934413a129e2371eb72a8999dc846e0cee12648e68ea9f3b01264aea4c1b5fb2f9081e039b02bc7f5c808307135e8675e05f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/vi/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/vi/firefox-60.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "5ae557d429613cc9bb3fb4220d3242fad8b7b5a625b01bbe662283b78153b9d96f4d27907e63488500a766606196d8292b61614d007c6c5a4391dc8f88332e5d";
+      sha512 = "c2bd138c1edd4425ee7f9cf341cb01d2ef04c1924185c8632a7b2e8ce3c87b4847611827dedfd826ad12028d486a27536c2053b9a677edcf74232183f36a49d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/xh/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/xh/firefox-60.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "4fac1b8bce8770812566dd05460d7d580f2fca9b4b006c5aefe50ecb8e24d104f725c0fe952e59492d438e5c98e683bf4b55df12a18748eb3daffa59aa4de35e";
+      sha512 = "2ee93f40b882c52b80297075864a079b9a91ad30f9fbb64d64d4eeddf9cee31b717d4fbf59d25c8fd40944a2df2f0b67e95d1a57cb1031277429a7fe97be0d05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/zh-CN/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/zh-CN/firefox-60.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0f1adcc43685a0da2e855ad8b679270be7131343f92c4f3f19048049696ce75b03e5a8b508a0d025b1348a66f18e65ccbb7def6382d3bb51152d7b9389f53656";
+      sha512 = "1ab340e9827d84d757f7b88c165ff07ab2d6202cdf939b6a50d40e23d09c002a49daaf9d4e7b90fdf20cfe36160e2d6518fcedf455de5a9f49c05badd6f0cb69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0/linux-i686/zh-TW/firefox-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/60.0.1/linux-i686/zh-TW/firefox-60.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "9a53a37523125ae165f2fd71957f748841302918812b0dea1b1b088eb56906524ddb0a3dc27bbfe7e0b9e7adec2823d5656561eed662c9239473fa21feaf8184";
+      sha512 = "3886ef200481d8f0dcb4add628144dfda705edeea37f1560fdeee7a45e797b75b885a2e590193d59f84d13b2c848c42d0e0f94986d3f4c514a9410e6924a71f4";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -59,17 +59,17 @@ rec {
       description = "A web browser built from Firefox Extended Support Release source tree";
     };
     updateScript = callPackage ./update.nix {
-      attrPath = "firefox-esr-unwrapped";
+      attrPath = "firefox-esr-52-unwrapped";
       versionSuffix = "esr";
     };
   } {};
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    version = "60.0esr";
+    version = "60.0.1esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "20whvk4spdi4yb3alb492c1jca60p4p70mgj2bypa7r8fgjqn57pyh9rcvnci61asar0zvmlihq46ywzrijm1804iw8c4wmlv7qy8dv";
+      sha512 = "2kswaf2d8qbhx1ry4ai7y2hr8cprpm00wwdr9qwpdr31m7w0jzndh0fn7jn1f57s42j6jk0jg78d34x10p2rvdii8hrbbr9q9sw8v4b";
     };
 
     patches = nixpkgsPatches ++ [
@@ -80,7 +80,7 @@ rec {
       description = "A web browser built from Firefox Extended Support Release source tree";
     };
     updateScript = callPackage ./update.nix {
-      attrPath = "firefox-esr-unwrapped";
+      attrPath = "firefox-esr-60-unwrapped";
       versionSuffix = "esr";
     };
   } {};

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -24,10 +24,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "60.0";
+    version = "60.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "3ya0rq50cwryza7d56mm3g2h7kayh17vry565qvaq7wsi9gcd4cbjk4z7a1s4bdka0xsxg2l7v0zkaj666nbllky2462svbi8imdhb3";
+      sha512 = "083bhfh32dy1cz4c4wn92i2lnl9mqikkd9dlkwd5i6clyjb9pc6d5g87kvb8si0n6jll4alyhw792j56a7gmzny3d93068hr4zyh3qn";
     };
 
     patches = nixpkgsPatches ++ [


### PR DESCRIPTION
###### Motivation for this change

Bug fixes.
https://www.mozilla.org/en-US/firefox/60.0.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only the binary package.

ESR 52.x is not updated.

---

