### PR TITLE
WIP: pythonPackages.ModernGL: init at 5.2.1

### DIFF
--- a/pkgs/development/python-modules/ModernGL/default.nix
+++ b/pkgs/development/python-modules/ModernGL/default.nix
@@ -1,0 +1,32 @@
+{  buildPythonPackage, python, glibcLocales, fetchPypi, sphinx }:
+
+buildPythonPackage rec {
+  pname = "ModernGL";
+  version = "4.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "290ae98a8f5d3ff7b32418d5f8c25e3800abc7985327053e15aeeb5b88a4d56d";
+  };
+
+  #LC_ALL = "en_US.utf-8";
+
+  # ipaddress is part of the standard library of Python 3.3+
+  #prePatch = lib.optionalString (!pythonOlder "3.3") ''
+  #  substituteInPlace requirements.txt \
+  #    --replace "ipaddress" ""
+  #'';
+
+  #nativeBuildInputs = [ glibcLocales ];
+  propagatedBuildInputs = [ sphinx ];
+
+  # Taken from .travis.yml
+ # checkPhase = ''
+ #   ${python.interpreter} tests/test_main.py
+ #   ${python.interpreter} -m mailparser -v
+ #   ${python.interpreter} -m mailparser -h
+ #   ${python.interpreter} -m mailparser -f tests/mails/mail_malformed_3 -j
+ #   cat tests/mails/mail_malformed_3 | ${python.interpreter} -m mailparser -k -j
+ # '';
+
+}

--- a/pkgs/development/python-modules/ModernGL/default.nix
+++ b/pkgs/development/python-modules/ModernGL/default.nix
@@ -19,6 +19,7 @@ buildPythonPackage rec {
   checkPhase = ''
     py.test
   '';
+
   meta = with stdenv.lib; {
     description = "ModernGL: High performance rendering for Python 3";
     homepage = https://github.com/cprogrammer1994/ModernGL;

--- a/pkgs/development/python-modules/ModernGL/default.nix
+++ b/pkgs/development/python-modules/ModernGL/default.nix
@@ -1,32 +1,29 @@
-{  buildPythonPackage, python, glibcLocales, fetchPypi, sphinx }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k, sphinx, libGLU_combined, libX11, pytest, pycodestyle, numpy }:
 
 buildPythonPackage rec {
   pname = "ModernGL";
-  version = "4.1.2";
+  version = "5.2.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "290ae98a8f5d3ff7b32418d5f8c25e3800abc7985327053e15aeeb5b88a4d56d";
+  src = fetchFromGitHub {
+    owner = "cprogrammer1994";
+    repo = pname;
+    rev = version;
+    sha256 = "1ap1b3isvvxbjxr741l6r3m30ki2dj2yqswb33928iawfpamqc4g";
   };
 
-  #LC_ALL = "en_US.utf-8";
+  disabled = !isPy3k;
 
-  # ipaddress is part of the standard library of Python 3.3+
-  #prePatch = lib.optionalString (!pythonOlder "3.3") ''
-  #  substituteInPlace requirements.txt \
-  #    --replace "ipaddress" ""
-  #'';
+  propagatedBuildInputs = [ sphinx libGLU_combined libX11 ];
+  checkInputs = [ pytest pycodestyle numpy ];
 
-  #nativeBuildInputs = [ glibcLocales ];
-  propagatedBuildInputs = [ sphinx ];
-
-  # Taken from .travis.yml
- # checkPhase = ''
- #   ${python.interpreter} tests/test_main.py
- #   ${python.interpreter} -m mailparser -v
- #   ${python.interpreter} -m mailparser -h
- #   ${python.interpreter} -m mailparser -f tests/mails/mail_malformed_3 -j
- #   cat tests/mails/mail_malformed_3 | ${python.interpreter} -m mailparser -k -j
- # '';
+  checkPhase = ''
+    py.test
+  '';
+  meta = with stdenv.lib; {
+    description = "ModernGL: High performance rendering for Python 3";
+    homepage = https://github.com/cprogrammer1994/ModernGL;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
 
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -277,7 +277,9 @@ in {
 
   logster = callPackage ../development/python-modules/logster { };
 
-  mail-parser = callPackage ../development/python-modules/mail-parser {  };
+  mail-parser = callPackage ../development/python-modules/mail-parser { };
+
+  ModernGL = callPackage ../development/python-modules/ModernGL { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -279,7 +279,7 @@ in {
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
-  ModernGL = callPackage ../development/python-modules/ModernGL { };
+  moderngl = callPackage ../development/python-modules/ModernGL { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;


### PR DESCRIPTION
###### Motivation for this change

ModernGL: High performance rendering for Python 3

Still have the tests failing cause of this error:  `mgl.Error: cannot detect the display`

It would be great if anyone can help me understand that issue  (tried including pyopengl in check input but no good)

The build succeed when disabling the checks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

