### PR TITLE
s-tar: init at 1.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4126,6 +4126,11 @@
     github = "wscott";
     name = "Wayne Scott";
   };
+  wucke13 = {
+    email = "info@wucke13.de";
+    github = "wucke13";
+    name = "Wucke";
+  };
   wyvie = {
     email = "elijahrum@gmail.com";
     github = "wyvie";

--- a/pkgs/tools/archivers/s-tar/default.nix
+++ b/pkgs/tools/archivers/s-tar/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "star-${version}";
+  name = "s-tar-${version}";
   version = "1.5.3";
   src = fetchurl {
-    url = "mirror://sourceforge/s-tar/${name}.tar.bz2";
+    url = "mirror://sourceforge/s-tar/star-${version}.tar.bz2";
     sha256 = "0nsg3adv8lwqsbizicgmyxx8w26d1f4almprkcb08cd87s1l40q7";
   };
 

--- a/pkgs/tools/archivers/star/default.nix
+++ b/pkgs/tools/archivers/star/default.nix
@@ -4,31 +4,32 @@ stdenv.mkDerivation rec {
   name = "star-${version}";
   version = "1.5.3";
   src = fetchurl {
-    url = "https://sourceforge.net/projects/s-tar/files/${name}.tar.gz";
-    sha256 = "1yii6p6x38r6w12s5yrdi08aij481jcg3xf8g738nmh0hqypbfl7";
+    url = "mirror://sourceforge/s-tar/${name}.tar.bz2";
+    sha256 = "0nsg3adv8lwqsbizicgmyxx8w26d1f4almprkcb08cd87s1l40q7";
   };
 
   preConfigure = "rm configure";
   preBuild = "sed 's_/bin/__g' -i RULES/*";
-  makeFlags = [ "DESTDIR=$(out)" "INS_BASE=/ install"];
+  makeFlags = [ "GMAKE_NOWARN=true" ];
+  installFlags = [ "DESTDIR=$(out)" "INS_BASE=/" ];
   postInstall = ''
-  find $out/bin -type l -delete
-  rm -r $out/etc $out/include $out/sbin
+    find $out/bin -type l -delete
+    rm -r $out/etc $out/include $out/sbin
   '';
 
   meta = {
-    description = "Star is a very fast tar like tape archiver with  improved functionality.";
+    description = "A very fast tar like tape archiver with improved functionality";
     longDescription = ''
-Star archives and extracts multiple files to and from a single file called a tarfile.
-A tarfile is usually a magnetic tape, but it can be any file.
-In all cases, appearance of a directory name refers to the files and (recursively) sub-directories of that directory.
-Star's actions are controlled by the mandatory command flags from the list below.
-The way star acts may be modified by additional options.
-Note that unpacking tar archives may be a security risk because star may overwrite existing files.
+      Star archives and extracts multiple files to and from a single file called a tarfile.
+      A tarfile is usually a magnetic tape, but it can be any file.
+      In all cases, appearance of a directory name refers to the files and (recursively) sub-directories of that directory.
+      Star's actions are controlled by the mandatory command flags from the list below.
+      The way star acts may be modified by additional options.
+      Note that unpacking tar archives may be a security risk because star may overwrite existing files.
     '';
     homepage = http://cdrtools.sourceforge.net/private/star.html;
     license = stdenv.lib.licenses.cddl;
     maintainers = [ stdenv.lib.maintainers.wucke13 ];
-    platforms = stdenv.lib.platforms.all;
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/archivers/star/default.nix
+++ b/pkgs/tools/archivers/star/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "star-${version}";
+  version = "1.5.3";
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/s-tar/files/${name}.tar.gz";
+    sha256 = "1yii6p6x38r6w12s5yrdi08aij481jcg3xf8g738nmh0hqypbfl7";
+  };
+
+  preConfigure = "rm configure";
+  preBuild = "sed 's_/bin/__g' -i RULES/*";
+  makeFlags = [ "DESTDIR=$(out)" "INS_BASE=/ install"];
+  postInstall = ''
+  find $out/bin -type l -delete
+  rm -r $out/etc $out/include $out/sbin
+  '';
+
+  meta = {
+    description = "Star is a very fast tar like tape archiver with  improved functionality.";
+    longDescription = ''
+Star archives and extracts multiple files to and from a single file called a tarfile.
+A tarfile is usually a magnetic tape, but it can be any file.
+In all cases, appearance of a directory name refers to the files and (recursively) sub-directories of that directory.
+Star's actions are controlled by the mandatory command flags from the list below.
+The way star acts may be modified by additional options.
+Note that unpacking tar archives may be a security risk because star may overwrite existing files.
+    '';
+    homepage = http://cdrtools.sourceforge.net/private/star.html;
+    license = stdenv.lib.licenses.cddl;
+    maintainers = [ stdenv.lib.maintainers.wucke13 ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2138,7 +2138,7 @@ with pkgs;
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
-  standard-tar = callPackages ../tools/archivers/star {};
+  s-tar = callPackages ../tools/archivers/s-tar {};
 
   tealdeer = callPackage ../tools/misc/tealdeer/default.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2138,6 +2138,8 @@ with pkgs;
 
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
+  standard-tar = callPackages ../tools/archivers/star {};
+
   tealdeer = callPackage ../tools/misc/tealdeer/default.nix { };
 
   uudeview = callPackage ../tools/misc/uudeview { };


### PR DESCRIPTION
Also added myself to the maintainers list.

###### Motivation for this change
Needed the package

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

