### PR TITLE
heaptrack: 2018-01-28 -> 1.1.0

### DIFF
--- a/pkgs/development/tools/profiling/heaptrack/default.nix
+++ b/pkgs/development/tools/profiling/heaptrack/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "heaptrack-${version}";
-  version = "2018-01-28";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "KDE";
     repo = "heaptrack";
-    rev = "a4534d52788ab9814efca1232d402b2eb319342c";
-    sha256 = "00xfv51kavvcmwgfmcixx0k5vhd06gkj5q0mm8rwxiw6215xp41a";
+    rev = "v${version}";
+    sha256 = "0vgwldl5n41r4y3pv8w29gmyln0k2w6m59zrfw9psm4hkxvivzlx";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];


### PR DESCRIPTION
use new stable release!




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---