### PR TITLE
antibody: init at 3.4.6

### DIFF
--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "antibody-${version}";
+  version = "3.4.6";
+  rev = "v${version}";
+  
+  goPackagePath = "github.com/getantibody/antibody";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner  = "getantibody";
+    repo   = "antibody";
+    sha256 = "0pvsngvlxv5iw7yj18snslag8c61ji4w3j3rw543ckl6k3f9zq6c";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "The fastest shell plugin manager";
+    homepage    = https://github.com/getantibody/antibody;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ worldofpeace ];
+  };
+}

--- a/pkgs/shells/zsh/antibody/deps.nix
+++ b/pkgs/shells/zsh/antibody/deps.nix
@@ -1,0 +1,83 @@
+[
+  {
+    goPackagePath = "github.com/alecthomas/kingpin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kingpin";
+      rev = "a39589180ebd6bbf43076e514b55f20a95d43086";
+      sha256 = "0b00bfiwl76qflnmnk3cnlaii6wxgzzdnby99cxdych4f8qmzlv3";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev = "a0175ee3bccc567396460bf5acd36800cb10c49c";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath = "github.com/caarlos0/gohome";
+    fetch = {
+      type = "git";
+      url = "https://github.com/caarlos0/gohome";
+      rev = "c08fdebe2a8b9b92637a423c66ac5d4a8f4e91e8";
+      sha256 = "1wpg7dpi44kic4y20bk6fjwpanm65h1hj4762dsp41kbdfzc8322";
+    };
+  }
+  {
+    goPackagePath = "github.com/getantibody/folder";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getantibody/folder";
+      rev = "e65aa38ebeb03e6d6e91b90a637f3b7c17e1b6d6";
+      sha256 = "0h8al3sl4gxg1p33s8jrz91i7vrqahk12p0b3srlhnz1sn4ahn8n";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "1a580b3eff7814fc9b40602fd35256c63b50f491";
+      sha256 = "11adgxc6fzcb3dxr5v2g4nk6ggrz04qnx633hzgmzfh2wv3blgv7";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "2491c5de3490fced2f6cff376127c667efeed857";
+      sha256 = "1wmijnrxi9p2rv8g6clqkzdihn5ncv29j0s4s1bz9ksncdr36ll3";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "1d60e4601c6fd243af51cc01ddf169918a5407ca";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b";
+      sha256 = "03fhkng37rczqwfgah5hd7d373jps3hcfx79dmky2fh62yvpcyn3";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1453,6 +1453,8 @@ with pkgs;
     utillinux = utillinuxMinimal;
   };
 
+  antibody = callPackage ../shells/zsh/antibody { };
+  
   antigen = callPackage ../shells/zsh/antigen { };
 
   apparix = callPackage ../tools/misc/apparix { };


### PR DESCRIPTION
###### Motivation for this change
It's like way faster than antigen.
And someone in irc (nikivi) needed it :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
