### PR TITLE
db dependees: fix regression from introducing multiple outputs

### DIFF
--- a/doc/languages-frameworks/perl.xml
+++ b/doc/languages-frameworks/perl.xml
@@ -109,7 +109,7 @@ buildPerlPackage rec {
   };
 
   preConfigure = ''
-    echo "LIB = ${db}/lib" > config.in
+    echo "LIB = ${db.lib}/lib" > config.in
     echo "INCLUDE = ${db}/include" >> config.in
   '';
 }

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-apr=${apr.dev}" "--with-expat=${expat.dev}" ]
     ++ optional (!stdenv.isCygwin) "--with-crypto"
     ++ optional sslSupport "--with-openssl=${openssl.dev}"
-    ++ optional bdbSupport "--with-berkeley-db=${db}"
+    ++ optional bdbSupport "--with-berkeley-db=${db.lib}"
     ++ optional ldapSupport "--with-ldap=ldap"
     ++ optionals stdenv.isCygwin
       [ "--without-pgsql" "--without-sqlite2" "--without-sqlite3"

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -39,7 +39,8 @@ stdenv.mkDerivation rec {
     "--with-libedit=${libedit}"
     "--with-openssl=${openssl.dev}"
     "--without-x"
-    "--with-berkeley-db=${db}"
+    "--with-berkeley-db"
+    "--with-berkeley-db-include=${db.out}/include"
   ] ++ optionals (!libOnly) [
     "--with-openldap=${openldap.dev}"
   ] ++ optionals (!stdenv.isFreeBSD) [

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, python2, perl, yacc, flex
 , texinfo, perlPackages
 , openldap, libcap_ng, sqlite, openssl, db, libedit, pam
-
+, CoreFoundation, Security, SystemConfiguration
 # Extra Args
 , type ? ""
 }:
@@ -26,8 +26,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig python2 perl yacc flex ]
     ++ (with perlPackages; [ JSON ])
     ++ optional (!libOnly) texinfo;
-  buildInputs = optionals (!stdenv.isFreeBSD) [ libcap_ng db ]
-    ++ [ sqlite openssl libedit ]
+  buildInputs = optionals (stdenv.isLinux) [ libcap_ng ]
+    ++ [ db sqlite openssl libedit ]
+    ++ optionals (stdenv.isDarwin) [ CoreFoundation Security SystemConfiguration ]
     ++ optionals (!libOnly) [ openldap pam ];
 
   ## ugly, X should be made an option
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
     "--with-berkeley-db-include=${db.out}/include"
   ] ++ optionals (!libOnly) [
     "--with-openldap=${openldap.dev}"
-  ] ++ optionals (!stdenv.isFreeBSD) [
+  ] ++ optionals (stdenv.isLinux) [
     "--with-capng"
   ];
 
@@ -93,7 +94,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "An implementation of Kerberos 5 (and some more stuff)";
     license = licenses.bsd3;
-    platforms = platforms.linux ++ platforms.freebsd;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ wkennington ];
   };
 

--- a/pkgs/development/libraries/librdf/raptor2.nix
+++ b/pkgs/development/libraries/librdf/raptor2.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = http://librdf.org/raptor;
     license = with stdenv.lib.licenses; [ lgpl21 asl20 ];
     maintainers = with stdenv.lib.maintainers; [ marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/librdf/rasqal.nix
+++ b/pkgs/development/libraries/librdf/rasqal.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = http://librdf.org/rasqal;
     license = with stdenv.lib.licenses; [ lgpl21 asl20 ];
     maintainers = with stdenv.lib.maintainers; [ marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, openssl, libxslt, perl
-, curl, pcre, libxml2, librdf_rasqal
+, curl, pcre, libxml2, librdf_rasqal, gmp
 , mysql, withMysql ? false
 , postgresql, withPostgresql ? false
 , sqlite, withSqlite ? true
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl pkgconfig ];
 
-  buildInputs = [ openssl libxslt curl pcre libxml2 ]
+  buildInputs = [ openssl libxslt curl pcre libxml2 gmp ]
     ++ stdenv.lib.optional withMysql mysql.connector-c
     ++ stdenv.lib.optional withSqlite sqlite
     ++ stdenv.lib.optional withPostgresql postgresql
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = http://librdf.org/;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -28,7 +28,10 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     [ "--with-threads" ]
-    ++ stdenv.lib.optional withBdb "--with-bdb=${db}";
+    ++ stdenv.lib.optionals withBdb [
+      "--with-bdb-include=${db.out}/include"
+      "--with-bdb-lib=${db.lib}/lib"
+    ];
 
   # Fix broken DT_NEEDED in lib/redland/librdf_storage_sqlite.so.
   NIX_CFLAGS_LINK = "-lraptor2";

--- a/pkgs/development/perl-modules/BerkeleyDB/default.nix
+++ b/pkgs/development/perl-modules/BerkeleyDB/default.nix
@@ -9,7 +9,7 @@ buildPerlPackage rec {
   };
 
   preConfigure = ''
-    echo "LIB = ${db}/lib" > config.in
+    echo "LIB = ${db.lib}/lib" > config.in
     echo "INCLUDE = ${db}/include" >> config.in
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9407,7 +9407,9 @@ with pkgs;
 
   hamlib = callPackage ../development/libraries/hamlib { };
 
-  heimdal = callPackage ../development/libraries/kerberos/heimdal.nix { };
+  heimdal = callPackage ../development/libraries/kerberos/heimdal.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
+  };
   libheimdal = heimdal.override { type = "lib"; };
 
   harfbuzz = callPackage ../development/libraries/harfbuzz { };


### PR DESCRIPTION
###### Motivation for this change
This fixes some builds on staging related to a regression introduced by splitting Berkeley DB into multiple outputs in 4b0638394d9fb0c4ce505b1187cc4ff3c5f54a10.
They're broken in staging since: https://hydra.nixos.org/eval/1451699?full=1#tabs-now-fail


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

