### PR TITLE
openbox: fix wrapping of openbox-xdg-autostart

### DIFF
--- a/pkgs/applications/window-managers/openbox/default.nix
+++ b/pkgs/applications/window-managers/openbox/default.nix
@@ -6,20 +6,24 @@ stdenv.mkDerivation rec {
   name = "openbox-${version}";
   version = "3.6.1";
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    libxml2
-    libXinerama libXcursor libXau libXrandr libICE libSM
-    libstartup_notification makeWrapper
+  nativeBuildInputs = [
+    pkgconfig
+    makeWrapper
     python2.pkgs.wrapPython
   ];
 
-  pythonPath = with python2.pkgs; [
-    pyxdg
+  buildInputs = [
+    libxml2
+    libXinerama libXcursor libXau libXrandr libICE libSM
+    libstartup_notification
   ];
 
   propagatedBuildInputs = [
     pango imlib2
+  ];
+
+  pythonPath = with python2.pkgs; [
+    pyxdg
   ];
 
   src = fetchurl {
@@ -41,7 +45,7 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/openbox-session" --prefix XDG_DATA_DIRS : "$out/share"
     wrapProgram "$out/bin/openbox-gnome-session" --prefix XDG_DATA_DIRS : "$out/share"
     wrapProgram "$out/bin/openbox-kde-session" --prefix XDG_DATA_DIRS : "$out/share"
-    wrapPythonPrograms
+    wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

`openbox-xdg-autostart` is a Python script that was not being correctly wrapped.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).