### PR TITLE
elixir: 1.6.4 -> 1.6.5

### DIFF
--- a/pkgs/development/interpreters/elixir/1.6.nix
+++ b/pkgs/development/interpreters/elixir/1.6.nix
@@ -1,7 +1,7 @@
 { mkDerivation }:
 
 mkDerivation rec {
-  version = "1.6.4";
-  sha256 = "0li2zb5ha7fdkjnzjbj3dxb9xls8xn6xr23fqwl7gp2697vcw3ws";
+  version = "1.6.5";
+  sha256 = "0il1fraz6c8qbqv4wrp16jqrkf3xglfa9f3sdm6q4vv8kjf3lxxb";
   minimumOTPVersion = "18";
 }


### PR DESCRIPTION
###### Motivation for this change

New Elixir version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

