### PR TITLE
yarn: use nodejs 8.x

### DIFF
--- a/pkgs/development/tools/yarn/default.nix
+++ b/pkgs/development/tools/yarn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, nodejs, fetchzip, makeWrapper }:
+{ stdenv, nodejs-8_x, fetchzip, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "yarn-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0bblp1jy4s9y5rpcqn40w61qwsmxr342xkcn7ykk88i7sng2cgfw";
   };
 
-  buildInputs = [makeWrapper nodejs];
+  buildInputs = [makeWrapper nodejs-8_x];
 
   installPhase = ''
     mkdir -p $out/{bin,libexec/yarn/}


### PR DESCRIPTION
###### Motivation for this change

Some npm packages no longer install correctly when using the Node.js 6.x that is currently used, such as [openpgp](https://www.npmjs.com/package/openpgp):

```
[nix-shell:~]$ yarn
yarn install v1.6.0
[1/4] Resolving packages...
[2/4] Fetching packages...
error openpgp@3.0.7: The engine "node" is incompatible with this module. Expected version ">= 8.0.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Node.js 6.x is also a [maintenance LTS now](https://github.com/nodejs/Release#release-schedule), whereas 8.x is an Active LTS until April 2019.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

