### PR TITLE
pythonPackages.clustershell: init at 1.8

### DIFF
--- a/pkgs/development/python-modules/clustershell/default.nix
+++ b/pkgs/development/python-modules/clustershell/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, buildPythonPackage, fetchPypi, pyyaml, openssh
+, nose, bc, hostname, coreutils, bash, gnused
+}:
+
+buildPythonPackage rec {
+  pname = "ClusterShell";
+  version = "1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bm0pq8w2rql9q9i2bhs865rqvb6zck3h3gkb1d0mh59arrr7p4m";
+  };
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  postPatch = ''
+    substituteInPlace lib/ClusterShell/Worker/Ssh.py \
+      --replace '"ssh"' '"${openssh}/bin/ssh"' \
+      --replace '"scp"' '"${openssh}/bin/scp"'
+
+    substituteInPlace lib/ClusterShell/Worker/fastsubprocess.py \
+      --replace '"/bin/sh"' '"${bash}/bin/sh"'
+  '';
+
+  checkInputs = [ nose bc hostname coreutils gnused ];
+
+  # Many tests want to open network connections
+  # https://github.com/cea-hpc/clustershell#test-suite
+  #
+  # Several tests fail on Darwin
+  checkPhase = ''
+    for f in tests/*; do
+      substituteInPlace $f \
+        --replace '/bin/hostname'   '${hostname}/bin/hostname' \
+        --replace '/bin/sleep'      '${coreutils}/bin/sleep' \
+        --replace '"sleep'          '"${coreutils}/bin/sleep' \
+        --replace '/bin/echo'       '${coreutils}/bin/echo' \
+        --replace '/bin/uname'      '${coreutils}/bin/uname' \
+        --replace '/bin/false'      '${coreutils}/bin/false' \
+        --replace '/bin/true'       '${coreutils}/bin/true' \
+        --replace '/usr/bin/printf' '${coreutils}/bin/printf' \
+        --replace '"sed'            '"${gnused}/bin/sed' \
+        --replace ' sed '           ' ${gnused}/bin/sed '
+    done
+
+    rm tests/CLIClushTest.py
+    rm tests/TreeWorkerTest.py
+    rm tests/TaskDistantMixin.py
+    rm tests/TaskDistantTest.py
+    rm tests/TaskDistantPdshMixin.py
+    rm tests/TaskDistantPdshTest.py
+    rm tests/TaskRLimitsTest.py
+
+    nosetests -v \
+      -e test_channel_ctl_shell_remote1 \
+      -e test_channel_ctl_shell_remote2 \
+      -e test_fromall_grouplist \
+      -e test_rank_placeholder \
+      -e test_engine_on_the_fly_launch \
+      -e test_ev_pickup_fanout \
+      -e test_ev_pickup_fanout_legacy \
+      -e test_timeout \
+      -e test_008_broken_pipe_on_write \
+      -e testLocalBufferRCGathering \
+      -e testLocalBuffers \
+      -e testLocalErrorBuffers \
+      -e testLocalFanout \
+      -e testLocalRetcodes \
+      -e testLocalRCBufferGathering \
+      -e testLocalSingleLineBuffers \
+      -e testLocalWorkerFanout \
+      -e testSimpleMultipleCommands \
+      -e testClushConfigSetRlimit  \
+      -e testTimerInvalidateInHandler \
+      -e testTimerSetNextFireInHandler \
+      -e test_channel_ctl_shell_mlocal1 \
+      -e test_channel_ctl_shell_mlocal2 \
+      -e test_channel_ctl_shell_mlocal3 \
+      -e test_node_placeholder \
+    tests/*.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Scalable Python framework for cluster administration";
+    homepage = https://cea-hpc.github.io/clustershell;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.alexvorobiev ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -225,6 +225,8 @@ in {
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };
 
+  clustershell = callPackage ../development/python-modules/clustershell { };
+
   dendropy = callPackage ../development/python-modules/dendropy { };
 
   dbf = callPackage ../development/python-modules/dbf { };


### PR DESCRIPTION
###### Motivation for this change
NixOS derivation for ClusterShell (http://clustershell.readthedocs.io/en/latest/intro.html)

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

