### PR TITLE
vala: 0.36, 0.38 and 0.40 update point releases

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -37,12 +37,6 @@ let
 
 in rec {
 
-  vala_0_23 = generic {
-    major   = "0.23";
-    minor   = "3";
-    sha256  = "101xjbc818g4849n9a80c2aai13zakj7mpnd7470xnkvz5jwqq96";
-  };
-
   vala_0_26 = generic {
     major   = "0.26";
     minor   = "2";

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, flex, bison, libxslt, autoconf, graphviz
+{ stdenv, lib, fetchurl, pkgconfig, flex, bison, libxslt, autoconf, graphviz
 , glib, libiconv, libintl, libtool, expat
 }:
 
 let
   generic = { major, minor, sha256, extraNativeBuildInputs ? [], extraBuildInputs ? [] }:
-  stdenv.mkDerivation rec {
+  let
+    atLeast = lib.versionAtLeast "${major}.${minor}";
+  in stdenv.mkDerivation rec {
     name = "vala-${major}.${minor}";
 
     src = fetchurl {
@@ -14,9 +16,15 @@ let
 
     outputs = [ "out" "devdoc" ];
 
-    nativeBuildInputs = [ pkgconfig flex bison libxslt ] ++ extraNativeBuildInputs;
+    nativeBuildInputs = [
+      pkgconfig flex bison libxslt
+    ] ++ lib.optional (stdenv.isDarwin && (atLeast "0.38")) expat
+      ++ extraNativeBuildInputs;
 
-    buildInputs = [ glib libiconv libintl ] ++ extraBuildInputs;
+    buildInputs = [
+      glib libiconv libintl
+    ] ++ lib.optional (atLeast "0.38") graphviz
+      ++ extraBuildInputs;
 
     meta = with stdenv.lib; {
       description = "Compiler for GObject type system";
@@ -61,24 +69,21 @@ in rec {
 
   vala_0_36 = generic {
     major   = "0.36";
-    minor   = "12";
-    sha256  = "1nvw721piwdh15bipg0sdll9kvgpz0y9i5fpszlc7y9w64yis25l";
+    minor   = "13";
+    sha256  = "0gxz7yisd9vh5d2889p60knaifz5zndgj98zkdfkkaykdfdq4m9k";
   };
 
   vala_0_38 = generic {
     major   = "0.38";
-    minor   = "4";
-    sha256  = "1sg5gaq3jhgr9vzh2ypiw475167k150wmyglymr7wwqppmikmcrc";
-    extraNativeBuildInputs = [ autoconf ] ++ stdenv.lib.optionals stdenv.isDarwin [ libtool expat ];
-    extraBuildInputs = [ graphviz ];
+    minor   = "9";
+    sha256  = "1dh1qacfsc1nr6hxwhn9lqmhnq39rv8gxbapdmj1v65zs96j3fn3";
+    extraNativeBuildInputs = [ autoconf ] ++ lib.optional stdenv.isDarwin libtool;
   };
 
   vala_0_40 = generic {
     major   = "0.40";
-    minor   = "0";
-    sha256  = "0wcfljl55a9qvslfcc4sf76wdpwgn83n96b7fgb7r49ib35qz20m";
-    extraNativeBuildInputs = stdenv.lib.optionals stdenv.isDarwin [ expat ];
-    extraBuildInputs = [ graphviz ];
+    minor   = "6";
+    sha256  = "1qjbwhifwwqbdg5zilvnwm4n76g8p7jwqs3fa0biw3rylzqm193d";
   };
 
   vala = vala_0_38;


### PR DESCRIPTION
###### Motivation for this change

Regular updates and drop packages no longer in use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

