### PR TITLE
 thunderbird, thunderbird-bin: 52.7.0 -> 52.8.0 [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,595 @@
 {
-  version = "52.7.0";
+  version = "52.8.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ar/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ar/thunderbird-52.8.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "af887818b7859b8bfc87e0ac7ff26c1fbb98a50968d18d174bce37c2132a5957a8c5153f0364aa3ec0f636831313dd3bac6512dd6e7f932ed5cc99ed2016e9b5";
+      sha512 = "7ba3e6d4a64ce91b16d79607c3530deba2d68b09c81f7509991c62a11736ee51278b3cd60ca8063ce94748bf0b483cd9d9ea3be4ba84b24bef56194053502550";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ast/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ast/thunderbird-52.8.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "dcf8ab98558b7d2b8e5d2a97406eb13cc93900fcd60502ea4d8469179d08c55d91e66c7b99a024fbc6705e339750b41d9537d4d81f53f8d1f83461b986a6487a";
+      sha512 = "192442636ec56f7751d752572122c8b435fb28d6801a398dc6d02896d1f99d51feebbdb906f3911da08bb9da2851d3ea29eb064949d53436a6764292a6aeee7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/be/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/be/thunderbird-52.8.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "021f531995db9a0993e830fa8f1da6089d0703424dd8993c23e59939091f58c4baae5ecb6cf51770ff73743c227129ac3215ec46d7181d88cd52a39b2e0e41ee";
+      sha512 = "facdfa7f6ec8eacc6a9294958c879a32cd5dadd31364d64894f8ad1a38ff883a9f2471d49d1358fa79b2b585a33ba7d710b195ec6101760289b8429d073004a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/bg/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/bg/thunderbird-52.8.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "a60f13e7b2760e19592e99eef1bc52593cabcf1b70b7803dd4262b2743e3c755cb4381ccaf1e75f41d4360897dcac3edd7e79648a6f4e81da4a1e83d67bb3ffe";
+      sha512 = "5dae827d4111bf6f07f1f794ab71cfabd4763d9f344b9666143a0c559c93479da532056d43f25b8d130284b9affeddd4d08c8e7042c86b681a1566a7b8822c87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/bn-BD/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/bn-BD/thunderbird-52.8.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "a73074fa5dfaf121b8f12e86dfc29189e9700a71a868f68a70ccd17c47df3a8512700893f981e065c5c20f9432ca764f3c59d4726a2c6abf3fd25530eca0d9a5";
+      sha512 = "fc5816d829c836b8c0995405c9e33ead778ffdff7d1ec11c57113b87954ca1be6e58281244fe5985f7eb84572e56202a700d7bf382c0abe0e4f11598929cccea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/br/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/br/thunderbird-52.8.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "28f4bff69059dbd1077641e888b234b0db95feb11bcb1db1ed047f3ab12282b9f95138835cca5f7eeb87a15ec1057b60587cadcb5fd658fbbe4c556d7eeed47a";
+      sha512 = "4b2ad9013cfe07708ec6cbab5fa79556d20d0146e5d853951c11c2d7629d795a7a9a16a6d7faf3c2dac535f5d368d98d98ca631c367c8b9cc6e3cd13763f6146";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ca/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ca/thunderbird-52.8.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "a9e45eda2b36bb12321140854e685fe4e203c7f56c1c8184a776c38d984f8381c6553cb5f601677f8e0e74ad497a040a18f5f392b99bdbe9535e19aa9afdcb7c";
+      sha512 = "2ef0f547dfea3d1ab97fba96673ff10d6bc0bdb24ea20c457b4baaf6cb987166219eb8d7c4e9c7a8f89b5933f65654f3cf8da8be7145c1378f1d5f51b8751825";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/cs/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/cs/thunderbird-52.8.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "2c0f60ccc5c9a9fd66526af3aedbe2749f35a5fa7509c93b7b60d9babb1b4968eac6bff48d042ac8112793fe2825467de4d0efc42afda19547e8c6803b723119";
+      sha512 = "57f55ea5c102274b42154433a9df9663f8594d62a5b25aa18fcdaedeeb52d6556cdbce8542f2f301f5c7ea08354d90ed769c9e6b95664d6aecdd3f58e7e7aaeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/cy/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/cy/thunderbird-52.8.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "611ffc3d156ce4cedec0679bd9af3e8376dca5b20af2457a75d83dac7c71640a23a6cd544c190551480d6b37bcb9a9ec91342c2bca95cf10acb642d067056a04";
+      sha512 = "241729c3a385ca1fba281b5985513486a3fc9b768a41c4d8d1c0249bd9d3b4de032a76c6b2df383041840ec2913eadc854f2f8b85bc7de782a4f09001f0f5ab8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/da/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/da/thunderbird-52.8.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "0b858b5be09e038983a21715f58a215ea70fd811f7c8acd4ddb89611dd5590599339ab26913865b2ba75f4538cc95bd3e38e28646c281c041b0b08002aef033a";
+      sha512 = "4368a9301d40becf9675379c217040023faac8862482c5521a47f06e6c2a7466ec0b251475db111ed7f37c72cab0742e20b58463d2519a1fd6f77bc8e360330a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/de/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/de/thunderbird-52.8.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "cfcdbaec0a026ab246d45e00232f5d5f3f240f4957bbe41d70cfb421be438cbf8986920784d4d0350a274284b39ec42c20d33883f3f7fabf3b51df3a062fac15";
+      sha512 = "08c2fa848f3dc5fdccc498c935a03ac4e12d3bc3707beaafa5b9bff1c2aa51d6eb2a6e8373a0185f123a1ba77bb720e40ec9f8b364ef5b7a2f7810260ca9c372";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/dsb/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/dsb/thunderbird-52.8.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "52ef4b0dda8fe163675d46e7233b935b38a5899763012b0b9befb1ddd015f0a8d265de2adb4924856a4bc7753b3eaac2dc7861c5b75d8b231e667d29a583d673";
+      sha512 = "83ccb82aad5d63952674707c2c2317b4296f4b8ac56cd3ff9e294023036c1354f8f373d3b977f5f1cc5f9a9fb4876cb68b8dca786d5e2a07e28443e85e531e63";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/el/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/el/thunderbird-52.8.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "ab92343651598eea5f8010829bde589eb88a795ad0a3d0dbd1a5889d162b966e0e9bdf7bd32f49c59eb49b29261a075da1f4e75de49f87aa3fbf95796281062a";
+      sha512 = "4e6f9982e661d6935bbf6b4490a0f66ab2c082ecaf3e6bfc67e32a878b3cb60c7e98d2b5ae07439e43aa4f0f5f7b64616dd22fe1e3db9a5e28e42285a2c1ac6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/en-GB/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/en-GB/thunderbird-52.8.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "1b0e11a1f8daba6a57ac619d764a60e9af6874cf7468c9487e55cc4be7c981d9dd375931b8956ee307754eb846900d4831c313fbdd3eba4658eaf77940e4436e";
+      sha512 = "3ffb11f6ad966980eefa882933b2ac791d73eb338907b8c3915905420318f0e52e16037fb6e04c2add9641e4d89424a48d769cc472234c4b25ddcaa51913d1c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/en-US/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/en-US/thunderbird-52.8.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "a8f4cb2238c3bf0ea6e4f8b444991bf0d6a4fe42cf7c0e38ae3738167900ac52debc0daf8bf4d7fb1e63326626072fc498db6b227337eab82ea48f2fcd561334";
+      sha512 = "d5c2ab406d1820745bf425ba7bf6b947166747d0037f1519c0e4a76a6036be9eed1e00e563c7f663f7472ef77a6a85b646f9ed706f26666dc1d4dd39dba3f917";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/es-AR/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/es-AR/thunderbird-52.8.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "adddbaee6899434a0eb1fb955cd99c33786dc9c7376f1e84bb8036ed41d5731c48917ddd5d677a9dcefe3e7f382bcbbd51921afe1e6e119a4d32fe2cf9ae23cf";
+      sha512 = "c5971b74a717f24047cf43c4a20ee5c3d0c952a1f3c28ca2692887426746afaa1e8fdf4abbb601193cdf594912013b20ecabdcf8dcd301db221a8a632056e0ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/es-ES/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/es-ES/thunderbird-52.8.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "aaafff39c8f5566056f5339310c8f633e48f78c57d2b4730a13377aa5c09e9698295e59e7b137def2706a3dbff9b48710e25a0db24e60dec75c06f9d0713cead";
+      sha512 = "7b58ae76bd7026088c5d3a6e00b64e8445c29a898aaba8363524d436dba650ae1438feabe28e599e116ea7d995c864ff84688a09606476109bdd6aad48304973";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/et/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/et/thunderbird-52.8.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "8eab1f67c3f56a39e21734cfefd11e84fea60fdbd3e470c1e777b607535923c451d7318c2bd7958435ae137928e14f97559781458d8bd6cb2e1e88d47dabfc2d";
+      sha512 = "a71f40dadab629369f8ece09613c8d7ad78314da38489705a880b436afb7649523f50c189501279c1c0269953c7561b81d1de29ff9c1fe1bd22fab734772e8bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/eu/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/eu/thunderbird-52.8.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "be2dd281a0a219e031cc485c21341d259aeeb56d34f79a9db82033d1e17647cf8c8617a2fcbc6a46b2025842a46f1117e43ca769a449a64577df691bdfa18801";
+      sha512 = "2e9e6f58505c4873e5f3f263b75ea56bf50fd82320b78b2bb5ea0876773fe87ce5b76cd4e48c0781565690a28e86cc611ff17e7223db4134e2978e0729e2630a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/fi/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/fi/thunderbird-52.8.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "21535608a1197744f9385b3eca5c7dbef8f3a05f9639b5011f8abf0bbc0143db17954ca4ce1bfc9ba1f5c4659a4a0a74351e30e5f57c1d416d7bf11273211f61";
+      sha512 = "5b22836043bddda0abefd5a9613f17ee147988de819d221f184482161d1667c4a9555763376e5d0e28b3f0fe0ec4482994368ca26745ccabd1826db0bd847af9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/fr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/fr/thunderbird-52.8.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "ddda6457d4bd737778105d0bc7086e64ba58d9fb23a083977b456873fafd3170df495a2d81fa19c6b12a06d32e448a2cd224263f4773c0d165226c6f56cfbcec";
+      sha512 = "c465c33cf95bced2fddd7d4e3c624c3f98ffe02c2aeb21ab8946c1b1c37a31211bf79fb80a5fe767872dbe9cb1cfeabcbebea7bfc8e8dee1404b8c75c9aa6a4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/fy-NL/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/fy-NL/thunderbird-52.8.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "aa3844d3d17a8fdc201e55352f52fa7805328e9f0b105b729cc8cbcde117885a6a6671d343469e7fad61fd9a5ebd8d87faec8f4a214744771ec4d2b43015c975";
+      sha512 = "51d262f87d2766e1c44370ba8f9d22df7e2b0876059bcfdef4b9b7809056468fab1cc6ee7abb892ce293d392548ebbaeccc55bf58c251aa774a8d936a7a50ef3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ga-IE/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ga-IE/thunderbird-52.8.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "30e88160a0c19fa58d6d86f916a86d95362bb8b8d073b1ac0e17608c0c5bd9ac040402dc950579602f5124e40a814e582ad98cf0853ecd8c7b11a7418bf0441d";
+      sha512 = "f9354bb331f6ef82cccde57eaaaf73887d904b76ed2157ab4ffcf37109928160127714cf51586032049a78e7215c43211719f2be1c860828585a344742c1ec91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/gd/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/gd/thunderbird-52.8.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "7458c820056c89b15988424325785ef4e525c2fb970b6c7c04d8c3e8b09cf7a3592e16b5c15862c84bcf95e2b399e37874f2c099c61bbc76293e4d5d8ed5980d";
+      sha512 = "926060b60e5fef2020c27e64a93c246ea9f477d82d8138c1a1e6439098e8e1809aa74747d45ee9b069dd32ac07624b24b022d318efaa3c1b5b02e8c8d599a54f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/gl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/gl/thunderbird-52.8.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "6be48b4ac248cff0842a5b78023dcb9787588c74ce1db89bb03a9a99ac0a2ac24a6949ae125219e99caf93260574d1c84355ca8f0f9c76ed15731d8a4950c98c";
+      sha512 = "d07e61440f1e938b0af4b5db38187a7cf7c6ca8584eec093c292b5f6b7096b529fc20db06766b11001f8d13e1c7dae7a5d3c798e82f3eac9dadcf8a8a50107bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/he/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/he/thunderbird-52.8.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "3dca324d7b3b00a2cc98f8949165d178be7bd68b118ae66383a0d3705925e3f6bda14aa25475886c1f9810cd15a48a79e81924b8ebccfb528ad4bd21e36ebf8e";
+      sha512 = "7661135b35207b781bdc9a402128eaaace6f67c8558e6cdff271d946c88cf023de8307ca1a7c0ece4e0424e37d38b2b5e2f24fa966f7e13078dd56dc6a1972d3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/hr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/hr/thunderbird-52.8.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "23d5b2b0cb48fd274856a60dd9f916d294c8ec133771ff624e88cbdec214182c443ed5fd2d424475ed748113f84b74c732092f51061571104b1a62c301affabe";
+      sha512 = "d5db8e96bdf2061d8f24b9b332b9ca4e7fe64316385e32f01023520f80605bba50b2de8263d7aa67fbd5b3a9b39fd20a050bef4742804da4ae03b4d866ed8012";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/hsb/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/hsb/thunderbird-52.8.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "7360e964d5322e433014eb10f369f27a6e4ff688ed441671ddaaa3526b70d212509c16624ca854e988ca581d0f60ccf31db1bb49b5c93521a5d07e697be84a4c";
+      sha512 = "9cff35b2b5a4dab919e38180cfa88d7c3c249c9e119f6de850bd6e72018e6a62b1078ddafaef6c73c210b8c1dea3caa7987d88c75513f76033186bb7926f5e81";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/hu/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/hu/thunderbird-52.8.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "5aaaf22f17015026a32c3648323fbca16b3845c0f52ebfd3414c11e1d7cd1a0e72a8319e924b9eea67bd9c1448b87585709d3b99a8783ed580e11020a762eb31";
+      sha512 = "56057845898226d58981107d1ab14c3ca02547c0767e768f45c48f30097e14a7745c43b3b2b0bbdae81bc6ecdcd323194d30006ad20ab2b0de2cb3b29c15dba0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/hy-AM/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/hy-AM/thunderbird-52.8.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "7159dcfddf5981e1ddec5ac11613a7b30c513e0319249f08196ec88fe3e2256b52f3e1e418e46e276c1f35195f15d778b83d27e3186b2b8571e0b374844f6248";
+      sha512 = "6595e53a1b790cc2ee47f071d395dce94b44aafee80d2efc1613ee44d3698736db972f45806848dd9b35de699dec53b8b5e64e596b0b49b1e829326e57880904";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/id/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/id/thunderbird-52.8.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "9cf647ea244bcd046f73cfcca97c5b5f2dc3f5b0991d6edb100b4c4263ab75d8b5d07a418b906b66b50d9c4f29360637ff4ce605dbed7bd85c9b624d33331ae6";
+      sha512 = "878b475a2073c97e6af40bac24c2cfb88a73c8bdcba58b5d8cb2958f5114093fabaa6309f32096347c4ebb4baa828bbdf0077995284f1d2ae32eb234a7ca1d78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/is/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/is/thunderbird-52.8.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "d567dd894926e7a5288da3f7a2837ded333772c799acf6f27489327b3e50236561dd0a9d04e3623d23a6d00e7b35c7b8572c611bf1e767b4f43f7d5164ea3787";
+      sha512 = "a8ed951689420281cbfd660bf23a4e5e3764da4894b31eb723b18c2923ca7f5f1b13d6a279f93d3cdf524f0a9387bb706c3d187ee4b84c74490fdba7867ffe25";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/it/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/it/thunderbird-52.8.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "e3511d7fed2617cb6cd59b1b56189a5f70db7f98cf889ce0be31d6931d0500a61b7d6a7f9907009bdaf37ad968b50aebae0930467cd5b0b70a6d2caaf89bc5ea";
+      sha512 = "24942a2fb5dc9a41641232f728077c8bfe5e99c5766ef4327a11e7e60858520a267ef12e0bebed7d9ff2664ba45d672fa1aa24c9ebdba9048bba10f6e73f6d85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ja/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ja/thunderbird-52.8.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "0a4cac4b246542a42534e2b028a84cfef470c884143a08c489b56906a1d167ef66de82d326874e49d22a64c259aeac21b76f4cc2b20acf2885040db35decbc41";
+      sha512 = "291e715308f4bfb605fe987ce774d3f5cac211f920f62ea5e8abf12b51458f2da19c36329eca8fbbf185ec2eac9793dccc3d7483b320c0341ecc17bb477af263";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/kab/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/kab/thunderbird-52.8.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "9b6939d454dd5f0635d6fa3cd78d57d4c3461df67108a9c20a85cded552bffb68ca9f8e9af037150a0cb31588fcc663a0f1a8b91183fd257eec5e144516b5ca6";
+      sha512 = "de78483cd0b0a35687e091c52bd57d9de400a97ddeafd3b7708565501ff20da7ca1025940198aba6d410646d72be39bfca780d36df6b323ceef63cb085b214ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ko/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ko/thunderbird-52.8.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "c965abf90339a3b8dbaffacd61b33729a0312052ced29cd8300cd5dbb577b7b663a314a5d27528f9e03ca55753ee96b392ae745558e59eeebec80857dcf34b3c";
+      sha512 = "b87fcc1baee680496b5bc13b1c87a3440c50f46be6e22b175cc8aff51bfc18bdeaad662d3cc10ebb255cfdf6d35ff2e59e9082f9d36dc5ddb079c49cda4d9d70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/lt/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/lt/thunderbird-52.8.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "f8724c9f29d2965e23a90156586ea85721b5c5693c56fbc5932ee367c87a4531fdd318968cb38046f748dd60f4ef0ebb4636a2034f061e3e5926826aaccff410";
+      sha512 = "093519e8b927f2d716f76925fe40dc0b63835e51c446bf6759992419396f922a38f24d6f8e3fa2c0c252f391a2ff812084d26d36d414d77ba5d961a091b12756";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/nb-NO/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/nb-NO/thunderbird-52.8.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "87bd58ae4dcd766c0b3403e578c41ddc46b5801bd743747a23802770099ce37f55daed7beca134835f0f16939784d7d082b8d6903fdcc993cec56846b1d55c5c";
+      sha512 = "970a4d41c779e224504524ab8aa2b3bf83c71facc5f666c887b2eff27a8ee39e15404c0812376280dffa0c0642216e6e966004b577572ddb8d9e7cfae0544059";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/nl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/nl/thunderbird-52.8.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "3f332437788bd314e8a19fe3263631c2000cdaf30505129b37693fbf499fac3d15736b51d2838e49daad8e9225094a92bf3638fee6a6e33f2cfff6357f1a1597";
+      sha512 = "7248b9d9a51f5f0b5b628b744e935c1d9c21a0a41cb5d77ab66b2e470bf6788774f1b769435f4526afb8d7c28d8fb240a3b3a918b6f20db617b599285e11b5fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/nn-NO/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/nn-NO/thunderbird-52.8.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "4bd2918e59a87ad0afcba3e82640a0c729fdf672c1d977cce62f3bb7d92e14e008c83fc362a5c162090a3d4c0a5608262f5859ced2327274231ff534b6768694";
+      sha512 = "6f8e73df3122bc6985f7c37b5eed90c64914e83a800caabeb27a5b155085b5def8685c6af237e8f0cd605db28681a5df0cf4cfed32fa97b6d594666041bbca16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/pa-IN/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/pa-IN/thunderbird-52.8.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "f0c448cf25471b1aa4387208a8d0bd7e41531fca86dc7118f4467d2db101835af3be9ba79713bcbd8d8556895efe4a2af68606df18fbd506734359950e00ebe9";
+      sha512 = "56f1e10c22acb54a5e6dea22be888525f24e9afc7ec2dfbe8cefee45196737bc68f0a39e7b25e0ab1376b3d7301f753958a11e66f60392f340a3f3f5896c9d5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/pl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/pl/thunderbird-52.8.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "5f9bbd0a1be4d0ac5c50c281ae75025f4b12d8781a73463876f26861c9289c51165cb68ab4438401ded5ea484477c1fe862f5d57430624bc11871f0b36e2c50c";
+      sha512 = "3dc5ae6f3e6451fa942fada6e2b7d7643975782cd9c43f0df9473f40117a5b8f91784462c444683aa180ff6decb677bbb1765bdbbd5ba69080fac806b4c7b97a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/pt-BR/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/pt-BR/thunderbird-52.8.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "afb4ed9a2739e0d590ace16f4dc8c4b1d19d05537fcdbd1f23e404218387d2c016715a074b630885a903588b8bd4a8329190d6ddb9231805a8538b4199513a6d";
+      sha512 = "ea4e6eae43d379e92adb54cf8a0e7cc1baf23bfb427e752f41d95bf9411dbf092ac94794aefbf2983dd7031db0961585c7bef31be63633035f907afb5a8f1a9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/pt-PT/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/pt-PT/thunderbird-52.8.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "d907bee397dcfac8763c7dfd18d5bdb5bd99afbef554a98f625c36aedde922fa03c5f79e46acca4ecb07f9adf6eb59c869b1694c68e88ed759e04abab13a210d";
+      sha512 = "0de5ad70739e456fdbceef8ba89445f37ca4be23a9b213ad5b52b92656b702dc7ab39d6b27f2d9012ee27c46a4749444a210070ced586963577ee386726ee72a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/rm/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/rm/thunderbird-52.8.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "61c70149b717b193e541e49614027a5cc5c4f5a0a4642bb5445843b2c53165ae29088773498245de3e8d3324c26d6d96cd225d9e3e2e491f06d0b60586f23d2e";
+      sha512 = "dd947ad65fa23c42f2a1d118343b54deb2e7c9ef374118e2bfcbbec0d5ccfe5217ad0d636e9b4eee56f1e373beca52d8ff9f12593ce77b9f5aa94a1f62f2dcc6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ro/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ro/thunderbird-52.8.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "d9d604216c4805fbaa0444c5f61c7e1f8dc5609adde7bd8fc301e4ff0577b73a255cc95aa07f13543ce82b5487212b9b0e4284be47b2eb897a5c1880ed9fcaa5";
+      sha512 = "41b74b034f00a7ec26aabe5b5cca0b4a332b161be06f15a41e0c850ef53760ce1b284bcc8b71e1657a20b46c436c4ab6ef0bedb8f4a00c46b59bff825c5d5583";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ru/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ru/thunderbird-52.8.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "e385a46635372660a304d4cceb86be56d2a07b767a4eb17b131d67eb33494c878ed4e4cf3da3a1a198a9f3cab7c541161e325cbd9d5957c8af56d2a62118ffec";
+      sha512 = "4bc1aee9cb629f59aba733a08d4c2f5951006e30ad38584688fce6772d19e2a01dc6ddb43b6c0d7375638c8e0714703e6e4cf47fc639c449a1ba02dabe7dc44f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/si/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/si/thunderbird-52.8.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "952e89769e201e9320929f0562f27ca2de25a7bf4f0098964df6974831ef342f228de0278dd2de55a0d11c36804d04f42b9c9714f2c1ad44f5d68da1ae184d54";
+      sha512 = "663ab05d2e5f90f1be7fa9b2b61734f2c5c7d314ab86196629447c05d220f8de0a405d7ecb67e333d0c31006c0f0c384fa891fa087335f585a757b397d29769b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/sk/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/sk/thunderbird-52.8.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "827243b12ae2eafbb0da9673f914e26755dd3a54931e41a85ce89ab236b56bdf4ac4c256769865928509be4b998dac4a4924895ba583192d95b7271788185822";
+      sha512 = "4e925c2ec5d218b82722d6141b4e7b9f3216ba35b5e8260cf15c58f647b60e93161e9bdc8501865567e693ccbe3b40458b69e85e7b7a0884a522a68cce2df123";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/sl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/sl/thunderbird-52.8.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "d4063aa855abd1701feb078471e628728e3bb61e8799ac186c75b325b4db14a81734befe4782d75cd07170cceaa37b83de90d1d1ba73f950f7f76e24265cf49f";
+      sha512 = "9c0e33622d3cc6e735978b35643ae6c4028456964255b04aeee28486177e1711354cf1de02db84c6af928ba176578abf5b6a2a12a248389790fc6ade6fa96e2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/sq/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/sq/thunderbird-52.8.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "a90f3446a0a759fd9cdac2ea0251c676539f5dea56099d0e515fdcac72e881f54a95506f257da91b87d4be547b4377cfe8a7345e5087ff63d24e8bd2fc6742bb";
+      sha512 = "a6642a2c55db02058ce8bb9111afa3a9433372494e1e613fd8f1d575c64ce95e0c0e61a8b9cd60c662266f3347cabfebfbc606bfa333a121396caf3c0f89737d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/sr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/sr/thunderbird-52.8.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "f313d71b58efbe34f96ecdccb0ed14977899b6038d2a5d0d7c3138881a7668e8282e4c927f106fdfd1d74774404734e57d97d0004086997ace4ca53921321adb";
+      sha512 = "e472a07bf64547b912b80a32212fa9a0c25023044aff165cf92cad8af1796fbda9d36ef32f6c11bf9b87b75babb4c6fc6d9d5463b7b88f31649298adc6947b50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/sv-SE/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/sv-SE/thunderbird-52.8.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "0889f3c2917b01211dbb5d28262726a3dd077dfd5327fe1f3dd4742cd45aab9ab8d7bfeb141a5a2c120239c522182e46a263ad0d6cb8c2d71d4c9c004d734a68";
+      sha512 = "18cc4af474e717dbec7ff88fffc6635b7fec7d8936f0c7d903c42a1b9482186d5d0a2ca661491f76b477c57de45e03c995c562e295e5fca574534d81d6e6d30b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/ta-LK/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/ta-LK/thunderbird-52.8.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-x86_64";
-      sha512 = "49bd7127f1412a48aa7e66bbd2957cbdb4f02d4f43cf856b8b796562e945a1016852d695773351b30b65ee0d2d4b65c9aff4c347e9a5c2b64bc3818cce65ae54";
+      sha512 = "22f8d3345de9de5eae1cb05bbeaead160779b9f8c1187ace426d7ff026ec0ee0762a56b909f22c2bcdc186088b333d6fcf52a0ebf87ff56959b31b1f6dd7777a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/tr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/tr/thunderbird-52.8.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "6b50781107d219c7a86bce30b51c5e791627fd6305d1573d4fda98321e8476c3978a3b8d388005bb6d05ceb0ed0c6c119f9baf1d057b1f6d533d0e42baa90a51";
+      sha512 = "fc9365d3c869c1c3c1c9435f00b5f8eeee6fb231230a5fb0ff48cc59a8184f57bc558ab7f7386ebaee74b9c61c34bf5f7c6e882cd0e431749247b4a58d068c50";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/uk/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/uk/thunderbird-52.8.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "58e7e921d7d2ad46237ff66bf0f2cb0de448f68668968b56779ee874d0a9eb29ffc46876b6aab4a0c30e4aba597039c73939e6d454c8feb56cbb6b4215791016";
+      sha512 = "60ed7415eb87d9f1eedc2c92078823dc49db80652f6ad26de0ceeef34b7c499ec940ac3bf083a7731bac9c144b6bc04546209aabd1ddc0b399ac174fb88be6e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/vi/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/vi/thunderbird-52.8.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "5a2bee3035e76deb55d24d5043967e51dbb9d79dbc7cdb5dd9f59cfa2311391fc25017f08c709e7d33a5fa7ca0d8ae375ba074ae382a67f46b04e36eed504f53";
+      sha512 = "ea5892eb57fbdc0169f5dc39b2edb5eff2d06cddeae506e979d7556164fe55a65a402c7d791c873e6d0a3b48b97722d8dc90aae1b7389aaef3db836e803b9825";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/zh-CN/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/zh-CN/thunderbird-52.8.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "73983afdd0e07a394029f64f1fba5f24ae0bce80ef7f9fa3f5374af3b5e6a094bb41d7428a252396b433ca59a092e5d19b20eeefc5867d68bef00a1894437159";
+      sha512 = "22ab8baa3a41beda58f02612bcd5e0a9848c3cb93bc68037ea504cdd0b2a0b5ea5bf78e5bf735dcbad4079ebcb3c5434c34d6a5e2a9f09a513f91018084ce960";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-x86_64/zh-TW/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-x86_64/zh-TW/thunderbird-52.8.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "71ba36ffb59a94191ffd6bd24a00d3e35422601310b70a6f411b8ad0175d7f67efe9ccb8d0a2a7c1d47263d5d1cbd0a4f790ef54cd174875d0c0bafa86481457";
+      sha512 = "6c089225c57a0e010b0d413046004b53570afbf2d3b673dbca9a6e8cc102b6edf0e3a4f4858add4f5c1a4bb1fadc2641bd1c1dbc8659f970c84f61869b3634ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ar/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ar/thunderbird-52.8.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "fc69ea6bc9393f55e247a78eb747c4ae6ae0c30efad8188d50eb52f4bc3f2e47e328788cf329966e8184b468a58bb923fdfdc736ff7b7b37cbbfa31bc619e065";
+      sha512 = "d48822233fa44e48b762e6aa2da302dafb38c32827b112197563952b35ee453a361a45eee35c6ee88317d6cc5215d0276e74862b167b01adf62f9c275f89a38b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ast/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ast/thunderbird-52.8.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "74a6ed4829522c0ac7a4411ab4d269f557391c53d1313eb1b70bb6e3fbba30217343945e60d46bb7c5fcfb20a40b2e6bc0c40cb66bb72259be4f9ad78796bedd";
+      sha512 = "3894ea6a01b335b92fa0d9f175aacefdf4fdcbfaeab3f3f5faa37f0bea090ebc7bfc130fb42ffff2293ecc95e3bdc8bf6142a5896dd4165fc3fa9f8e09fc3b5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/be/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/be/thunderbird-52.8.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "ba645d2eaf0eaf90a0c1f2f24aa87c6783405fab00b2608aa1e3f88f1f81877c4927e93e2090509b9e06c8e2655a4aa731bed47ecf8992bf12b9c5dcb189c0eb";
+      sha512 = "ad93e61d4d1437681bdd772ad815efcb30716e716a08a442b9df2351b27118a590426d0ac054c6f41c29f4abd14f6e8fe7a54206eed810bddf1a70d6afa6776e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/bg/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/bg/thunderbird-52.8.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "62dabdc80e0e3d46b42c69462d18964e584b54fee80bd632c0a3be19fceabf6bbcb80ee6b200472e52998f90252a7e62355cfa9d7d8ba3b3bd0f7bf247557c59";
+      sha512 = "de09ff65e4c24aad1faded64897f9cf7bbdcc21d4ed609fa1bb0d9ad5d5a9d1d4e780fc2d8a386890e6cf59641697fd1542701689ba82e22c844ac29012633b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/bn-BD/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/bn-BD/thunderbird-52.8.0.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "11acf4d6546aa3b3b1ee3159fb54e0769617664155d1dde4ec7d5af28335e90b428559b80e570d2b1829153f2edf8472e37e8e2cbf1d72567258e0c76aab4704";
+      sha512 = "a5f3737e2cdfa540adb3682542163a5f9c34605e975fd66bbb579c1508f485ff891f997a8c90d576fbc09d5c4cd183f123f020df7a3cd1f23401e7d92e930724";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/br/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/br/thunderbird-52.8.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "1056f78922c277ba64e3dad8e41ebed516495d41c07be4026271a2ca97d314218ce5a46c8b29be38645507a9f2070663cc6bb5deb194ee2d57df01809cb2d3ac";
+      sha512 = "37222d22ed65271e08fbfd32d5e6fa7cfe65d5d002116bdfbde8fec9c3877bafff6b6ef38680cd4373a1c86ed92402aa5afd5bf04f369029669af5451c9d884c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ca/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ca/thunderbird-52.8.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "f50bdc6d1bdfbe4bbfd8aa8ce3938e2ca6963d0fbc0fd47d23505158bccfe328195e45c0215dfcd354847e5e3a0897941790a7cc1f1db31ec29cbfaa1cae7a33";
+      sha512 = "87adf55bc6b50881b8d7ce30170f6e2f346db2c7f9801abbe37a17ef274417a3fb7dccab8d2eecb25d6c61a888ffede95c2ed40b6fe097fff2cf49a0e9490a00";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/cs/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/cs/thunderbird-52.8.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "7d8c6d9be08bff6fcea06a994c637ea83576377975476edc01dbb152c8cc8768b00bab4295d5f13ca01451344aa64af6ad227e359f3d11bcc0228b31fd13c1f8";
+      sha512 = "055df8c29546975bfca186dfccfc9fde5ba418f3f2be1e15c77ac00c3b759527609427aa6590e3bb06e417211be6642bc37db4d19be6c3b866358d65c3aa3bbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/cy/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/cy/thunderbird-52.8.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "8bc583a05e872f36df9512ffd5c06cafcee81c632358b5bb13d8a920689b030e8ed4996bfc265c074d5d7959a1e75c7180900b51adb30ff3181de496cd34a4eb";
+      sha512 = "c60e61146c3fc195c482106d40a2eac47d0b621a13bcaeee5fd95a40ffaa5ae810f58a5ba85b2676a4277ad3fc6d7caa3907b1d4962fd42887e762236e7e9366";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/da/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/da/thunderbird-52.8.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "ccef5bffe4a807d55924ebc8b36f0065891f03520fbb015547da1264997e95cb9e919aa5af838686af070715ffb314ddf6abda0e99e1e06657a2ea6fbc956441";
+      sha512 = "1f8634f680512bf4ed0a44b41f3be55c118a114dcc262ee41010e58abc29f8bc3032a4c5264b948b9e4e13684d42761d97bf612050b891b4f52c78e91aa5a0c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/de/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/de/thunderbird-52.8.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "02061b7572ad3b784a28926da15abea9fd9c93b4df9c40a5435190e6d872d356b6001cf0666e4cef0696da32c76e64cadfbeca28f6f894b1b230033d451fe105";
+      sha512 = "9422296b970e77217581c0a10efb928923e55272baa485ccd1a7446d6e9a84da23e6f2b93623922ac85db84861ab4813282e328315bedf9e3b8cf344d869108e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/dsb/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/dsb/thunderbird-52.8.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "458785317a61ff0fba04524b13cd72e22d4cdeee69bb99c849f4b12385a19f3236b586ab6a12cf9c8042a444553d1a3f82bef1f51fa9cd11639ec3911eff0013";
+      sha512 = "281736767a8d59830b1452eff5e5058c4090661030068bdc33d2ceb960f10c38284c32ff94345685fa7a7781da502f67c34fc83314728161d75c5fb3fd0ad0b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/el/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/el/thunderbird-52.8.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "5b8fdd6a65b4057eff462c5ae8cee366ced8ee482892c0457a6fbc52303b8dad96437230f18f560a3bef3f392eec43194b89715071b559623ada47fd031680a5";
+      sha512 = "baa144336339a3a271f5a852b3130d20054baab3633d453015a5862e630dd73f3a99f50b979da7910810e84e99120a2afa96f8dca8c8ce0017824851deb9d702";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/en-GB/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/en-GB/thunderbird-52.8.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "0c32a412f9c7ad9195e113ab994ed8e0d80a14bcfdd70b3fc51399eca7e34241a265a7d81d5cdeb8a7217a0c694ebceed45c3b038de0656ee3a03bfde1887b3b";
+      sha512 = "b9573d177ff237ad833e8064ac72f7560940c5accbb7b7f663f53f6942e0326ed451e2290b09003ef6b320b860cd388020b00cb340d39af34b38678556704390";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/en-US/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/en-US/thunderbird-52.8.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "f7f8bf3f74052310987b546bba0f986abcfd65e53125c2cbde4bc4744e27de054f21eba8080313c28c9c3b44de1d773e4471facc9b71f520b6085c32cfe721c2";
+      sha512 = "5f0d43831c256e00eb3cbe5953cae5b6e84f54bbbde8b71c83f841c38b3704620e1163bcc5cc903a0b716685371912401f90bd00f5500fd42cc6debe97b28470";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/es-AR/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/es-AR/thunderbird-52.8.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "0187b3cb9b91d43d6faf217dca8566429103f2bb3c04bfb59e842da9c464cfba3f542be3789bf0fd46e6ca4c355d632f50b16b01667671e41231b8ca8d5b75d4";
+      sha512 = "ad640b2048f064d3e0914a0e79311e66c169258dd259a6873983147c37778616eecdc6e22aa64db272b534813a11fd1a0e5c555ca158d565513f3f201197a9a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/es-ES/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/es-ES/thunderbird-52.8.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "876de2da5068acdb546d5091c64bf3edc4269a3e6dde2c2d928cd05439570773db4272819fcf8e12c63f94cdc41f0721412e108f078d1cd11501dc31966ee3d2";
+      sha512 = "12c3f601473909f38f737a353dbda2bea515cec0e6934c389daeeb470a489104d8aa7f920b0d81f6da930f886ea74b0c82dc6a49a2142c1e843c458f597c1a5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/et/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/et/thunderbird-52.8.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "2ff7a791390e955cb2489c685504b5a118396d99d225e616e9bbc09b4f7be70d7a2f1a925d5cdc38b944e2476904604356d9e3e0dbc497258a133ec80ab499cb";
+      sha512 = "840cee14b983e20a0aa6847e15aba2babdbba947b6df38c14d3d5f3b50dcdf6cddafec13191c75718634a15ec757ebeb664172d09f841fa2ee55db02bdc67cee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/eu/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/eu/thunderbird-52.8.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "bef88a12c122f2d275e1fa24a92f5cc6fbc11534414ebd151e7d53d95d1c5ab06045270221ceb46629160eafd60bc1fd8a8928c13915493c83db231785507c21";
+      sha512 = "d6b4c9edcc54f22f39991c206e7316ea172e4450fca39202a81cb522040abea08eb9b48e296baaa19aca12d34de0b8af8379c1faf30a1111648a1c0cee84ac70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/fi/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/fi/thunderbird-52.8.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "d2c1be7209706fa96dc20af9c30be61557e0bf82da575c7b95fa8b5d2fc7ac6b7b2101bdf0db169694fde66cd1da60edcd4b505b849b1949ee72f12d7dbef200";
+      sha512 = "23b25a0ab4879ddada9026991fb9955df9d32d635c4d0f746d329dcdfbce4593cbf7a3217845b8ef5f5a1b8e39a8a6bb1447557a5098f19acb82027e5993d549";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/fr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/fr/thunderbird-52.8.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "194711b687ec4ededcb9140c7c1c3e1a0ccb47759cd00ba56819a3a7d9be66f9a7a29e2a91db0b1d573d584953871a37781877f43e734a8e39599dc6e8027622";
+      sha512 = "4033f784c31e8e13cfe408782e8b4e528f4d099abd02480090a28c6d0079a5bdd29ee0cd0953d5b94434c60d11c6b9867b355a8d8b6296ffee51d78337df3931";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/fy-NL/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/fy-NL/thunderbird-52.8.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "7b9ef6651166e66c6abb88b79628a0c51f576f2ccf2dc5eaefd1c01100a492ca9fe1657aa2d6745079e0f422e0f2692d24389577b47248ec6713817e51543c6e";
+      sha512 = "64959a9a0d45564ff2ff344e1494c7f3d80792ecd8fd7df8f2ce3f35676533b033183f24ce44416f3cbd281dde20a7c7f2c3c488e8476d606d0416bdc341c02a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ga-IE/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ga-IE/thunderbird-52.8.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "801af21d297c95505afb3bb6cc79edf72057ffbb9ee9da56c1f283043e6df921239a4ac8eb3d7442286b27265d3462569f79e29adc88b7674f7e9d8396ff3109";
+      sha512 = "255215853d3eccc809b71b653d6e830d1cc3e5857409f8d8f91b9f7a2d6e4cfb1033ba927e79a407f482ef8b56c1175d2b0162eb04a153cda8c2e156b0da8c16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/gd/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/gd/thunderbird-52.8.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "f778ff74408d3d9c7ba9c62cfa2c9447932b15446801df1c5363cf7c2059e1aa89539c1270fadbfc482c42b5c1845376e2fe037741fc267461d0b22f8edaf859";
+      sha512 = "483550a103337dd7807b85ff87ce0fead21851ebba75a470be88796017bf412979be6020eb3daacb7bbc15044236093277b6b2dac1ac66fa2c3b2fc2e403911f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/gl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/gl/thunderbird-52.8.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "ce541ef081ee8f8946f71b07a820ec31c4241730e565a8bf781a844a79fbfb0258d2f0d371ae3f4690067b6c520a103f4df996e8085d2a8afb997a4f1fefd288";
+      sha512 = "bbd79bf49e94720ffed29c07555488164de1188212fe4ae0e6076ede587997b3def662f880176e267d11c4ba1b1d4cdc6ed6721ee771a7cd9acabc3a231f76e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/he/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/he/thunderbird-52.8.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "ec3cef4bd411f6604e1ec3486272208aaa41b1154dad1473c6fbb483ec2d3960aaadc11cb592777f49571bba35a0812f4f0a14c0edf9eb8a7b1fc70d56fcd4a1";
+      sha512 = "99b135b3f4aed9909daf8c2711ac10ad9ee85beecbc127e112fd61fb51a7d3d8f8575722cef0e7da6d4f79aa38de72ea4807c9503af5974c1ba9787180ec014f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/hr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/hr/thunderbird-52.8.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "f27bd94723f65c4972ee41cf6a9397098cfbf9097e3eeb06b7b41d50b4f0143711fcd0ad59a04f23ab9acb42d3f9515900c067f9532366ae3333ecae2a54f965";
+      sha512 = "a11ff16f2993d07d748630e94ec7bd6cd7634506535f3b7e7cfa5d16439fb6d2118ec195752cdedb87bfbee20feb629b72d6ce2f84b72a1da87b876e8e9786dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/hsb/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/hsb/thunderbird-52.8.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "7caad57604b9d83e64e8e30e03e89c4661e8d81d2ce833a6908e2d662d4d6c7ffbbb8b071e8657fabb0ebc0c0f84b07617ac878c9bbcfb400b711654e36f66d7";
+      sha512 = "9090e5766ca42f0a633a2e639a520cf6f89a0a08f9d81d7e35fdec64b9effaab8759fb7241ab77c4b31b217e5fd72d52fc953544dd55c3b141a9a6d2e631ca5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/hu/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/hu/thunderbird-52.8.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "382d79b8513ad28f06233af3473c2fef995d72c9913f64adce5a86528ae0ead883e94f91b4d394cf30541e690da5aad77dc48b8c2a4a84ea6c5fef86c22a4159";
+      sha512 = "f5158c0d4ba87f2472fb07f850a709e174577293e431b482f0d67e3ecb16d818544a02e221d3b68dcbd1d8e750795d51254ad87eac98350f4919979651261e5f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/hy-AM/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/hy-AM/thunderbird-52.8.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "3a4e5878e4fcc9c493cf1de1393da8efe85ff86d96702f57f085da42cac990290b054a3998e96cce69dca17ada849301a6724fd6ae245bf4aa396db5ce76aac4";
+      sha512 = "c902f41fa9353e57c666876715da6175ee9bad96ed45e0e858b436fb5c10164038a56bea670fb73a8b0eb2a60ceed33a7c08e790718efe2e22e6883768b21529";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/id/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/id/thunderbird-52.8.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "dca16b2c0b5034e1be2831a1992ca47f6a7c614382e781e86095df11f34193f13868bdd7f972f54e72d7f844cb24172057155d5457fc6ec98ee476ed01d8899c";
+      sha512 = "2366a3c32145012e073c84527f7e0f8cb1b311728b414084ee7b99727df5ea2ba6b6323def0c7fff2df20066f65ee530ed635a981e42bd1b7fe21874b893a680";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/is/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/is/thunderbird-52.8.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "181868826a0da43deeb2ef68a307ba195fa7a470651d4a08e904bde994320e832a04c44fa355cdaa94bd4c8258471e6849cf06dae8284d43f43defc7a3976816";
+      sha512 = "ae858675cac66dec80de439a2d9a1290ef2d6644a896b183692a10924eb55184b18866227787bae30cc01482453e65040618158a05c2f8d6d9dc2b7b60dca09b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/it/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/it/thunderbird-52.8.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "88c906753878c7b8b0a3d60de21813017ae6ba63b6be9c5d24b6072f1a4aa3a1cc01e56433f960c02f33317cb113266200fbeedc397cd3a5587aa592fdaaacfb";
+      sha512 = "ace77d1b7385f9aa825d5f67f640a77187891d5a257a00a4a9c565f46f742d931093a26f1d234f65f5e372d9598cb26c98766913e5b10a1c593fc6faab32edf3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ja/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ja/thunderbird-52.8.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "0e53d3f877793afa9c3ecb48f73640ff3974633bd28ce036b96c7ed29f3b9a4af47e1fca89da9d594c879f534e7c4dc27ca05ece8ec33909fe2dfd57800b3a11";
+      sha512 = "cb61fdcf68f4d02340a25c5b01b7037a7d102423bbd7068a9e7766f823a88ce461d52d6aca4211c1d871d31b8503477bd606c1f814c725f65240c260284e63f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/kab/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/kab/thunderbird-52.8.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "feeef278ab269f6e33b479b38f32004a5ece2a37ed2aad97c87e68dd0a8195ffe3428ac9dce0a3e72349d3c136b6b5bfdc25916bc57f4fa043eecffc64bafc3c";
+      sha512 = "a52705049e4baef0e8f884f97fd3dc15097c855987e540adcca6b9d27d9d1a38538e326bf1f6bb2893055f72f3fdefe0563b6e048c02031af4e7e4bb77140698";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ko/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ko/thunderbird-52.8.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "c138dcbb692780cc1598906a630e90c8102d6a562f922ee28bc88e25624eb88aea20bf3d6fa6b87719f2a9fda0962bc413ce7e6d07147efb47dee7fd670a5c76";
+      sha512 = "a4bbe35e6a5fbf4db08982b0538390e3ec5e54d4e8b627a0e9267ae9137822710add418e5042ace3be8da3d5d56ea41ee4d5bbc5bfb95afe1587a5f81d5b32d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/lt/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/lt/thunderbird-52.8.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "96e5cbd33b57fe02134aac190347f0ac37fdb9f847ad74a44f59004cb739579b9309442605e3c9c2693bbc484372505aeff9378bb7bccfe8e1432da7a5508ff4";
+      sha512 = "0ef3fdb51246274198221cdbe07ebe6083c36759edd73243ed3568650b2d6570e90fc25b414d61d6a4bc0755b44eea21818cac09900c6eeef9dfcf24b403d3a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/nb-NO/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/nb-NO/thunderbird-52.8.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "913a731cf2c063be645cca94ea4beab6601e2536baad9369f9804af663e7b1a024024ff2b5befda1ac8169db0e8cf9ce5c9ca5d0ce650fe629e606c221776e8a";
+      sha512 = "4a08c425fc32dccd29901e7211b2e35dc151d954c1a6ec607ece3ffeedff1a913bef8910b46e4285edb785111643d6b1eeb19284af953e8446d92c055c62621a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/nl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/nl/thunderbird-52.8.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "79ceea0143319e4b883d2c59949fe3ddc62af70e9fe6653b745fedd2e683aaaf4c6f10d55688b83085abcd36672242f21ea0c592930cdcc7cfef7e32dcc72230";
+      sha512 = "8f54f5b2131bdd6579dcf7dce3afea57ac069206258ba52649d4f587aeed6e9aac9a08c4dc3920fd9be37074c2e619071bf502490b43d40a164d3f8d283de5f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/nn-NO/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/nn-NO/thunderbird-52.8.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "c524517c417b977e9e8c3b0d3b9a8f1b256c68360f70e61ba4d1b2f887fe550222843de1f9c42081db935e27b3ec63ed8b1a1b5658f48f9534eb787d4fc28d54";
+      sha512 = "2d93dc0829669babf3ae3c3d6f16a7c9d2c9491c6127b1d7adc9b071cc6343e6383f0eed78bde342ce52d9570cc56b74595970e48430f08215143ed9642ad6cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/pa-IN/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/pa-IN/thunderbird-52.8.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "10e8c6a1faf395371421387ec1cc6891d8e0bc9f69f37f2e4fc414dd9a5e4c10246f279e15804280a550ab7acc265b8a3691ef1d089459cb58cbf06896f88806";
+      sha512 = "98a844a40538224f750934132deac0270fa401afac00cc19352798ba813249408f976809b261419d0b8613a4ebbaf7e8ed2b8669f0d3ffed63916b9e71f1b28d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/pl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/pl/thunderbird-52.8.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "13afd039d50bc7c6ead72e9d69f5dd6dafa0fc2b5d1f18a207a15192cda4473ca8706386eba98b522667cd036ded38bfcb67fb3dd8c2e50629c3db9a1243c3e6";
+      sha512 = "8c7465446cd1cae4d1bbaae69541516765d9388c79e73bb64996fa0154802f5a20f86cd6c1d0f835f7f7b631455d0b5d1ccc1d0d6119705bc5a9f6f06ecce8de";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/pt-BR/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/pt-BR/thunderbird-52.8.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "9c024bfa1733d144ff4fa58e7ce8a2127528d7fe05e64142a3b1d8a0fdaeda1b1c02998089fd219804571cae4072db984a74a40c4a22bcc18dfb68c849aa37cc";
+      sha512 = "718b4af9ae8b205f1cdf666b68b851b7c0fd5f0152237f8933dc1ccc843265fe8a869c2656d044ce7b5ef857981c827fc6dee85ff1008921108313bbfe1266a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/pt-PT/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/pt-PT/thunderbird-52.8.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "ed4d7117bc87cb2ec6df65667f554a83f2fcddbf4eafd6a587082ad42cab69fab5c1d9fc36e132660911840fe85dcc18ab4b23e83b9b57317b900db820483b40";
+      sha512 = "3bf4ae15abfc39505f7f846e468baaa70b01e370a05258f31150e778ff67517098e27a9be135ead2f8f53ef96291d8d04a201d6aeb7d56a9e45e211f44246b21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/rm/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/rm/thunderbird-52.8.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "d1e1e48c47866b89e05c975cc6d4d70120173066457a4c05de1ab9222dee87b0d562959c63afbe024681b0a3f9f8cb3c836f2f0a0e910507e5211a430b1f9bab";
+      sha512 = "9214ecc41dd65de573cb21bb9ad56bc53baf8b86261ab41fdddca57173d157cb055f46aa2a087151c0a9b0dca4960914e7afc1095d118754f847dbc952a4a998";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ro/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ro/thunderbird-52.8.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "c1929be134d8127433eb4b26468379a631456681a6dc3d98bf9ec313576a4c951d5fa7f08ae2d3bc5e8563eecda0a71c412c62a970a0cec618e06d5cdcbc46fa";
+      sha512 = "aa46ef621604b95cb97b0e9cd4400a5f57aac58f82b3a5225a7828a757a24fa3e03d80839e1c6c03f914632fa6652386fc1787b8879343b06b6a59f9fe08b87c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ru/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ru/thunderbird-52.8.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "aa7893b8ea0f44f625afca61adc5942dfaf2eadc6cc7ead569a3536ad827a9b4f88f225dd01a9c5e375eb24a9940de6f65413ab6d93ec2bd736f0bca711739a3";
+      sha512 = "f07d8fe2b6f81ebd151804d1c0f0a39851bf3ee1e468092a2b0eee5f69438a94872b467840da11aaa7fa5f5604dd86f28ee61c85fe62ae283f844f8aac4ced7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/si/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/si/thunderbird-52.8.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "ed425325419e0598e3cc5abd0d2b2898ef781c4be847aa8d9c93596f6dca0b718cb7035479d4013d3213b97a440dea2560549619c3ca330df9bda7b287cea673";
+      sha512 = "8f1b53473fb3e995c499e1583156114557548c1dc8a283a2e8f8c32a90cf2f765b3827455b1abb11272eae3dcd02d39e10b4eb4c2d6cd138f1905cf47bb8c696";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/sk/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/sk/thunderbird-52.8.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "bd576b29abe39634c864a27f5ab8d59ada34bfd069a7eb9fbe6af1cd79f2e0fdd61ab4fe06cc3944a92b06634bde9faa68ad6d56399085999df5e7827dd121bd";
+      sha512 = "9d40559c28a79375bd70b382b959227be036b00115b8c331d1383eadcc4599099247d76a67880e284e8cf9137bed0271c8edc2b61059ae4d91a540de5f50bec8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/sl/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/sl/thunderbird-52.8.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "98abc990d644a991abd9f513e205556974905c82c93e0fe8171608ec4d1aac7883ecdab5bf86ed287f43e6c5e45661b79ad012a4dda7b1e5cf6c3411dce7ea2c";
+      sha512 = "9426449a10bcc6ed3f24123fd5452cfcc87bead7014877a05be59d54db77af0833c15614c8c6e42f57005c9b773b1ebb2e59bcd9afd17177160b4010c0d5423a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/sq/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/sq/thunderbird-52.8.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "d45920069f8c0808b4965118be5ba6e4cf36b99bac9add6d1ac2e20051e95ebf09eaaa9ac559515803b655a61608bb4afab0d69d720ca74f57ec5a643b151f24";
+      sha512 = "a6d914e1df0b240afba8aa5467f5c1e62b48a263e86d32ab5b8e2cf07b8ad747ceeb733e9431f018779f4e1e9f6a9291f29f3e05681727a9b4981ad09a8cba45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/sr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/sr/thunderbird-52.8.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "7d77124de3cdd684f13fb824a0bcf7a9440ec7c626ba34deeb04478950bfc908494bc97de5f2d8d8dc0b0abfaa3f7c88b3948a10b7fd31de092702c755cacf25";
+      sha512 = "f333626201a1445aebeef71926fe3d57f08fb0fbbeb2adf50b30fa75d3c28c4828489675e74a76fe07b0684e2ab949bc13b87ead003b54119efd11b1c7c11cc8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/sv-SE/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/sv-SE/thunderbird-52.8.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "e16fdb819ca8ae5c8392eae50115d6b6853678c002de3a18fff25ae0e7e7fa2af06dab17a6a2dff31440608373a5268197efedeaf36f0012c2763080f4b51cc5";
+      sha512 = "5fcc5b4210320f5d571938fddd312493615e829bd6415aeaca2c37ec63db46a1e2d8942e9ce58164c4b8d1d40e88eff0de43861f0e20d796129d9088e624a4ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/ta-LK/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/ta-LK/thunderbird-52.8.0.tar.bz2";
       locale = "ta-LK";
       arch = "linux-i686";
-      sha512 = "3c8429d8a31771452e108c0a7b16070138ea1e82aa16536bad4d7570117f0790045e9a34fb9f7546eb3d749e0d94b2a1a7a65b93198909189cbd2f1bf872af94";
+      sha512 = "6f48b7b74a11e42fab58436112f8216942dc288e57594e4bd99d951efd8a4f4e2fee668425342635ce1fece60f0fb21027932b4e678a119f38ac45a6f7a89365";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/tr/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/tr/thunderbird-52.8.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "effe30bec8c4b0fc1428681888ea1e0a79eefa1f60fc3964e08142d00c6db065ff9a2acf989765497520f27504b4ea3c8104a084f63abe4358d165c5bfecc680";
+      sha512 = "c6a5c01c21e9b07fe1555c9f9148f888c793d4290d9b582cfd2741b895166a6b2407f0ff94de098f136758a816d59a1e6064f38c927574bc175afff168be72a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/uk/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/uk/thunderbird-52.8.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "92cca4a0b9ac66bd4c0e14d0c04a162dbe2a3aac3a9fa95e26e6eef8ef1716fc21832967323ca5b46df19b28843de6e4781ea323120bac37a9821745f7ca9af7";
+      sha512 = "6492260323d1e50a2bc129ba22008d3681283b2931bd6df0d5e5d9087a45294cffc74e711a40994d86d98c1d430f4349ffc4b97d0a1b539c35653c6ed6ea877b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/vi/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/vi/thunderbird-52.8.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "b470364cac631fe944e7c06a27299e8ddf65605aaa1550d0736ab6088e38cf008d224b920111a17f6d87aceda3b95ad0ebb01351ed2339680530629a70fca1b9";
+      sha512 = "d43c675312a30a3e6c02f70e9af921025a6798bb5143864ef7d1bc44e11ad654be66a79590698faa44fd404a4090d6dde37088a26339f3c244e0f1cc4d9042f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/zh-CN/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/zh-CN/thunderbird-52.8.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "1840d47835805c0ab854dde0a08fed90c785377d14b8f53b303fbd65bc5dc8e967146ae5d26ef4a0693df89679cff27ccbad0cabde27356dff97701fd3c91579";
+      sha512 = "fe81ec132fbfd17a15f76299853c45306be9f801d2c03a10fa9e4b25ac48e6e14efe4bc4ff2e5f01a94e46b0c1752add48e5277b11dee7d52325bebf5126616f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.7.0/linux-i686/zh-TW/thunderbird-52.7.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.8.0/linux-i686/zh-TW/thunderbird-52.8.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "aaaef2821bb128218a6c9bbf07b1f017574f39a20664e0e82a396ddebeb4b2ac754fa1ece956ab70b1f55ef5e2a750d612cd6ebbd2a747d28f9c24a5b994c730";
+      sha512 = "96b53b5287e3625b4045588118427fe696827aa25b790665aeacb9096ca9ee8bca8a67bd28f733d128d08541069a1e684819f4ce8a1fd29cf683bce546a04fd5";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -22,11 +22,11 @@ let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.7.0";
+  version = "52.8.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "875ad6f2b030c65d248ecec4f4a5b51767c3ee7944ac72893237efd2af50145ec2e4a9efa8d60807b78bcfb8189969e5a67d15124710e8b0091f639cddfbfe21";
+    sha512 = "ce44f32f44244560499c44dbe963a8296cf58cf33e3f26d07be455746ed7f77791084e41bc66b2c90fe46e97fa15ae2041b1f5fcfa94d15b45c4f90172230d03";
   };
 
   # New sed no longer tolerates this mistake.


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes

https://www.thunderbird.net/en-US/thunderbird/52.8.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2018-13/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

