### PR TITLE
pyogg: init at 0.6.2a1

### DIFF
--- a/pkgs/development/python-modules/pyogg/default.nix
+++ b/pkgs/development/python-modules/pyogg/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchPypi, buildPythonPackage, fetchurl, libvorbis, flac, libogg, libopus, opusfile }:
+
+buildPythonPackage rec {
+    pname = "PyOgg";
+    version = "0.6.2a1";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "1mjh5zx7mfy246lya1qc42j4q4pz6v5zbd8blnfib9ncswcb1v6l";
+    };
+
+    buildInputs = [ libvorbis flac libogg libopus ];
+    propagatedBuidInputs = [ libvorbis flac libogg libopus opusfile ];
+    # There are no tests in this package.
+    doCheck = false;
+    postPatch = ''
+      substituteInPlace pyogg/vorbis.py --replace \
+        'libvorbisfile = ExternalLibrary.load("vorbisfile")' "libvorbisfile = ctypes.CDLL('${libvorbis}/lib/libvorbisfile${stdenv.hostPlatform.extensions.sharedLibrary}')"
+      substituteInPlace pyogg/vorbis.py --replace \
+        'libvorbisenc = ExternalLibrary.load("vorbisenc")' "libvorbisenc = ctypes.CDLL('${libvorbis}/lib/libvorbisenc${stdenv.hostPlatform.extensions.sharedLibrary}')"
+      substituteInPlace pyogg/vorbis.py --replace \
+        'libvorbis = ExternalLibrary.load("vorbis")' "libvorbis = ctypes.CDLL('${libvorbis}/lib/libvorbis${stdenv.hostPlatform.extensions.sharedLibrary}')"
+      substituteInPlace pyogg/flac.py --replace \
+        'libflac = ExternalLibrary.load("flac")' "libflac = ctypes.CDLL('${flac.out}/lib/libFLAC${stdenv.hostPlatform.extensions.sharedLibrary}')"
+      substituteInPlace pyogg/ogg.py --replace \
+        'libogg = ExternalLibrary.load("ogg")' "libogg = ctypes.CDLL('${libogg}/lib/libogg${stdenv.hostPlatform.extensions.sharedLibrary}')"
+      substituteInPlace pyogg/opus.py --replace \
+        'libopus = ExternalLibrary.load("opus")' "libopus = ctypes.CDLL('${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}')"
+      substituteInPlace pyogg/opus.py --replace \
+        'libopusfile = ExternalLibrary.load("opusfile")' "libopusfile = ctypes.CDLL('${opusfile}/lib/libopusfile${stdenv.hostPlatform.extensions.sharedLibrary}')"
+    '';
+
+  meta = {
+    description = "Xiph.org's Ogg Vorbis, Opus and FLAC for Python";
+    homepage = https://github.com/Zuzu-Typ/PyOgg;
+    license = lib.licenses.publicDomain;
+    maintainers = with lib.maintainers; [ pmiddend ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18196,6 +18196,8 @@ EOF
   prometheus_client = callPackage ../development/python-modules/prometheus_client { };
 
   pysdl2 = callPackage ../development/python-modules/pysdl2 { };
+
+  pyogg = callPackage ../development/python-modules/pyogg { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

The package is missing in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

