### PR TITLE
fetch-kde-qt: Store downloaded files directly in nix/store

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -40,6 +40,7 @@ gawk -F , "{ print \$1 }" $csv | sort | uniq | while read name; do
     filename=$(gawk -F , "/^$name,$latestVersion,/ { print \$4 }" $csv)
     url="${src:2}"
     sha256=$(nix-hash --type sha256 --base32 --flat "$src")
+    nix-store --add "$src" > /dev/null
     cat >>"$SRCS" <<EOF
   $name = {
     version = "$latestVersion";


### PR DESCRIPTION
###### Motivation for this change
Prevents redownloading files :)

@ttuegel 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

