### PR TITLE
openshift: add {bash,zsh}-completion

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -69,12 +69,8 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     cp -a "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$out/bin/"
-    mkdir -p "$out/etc/bash_completion.d"
-    cp -a contrib/completions/bash/oc "$out/etc/bash_completion.d"
-    cp -a contrib/completions/bash/openshift "$out/etc/bash_completion.d"
-    mkdir -p "$out/share/zsh/site-functions"
-    cp -a contrib/completions/zsh/oc "$out/share/zsh/site-functions"
-    cp -a contrib/completions/zsh/openshift "$out/share/zsh/site-functions"
+    install -D -t "$out/etc/bash_completion.d" contrib/completions/bash/*
+    install -D -t "$out/share/zsh/site-functions" contrib/completions/zsh/*
   '';
 
   preFixup = ''

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -69,6 +69,12 @@ in stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p "$out/bin"
     cp -a "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$out/bin/"
+    mkdir -p "$out/etc/bash_completion.d"
+    cp -a contrib/completions/bash/oc "$out/etc/bash_completion.d"
+    cp -a contrib/completions/bash/openshift "$out/etc/bash_completion.d"
+    mkdir -p "$out/share/zsh/site-functions"
+    cp -a contrib/completions/zsh/oc "$out/share/zsh/site-functions"
+    cp -a contrib/completions/zsh/openshift "$out/share/zsh/site-functions"
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change
Adding bash and zsh completion scripts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

