### PR TITLE
WireGuard: Make tools available on other platforms

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -193,7 +193,7 @@ let
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         environment.DEVICE = name;
-        path = with pkgs; [ kmod iproute wireguard ];
+        path = with pkgs; [ kmod iproute wireguard-tools ];
 
         serviceConfig = {
           Type = "oneshot";
@@ -279,7 +279,7 @@ in
   config = mkIf (cfg.interfaces != {}) {
 
     boot.extraModulePackages = [ kernel.wireguard ];
-    environment.systemPackages = [ pkgs.wireguard ];
+    environment.systemPackages = [ pkgs.wireguard-tools ];
 
     systemd.services = mapAttrs' generateUnit cfg.interfaces;
 

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, kernel }:
+{ stdenv, fetchzip, kernel }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
 assert stdenv.lib.versionAtLeast kernel.version "3.10";
@@ -7,9 +7,9 @@ stdenv.mkDerivation rec {
   name = "wireguard-${version}";
   version = "0.0.20180514";
 
-  src = fetchurl {
+  src = fetchzip {
     url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1nk6yj1gdmpar99zzw39n1v795m6fxsrilg37d02jm780rgbd5g8";
+    sha256 = "15z0s1i8qyq1fpw8j6rky53ffrpp3f49zn1022jwdslk4g0ncaaj";
   };
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, kernel }:
+{ stdenv, fetchzip, kernel, wireguard-tools }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
 assert stdenv.lib.versionAtLeast kernel.version "3.10";
@@ -7,10 +7,7 @@ stdenv.mkDerivation rec {
   name = "wireguard-${version}";
   version = "0.0.20180514";
 
-  src = fetchzip {
-    url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "15z0s1i8qyq1fpw8j6rky53ffrpp3f49zn1022jwdslk4g0ncaaj";
-  };
+  inherit (wireguard-tools) src;
 
   preConfigure = ''
     cd src

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,11 +1,10 @@
-{ stdenv, fetchurl, libmnl, kernel ? null }:
+{ stdenv, fetchurl, kernel }:
 
 # module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
-assert kernel != null -> stdenv.lib.versionAtLeast kernel.version "3.10";
+assert stdenv.lib.versionAtLeast kernel.version "3.10";
 
-let
+stdenv.mkDerivation rec {
   name = "wireguard-${version}";
-
   version = "0.0.20180514";
 
   src = fetchurl {
@@ -13,61 +12,28 @@ let
     sha256 = "1nk6yj1gdmpar99zzw39n1v795m6fxsrilg37d02jm780rgbd5g8";
   };
 
+  preConfigure = ''
+    cd src
+    sed -i '/depmod/,+1d' Makefile
+  '';
+
+  hardeningDisable = [ "pic" ];
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = "\${out}";
+
+  NIX_CFLAGS = ["-Wno-error=cpp"];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildPhase = "make module";
+
   meta = with stdenv.lib; {
     homepage     = https://www.wireguard.com/;
     downloadPage = https://git.zx2c4.com/WireGuard/refs/;
-    description  = "A prerelease of an experimental VPN tunnel which is not to be depended upon for security";
+    description  = " Tools for the WireGuard secure network tunnel";
     maintainers  = with maintainers; [ ericsagnes mic92 zx2c4 ];
     license      = licenses.gpl2;
     platforms    = platforms.linux;
   };
-
-  module = stdenv.mkDerivation {
-    inherit src meta name;
-
-    preConfigure = ''
-      cd src
-      sed -i '/depmod/,+1d' Makefile
-    '';
-
-    hardeningDisable = [ "pic" ];
-
-    KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-    INSTALL_MOD_PATH = "\${out}";
-
-    NIX_CFLAGS = ["-Wno-error=cpp"];
-
-    nativeBuildInputs = kernel.moduleBuildDependencies;
-
-    buildPhase = "make module";
-  };
-
-  tools = stdenv.mkDerivation {
-    inherit src meta name;
-
-    preConfigure = "cd src";
-
-    buildInputs = [ libmnl ];
-
-    enableParallelBuilding = true;
-
-    makeFlags = [
-      "WITH_BASHCOMPLETION=yes"
-      "WITH_WGQUICK=yes"
-      "WITH_SYSTEMDUNITS=yes"
-      "DESTDIR=$(out)"
-      "PREFIX=/"
-      "-C" "tools"
-    ];
-
-    buildPhase = "make tools";
-
-    postInstall = ''
-      substituteInPlace $out/lib/systemd/system/wg-quick@.service \
-        --replace /usr/bin $out/bin
-    '';
-  };
-
-in if kernel == null
-   then tools
-   else module
+}

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, libmnl, useSystemd ? stdenv.isLinux }:
+{ stdenv, lib, fetchzip, libmnl, useSystemd ? stdenv.isLinux }:
 
 let
   inherit (lib) optional optionalString;
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
   name = "wireguard-tools-${version}";
   version = "0.0.20180514";
 
-  src = fetchurl {
+  src = fetchzip {
     url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1nk6yj1gdmpar99zzw39n1v795m6fxsrilg37d02jm780rgbd5g8";
+    sha256 = "15z0s1i8qyq1fpw8j6rky53ffrpp3f49zn1022jwdslk4g0ncaaj";
   };
 
   preConfigure = "cd src";

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchurl, libmnl, useSystemd ? stdenv.isLinux }:
+
+let
+  inherit (lib) optional optionalString;
+in
+
+stdenv.mkDerivation rec {
+  name = "wireguard-tools-${version}";
+  version = "0.0.20180514";
+
+  src = fetchurl {
+    url    = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
+    sha256 = "1nk6yj1gdmpar99zzw39n1v795m6fxsrilg37d02jm780rgbd5g8";
+  };
+
+  preConfigure = "cd src";
+
+  buildInputs = optional stdenv.isLinux libmnl;
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "WITH_BASHCOMPLETION=yes"
+    "WITH_WGQUICK=yes"
+    "WITH_SYSTEMDUNITS=${if useSystemd then "yes" else "no"}"
+    "DESTDIR=$(out)"
+    "PREFIX=/"
+    "-C" "tools"
+  ];
+
+  buildPhase = "make tools";
+
+  postInstall = optionalString useSystemd ''
+    substituteInPlace $out/lib/systemd/system/wg-quick@.service \
+      --replace /usr/bin $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage     = https://www.wireguard.com/;
+    downloadPage = https://git.zx2c4.com/WireGuard/refs/;
+    description  = " Tools for the WireGuard secure network tunnel";
+    maintainers  = with maintainers; [ ericsagnes mic92 zx2c4 ];
+    license      = licenses.gpl2;
+    platforms    = platforms.unix;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -228,6 +228,7 @@ mapAliases (rec {
   vorbisTools = vorbis-tools; # added 2016-01-26
   wineStaging = wine-staging; # added 2018-01-08
   winusb = woeusb; # added 2017-12-22
+  wireguard = wireguard-tools; # added 2018-05-19
   x11 = xlibsWrapper; # added 2015-09
   xf86_video_nouveau = xorg.xf86videonouveau; # added 2015-09
   xlibs = xorg; # added 2015-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5500,6 +5500,8 @@ with pkgs;
 
   whois = callPackage ../tools/networking/whois { };
 
+  wireguard-tools = callPackage ../tools/networking/wireguard-tools { };
+
   woff2 = callPackage ../development/web/woff2 { };
 
   woof = callPackage ../tools/misc/woof { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18544,8 +18544,6 @@ with pkgs;
     erlang = erlangR18;
   };
 
-  wireguard = callPackage ../os-specific/linux/wireguard { };
-
   alsamixer.app = callPackage ../applications/window-managers/windowmaker/dockapps/alsamixer.app.nix { };
 
   wllvm = callPackage  ../development/tools/wllvm { };


### PR DESCRIPTION
Wireguard is now split into two pretty much independent packages: `wireguard` (Linux-specific kernel module) and `wireguard-tools`, which is cross-platform.

###### Motivation for this change

Make tools available on darwin and any other platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have built a NixOS configuration but have not actually activated it, merely made sure there were no errors and checked visually that the module and tools seem to be present in it as expected.