### PR TITLE
blockhash: init at 0.3

### DIFF
--- a/pkgs/tools/graphics/blockhash/default.nix
+++ b/pkgs/tools/graphics/blockhash/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, python, pkgconfig, imagemagick }:
+
+stdenv.mkDerivation rec {
+  name = "blockhash-${version}";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "commonsmachinery";
+    repo = "blockhash";
+    rev = "v${version}";
+    sha256 = "15iwljpkykn2711jhls7cwkb23gk6iawlvvk4prl972wic2wlxcj";
+  };
+
+  nativeBuildInputs = [ python pkgconfig ];
+  buildInputs = [ imagemagick ];
+
+  configurePhase = "python waf configure --prefix=$out";
+  buildPhase = "python waf";
+  installPhase = "python waf install";
+
+  meta = with stdenv.lib; {
+    homepage = "http://blockhash.io/";
+    description = ''
+      This is a perceptual image hash calculation tool based on algorithm
+      descibed in Block Mean Value Based Image Perceptual Hashing by Bian Yang,
+      Fan Gu and Xiamu Niu.
+    '';
+    license = licenses.mit;
+    maintainers = [ maintainers.infinisil ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -839,6 +839,8 @@ with pkgs;
 
   blink = callPackage ../applications/networking/instant-messengers/blink { };
 
+  blockhash = callPackage ../tools/graphics/blockhash { };
+
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
 
   libqmatrixclient = libsForQt5.callPackage ../development/libraries/libqmatrixclient { };
@@ -3161,7 +3163,7 @@ with pkgs;
   jing-trang = callPackage ../tools/text/xml/jing-trang { };
 
   jira-cli = callPackage ../development/tools/jira_cli { };
- 
+
   jl = haskellPackages.callPackage ../development/tools/jl { };
 
   jmespath = callPackage ../development/tools/jmespath { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/commonsmachinery/blockhash

This is a very simple C implementation of a perceptual hashing algorithm:
```
$ blockhash ~/pics/r4oNq75.jpg
ffffc38381c18181c5f9901b11d901ff08c3e1c3e5c9eb1dc20dca09e603ff9b  /home/infinisil/pics/r4oNq75.jpg
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

