### PR TITLE
nixos/tests/nexus: fix for i686

### DIFF
--- a/nixos/tests/nexus.nix
+++ b/nixos/tests/nexus.nix
@@ -13,7 +13,7 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     server =
       { config, pkgs, ... }:
-      { virtualisation.memorySize = 2048;
+      { virtualisation.memorySize = 2047; # qemu-system-i386 has a 2047M limit
         virtualisation.diskSize = 2048;
 
         services.nexus.enable = true;


### PR DESCRIPTION
###### Motivation for this change

#40257. Test failed on i686 because qemu-system-i386 can only simulate 2047M RAM (not 2048).

/cc @Ma27

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
---

