### PR TITLE
stdenv, binutils: Build cctools targeting macOS on Linux without pointless rebuilds

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -19,10 +19,11 @@ in
 stdenv.mkDerivation rec {
   name = targetPrefix + basename;
 
-  src = fetchurl {
+  # HACK to ensure that we preserve source from bootstrap binutils to not rebuild LLVM
+  src = stdenv.__bootPackages.binutils-unwrapped.src or (fetchurl {
     url = "mirror://gnu/binutils/${basename}.tar.bz2";
     sha256 = "028cklfqaab24glva1ks2aqa1zxa6w6xmc8q34zs1sb7h22dxspg";
-  };
+  });
 
   patches = [
     # Turn on --enable-new-dtags by default to make the linker set

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -90,9 +90,14 @@ let
       '' + lib.optionalString hostPlatform.isDarwin ''
         export NIX_DONT_SET_RPATH=1
         export NIX_NO_SELF_RPATH=1
-      '' + lib.optionalString targetPlatform.isDarwin ''
-        export NIX_TARGET_DONT_SET_RPATH=1
-      '';
+      ''
+      # TODO this should be uncommented, but it causes stupid mass rebuilds. I
+      # think the best solution would just be to fixup linux RPATHs so we don't
+      # need to set `-rpath` anywhere.
+      # + lib.optionalString targetPlatform.isDarwin ''
+      #   export NIX_TARGET_DONT_SET_RPATH=1
+      # ''
+      ;
 
       inherit initialPath shell
         defaultNativeBuildInputs defaultBuildInputs;


### PR DESCRIPTION
###### Motivation for this change

Most things that used to be in here could get merged straight to master (yay!). What's left is these two ugly things. Contrary to the branch name, this does *not* give full linux->darwin cross, as that requires #36867, but it does allow doing:
```
nix-build --arg crossSystem '{ config = "x86_64-apple-darwin"; }' -A buildPackages.darwin.cctools
```
And not waiting far too long for pointless rebuilds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @alexfmpe @ElvishJerricco 
