### PR TITLE
gmsh: gfortran -> nativeBuildInputs (fix #40976)

### DIFF
--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -15,10 +15,12 @@ stdenv.mkDerivation {
   # that is supposed to work without Fortran but didn't for me.
   patches = [ ./CMakeLists.txt.patch ];
 
-  buildInputs = [ cmake blas liblapack gfortran gmm fltk libjpeg zlib libGLU_combined
+  buildInputs = [ cmake blas liblapack gmm fltk libjpeg zlib libGLU_combined
     libGLU xorg.libXrender xorg.libXcursor xorg.libXfixes xorg.libXext
     xorg.libXft xorg.libXinerama xorg.libX11 xorg.libSM xorg.libICE
   ];
+
+  nativeBuildInputs = [ gfortran ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
With gfortran in buildInputs, linking of gfortran failed in one case as shown in #40976 
I don't understand *why* this was the case when there's no specific cross building going on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

