### PR TITLE
pygments: add pillow dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3895,6 +3895,11 @@
     github = "typetetris";
     name = "Eric Wolf";
   };
+  udono = {
+    email = "udono@virtual-things.biz";
+    github = "udono";
+    name = "Udo Spallek";
+  };
   unode = {
     email = "alves.rjc@gmail.com";
     github = "unode";

--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -25,16 +25,18 @@ import ./make-test.nix ({ pkgs, ...} : {
 
   testScript =
     ''
+      $machine->waitForUnit("multi-user.target");
+
       # Test hidepid
       subtest "hidepid", sub {
           $machine->succeed("grep -Fq hidepid=2 /proc/mounts");
-          $machine->succeed("[ `su - sybil -c 'pgrep -c -u root'` = 0 ]");
-          $machine->succeed("[ `su - alice -c 'pgrep -c -u root'` != 0 ]");
+          # cannot use pgrep -u here, it segfaults when access to process info is denied
+          $machine->succeed("[ `su - sybil -c 'ps --no-headers --user root | wc -l'` = 0 ]");
+          $machine->succeed("[ `su - alice -c 'ps --no-headers --user root | wc -l'` != 0 ]");
       };
 
       # Test kernel module hardening
       subtest "lock-modules", sub {
-          $machine->waitForUnit("multi-user.target");
           # note: this better a be module we normally wouldn't load ...
           $machine->fail("modprobe dccp");
       };

--- a/pkgs/applications/misc/houdini/runtime.nix
+++ b/pkgs/applications/misc/houdini/runtime.nix
@@ -1,11 +1,11 @@
-{ stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, alsaLib, dbus, xkeyboardconfig, bc }:
+{ stdenv, requireFile, zlib, libpng, libSM, libICE, fontconfig, xorg, libGLU, libGL, alsaLib, dbus, xkeyboardconfig, bc }:
 
 let
   ld_library_path = builtins.concatStringsSep ":" [
     "${stdenv.cc.cc.lib}/lib64"
-    "/run/opengl-driver/lib"
     (stdenv.lib.makeLibraryPath [
       libGLU
+      libGL
       xorg.libXmu
       xorg.libXi
       xorg.libXext

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -24,9 +24,10 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A fast replacement for PGAdmin";
     longDescription = ''
-      At the heart of Postage is a modern, fast, event-based C-binary, built in
-      the style of NGINX and Node.js. This heart makes Postage as fast as any
-      PostgreSQL interface can hope to be.
+      At the heart of pgManage is a modern, fast, event-based C-binary, built in
+      the style of NGINX and Node.js. This heart makes pgManage as fast as any
+      PostgreSQL interface can hope to be. (Note: pgManage replaces Postage,
+      which is no longer maintained.)
     '';
     homepage = https://github.com/pgManage/pgManage;
     license = licenses.postgresql;

--- a/pkgs/applications/networking/instant-messengers/gomuks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gomuks/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGo110Package, fetchFromGitHub }:
+
+buildGo110Package rec {
+  name = "gomuks-${version}";
+  version = "2018-05-16";
+
+  goPackagePath = "maunium.net/go/gomuks";
+
+  src = fetchFromGitHub {
+    owner = "tulir";
+    repo = "gomuks";
+    rev = "512ca88804268bf58a754e8a02be556f953db317";
+    sha256 = "1bpgjkpvqqks3ljw9s0hm5pgscjs4rjy8rfpl2444m4rbpz1xvmr";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://maunium.net/go/gomuks/;
+    description = "A terminal based Matrix client written in Go";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ tilpner ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -1,22 +1,45 @@
-{ stdenv, fetchurl, python2Packages, librsvg }:
+{ stdenv
+, python2Packages
+, pkgconfig
+, librsvg
+, gobjectIntrospection
+, atk
+, gtk3
+, gtkspell3
+, gnome3
+, goocanvas2
+}:
 
 with stdenv.lib;
 
 python2Packages.buildPythonApplication rec {
-  name = "tryton-${version}";
-  version = "4.6.2";
-  src = fetchurl {
-    url = "mirror://pypi/t/tryton/${name}.tar.gz";
-    sha256 = "0bamr040np02gfjk8c734rw3mbgg75irfgpdcl2npgkdzyw1ksf9";
+  pname = "tryton";
+  version = "4.8.0";
+  src = python2Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1ywgna4hhmji8pfrwhdfj1ns49vs9nwppqb7iy7jr27wrxk4bm6b";
   };
+  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
   propagatedBuildInputs = with python2Packages; [
     chardet
     dateutil
     pygtk
     librsvg
+    pygobject3
+    goocalendar
+    cdecimal
+  ];
+  buildInputs = [
+    atk
+    gtk3
+    gnome3.defaultIconTheme
+    gtkspell3
+    goocanvas2
   ];
   makeWrapperArgs = [
     ''--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"''
+    ''--set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"''
+    ''--suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"''
   ];
   meta = {
     description = "The client of the Tryton application platform";
@@ -30,6 +53,6 @@ python2Packages.buildPythonApplication rec {
     '';
     homepage = http://www.tryton.org/;
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.johbo ];
+    maintainers = with maintainers; [ johbo udono ];
   };
 }

--- a/pkgs/applications/office/trytond/default.nix
+++ b/pkgs/applications/office/trytond/default.nix
@@ -4,11 +4,11 @@
 with stdenv.lib;
 
 python2Packages.buildPythonApplication rec {
-  name = "trytond-${version}";
-  version = "4.6.2";
-  src = fetchurl {
-    url = "mirror://pypi/t/trytond/${name}.tar.gz";
-    sha256 = "0asc3pd37h8ky8j66iqxr0fv0k6mpjcwxwm0xgm5hrdi32l5cdda";
+  pname = "trytond";
+  version = "4.8.0";
+  src = python2Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "114c0ea15b8395117bf8c669b7da8af4961001297fbd034c780a42a40e079e3a";
   };
 
   # Tells the tests which database to use
@@ -25,12 +25,15 @@ python2Packages.buildPythonApplication rec {
     relatorio
     werkzeug
     wrapt
+    ipaddress
 
     # extra dependencies
     bcrypt
     pydot
     python-Levenshtein
     simplejson
+    cdecimal
+    html2text
   ] ++ stdenv.lib.optional withPostgresql psycopg2);
   meta = {
     description = "The server of the Tryton application platform";
@@ -44,6 +47,6 @@ python2Packages.buildPythonApplication rec {
     '';
     homepage = http://www.tryton.org/;
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.johbo ];
+    maintainers = with maintainers; [ udono johbo ];
   };
 }

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -62,10 +62,6 @@ let version = "5.5.0";
       ++ optional (targetPlatform != hostPlatform) ../libstdc++-target.patch
       ++ optional noSysDirs ../no-sys-dirs.patch
       ++ optional langFortran ../gfortran-driving.patch
-
-      # This could be applied unconditionally but I don't want to cause a full
-      # Linux rebuild.
-      ++ optional stdenv.cc.isClang ./libcxx38-and-above.patch
       ++ optional stdenv.hostPlatform.isMusl (fetchpatch {
         url = https://raw.githubusercontent.com/richfelker/musl-cross-make/e84b1bd1fc12a3def33111ca6df522cd6e5ec361/patches/gcc-5.3.0/0001-musl.diff;
         sha256 = "0pppbf8myi2kjhm3z3479ihn1cm60kycfv60gj8yy1bs0pl1qcfm";

--- a/pkgs/development/coq-modules/stdpp/default.nix
+++ b/pkgs/development/coq-modules/stdpp/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchzip, coq }:
+
+stdenv.mkDerivation {
+  name = "coq${coq.coq-version}-stdpp-1.1";
+  src = fetchzip {
+    url = "https://gitlab.mpi-sws.org/robbertkrebbers/coq-stdpp/-/archive/coq-stdpp-1.1.0/coq-stdpp-coq-stdpp-1.1.0.tar.gz";
+    sha256 = "0z8zl288x9w32w06sjax01jcpy12wd5i3ygps58dl2hfy7r3lwg0";
+  };
+
+  buildInputs = [ coq ];
+
+  enableParallelBuilding = true;
+
+  installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
+
+  meta = {
+    homepage = "https://gitlab.mpi-sws.org/robbertkrebbers/coq-stdpp";
+    description = "An extended “Standard Library” for Coq";
+    inherit (coq.meta) platforms;
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: stdenv.lib.versionAtLeast v "8.6";
+  };
+
+}

--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -8,12 +8,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.2.4";
+  version = "2.3.0";
   name = "gdal-${version}";
 
   src = fetchurl {
     url = "http://download.osgeo.org/gdal/${version}/${name}.tar.xz";
-    sha256 = "0y1237m2wilxgrsd0cdjpbf1zj9z954sd8518g53hlmkmk8v27j4";
+    sha256 = "18iaamzkn0lipizynvspf3bs5qzgcy36hn6bbi941q8dlfdf8xbg";
   };
 
   buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite

--- a/pkgs/development/python-modules/Pygments/default.nix
+++ b/pkgs/development/python-modules/Pygments/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , docutils
+, pillow
 }:
 
 buildPythonPackage rec {
@@ -14,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "1k78qdvir1yb1c634nkv6rbga8wv4289xarghmsbbvzhvr311bnv";
   };
 
-  propagatedBuildInputs = [ docutils ];
+  propagatedBuildInputs = [ docutils pillow ];
 
   # Circular dependency with sphinx
   doCheck = false;

--- a/pkgs/development/python-modules/cdecimal/default.nix
+++ b/pkgs/development/python-modules/cdecimal/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, wget, buildPythonPackage, isPy3k }:
+
+with stdenv.lib;
+
+buildPythonPackage rec {
+  pname = "cdecimal";
+  version = "2.3";
+
+  disabled = isPy3k;
+
+  src = fetchurl {
+    url="http://www.bytereef.org/software/mpdecimal/releases/${pname}-${version}.tar.gz";
+    sha256 = "d737cbe43ed1f6ad9874fb86c3db1e9bbe20c0c750868fde5be3f379ade83d8b";
+  };
+
+  # Upstream tests are not included s. a. http://www.bytereef.org/mpdecimal/testing.html
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Fast drop-in replacement for decimal.py";
+    homepage    = http://www.bytereef.org/mpdecimal/;
+    license     = licenses.bsd2;
+    maintainers = [ maintainers.udono ];
+  };
+}

--- a/pkgs/development/python-modules/goocalendar/default.nix
+++ b/pkgs/development/python-modules/goocalendar/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchPypi
+, buildPythonPackage
+, pkgconfig
+, gtk3
+, gobjectIntrospection
+, pygtk
+, pygobject3
+, goocanvas2
+, isPy3k
+ }:
+
+with stdenv.lib;
+
+buildPythonPackage rec {
+  pname = "GooCalendar";
+  version = "0.3";
+
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1p7qbcv06xipg48sgpdlqf72ajl3n1qlypcc0giyi1a72zpyf823";
+  };
+  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  propagatedBuildInputs = [
+    pygtk
+    pygobject3
+  ];
+  buildInputs = [
+    gtk3
+    goocanvas2
+  ];
+
+  # No upstream tests available
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A calendar widget for GTK using PyGoocanvas.";
+    homepage    = https://goocalendar.tryton.org/;
+    license     = licenses.gpl2;
+    maintainers = [ maintainers.udono ];
+  };
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -15,6 +15,15 @@
     inputs = [ pkgs.brotli ];
   };
 
+  ipscrub = {
+    src = fetchFromGitHub {
+      owner = "masonicboom";
+      repo = "ipscrub";
+      rev = "99230f66d5afe1f929cf4ed217901acb6206f620";
+      sha256 = "0mfrwkg4srql38w713pg6qxi0h4hgy8inkvgc9cm80bwlv2ng9s1";
+    } + "/ipscrub";
+  };
+
   rtmp ={
     src = fetchFromGitHub {
       owner = "arut";

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPerlPackage, fetchurl
-, perl, perlPackages }:
+, perl, perlPackages, fetchpatch }:
 
 buildPerlPackage rec {
   name = "slimserver-${version}";
@@ -9,6 +9,11 @@ buildPerlPackage rec {
     url = "https://github.com/Logitech/slimserver/archive/${version}.tar.gz";
     sha256 = "0szp5zkmx2b5lncsijf97asjnl73fyijkbgbwkl1i7p8qnqrb4mp";
   };
+
+  patches = [ (fetchpatch {
+    url = "https://github.com/Logitech/slimserver/pull/204.patch";
+    sha256 = "0n1c8nsbvqkmwj5ivkcxh1wkqqm1lwymmfz9i47ih6ifj06hkpxk";
+  } ) ];
 
   buildInputs = [
     perl

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -3,11 +3,11 @@
 
 buildPerlPackage rec {
   name = "slimserver-${version}";
-  version = "7.9.0";
+  version = "7.9.1";
 
   src = fetchurl {
     url = "https://github.com/Logitech/slimserver/archive/${version}.tar.gz";
-    sha256 = "07rhqipg7m28x0nqdd83nyzi88dp9cf8rr2pamdyrfcwyp1h1b44";
+    sha256 = "0szp5zkmx2b5lncsijf97asjnl73fyijkbgbwkl1i7p8qnqrb4mp";
   };
 
   buildInputs = [

--- a/pkgs/tools/misc/mongodb-compass/default.nix
+++ b/pkgs/tools/misc/mongodb-compass/default.nix
@@ -1,0 +1,86 @@
+{ stdenv, fetchurl, dpkg
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
+, gnome2, libnotify, libxcb, nspr, nss, systemd, xorg }:
+
+let
+
+  version = "1.13.1";
+
+  rpath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gnome2.GConf
+    gnome2.gdk_pixbuf
+    gnome2.gtk
+    gnome2.pango
+    libnotify
+    libxcb
+    nspr
+    nss
+    stdenv.cc.cc
+    systemd
+
+    xorg.libxkbfile
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libXScrnSaver
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+  src =
+    if stdenv.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://downloads.mongodb.com/compass/mongodb-compass_${version}_amd64.deb";
+        sha256 = "0x23jshnr0rafm5sn2vhq2y2gryg8mksahzyv5fszblgaxay234p";
+      }
+    else
+      throw "MongoDB compass is not supported on ${stdenv.system}";
+
+in stdenv.mkDerivation {
+  name = "mongodb-compass-${version}";
+
+  inherit src;
+
+  buildInputs = [ dpkg ];
+  unpackPhase = "true";
+
+  buildCommand = ''
+    IFS=$'\n'
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm -rf $out/share/lintian
+    #The node_modules are bringing in non-linux files/dependencies
+    find $out -name "*.app" -exec rm -rf {} \; || true
+    find $out -name "*.dll" -delete
+    find $out -name "*.exe" -delete
+    # Otherwise it looks "suspicious"
+    chmod -R g-w $out
+    for file in `find $out -type f -perm /0111 -o -name \*.so\*`; do
+      echo "Manipulating file: $file"
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+      patchelf --set-rpath ${rpath}:$out/share/mongodb-compass "$file" || true
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The GUI for MongoDB";
+    homepage = https://www.mongodb.com/products/compass;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/tools/networking/yrd/default.nix
+++ b/pkgs/tools/networking/yrd/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+let
+  pname = "yrd";
+  version = "0.5.3";
+  sha256 = "1yx1hr8z4cvlb3yi24dwafs0nxq41k4q477jc9q24w61a0g662ps";
+
+in pythonPackages.buildPythonApplication {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "kpcyrd";
+    repo = "${pname}";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ argh ];
+
+  meta = with stdenv.lib; {
+    description = "Cjdns swiss army knife";
+    maintainers = with maintainers; [ akru ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    homepage = https://github.com/kpcyrd/yrd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1420,6 +1420,8 @@ with pkgs;
 
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
+  mongodb-compass = callPackage ../tools/misc/mongodb-compass { };
+  
   mongodb-tools = callPackage ../tools/misc/mongodb-tools { };
 
   mozlz4a = callPackage ../tools/compression/mozlz4a {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21502,4 +21502,7 @@ with pkgs;
 
   inherit (recurseIntoAttrs (callPackages ../os-specific/bsd { }))
           netbsd;
+
+  yrd = callPackage ../tools/networking/yrd { };
+
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15773,6 +15773,8 @@ with pkgs;
 
   goldendict = libsForQt5.callPackage ../applications/misc/goldendict { };
 
+  gomuks = callPackage ../applications/networking/instant-messengers/gomuks { };
+
   inherit (ocamlPackages) google-drive-ocamlfuse;
 
   google-musicmanager = callPackage ../applications/audio/google-musicmanager { };

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -36,6 +36,7 @@ let
       paco = callPackage ../development/coq-modules/paco {};
       QuickChick = callPackage ../development/coq-modules/QuickChick {};
       ssreflect = callPackage ../development/coq-modules/ssreflect { };
+      stdpp = callPackage ../development/coq-modules/stdpp { };
       tlc = callPackage ../development/coq-modules/tlc {};
     };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -223,6 +223,8 @@ in {
 
   bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};
 
+  cdecimal = callPackage ../development/python-modules/cdecimal { };
+
   dendropy = callPackage ../development/python-modules/dendropy { };
 
   dbf = callPackage ../development/python-modules/dbf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -253,6 +253,8 @@ in {
 
   globus-sdk = callPackage ../development/python-modules/globus-sdk { };
 
+  goocalendar = callPackage ../development/python-modules/goocalendar { };
+
   gssapi = callPackage ../development/python-modules/gssapi { };
 
   h5py = callPackage ../development/python-modules/h5py {


### PR DESCRIPTION
Without pillow, pygmentize fails to create a picture give a source
file with the error:

```
*** Error while highlighting:
PilNotAvailable: Python Imaging Library is required for this formatter
   (file "/nix/store/rd48ryf5yw14c0f4wa30m079lyvxjd4m-python2.7-Pygments-2.2.0/lib/python2.7/site-packages/pygments/formatters/img.py", line 336, in __init__)
*** If this is a bug you want to report, please rerun with -v.
```

The only remaining issue is that the default font may not be installed
on your system, but you can give it a different font via:

```
pygmentize -Ofont_name="Source Sans Pro" -o file.png file.yml
```

###### Motivation for this change

`pygmentize` was not able to generate pictures because of a missing library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

