### PR TITLE
lxqt: 0.12.0 -> 0.13.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -41,6 +41,18 @@ in
       name = "lxqt";
       bgSupport = true;
       start = ''
+        # Upstream installs default configuration files in
+        # $prefix/share/lxqt instead of $prefix/etc/xdg, (arguably)
+        # giving distributors freedom to ship custom default
+        # configuration files more easily. In order to let the session
+        # manager find them the share subdirectory is added to the
+        # XDG_CONFIG_DIRS environment variable.
+        #
+        # For an explanation see
+        # https://github.com/lxqt/lxqt/issues/1521#issuecomment-405097453
+        #
+        export XDG_CONFIG_DIRS=$XDG_CONFIG_DIRS''${XDG_CONFIG_DIRS:+:}${config.system.path}/share
+
         exec ${pkgs.lxqt.lxqt-session}/bin/startlxqt
       '';
     };
@@ -53,16 +65,11 @@ in
         config.environment.lxqt.excludePackages);
 
     # Link some extra directories in /run/current-system/software/share
-    environment.pathsToLink = [
-      "/share/desktop-directories"
-      "/share/icons"
-      "/share/lxqt"
-    ];
+    environment.pathsToLink = [ "/share" ];
 
     environment.variables.GIO_EXTRA_MODULES = [ "${pkgs.gvfs}/lib/gio/modules" ];
 
     services.upower.enable = config.powerManagement.enable;
   };
-
 
 }

