### PR TITLE
inav: init at 2.0.0-rc2; betaflight: 3.2.3 -> 3.4.0-rc4

### DIFF
--- a/pkgs/development/misc/stm32/betaflight/default.nix
+++ b/pkgs/development/misc/stm32/betaflight/default.nix
@@ -1,18 +1,17 @@
 { stdenv, fetchFromGitHub
 , gcc-arm-embedded, python2
 , skipTargets ? [
-  # These targets do not build for various unexplored reasons
-  # TODO ... fix them
-  "AFROMINI"
-  "ALIENWHOOP"
-  "BEEBRAIN"
-  "CJMCU"
-  "FRSKYF3"
+  # These targets do not build, for the reasons listed, along with the last version checked.
+  # Probably all of the issues with these targets need to be addressed upstream.
+  "AG3X"       # 3.4.0-rc4: has not specified a valid STM group, must be one of F1, F3, F405, F411 or F7x5. Have you prepared a valid target.mk?
+  "ALIENWHOOP" # 3.4.0-rc4: has not specified a valid STM group, must be one of F1, F3, F405, F411 or F7x5. Have you prepared a valid target.mk?
+  "FURYF3"     # 3.4.0-rc4: flash region overflow
+  "OMNINXT"    # 3.4.0-rc4: has not specified a valid STM group, must be one of F1, F3, F405, F411 or F7x5. Have you prepared a valid target.mk?
 ]}:
 
 let
 
-  version = "3.2.3";
+  version = "3.4.0-rc4";
 
 in stdenv.mkDerivation rec {
 
@@ -21,8 +20,8 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "betaflight";
     repo = "betaflight";
-    rev = "v${version}";
-    sha256 = "0vbjyxfjxgpaiiwvj5bscrlfikzp3wnxpmc4sxcz5yw5mwb9g428";
+    rev = "8e9e7574481b1abba9354b24f41eb31054943785"; # Always use a commit id here!
+    sha256 = "1wyp23p876xbfi9z6gm4xn1nwss3myvrjjjq9pd3s0vf5gkclkg5";
   };
 
   buildInputs = [
@@ -31,7 +30,7 @@ in stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    sed -ri "s/REVISION.*=.*git log.*/REVISION = ${builtins.substring 0 9 src.rev}/" Makefile # Let's not require git in shell
+    sed -ri "s/REVISION.*=.*git log.*/REVISION = ${builtins.substring 0 10 src.rev}/" Makefile # Simulate abbrev'd rev.
     sed -ri "s/binary hex/hex/" Makefile # No need for anything besides .hex
   '';
 
@@ -39,7 +38,7 @@ in stdenv.mkDerivation rec {
 
   preBuild = ''
     buildFlagsArray=(
-      "SKIP_TARGETS=${toString skipTargets}"
+      "NOBUILD_TARGETS=${toString skipTargets}"
       "GCC_REQUIRED_VERSION=$(arm-none-eabi-gcc -dumpversion)"
       all
     )
@@ -59,7 +58,7 @@ in stdenv.mkDerivation rec {
     homepage = https://github.com/betaflight/betaflight;
     license = licenses.gpl3;
     maintainers = with maintainers; [ elitak ];
-    platforms = platforms.linux;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 
 }

--- a/pkgs/development/misc/stm32/inav/default.nix
+++ b/pkgs/development/misc/stm32/inav/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchFromGitHub
+, gcc-arm-embedded, ruby
+}:
+
+let
+
+  version = "2.0.0-rc2";
+
+in stdenv.mkDerivation rec {
+
+  name = "inav-${version}";
+
+  src = fetchFromGitHub {
+    owner = "iNavFlight";
+    repo = "inav";
+    rev = "a8415e89c2956d133d8175827c079bcf3bc3766c"; # Always use a commit id here!
+    sha256 = "15zai8qf43b06fmws1sbkmdgip51zp7gkfj7pp9b6gi8giarzq3y";
+  };
+
+  buildInputs = [
+    gcc-arm-embedded
+    ruby
+  ];
+
+  postPatch = ''
+    sed -ri "s/REVISION.*=.*shell git.*/REVISION = ${builtins.substring 0 10 src.rev}/" Makefile # Simulate abbrev'd rev.
+    sed -ri "s/-j *[0-9]+//" Makefile # Eliminate parallel build args in submakes
+    sed -ri "s/binary hex/hex/" Makefile # No need for anything besides .hex
+  '';
+
+  enableParallelBuilding = true;
+
+  preBuild = ''
+    buildFlagsArray=(
+      all
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp obj/*.hex $out
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Navigation-enabled flight control software";
+    homepage = https://inavflight.github.io;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ elitak ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7688,6 +7688,8 @@ with pkgs;
     guile = guile_2_0;
   };
 
+  inav = callPackage ../development/misc/stm32/inav { };
+
   pharo-vms = callPackage ../development/pharo/vm { };
   pharo = pharo-vms.multi-vm-wrapper;
   pharo-cog32 = pharo-vms.cog32;


### PR DESCRIPTION
###### Motivation for this change
betaflight version bump and inav init (fork of betaflight with almost identical build)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

