### PR TITLE
adding new package: pyre-check (untested)

### DIFF
--- a/pkgs/development/tools/pyre-check/default.nix
+++ b/pkgs/development/tools/pyre-check/default.nix
@@ -1,0 +1,37 @@
+{stdenv, lib, fetchFromGitHub, ocaml, makeWrapper}:
+
+stdenv.mkDerivation (rec {
+
+  name = "pyre-check";
+  version = "0.0.6";
+
+  src = fetchFromGitHub {
+    inherit repo;
+    owner = "facebook";
+    rev = "${version}";
+    sha256 = "0q7f5iin7ilkhs2zgkk527ryw9x1r6pnzgy1lc4d3j3vg6ifhcgc";
+  };
+
+  buildInputs = [ ocaml makeWrapper ];
+
+  buildPhase = ''
+    ./scripts/setup.sh --local
+    make
+  '';
+
+  checkPhase = ''
+    make test
+    make python_tests
+  '';
+  
+  # installPhase = ''
+  # '';
+
+  meta = {
+    homepage = https://pyre-check.org/;
+    description = "A performant type-checker for Python 3";
+    license = stdenv.lib.licenses.mit;
+    platforms = with stdenv.lib.platforms; unix;
+  };
+
+})


### PR DESCRIPTION
###### Motivation for this change

Adding pyre-check; a static analysis package for python 3.5+.

###### Things done

I haven't tested so far due to #40782 blocking me from testing my local nixpkgs repo.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

