### PR TITLE
swift-im: init at 4.0.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/swift-im/default.nix
+++ b/pkgs/applications/networking/instant-messengers/swift-im/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, pkgconfig, qttools, scons
+, GConf, avahi, boost, hunspell, libXScrnSaver, libedit, libidn, libnatpmp, libxml2
+, lua, miniupnpc, openssl, qtbase, qtmultimedia, qtsvg, qtwebkit, qtx11extras, zlib
+}:
+
+let
+  _scons = "scons -j$NIX_BUILD_CORES";
+in stdenv.mkDerivation rec {
+  name = "swift-im-${version}";
+  version = "4.0.2";
+
+  src = fetchurl {
+    url = "https://swift.im/downloads/releases/swift-${version}/swift-${version}.tar.gz";
+    sha256 = "0w0aiszjd58ynxpacwcgf052zpmbpcym4dhci64vbfgch6wryz0w";
+  };
+
+  patches = [ ./scons.patch ];
+
+  nativeBuildInputs = [ pkgconfig qttools scons ];
+
+  buildInputs = [
+    GConf avahi boost hunspell libXScrnSaver libedit libidn libnatpmp libxml2
+    lua miniupnpc openssl qtbase qtmultimedia qtsvg qtwebkit qtx11extras zlib
+  ];
+
+  propagatedUserEnvPkgs = [ GConf ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${libxml2.dev}/include/libxml2"
+    "-I${miniupnpc}/include/miniupnpc"
+  ];
+
+  buildPhase = ''
+    ${_scons} Swift
+  '';
+
+  installPhase = ''
+    ${_scons} SWIFT_INSTALLDIR=$out $out
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://swift.im/;
+    description = "Qt XMPP client";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/instant-messengers/swift-im/scons.patch
+++ b/pkgs/applications/networking/instant-messengers/swift-im/scons.patch
@@ -1,0 +1,53 @@
+diff --git a/BuildTools/SCons/SConscript.boot b/BuildTools/SCons/SConscript.boot
+index 40f242513..53e1ff26a 100644
+--- a/BuildTools/SCons/SConscript.boot
++++ b/BuildTools/SCons/SConscript.boot
+@@ -508,6 +508,7 @@ if env.get("distcc", False) :
+         if var.startswith("DISTCC_") :
+             env["ENV"][var] = os.environ[var]
+ 
++env["ENV"] = os.environ
+ conf_env = env.Clone()
+ 
+ Export("env")
+diff --git a/BuildTools/SCons/SConstruct b/BuildTools/SCons/SConstruct
+index 70bffbcfe..fef281899 100644
+--- a/BuildTools/SCons/SConstruct
++++ b/BuildTools/SCons/SConstruct
+@@ -272,7 +272,7 @@ if env.get("try_gconf", True) and env["PLATFORM"] != "win32" and env["PLATFORM"]
+     gconf_env = conf_env.Clone()
+     conf = Configure(gconf_env, custom_tests = {"CheckPKG": CheckPKG})
+     if conf.CheckPKG("gconf-2.0") :
+-        gconf_bare_env = Environment()
++        gconf_bare_env = Environment(ENV = os.environ)
+         gconf_bare_env.ParseConfig('pkg-config --cflags gconf-2.0 gobject-2.0 --libs gconf-2.0 gobject-2.0')
+         if os.path.basename(env["CXX"]).startswith(("g++", "clang++")) :
+             gconf_bare_env["CCFLAGS"] = [("-isystem" + ccflag) for ccflag in gconf_bare_env["CPPPATH"]]
+@@ -634,9 +634,9 @@ hunspell_env.MergeFlags(hunspell_flags)
+ env["HAVE_HUNSPELL"] = 0;
+ if env.get("hunspell_enable", False) :
+     hunspell_conf = Configure(hunspell_env)
+-    if hunspell_conf.CheckCXXHeader("hunspell/hunspell.hxx") and hunspell_conf.CheckLib("hunspell") :
++    if hunspell_conf.CheckCXXHeader("hunspell/hunspell.hxx") and hunspell_conf.CheckLib("hunspell-1.6") :
+         env["HAVE_HUNSPELL"] = 1
+-        hunspell_flags["LIBS"] = ["hunspell"]
++        hunspell_flags["LIBS"] = ["hunspell-1.6"]
+         env["HUNSPELL_FLAGS"] = hunspell_flags
+     hunspell_conf.Finish()
+ 
+diff --git a/BuildTools/SCons/Tools/textfile.py b/BuildTools/SCons/Tools/textfile.py
+index 89f8963dc..b8559f7a6 100644
+--- a/BuildTools/SCons/Tools/textfile.py
++++ b/BuildTools/SCons/Tools/textfile.py
+@@ -113,7 +113,10 @@ def _action(target, source, env):
+     lsep = None
+     for s in source:
+         if lsep: fd.write(lsep)
+-        fd.write(_do_subst(s, subs))
++        b = _do_subst(s, subs)
++        if isinstance(b, unicode):
++            b = b.encode('UTF-8')
++        fd.write(b)
+         lsep = linesep
+     fd.close()
+ 

--- a/pkgs/development/libraries/libnatpmp/default.nix
+++ b/pkgs/development/libraries/libnatpmp/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libnatpmp-${version}";
+  version = "20150609";
+
+  src = fetchurl {
+    name = "${name}.tar.gz";
+    url = "http://miniupnp.free.fr/files/download.php?file=${name}.tar.gz";
+    sha256 = "1c1n8n7mp0amsd6vkz32n8zj3vnsckv308bb7na0dg0r8969rap1";
+  };
+
+  makeFlags = [ "INSTALLPREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = http://miniupnp.free.fr/libnatpmp.html;
+    description = "NAT-PMP client";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18072,6 +18072,10 @@ with pkgs;
 
   swh_lv2 = callPackage ../applications/audio/swh-lv2 { };
 
+  swift-im = libsForQt5.callPackage ../applications/networking/instant-messengers/swift-im {
+    inherit (gnome2) GConf;
+  };
+
   sylpheed = callPackage ../applications/networking/mailreaders/sylpheed { };
 
   symlinks = callPackage ../tools/system/symlinks { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10119,6 +10119,8 @@ with pkgs;
     mysql = mysql57;
   };
 
+  libnatpmp = callPackage ../development/libraries/libnatpmp { };
+
   libnatspec = callPackage ../development/libraries/libnatspec { };
 
   libndp = callPackage ../development/libraries/libndp { };


### PR DESCRIPTION
###### Motivation for this change

The software is actually called Swift; I am following the example of [AUR](https://aur.archlinux.org/packages/swift-im/) by using the attribute `swift-im` to disambiguate with other Swifts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
