### PR TITLE
fix xf86-video-amdgpu

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1839,9 +1839,9 @@ let
       sha256 = "0z56ifw3xiq9dychv8chg1cny0hq4v3c1r9pqcybk5fp7nzw9jpq";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ fontsproto libGL libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
+    buildInputs = [ fontsproto mesa_noglu libGL libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ];
     meta.platforms = stdenv.lib.platforms.unix;
-  }) // {inherit fontsproto libGL libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
+  }) // {inherit fontsproto mesa_noglu libGL libdrm udev randrproto renderproto videoproto xextproto xf86driproto xorgserver xproto ;};
 
   xf86videoark = (mkDerivation "xf86videoark" {
     name = "xf86-video-ark-0.7.5";

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2570,9 +2570,6 @@ let
       url = mirror://xorg/individual/util/xorg-cf-files-1.0.6.tar.bz2;
       sha256 = "0kckng0zs1viz0nr84rdl6dswgip7ndn4pnh5nfwnviwpsfmmksd";
     };
-    postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
-      substituteInPlace $out/lib/X11/config/darwin.cf --replace "/usr/bin/" ""
-    '';
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ ];
     meta.platforms = stdenv.lib.platforms.unix;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -35,6 +35,7 @@ $pcMap{"dbus-1"} = "dbus";
 $pcMap{"uuid"} = "libuuid";
 $pcMap{"libudev"} = "udev";
 $pcMap{"gl"} = "libGL";
+$pcMap{"gbm"} = "mesa_noglu";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "renderproto";
 $pcMap{"\$DRI3PROTO"} = "dri3proto";

--- a/pkgs/servers/x11/xorg/old.list
+++ b/pkgs/servers/x11/xorg/old.list
@@ -3,7 +3,7 @@ mirror://xorg/individual/app/xclock-1.0.7.tar.bz2
 mirror://xorg/individual/app/xdm-1.1.11.tar.bz2
 mirror://xorg/individual/app/xeyes-1.1.1.tar.bz2
 mirror://xorg/individual/app/xfs-1.1.4.tar.bz2
-mirror://xorg/individual/app/xinit-1.3.4.tar.bz2
+mirror://xorg/individual/app/xinit-1.4.0.tar.bz2
 mirror://xorg/individual/app/xmessage-1.0.4.tar.bz2
 mirror://xorg/individual/lib/libXp-1.0.3.tar.bz2
 mirror://xorg/individual/lib/libXxf86misc-1.0.3.tar.bz2

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -650,6 +650,12 @@ in
     ];
   };
 
+  xorgcffiles = attrs: attrs // {
+    postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace $out/lib/X11/config/darwin.cf --replace "/usr/bin/" ""
+    '';
+  };
+
   xwd = attrs: attrs // {
     buildInputs = with xorg; attrs.buildInputs ++ [libXt libxkbfile];
   };

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -68,7 +68,7 @@ mirror://xorg/individual/lib/libXcursor-1.1.15.tar.bz2
 mirror://xorg/individual/lib/libXdamage-1.1.4.tar.bz2
 mirror://xorg/individual/lib/libXdmcp-1.1.2.tar.bz2
 mirror://xorg/individual/lib/libXext-1.3.3.tar.bz2
-mirror://xorg/individual/lib/libXfixes-5.0.2.tar.bz2
+mirror://xorg/individual/lib/libXfixes-5.0.3.tar.bz2
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.3.tar.bz2
 mirror://xorg/individual/lib/libXft-2.3.2.tar.bz2
@@ -101,7 +101,7 @@ mirror://xorg/individual/app/sessreg-1.1.1.tar.bz2
 mirror://xorg/individual/app/setxkbmap-1.3.1.tar.bz2
 mirror://xorg/individual/app/smproxy-1.0.6.tar.bz2
 mirror://xorg/individual/app/twm-1.0.9.tar.bz2
-mirror://xorg/individual/util/util-macros-1.19.1.tar.bz2
+mirror://xorg/individual/util/util-macros-1.19.2.tar.bz2
 mirror://xorg/individual/proto/videoproto-2.3.3.tar.bz2
 mirror://xorg/X11R7.7/src/everything/windowswmproto-1.0.4.tar.bz2
 mirror://xorg/individual/app/x11perf-1.6.0.tar.bz2
@@ -131,7 +131,7 @@ mirror://xorg/individual/driver/xf86-input-void-1.4.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-amdgpu-1.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ark-0.7.5.tar.bz2
 mirror://xorg/individual/driver/xf86-video-ast-1.1.5.tar.bz2
-mirror://xorg/individual/driver/xf86-video-ati-7.9.0.tar.bz2
+mirror://xorg/individual/driver/xf86-video-ati-18.0.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-nouveau-1.0.15.tar.bz2
 mirror://xorg/individual/driver/xf86-video-chips-1.2.7.tar.bz2
 mirror://xorg/individual/driver/xf86-video-cirrus-1.5.3.tar.bz2
@@ -164,7 +164,7 @@ mirror://xorg/individual/driver/xf86-video-tdfx-1.4.7.tar.bz2
 mirror://xorg/individual/driver/xf86-video-tga-1.2.2.tar.bz2
 mirror://xorg/individual/driver/xf86-video-trident-1.3.8.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-video-v4l-0.2.0.tar.bz2
-mirror://xorg/individual/driver/xf86-video-vesa-2.3.4.tar.bz2
+mirror://xorg/individual/driver/xf86-video-vesa-2.4.0.tar.bz2
 mirror://xorg/individual/driver/xf86-video-vmware-13.2.1.tar.bz2
 mirror://xorg/individual/driver/xf86-video-voodoo-1.2.5.tar.bz2
 mirror://xorg/X11R7.7/src/everything/xf86-video-wsfb-0.4.0.tar.bz2


### PR DESCRIPTION
###### Motivation for this change

The amdgpu driver has been failing to build for a while due to missing gbm, which is provided by `mesa_noglu`.  I was unable to (easily) bisect where it was broken (probably in the great libGL migration?) due to xorgserver being broken for big chunks of recent history.

I also fixed the problems I found with the xorg expression generator, so it can be run again without generating diffs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

