### PR TITLE
nix-du: init at 0.1.1

### DIFF
--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, rustPlatform, nix, boost, graphviz }:
+rustPlatform.buildRustPackage rec {
+  name = "nix-du-${version}";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "symphorien";
+    repo = "nix-du";
+    rev = "v${version}";
+    sha256 = "0kxacn5qw21pp4zl6wr9wyb2mm2nlnp6mla3m5p9dm7vrm1fd1x9";
+  };
+  cargoSha256 = "04c48lzi7hny3nq4ffdpvsr4dxbi32faka163fp1yc9953zdw9az";
+
+  doCheck = !stdenv.isDarwin;
+  checkInputs = [ graphviz ];
+  nativeBuildInputs = [] ++ stdenv.lib.optionals doCheck checkInputs;
+
+  buildInputs = [
+    boost
+    nix
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A tool to determine which gc-roots take space in your nix store";
+    homepage = https://github.com/symphorien/nix-du;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.symphorien ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20729,6 +20729,8 @@ with pkgs;
   nix-deploy = haskell.lib.justStaticExecutables haskellPackages.nix-deploy;
   nix-diff = haskell.lib.justStaticExecutables haskellPackages.nix-diff;
 
+  nix-du = callPackage ../tools/package-management/nix-du { };
+
   nix-info = callPackage ../tools/nix/info { };
   nix-info-tested = callPackage ../tools/nix/info { doCheck = true; };
 


### PR DESCRIPTION
###### Motivation for this change

package https://github.com/symphorien/nix-du

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

