### PR TITLE
fplll: 5.2.0 -> 5.2.1, pythonPackages.fpylll: 0.3.0dev -> 0.4.0dev

### DIFF
--- a/pkgs/development/libraries/fplll/default.nix
+++ b/pkgs/development/libraries/fplll/default.nix
@@ -4,12 +4,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "fplll";
-  version = "5.2.0";
+  version = "5.2.1";
   src = fetchFromGitHub {
     owner = "${pname}";
     repo = "${pname}";
     rev = "${version}";
-    sha256 = "0931i4q49lzlifsg9zd8a2yzj626i1s2bqhkfxvcxv94c38s0nh1";
+    sha256 = "015qmrd7nfaysbv1hbwiprz9g6hnww1y1z1xw8f43ysb7k1b5nbg";
   };
   nativeBuildInputs = [autoconf automake libtool gettext autoreconfHook];
   buildInputs = [gmp mpfr];

--- a/pkgs/development/python-modules/fpylll/default.nix
+++ b/pkgs/development/python-modules/fpylll/default.nix
@@ -1,5 +1,5 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
 , pkgconfig
 , gmp
@@ -14,11 +14,13 @@
 
 buildPythonPackage rec {
   pname = "fpylll";
-  version = "0.3.0dev";
+  version = "0.4.1dev";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0bjkh02fnxsrxwjzai8ij12zl2wq319z8y25sn9pvvzla5izgnp9";
+  src = fetchFromGitHub {
+    owner = "fplll";
+    repo = "fpylll";
+    rev = version;
+    sha256 = "01x2sqdv0sbjj4g4waj0hj4rcn4bq7h17442xaqwbznym9azmn9w";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This fixes the fpylll tests on 32 bit machines (see https://github.com/fplll/fpylll/issues/112).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

