### PR TITLE
bloaty: 2017-10-05 -> 2018-05-22

### DIFF
--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,26 +1,22 @@
-{ stdenv, binutils, cmake, fetchFromGitHub }:
+{ stdenv, binutils, cmake, zlib, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "2017-10-05";
+  version = "2018-05-22";
   name = "bloaty-${version}";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "bloaty";
-    rev = "e47b21b01ceecf001e1965e9da249d48d86a1749";
-    sha256 = "1il3z49hi0b07agjwr5fg1wzysfxsamfv1snvlp33vrlyl1m7cbm";
+    rev = "054788b091ccfd43b05b9817062139145096d440";
+    sha256 = "0pmv66137ipzsjjdz004n61pz3aipjhh3b0w0y1406clqpwkvpjm";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];
 
-  enableParallelBuilding = true;
+  buildInputs = [ zlib ];
 
-  preConfigure = ''
-    substituteInPlace src/bloaty.cc \
-      --replace "c++filt" \
-                "${binutils.bintools}/bin/c++filt"
-  '';
+  enableParallelBuilding = true;
 
   doCheck = true;
 


### PR DESCRIPTION
* add zlib dep (cmake tries to find it, provide it JIC)
* no need to populate with path to c++filt, handled internally now
* continue to copy ourselves, new install target isn't ready yet




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---