### PR TITLE
geojson: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/geojson/default.nix
+++ b/pkgs/development/python-modules/geojson/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, glibcLocales }:
+
+buildPythonPackage rec {
+  pname = "geojson";
+  version = "2.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "06ihcb8839zzgk5jcv18kc6nqld4hhj3nk4f3drzcr8n8893v1y8";
+  };
+
+  LC_ALL = "en_US.UTF-8";
+  checkInputs = [ glibcLocales ];
+
+  meta = {
+    homepage = https://github.com/frewsxcv/python-geojson;
+    description = "Python bindings and utilities for GeoJSON";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ geistesk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5981,6 +5981,8 @@ in {
 
   geopandas = callPackage ../development/python-modules/geopandas { };
 
+  geojson = callPackage ../development/python-modules/geojson { };
+
   gevent-websocket = buildPythonPackage rec {
     name = "gevent-websocket-0.9.3";
 


### PR DESCRIPTION
###### Motivation for this change
Adds the [geojson](https://github.com/frewsxcv/python-geojson) Python-module to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

