### PR TITLE
vim_configurable: unpin from old lua 5.1

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18318,9 +18318,9 @@ with pkgs;
   vim_configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa Foundation CoreData;
     inherit (darwin) libobjc cf-private;
+    inherit lua;
 
     features = "huge"; # one of  tiny, small, normal, big or huge
-    lua = pkgs.lua5_1;
     gui = config.vim.gui or "auto";
 
     # optional features by flags


### PR DESCRIPTION
This pin was added in 2014 during a lua upgrade, but it appears vim today builds
fine with lua 5.2, so we can have it just depend on the `lua` package.

###### Motivation for this change
Noticed while building that lua 5.1 is broken (https://github.com/NixOS/nixpkgs/pull/40748) so I tried just using lua.  Seems to work fine.

###### Things done
I'm not sure why callPackage wasn't sufficient to pass this a lua, but with the inherit it's clearly picking up the unpinned `lua` package as intended
```
...
configure flags: --prefix=/nix/store/xpafpgylq737q5rrz16zsycq1k3r71r1-vim_configurable-8.0.1655 --with-lua-prefix=/nix/store/8v6cpmd211q4z0maxna8fqykfxpfaar5-lua-5.2.3 --enable-luainterp ...
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

