### PR TITLE
Stop requiring the nixpkgs symlink in NixOS channel tarballs

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -340,7 +340,7 @@ in
         default =
           [
             "$HOME/.nix-defexpr/channels"
-            "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs"
+            "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
             "nixos-config=/etc/nixos/configuration.nix"
             "/nix/var/nix/profiles/per-user/root/channels"
           ];


### PR DESCRIPTION
Ideally I'd like the whole `nixos`/`nixpkgs` channel distinction to disappear, but this is a step along that path. After a while being in this state, we can stop creating the magic `nixpkgs -> .` symlink inside our `nixos` channel tarballs and simplify that whole mess a bit.

###### Motivation for this change

The distinction between `nixos` and `nixpkgs` as channels has been confusing for a long time.