### PR TITLE
Slimserver: Fix media scanning & transcoding (backport)

### DIFF
--- a/nixos/modules/services/audio/slimserver.nix
+++ b/nixos/modules/services/audio/slimserver.nix
@@ -51,7 +51,8 @@ in {
       serviceConfig = {
         User = "slimserver";
         PermissionsStartOnly = true;
-        ExecStart = "${cfg.package}/slimserver.pl --logdir ${cfg.dataDir}/logs --prefsdir ${cfg.dataDir}/prefs --cachedir ${cfg.dataDir}/cache";
+        # Issue 40589: Disable broken image/video support (audio still works!)
+        ExecStart = "${cfg.package}/slimserver.pl --logdir ${cfg.dataDir}/logs --prefsdir ${cfg.dataDir}/prefs --cachedir ${cfg.dataDir}/cache --noimage --novideo";
       };
     };
 

--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, buildPerlPackage, fetchurl
-, perl, perlPackages }:
+{ stdenv, buildPerlPackage, fetchurl, makeWrapper
+, perl, perlPackages, flac, faad2, sox, lame, monkeysAudio, wavpack }:
 
 buildPerlPackage rec {
   name = "slimserver-${version}";
@@ -11,6 +11,7 @@ buildPerlPackage rec {
   };
 
   buildInputs = [
+    makeWrapper
     perl
     perlPackages.AnyEvent
     perlPackages.AudioScan
@@ -70,17 +71,19 @@ buildPerlPackage rec {
 
   preConfigurePhase = "";
 
-  buildPhase = "
+  buildPhase = ''
     mv lib tmp
     mkdir -p lib/perl5/site_perl
     mv CPAN_used/* lib/perl5/site_perl
     cp -rf tmp/* lib/perl5/site_perl
-  ";
+  '';
 
   doCheck = false;
 
   installPhase = ''
     cp -r . $out
+    wrapProgram $out/slimserver.pl \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ lame flac faad2 sox monkeysAudio wavpack ]}"
   '';
 
   outputs = [ "out" ];


### PR DESCRIPTION
###### Motivation for this change

Backport of #40778 

Fixes some serious bugs in slimserver.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

