### PR TITLE
nix-du: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform, nix, boost, graphviz }:
 rustPlatform.buildRustPackage rec {
   name = "nix-du-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "symphorien";
     repo = "nix-du";
     rev = "v${version}";
-    sha256 = "0kxacn5qw21pp4zl6wr9wyb2mm2nlnp6mla3m5p9dm7vrm1fd1x9";
+    sha256 = "1y7ifr4c3v1494swh6akvna0d0rxjy9jw3mw2wdd6vj1xphvmimq";
   };
-  cargoSha256 = "04c48lzi7hny3nq4ffdpvsr4dxbi32faka163fp1yc9953zdw9az";
+  cargoSha256 = "0qq7a6ncxnbjvnmly99awqrk9f3z9b55ifil7b0bn5yhk4h9sa6y";
 
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
   checkInputs = [ graphviz ];
   nativeBuildInputs = [] ++ stdenv.lib.optionals doCheck checkInputs;
 


### PR DESCRIPTION
###### Motivation for this change

should fix a bug found by @lheckemann 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

