### PR TITLE
materia-theme: 20180321 -> 20180519

### DIFF
--- a/pkgs/misc/themes/materia-theme/default.nix
+++ b/pkgs/misc/themes/materia-theme/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "materia-theme-${version}";
-  version = "20180321";
+  version = "20180519";
 
   src = fetchFromGitHub {
     owner = "nana-4";
     repo = "materia-theme";
     rev = "v${version}";
-    sha256 = "1nj9ylg9g74smd2kdyzlamdw9cg0f3jz77vn5898drjyscw5qpp6";
+    sha256 = "0javva2a3kmwb7xss2zmbpc988gagrkjgxncy7i1jifyvbnamf70";
   };
 
   nativeBuildInputs = [ gnome3.glib libxml2 bc ];
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
       -e "s|if .*which gnome-shell.*;|if true;|" \
       -e "s|CURRENT_GS_VERSION=.*$|CURRENT_GS_VERSION=${gnome3.version}|"
     mkdir -p $out/share/themes
-    # name is used internally by the package installation script
-    name= ./install.sh --dest $out/share/themes
+    ./install.sh --dest $out/share/themes
     rm $out/share/themes/*/COPYING
   '';
 


### PR DESCRIPTION
###### Motivation for this change

- Update to version [20180519](https://github.com/nana-4/materia-theme/releases/tag/v20180519)

- Do not unset the environment variable 'name' anymore before running
install.sh. It has been renamed to '_name' in upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).