### PR TITLE
Nixos/boot: fixing yubikey dynamic linking

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -495,6 +495,9 @@ in
         EOF
         chmod +x $out/bin/openssl-wrap
       ''}
+      find $out/bin $out/lib -type f | while read BIN; do
+        copy_libs $BIN
+      done
     '';
 
     boot.initrd.extraUtilsCommandsTest = ''


### PR DESCRIPTION
###### Motivation for this change

After changes in the `yubikey-personalization` package, a dynamically-linked library could not be found. This PR fixes this.

The bug is relatively serious: it is luckily caught by tests at updates (causing all NixOS updates in the last n months to fail silently for an unknown n), but any mistake there could potentially make encrypted partitions undecipherable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

