### PR TITLE
ocamlPackages.earley_ocaml: init at 1.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/earley_ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/earley_ocaml/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, which, ocaml, findlib, ocamlbuild, earley }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.2";
+  name = "ocaml${ocaml.version}-earley_ocaml-${version}";
+  src = fetchFromGitHub {
+    owner = "rlepigre";
+    repo = "ocaml-earley-ocaml";
+    rev = "ocaml-earley-ocaml_${version}";
+    sha256 = "0f8kr49r2xfs7cbzps4r9i92ckhwssaiydam846jrky3z5djn2jc";
+  };
+
+  buildInputs = [ which ocaml findlib ocamlbuild ];
+
+  propagatedBuildInputs = [ earley ];
+
+  preBuild = "make";
+
+  createFindlibDestdir = true;
+
+  installFlags = [ "BINDIR=$(out)/bin" ];
+
+  meta = {
+    description = "Extensible OCaml parser to be used with Earley";
+    license = stdenv.lib.licenses.cecill-b;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -217,6 +217,8 @@ let
 
     earley = callPackage ../development/ocaml-modules/earley { };
 
+    earley_ocaml = callPackage ../development/ocaml-modules/earley_ocaml { };
+
     easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
     eliom = callPackage ../development/ocaml-modules/eliom { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

