### PR TITLE
[ghc] fix dylib load command limits

### DIFF
--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -84,7 +84,8 @@ stdenv.mkDerivation rec {
       extraPrefix = "libraries/Cabal/";
     })
   ] ++ stdenv.lib.optional stdenv.isLinux ./ghc-no-madv-free.patch
-    ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch;
+    ++ stdenv.lib.optional stdenv.isDarwin ./ghc-8.0.2-no-cpp-warnings.patch
+    ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch;
 
   # GHC is a bit confused on its cross terminology.
   preConfigure = ''

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -95,7 +95,8 @@ stdenv.mkDerivation rec {
     (fetchpatch { # Backport of https://phabricator.haskell.org/D4388 for more determinism
       url = "https://github.com/shlevy/ghc/commit/fec1b8d3555c447c0d8da0e96b659be67c8bb4bc.patch";
       sha256 = "1lyysz6hfd1njcigpm8xppbnkadqfs0kvrp7s8vqgb38pjswj5hg";
-    });
+    })
+    ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch;
 
   postPatch = "patchShebangs .";
 

--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -86,7 +86,8 @@ stdenv.mkDerivation rec {
     sha256 = "0plzsbfaq6vb1023lsarrjglwgr9chld4q3m99rcfzx0yx5mibp3";
     extraPrefix = "utils/hsc2hs/";
     stripLen = 1;
-  })];
+  })]
+    ++ stdenv.lib.optional stdenv.isDarwin ./backport-dylib-command-size-limit.patch;
 
   postPatch = "patchShebangs .";
 

--- a/pkgs/development/compilers/ghc/backport-dylib-command-size-limit.patch
+++ b/pkgs/development/compilers/ghc/backport-dylib-command-size-limit.patch
@@ -1,0 +1,24 @@
+diff --git a/compiler/main/DriverPipeline.hs b/compiler/main/DriverPipeline.hs
+index acd0d61..3e83c15 100644
+--- a/compiler/main/DriverPipeline.hs
++++ b/compiler/main/DriverPipeline.hs
+@@ -1916,6 +1916,7 @@ linkBinary' staticLink dflags o_files dep_packages = do
+                       ++ pkg_framework_opts
+                       ++ debug_opts
+                       ++ thread_opts
++                      ++ (if (platformOS platform `elem` [OSDarwin, OSiOS]) then [ "-Wl,-dead_strip_dylibs", "-Wl,-dead_strip" ] else [])
+                     ))
+ 
+ exeFileName :: Bool -> DynFlags -> FilePath
+diff --git a/compiler/main/SysTools.hs b/compiler/main/SysTools.hs
+index 1ab5b13..2ebbf51 100644
+--- a/compiler/main/SysTools.hs
++++ b/compiler/main/SysTools.hs
+@@ -1737,6 +1737,7 @@ linkDynLib dflags0 o_files dep_packages
+                  ++ map Option pkg_lib_path_opts
+                  ++ map Option pkg_link_opts
+                  ++ map Option pkg_framework_opts
++                 ++ [ Option "-Wl,-dead_strip_dylibs" ]
+               )
+         OSiOS -> throwGhcExceptionIO (ProgramError "dynamic libraries are not supported on iOS target")
+         _ -> do

--- a/pkgs/development/compilers/ghc/backport-dylib-command-size-limit.patch
+++ b/pkgs/development/compilers/ghc/backport-dylib-command-size-limit.patch
@@ -6,7 +6,7 @@ index acd0d61..3e83c15 100644
                        ++ pkg_framework_opts
                        ++ debug_opts
                        ++ thread_opts
-+                      ++ (if (platformOS platform `elem` [OSDarwin, OSiOS]) then [ "-Wl,-dead_strip_dylibs", "-Wl,-dead_strip" ] else [])
++                      ++ (if (platformOS platform `elem` [OSDarwin]) then [ "-Wl,-dead_strip_dylibs" ] else [])
                      ))
  
  exeFileName :: Bool -> DynFlags -> FilePath


### PR DESCRIPTION
###### Motivation for this change

See https://phabricator.haskell.org/D4714 for the full details.
This will be part of ghc 8.6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

