### PR TITLE
connman: 1.35 -> 1.36

### DIFF
--- a/pkgs/tools/networking/connman/default.nix
+++ b/pkgs/tools/networking/connman/default.nix
@@ -4,10 +4,10 @@
 
 stdenv.mkDerivation rec {
   name = "connman-${version}";
-  version = "1.35";
+  version = "1.36";
   src = fetchurl {
     url = "mirror://kernel/linux/network/connman/${name}.tar.xz";
-    sha256 = "1apj5j25kj7v1bsfv3nh54aiq873nfrsjfbj85p5qm3ihfwxxmv6";
+    sha256 = "0x00dq5c2frz06md3g5y0jh5kbcj2hrfl5qjcqga8gs4ri0xp2f7";
   };
 
   buildInputs = [ openconnect polkit
@@ -15,14 +15,6 @@ stdenv.mkDerivation rec {
                   wpa_supplicant readline6 pptp ppp ];
 
   nativeBuildInputs = [ pkgconfig file gawk ];
-
-  patches = [
-    (fetchpatch {
-      name = "header-include.patch";
-      url = "https://git.kernel.org/pub/scm/network/connman/connman.git/patch/?id=bdfb3526466f8fb8f13d9259037d8f42c782ce24";
-      sha256 = "0q6ysy2xvvcmkcbw1y29x90g7g7kih7v95k1xbxdcxkras5yl8nf";
-    })
-  ];
 
   preConfigure = ''
     export WPASUPPLICANT=${wpa_supplicant}/sbin/wpa_supplicant
@@ -61,7 +53,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A daemon for managing internet connections";
-    homepage = https://connman.net/;
+    homepage = https://01.org/connman;
     maintainers = [ maintainers.matejc ];
     platforms = platforms.linux;
     license = licenses.gpl2;


### PR DESCRIPTION
ver 1.36:
	Fix issue with DNS short response on error handling.
	Fix issue with handling incoming DNS requests.
	Fix issue with handling empty timeserver list.
	Fix issue with incorrect DHCP byte order.
	Fix issue with AllowDomainnameUpdates handling.
	Fix issue with IPv4 link-local IP conflict error.
	Fix issue with handling WISPr over TLS connections.
	Fix issue with WiFi background scanning handling.
	Fix issue with WiFi disconnect+connect race condition.
	Fix issue with WiFi scanning and tethering operation.
	Fix issue with WiFi security change handling.
	Fix issue with missing signal for WPS changes.
	Fix issue with online check retry handling.
	Add support for systemd-resolved backend.
	Add support for mDNS configuration setup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

