### PR TITLE
slib: 3b2 -> 3b5

### DIFF
--- a/pkgs/development/libraries/slib/default.nix
+++ b/pkgs/development/libraries/slib/default.nix
@@ -1,28 +1,18 @@
 { fetchurl, stdenv, unzip, scheme, texinfo }:
 
 stdenv.mkDerivation rec {
-  name = "slib-3b2";
+  name = "slib-3b5";
 
   src = fetchurl {
     url = "http://groups.csail.mit.edu/mac/ftpdir/scm/${name}.zip";
-    sha256 = "1s6a7f3ha2bhwj4nkg34n0j511ww1nlgrn5xis8k53l8ghdrrjxi";
+    sha256 = "0q0p2d53p8qw2592yknzgy2y1p5a9k7ppjx0cfrbvk6242c4mdpq";
   };
 
   patches = [ ./catalog-in-library-vicinity.patch ];
 
   buildInputs = [ unzip scheme texinfo ];
 
-  configurePhase = ''
-    mkdir -p "$out"
-    sed -i "Makefile" \
-        -e "s|^[[:blank:]]*prefix[[:blank:]]*=.*$|prefix = $out/|g"
-  '';
-
-  buildPhase = "make infoz";
-
-  installPhase = ''
-    make install
-
+  postInstall = ''
     ln -s mklibcat{.scm,}
     SCHEME_LIBRARY_PATH="$out/lib/slib" make catalogs
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

