### PR TITLE
nixos/hledger: initial web/api services

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -647,6 +647,7 @@
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/frab.nix
+  ./services/web-apps/hledger.nix
   ./services/web-apps/mattermost.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/pgpkeyserver-lite.nix

--- a/nixos/modules/services/web-apps/hledger.nix
+++ b/nixos/modules/services/web-apps/hledger.nix
@@ -1,0 +1,141 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.hledger;
+
+in
+
+{
+  options = {
+    services.hledger = {
+      web = {
+        enable = mkEnableOption "hledger-web accounting webserver";
+        listenHost = mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          description = ''
+            Address and port this hledger-web instance listens to.
+          '';
+        };
+        listenPort = mkOption {
+          type = types.str;
+          default = "5000";
+          description = ''
+            Port this hledger-web instance listens to.
+          '';
+        };
+        baseURL = mkOption {
+          type = types.str;
+          default = "http://127.0.0.1:${cfg.web.listenPort}/";
+          description = ''
+            Base URL of this hledger-web instance.
+          '';
+        };
+      };
+      api = {
+        enable = mkEnableOption "hledger-api accounting apiserver";
+        listenHost = mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          description = ''
+            Address and port this hledger-api instance listens to.
+          '';
+        };
+        listenPort = mkOption {
+          type = types.str;
+          default = "8001";
+          description = ''
+            Port this hledger-api instance listens to.
+          '';
+        };
+      };
+
+      statePath = mkOption {
+        type = types.str;
+        default = "/var/lib/hledger";
+        description = "hledger working directory";
+      };
+
+      stateFileName = mkOption {
+        type = types.str;
+        default = ".hledger.journal";
+        description = "hledger filename";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "hledger";
+        description = ''
+          User which runs the hledger-web service.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "hledger";
+        description = ''
+          Group which runs the hledger-web service.
+        '';
+      };
+
+    };
+  };
+
+  config = mkMerge [ (mkIf (cfg.web.enable || cfg.api.enable) {
+    users.extraUsers = optionalAttrs (cfg.user == "hledger") (singleton {
+      name = "hledger";
+      group = cfg.group;
+      home = cfg.statePath;
+      createHome = true;
+    });
+
+    users.extraGroups = optionalAttrs (cfg.group == "hledger") (singleton {
+      name = "hledger";
+    });
+
+  }) (mkIf cfg.web.enable {
+    systemd.services.hledger-web = {
+      description = "hledger-web accounting";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      preStart = ''
+        mkdir -p ${cfg.statePath}
+        chown -R ${cfg.user}:${cfg.group} ${cfg.statePath}
+        touch ${cfg.statePath}/${cfg.stateFileName}
+      '';
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+        ExecStart = "${pkgs.hledger-web}/bin/hledger-web --serve --base-url=${cfg.web.baseURL} --host ${cfg.web.listenHost} --port ${cfg.web.listenPort} --file ${cfg.statePath}/${cfg.stateFileName}";
+        WorkingDirectory = "${cfg.statePath}";
+        Restart = "always";
+        RestartSec = "10";
+      };
+    };
+  }) (mkIf cfg.api.enable {
+    systemd.services.hledger-api = {
+      description = "hledger-api accounting";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      preStart = ''
+        mkdir -p ${cfg.statePath}
+        chown -R ${cfg.user}:${cfg.group} ${cfg.statePath}
+        touch ${cfg.statePath}/${cfg.stateFileName}
+      '';
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+        ExecStart = "${pkgs.hledger-api}/bin/hledger-api --host ${cfg.api.listenHost} --port ${cfg.api.listenPort} --file ${cfg.statePath}/${cfg.stateFileName}";
+        WorkingDirectory = "${cfg.statePath}";
+        Restart = "always";
+        RestartSec = "10";
+      };
+    };
+  })];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16263,6 +16263,7 @@ with pkgs;
   hledger = haskell.lib.justStaticExecutables haskellPackages.hledger;
   hledger-ui = haskell.lib.justStaticExecutables haskellPackages.hledger-ui;
   hledger-web = haskell.lib.justStaticExecutables haskellPackages.hledger-web;
+  hledger-api = haskell.lib.justStaticExecutables haskellPackages.hledger-api;
 
   homebank = callPackage ../applications/office/homebank {
     gtk = gtk3;


### PR DESCRIPTION
###### Motivation for this change
adds web/api services for hledger

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

