### PR TITLE
doc: use "with stdenv.lib" in meta

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -8,16 +8,16 @@
   and so on. For instance, the GNU Hello package has a <varname>meta</varname>
   declaration like this:
 <programlisting>
-meta = {
+meta = with stdenv.lib; {
   description = "A program that produces a familiar, friendly greeting";
   longDescription = ''
     GNU Hello is a program that prints "Hello, world!" when you run it.
     It is fully customizable.
   '';
   homepage = http://www.gnu.org/software/hello/manual/;
-  license = stdenv.lib.licenses.gpl3Plus;
-  maintainers = [ stdenv.lib.maintainers.eelco ];
-  platforms = stdenv.lib.platforms.all;
+  license = licenses.gpl3Plus;
+  maintainers = [ maintainers.eelco ];
+  platforms = platforms.all;
 };
 </programlisting>
  </para>

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -10,15 +10,15 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A program that produces a familiar, friendly greeting";
     longDescription = ''
       GNU Hello is a program that prints "Hello, world!" when you run it.
       It is fully customizable.
     '';
     homepage = http://www.gnu.org/software/hello/manual/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.eelco ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

People would not accept a PR to nixpkgs where ```stdenv.lib.``` occurs three times. Documentation should not suggest things that are clearly not allowed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
