### PR TITLE
0ad: 0.0.22 -> 0.0.23

### DIFF
--- a/pkgs/games/0ad/data.nix
+++ b/pkgs/games/0ad/data.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, zeroad-unwrapped }:
 
 stdenv.mkDerivation rec {
   name = "0ad-data-${version}";
-  version = "0.0.22";
+  inherit (zeroad-unwrapped) version;
 
   src = fetchurl {
     url = "http://releases.wildfiregames.com/0ad-${version}-alpha-unix-data.tar.xz";
-    sha256 = "0vknk9ay9h2p34r7mym2g066f3s3c5d5vmap0ckcs5b86h5cscjc";
+    sha256 = "1b6qcvd8yyyxavgdwpcs7asmln3xgnvjkglz6ggvwb956x37ggzx";
   };
 
   installPhase = ''

--- a/pkgs/games/0ad/default.nix
+++ b/pkgs/games/0ad/default.nix
@@ -1,10 +1,10 @@
-{ newScope }:
+{ wxGTK, newScope }:
 
 let
   callPackage = newScope self;
 
   self = {
-    zeroad-unwrapped = callPackage ./game.nix { };
+    zeroad-unwrapped = callPackage ./game.nix { inherit wxGTK; };
 
     zeroad-data = callPackage ./data.nix { };
 

--- a/pkgs/games/0ad/game.nix
+++ b/pkgs/games/0ad/game.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, callPackage, perl, fetchurl, python2
-, pkgconfig, spidermonkey_38, boost, icu, libxml2, libpng
+, pkgconfig, spidermonkey_38, boost, icu, libxml2, libpng, libsodium
 , libjpeg, zlib, curl, libogg, libvorbis, enet, miniupnpc
-, openal, libGLU_combined, xproto, libX11, libXcursor, nspr, SDL, SDL2
+, openal, libGLU_combined, xproto, libX11, libXcursor, nspr, SDL2
 , gloox, nvidia-texture-tools
 , withEditor ? true, wxGTK ? null
 }:
@@ -10,11 +10,11 @@ assert withEditor -> wxGTK != null;
 
 stdenv.mkDerivation rec {
   name = "0ad-${version}";
-  version = "0.0.22";
+  version = "0.0.23";
 
   src = fetchurl {
     url = "http://releases.wildfiregames.com/0ad-${version}-alpha-unix-build.tar.xz";
-    sha256 = "1cgmr4g5g9wv36v7ylbrvqhsjwgcsdgbqwc8zlqmnayk9zgkdpgx";
+    sha256 = "0qz1sg4n5y766qwgi63drrrx6k17kk0rcnn9a4a9crllk2vf78fg";
   };
 
   nativeBuildInputs = [ python2 perl pkgconfig ];
@@ -23,14 +23,13 @@ stdenv.mkDerivation rec {
     spidermonkey_38 boost icu libxml2 libpng libjpeg
     zlib curl libogg libvorbis enet miniupnpc openal
     libGLU_combined xproto libX11 libXcursor nspr SDL2 gloox
-    nvidia-texture-tools
+    nvidia-texture-tools libsodium
   ] ++ lib.optional withEditor wxGTK;
 
   NIX_CFLAGS_COMPILE = [
     "-I${xproto}/include/X11"
     "-I${libX11.dev}/include/X11"
     "-I${libXcursor.dev}/include/X11"
-    "-I${SDL.dev}/include/SDL"
     "-I${SDL2}/include/SDL2"
   ];
 
@@ -77,16 +76,14 @@ stdenv.mkDerivation rec {
     ''}
 
     # Copy l10n data.
-    mkdir -p "$out"/share/0ad/data
-    cp -r binaries/data/l10n "$out"/share/0ad/data
+    install -Dm755 -t $out/share/0ad/data/l10n binaries/data/l10n/*
 
     # Copy libraries.
-    mkdir -p "$out"/lib/0ad
-    cp binaries/system/*.so "$out"/lib/0ad/
+    install -Dm644 -t $out/lib/0ad        binaries/system/*.so
 
     # Copy icon.
-    install -D build/resources/0ad.png "$out"/share/icons/hicolor/128x128/0ad.png
-    install -D build/resources/0ad.desktop "$out"/share/applications/0ad.desktop
+    install -D build/resources/0ad.png     $out/share/icons/hicolor/128x128/0ad.png
+    install -D build/resources/0ad.desktop $out/share/applications/0ad.desktop
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19711,7 +19711,9 @@ with pkgs;
 
   keen4 = callPackage ../games/keen4 { };
 
-  zeroadPackages = callPackage ../games/0ad { };
+  zeroadPackages = callPackage ../games/0ad {
+    wxGTK = wxGTK30;
+  };
 
   zeroad = zeroadPackages.zeroad;
 


### PR DESCRIPTION
###### Motivation for this change

1. General update
2. Get rid of old SDL1 dependency which is no longer needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

