### PR TITLE
kakoune-unstable: 2018-03-22 -> 2018-05-21, debug mode disabled

### DIFF
--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -4,15 +4,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "kakoune-unstable-${version}";
-  version = "2018-03-22";
+  version = "2018-05-21";
   src = fetchFromGitHub {
     repo = "kakoune";
     owner = "mawww";
-    rev = "f8e297acef1be0657b779fea5256f606a6c6a3a3";
-    sha256 = "14xmw3lkwzppm9bns55nmyb1lfihzhdyisf6xjqlszdj4mcf94jl";
+    rev = "878d2a4bdb674a5e7703a66e530520f48efba641";
+    sha256 = "0pwy6ilsb62s1792gjyvhvq8shj60l8lx26b58zvpfb54an4s6rk";
   };
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses asciidoc docbook_xsl libxslt ];
+  makeFlags = [ "debug=no" ];
 
   postPatch = ''
     export PREFIX=$out


### PR DESCRIPTION
###### Motivation for this change
Kakoune version provided in nixpkgs was quite old, and debug mode is generally not recommended to use.

> Note that if your distribution provides a "kakoune" package, the program should already be built in non-debug mode (if you still experience slowness, please report the issue on the bug tracker).

From https://github.com/mawww/kakoune/blob/master/doc/pages/faq.asciidoc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

