### PR TITLE
electrum and electron-cash: add support for btchip library

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -34,6 +34,7 @@ python3Packages.buildPythonApplication rec {
     # plugins
     keepkey
     trezor
+    btchip
   ];
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -41,10 +41,10 @@ python3Packages.buildPythonApplication rec {
     # plugins
     keepkey
     trezor
+    btchip
 
     # TODO plugins
     # amodem
-    # btchip
   ];
 
   preBuild = ''

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "btchip-python";
-  version = "0.1.21";
+  version = "0.1.27";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16g9l3rpxpvvkdx08mgy0ligvsfcpzdrh4hplj104cpprrbsqd6v";
+    sha256 = "0aq3wg63w49rl3wrby67284ccdr504cam2w5yhdr1n5jpcd992p5";
   };
 
   propagatedBuildInputs = [ hidapi pyscard ecdsa ];

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -12,6 +12,9 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ hidapi pyscard ecdsa ];
 
+  # tests requires hardware
+  doCheck = false;
+
   meta = with stdenv.lib; {
     description = "Python communication library for Ledger Hardware Wallet products";
     homepage = "https://github.com/LedgerHQ/btchip-python";

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "btchip-python";
-  version = "0.1.27";
+  version = "0.1.28";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0aq3wg63w49rl3wrby67284ccdr504cam2w5yhdr1n5jpcd992p5";
+    sha256 = "10yxwlsr99gby338rsnczkfigcy36fiajpkr6f44438qlvbx02fs";
   };
 
   propagatedBuildInputs = [ hidapi pyscard ecdsa ];

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -15,6 +15,6 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python communication library for Ledger Hardware Wallet products";
     homepage = "https://github.com/LedgerHQ/btchip-python";
-    license = licenses.apache2;
+    license = licenses.asl20;
   };
 }

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "16g9l3rpxpvvkdx08mgy0ligvsfcpzdrh4hplj104cpprrbsqd6v";
   };
 
-  buildInputs = [ hidapi pyscard ecdsa ];
+  propagatedBuildInputs = [ hidapi pyscard ecdsa ];
 
   meta = with stdenv.lib; {
     description = "Python communication library for Ledger Hardware Wallet products";

--- a/pkgs/development/python-modules/btchip/default.nix
+++ b/pkgs/development/python-modules/btchip/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, hidapi, pyscard, ecdsa }:
+
+buildPythonPackage rec {
+  pname = "btchip-python";
+  version = "0.1.21";
+  name = "${pname}-${version}";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "16g9l3rpxpvvkdx08mgy0ligvsfcpzdrh4hplj104cpprrbsqd6v";
+  };
+
+  buildInputs = [ hidapi pyscard ecdsa ];
+
+  meta = with stdenv.lib; {
+    description = "Python communication library for Ledger Hardware Wallet products";
+    homepage = "https://github.com/LedgerHQ/btchip-python";
+    license = licenses.apache2;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -250,6 +250,8 @@ in {
 
   dependency-injector = callPackage ../development/python-modules/dependency-injector { };
 
+  btchip = callPackage ../development/python-modules/btchip { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };


### PR DESCRIPTION
###### Motivation for this change

Adding support for Ledger Nano S hardware wallet in electrum by adding a dependency on `btchip`.

Close #30347 (kudo for @k0001)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

