### PR TITLE
mattermost-desktop: init at 4.1.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mattermost-desktop/default.nix
@@ -1,0 +1,81 @@
+{ stdenv, lib, fetchurl, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
+fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
+libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
+nspr, alsaLib, cups, expat, udev }:
+let
+  rpath = lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gnome2.gtk
+    gnome2.pango
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    nspr
+    nss
+    stdenv.cc.cc
+    udev
+    xorg.libxcb
+  ];
+
+in
+  stdenv.mkDerivation rec {
+    name = "mattermost-desktop-${version}";
+    version = "4.1.1";
+
+    src =
+      if stdenv.system == "x86_64-linux" then
+        fetchurl {
+          url = "https://releases.mattermost.com/desktop/${version}/${name}-linux-x64.tar.gz";
+          sha256 = "0kq89xylfv2rfmd4wj08d02gjzywlq1p8xmk313i58334xm7srja";
+        }
+      else if stdenv.system == "i686-linux" then
+        fetchurl {
+          url = "https://releases.mattermost.com/desktop/${version}/${name}-linux-ia32.tar.gz";
+          sha256 = "1jiknxpb44bhxrl0xa57kf3wxlzifbpnn3vblp8l4pr2wx146pzx";
+        }
+      else
+        throw "Mattermost-Desktop is not currently supported on ${stdenv.system}";
+
+    phases = [ "unpackPhase" "installPhase" ];
+    installPhase = ''
+      mkdir -p $out
+      cp -R . $out
+
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+               --set-rpath ${rpath}:$out $out/mattermost-desktop
+
+      patchShebangs $out/create_desktop_file.sh
+      $out/create_desktop_file.sh
+
+      mkdir -p $out/{bin,share/applications}
+      cp Mattermost.desktop $out/share/applications/Mattermost.desktop
+      ln -s $out/mattermost-desktop $out/bin/mattermost-desktop
+    '';
+
+    meta = {
+      description = "Mattermost Desktop client";
+      homepage    = https://about.mattermost.com/;
+      license     = lib.licenses.asl20;
+      platforms   = [
+        "x86_64-linux" "i686-linux"
+      ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12574,6 +12574,8 @@ with pkgs;
   matterircd = callPackage ../servers/mattermost/matterircd.nix { };
   matterbridge = callPackage ../servers/matterbridge { };
 
+  mattermost-desktop = callPackage ../applications/networking/instant-messengers/mattermost-desktop { };
+
   mediatomb = callPackage ../servers/mediatomb { };
 
   memcached = callPackage ../servers/memcached {};


### PR DESCRIPTION
###### Motivation for this change
Electron-based desktop client for mattermost. The derivation is based on and therefore very similar to signal-desktop.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

