### PR TITLE
tmon: fix missing libgcc_s.so required by pthreads

### DIFF
--- a/pkgs/os-specific/linux/tmon/default.nix
+++ b/pkgs/os-specific/linux/tmon/default.nix
@@ -12,6 +12,7 @@ stdenv.mkDerivation {
   '';
 
   makeFlags = kernel.makeFlags ++ [ "INSTALL_ROOT=\"$(out)\"" "BINDIR=bin" ];
+  NIX_CFLAGS_LINK = "-lgcc_s";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Tmon crashes on exit when cross-compiled, with this error:
```
libgcc_s.so.1 must be installed for pthread_cancel to work
```

This is caused by what appears to be a bug with where `libgcc_s.so` is placed, see: #40797

###### Things done

This PR fixes this issue by manually linking to `libgcc_s` as is done in a number of other packages.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

