### PR TITLE
dockerTools: fixes extraCommands for mkRootLayer.

### DIFF
--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -45,5 +45,11 @@ import ./make-test.nix ({ pkgs, ... }: {
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.onTopOfPulledImage}'");
       $docker->succeed("docker run --rm ontopofpulledimage hello");
       $docker->succeed("docker rmi ontopofpulledimage");
+
+      # Regression test for issue #34779
+      $docker->succeed("docker load --input='${pkgs.dockerTools.examples.runAsRootExtraCommands}'");
+      $docker->succeed("docker run --rm runasrootextracommands cat extraCommands");
+      $docker->succeed("docker run --rm runasrootextracommands cat runAsRoot");
+      $docker->succeed("docker rmi '${pkgs.dockerTools.examples.runAsRootExtraCommands.imageName}'");
     '';
 })

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -360,7 +360,9 @@ rec {
     extraCommands ? ""
   }:
     # Generate an executable script from the `runAsRoot` text.
-    let runAsRootScript = shellScript "run-as-root.sh" runAsRoot;
+    let
+      runAsRootScript = shellScript "run-as-root.sh" runAsRoot;
+      extraCommandsScript = shellScript "extra-commands.sh" extraCommands;
     in runWithOverlay {
       name = "docker-layer-${name}";
 
@@ -398,7 +400,7 @@ rec {
       '';
 
       postUmount = ''
-        (cd layer; eval "${extraCommands}")
+        (cd layer; ${extraCommandsScript})
 
         echo "Packing layer..."
         mkdir $out

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -124,4 +124,16 @@ rec {
     fromImage = nixFromDockerHub;
     contents = [ pkgs.hello ];
   };
+
+  # 8. regression test for erroneous use of eval and string expansion.
+  # See issue #34779 and PR #40947 for details.
+  runAsRootExtraCommands = pkgs.dockerTools.buildImage {
+    name = "runAsRootExtraCommands";
+    contents = [ pkgs.coreutils ];
+    # The parens here are to create problematic bash to embed and eval. In case
+    # this is *embedded* into the script (with nix expansion) the initial quotes
+    # will close the string and the following parens are unexpected
+    runAsRoot = ''echo "(runAsRoot)" > runAsRoot'';
+    extraCommands = ''echo "(extraCommand)" > extraCommands'';
+  };
 }


### PR DESCRIPTION
The extraCommands was, previously, simply put in the body of the script
using nix expansion `${extraCommands}` (which looks exactly like bash
expansion!).

This causes issues like in #34779 where scripts will eventually create
invalid bash.

The solution used was to use `$extraCommands` the way `mkPureLayer`
does, by using the variable from the environment instead of expanding
it inside the script.

 * * *

Fixes #34779

###### Motivation for this change

See #34779, this fixes it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ❌ other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- 🆖 Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This was verified using this:

`nix-build -I nixpkgs=/path/to/checkout/of/nixpkgs repro.nix`

Using this `repro.nix`:
```nix
with import <nixpkgs> {};
  dockerTools.buildImageWithNixDb {
    name = "nix";
    contents = [
      coreutils
      nix
    ];
    runAsRoot = ''
      #!${pkgs.stdenv.shell}
      echo "everything is working fine"
    '';
    config = {
      Env = [ "NIX_PAGER=cat" ];
    };
  }
```

This is now verified in a nixos test

```
NIX_PATH=nixpkgs=/path/to/checkout/of/nixpkgs nix-build '<nixpkgs/nixos/tests/docker-tools.nix>'
```

Apply the test before the fix to verify the test tests for regression.

---

*cc @nlewo (who seemed to work on the docker tooling a bunch)*