### PR TITLE
zziplib: 0.13.68 -> 0.13.69

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -2,18 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "zziplib-${version}";
-  version = "0.13.68";
+  version = "0.13.69";
 
   src = fetchurl {
     url = "https://github.com/gdraheim/zziplib/archive/v${version}.tar.gz";
-    sha256 = "0chhl6m02562z6c4hjy568mh11pbq2qngw6g2x924ajr8sdr2q4l";
+    sha256 = "0i052a7shww0fzsxrdp3rd7g4mbzx7324a8ysbc0br7frpblcql4";
   };
 
   postPatch = ''
     sed -i -e s,--export-dynamic,, configure
   '';
-
-  # TODO: still an issue: https://github.com/gdraheim/zziplib/issues/27
 
   buildInputs = [ docbook_xml_dtd_412 perl python2 zip xmlto zlib ];
 


### PR DESCRIPTION
Backport of 3f36f6095fef0b83b9e8f5fc9d0b8ad42dfccaa6 (bump to 0.13.69) from master to address https://github.com/gdraheim/zziplib/issues/27, maybe part of CVE-2018-6869 and CVE-2018-6484.

###### Motivation for this change
This possible CVE fix is not yet in release-18.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

