### PR TITLE
purple-lurch: init at 0.6.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1236,6 +1236,11 @@
     github = "ElvishJerricco";
     name = "Will Fancher";
   };
+  emmanuelrosa = {
+      email = "emmanuel_rosa@aol.com";
+      github = "emmanuelrosa";
+      name = "Emmanuel Rosa";
+  };
   endgame = {
     email = "jack@jackkelly.name";
     github = "endgame";

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-lurch/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-lurch/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, pidgin, minixml, libxml2, sqlite, libgcrypt }:
+
+stdenv.mkDerivation rec {
+  name = "purple-lurch-${version}";
+  version = "0.6.7";
+
+  src = fetchFromGitHub {
+    owner = "gkdr";
+    repo = "lurch";
+    rev = "v${version}";
+    sha256 = "029jjqinsfhpv0zgji3sv1cyk54fn9qp176fwy97d1clf0vflxrz";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ pidgin minixml libxml2 sqlite libgcrypt ];
+
+  dontUseCmakeConfigure = true;
+
+  installPhase = ''
+    install -Dm755 -t $out/lib/purple-2 build/lurch.so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gkdr/lurch;
+    description = "XEP-0384: OMEMO Encryption for libpurple";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ emmanuelrosa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1451,7 +1451,7 @@ with pkgs;
   mcrypt = callPackage ../tools/misc/mcrypt { };
 
   mongodb-compass = callPackage ../tools/misc/mongodb-compass { };
-  
+
   mongodb-tools = callPackage ../tools/misc/mongodb-tools { };
 
   mozlz4a = callPackage ../tools/compression/mozlz4a {
@@ -1467,7 +1467,7 @@ with pkgs;
   };
 
   antibody = callPackage ../shells/zsh/antibody { };
-  
+
   antigen = callPackage ../shells/zsh/antigen { };
 
   apparix = callPackage ../tools/misc/apparix { };
@@ -17445,6 +17445,8 @@ with pkgs;
   purple-discord = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-discord { };
 
   purple-hangouts = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-hangouts { };
+
+  purple-lurch = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-lurch { };
 
   purple-matrix = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-matrix { };
 


### PR DESCRIPTION
###### Motivation for this change

This change adds the pidgin/libpurple plugin lurch, which provides an implementation for XEP-0384: OMEMO Encryption. As long as the XMPP server of both parties supports OMEMO, this plugin allows for encrypted messaging. See https://github.com/gkdr/lurch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~ Technically should build on macOS, but I have no way of confirming.
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [X] Tested execution of plugin using `pidgin`
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

![omemo-1](https://user-images.githubusercontent.com/13485450/40273287-84f19366-5b8b-11e8-93b2-c7e4a494a8f0.png)
![ememo-2](https://user-images.githubusercontent.com/13485450/40273286-84dbdc24-5b8b-11e8-83f4-67f32c429955.png)



---

