### PR TITLE
Unify some shell init logic with Nix's nix-profile.sh.in

### DIFF
--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -23,39 +23,39 @@ in
     environment.shellInit =
       ''
         # Set up the per-user profile.
-        mkdir -m 0755 -p $NIX_USER_PROFILE_DIR
-        if test "$(stat --printf '%u' $NIX_USER_PROFILE_DIR)" != "$(id -u)"; then
+        mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
+        if test "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)"; then
             echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
         fi
 
-        if test -w $HOME; then
-          if ! test -L $HOME/.nix-profile; then
+        if test -w "$HOME"; then
+          if ! test -L "$HOME/.nix-profile"; then
               if test "$USER" != root; then
-                  ln -s $NIX_USER_PROFILE_DIR/profile $HOME/.nix-profile
+                  ln -s "$NIX_USER_PROFILE_DIR/profile" "$HOME/.nix-profile"
               else
                   # Root installs in the system-wide profile by default.
-                  ln -s /nix/var/nix/profiles/default $HOME/.nix-profile
+                  ln -s /nix/var/nix/profiles/default "$HOME/.nix-profile"
               fi
           fi
 
           # Subscribe the root user to the NixOS channel by default.
-          if [ "$USER" = root -a ! -e $HOME/.nix-channels ]; then
-              echo "${config.system.nixos.defaultChannel} nixos" > $HOME/.nix-channels
+          if [ "$USER" = root -a ! -e "$HOME/.nix-channels" ]; then
+              echo "${config.system.nixos.defaultChannel} nixos" > "$HOME/.nix-channels"
           fi
 
           # Create the per-user garbage collector roots directory.
-          NIX_USER_GCROOTS_DIR=/nix/var/nix/gcroots/per-user/$USER
-          mkdir -m 0755 -p $NIX_USER_GCROOTS_DIR
-          if test "$(stat --printf '%u' $NIX_USER_GCROOTS_DIR)" != "$(id -u)"; then
+          NIX_USER_GCROOTS_DIR="/nix/var/nix/gcroots/per-user/$USER"
+          mkdir -m 0755 -p "$NIX_USER_GCROOTS_DIR"
+          if test "$(stat --printf '%u' "$NIX_USER_GCROOTS_DIR")" != "$(id -u)"; then
               echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
           fi
 
           # Set up a default Nix expression from which to install stuff.
-          if [ ! -e $HOME/.nix-defexpr -o -L $HOME/.nix-defexpr ]; then
-              rm -f $HOME/.nix-defexpr
-              mkdir -p $HOME/.nix-defexpr
+          if [ ! -e "$HOME/.nix-defexpr" -o -L "$HOME/.nix-defexpr" ]; then
+              rm -f "$HOME/.nix-defexpr"
+              mkdir -p "$HOME/.nix-defexpr"
               if [ "$USER" != root ]; then
-                  ln -s /nix/var/nix/profiles/per-user/root/channels $HOME/.nix-defexpr/channels_root
+                  ln -s /nix/var/nix/profiles/per-user/root/channels "$HOME/.nix-defexpr/channels_root"
               fi
           fi
         fi

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -25,7 +25,7 @@ in
         # Set up the per-user profile.
         mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
         if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
-            echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
+            echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR, should be $(id -u)" >&2
         fi
 
         if [ -w "$HOME" ]; then
@@ -47,7 +47,7 @@ in
           NIX_USER_GCROOTS_DIR="/nix/var/nix/gcroots/per-user/$USER"
           mkdir -m 0755 -p "$NIX_USER_GCROOTS_DIR"
           if [ "$(stat --printf '%u' "$NIX_USER_GCROOTS_DIR")" != "$(id -u)" ]; then
-              echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
+              echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR, should be $(id -u)" >&2
           fi
 
           # Set up a default Nix expression from which to install stuff.

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -24,13 +24,13 @@ in
       ''
         # Set up the per-user profile.
         mkdir -m 0755 -p "$NIX_USER_PROFILE_DIR"
-        if test "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)"; then
+        if [ "$(stat --printf '%u' "$NIX_USER_PROFILE_DIR")" != "$(id -u)" ]; then
             echo "WARNING: bad ownership on $NIX_USER_PROFILE_DIR" >&2
         fi
 
-        if test -w "$HOME"; then
-          if ! test -L "$HOME/.nix-profile"; then
-              if test "$USER" != root; then
+        if [ -w "$HOME" ]; then
+          if ! [ -L "$HOME/.nix-profile" ]; then
+              if [ "$USER" != root ]; then
                   ln -s "$NIX_USER_PROFILE_DIR/profile" "$HOME/.nix-profile"
               else
                   # Root installs in the system-wide profile by default.
@@ -46,7 +46,7 @@ in
           # Create the per-user garbage collector roots directory.
           NIX_USER_GCROOTS_DIR="/nix/var/nix/gcroots/per-user/$USER"
           mkdir -m 0755 -p "$NIX_USER_GCROOTS_DIR"
-          if test "$(stat --printf '%u' "$NIX_USER_GCROOTS_DIR")" != "$(id -u)"; then
+          if [ "$(stat --printf '%u' "$NIX_USER_GCROOTS_DIR")" != "$(id -u)" ]; then
               echo "WARNING: bad ownership on $NIX_USER_GCROOTS_DIR" >&2
           fi
 


### PR DESCRIPTION
###### Motivation for this change

I was looking into unifying some of the NixOS shell init logic and the Nix single-user logic at https://github.com/NixOS/nix/blob/master/scripts/nix-profile.sh.in. Here's a first pass of unification in the Nix -> NixOS direction.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))