### PR TITLE
[wip] 0ad: add darwin support

### DIFF
--- a/pkgs/development/tools/misc/premake/default.nix
+++ b/pkgs/development/tools/misc/premake/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     homepage = http://industriousone.com/premake;
     description = "A simple build configuration and project generation tool using lua";
     license = stdenv.lib.licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/games/0ad/data.nix
+++ b/pkgs/games/0ad/data.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     description = "A free, open-source game of ancient warfare -- data files";
     homepage = "https://play0ad.com/";
     license = licenses.cc-by-sa-30;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     hydraPlatforms = [];
   };
 }

--- a/pkgs/games/0ad/default.nix
+++ b/pkgs/games/0ad/default.nix
@@ -1,10 +1,13 @@
-{ wxGTK, newScope }:
+{ wxGTK, newScope, darwin }:
 
 let
   callPackage = newScope self;
 
   self = {
-    zeroad-unwrapped = callPackage ./game.nix { inherit wxGTK; };
+    zeroad-unwrapped = callPackage ./game.nix {
+      inherit wxGTK;
+      inherit (darwin.apple_sdk.frameworks) CoreServices;
+    };
 
     zeroad-data = callPackage ./data.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
This is an attempt to get 0ad working on Darwin/macOS.

Currently fails with:

```
==== Building mocks_real (release) ====
mocks_real.cpp
In file included from source/mocks/mocks_real.cpp:26:
In file included from source/lib/precompiled.h:68:
In file included from source/lib/sysdep/stl.h:78:
In file included from source/lib/sysdep/os/osx/osx_stl_fixes.h:26:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/istream:163:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/ostream:138:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/ios:216:
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:94:20: error: use of undeclared identifier 'LC_COLLATE_MASK'
        collate  = LC_COLLATE_MASK,
                   ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:95:20: error: use of undeclared identifier 'LC_CTYPE_MASK'
        ctype    = LC_CTYPE_MASK,
                   ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:96:20: error: use of undeclared identifier 'LC_MONETARY_MASK'
        monetary = LC_MONETARY_MASK,
                   ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:97:20: error: use of undeclared identifier 'LC_NUMERIC_MASK'
        numeric  = LC_NUMERIC_MASK,
                   ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:98:20: error: use of undeclared identifier 'LC_TIME_MASK'
        time     = LC_TIME_MASK,
                   ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:99:20: error: use of undeclared identifier 'LC_MESSAGES_MASK'
        messages = LC_MESSAGES_MASK,
                   ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:308:5: error: unknown type name 'locale_t'; did you mean 'locale'?
    locale_t __l;
    ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:83:24: note: 'locale' declared here
class _LIBCPP_TYPE_VIS locale
                       ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:327:5: error: unknown type name 'locale_t'; did you mean 'locale'?
    locale_t __l;
    ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:83:24: note: 'locale' declared here
class _LIBCPP_TYPE_VIS locale
                       ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:686:5: error: unknown type name 'locale_t'; did you mean 'locale'?
    locale_t __l;
    ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:83:24: note: 'locale' declared here
class _LIBCPP_TYPE_VIS locale
                       ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:704:5: error: unknown type name 'locale_t'; did you mean 'locale'?
    locale_t __l;
    ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:83:24: note: 'locale' declared here
class _LIBCPP_TYPE_VIS locale
                       ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:936:5: error: unknown type name 'locale_t'; did you mean 'locale'?
    locale_t __l;
    ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__locale:83:24: note: 'locale' declared here
class _LIBCPP_TYPE_VIS locale
                       ^
In file included from source/mocks/mocks_real.cpp:26:
In file included from source/lib/precompiled.h:68:
In file included from source/lib/sysdep/stl.h:78:
In file included from source/lib/sysdep/os/osx/osx_stl_fixes.h:26:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/istream:163:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/ostream:140:
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:739:26: error: use of undeclared identifier 'strtoll_l'
        long long __ll = strtoll_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
                         ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:779:35: error: use of undeclared identifier 'strtoull_l'
        unsigned long long __ll = strtoull_l(__a, &__p2, __base, _LIBCPP_GET_C_LOCALE);
                                  ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:807:12: error: use of undeclared identifier 'strtof_l'
    return strtof_l(__a, __p2, _LIBCPP_GET_C_LOCALE);
           ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:813:12: error: use of undeclared identifier 'strtod_l'
    return strtod_l(__a, __p2, _LIBCPP_GET_C_LOCALE);
           ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:819:12: error: use of undeclared identifier 'strtold_l'; did you mean 'strtoll'?
    return strtold_l(__a, __p2, _LIBCPP_GET_C_LOCALE);
           ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/cstdlib:117:9: note: 'strtoll' declared here
using ::strtoll;
        ^
In file included from source/mocks/mocks_real.cpp:26:
In file included from source/lib/precompiled.h:68:
In file included from source/lib/sysdep/stl.h:78:
In file included from source/lib/sysdep/os/osx/osx_stl_fixes.h:26:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/istream:163:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/ostream:140:
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:1093:9: error: use of undeclared identifier 'sscanf_l'
    if (__libcpp_sscanf_l(__buf.c_str(), _LIBCPP_GET_C_LOCALE, "%p", &__v) != 1)
        ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/__bsd_locale_defaults.h:35:61: note: expanded from macro '__libcpp_sscanf_l'
#define __libcpp_sscanf_l(...)                              sscanf_l(__VA_ARGS__)
                                                            ^
In file included from source/mocks/mocks_real.cpp:26:
In file included from source/lib/precompiled.h:68:
In file included from source/lib/sysdep/stl.h:78:
In file included from source/lib/sysdep/os/osx/osx_stl_fixes.h:26:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/istream:163:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/ostream:140:
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:1198:18: error: use of undeclared identifier 'isxdigit_l'; did you mean 'isxdigit'?
            if (!isxdigit_l(*__ns, _LIBCPP_GET_C_LOCALE))
                 ^
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/cctype:115:9: note: 'isxdigit' declared here
using ::isxdigit;
        ^
In file included from source/mocks/mocks_real.cpp:26:
In file included from source/lib/precompiled.h:68:
In file included from source/lib/sysdep/stl.h:78:
In file included from source/lib/sysdep/os/osx/osx_stl_fixes.h:26:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/istream:163:
In file included from /nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/ostream:140:
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/locale:1198:18: error: too many arguments to function call, expected 1, have 2; did you mean '::std::isxdigit'?
            if (!isxdigit_l(*__ns, _LIBCPP_GET_C_LOCALE))
                 ^~~~~~~~~~
/nix/store/zl3vsrqfwx4xvxagdrdqav73yl53cxps-libc++-5.0.1/include/c++/v1/cctype:115:9: note: '::std::isxdigit' declared here
using ::isxdigit;
        ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[1]: *** [mocks_real.make:139: obj/mocks_real_Release/mocks_real.o] Error 1
make: *** [Makefile:143: mocks_real] Error 2
note: keeping build directory '/private/tmp/nix-build-0ad-0.0.23.drv-5'
builder for '/nix/store/sd2dq7yhs3hqvjdxgpy07pj41frb8m34-0ad-0.0.23.drv' failed with exit code 2
cannot build derivation '/nix/store/qbf6fys0n1cz7wlpfdjwrzk7rxnrizxs-zeroad-0.0.23.drv': 1 dependencies couldn't be built
```

I wonder if anyone has ideas on what's causing this?