--- a/pkgs/desktops/lxqt/base/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/base/liblxqt/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools,
-  qtx11extras, qttools, qtsvg, libqtxdg, kwindowsystem, xorg }:
+{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras,
+  qttools, qtsvg, libqtxdg, polkit-qt, kwindowsystem, xorg }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "liblxqt";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1852vfbkbpw49i8ad682jhqmnskmc9a90qwpalipgak7m64azg3j";
+    sha256 = "1lbvnx6gg15k7fy1bnv5sjji659f603glblcl8c9psh0m1cjdbll";
   };
 
   nativeBuildInputs = [
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     qtx11extras
     qttools
     qtsvg
+    polkit-qt
     kwindowsystem
     libqtxdg
     xorg.libXScrnSaver
@@ -31,11 +32,12 @@ stdenv.mkDerivation rec {
     "-DPULL_TRANSLATIONS=NO"
     "-DLXQT_ETC_XDG_DIR=/run/current-system/sw/etc/xdg"
   ];
-  
+
   patchPhase = ''
     sed -i 's|set(LXQT_SHARE_DIR .*)|set(LXQT_SHARE_DIR "/run/current-system/sw/share/lxqt")|' CMakeLists.txt
+    sed -i "s|\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}|''${out}/share/polkit-1/actions|" CMakeLists.txt
   '';
-  
+
   meta = with stdenv.lib; {
     description = "Core utility library for all LXQt components";
     homepage = https://github.com/lxqt/liblxqt;

--- a/pkgs/desktops/lxqt/base/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/base/liblxqt/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1852vfbkbpw49i8ad682jhqmnskmc9a90qwpalipgak7m64azg3j";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   
   meta = with stdenv.lib; {
     description = "Core utility library for all LXQt components";
-    homepage = https://github.com/lxde/liblxqt;
+    homepage = https://github.com/lxqt/liblxqt;
     license = licenses.lgpl21Plus;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/base/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/base/libqtxdg/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "libqtxdg-${version}";
-  version = "3.1.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "libqtxdg";
     rev = version;
-    sha256 = "03kdrx5sgrl93yband87n30i0k2mv6dknwdw2adz45j5z9rhd3z6";
+    sha256 = "0lkmwnqk314mlr811rdb96p6i7zg67slxdvd4cdkiwakgbzzaa4m";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/desktops/lxqt/base/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/base/libqtxdg/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "3.1.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = "libqtxdg";
     rev = version;
     sha256 = "03kdrx5sgrl93yband87n30i0k2mv6dknwdw2adz45j5z9rhd3z6";
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Qt implementation of freedesktop.org xdg specs";
-    homepage = https://github.com/lxde/libqtxdg;
+    homepage = https://github.com/lxqt/libqtxdg;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/base/libsysstat/default.nix
+++ b/pkgs/desktops/lxqt/base/libsysstat/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.4.1";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = "libsysstat";
     rev = version;
     sha256 = "0ad5pcr5lq1hvrfijvddvz2fvsmh1phb54wb0f756av0kyiwq0gb";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library used to query system info and statistics";
-    homepage = https://github.com/lxde/libsysstat;
+    homepage = https://github.com/lxqt/libsysstat;
     license = licenses.lgpl21Plus;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/base/lxqt-build-tools/default.nix
+++ b/pkgs/desktops/lxqt/base/lxqt-build-tools/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = "lxqt-build-tools";
     rev = version;
     sha256 = "0dcwzrijmn4sgivmy2zwz3xa4y69pwhranyw0m90g0pp55di2psz";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Various packaging tools and scripts for LXQt applications";
-    homepage = https://github.com/lxde/lxqt-build-tools;
+    homepage = https://github.com/lxqt/lxqt-build-tools;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/libfm-qt/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "0.13.1";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1g8j1lw74qvagqhqsx45b290fjwh3jfl3i0366m0w4la03v0rw5j";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Core library of PCManFM-Qt (Qt binding for libfm)";
-    homepage = https://github.com/lxde/libfm-qt;
+    homepage = https://github.com/lxqt/libfm-qt;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-about/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "13knjxbnq0mh9jgkllarf6rjxkvj2c93l0srnlrqp3939gcpwxh3";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Dialogue window providing information about LXQt and the system it's running on";
-    homepage = https://github.com/lxde/lxqt-about;
+    homepage = https://github.com/lxqt/lxqt-about;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-about/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-about";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "13knjxbnq0mh9jgkllarf6rjxkvj2c93l0srnlrqp3939gcpwxh3";
+    sha256 = "03f53rnn4rkd1xc2q9abnw37aq4sgvpbwhmcnckqyzc87lj6ici0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-admin/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "0dg3gm5m19dc4jarh8xcn0mcnpgxzz7nhy5dzm8chddaa6pdm7vi";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "LXQt system administration tool";
-    homepage = https://github.com/lxde/lxqt-admin;
+    homepage = https://github.com/lxqt/lxqt-admin;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-admin/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, polkit }:
+{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtx11extras, qttools, qtsvg, kwindowsystem, liblxqt, libqtxdg, polkit-qt }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-admin";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0dg3gm5m19dc4jarh8xcn0mcnpgxzz7nhy5dzm8chddaa6pdm7vi";
+    sha256 = "1nsf8sbgmfanvcxw67drhz1wrizkcd0p87jwr1za5rcgd50bi2yy";
   };
 
   nativeBuildInputs = [
@@ -24,8 +24,13 @@ stdenv.mkDerivation rec {
     kwindowsystem
     liblxqt
     libqtxdg
-    polkit
+    polkit-qt
   ];
+
+  patchPhase = ''
+    sed "s|\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}|''${out}/share/polkit-1/actions|" \
+      -i lxqt-admin-user/CMakeLists.txt
+  '';
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];
 

--- a/pkgs/desktops/lxqt/core/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-config/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1ccxkdfhgf40jxiy0132yr9b28skvs9yr8j75w663hnqi6ccn377";
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tools to configure LXQt and the underlying operating system";
-    homepage = https://github.com/lxde/lxqt-config;
+    homepage = https://github.com/lxqt/lxqt-config;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-config/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-config";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1ccxkdfhgf40jxiy0132yr9b28skvs9yr8j75w663hnqi6ccn377";
+    sha256 = "0r5vwkyz0c9b9py3wni4yzkmsvgs6psk9dp1fhfzvbjbknb21bfa";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-globalkeys/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-globalkeys";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "14icyik9x47wi3gfkmkyhag26a2ivyc42f4f8qwdgbr3dcg10b9a";
+    sha256 = "1fmi0n5chnrpbgf7zwzc3hi55r85hkxaq5jylbwaahmxhnb5hdid";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-globalkeys/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "14icyik9x47wi3gfkmkyhag26a2ivyc42f4f8qwdgbr3dcg10b9a";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Daemon used to register global keyboard shortcuts";
-    homepage = https://github.com/lxde/lxqt-globalkeys;
+    homepage = https://github.com/lxqt/lxqt-globalkeys;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-l10n/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-l10n/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = "lxqt-l10n";
     rev = version;
     sha256 = "0q1hzj6sa4wc8sgqqqsqfldjpnvihacfq73agvc2li3q6qi5rr0k";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   
   meta = with stdenv.lib; {
     description = "Translations of LXQt";
-    homepage = https://github.com/lxde/lxqt-l10n;
+    homepage = https://github.com/lxqt/lxqt-l10n;
     license = licenses.lgpl21Plus;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "0pmpdqgnb2dfxw5lirh89j8hnrwwcn2zc64byg4zi0xdvq6qms43";
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The LXQt notification daemon";
-    homepage = https://github.com/lxde/lxqt-notificationd;
+    homepage = https://github.com/lxqt/lxqt-notificationd;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-notificationd/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-notificationd";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0pmpdqgnb2dfxw5lirh89j8hnrwwcn2zc64byg4zi0xdvq6qms43";
+    sha256 = "0vjpl3ipc0hrz255snkp99h6xrlid490ml8jb588rdpfina66sp1";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-openssh-askpass/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "16xcw4yll6i9vij16kdb10s4aq2s57x4yjlwv6d8r75y5gq9iiw6";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GUI to query passwords on behalf of SSH agents";
-    homepage = https://github.com/lxde/lxqt-openssh-askpass;
+    homepage = https://github.com/lxqt/lxqt-openssh-askpass;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-openssh-askpass/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-openssh-askpass";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "16xcw4yll6i9vij16kdb10s4aq2s57x4yjlwv6d8r75y5gq9iiw6";
+    sha256 = "19djmqwk4kj3rxs4h7a471ydcz87j5z4yv8a6pgblvqdkkn0ylk9";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "01xmnb17jpydyfvxwaa6kymzdasnyd94z62gjah8y4pzsmykcr4x";
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The LXQt desktop panel";
-    homepage = https://github.com/lxde/lxqt-panel;
+    homepage = https://github.com/lxqt/lxqt-panel;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-panel/default.nix
@@ -10,13 +10,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-panel";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "01xmnb17jpydyfvxwaa6kymzdasnyd94z62gjah8y4pzsmykcr4x";
+    sha256 = "056khr3smyrdi26zpclwv1qrmk0zxr9cnk65ad9c0xavzk6ya3xz";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1hxz5bxxi118g255aqb3da767va0wd25y671lk2w9r1641j8zf2d";
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The LXQt PolicyKit agent";
-    homepage = https://github.com/lxde/lxqt-policykit;
+    homepage = https://github.com/lxqt/lxqt-policykit;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-policykit/default.nix
@@ -7,13 +7,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-policykit";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1hxz5bxxi118g255aqb3da767va0wd25y671lk2w9r1641j8zf2d";
+    sha256 = "1m9v4hl1hyd8rmlh6z2zy6287qfnavsm9khl526jf8f7bjgpifvd";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-powermanagement/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-powermanagement";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1fxklxmvjaykdpf0nj6cpgwx4yf52087g25k1zdak9n0l9n7hm8d";
+    sha256 = "04mx1nxqqqjg3wsql4ch4j1a4cbqfvpq0iwi6b9yhaf04n0dwrvn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-powermanagement/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1fxklxmvjaykdpf0nj6cpgwx4yf52087g25k1zdak9n0l9n7hm8d";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Power management module for LXQt";
-    homepage = https://github.com/lxde/lxqt-powermanagement;
+    homepage = https://github.com/lxqt/lxqt-powermanagement;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-qtplugin/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-qtplugin/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "19y5dvbj7gwyh8glc6vi6hb5snvkd3jwvss6j0sn2sy2gp9g9ryb";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "LXQt Qt platform integration plugin";
-    homepage = https://github.com/lxde/lxqt-qtplugin;
+    homepage = https://github.com/lxqt/lxqt-qtplugin;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1354vdaskhch1n8v3kdy15nszgqb1092csr84nbhymzgrhrq1093";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Tool used to launch programs quickly by typing their names";
-    homepage = https://github.com/lxde/lxqt-runner;
+    homepage = https://github.com/lxqt/lxqt-runner;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-runner/default.nix
@@ -4,13 +4,13 @@ menu-cache, muparser, pcre }:
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-runner";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1354vdaskhch1n8v3kdy15nszgqb1092csr84nbhymzgrhrq1093";
+    sha256 = "0w6r9lby35p0lf5klasa5l2lscx6dmv16kzfhl4lc6w2qfwjb9vi";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-session/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "03gi9svxqsfjhk5ifbaalq9i44ggx8afwms1hb312czqn82wrszb";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An alternative session manager ported from the original razor-session";
-    homepage = https://github.com/lxde/lxqt-session;
+    homepage = https://github.com/lxqt/lxqt-session;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-session/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-session";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "03gi9svxqsfjhk5ifbaalq9i44ggx8afwms1hb312czqn82wrszb";
+    sha256 = "0ngcrkmfpahii4yibsh03b8v8af93hhqm42kk1nnhczc8dg49mhs";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-sudo/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.12.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "0ql436yb51qwbnj5gbzvqi4rqx4zkmja5rdjs6yavb1x8ggn1jv6";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GUI frontend for sudo/su";
-    homepage = https://github.com/lxde/lxqt-sudo;
+    homepage = https://github.com/lxqt/lxqt-sudo;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-sudo/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "lxqt-sudo";
-  version = "0.12.0";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0ql436yb51qwbnj5gbzvqi4rqx4zkmja5rdjs6yavb1x8ggn1jv6";
+    sha256 = "1gpn3dhmzabx0jrqxq63549sah03kf6bmdc9d9kmg6hyr5xg3i1h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/core/lxqt-themes/default.nix
+++ b/pkgs/desktops/lxqt/core/lxqt-themes/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "026hbblxdbq48n9691b1z1xiak99khsk3wf09vn4iaj5zi7dwhw5";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Themes, graphics and icons for LXQt";
-    homepage = https://github.com/lxde/lxqt-themes;
+    homepage = https://github.com/lxqt/lxqt-themes;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/pavucontrol-qt/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1bxqpasfvaagbq8azl7536z2zk2725xg7jkvad5xh95zq1gb4hgk";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A Pulseaudio mixer in Qt (port of pavucontrol)";
-    homepage = https://github.com/lxde/pavucontrol-qt;
+    homepage = https://github.com/lxqt/pavucontrol-qt;
     license = licenses.gpl2;
     platforms = with platforms; linux;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/pcmanfm-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, lxqt, libfm, menu-cache, lxmenu-data }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, lxqt-build-tools, qt5, libfm-qt, menu-cache, lxmenu-data }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -15,15 +15,15 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkgconfig
