### PR TITLE
treewide: Remove uses of builtins.toPath.

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -492,7 +492,7 @@ rec {
   isStorePath = x:
        isCoercibleToString x
     && builtins.substring 0 1 (toString x) == "/"
-    && dirOf (builtins.toPath x) == builtins.storeDir;
+    && dirOf x == builtins.storeDir;
 
   /* Convert string to int
      Obviously, it is a bit hacky to use fromJSON that way.
@@ -528,11 +528,10 @@ rec {
   */
   readPathsFromFile = rootPath: file:
     let
-      root = toString rootPath;
       lines = lib.splitString "\n" (builtins.readFile file);
       removeComments = lib.filter (line: line != "" && !(lib.hasPrefix "#" line));
       relativePaths = removeComments lines;
-      absolutePaths = builtins.map (path: builtins.toPath (root + "/" + path)) relativePaths;
+      absolutePaths = builtins.map (path: rootPath + "/${path}") relativePaths;
     in
       absolutePaths;
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -97,7 +97,7 @@ runTests {
         storePathAppendix = isStorePath
           "${goodPath}/bin/python";
         nonAbsolute = isStorePath (concatStrings (tail (stringToCharacters goodPath)));
-        asPath = isStorePath (builtins.toPath goodPath);
+        asPath = isStorePath goodPath;
         otherPath = isStorePath "/something/else";
         otherVals = {
           attrset = isStorePath {};
@@ -318,7 +318,7 @@ runTests {
       int = 42;
       bool = true;
       string = ''fno"rd'';
-      path = /. + "/foo"; # toPath returns a string
+      path = /. + "/foo";
       null_ = null;
       function = x: x;
       functionArgs = { arg ? 4, foo }: arg;

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -28,7 +28,7 @@
 
 let extraArgs_ = extraArgs; pkgs_ = pkgs;
     extraModules = let e = builtins.getEnv "NIXOS_EXTRA_MODULE_PATH";
-                   in if e == "" then [] else [(import (builtins.toPath e))];
+                   in if e == "" then [] else [(import e)];
 in
 
 let

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -61,7 +61,7 @@ in
       '';
     }];
 
-    security.wrappers = (import (builtins.toPath "${e.enlightenment}/e-wrappers.nix")).security.wrappers;
+    security.wrappers = (import "${e.enlightenment}/e-wrappers.nix").security.wrappers;
 
     environment.etc = singleton
       { source = xcfg.xkbDir;

--- a/pkgs/build-support/fetchdocker/default.nix
+++ b/pkgs/build-support/fetchdocker/default.nix
@@ -22,8 +22,8 @@ assert null == lib.findFirst (c: "/"==c) null (lib.stringToCharacters repository
 assert null == lib.findFirst (c: "/"==c) null (lib.stringToCharacters imageName);
 
 let
-  # Abuse `builtins.toPath` to collapse possible double slashes
-  repoTag0 = builtins.toString (builtins.toPath "/${stripScheme registry}/${repository}/${imageName}");
+  # Abuse paths to collapse possible double slashes
+  repoTag0 = builtins.toString (/. + "/${stripScheme registry}/${repository}/${imageName}");
   repoTag1 = lib.removePrefix "/" repoTag0;
 
   layers = builtins.map stripNixStore imageLayers;

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
           patch -p1 \
             --no-backup-if-mismatch \
-            -d $out/libexec/${name} < ${ ./. + builtins.toPath ("/make_standalone_toolchain.py_" + "${version}" + ".patch") }
+            -d $out/libexec/${name} < ${ ./. + "/make_standalone_toolchain.py_${version}.patch" }
           wrapProgram ${pkg_path}/build/tools/make_standalone_toolchain.py --prefix PATH : "${runtime_paths}"
         ''
     }

--- a/pkgs/os-specific/darwin/apple-source-releases/libsecurity_generic/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libsecurity_generic/default.nix
@@ -1,7 +1,7 @@
 { appleDerivation_, applePackage, pkgs, stdenv }:
 name: version: sha256: args: let
   n = stdenv.lib.removePrefix "lib" name;
-  makeFile = ../. + builtins.toPath "/${name}/GNUmakefile";
+  makeFile = ../. + "/${name}/GNUmakefile";
   appleDerivation = appleDerivation_ name version sha256;
   in applePackage name version sha256 (args // {
     appleDerivation = a:

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -17,7 +17,7 @@ let
       buildInputs = [ readline ];
 
       patches = [
-        (./. + (builtins.toPath "/dont-create-sysconfdir-${builtins.substring 0 1 version}.patch"))
+        (./. + "/dont-create-sysconfdir-${builtins.substring 0 1 version}.patch")
       ];
 
       configureFlags = [

--- a/pkgs/servers/monitoring/telegraf/default.nix
+++ b/pkgs/servers/monitoring/telegraf/default.nix
@@ -19,7 +19,7 @@ buildGoPackage rec {
     -X main.version=${version}
   '' ];
 
-  goDeps = ./. + builtins.toPath "/deps-${version}.nix";
+  goDeps = ./. + "/deps-${version}.nix";
 
   meta = with lib; {
     description = "The plugin-driven server agent for collecting & reporting metrics.";

--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -20,7 +20,7 @@ buildGoPackage rec {
   excludedPackages = "test";
 
   # Generated with the nix2go
-  goDeps = ./. + builtins.toPath "/deps-${version}.nix";
+  goDeps = ./. + "/deps-${version}.nix";
 
   meta = with lib; {
     description = "An open-source distributed time series database";

--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -35,7 +35,7 @@ let
 
   mkUniquePkgs = pkgs: fastUnique (a: b: a < b) # highlighting hack: >
     # here we deal with those dummy packages needed for hyphenation filtering
-    (map (p: if lib.isDerivation p then builtins.toPath p else "") pkgs);
+    (map (p: if lib.isDerivation p then p.outPath else "") pkgs);
 
 in buildEnv {
   name = "texlive-${extraName}-${bin.texliveYear}";


### PR DESCRIPTION
toPath has confusing semantics and is never necessary; it can always
either just be omitted or replaced by pre-concatenating `/.`. It has
been marked as "!!! obsolete?" for more than 10 years in a C++
comment, hopefully removing it will let us properly deprecate and,
eventually, remove it.