### PR TITLE
xbps: init at 0.52

### DIFF
--- a/pkgs/tools/package-management/xbps/cert-paths.patch
+++ b/pkgs/tools/package-management/xbps/cert-paths.patch
@@ -1,0 +1,25 @@
+From d13a550dbc8876c35b912fe3e0eadd45b278be27 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Fri, 18 May 2018 09:51:48 -0500
+Subject: [PATCH] add certificate path fallbacks
+
+---
+ lib/fetch/common.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/fetch/common.c b/lib/fetch/common.c
+index 94fb2651..79b50115 100644
+--- a/lib/fetch/common.c
++++ b/lib/fetch/common.c
+@@ -1012,6 +1012,8 @@ fetch_ssl_setup_peer_verification(SSL_CTX *ctx, int verbose)
+ 
+ 	if (getenv("SSL_NO_VERIFY_PEER") == NULL) {
+ 		ca_cert_file = getenv("SSL_CA_CERT_FILE");
++		ca_cert_file = ca_cert_file ? ca_cert_file : getenv("NIX_SSL_CERT_FILE");
++		ca_cert_file = ca_cert_file ? ca_cert_file : "/etc/ssl/certs/ca-certificates.crt";
+ 		ca_cert_path = getenv("SSL_CA_CERT_PATH") != NULL ?
+ 		    getenv("SSL_CA_CERT_PATH") : X509_get_default_cert_dir();
+ 		if (verbose) {
+-- 
+2.17.0
+

--- a/pkgs/tools/package-management/xbps/default.nix
+++ b/pkgs/tools/package-management/xbps/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/voidlinux/xbps;
     description = "The X Binary Package System";
+    platforms = platforms.linux; # known to not work on Darwin, at least
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
   };

--- a/pkgs/tools/package-management/xbps/default.nix
+++ b/pkgs/tools/package-management/xbps/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pkgconfig, which, zlib, openssl, libarchive }:
+
+stdenv.mkDerivation rec {
+  name = "xbps-${version}";
+  version = "0.52";
+
+  src = fetchFromGitHub {
+    owner = "voidlinux";
+    repo = "xbps";
+    rev = version;
+    sha256 = "1sf6iy9l3dijsczsngzbhksshfm1374g2rrdasc04l6gz35l2cdp";
+  };
+
+  nativeBuildInputs = [ pkgconfig which ];
+
+  buildInputs = [ zlib openssl libarchive ];
+
+  patches = [ ./cert-paths.patch ];
+
+  postPatch = ''
+    # fix unprefixed ranlib (needed on cross)
+    substituteInPlace lib/Makefile \
+      --replace 'SILENT}ranlib ' 'SILENT}$(RANLIB) '
+
+    # Don't try to install keys to /var/db/xbps, put in $out/share for now
+    substituteInPlace data/Makefile \
+      --replace '$(DESTDIR)/$(DBDIR)' '$(DESTDIR)/$(SHAREDIR)'
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/voidlinux/xbps;
+    description = "The X Binary Package System";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21257,6 +21257,8 @@ with pkgs;
 
   xboxdrv = callPackage ../misc/drivers/xboxdrv { };
 
+  xbps = callPackage ../tools/package-management/xbps { };
+
   xcftools = callPackage ../tools/graphics/xcftools { };
 
   xhyve = callPackage ../applications/virtualization/xhyve {


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---