### PR TITLE
rust-bindgen: wrap with cc-wrapper to provide location of headers

### DIFF
--- a/pkgs/development/tools/rust/bindgen/upper-wrapper.py
+++ b/pkgs/development/tools/rust/bindgen/upper-wrapper.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import sys
+import os
+import json
+
+dummy_args = ["dummy_input_file.c", "-c", "-o", "dummy_output_file.o"]
+argv = sys.argv[1:]
+if "--" not in argv:
+    argv.append("--")
+argv += dummy_args
+split = argv.index("--")
+bindgen_args = argv[:split]
+os.environ["BINDGEN_ARGS"] = json.dumps(bindgen_args)
+clang_args = argv[split+1:]
+
+os.execv("@clang@", ["clang"] + clang_args)

--- a/pkgs/development/tools/rust/bindgen/wrapper.nix
+++ b/pkgs/development/tools/rust/bindgen/wrapper.nix
@@ -1,0 +1,66 @@
+/*
+bindgen uses the raw libclang and therefore cannot find any headers.  those
+are provided to clang by cc-wrapper.  In this file, we implement such a wrapper
+for bindgen.
+
+To prevent code duplication and have a more or less
+cc-wrapper-internals-agnostic wrapper, we use the trick of wrapping a fake
+clang with the real cc-wrapper and then harvest the arguments. More precisely:
+
+* upper-wrapper.py splits command line arguments between those destined to
+bindgen and this destined to clang. It stores the arguments for bindgen in an
+environment variable, and execs the fake cc-wrapped clang with the arguments
+destined to clang only. (plus a fake file and -c to prevent warnings)
+* cc-wrapper does its job and adds most include flags and then execs the fake
+clang which is in fact wrapper.py.
+* wrapper.py reads the bindgen flags, removes -c and other fake flags we added
+before and execs the real bindgen.
+
+This nearly works, but we still have to add include flags for
+* clang/lib/clang/${version}/include for things like stddef.h
+* libstdc++
+The former is added by wrapper.py and the latter is added by propagating libstdcxxHook
+like clang-wrapped does.
+*/
+{ stdenv, ccWrapperFun, libstdcxxHook, clangStdenv, python3, rust-bindgen-unwrapped }:
+let
+clang = clangStdenv.cc.cc;
+clangVersion = (builtins.parseDrvName clang.name).version;
+# inner wrapper
+fakeClang = stdenv.mkDerivation {
+  name = "rust-bindgen-wrapper";
+  buildInputs = [ python3 ];
+  src = ./wrapper.py;
+  unpackPhase = ":";
+  installPhase = ''
+    mkdir -p $out/bin
+    substitute $src $out/bin/clang \
+      --subst-var-by bindgen ${rust-bindgen-unwrapped}/bin/bindgen \
+      --subst-var-by internal_includes ${clang}/lib/clang/${clangVersion}/include
+    chmod +x $out/bin/clang
+  '';
+  /* attributes for ccWrapperFun */
+  isClang = true;
+  inherit (clang) gcc;
+};
+# copied from pkgs/development/compilers/llvm/5/default.nix, definition of libStdcxxClang
+wrappedFakeClang = ccWrapperFun {
+      cc = fakeClang;
+      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
+    };
+in
+stdenv.mkDerivation {
+  name = "rust-bindgen-upper-wrapper";
+  buildInputs = [ python3 ];
+  propagatedBuildInputs = [
+    libstdcxxHook # to have bindgen find libstd++
+  ];
+  src = ./upper-wrapper.py;
+  unpackPhase = ":";
+  installPhase = ''
+    mkdir -p $out/bin
+    substitute $src $out/bin/bindgen --subst-var-by clang ${wrappedFakeClang}/bin/clang
+    chmod +x $out/bin/bindgen
+  '';
+  inherit (rust-bindgen-unwrapped) meta;
+}

--- a/pkgs/development/tools/rust/bindgen/wrapper.py
+++ b/pkgs/development/tools/rust/bindgen/wrapper.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import sys
+import os
+import json
+
+# args we added in upper-wrapper.py and which must be removed
+dummy_args = {"dummy_input_file.c", "-c", "-o", "dummy_output_file.o"}
+# load args for bindgen
+bindgen_args = json.loads(os.environ["BINDGEN_ARGS"])
+# filter clang args
+clang_args = [i for i in sys.argv[1:] if i not in dummy_args]
+
+# exec bindgen
+os.execv("@bindgen@",
+         ["bindgen"] + bindgen_args +
+         ["--"] +
+         ["-isystem", "@internal_includes@"] +
+         clang_args)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6841,7 +6841,8 @@ with pkgs;
   rustfmt = callPackage ../development/tools/rust/rustfmt { };
   rustracer = callPackage ../development/tools/rust/racer { };
   rustracerd = callPackage ../development/tools/rust/racerd { };
-  rust-bindgen = callPackage ../development/tools/rust/bindgen { };
+  rust-bindgen = callPackage ../development/tools/rust/bindgen/wrapper.nix { };
+  rust-bindgen-unwrapped = callPackage ../development/tools/rust/bindgen { };
   rustup = callPackage ../development/tools/rust/rustup {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
`bindgen` uses the raw `libclang` and therefore cannot find any header. This makes it nearly unusable.

This commit wraps bindgen to provide the correct include flags. Reimplementing `cc-wrapper `would be
hard and error prone, so I tried to reuse `cc-wrapper`. The result is ugly but I think it will be more robust
against changes in `cc-wrapper`.

The idea is to make bindgen a fake clang and wrap it with cc-wrapper. Since bindgen has its own
set of flags, we wrap it to remove those extra flags, pass the pure clang flags to cc-wrapper, and
then readd the bindgen-specific flags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

