### PR TITLE
llvm, top-level: Baby steps towards cross support

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, bash, which, m4, python, bison, flex, llvmPackages, clangWrapSelf,
+{stdenv, fetchFromGitHub, bash, which, m4, python, bison, flex, llvmPackages,
 testedTargets ? ["sse2" "host"] # the default test target is sse4, but that is not supported by all Hydra agents
 }:
 

--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -1,5 +1,5 @@
 { newScope, stdenv, libstdcxxHook, cmake, libxml2, python2, isl, fetchurl
-, overrideCC, wrapCC, ccWrapperFun, darwin
+, overrideCC, wrapCCWith, darwin
 }:
 
 let
@@ -27,17 +27,13 @@ let
 
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    libstdcxxClang = ccWrapperFun {
+    libstdcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ libstdcxxHook ];
     };
 
-    libcxxClang = ccWrapperFun {
+    libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 

--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -1,5 +1,7 @@
 { newScope, stdenv, libstdcxxHook, cmake, libxml2, python2, isl, fetchurl
 , overrideCC, wrapCCWith, darwin
+, buildLlvmPackages # ourself, but from the previous stage, for cross
+, targetLlvmPackages # ourself, but from the next stage, for cross
 }:
 
 let
@@ -34,7 +36,7 @@ let
 
     libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      extraPackages = [ self.libcxx self.libcxxabi ];
+      extraPackages = [ targetLlvmPackages.libcxx targetLlvmPackages.libcxxabi ];
     };
 
     stdenv = stdenv.override (drv: {
@@ -44,7 +46,7 @@ let
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
-      cc = self.libcxxClang;
+      cc = buildLlvmPackages.libcxxClang;
     });
 
     lldb = callPackage ./lldb.nix {};

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -1,4 +1,8 @@
-{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCCWith, darwin }:
+{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCCWith, darwin
+, buildLlvmPackages # ourself, but from the previous stage, for cross
+, targetLlvmPackages # ourself, but from the next stage, for cross
+}:
+
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
@@ -33,7 +37,7 @@ let
 
     libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      extraPackages = [ self.libcxx self.libcxxabi ];
+      extraPackages = [ targetLlvmPackages.libcxx targetLlvmPackages.libcxxabi ];
     };
 
     stdenv = stdenv.override (drv: {
@@ -43,7 +47,7 @@ let
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
-      cc = self.libcxxClang;
+      cc = buildLlvmPackages.libcxxClang;
     });
 
     lldb = callPackage ./lldb.nix {};

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun, darwin }:
+{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCCWith, darwin }:
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
@@ -26,17 +26,13 @@ let
 
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    libstdcxxClang = ccWrapperFun {
+    libstdcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ libstdcxxHook ];
     };
 
-    libcxxClang = ccWrapperFun {
+    libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -1,4 +1,8 @@
-{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCCWith, darwin }:
+{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCCWith, darwin
+, buildLlvmPackages # ourself, but from the previous stage, for cross
+, targetLlvmPackages # ourself, but from the next stage, for cross
+}:
+
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
@@ -33,7 +37,7 @@ let
 
     libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      extraPackages = [ self.libcxx self.libcxxabi ];
+      extraPackages = [ targetLlvmPackages.libcxx targetLlvmPackages.libcxxabi ];
     };
 
     stdenv = stdenv.override (drv: {
@@ -43,7 +47,7 @@ let
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
-      cc = self.libcxxClang;
+      cc = buildLlvmPackages.libcxxClang;
     });
 
     lldb = callPackage ./lldb.nix {};

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -1,4 +1,4 @@
-{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun, darwin }:
+{ newScope, stdenv, libstdcxxHook, isl, fetchurl, overrideCC, wrapCCWith, darwin }:
 let
   callPackage = newScope (self // { inherit stdenv isl version fetch; });
 
@@ -26,17 +26,13 @@ let
 
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    libstdcxxClang = ccWrapperFun {
+    libstdcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ libstdcxxHook ];
     };
 
-    libcxxClang = ccWrapperFun {
+    libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,6 +1,8 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
 , libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , darwin
+, buildLlvmPackages # ourself, but from the previous stage, for cross
+, targetLlvmPackages # ourself, but from the next stage, for cross
 }:
 
 let
@@ -47,7 +49,7 @@ let
 
     libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      extraPackages = [ self.libcxx self.libcxxabi ];
+      extraPackages = [ targetLlvmPackages.libcxx targetLlvmPackages.libcxxabi ];
     };
 
     stdenv = stdenv.override (drv: {
@@ -57,7 +59,7 @@ let
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
-      cc = self.libcxxClang;
+      cc = buildLlvmPackages.libcxxClang;
     });
 
     lld = callPackage ./lld.nix {};

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
-, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , darwin
 }:
 
