### PR TITLE
gauche: init at 0.9.5

### DIFF
--- a/pkgs/development/interpreters/gauche/default.nix
+++ b/pkgs/development/interpreters/gauche/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, pkgconfig, texinfo, libiconv, gdbm, openssl, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "gauche-${version}";
+  version = "0.9.5";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/gauche/Gauche-${version}.tgz";
+    sha256 = "0g77nik15whm5frxb7l0pwzd95qlq949dym5pn5p04p17lhm72jc";
+  };
+
+  nativeBuildInputs = [ pkgconfig texinfo ];
+
+  buildInputs = [ libiconv gdbm openssl zlib ];
+
+  configureFlags = [
+    "--enable-multibyte=utf-8"
+    "--with-iconv=${libiconv}"
+    "--with-dbm=gdbm"
+    "--with-zlib=${zlib}"
+    # TODO: Enable slib
+    #       Current slib in nixpkgs is specialized to Guile
+    # "--with-slib=${slibGuile}/lib/slib"
+  ];
+
+  enableParallelBuilding = true;
+
+  # TODO: Fix tests that fail in sandbox build
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "R7RS Scheme scripting engine";
+    homepage = https://practical-scheme.net/gauche/;
+    maintainers = with maintainers; [ mnacamura ];
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15748,6 +15748,8 @@ with pkgs;
 
   ganttproject-bin = callPackage ../applications/misc/ganttproject-bin { };
 
+  gauche = callPackage ../development/interpreters/gauche { };
+
   gcal = callPackage ../applications/misc/gcal { };
 
   geany = callPackage ../applications/editors/geany { };


### PR DESCRIPTION
###### Motivation for this change

I'd like to use Gauche, a Scheme implementation, in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

