### PR TITLE
Revert "zsh: move setEnvironment stuff to zprofile"

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -108,6 +108,8 @@ in
         if [ -n "$__ETC_ZSHENV_SOURCED" ]; then return; fi
         export __ETC_ZSHENV_SOURCED=1
 
+        ${config.system.build.setEnvironment.text}
+
         ${cfge.shellInit}
 
         ${cfg.shellInit}
@@ -126,8 +128,6 @@ in
         # Only execute this file once per shell.
         if [ -n "$__ETC_ZPROFILE_SOURCED" ]; then return; fi
         __ETC_ZPROFILE_SOURCED=1
-
-        ${config.system.build.setEnvironment.text}
 
         ${cfge.loginShellInit}
 


### PR DESCRIPTION
This reverts commit 77a6cbb1c1feeb6b6424d35319ac6226c780b34a.

###### Motivation for this change

Start of non-interactive, non-login shells (e.g. directly executing commands via ssh) is broken due to missing `$PATH`.

`cfg.shellInit` and `cfge.shellInit` need `$PATH`, too:

> /etc/zshenv:10: command not found: mkdir                                                                                                                                                                                                               
> /etc/zshenv:11: command not found: stat                                                                                                                                                                                                                
> /etc/zshenv:11: command not found: id
> /etc/zshenv:32: command not found: mkdir
> /etc/zshenv:33: command not found: stat
> /etc/zshenv:33: command not found: id

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

