### PR TITLE
helmfile: init at 0.16.0

### DIFF
--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub, ... }:
+
+let version = "0.16.0"; in
+
+buildGoPackage {
+  name = "helmfile-${version}";
+
+  src = fetchFromGitHub {
+    owner = "roboll";
+    repo = "helmfile";
+    rev = "v${version}";
+    sha256 = "12gxlan89h0r83aaacshh58nd1pi26gx5gkna0ksll9wsfvraj4d";
+  };
+
+  goPackagePath = "github.com/roboll/helmfile";
+
+  meta = {
+    description = "Deploy Kubernetes Helm charts";
+    homepage = https://github.com/roboll/helmfile;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pneumaticat ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20797,6 +20797,8 @@ with pkgs;
 
   helm = callPackage ../applications/audio/helm { };
 
+  helmfile = callPackage ../applications/networking/cluster/helmfile { };
+
   heptio-ark = callPackage ../applications/networking/cluster/heptio-ark { };
 
   hplip = callPackage ../misc/drivers/hplip { };


### PR DESCRIPTION
###### Motivation for this change

Adds https://github.com/roboll/helmfile, a useful tool for managing Helm charts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

