### PR TITLE
gitAndTools.git-dit: Fix darwin build

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -67,7 +67,9 @@ rec {
 
   git-crypt = callPackage ./git-crypt { };
 
-  git-dit = callPackage ./git-dit { };
+  git-dit = callPackage ./git-dit {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
+  };
 
   git-extras = callPackage ./git-extras { };
 

--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -8,6 +8,10 @@
 , perl
 , pkgconfig
 , rustPlatform
+, curl
+, libiconv
+, CoreFoundation
+, Security
 }:
 
 with rustPlatform;
@@ -35,6 +39,11 @@ buildRustPackage rec {
     openssl
     libssh
     zlib
+  ] ++ stdenv.lib.optionals (stdenv.isDarwin) [
+    curl
+    libiconv
+    CoreFoundation
+    Security
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
This fixes the git-dit build on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

