### PR TITLE
darwin stdenv: Properly compose overrides

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -294,7 +294,7 @@ in rec {
     extraPreHook = ''
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
-    overrides = self: super: (persistent self super) // {
+    overrides = lib.composeExtensions persistent (self: super: {
       # Hack to make sure we don't link ncurses in bootstrap tools. The proper
       # solution is to avoid passing -L/nix-store/...-bootstrap-tools/lib,
       # quite a sledgehammer just to get the C runtime.
@@ -303,7 +303,7 @@ in rec {
            "--disable-curses"
          ];
       });
-    };
+    });
   };
 
   stdenvDarwin = prevStage: let
@@ -386,16 +386,15 @@ in rec {
       dyld Libsystem CF cctools ICU libiconv locale
     ]);
 
-    overrides = self: super:
-      let persistent' = persistent self super; in persistent' // {
-        clang = cc;
-        llvmPackages = persistent'.llvmPackages // { clang = cc; };
-        inherit cc;
+    overrides = lib.composeExtensions persistent (self: super: {
+      clang = cc;
+      llvmPackages = super.llvmPackages // { clang = cc; };
+      inherit cc;
 
-        darwin = super.darwin // {
-          xnu = super.darwin.xnu.override { python = super.python.override { configd = null; }; };
-        };
+      darwin = super.darwin // {
+        xnu = super.darwin.xnu.override { python = super.python.override { configd = null; }; };
       };
+    });
   };
 
   stagesDarwin = [


### PR DESCRIPTION
##### Motivation for this change

`super` usage was very suspect. CC @oxij this might help with one of the rebuilds you found.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

