### PR TITLE
home-assistant: deal with multiple packages matching requirement

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -167,7 +167,7 @@
     "lutron_caseta" = ps: with ps; [  ];
     "matrix" = ps: with ps; [ matrix-client ];
     "maxcube" = ps: with ps; [  ];
-    "media_extractor" = ps: with ps; [  ];
+    "media_extractor" = ps: with ps; [ youtube-dl-light ];
     "media_player.anthemav" = ps: with ps; [  ];
     "media_player.aquostv" = ps: with ps; [  ];
     "media_player.blackbird" = ps: with ps; [  ];
@@ -276,7 +276,7 @@
     "satel_integra" = ps: with ps; [  ];
     "scene.hunterdouglas_powerview" = ps: with ps; [  ];
     "scsgate" = ps: with ps; [  ];
-    "sensor.airvisual" = ps: with ps; [  ];
+    "sensor.airvisual" = ps: with ps; [ pyairvisual ];
     "sensor.alpha_vantage" = ps: with ps; [  ];
     "sensor.bbox" = ps: with ps; [  ];
     "sensor.bh1750" = ps: with ps; [  ];


### PR DESCRIPTION
###### Motivation for this change
There is `pythonPackages.youtube-dl` and `pythonPackages.youtube-dl-light`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg @FRidh 