-    lxqt.lxqt-build-tools
+    lxqt-build-tools
   ];
 
   buildInputs = [
     qt5.qtbase
     qt5.qttools
     qt5.qtx11extras
-    lxqt.libfm-qt
-    libfm
+    libfm-qt
+    libfm-qt
     menu-cache
     lxmenu-data
   ];

--- a/pkgs/desktops/lxqt/core/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/core/pcmanfm-qt/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "0xnhdxx45fmbi5dqic3j2f7yq01s0xysimafj5zqs0a29zw3i4m0";
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "File manager and desktop icon manager (Qt port of PCManFM and libfm)";
-    homepage = https://github.com/lxde/pcmanfm-qt;
+    homepage = https://github.com/lxqt/pcmanfm-qt;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/qtermwidget/0.7.1.nix
+++ b/pkgs/desktops/lxqt/core/qtermwidget/0.7.1.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.7.1";
 
   srcs = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "0awp33cnkpi9brpx01mz5hwj7j2lq1wdi8cabk3wassd99vvxdxz";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A terminal emulator widget for Qt 5";
-    homepage = https://github.com/lxde/qtermwidget;
+    homepage = https://github.com/lxqt/qtermwidget;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/core/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/core/qtermwidget/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "05gbdjzgmcr3ljs9ba3qvh7a3v6yn6vakwfy8avld9gy5bdd76rg";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A terminal emulator widget for Qt 5";
-    homepage = https://github.com/lxde/qtermwidget;
+    homepage = https://github.com/lxqt/qtermwidget;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -4,7 +4,7 @@ let
   packages = self: with self; {
 
     # For compiling information, see:
-    # - https://github.com/lxde/lxqt/wiki/Building-from-source
+    # - https://github.com/lxqt/lxqt/wiki/Building-from-source
 
     ### BASE
     libqtxdg = callPackage ./base/libqtxdg { };

--- a/pkgs/desktops/lxqt/optional/compton-conf/default.nix
+++ b/pkgs/desktops/lxqt/optional/compton-conf/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1r187fx1vivzq1gcwwawax36mnlmfig5j1ba4s4wfdi3q2wcq7mw";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GUI configuration tool for compton X composite manager";
-    homepage = https://github.com/lxde/compton-conf;
+    homepage = https://github.com/lxqt/compton-conf;
     license = licenses.lgpl21;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, xorg, lxqt, libfm, libexif }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt5, xorg, lxqt-build-tools, libfm-qt, libexif }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkgconfig
