### PR TITLE
pythonPackages.typing-extensions: init at 3.6.5

### DIFF
--- a/pkgs/development/python-modules/typing-extensions/default.nix
+++ b/pkgs/development/python-modules/typing-extensions/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, isPy3k, python, typing }:
+let
+  testDir = if isPy3k then "src_py3" else "src_py2";
+
+in buildPythonPackage rec {
+  pname = "typing_extensions";
+  version = "3.6.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09xxykw8mk30r0g33r2gy5qlqw3sqj5vkp6h7nh0flp59hxqw2hw";
+  };
+
+  checkInputs = lib.optional (pythonOlder "3.5") typing;
+
+  # Error for Python3.6: ImportError: cannot import name 'ann_module'
+  # See https://github.com/python/typing/pull/280
+  doCheck = pythonOlder "3.6";
+
+  checkPhase = ''
+    cd ${testDir}
+    ${python.interpreter} -m unittest discover
+  '';
+
+  meta = with lib; {
+    description = "Backported and Experimental Type Hints for Python 3.5+";
+    homepage = https://github.com/python/typing;
+    license = licenses.psfl;
+    maintainers = with maintainers; [ pmiddend ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12446,6 +12446,8 @@ in {
 
   typing = callPackage ../development/python-modules/typing { };
 
+  typing-extensions = callPackage ../development/python-modules/typing-extensions { };
+
   typeguard = callPackage ../development/python-modules/typeguard { };
 
   ruamel_yaml = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

This package is missing from nixpkgs (and is different than the existing `typing`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

