### PR TITLE
zeronet: init at 0.6.2

### DIFF
--- a/pkgs/applications/networking/p2p/zeronet/default.nix
+++ b/pkgs/applications/networking/p2p/zeronet/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, python2Packages }:
+
+python2Packages.buildPythonApplication rec {
+  pname = "zeronet";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "HelloZeroNet";
+    repo = "ZeroNet";
+    rev = "v${version}";
+    sha256 = "0v19jjirkyv8hj2yfdj0c40zwynn51h2bj4issn5blr95vhfm8s7";
+  };
+
+  propagatedBuildInputs = with python2Packages; [ msgpack gevent ];
+
+  format = "other";
+
+  buildPhase = "${python2Packages.python.interpreter} -O -m compileall .";
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp -r plugins src tools *.py $out/share/
+  '';
+
+  # Wrap the main executable and set the log and data dir to something out of
+  # the store
+  postFixup = ''
+    makeWrapper "$out/share/zeronet.py" "$out/bin/zeronet" \
+        --set PYTHONPATH "$PYTHONPATH" \
+        --set PATH ${python2Packages.python}/bin \
+        --add-flags "--log_dir \$HOME/.local/share/zeronet/logs" \
+        --add-flags "--data_dir \$HOME/.local/share/zeronet"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Decentralized websites using Bitcoin crypto and BitTorrent network";
+    homepage = "https://zeronet.io/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18983,6 +18983,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  zeronet = callPackage ../applications/networking/p2p/zeronet { };
+
   zexy = callPackage ../applications/audio/pd-plugins/zexy  { };
 
   zgrviewer = callPackage ../applications/graphics/zgrviewer {};


### PR DESCRIPTION
###### Motivation for this change

https://zeronet.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Is the path correct or should I put it under pkgs/servers?

This probably needs a nixos module too but I won't add it in this pr.