@@ -40,17 +40,13 @@ let
 
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    libstdcxxClang = ccWrapperFun {
+    libstdcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ libstdcxxHook ];
     };
 
-    libcxxClang = ccWrapperFun {
+    libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,6 +1,8 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
 , libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , darwin
+, buildLlvmPackages # ourself, but from the previous stage, for cross
+, targetLlvmPackages # ourself, but from the next stage, for cross
 }:
 
 let
@@ -47,7 +49,7 @@ let
 
     libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      extraPackages = [ self.libcxx self.libcxxabi ];
+      extraPackages = [ targetLlvmPackages.libcxx targetLlvmPackages.libcxxabi ];
     };
 
     stdenv = stdenv.override (drv: {
@@ -57,7 +59,7 @@ let
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
-      cc = self.libcxxClang;
+      cc = buildLlvmPackages.libcxxClang;
     });
 
     lld = callPackage ./lld.nix {};

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
-, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , darwin
 }:
 
@@ -40,17 +40,13 @@ let
 
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    libstdcxxClang = ccWrapperFun {
+    libstdcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ libstdcxxHook ];
     };
 
-    libcxxClang = ccWrapperFun {
+    libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,6 +1,8 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
 , libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , darwin
+, buildLlvmPackages # ourself, but from the previous stage, for cross
+, targetLlvmPackages # ourself, but from the next stage, for cross
 }:
 
 let
@@ -47,7 +49,7 @@ let
 
     libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      extraPackages = [ self.libcxx self.libcxxabi ];
