### PR TITLE
purple-xmpp-http-upload: init at 178096c

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-xmpp-http-upload/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/purple-xmpp-http-upload/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchgit, pidgin, glib, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "purple-xmpp-upload-${version}";
+  version = "178096cbfc9df165c2dc1677666439969d212b37";
+
+  src = fetchgit {
+    url = "https://github.com/Junker/purple-xmpp-http-upload";
+    rev = version;
+    sha256 = "12l9rqlgb4i50xxrfnvwz9sqfk0d3c0m6l09mnvfixqi8illyvlp";
+  };
+
+  buildInputs = [ pidgin glib libxml2 ];
+
+  installPhase = ''
+    install -Dm644 -t $out/lib/purple-2 jabber_http_file_upload.so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Junker/purple-xmpp-http-upload;
+    description = "HTTP File Upload plugin for libpurple (XMPP Protocol XEP-0363)";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ emmanuelrosa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17466,6 +17466,8 @@ with pkgs;
 
   purple-vk-plugin = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-vk-plugin { };
 
+  purple-xmpp-http-upload = callPackage ../applications/networking/instant-messengers/pidgin-plugins/purple-xmpp-http-upload { };
+
   telegram-purple = callPackage ../applications/networking/instant-messengers/pidgin-plugins/telegram-purple { };
 
   toxprpl = callPackage ../applications/networking/instant-messengers/pidgin-plugins/tox-prpl {


### PR DESCRIPTION
###### Motivation for this change

Adds purple-xmpp-http-upload pidgin/libpurple plugin, which provides support for HTTP File Upload  (XMPP Protocol XEP-0363). This allows libpurple clients to send files via XMPP to clients which support XEP-0363. 

**Note:** This will not allow you to send files to Conversations (Android XMPP client). Conversations uses Jingle (a different XEP) for file transfers. 

**Important:** Be mindful that even when using OMEMO (lurch plugin) files are sent clear-text.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~
   - [X] other Linux distributions (Tested on Xubuntu)
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~ New package, so there are no dependents.
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

