### PR TITLE
ocamlPackages.imagelib: init at 20171028

### DIFF
--- a/pkgs/development/ocaml-modules/imagelib/default.nix
+++ b/pkgs/development/ocaml-modules/imagelib/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, which, ocaml, findlib, ocamlbuild, decompress }:
+
+stdenv.mkDerivation rec {
+  version = "20171028";
+  name = "ocaml${ocaml.version}-imagelib-${version}";
+  src = fetchFromGitHub {
+    owner = "rlepigre";
+    repo = "ocaml-imagelib";
+    rev = "ocaml-imagelib_${version}";
+    sha256 = "1frkrgcrv4ybdmqcfxpfsywx0hm1arxgxp32n8kzky6qip1g0zxf";
+  };
+
+  buildInputs = [ which ocaml findlib ocamlbuild ];
+
+  propagatedBuildInputs = [ decompress ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "Image formats such as PNG and PPM in OCaml";
+    license = stdenv.lib.licenses.lgpl3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -269,6 +269,8 @@ let
 
     higlo = callPackage ../development/ocaml-modules/higlo { };
 
+    imagelib = callPackage ../development/ocaml-modules/imagelib { };
+
     inotify = callPackage ../development/ocaml-modules/inotify { };
 
     integers = callPackage ../development/ocaml-modules/integers { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

