### PR TITLE
1password: 0.4 -> 0.4.1

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   name = "1password-${version}";
-  version = "0.4";
+  version = "0.4.1";
   src =
     if stdenv.system == "i686-linux" then
       fetchzip {
-        url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
-        sha256 = "0mhlqvd3az50gnfil0xlq10855v3bg7yb05j6ndg4h2c551jrq41";
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4.1/op_linux_386_v${version}.zip";
+        sha256 = "0mv2m6rm6bdpca8vhyx213bg4kh06jl2sx8q7mnrp22c3f0yzh7f";
         stripRoot = false;
       }
     else if stdenv.system == "x86_64-linux" then
       fetchzip {
-        url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
-        sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4.1/op_linux_amd64_v${version}.zip";
+        sha256 = "016h5jcy6jic8j3mvlnpcig9jxs22vj71gh6rrap2q950bzi6fi1";
         stripRoot = false;
       }
     else if stdenv.system == "x86_64-darwin" then
       fetchzip {
-        url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4/op_darwin_amd64_v${version}.zip";
-        sha256 = "0yzr9m91k3lhl8am3dfzh4ql2zxsa66nw43h17ny61wraiz315cr";
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4.1/op_darwin_amd64_v${version}.zip";
+        sha256 = "1l0bi0f6gd4q19wn3v409gj64wp51mr0xpb09da1fl33rl5fpszb";
         stripRoot = false;
       }
     else throw "Architecture not supported";

--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -3,32 +3,45 @@
 stdenv.mkDerivation rec {
   name = "1password-${version}";
   version = "0.4";
-  src = if stdenv.system == "i686-linux" then fetchzip {
-    url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
-    sha256 = "0mhlqvd3az50gnfil0xlq10855v3bg7yb05j6ndg4h2c551jrq41";
-    stripRoot = false;
-  } else fetchzip {
-    url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
-    sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
-    stripRoot = false;
-  };
+  src =
+    if stdenv.system == "i686-linux" then
+      fetchzip {
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
+        sha256 = "0mhlqvd3az50gnfil0xlq10855v3bg7yb05j6ndg4h2c551jrq41";
+        stripRoot = false;
+      }
+    else if stdenv.system == "x86_64-linux" then
+      fetchzip {
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
+        sha256 = "15cv8xi4slid9jicdmc5xx2r9ag63wcx1mn7hcgzxbxbhyrvwhyf";
+        stripRoot = false;
+      }
+    else if stdenv.system == "x86_64-darwin" then
+      fetchzip {
+        url = "https://cache.agilebits.com/dist/1P/op/pkg/v0.4/op_darwin_amd64_v${version}.zip";
+        sha256 = "0yzr9m91k3lhl8am3dfzh4ql2zxsa66nw43h17ny61wraiz315cr";
+        stripRoot = false;
+      }
+    else throw "Architecture not supported";
 
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''
-    mkdir -p $out/bin
-    install -D op $out/share/1password/op
-
-    # https://github.com/NixOS/patchelf/issues/66#issuecomment-267743051
-    makeWrapper $(cat $NIX_CC/nix-support/dynamic-linker) $out/bin/op \
-      --argv0 op \
-      --add-flags $out/share/1password/op
+    install -D op $out/bin/op
+  '';
+  postFixup = stdenv.lib.optionalString stdenv.isLinux ''
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/bin/op
   '';
 
   meta = with stdenv.lib; {
     description = "1Password command-line tool";
-    homepage    = "https://blog.agilebits.com/2017/09/06/announcing-the-1password-command-line-tool-public-beta/";
+    homepage    = [
+      "https://blog.agilebits.com/2017/09/06/announcing-the-1password-command-line-tool-public-beta/"
+      "https://app-updates.agilebits.com/product_history/CLI"
+    ];
     maintainers = with maintainers; [ joelburget ];
     license     = licenses.unfree;
-    platforms   = [ "i686-linux" "x86_64-linux" ];
+    platforms   = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
+ Update 1password cli
+ Fix darwin build

cc @joelburget

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

