### PR TITLE
Rust 1.25.0 -> 1.26.0

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.24.1";
+  version = "1.25.0";
 
-  # fetch hashes by running `print-hashes.sh 1.24.1`
+  # fetch hashes by running `print-hashes.sh 1.25.0`
   hashes = {
-    i686-unknown-linux-gnu = "a483576bb2ab237aa1ef62b66c0814f934afd8129d7c9748cb9a75da4a678c98";
-    x86_64-unknown-linux-gnu = "4567e7f6e5e0be96e9a5a7f5149b5452828ab6a386099caca7931544f45d5327";
-    armv7-unknown-linux-gnueabihf = "1169ab005b771c4befcdab536347a90242cae544b6b76eccd0f76796b61a534c";
-    aarch64-unknown-linux-gnu = "64bb25a9689b18ddadf025b90d9bdb150b809ebfb74432dc69cc2e46120adbb2";
-    i686-apple-darwin = "c96f7579e2406220895da80a989daaa194751c141e112ebe95761f2ed4ecb662";
-    x86_64-apple-darwin = "9d4aacdb5849977ea619d399903c9378163bd9c76ea11dac5ef6eca27849f501";
+    i686-unknown-linux-gnu = "56c5ffdca29f8a3657d012d24644fd335405d7dac0b720b17f6321111f9c0e55";
+    x86_64-unknown-linux-gnu = "06fb45fb871330a2d1b32a27badfe9085847fe824c189ddc5204acbe27664f5e";
+    armv7-unknown-linux-gnueabihf = "3fc17d77c6d7d2053d0b376974b5d3d07994f71f419fd4eb03bfcb890186d7a5";
+    aarch64-unknown-linux-gnu = "19a43451439e515a216d0a885d14203f9a92502ee958abf86bf7000a7d73d73d";
+    i686-apple-darwin = "bc67b881b8c40f16640cf4e24da7b609feb4e4e1babaa0cce37a2fe33ca63633";
+    x86_64-apple-darwin = "fcd0302b15e857ba4a80873360cf5453275973c64fa82e33bfbed02d88d0ad17";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -6,11 +6,11 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
-  version = "1.25.0";
-  cargoVersion = "0.26.0";
+  version = "1.26.0";
+  cargoVersion = "1.26.0";
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "0baxjr99311lvwdq0s38bipbnj72pn6fgbk6lcq7j555xq53mxpf";
+    sha256 = "1pc148is2mcan4ladijyfhcj5hxbikrs6dwaw35ivdrkwb29pc2g";
   };
 in rec {
   rustc = callPackage ./rustc.nix {

--- a/pkgs/development/compilers/rust/patches/grsec.patch
+++ b/pkgs/development/compilers/rust/patches/grsec.patch
@@ -1,7 +1,7 @@
 diff --git a/src/test/run-make/relocation-model/Makefile b/src/test/run-make/relocation-model/Makefile
 index b22f34f..c6489bd 100644
---- a/src/test/run-make/relocation-model/Makefile
-+++ b/src/test/run-make/relocation-model/Makefile
+--- a/src/test/run-make-fulldeps/relocation-model/Makefile
++++ b/src/test/run-make-fulldeps/relocation-model/Makefile
 @@ -2,9 +2,11 @@
  
  all: others


### PR DESCRIPTION
###### Motivation for this change

Rust 1.26 has some awesome new features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Thanks to @andir for helping me on this one and on finding the fix for the `grse.patch`.

We are currently running testbuilds.
