### PR TITLE
vim_configurable: restore ability to override python for modules

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -5,9 +5,12 @@ args@{ source ? "default", callPackage, fetchurl, stdenv, ncurses, pkgconfig, ge
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 , vimPlugins
+, makeWrapper
 
 # apple frameworks
 , CoreServices, CoreData, Cocoa, Foundation, libobjc, cf-private
+
+, wrapPythonDrv ? false
 
 , ... }: with args;
 
@@ -106,6 +109,11 @@ composableDerivation {
         feat = "python${if python ? isPy3 then "3" else ""}interp";
         enable = {
           buildInputs = [ python ];
+        } // lib.optionalAttrs wrapPythonDrv {
+          nativeBuildInputs = [ makeWrapper ];
+          postInstall = ''
+            wrapProgram "$out/bin/vim" --prefix PATH : "${python}/bin"
+          '';
         } // lib.optionalAttrs stdenv.isDarwin {
           configureFlags
             = [ "--enable-python${if python ? isPy3 then "3" else ""}interp=yes"


### PR DESCRIPTION
###### Motivation for this change

It seems as Python will be fetched from $PATH in Vim 8.1:

```
stat("/home/ma27/bin/python", 0x7ffe57a317b0) = -1 ENOENT (No such file or directory)
stat("/run/wrappers/bin/python", 0x7ffe57a317b0) = -1 ENOENT (No such file or directory)
stat("/home/ma27/.nix-profile/bin/python", 0x7ffe57a317b0) = -1 ENOENT (No such file or directory)
stat("/nix/var/nix/profiles/default/bin/python", 0x7ffe57a317b0) = -1 ENOENT (No such file or directory)
stat("/run/current-system/sw/bin/python", {st_mode=S_IFREG|0555, st_size=291, ...}) = 0
readlink("/run/current-system/sw/bin/python", "/nix/store/ggjkqbvwnv7dflkmdgmmp"..., 4096) = 72
```

This breaks in cases where you want to use a modified Python derivation
for the VIM plugins you use in `vim_configurable`:

```
let
  vim_configurable' = vim_configurable.override {
    # python with modules for ensime
    python = python.withPackages (ps: with ps; [ sexpdata websocket_client ]);
  };
in
  vim_configurable'.customize {
    # ...
  }
```

With VIM 8.0 this worked perfectly fine, now it's necessary to install
the modified `python` in $PATH to actually use it, otherwise an error
like this arises:

```
[ensime] A dependency is missing, please `pip2 install sexpdata websocket-client` and restart Vim.
Press ENTER or type command to continue
```

However it should be possible to pass the modified Python to the
modules, the easiest workaround is to write a wrapper which prefixes
$PATH to have the Python derivation available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

