### PR TITLE
dmd,dtools,dub: 2.079.0 -> 2.079.1

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, overrideCC, gcc5
 , makeWrapper, unzip, which
 , curl, tzdata, gdb, darwin
-, callPackage
+, callPackage, targetPackages
 , bootstrapVersion ? false
-, version ? "2.079.0"
-, dmdSha256 ? "1k6cky71pqnss6h6391p1ich2mjs598f5fda018aygnxg87qgh4y"
-, druntimeSha256 ? "183pqygj5w4105czs5kswyjn9mrcybx3wmkynz3in0m3ylzzjmvl"
-, phobosSha256 ? "0y9i86ggmf41ww2xk2bsrlsv9b1blj5dbyan6q6r6xp8dmgrd79w"
+, version ? "2.079.1"
+, dmdSha256 ? "0mlk095aw94d940qkymfp85daggiz3f0xv598nlc7acgp6408kyj"
+, druntimeSha256 ? "18r8gwvb54ar80j5155wx0qbqq4w56hqmbf6wap20xwijg2rw90g"
+, phobosSha256 ? "1x5v1ln51nr8x2vyki864160bakdyq0acmvbfv7jcipaj2w3m9bb"
 }:
 
 let
@@ -143,6 +143,9 @@ let
     + stdenv.lib.optionalString (stdenv.hostPlatform.isLinux && bootstrapVersion) ''
       substituteInPlace ${dmdPath}/root/port.c \
         --replace "#include <bits/mathdef.h>" "#include <complex.h>"
+
+      substituteInPlace ${dmdPath}/root/port.c \
+        --replace "#include <bits/nan.h>" "#include <math.h>"
     ''
 
     + stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -198,6 +201,8 @@ let
     
     extension = if stdenv.hostPlatform.isDarwin then "a" else "{a,so}";
 
+    dontStrip = true;
+
     installPhase = ''
         cd dmd
         mkdir $out
@@ -222,13 +227,13 @@ let
         cp -r etc $out/include/d2
 
         wrapProgram $out/bin/dmd \
-            --prefix PATH ":" "${stdenv.cc}/bin" \
-            --set-default CC "$CC"
+            --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \
+            --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
 
         cd $out/bin
         tee dmd.conf << EOF
         [Environment]
-        DFLAGS=-I$out/include/d2 -L-L$out/lib ${stdenv.lib.optionalString (!stdenv.cc.isClang) "-L--export-dynamic"} -fPIC
+        DFLAGS=-I$out/include/d2 -L-L$out/lib ${stdenv.lib.optionalString (!targetPackages.stdenv.cc.isClang) "-L--export-dynamic"} -fPIC
         EOF
     '';
 

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, fetchurl, cmake, llvm, curl, tzdata
 , python, libconfig, lit, gdb, unzip, darwin, bash
-, callPackage
+, callPackage, makeWrapper, targetPackages
 , bootstrapVersion ? false
 , version ? "1.7.0"
 , ldcSha256 ? "1g8qvmlzvsp030z2rw6lis4kclsd9mlmnbim5kas0k1yr9063m3w"
@@ -125,7 +125,7 @@ let
             --replace "tzName == \"+VERSION\"" "baseName(tzName) == \"leapseconds\" || tzName == \"+VERSION\""
     '';
 
-    nativeBuildInputs = [ cmake llvm bootstrapLdc python lit gdb unzip ]
+    nativeBuildInputs = [ cmake makeWrapper llvm bootstrapLdc python lit gdb unzip ]
 
     ++ stdenv.lib.optional (bootstrapVersion) [
       libconfig
@@ -136,7 +136,7 @@ let
     ]);
 
 
-    buildInputs = [ curl tzdata stdenv.cc ];
+    buildInputs = [ curl tzdata ];
 
     preConfigure = ''
       cmakeFlagsArray=("-DINCLUDE_INSTALL_DIR=$out/include/dlang/ldc"
@@ -159,13 +159,19 @@ let
     doCheck = true;
 
     checkPhase = ''
-	# Build and run LDC D unittests.
-	ctest --output-on-failure -R "ldc2-unittest"
-	# Run LIT testsuite.
-	ctest -V -R "lit-tests"
-	# Run DMD testsuite.
-	DMD_TESTSUITE_MAKE_ARGS=-j$NIX_BUILD_CORES ctest -V -R "dmd-testsuite"
+      # Build and run LDC D unittests.
+      ctest --output-on-failure -R "ldc2-unittest"
+      # Run LIT testsuite.
+      ctest -V -R "lit-tests"
+      # Run DMD testsuite.
+      DMD_TESTSUITE_MAKE_ARGS=-j$NIX_BUILD_CORES ctest -V -R "dmd-testsuite"
     '';
+
+    postInstall = ''
+      wrapProgram $out/bin/ldc2 \
+          --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \
+          --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
+     '';
 
     meta = with stdenv.lib; {
       description = "The LLVM-based D compiler";

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -4,7 +4,7 @@ let
 
   dubBuild = stdenv.mkDerivation rec {
     name = "dubBuild-${version}";
-    version = "1.8.0";
+    version = "1.8.1";
 
     enableParallelBuilding = true;
 
@@ -12,7 +12,7 @@ let
       owner = "dlang";
       repo = "dub";
       rev = "v${version}";
-      sha256 = "0788d375sc6xdak9x6xclkkz243lb7di68yxfvl4v0n178mi22bk";
+      sha256 = "16r7x4jsfv5fjssvs6mwj8ymr6fjpvbkjhpr4f4368sjr5iyfad6";
     };
 
     postUnpack = ''
@@ -75,6 +75,7 @@ let
       # file under ../etc relative to the dub location.
       cp ${dubBuild}/bin/dub bin/
       export DUB=$NIX_BUILD_TOP/source/bin/dub
+      export PATH=$PATH:$NIX_BUILD_TOP/source/bin/
       export DC=${dmd.out}/bin/dmd
       export HOME=$TMP
       ./test/run-unittest.sh

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "dtools-${version}";
-  version = "2.079.0";
+  version = "2.079.1";
 
   srcs = [
     (fetchFromGitHub {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "1k6cky71pqnss6h6391p1ich2mjs598f5fda018aygnxg87qgh4y";
+      sha256 = "0mlk095aw94d940qkymfp85daggiz3f0xv598nlc7acgp6408kyj";
       name = "dmd";
     })
     (fetchFromGitHub {


### PR DESCRIPTION
dmd,dtools,dub: 2.079.0 -> 2.079.1 and wrap ldc2 binary with $CC

(cherry picked from commit 4aa04d185cff21f3c6ea3e75256835daa621d1e3)

Reason: This bumps the version to a newer release and fixes package
issues which are important for release too.
