### PR TITLE
sc-im: available on the other Unix-like platforms

### DIFF
--- a/pkgs/applications/misc/sc-im/default.nix
+++ b/pkgs/applications/misc/sc-im/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "SC-IM - Spreadsheet Calculator Improvised - SC fork";
     license = licenses.bsdOriginal;
     maintainers = [ ];
-    platforms = platforms.linux; # Cannot test others
+    platforms = platforms.unix;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

I confirmed that at least on Darwin, it can be built successfully.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

