### PR TITLE
pythonPackages.pynmea2: init at 1.12.0

### DIFF
--- a/pkgs/development/python-modules/pynmea2/default.nix
+++ b/pkgs/development/python-modules/pynmea2/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "pynmea2";
+  version = "1.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "185wxn8gag9whxmysspbh8s7wn3sh1glgf508w2zzwi4lklryl7i";
+  };
+
+  checkInputs = [ pytest ];
+  checkPhase = "pytest";
+
+  meta = {
+    homepage = https://github.com/Knio/pynmea2;
+    description = "Python library for the NMEA 0183 protcol";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11273,6 +11273,8 @@ in {
     inherit (pkgs) fetchurl systemd;
   };
 
+  pynmea2 = callPackage ../development/python-modules/pynmea2 {};
+
   pynzb = buildPythonPackage (rec {
     name = "pynzb-0.1.0";
 


### PR DESCRIPTION
###### Motivation for this change
Adds the [pynmea2](https://github.com/Knio/pynmea2/) package to the nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

