### PR TITLE
nixos/cjdns: fix service for i686

### DIFF
--- a/nixos/modules/services/networking/cjdns.nix
+++ b/nixos/modules/services/networking/cjdns.nix
@@ -260,7 +260,8 @@ in
         RestartSec = 1;
         CapabilityBoundingSet = "CAP_NET_ADMIN CAP_NET_RAW CAP_SETUID";
         ProtectSystem = true;
-        MemoryDenyWriteExecute = true;
+        # Doesn't work on i686, causing service to fail
+        MemoryDenyWriteExecute = !pkgs.stdenv.isi686;
         ProtectHome = true;
         PrivateTmp = true;
       };


### PR DESCRIPTION
###### Motivation for this change

#40257. Failing test pointed to a bug in the systemd service: It failed to start because of the systemd unit option `MemoryDenyWriteExecute = true`, which doesn't seem to work on i686.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
---

