### PR TITLE
x2goclient: 4.1.0.0 -> 4.1.1.1

### DIFF
--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "x2goclient-${version}";
-  version = "4.1.0.0";
+  version = "4.1.1.1";
 
   src = fetchurl {
     url = "http://code.x2go.org/releases/source/x2goclient/${name}.tar.gz";
-    sha256 = "0sibrj4qppww7mirdixrqrknkyq3g97s64186h88j8k66sy1anab";
+    sha256 = "0jzlwn0v8b123h5l7hrhs35x2z6mb98zg1s0shqb4yfp2g641yp3";
   };
 
   buildInputs = [ cups libssh libXpm nxproxy openldap openssh qt4 ];
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
      substituteInPlace Makefile \
+       --replace "SHELL=/bin/bash" "SHELL=$SHELL" \
        --replace "lrelease-qt4" "${qt4}/bin/lrelease" \
        --replace "qmake-qt4" "${qt4}/bin/qmake" \
        --replace "-o root -g root" ""


### PR DESCRIPTION
###### Motivation for this change
upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

