### PR TITLE
nixos/thinkfan: use non-deprecated keywords in config file.

### DIFF
--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -32,7 +32,6 @@ let
     # will add a fixed value of 10 °C the 3rd value read from that file. Check out
     # http://www.thinkwiki.org/wiki/Thermal_Sensors to find out how much you may
     # want to add to certain temperatures.
-    
 
     ${cfg.fan}
     ${cfg.sensors}
@@ -55,6 +54,7 @@ in {
     services.thinkfan = {
 
       enable = mkOption {
+        type = types.bool;
         default = false;
         description = ''
           Whether to enable thinkfan, fan controller for IBM/Lenovo ThinkPads.
@@ -62,6 +62,7 @@ in {
       };
 
       sensors = mkOption {
+        type = types.lines;
         default = ''
           tp_thermal /proc/acpi/ibm/thermal (0,0,10)
         '';
@@ -79,28 +80,26 @@ in {
             S.M.A.R.T. (since 0.9 and requires the USE_ATASMART compilation flag)
               Which reads the temperature directly from the hard
               disk using libatasmart (keyword atasmart)
+
           Multiple sensors may be added, in which case they will be
           numbered in their order of appearance.
         '';
       };
 
       fan = mkOption {
+        type = types.str;
         default = "tp_fan /proc/acpi/ibm/fan";
         description =''
           Specifies the fan we want to use.
           On anything other than a Thinkpad you'll probably
           use some PWM control file in /sys/class/hwmon.
-          Remember that fan levels range from 0 to 255 and that
-          they're just a number, not including the word "level"
-          as seen below.
           A sysfs fan would be specified like this:
             pwm_fan /sys/class/hwmon/hwmon2/device/pwm1
-
-          Remember you can only have one fan.
         '';
       };
 
       levels = mkOption {
+        type = types.lines;
         default = ''
           (0,     0,      55)
           (1,     48,     60)
@@ -110,13 +109,12 @@ in {
           (7,     60,     85)
           (127,   80,     32767)
         '';
-        description =''
-					Syntax:
-					(LEVEL, LOW, HIGH)
-					LEVEL is the fan level to use (0-7 with thinkpad_acpi)
-					LOW is the temperature at which to step down to the previous level
-					HIGH is the temperature at which to step up to the next level
-					All numbers are integers.
+        description = ''
+          (LEVEL, LOW, HIGH)
+          LEVEL is the fan level to use (0-7 with thinkpad_acpi).
+          LOW is the temperature at which to step down to the previous level.
+          HIGH is the temperature at which to step up to the next level.
+          All numbers are integers.
         '';
       };
 

--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -28,11 +28,15 @@ let
     # temperatures are read from the file.
     #
     # For example:
-    # sensor /proc/acpi/ibm/thermal (0, 0, 10)
+    # tp_thermal /proc/acpi/ibm/thermal (0, 0, 10)
     # will add a fixed value of 10 °C the 3rd value read from that file. Check out
     # http://www.thinkwiki.org/wiki/Thermal_Sensors to find out how much you may
     # want to add to certain temperatures.
     
+
+    ${cfg.fan}
+    ${cfg.sensors}
+
     #  Syntax:
     #  (LEVEL, LOW, HIGH)
     #  LEVEL is the fan level to use (0-7 with thinkpad_acpi)
@@ -41,8 +45,6 @@ let
     #  All numbers are integers.
     #
 
-    sensor ${cfg.sensor} (0, 10, 15, 2, 10, 5, 0, 3, 0, 3)
-    
     ${cfg.levels}
   '';
 
@@ -59,10 +61,42 @@ in {
         '';
       };
 
-      sensor = mkOption {
-        default = "/proc/acpi/ibm/thermal";
+      sensors = mkOption {
+        default = ''
+          tp_thermal /proc/acpi/ibm/thermal (0,0,10)
+        '';
         description =''
-          Sensor used by thinkfan
+          thinkfan can read temperatures from three possible sources:
+
+            /proc/acpi/ibm/thermal
+              Which is provided by the thinkpad_acpi kernel
+              module (keyword tp_thermal)
+
+            /sys/class/hwmon/*/temp*_input
+              Which may be provided by any hwmon drivers (keyword
+              hwmon)
+
+            S.M.A.R.T. (since 0.9 and requires the USE_ATASMART compilation flag)
+              Which reads the temperature directly from the hard
+              disk using libatasmart (keyword atasmart)
+          Multiple sensors may be added, in which case they will be
+          numbered in their order of appearance.
+        '';
+      };
+
+      fan = mkOption {
+        default = "tp_fan /proc/acpi/ibm/fan";
+        description =''
+          Specifies the fan we want to use.
+          On anything other than a Thinkpad you'll probably
+          use some PWM control file in /sys/class/hwmon.
+          Remember that fan levels range from 0 to 255 and that
+          they're just a number, not including the word "level"
+          as seen below.
+          A sysfs fan would be specified like this:
+            pwm_fan /sys/class/hwmon/hwmon2/device/pwm1
+
+          Remember you can only have one fan.
         '';
       };
 
@@ -77,7 +111,12 @@ in {
           (127,   80,     32767)
         '';
         description =''
-          Sensor used by thinkfan
+					Syntax:
+					(LEVEL, LOW, HIGH)
+					LEVEL is the fan level to use (0-7 with thinkpad_acpi)
+					LOW is the temperature at which to step down to the previous level
+					HIGH is the temperature at which to step up to the next level
+					All numbers are integers.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change
Currently, the thinkfan config written by nix is not being correctly read as it uses the deprecated keyword `sensor` (see <https://man.cx/thinkfan(1)>). For instance, if I add the following expression to my configuration.nix file:
```
services.thinkfan = {
  enable = true;
  sensor = "/sys/devices/virtual/hwmon/hwmon0/temp1_input";
};
```

thinkfan will print error messages in `journalctl`:
```
May 19 11:38:29 nixos thinkfan[1067]: thinkfan 0.9.1 starting...
May 19 11:38:29 nixos systemd[1]: Started Thinkfan.
May 19 11:38:29 nixos thinkfan[1067]: /nix/store/sj9nqnwyjk36g7q8mq6iyy1dhv2wmjck-thinkfan.conf:35:sensor /sys/devices/virtual/hwmon/hwmon0/temp1_input (0, 10, 15, >
May 19 11:38:29 nixos thinkfan[1067]: WARNING: The `sensor' keyword is deprecated. Please use the `hwmon' or `tp_thermal' keywords instead!
```

What's more, thinkfan may read temperatures from multiple sensors, and offers an option to specify the fan.

###### Things done
**The change is breaking**. However since the previous way of doing it does not really work in practice I think it is the way to go.

I modified the configuration options of the thinkfan service to allow multiple thermal sensors (in `services.thinkfan.sensors`) and removed the hard-coded `sensor` keyword.

To note: 
1. in the description of the keyword `sensor`, I noted that thinkfan may monitor hard drives temperatures if it had been compiled with the `USE_ATASMART` file, but I didn't enable this flag because thinkfan author's notes : "Enable libatasmart to read temperatures directly from hard disks. Use this only when you really need it, since libatasmart is unreasonably CPU-intensive."

2. I did not test these changes, I do not know how to test services.

3. Maybe it would be better to leave the defaults empty: an incorrect configuration for a given system may lead to overheating (and permanent damage). Nevertheless, I left it the way it was, I expect thinkfan users to be quite knowledgeable, and defaults may therefore serve as examples. 



- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