-    lxqt.lxqt-build-tools
+    lxqt-build-tools
   ];
 
   buildInputs = [
@@ -23,10 +23,9 @@ stdenv.mkDerivation rec {
     qt5.qttools
     qt5.qtx11extras
     qt5.qtsvg
-    lxqt.libfm-qt
+    libfm-qt
     xorg.libpthreadstubs
     xorg.libXdmcp
-    libfm
     libexif
   ];
 

--- a/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/optional/lximage-qt/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.7.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1slmaic9cmj5lqa5kwc1qfbbycwh8840wnkg0nxc99ls0aazlpzi";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The image viewer and screenshot tool for lxqt";
-    homepage = https://github.com/lxde/lximage-qt;
+    homepage = https://github.com/lxqt/lximage-qt;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/optional/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/optional/obconf-qt/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "0mixf35p7b563f77vnikk9b1wqhbdawp723sd30rfql76gkjwjcn";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The Qt port of obconf, the Openbox configuration tool";
-    homepage = https://github.com/lxde/obconf-qt;
+    homepage = https://github.com/lxqt/obconf-qt;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/optional/qps/default.nix
+++ b/pkgs/desktops/lxqt/optional/qps/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "1.10.17";
 
   src = fetchFromGitHub {
-    owner = "QtDesktop";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1d5r6w9wsxjdrzq2hllrj2n1d9azy6g05hg0w0s6pikrmn1yl0a3";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The Qt process manager";
-    homepage = https://github.com/QtDesktop/qps;
+    homepage = https://github.com/lxqt/qps;
     license = licenses.gpl2;
     maintainers = with maintainers; [ romildo ];
     platforms = with platforms; unix;

--- a/pkgs/desktops/lxqt/optional/qps/default.nix
+++ b/pkgs/desktops/lxqt/optional/qps/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "qps";
-  version = "1.10.17";
+  version = "1.10.18";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1d5r6w9wsxjdrzq2hllrj2n1d9azy6g05hg0w0s6pikrmn1yl0a3";
+    sha256 = "1cq5z4w2n119z2bq0njn508g5582jljdx2n38cv5b3cf35k91a49";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/desktops/lxqt/optional/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/optional/qterminal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, qt5, lxqt }:
+{ stdenv, fetchFromGitHub, cmake, lxqt-build-tools, qtermwidget, qt5 }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -14,14 +14,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    lxqt.lxqt-build-tools
+    lxqt-build-tools
   ];
 
   buildInputs = [
     qt5.qtbase
     qt5.qttools
     qt5.qtx11extras
-    lxqt.qtermwidget
+    qtermwidget
   ];
 
   cmakeFlags = [ "-DPULL_TRANSLATIONS=NO" ];

