### PR TITLE
lxqt: 0.12.0 -> 0.13.0 [WIP]

### DIFF
--- a/pkgs/desktops/lxqt/base/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/base/liblxqt/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "liblxqt";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1852vfbkbpw49i8ad682jhqmnskmc9a90qwpalipgak7m64azg3j";
+    sha256 = "1lbvnx6gg15k7fy1bnv5sjji659f603glblcl8c9psh0m1cjdbll";
   };
 
   nativeBuildInputs = [
@@ -31,11 +31,11 @@ stdenv.mkDerivation rec {
     "-DPULL_TRANSLATIONS=NO"
     "-DLXQT_ETC_XDG_DIR=/run/current-system/sw/etc/xdg"
   ];
-  
+
   patchPhase = ''
     sed -i 's|set(LXQT_SHARE_DIR .*)|set(LXQT_SHARE_DIR "/run/current-system/sw/share/lxqt")|' CMakeLists.txt
   '';
-  
+
   meta = with stdenv.lib; {
     description = "Core utility library for all LXQt components";
     homepage = https://github.com/lxde/liblxqt;

--- a/pkgs/desktops/lxqt/base/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/base/libqtxdg/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libqtxdg-${version}";
-  version = "3.1.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = "libqtxdg";
     rev = version;
-    sha256 = "03kdrx5sgrl93yband87n30i0k2mv6dknwdw2adz45j5z9rhd3z6";
+    sha256 = "0lkmwnqk314mlr811rdb96p6i7zg67slxdvd4cdkiwakgbzzaa4m";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/desktops/lxqt/base/libsysstat/default.nix
+++ b/pkgs/desktops/lxqt/base/libsysstat/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, cmake, qt5, lxqt }:
+{ stdenv, fetchFromGitHub, cmake, qt5, lxqt, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "libsysstat-${version}";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "lxde";
@@ -11,9 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "0yl20dj553z1ijkfxl9n45qvkzxyl9rqw12vb4v6zj3ch6hzbzsx";
   };
 
-  nativeBuildInputs = [ cmake lxqt.lxqt-build-tools ];
+  patches = [
+    # Backport "Drop Qt foreach", I believe the version of QT we are using is too new
+    (fetchurl {
+      url = "https://github.com/lxqt/libsysstat/commit/e4904ad.patch";
+      sha256 = "0d9bza95n0w27lvlx64c93fan4vms236jhx0ysynj3902yzdn5yd";
+    })
+  ];
 
-  buildInputs = [ qt5.qtbase ];
+  nativeBuildInputs = [ cmake lxqt.lxqt-build-tools qt5.qtbase ];
+
+  buildInputs = with qt5; [ qtbase qtsvg ];
 
   meta = with stdenv.lib; {
     description = "Library used to query system info and statistics";

--- a/pkgs/desktops/lxqt/base/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/base/lxqt-build-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "lxqt-build-tools-${version}";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = "lxqt-build-tools";
     rev = version;
-    sha256 = "0i3pzgyd80n73dnqs8f6axinaji7biflgqsi33baxn4r1hy58ym1";
+    sha256 = "0dcwzrijmn4sgivmy2zwz3xa4y69pwhranyw0m90g0pp55di2psz";
   };
 
   nativeBuildInputs = [ cmake pkgconfig pcre qt5.qtbase ];

--- a/pkgs/desktops/lxqt/core/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/libfm-qt/default.nix
@@ -7,13 +7,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "libfm-qt";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "0932yl098pc5rwgy9irrc3ys47jx64m3wm702dvs8yy15alv6x4i";
+    sha256 = "18x5hx4b8wmn16w4m915glih8k97hsr206h5hxad1ywqcj8x9wjj";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-about/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-about";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "13knjxbnq0mh9jgkllarf6rjxkvj2c93l0srnlrqp3939gcpwxh3";
+    sha256 = "03f53rnn4rkd1xc2q9abnw37aq4sgvpbwhmcnckqyzc87lj6ici0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-admin/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-admin";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "0dg3gm5m19dc4jarh8xcn0mcnpgxzz7nhy5dzm8chddaa6pdm7vi";
+    sha256 = "1z9wlyj5i192jfq3dcxjf8wzx9x332f19c9ll7zv69cq21kyy9wn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-config/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-config";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1ccxkdfhgf40jxiy0132yr9b28skvs9yr8j75w663hnqi6ccn377";
+    sha256 = "0r5vwkyz0c9b9py3wni4yzkmsvgs6psk9dp1fhfzvbjbknb21bfa";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-globalkeys/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-globalkeys";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "14icyik9x47wi3gfkmkyhag26a2ivyc42f4f8qwdgbr3dcg10b9a";
+    sha256 = "1fmi0n5chnrpbgf7zwzc3hi55r85hkxaq5jylbwaahmxhnb5hdid";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-l10n/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-l10n/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "lxqt-l10n-${version}";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = "lxqt-l10n";
     rev = version;
-    sha256 = "025zg5y9f286p74rab4yxyz4cqlh4hqjq43xxpi76ma2fy2s03a4";
+    sha256 = "0q1hzj6sa4wc8sgqqqsqfldjpnvihacfq73agvc2li3q6qi5rr0k";
   };
 
   nativeBuildInputs = [
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     substituteInPlace CMakeLists.txt \
       --replace "\''${LXQT_TRANSLATIONS_DIR}" "$out"/share/lxqt/translations
   '';
-  
+
   meta = with stdenv.lib; {
     description = "Translations of LXQt";
     homepage = https://github.com/lxde/lxqt-l10n;

--- a/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-notificationd";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "0pmpdqgnb2dfxw5lirh89j8hnrwwcn2zc64byg4zi0xdvq6qms43";
+    sha256 = "0vjpl3ipc0hrz255snkp99h6xrlid490ml8jb588rdpfina66sp1";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-openssh-askpass/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-openssh-askpass";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "16xcw4yll6i9vij16kdb10s4aq2s57x4yjlwv6d8r75y5gq9iiw6";
+    sha256 = "19djmqwk4kj3rxs4h7a471ydcz87j5z4yv8a6pgblvqdkkn0ylk9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -10,13 +10,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-panel";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "01xmnb17jpydyfvxwaa6kymzdasnyd94z62gjah8y4pzsmykcr4x";
+    sha256 = "056khr3smyrdi26zpclwv1qrmk0zxr9cnk65ad9c0xavzk6ya3xz";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
@@ -7,13 +7,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-policykit";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1hxz5bxxi118g255aqb3da767va0wd25y671lk2w9r1641j8zf2d";
+    sha256 = "1m9v4hl1hyd8rmlh6z2zy6287qfnavsm9khl526jf8f7bjgpifvd";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-powermanagement/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-powermanagement";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1fxklxmvjaykdpf0nj6cpgwx4yf52087g25k1zdak9n0l9n7hm8d";
+    sha256 = "04mx1nxqqqjg3wsql4ch4j1a4cbqfvpq0iwi6b9yhaf04n0dwrvn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-qtplugin/default.nix
@@ -7,13 +7,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-qtplugin";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1i1rga0pg764ccwhq7acdsckxpl1apxwj4lv4gygxxmpkrg62zkv";
+    sha256 = "19y5dvbj7gwyh8glc6vi6hb5snvkd3jwvss6j0sn2sy2gp9g9ryb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
@@ -4,13 +4,13 @@ menu-cache, muparser, pcre }:
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-runner";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1354vdaskhch1n8v3kdy15nszgqb1092csr84nbhymzgrhrq1093";
+    sha256 = "0w6r9lby35p0lf5klasa5l2lscx6dmv16kzfhl4lc6w2qfwjb9vi";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-session/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-session";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "03gi9svxqsfjhk5ifbaalq9i44ggx8afwms1hb312czqn82wrszb";
+    sha256 = "0ngcrkmfpahii4yibsh03b8v8af93hhqm42kk1nnhczc8dg49mhs";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-sudo/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-sudo";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "0ql436yb51qwbnj5gbzvqi4rqx4zkmja5rdjs6yavb1x8ggn1jv6";
+    sha256 = "1gpn3dhmzabx0jrqxq63549sah03kf6bmdc9d9kmg6hyr5xg3i1h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-themes/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-themes/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-themes";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "0f7bipkxkl741lpb2cziw9wlqy05514nqqrppsz5g4y8bmzw910n";
+    sha256 = "026hbblxdbq48n9691b1z1xiak99khsk3wf09vn4iaj5zi7dwhw5";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/pavucontrol-qt/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "pavucontrol-qt";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1pfqdzsbygvq77npsizydps25d9g6vgw177yqvmz3cg3a68dad27";
+    sha256 = "1bxqpasfvaagbq8azl7536z2zk2725xg7jkvad5xh95zq1gb4hgk";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/pcmanfm-qt/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "pcmanfm-qt";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "050h5w1wph35l5m69qbxzvc96y7y0bg1m7flqdadrp688pbnzcxb";
+    sha256 = "0xnhdxx45fmbi5dqic3j2f7yq01s0xysimafj5zqs0a29zw3i4m0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/core/qtermwidget/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qtermwidget";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "14yjz6b1l2yd7sfsxjv26yg5153fpyq23443kswkgkd9jh32gxj4";
+    sha256 = "0awp33cnkpi9brpx01mz5hwj7j2lq1wdi8cabk3wassd99vvxdxz";
   };
 
   nativeBuildInputs = [ cmake lxqt.lxqt-build-tools ];

