### PR TITLE
wireguard: bump version and limit platforms

### DIFF
--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "wireguard-go-${version}";
-  version = "0.0.20180514";
+  version = "0.0.20180519";
 
   goPackagePath = "wireguard-go";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-    sha256 = "1i1w4vj8w353b92nfhs92k0f7fifrwi067qfmgckdk0kk76nv2id";
+    sha256 = "d2b0f43679b3559952cf8d244d537903d03699ed7c8a2c1e7fc37ee424e30439";
   };
 
   goDeps = ./deps.nix;
@@ -23,6 +23,6 @@ buildGoPackage rec {
     homepage = https://git.zx2c4.com/wireguard-go/about/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ kirelagin ];
-    platforms = with platforms; linux ++ darwin ++ windows;
+    platforms = with platforms; darwin;
   };
 }


### PR DESCRIPTION
This is not Linux or Windows software. The only platform this meant to be packaged for at the moment is Darwin. Do not package this for Linux. And obviously you didn't even test this on Windows since it doesn't build there.