### PR TITLE
tdesktop: enable on other platforms

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
@@ -90,6 +90,10 @@ mkDerivation rec {
     sed -i Telegram/gyp/qt_rcc.gypi \
       -e "s,/usr/bin/rcc,rcc,g"
 
+    # Build system assumes x86, but it works fine on non-x86 if we patch this one flag out
+    sed -i Telegram/ThirdParty/libtgvoip/libtgvoip.gyp \
+      -e "/-msse2/d"
+
     gyp \
       -Dbuild_defines=${GYP_DEFINES} \
       -Gconfig=Release \
@@ -133,7 +137,7 @@ mkDerivation rec {
     description = "Telegram Desktop messaging app "
       + (if stable then "(stable version)" else "(pre-release)");
     license = licenses.gpl3;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = platforms.linux;
     homepage = https://desktop.telegram.org/;
     maintainers = with maintainers; [ primeos abbradar garbas ];
   };


### PR DESCRIPTION
###### Motivation for this change
It works on armv7l-linux once the SSE2 assumption is patched out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