--- a/pkgs/desktops/lxqt/optional/compton-conf/default.nix
+++ b/pkgs/desktops/lxqt/optional/compton-conf/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "compton-conf";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1p1y7g5psczx1dgh6gd1h5iga8rylvczkwlfirzrh0rfl45dajgb";
+    sha256 = "1r187fx1vivzq1gcwwawax36mnlmfig5j1ba4s4wfdi3q2wcq7mw";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lximage-qt";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "0zmrpfgmlq005zikyvhqbpip6mz6pfcf9aqjpncyc5vlggmh28ym";
+    sha256 = "1slmaic9cmj5lqa5kwc1qfbbycwh8840wnkg0nxc99ls0aazlpzi";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/optional/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/optional/obconf-qt/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "obconf-qt";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1vwza1516z7f18s5vfnhzsiyxs6afb1hgr3yqkr7qhplmq5wjma5";
+    sha256 = "0mixf35p7b563f77vnikk9b1wqhbdawp723sd30rfql76gkjwjcn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/optional/qps/default.nix
+++ b/pkgs/desktops/lxqt/optional/qps/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qps";
-  version = "1.10.17";
+  version = "1.10.18";
 
   src = fetchFromGitHub {
     owner = "QtDesktop";
     repo = pname;
     rev = version;
-    sha256 = "1d5r6w9wsxjdrzq2hllrj2n1d9azy6g05hg0w0s6pikrmn1yl0a3";
+    sha256 = "1cq5z4w2n119z2bq0njn508g5582jljdx2n38cv5b3cf35k91a49";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/desktops/lxqt/optional/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/optional/qterminal/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qterminal";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "lxde";
     repo = pname;
     rev = version;
-    sha256 = "1899a5zc5kx7mxiyrncigqjia1k98qg526qynf4754nr9ifghxdw";
+    sha256 = "0pkm9my5v89kpdlipmryvhsvixzi1h02gqr7l0a7zhxqb2d53sfn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/optional/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/optional/screengrab/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "screengrab-${version}";
-  version = "1.97";
+  version = "1.98";
 
   src = fetchFromGitHub {
     owner = "QtDesktop";
     repo = "screengrab";
     rev = version;
-    sha256 = "0qhdxnv1pz745qgvdv5x7kyfx9dz9rrq0wxyfimppzxcszv4pl2z";
+    sha256 = "1y3r29220z6y457cajpad3pjnr883smbvh0kai8hc5hh4k4kxs6v";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Crossplatform tool for fast making screenshots";
-    homepage = https://github.com/lxde/screengrab;
+    homepage = https://github.com/lxqt/screengrab;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];


### PR DESCRIPTION
###### Motivation for this change

###### TODO:

[ ] liblxqt has a new dependency on polkit-qt, not sure how best to satisfy it
[ ] qterminal seems to have a dependency on qt5xdg 3.1.0 somehow? The latest version is 3.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

