### PR TITLE
purple-facebook: 0.9.3 -> 0.9.5

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-facebook/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-facebook/default.nix
@@ -5,18 +5,18 @@ let
   pidginHg = fetchhg {
     url = "https://bitbucket.org/pidgin/main";
     # take from VERSION file
-    rev = "c9b74a765767";
-    sha256 = "07bjz87jpslsb4gdqvcwp79mkahls2mfhlmpaa5w6n4xqhahw4j3";
+    rev = "9ff9acf9fa14";
+    sha256 = "06imlhsps4wrjgjb92zpaxprxfxl2pjb2x9pl859c8cryssrz2jv";
   };
 
 in stdenv.mkDerivation rec {
-  name = "purple-facebook-0.9.3";
+  name = "purple-facebook-0.9.5";
 
   src = fetchFromGitHub {
     owner = "dequis";
     repo = "purple-facebook";
-    rev = "v0.9.3-c9b74a765767";
-    sha256 = "10ncvg0arcxnd3cpb0nxry1plbws0mw9vhzjrhb40sv2i563dywb";
+    rev = "v0.9.5-9ff9acf9fa14";
+    sha256 = "0a1860bkzrmyxahm9rlxi80z335w491wzdaqaw6j9ccavbymhwhs";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrades the pidgin/libpurple facebook plugin. 

Happens to address the _Invalid HTTP response code (400)_ error which currently prevents the plugin from authenticating.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

