### PR TITLE
lfe: 1.2.1 -> 1.3

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -64,8 +64,9 @@ let
                        debugInfo = true;
                      };
 
-        lfe = lfe_1_2;
+        lfe = lfe_1_3;
         lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };
+        lfe_1_3 = lib.callLFE ../interpreters/lfe/1.3.nix { inherit erlang buildRebar3 buildHex; };
 
         # We list all base hex packages for beam tooling explicitly to ensure
         # tha the tooling does not break during hex-packages.nix updates.

--- a/pkgs/development/interpreters/lfe/1.3.nix
+++ b/pkgs/development/interpreters/lfe/1.3.nix
@@ -1,0 +1,44 @@
+{ fetchpatch, mkDerivation }:
+
+let
+  _fetchpatch =
+    { rev, sha256 }:
+    fetchpatch {
+      url = "https://github.com/rvirding/lfe/commit/${rev}.patch";
+      inherit sha256;
+    };
+  fetchPatches = map _fetchpatch;
+in
+
+mkDerivation {
+  version = "1.3";
+  sha256 = "0pgwi0h0d34353m39jin8dxw4yykgfcg90k6pc4qkjyrg40hh4l6";
+  maximumOTPVersion = "20";
+
+  patches = fetchPatches [
+    {
+      rev = "b457e5d521bb35008e6049fab31b4073cc10d583";
+      sha256 = "1zrq1b3291xhb0jsirgb5s8hacq5xvz7xidsp29aqcnpazdvivdc";
+    }
+    {
+      rev = "5fe9f37741b7d53bd43109fd3435e1437f124a0d";
+      sha256 = "1anqlcbih52lc0wynf58r67w1jhn264lz49rczwgh19pqg92dvqf";
+    }
+    {
+      rev = "b8f3e06511cb6805cf3a904c1589b27f33f3958d";
+      sha256 = "1zqafc0asm9m6cq7r0brvfawv69fqggy1phif3zknjmpicf25pqf";
+    }
+    {
+      rev = "40c239a608460e55563edb68c1b6faca57518b54";
+      sha256 = "03av5115jwyammw337xzy50l6api5h0wbwwda5vzw0w10zwb2z8y";
+    }
+    {
+      rev = "5faa7106419263689bfc0bc08a7451ccb1fba718";
+      sha256 = "0ml5yh5b3rn4ympks4bpx409hkra0i79zvq80azk0kmbjd869fxp";
+    }
+    {
+      rev = "9ff978693babcfd043d741b5c6940920b8315892";
+      sha256 = "04968dmp527wbkdv7dqpaj3nsyjls93whc1b5hx73b39dvl3n3y1";
+    }
+  ];
+}

--- a/pkgs/development/interpreters/lfe/dedup-ebins.patch
+++ b/pkgs/development/interpreters/lfe/dedup-ebins.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 59f2c06..5ee8f6e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -60,7 +60,7 @@ ESRCS = $(notdir $(wildcard $(SRCDIR)/*.erl))
+ XSRCS = $(notdir $(wildcard $(SRCDIR)/*.xrl))
+ YSRCS = $(notdir $(wildcard $(SRCDIR)/*.yrl))
+ LSRCS = $(notdir $(wildcard $(LSRCDIR)/*.lfe))
+-EBINS = $(ESRCS:.erl=.beam) $(XSRCS:.xrl=.beam) $(YSRCS:.yrl=.beam)
++EBINS = $(sort $(ESRCS:.erl=.beam) $(XSRCS:.xrl=.beam) $(YSRCS:.yrl=.beam))
+ LBINS = $(LSRCS:.lfe=.beam)
+ 
+ CSRCS = $(notdir $(wildcard $(CSRCDIR)/*.c))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1447,7 +1447,7 @@ with pkgs;
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
   mongodb-compass = callPackage ../tools/misc/mongodb-compass { };
-  
+
   mongodb-tools = callPackage ../tools/misc/mongodb-tools { };
 
   mozlz4a = callPackage ../tools/compression/mozlz4a {
@@ -3168,7 +3168,7 @@ with pkgs;
   jing-trang = callPackage ../tools/text/xml/jing-trang { };
 
   jira-cli = callPackage ../development/tools/jira_cli { };
- 
+
   jl = haskellPackages.callPackage ../development/tools/jl { };
 
   jmespath = callPackage ../development/tools/jmespath { };
@@ -7087,7 +7087,7 @@ with pkgs;
     erlang erlangR18 erlangR19 erlangR20
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
     elixir elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
-    lfe lfe_1_2;
+    lfe lfe_1_2 lfe_1_3;
 
   inherit (beam.packages.erlang)
     rebar rebar3-open rebar3

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -54,7 +54,7 @@ rec {
     # `beam.packages.erlangR19.elixir`.
     inherit (packages.erlang) elixir elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
 
-    inherit (packages.erlang) lfe lfe_1_2;
+    inherit (packages.erlang) lfe lfe_1_2 lfe_1_3;
   };
 
   # Helper function to generate package set with a specific Erlang version.


### PR DESCRIPTION
###### Motivation for this change

Hack together an `lfe_1_3` derivation and make it the default `lfe`.

Notably, the following now works.

```lfe
(include-lib "lfe/include/clj.lfe")
(-> 2 (+ 2) (== 4)) ; true
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
