### PR TITLE
openssh: 7.6p1 -> 7.7p1

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -12,26 +12,27 @@ let
   # **please** update this patch when you update to a new openssh release.
   gssapiPatch = fetchpatch {
     name = "openssh-gssapi.patch";
-    url = "https://anonscm.debian.org/cgit/pkg-ssh/openssh.git/plain/debian"
-        + "/patches/gssapi.patch?id=1e0d55f9163793742d20eaadd4784db16fd3459d";
-    sha256 = "130phj87q87p9crigd6852nnaqsqkfg09h45a32lk4524h9kkxgb";
+    url = "https://salsa.debian.org/ssh-team/openssh/raw/"
+      + "e395eed38096fcda74398424ea94de3ec44effd5"
+      + "/debian/patches/gssapi.patch";
+    sha256 = "0x7xysgdahb4jaq0f28g2d7yzp0d3mh59i4xnffszvjndhvbk27x";
   };
 
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "openssh-${version}";
-  version = if hpnSupport then "7.6p1" else "7.6p1";
+  version = if hpnSupport then "7.7p1" else "7.7p1";
 
   src = if hpnSupport then
       fetchurl {
-        url = "https://github.com/rapier1/openssh-portable/archive/hpn-KitchenSink-7_6_P1.tar.gz";
-        sha256 = "15b1zjk9f3jlxji1vpqfla40cnzy8hv2clk925cvpgz7lqgv4a1d";
+        url = "https://github.com/rapier1/openssh-portable/archive/hpn-KitchenSink-7_7_P1.tar.gz";
+        sha256 = "1l4k8mg3gnzxbz53cma8s6ak56waz03ijsr08p8vgpi0c2rc5ri5";
       }
     else
       fetchurl {
         url = "mirror://openbsd/OpenSSH/portable/${name}.tar.gz";
-        sha256 = "08qpsb8mrzcx8wgvz9insiyvq7sbg26yj5nvl2m5n57yvppcl8x3";
+        sha256 = "13vbbrvj3mmfhj83qyrg5c0ipr6bzw5s65dy4k8gr7p9hkkfffyp";
       };
 
   patches =

--- a/pkgs/tools/networking/openssh/dont_create_privsep_path.patch
+++ b/pkgs/tools/networking/openssh/dont_create_privsep_path.patch
@@ -1,11 +1,12 @@
-diff -ur openssh-7.2p2_orig/Makefile.in openssh-7.2p2/Makefile.in
---- openssh-7.2p2_orig/Makefile.in	2016-03-09 19:04:48.000000000 +0100
-+++ openssh-7.2p2/Makefile.in	2016-07-16 09:56:05.643903293 +0200
-@@ -301,7 +301,6 @@
- 	$(srcdir)/mkinstalldirs $(DESTDIR)$(mandir)/$(mansubdir)5
- 	$(srcdir)/mkinstalldirs $(DESTDIR)$(mandir)/$(mansubdir)8
- 	$(srcdir)/mkinstalldirs $(DESTDIR)$(libexecdir)
--	(umask 022 ; $(srcdir)/mkinstalldirs $(DESTDIR)$(PRIVSEP_PATH))
+diff --git i/Makefile.in w/Makefile.in
+index 04e1c8e5..9bd5d01b 100644
+--- i/Makefile.in
++++ w/Makefile.in
+@@ -329,7 +329,6 @@ install-files:
+ 	$(MKDIR_P) $(DESTDIR)$(mandir)/$(mansubdir)5
+ 	$(MKDIR_P) $(DESTDIR)$(mandir)/$(mansubdir)8
+ 	$(MKDIR_P) $(DESTDIR)$(libexecdir)
+-	$(MKDIR_P) -m 0755 $(DESTDIR)$(PRIVSEP_PATH)
  	$(INSTALL) -m 0755 $(STRIP_OPT) ssh$(EXEEXT) $(DESTDIR)$(bindir)/ssh$(EXEEXT)
  	$(INSTALL) -m 0755 $(STRIP_OPT) scp$(EXEEXT) $(DESTDIR)$(bindir)/scp$(EXEEXT)
  	$(INSTALL) -m 0755 $(STRIP_OPT) ssh-add$(EXEEXT) $(DESTDIR)$(bindir)/ssh-add$(EXEEXT)

--- a/pkgs/tools/networking/openssh/locale_archive.patch
+++ b/pkgs/tools/networking/openssh/locale_archive.patch
@@ -1,15 +1,15 @@
-diff --git a/session.c b/session.c
-index e032de6..44db2bb 100644
---- a/session.c
-+++ b/session.c
-@@ -1196,6 +1196,10 @@ do_setup_env(Session *s, const char *shell)
+diff --git i/session.c w/session.c
+index 58826db1..658dd911 100644
+--- i/session.c
++++ w/session.c
+@@ -1053,6 +1053,10 @@ do_setup_env(struct ssh *ssh, Session *s, const char *shell)
  	if (getenv("TZ"))
  		child_set_env(&env, &envsize, "TZ", getenv("TZ"));
  
-+  /* NixOS path to the glibc locale archive, to be set in the upstart job */
++	/* NixOS path to the glibc locale archive, to be set in the systemd job */
 +	if (getenv("LOCALE_ARCHIVE"))
 +		child_set_env(&env, &envsize, "LOCALE_ARCHIVE", getenv("LOCALE_ARCHIVE"));
 +
- 	/* Set custom environment options from RSA authentication. */
- 	if (!options.use_login) {
- 		while (custom_environment) {
+ 	/* Set custom environment options from pubkey authentication. */
+ 	if (options.permit_user_env) {
+ 		for (n = 0 ; n < auth_opts->nenv; n++) {


### PR DESCRIPTION
Release notes at https://www.openssh.com/txt/release-7.7;
primarily bugfixes.

Update ssh-hpn as well.

Switch to salsa.debian.org (from anonscm.debian.org) (helps with #39927).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).