### PR TITLE
oracle-instantclient: simplify a lot, use autoPatchelfHook

### DIFF
--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -86,6 +86,6 @@ in stdenv.mkDerivation rec {
     '';
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ pesterhazy ];
+    maintainers = with maintainers; [ pesterhazy flokli ];
   };
 }

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -56,5 +56,6 @@ in stdenv.mkDerivation rec {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ pesterhazy flokli ];
+    hydraPlatforms = [];
   };
 }

--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,8 +1,6 @@
-{ stdenv, requireFile, glibc, patchelf, rpmextract, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
+{ stdenv, requireFile, autoPatchelfHook, rpmextract, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
 
 assert odbcSupport -> unixODBC != null;
-
-with stdenv.lib;
 
 let
     baseVersion = "12.2";
@@ -27,55 +25,26 @@ in stdenv.mkDerivation rec {
   version = "${baseVersion}.0.1.0";
   name = "oracle-instantclient-${version}";
 
-  srcBase = (requireSource version "1" "basic" "43c4bfa938af741ae0f9964a656f36a0700849f5780a2887c8e9f1be14fe8b66");
-  srcDevel = (requireSource version "1" "devel" "4c7ad8d977f9f908e47c5e71ce56c2a40c7dc83cec8a5c106b9ff06d45bb3442");
-  srcSqlplus = (requireSource version "1" "sqlplus" "303e82820a10f78e401e2b07d4eebf98b25029454d79f06c46e5f9a302ce5552");
-  srcOdbc = optionalString odbcSupport (requireSource version "2" "odbc" "e870c84d2d4be6f77c0760083b82b7ffbb15a4bf5c93c4e6c84f36d6ed4dfdf1");
+  buildInputs = [ libaio stdenv.cc.cc.lib ] ++ stdenv.lib.optional odbcSupport unixODBC;
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper rpmextract ];
 
-  buildInputs = [ glibc ] ++
-    optional odbcSupport unixODBC;
+  srcs = [
+    (requireSource version "1" "basic" "43c4bfa938af741ae0f9964a656f36a0700849f5780a2887c8e9f1be14fe8b66")
+    (requireSource version "1" "devel" "4c7ad8d977f9f908e47c5e71ce56c2a40c7dc83cec8a5c106b9ff06d45bb3442")
+    (requireSource version "1" "sqlplus" "303e82820a10f78e401e2b07d4eebf98b25029454d79f06c46e5f9a302ce5552")
+  ] ++ stdenv.lib.optional odbcSupport (requireSource version "2" "odbc" "e870c84d2d4be6f77c0760083b82b7ffbb15a4bf5c93c4e6c84f36d6ed4dfdf1");
 
-  nativeBuildInputs = [ rpmextract patchelf makeWrapper ];
+  unpackCmd = "rpmextract $curSrc";
 
-  buildCommand = ''
-    mkdir -p "${name}"
-    cd "${name}"
-    ${rpmextract}/bin/rpmextract "${srcBase}"
-    ${rpmextract}/bin/rpmextract "${srcDevel}"
-    ${rpmextract}/bin/rpmextract "${srcSqlplus}"
-    '' + optionalString odbcSupport ''${rpmextract}/bin/rpmextract ${srcOdbc}
-    '' + ''
+  installPhase = ''
     mkdir -p "$out/"{bin,include,lib,"share/${name}/demo/"}
-    mv "usr/share/oracle/${baseVersion}/client64/demo/"* "$out/share/${name}/demo/"
-    mv "usr/include/oracle/${baseVersion}/client64/"* "$out/include/"
-    mv "usr/lib/oracle/${baseVersion}/client64/lib/"* "$out/lib/"
-    mv "usr/lib/oracle/${baseVersion}/client64/bin/"* "$out/bin/"
-    ln -s "$out/bin/sqlplus" "$out/bin/sqlplus64"
 
-    for lib in $out/lib/lib*.so; do
-      test -f $lib || continue
-      chmod +x $lib
-      patchelf --force-rpath --set-rpath "$out/lib:${libaio}/lib" \
-               $lib
-    done
-
-    for lib in $out/lib/libsqora*; do
-      test -f $lib || continue
-      chmod +x $lib
-      patchelf --force-rpath --set-rpath "$out/lib:${unixODBC}/lib" \
-               $lib
-    done
-
-    for exe in $out/bin/{adrci,genezi,sqlplus}; do
-      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-               --force-rpath --set-rpath "$out/lib:${libaio}/lib" \
-               $exe
-      wrapProgram $exe --prefix LD_LIBRARY_PATH ":" $out/lib
-    done
+    install -Dm755 lib/oracle/${baseVersion}/client64/bin/* $out/bin
+    ln -s $out/bin/sqlplus $out/bin/sqlplus64
+    install -Dm644 lib/oracle/${baseVersion}/client64/lib/* $out/lib
+    install -Dm644 include/oracle/${baseVersion}/client64/* $out/include
+    install -Dm644 share/oracle/${baseVersion}/client64/demo/* $out/share/${name}/demo
   '';
-
-  dontStrip = true;
-  dontPatchELF = true;
 
   meta = with stdenv.lib; {
     description = "Oracle instant client libraries and sqlplus CLI";


### PR DESCRIPTION
###### Motivation for this change
After fixing some things in `oracle-instantclient` for #40688, the expression still was very messy.

I did some refactoring of the build phase, and thanks to `autoPatchelfHook` we can get rid of all the manual `patchelf`ing, turning the expression a lot cleaner.

As now everything is much more maintainable, I'm happy with adding myself as one :-)

Tested connecting to an oracle database through `python3Packages.sqlalchemy` and `python3Packages.cx_oracle`, plus executing the `sqlplus` binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