+      extraPackages = [ targetLlvmPackages.libcxx targetLlvmPackages.libcxxabi ];
     };
 
     stdenv = stdenv.override (drv: {
@@ -57,7 +59,7 @@ let
 
     libcxxStdenv = stdenv.override (drv: {
       allowedRequisites = null;
-      cc = self.libcxxClang;
+      cc = buildLlvmPackages.libcxxClang;
     });
 
     lld = callPackage ./lld.nix {};

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,5 +1,5 @@
 { lowPrio, newScope, stdenv, targetPlatform, cmake, libstdcxxHook
-, libxml2, python2, isl, fetchurl, overrideCC, wrapCC, ccWrapperFun
+, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
 , darwin
 }:
 
@@ -40,17 +40,13 @@ let
 
     clang = if stdenv.cc.isGNU then self.libstdcxxClang else self.libcxxClang;
 
-    libstdcxxClang = ccWrapperFun {
+    libstdcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ libstdcxxHook ];
     };
 
-    libcxxClang = ccWrapperFun {
+    libcxxClang = wrapCCWith {
       cc = self.clang-unwrapped;
-      /* FIXME is this right? */
-      inherit (stdenv.cc) bintools libc nativeTools nativeLibc;
       extraPackages = [ self.libcxx self.libcxxabi ];
     };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6996,42 +6996,46 @@ with pkgs;
 
   wla-dx = callPackage ../development/compilers/wla-dx { };
 
-  wrapCCWith = { name ? "", cc, bintools, libc, extraBuildCommands ? "" }:
-      ccWrapperFun rec {
+  wrapCCWith =
+    { cc
+    , # This should be the only bintools runtime dep with this sort of logic. The
+      # Others should instead delegate to the next stage's choice with
+      # `targetPackages.stdenv.cc.bintools`. This one is different just to
+      # provide the default choice, avoiding infinite recursion.
+      bintools ? if targetPlatform.isDarwin then darwin.binutils else binutils
+    , libc ? bintools.libc
+    , ...
+    } @ extraArgs:
+      callPackage ../build-support/cc-wrapper (let self = {
     nativeTools = targetPlatform == hostPlatform && stdenv.cc.nativeTools or false;
     nativeLibc = targetPlatform == hostPlatform && stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
-    noLibc = !nativeLibc && (libc == null);
+    noLibc = !self.nativeLibc && (self.libc == null);
 
     isGNU = cc.isGNU or false;
     isClang = cc.isClang or false;
 
-    inherit name cc bintools libc extraBuildCommands;
-  };
-
-  ccWrapperFun = callPackage ../build-support/cc-wrapper;
-  bintoolsWrapperFun = callPackage ../build-support/bintools-wrapper;
+    inherit cc bintools libc;
+  } // extraArgs; in self);
 
   wrapCC = cc: wrapCCWith {
-    name = lib.optionalString (targetPlatform != hostPlatform) "gcc-cross-wrapper";
     inherit cc;
-    # This should be the only bintools runtime dep with this sort of logic. The
-    # Others should instead delegate to the next stage's choice with
-    # `targetPackages.stdenv.cc.bintools`. This one is different just to
-    # provide the default choice, avoiding infinite recursion.
-    bintools = if targetPlatform.isDarwin then darwin.binutils else binutils;
-    libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
   };
 
-  wrapBintoolsWith = { bintools, libc, extraBuildCommands ? "" }: bintoolsWrapperFun {
+  wrapBintoolsWith =
+    { bintools
+    , libc ? if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc
+    , ...
+    } @ extraArgs:
+      callPackage ../build-support/bintools-wrapper (let self = {
     nativeTools = targetPlatform == hostPlatform && stdenv.cc.nativeTools or false;
     nativeLibc = targetPlatform == hostPlatform && stdenv.cc.nativeLibc or false;
     nativePrefix = stdenv.cc.nativePrefix or "";
 
-    noLibc = (libc == null);
+    noLibc = (self.libc == null);
 
-    inherit bintools libc extraBuildCommands;
-  };
+    inherit bintools libc;
+  } // extraArgs; in self);
 
   # prolog
   yap = callPackage ../development/compilers/yap { };
@@ -7637,11 +7641,9 @@ with pkgs;
     noSysDirs = (targetPlatform != buildPlatform) || noSysDirs;
   };
   binutils = wrapBintoolsWith {
-    libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
     bintools = binutils-unwrapped;
   };
   binutils_nogold = lowPrio (wrapBintoolsWith {
-    libc = if targetPlatform != hostPlatform then libcCross else stdenv.cc.libc;
     bintools = binutils-unwrapped.override {
       gold = false;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6056,18 +6056,6 @@ with pkgs;
 
   clang-analyzer = callPackage ../development/tools/analysis/clang-analyzer { };
 
-  clangSelf = clangWrapSelf llvmPackagesSelf.clang;
-
-  clangWrapSelf = build: ccWrapperFun {
-    cc = build;
-    isClang = true;
-    inherit stdenvNoCC;
-    inherit (targetPackages.stdenv.cc) bintools libc;
-    extraPackages = [ libcxx libcxxabi ];
-    nativeTools = false;
-    nativeLibc = false;
-  };
-
   #Use this instead of stdenv to build with clang
   clangStdenv = if stdenv.cc.isClang then stdenv else lowPrio llvmPackages.stdenv;
   clang-sierraHack-stdenv = overrideCC stdenv clang-sierraHack;
@@ -6703,10 +6691,6 @@ with pkgs;
   llvm_34 = llvmPackages_34.llvm;
 
   llvmPackages = recurseIntoAttrs llvmPackages_5;
-
-  llvmPackagesSelf = llvmPackages_34.override {
-    stdenv = libcxxStdenv;
-  };
 
   llvmPackages_34 = callPackage ../development/compilers/llvm/3.4 ({
     isl = isl_0_12;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6706,30 +6706,40 @@ with pkgs;
 
   llvmPackages_37 = callPackage ../development/compilers/llvm/3.7 ({
     inherit (stdenvAdapters) overrideCC;
+    buildLlvmPackages = buildPackages.llvmPackages_37;
+    targetLlvmPackages = targetPackages.llvmPackages_37;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6;
   });
 
   llvmPackages_38 = callPackage ../development/compilers/llvm/3.8 ({
     inherit (stdenvAdapters) overrideCC;
+    buildLlvmPackages = buildPackages.llvmPackages_38;
+    targetLlvmPackages = targetPackages.llvmPackages_38;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6;
   });
 
   llvmPackages_39 = callPackage ../development/compilers/llvm/3.9 ({
     inherit (stdenvAdapters) overrideCC;
+    buildLlvmPackages = buildPackages.llvmPackages_39;
+    targetLlvmPackages = targetPackages.llvmPackages_39;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6;
   });
 
   llvmPackages_4 = callPackage ../development/compilers/llvm/4 ({
     inherit (stdenvAdapters) overrideCC;
+    buildLlvmPackages = buildPackages.llvmPackages_4;
+    targetLlvmPackages = targetPackages.llvmPackages_4;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6;
   });
 
   llvmPackages_5 = callPackage ../development/compilers/llvm/5 ({
     inherit (stdenvAdapters) overrideCC;
+    buildLlvmPackages = buildPackages.llvmPackages_5;
+    targetLlvmPackages = targetPackages.llvmPackages_5;
   } // stdenv.lib.optionalAttrs stdenv.isDarwin {
     cmake = cmake.override {
       isBootstrap = true;
@@ -6743,6 +6753,8 @@ with pkgs;
 
   llvmPackages_6 = callPackage ../development/compilers/llvm/6 ({
     inherit (stdenvAdapters) overrideCC;
+    buildLlvmPackages = buildPackages.llvmPackages_6;
+    targetLlvmPackages = targetPackages.llvmPackages_6;
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });


### PR DESCRIPTION
###### Motivation for this change

Tried to do what I could while preserving hashes (always a good test!). 

 - Less wrapper "helper" function madness
 - Clang wrapper and stdenvs at least try to refer to adjacent stages.
 - Removed some old dead clean stuff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

