### PR TITLE
requireFile: Use stdenvNoCC

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -157,14 +157,14 @@ rec {
       hash = if sha256 != null then sha256 else sha1;
       name_ = if name == null then baseNameOf (toString url) else name;
     in
-    stdenv.mkDerivation {
+    stdenvNoCC.mkDerivation {
       name = name_;
       outputHashMode = hashMode;
       outputHashAlgo = hashAlgo;
       outputHash = hash;
       preferLocalBuild = true;
       builder = writeScript "restrict-message" ''
-        source ${stdenv}/setup
+        source ${stdenvNoCC}/setup
         cat <<_EOF_
 
         ***


### PR DESCRIPTION
###### Motivation for this change

There's no need for a C compiler

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

