### PR TITLE
partition-manager: 3.0.1 -> 3.3.1

### DIFF
--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,26 +1,36 @@
 { mkDerivation, fetchurl, lib
 , extra-cmake-modules, kdoctools, wrapGAppsHook
 , kconfig, kcrash, kinit, kpmcore
-, eject, libatasmart }:
+, eject, libatasmart , utillinux, makeWrapper, qtbase
+}:
 
 let
   pname = "partitionmanager";
 in mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.0.1";
+  version = "3.3.1";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "08sb9xa7dvvgha3k2xm1srl339przxpxd2y5bh1lnx6k1x7dk410";
+    sha256 = "0jhggb4xksb0k0mj752n6pz0xmccnbzlp984xydqbz3hkigra1si";
   };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook makeWrapper ];
+
+  # refer to kpmcore for the use of eject
+  buildInputs = [ eject libatasmart utillinux ];
+  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/partitionmanager" --prefix QT_PLUGIN_PATH : "${kpmcore}/lib/qt-5.${lib.versions.minor qtbase.version}/plugins"
+  '';
 
   meta = with lib; {
     description = "KDE Partition Manager";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ peterhoeg ];
+    homepage = https://www.kde.org/applications/system/kdepartitionmanager/;
+    maintainers = with maintainers; [ peterhoeg ma27 ];
   };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
-  # refer to kpmcore for the use of eject
-  buildInputs = [ eject libatasmart ];
-  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
 }


### PR DESCRIPTION
###### Motivation for this change

The `3.0.1` build was broken (see the Hydra build from
https://hydra.nixos.org/build/74368257 for further reference).

Because of the missing `utillinux` build input the package fails fairly
early:

```
-- Checking for module 'blkid'
--   No package 'blkid' found
CMake Error at /nix/store/9hmhxgj4jk6jmxihgavj6gm0p759misc-cmake-3.10.2/share/cmake-3.10/Modules/FindPkgConfig.cmake:415 (message):
  A required package was not found
```

Additionally `partition-manager` was broken on non-KDE desktops (none+i3
in my case) as the plugins from `libsForQt5.kpmcore` couldn't be found
in `QT_PLUGIN_PATH` unless it's installed in
`environment.systemPackages` or with `nix-env -iA libsForQt5.kpmcore`.
This has been fixed by adding a wrapper in the `postInstall` hook which
prefixes the `QT_PLUGIN_PATH` with the plugin path from `kpmcore` used
for the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