--- a/pkgs/desktops/lxqt/optional/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/optional/qterminal/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "lxde";
+    owner = "lxqt";
     repo = pname;
     rev = version;
     sha256 = "1z9wlyj5i192jfq3dcxjf8wzx9x332f19c9ll7zv69cq21kyy9wn";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A lightweight Qt-based terminal emulator";
-    homepage = https://github.com/lxde/qterminal;
+    homepage = https://github.com/lxqt/qterminal;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/optional/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/optional/screengrab/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "screengrab-${version}";
-  version = "1.97";
+  version = "1.98";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = "screengrab";
     rev = version;
-    sha256 = "0qhdxnv1pz745qgvdv5x7kyfx9dz9rrq0wxyfimppzxcszv4pl2z";
+    sha256 = "1y3r29220z6y457cajpad3pjnr883smbvh0kai8hc5hh4k4kxs6v";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/desktops/lxqt/optional/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/optional/screengrab/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.97";
 
   src = fetchFromGitHub {
-    owner = "QtDesktop";
+    owner = "lxqt";
     repo = "screengrab";
     rev = version;
     sha256 = "0qhdxnv1pz745qgvdv5x7kyfx9dz9rrq0wxyfimppzxcszv4pl2z";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Crossplatform tool for fast making screenshots";
-    homepage = https://github.com/lxde/screengrab;
+    homepage = https://github.com/lxqt/screengrab;
     license = licenses.gpl2;
     platforms = with platforms; unix;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/desktops/lxqt/update.sh
+++ b/pkgs/desktops/lxqt/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p libarchive curl common-updater-scripts
+
+set -eu -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+root=../../..
+export NIXPKGS_ALLOW_UNFREE=1
+
+lxqt_version=0.13.0
+lxqtrepo=https://downloads.lxqt.org/${lxqt_version}.html
+
+version() {
+    (cd "$root" && nix-instantiate --eval --strict -A "$1.version" 2>/dev/null | tr -d '"')
+}
+
+update_lxqt() {
+    local pname
+    local pversion
+    curl -sS ${lxqtrepo} | sed -rne 's|.*<a href=.*>(.+) (.+)</a><br>|\1 \2|p' |
+        while read pname pversion; do
+            local pversionold=$(version lxqt.$pname)
+            if [[ "$pversion" = "$pversionold" ]]; then
+                echo "nothing to do, $pname $pversion is current"
+            else
+                echo "$pname: $pversionold -> $pversion"
+                (cd "$root"
+                 local pfile=$(EDITOR=echo nix edit -f. lxqt.$pname 2>/dev/null)
+                 update-source-version lxqt.$pname "$pversion"
+                 git add $pfile
+                 git commit -m "$pname: $pversionold -> $pversion"
+                )
+            fi
+            echo
+        done
+    echo DONE
+}
+
+update_lxqt


### PR DESCRIPTION
###### Motivation for this change

Update [LXQt](https://lxqt.org/) to version [0.13.0](https://forum.lxqt.org/t/release-lxqt-0-13-0/301).

###### TODO
- [x] Verify that the following change (from the release notes) works:
> Upstream configuration defaults were moved to `/usr/share/lxqt`, and distribution’s overrides can be placed into `/etc/lxqt`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).