### PR TITLE
 nixos/nginx: make sslCertificate and sslCertificateKey nullable

### DIFF
--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -118,13 +118,15 @@ with lib;
     };
 
     sslCertificate = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
+      default = null;
       example = "/var/host.cert";
       description = "Path to server SSL certificate.";
     };
 
     sslCertificateKey = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
+      default = null;
       example = "/var/host.key";
       description = "Path to server SSL certificate key.";
     };


### PR DESCRIPTION
This doesn't change any behavior, but extraordinarily simplifies `virtualHost` override via `options.services.nginx.virtualHosts.apply`.