### PR TITLE
pythonPackages.timeout-decorator: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/timeout-decorator/default.nix
+++ b/pkgs/development/python-modules/timeout-decorator/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  pname = "timeout-decorator";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bckwbi5078z3x9lyf8vl9dhx10nymwwnp46c98wm5m02x5j37g4";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Timeout decorator";
+    license = licenses.mit;
+    homepage = https://github.com/pnpnpn/timeout-decorator;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13034,15 +13034,7 @@ in {
     };
   };
 
-  timeout-decorator = buildPythonPackage rec {
-    name    = "timeout-decorator-${version}";
-    version = "0.3.2";
-
-    src = pkgs.fetchurl {
-      url    = "http://pypi.python.org/packages/source/t/timeout-decorator/${name}.tar.gz";
-      sha256 = "1x9l8bwdk72if2d5h5mi4lcaidbsmyh0iz114cfyyj1rzz5rxqaf";
-    };
-  };
+  timeout-decorator = callPackage ../development/python-modules/timeout-decorator { };
 
   pid = buildPythonPackage rec {
     name = "pid-${version}";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

