### PR TITLE
springlobby: 0.255 -> 0.264 with buildFHSUserEnv

### DIFF
--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -1,46 +1,67 @@
 { stdenv, fetchurl, cmake, wxGTK30, openal, pkgconfig, curl, libtorrentRasterbar
 , libpng, libX11, gettext, bash, gawk, boost, libnotify, gtk2, doxygen
-, makeWrapper, glib, minizip, alure, pcre, jsoncpp, buildFHSUserEnv, SDL2, libGLU, curlFull }:
-let
-  version = "0.264";
+, makeWrapper, glib, minizip, alure, pcre, jsoncpp, buildFHSUserEnv, SDL2
+, libGLU, curlFull }:
 
-  meta = with stdenv.lib; {
-    homepage = http://springlobby.info/;
-    repositories.git = git://github.com/springlobby/springlobby.git;
-    description = "Cross-platform lobby client for the Spring RTS project";
-    license = licenses.gpl2;
-    maintainers = with maintainers; [ phreedom qknight domenkozar ];
-    platforms = platforms.linux;
-  };
+let
   springlobby = stdenv.mkDerivation rec {
     name = "springlobby-${version}";
-    inherit version;
-    inherit meta;
+    version = "0.264";
 
     src = fetchurl {
       url = "http://www.springlobby.info/tarballs/springlobby-${version}.tar.bz2";
       sha256 = "5d3c98169a4c9106dd6f112823cfa0e44846cedca3920050151472bfb75561c4";
     };
 
-    nativeBuildInputs = [ pkgconfig ];
+    nativeBuildInputs = [
+      cmake
+      doxygen
+      makeWrapper
+      pkgconfig
+    ];
+    
     buildInputs = [
-      cmake wxGTK30 openal curl gettext libtorrentRasterbar pcre jsoncpp
-      boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
+      alure
+      boost
+      curl
+      doxygen
+      gettext
+      glib
+      gtk2
+      jsoncpp
+      libX11
+      libnotify
+      libpng
+      libtorrentRasterbar
+      minizip
+      openal
+      pcre
+      wxGTK30
     ];
 
-    patches = [ ./revert_58b423e.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
+    patches = [
+      # Allows springLobby to continue using system installed spring until
+      # https://github.com/springlobby/springlobby/issues/707 is fixed:
+      ./revert_58b423e.patch
+    ];
 
     enableParallelBuilding = true;
 
-    postInstall = ''
-      wrapProgram $out/bin/springlobby
-    '';
-
+    postInstall = "wrapProgram $out/bin/springlobby";
+    
+    meta = with stdenv.lib; {
+      description = "Cross-platform lobby client for the Spring RTS project";
+      homepage = http://springlobby.info/;
+      license = licenses.gpl2Plus;
+      maintainers = with maintainers; [ phreedom qknight domenkozar ];
+      platforms = platforms.linux;
+    };
   };
 in
-  buildFHSUserEnv {
-    name = "springlobby";
-    targetPkgs = pkgs: [ springlobby SDL2 libGLU openal curlFull ];
-    runScript = "springlobby";
-    inherit meta;
-  }
+
+buildFHSUserEnv {
+  name = "springlobby";
+  targetPkgs = _: [ curlFull libGLU openal SDL2 springlobby ];
+  runScript = "springlobby";
+  inherit (springlobby) meta;
+}

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -1,31 +1,8 @@
 { stdenv, fetchurl, cmake, wxGTK30, openal, pkgconfig, curl, libtorrentRasterbar
-, libpng, libX11, gettext, bash, gawk, boost, libnotify, gtk2, doxygen, spring
-, makeWrapper, glib, minizip, alure, pcre, jsoncpp }:
-
-stdenv.mkDerivation rec {
-  name = "springlobby-${version}";
-  version = "0.255";
-
-  src = fetchurl {
-    url = "http://www.springlobby.info/tarballs/springlobby-${version}.tar.bz2";
-    sha256 = "12iv6h1mz998lzxc2jwkza0m1yvaaq8h05k36i85xyp7g90197jw";
-  };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    cmake wxGTK30 openal curl gettext libtorrentRasterbar pcre jsoncpp
-    boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
-  ];
-
-  patches = [ ./revert_58b423e.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
-
-  enableParallelBuilding = true;
-
-  postInstall = ''
-    wrapProgram $out/bin/springlobby \
-      --prefix PATH : "${spring}/bin" \
-      --set SPRING_BUNDLE_DIR "${spring}/lib"
-  '';
+, libpng, libX11, gettext, bash, gawk, boost, libnotify, gtk2, doxygen
+, makeWrapper, glib, minizip, alure, pcre, jsoncpp, buildFHSUserEnv, SDL2, libGLU, curlFull }:
+let
+  version = "0.264";
 
   meta = with stdenv.lib; {
     homepage = http://springlobby.info/;
@@ -35,4 +12,35 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ phreedom qknight domenkozar ];
     platforms = platforms.linux;
   };
-}
+  springlobby = stdenv.mkDerivation rec {
+    name = "springlobby-${version}";
+    inherit version;
+    inherit meta;
+
+    src = fetchurl {
+      url = "http://www.springlobby.info/tarballs/springlobby-${version}.tar.bz2";
+      sha256 = "5d3c98169a4c9106dd6f112823cfa0e44846cedca3920050151472bfb75561c4";
+    };
+
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [
+      cmake wxGTK30 openal curl gettext libtorrentRasterbar pcre jsoncpp
+      boost libpng libX11 libnotify gtk2 doxygen makeWrapper glib minizip alure
+    ];
+
+    patches = [ ./revert_58b423e.patch ]; # Allows springLobby to continue using system installed spring until #707 is fixed
+
+    enableParallelBuilding = true;
+
+    postInstall = ''
+      wrapProgram $out/bin/springlobby
+    '';
+
+  };
+in
+  buildFHSUserEnv {
+    name = "springlobby";
+    targetPkgs = pkgs: [ springlobby SDL2 libGLU openal curlFull ];
+    runScript = "springlobby";
+    inherit meta;
+  }


### PR DESCRIPTION
###### Motivation for this change

This allows to drop the dependency on spring, which is
currently broken and to use spring versions downloaded by
springlobby instead

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

