### PR TITLE
vagrant: 2.0.4 -> 2.1.1

### DIFF
--- a/pkgs/development/tools/vagrant/Gemfile
+++ b/pkgs/development/tools/vagrant/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem 'vagrant', git: "https://github.com/hashicorp/vagrant.git", tag: "v2.0.4"
+gem 'vagrant', git: "https://github.com/hashicorp/vagrant.git", tag: "v2.1.1"

--- a/pkgs/development/tools/vagrant/Gemfile.lock
+++ b/pkgs/development/tools/vagrant/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/hashicorp/vagrant.git
-  revision: 6a6805f284dff05207e359acdfb1ca8443b78751
-  tag: v2.0.4
+  revision: b95e42ad6f0b6c8a92adf1d6f43537492947567d
+  tag: v2.1.1
   specs:
-    vagrant (2.0.4)
+    vagrant (2.1.1)
       childprocess (~> 0.6.0)
       erubis (~> 2.7.0)
       hashicorp-checkpoint (~> 0.1.5)

--- a/pkgs/development/tools/vagrant/gemset.nix
+++ b/pkgs/development/tools/vagrant/gemset.nix
@@ -282,12 +282,12 @@
     dependencies = ["childprocess" "erubis" "hashicorp-checkpoint" "i18n" "listen" "log4r" "net-scp" "net-sftp" "net-ssh" "rb-kqueue" "rest-client" "ruby_dep" "wdm" "win32-file" "win32-file-security" "winrm" "winrm-elevated" "winrm-fs"];
     source = {
       fetchSubmodules = false;
-      rev = "6a6805f284dff05207e359acdfb1ca8443b78751";
-      sha256 = "07c7r4xk0md9hkbcnij0kp7acxz0li9ak1ah7lmh52j10gq4cjmw";
+      rev = "b95e42ad6f0b6c8a92adf1d6f43537492947567d";
+      sha256 = "0q07y38icp71cj5v3m7fibgrk8v8k5ik34v8wmrcpd75zd8sdyh1";
       type = "git";
       url = "https://github.com/hashicorp/vagrant.git";
     };
-    version = "2.0.4";
+    version = "2.1.1";
   };
   wdm = {
     source = {


### PR DESCRIPTION
vagrant informs user new version is available,
so thought I'd give updating it a try :).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

It seems to work in my limited testing,
would be good to be vetted by someone else.