### PR TITLE
ocamlPackages.earley: init at 1.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/earley/default.nix
+++ b/pkgs/development/ocaml-modules/earley/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, which, ocaml, findlib, ocamlbuild }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "earley is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "1.0.2";
+  name = "ocaml${ocaml.version}-earley-${version}";
+  src = fetchFromGitHub {
+    owner = "rlepigre";
+    repo = "ocaml-earley";
+    rev = "ocaml-earley_${version}";
+    sha256 = "110njakmx1hyq42hyr6gx6qhaxly860whfhd6r0vks4yfp68qvcx";
+  };
+
+  buildInputs = [ which ocaml findlib ocamlbuild ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "Parser combinators based on Earley Algorithm";
+    license = stdenv.lib.licenses.cecill-b;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -215,6 +215,8 @@ let
 
     dtoa = callPackage ../development/ocaml-modules/dtoa { };
 
+    earley = callPackage ../development/ocaml-modules/earley { };
+
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
     eliom = callPackage ../development/ocaml-modules/eliom { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

