### PR TITLE
Remove "free and secure" from Discord description

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     };
 
     meta = with stdenv.lib; {
-        description = "All-in-one voice and text chat for gamers that’s free, secure, and works on both your desktop and phone";
+        description = "All-in-one voice and text chat for gamers";
         homepage = https://discordapp.com/;
         downloadPage = "https://github.com/crmarsh/discord-linux-bugs";
         license = licenses.unfree;

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     };
 
     meta = with stdenv.lib; {
-        description = "All-in-one voice and text chat for gamers";
+        description = "All-in-one cross-platform voice and text chat for gamers";
         homepage = https://discordapp.com/;
         downloadPage = "https://github.com/crmarsh/discord-linux-bugs";
         license = licenses.unfree;


### PR DESCRIPTION
Changed Discord package description to remove "free and secure". We can't vouch for its security, but it's not "free" in the sense that most users would read this description. Haven't tested this locally since it's only changing a package description.