### PR TITLE
Add versions to packages missing it

### DIFF
--- a/pkgs/applications/altcoins/dapp.nix
+++ b/pkgs/applications/altcoins/dapp.nix
@@ -2,7 +2,7 @@
 , seth, git, solc, shellcheck, nodejs, hevm }:
 
 stdenv.mkDerivation rec {
-  name = "dapp";
+  name = "dapp-${version}";
   version = "0.5.7";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/mist.nix
+++ b/pkgs/applications/altcoins/mist.nix
@@ -25,7 +25,7 @@ let
     categories = "Network;";
   };
 
-  mist = stdenv.mkDerivation {
+  mist = stdenv.lib.appendToName "unwrapped" (stdenv.mkDerivation {
     inherit name version;
 
     src = {
@@ -53,10 +53,10 @@ let
         --set-rpath "${atomEnv.libPath}:$out/lib/mist" \
         $out/lib/mist/mist
     '';
-  };
+  });
 in
 buildFHSUserEnv {
-  name = "mist";
+  name = "mist-${stdenv.lib.getVersion mist}";
 
   targetPkgs = pkgs: with pkgs; [
      mist

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -6,30 +6,34 @@
 # 2) Override the releasePath attribute to point to the location of the newly downloaded bundle.
 # Note: Renoise creates an individual build for each license which screws somewhat with the
 # use of functions like requireFile as the hash will be different for every user.
-let fileversion = "3_1_0";
+let
+  srcVersion = version: lib.replaceStrings ["."] ["_"] version;
 in
+
 stdenv.mkDerivation rec {
-  name = "renoise-${lib.replaceStrings ["_"] ["."] fileversion}";
-  buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
+  name = "renoise-${version}";
+  version = "3.1.0";
 
   src =
     if stdenv.system == "x86_64-linux" then
         if builtins.isNull releasePath then
         fetchurl {
-            url = "http://files.renoise.com/demo/Renoise_${fileversion}_Demo_x86_64.tar.bz2";
-            sha256 = "0pan68fr22xbj7a930y29527vpry3f07q3i9ya4fp6g7aawffsga";
+           url = "http://files.renoise.com/demo/Renoise_${srcVersion version}_Demo_x86_64.tar.bz2";
+           sha256 = "0pan68fr22xbj7a930y29527vpry3f07q3i9ya4fp6g7aawffsga";
         }
         else
         releasePath
     else if stdenv.system == "i686-linux" then
         if builtins.isNull releasePath then
         fetchurl {
-            url = "http://files.renoise.com/demo/Renoise_${fileversion}_Demo_x86.tar.bz2";
-            sha256 = "1lccjj4k8hpqqxxham5v01v2rdwmx3c5kgy1p9lqvzqma88k4769";
+          url = "http://files.renoise.com/demo/Renoise_${srcVersion version}_Demo_x86.tar.bz2";
+          sha256 = "1lccjj4k8hpqqxxham5v01v2rdwmx3c5kgy1p9lqvzqma88k4769";
         }
         else
         releasePath
     else throw "Platform is not supported by Renoise";
+
+  buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
 
   installPhase = ''
     cp -r Resources $out
@@ -52,9 +56,11 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath $out/lib $out/renoise
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Modern tracker-based DAW";
     homepage = http://www.renoise.com/;
-    license = stdenv.lib.licenses.unfree;
+    license = licenses.unfree;
+    maintainers = [];
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -9,7 +9,7 @@
 let fileversion = "3_1_0";
 in
 stdenv.mkDerivation rec {
-  name = "renoise";
+  name = "renoise-${lib.replaceStrings ["_"] ["."] fileversion}";
   buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
 
   src =

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, releasePath ? null }:
+{ stdenv, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, releasePath ? null }:
+
+with stdenv.lib;
 
 # To use the full release version:
 # 1) Sign into https://backstage.renoise.com and download the appropriate (x86 or x86_64) version
@@ -7,7 +9,7 @@
 # Note: Renoise creates an individual build for each license which screws somewhat with the
 # use of functions like requireFile as the hash will be different for every user.
 let
-  srcVersion = version: lib.replaceStrings ["."] ["_"] version;
+  urlVersion = replaceStrings [ "." ] [ "_" ];
 in
 
 stdenv.mkDerivation rec {
@@ -18,15 +20,15 @@ stdenv.mkDerivation rec {
     if stdenv.system == "x86_64-linux" then
         if builtins.isNull releasePath then
         fetchurl {
-           url = "http://files.renoise.com/demo/Renoise_${srcVersion version}_Demo_x86_64.tar.bz2";
-           sha256 = "0pan68fr22xbj7a930y29527vpry3f07q3i9ya4fp6g7aawffsga";
+          url = "http://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_x86_64.tar.bz2";
+          sha256 = "0pan68fr22xbj7a930y29527vpry3f07q3i9ya4fp6g7aawffsga";
         }
         else
         releasePath
     else if stdenv.system == "i686-linux" then
         if builtins.isNull releasePath then
         fetchurl {
-          url = "http://files.renoise.com/demo/Renoise_${srcVersion version}_Demo_x86.tar.bz2";
+          url = "http://files.renoise.com/demo/Renoise_${urlVersion version}_Demo_x86.tar.bz2";
           sha256 = "1lccjj4k8hpqqxxham5v01v2rdwmx3c5kgy1p9lqvzqma88k4769";
         }
         else
@@ -56,7 +58,7 @@ stdenv.mkDerivation rec {
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath $out/lib $out/renoise
   '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Modern tracker-based DAW";
     homepage = http://www.renoise.com/;
     license = licenses.unfree;

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -51,7 +51,7 @@ let
 
   in
   stdenv.mkDerivation {
-      inherit name;
+      name = "neovim-${stdenv.lib.getVersion neovim}";
       buildCommand = let bin="${neovim}/bin/nvim"; in ''
         if [ ! -x "${bin}" ]
         then

--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -1,27 +1,34 @@
-{
-  mkDerivation, lib, fetchurl,
-  extra-cmake-modules, kdoctools,
-  qtscript, kconfig, kinit, karchive, kcrash,
-  kcmutils, kconfigwidgets, knewstuff, kparts, qca-qt5,
-  shared-mime-info
-}:
+{ stdenv, fetchurl, extra-cmake-modules, kdoctools, qtscript, kconfig
+, kinit, karchive, kcrash, kcmutils, kconfigwidgets, knewstuff, kparts
+, qca-qt5, shared-mime-info }:
 
-let
-  version = "17.12.3";
-in mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "okteta-${version}";
+  version = "17.12.3";
+
   src = fetchurl {
-    url    = "mirror://kde/stable/applications/${version}/src/${name}.tar.xz";
+    url = "mirror://kde/stable/applications/${version}/src/${name}.tar.xz";
     sha256 = "03wsv83l1cay2dpcsksad124wzan7kh8zxdw1h0yicn398kdbck4";
   };
-  meta = {
-    license = with lib.licenses; [ gpl2 ];
-    maintainers = with lib.maintainers; [ peterhoeg bkchr ];
-  };
+  
   nativeBuildInputs = [ qtscript extra-cmake-modules kdoctools ];
   buildInputs = [ shared-mime-info ];
+  
   propagatedBuildInputs = [
-    kconfig kinit kcmutils kconfigwidgets knewstuff kparts qca-qt5
-    karchive kcrash
+    kconfig
+    kinit
+    kcmutils
+    kconfigwidgets
+    knewstuff
+    kparts
+    qca-qt5
+    karchive
+    kcrash
   ];
+  
+  meta = with stdenv.lib; {
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg bkchr ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -9,9 +9,9 @@
 let
   version = "17.12.3";
 in mkDerivation rec {
-  name = "okteta";
+  name = "okteta-${version}";
   src = fetchurl {
-    url    = "mirror://kde/stable/applications/${version}/src/${name}-${version}.tar.xz";
+    url    = "mirror://kde/stable/applications/${version}/src/${name}.tar.xz";
     sha256 = "03wsv83l1cay2dpcsksad124wzan7kh8zxdw1h0yicn398kdbck4";
   };
   meta = {

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -22,9 +22,8 @@ let
     '';
   }
   // a
-    # don't call this gimp-* unless you want nix replace gimp by a plugin :-)
   // {
-      name = "${a.name}-${gimp.name}-plugin";
+      name = "gimp-plugin-${a.name}";
       buildInputs = [ gimp gimp.gtk glib ] ++ (a.buildInputs or []);
       nativeBuildInputs = [ pkgconfig intltool ] ++ (a.nativeBuildInputs or []);
     }

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -60,8 +60,8 @@ let
           # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
           if actualPlugins == []
             then terraform.overrideAttrs (orig: { passthru = orig.passthru // passthru; })
-            else stdenv.mkDerivation {
-              name = "${terraform.name}-with-plugins";
+            else lib.appendToName "with-plugins "(stdenv.mkDerivation {
+              inherit (terraform) name;
               buildInputs = [ makeWrapper ];
 
               buildCommand = ''
@@ -72,7 +72,7 @@ let
               '';
 
               inherit passthru;
-            };
+            });
     in withPlugins (_: []);
 
   plugins = import ./providers { inherit stdenv lib buildGoPackage fetchFromGitHub; };

--- a/pkgs/applications/networking/gmailieer/default.nix
+++ b/pkgs/applications/networking/gmailieer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
-  name = "gmailieer";
+  name = "gmailieer-${version}";
   version = "0.6";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/office/atlassian-cli/default.nix
+++ b/pkgs/applications/office/atlassian-cli/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchzip, jre }:
-stdenv.mkDerivation {
-  name = "atlassian-cli";
+stdenv.mkDerivation rec {
+  name = "atlassian-cli-${version}";
   version = "7.8.0";
   src = fetchzip {
-    url            = https://bobswift.atlassian.net/wiki/download/attachments/16285777/atlassian-cli-7.8.0-distribution.zip;
+    url            = "https://bobswift.atlassian.net/wiki/download/attachments/16285777/${name}-distribution.zip";
     sha256         = "111s4d9m6vxq8jwh1d6ar1f4n5zmyjg7gi2vl3aq63kxbfld9vw7";
     extraPostFetch = "chmod go-w $out";
   };

--- a/pkgs/applications/office/atlassian-cli/default.nix
+++ b/pkgs/applications/office/atlassian-cli/default.nix
@@ -1,14 +1,30 @@
 { stdenv, fetchzip, jre }:
+
 stdenv.mkDerivation rec {
   name = "atlassian-cli-${version}";
   version = "7.8.0";
+  
   src = fetchzip {
-    url            = "https://bobswift.atlassian.net/wiki/download/attachments/16285777/${name}-distribution.zip";
-    sha256         = "111s4d9m6vxq8jwh1d6ar1f4n5zmyjg7gi2vl3aq63kxbfld9vw7";
+    url  = "https://bobswift.atlassian.net/wiki/download/attachments/16285777/${name}-distribution.zip";
+    sha256  = "111s4d9m6vxq8jwh1d6ar1f4n5zmyjg7gi2vl3aq63kxbfld9vw7";
     extraPostFetch = "chmod go-w $out";
   };
-  tools = [ "agile" "bamboo" "bitbucket" "confluence" "csv"
-    "hipchat" "jira" "servicedesk" "structure" "tempo" "trello" "upm" ];
+  
+  tools = [
+    "agile"
+    "bamboo"
+    "bitbucket"
+    "confluence"
+    "csv"
+    "hipchat"
+    "jira"
+    "servicedesk"
+    "structure"
+    "tempo"
+    "trello"
+    "upm"
+  ];
+  
   installPhase = ''
     mkdir -p $out/{bin,share/doc/atlassian-cli}
     cp -r lib $out/share/java
@@ -22,10 +38,12 @@ stdenv.mkDerivation rec {
       chmod +x $out/bin/$tool
     done
   '';
+  
   meta = with stdenv.lib; {
     description = "An integrated family of CLI’s for various Atlassian applications";
-    homepage    = https://bobswift.atlassian.net/wiki/spaces/ACLI/overview;
-    maintainers = [ maintainers.twey ];
-    license     = [ licenses.unfreeRedistributable ];
+    homepage = https://bobswift.atlassian.net/wiki/spaces/ACLI/overview;
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ twey ];
+    inherit (jre.meta) platforms;
   };
 }

--- a/pkgs/applications/science/machine-learning/torch/torch-distro.nix
+++ b/pkgs/applications/science/machine-learning/torch/torch-distro.nix
@@ -57,6 +57,8 @@ let
       in
       stdenv.mkDerivation (args // {
 
+        name = "${args.name}-${lua.luaversion}";
+
         inherit preBuild postInstall;
 
         inherit luadeps runtimeDeps;

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -10,41 +10,37 @@
 , moreTests ? false
 }:
 
-# helpers for options
-let optionals       = stdenv.lib.optionals;
-    optionalString = stdenv.lib.optionalString;
-    optionOnOff = option: "${if option then "on" else "off"}";
+with stdenv.lib;
+
+let
+  optionOnOff = option: "${if option then "on" else "off"}";
+  urlVersion = replaceStrings ["."] ["_"];
 in
 
 stdenv.mkDerivation rec {
-  major_version = "3";
-  minor_version = "17";
-  version = "${major_version}.${minor_version}";
   name = "simgrid-${version}";
+  version = "3.17";
 
   src = fetchFromGitHub {
     owner = "simgrid";
     repo = "simgrid";
-    rev = "v${major_version}_${minor_version}";
+    rev = "v${urlVersion version}";
     sha256 = "0ffs9w141qhw571jsa9sch1cnr332vs4sgj6dsiij2mc24m6wpb4";
-    #rev = "master";
-    #sha256 = "0qvh1jzc2lpnp8234kjx1x4g1a5kfdn6kb15vhk160qgvj98nyqm";
   };
 
-  nativeBuildInputs = [ cmake perl elfutils python3 boost valgrind]
-      ++ optionals fortranSupport [gfortran]
-      ++ optionals buildJavaBindings [openjdk]
-      ++ optionals buildDocumentation [transfig ghostscript doxygen]
-      ++ optionals modelCheckingSupport [libunwind libevent];
+  nativeBuildInputs = [ cmake perl elfutils python3 boost valgrind ]
+      ++ optionals fortranSupport [ gfortran ]
+      ++ optionals buildJavaBindings [ openjdk ]
+      ++ optionals buildDocumentation [ transfig ghostscript doxygen ]
+      ++ optionals modelCheckingSupport [ libunwind libevent ];
 
   #buildInputs = optional luaSupport lua5;
 
-  preConfigure =
-    # Make it so that libsimgrid.so will be found when running programs from
-    # the build dir.
-    ''
+  # Make it so that libsimgrid.so will be found when running programs from
+  # the build dir.
+  preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/build/lib"
-    '';
+  '';
 
   # Release mode is not supported in SimGrid
   cmakeBuildType = "Debug";
@@ -59,58 +55,57 @@ stdenv.mkDerivation rec {
   # For more information see:
   # http://simgrid.gforge.inria.fr/simgrid/latest/doc/install.html#install_cmake_list
   cmakeFlags= ''
-       -Denable_documentation=${optionOnOff buildDocumentation}
-       -Denable_java=${optionOnOff buildJavaBindings}
-       -Denable_fortran=${optionOnOff fortranSupport}
-       -Denable_model-checking=${optionOnOff modelCheckingSupport}
-       -Denable_ns3=off
-       -Denable_lua=off
-       -Denable_lib_in_jar=off
-       -Denable_maintainer_mode=off
-       -Denable_mallocators=on
-       -Denable_debug=on
-       -Denable_smpi=on
-       -Denable_smpi_ISP_testsuite=${optionOnOff moreTests}
-       -Denable_smpi_MPICH3_testsuite=${optionOnOff moreTests}
-       -Denable_compile_warnings=${optionOnOff debug}
-       -Denable_compile_optimizations=${optionOnOff (!debug)}
-       -Denable_lto=${optionOnOff (!debug)}
-       '';
-       #-Denable_lua=${optionOnOff luaSupport}
-       #-Denable_smpi_papi=${optionOnOff moreTests}
+    -Denable_documentation=${optionOnOff buildDocumentation}
+    -Denable_java=${optionOnOff buildJavaBindings}
+    -Denable_fortran=${optionOnOff fortranSupport}
+    -Denable_model-checking=${optionOnOff modelCheckingSupport}
+    -Denable_ns3=off
+    -Denable_lua=off
+    -Denable_lib_in_jar=off
+    -Denable_maintainer_mode=off
+    -Denable_mallocators=on
+    -Denable_debug=on
+    -Denable_smpi=on
+    -Denable_smpi_ISP_testsuite=${optionOnOff moreTests}
+    -Denable_smpi_MPICH3_testsuite=${optionOnOff moreTests}
+    -Denable_compile_warnings=${optionOnOff debug}
+    -Denable_compile_optimizations=${optionOnOff (!debug)}
+    -Denable_lto=${optionOnOff (!debug)}
+  '';
+  # -Denable_lua=${optionOnOff luaSupport}
+  # -Denable_smpi_papi=${optionOnOff moreTests}
 
   makeFlags = optionalString debug "VERBOSE=1";
 
-  preBuild =
-    ''
-       # Some perl scripts are called to generate test during build which
-       # is before the fixupPhase of nix, so do this manualy here:
-       patchShebangs ..
-    '';
+  # Some Perl scripts are called to generate test during build which
+  # is before the fixupPhase, so do this manualy here:
+  preBuild = ''
+    patchShebangs ..
+  '';
 
   doCheck = true;
+  
   checkPhase = ''
     runHook preCheck
-
     ctest --output-on-failure -E smpi-replay-multiple
-
     runHook postCheck
-    '';
+  '';
+    
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "Framework for the simulation of distributed applications";
-    longDescription =
-      '' SimGrid is a toolkit that provides core functionalities for the
-         simulation of distributed applications in heterogeneous distributed
-         environments.  The specific goal of the project is to facilitate
-         research in the area of distributed and parallel application
-         scheduling on distributed computing platforms ranging from simple
-         network of workstations to Computational Grids.
-      '';
+    longDescription = ''
+      SimGrid is a toolkit that provides core functionalities for the
+      simulation of distributed applications in heterogeneous distributed
+      environments.  The specific goal of the project is to facilitate
+      research in the area of distributed and parallel application
+      scheduling on distributed computing platforms ranging from simple
+      network of workstations to Computational Grids.
+    '';
     homepage = http://simgrid.gforge.inria.fr/;
+    license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ mickours ];
     platforms = platforms.x86_64;
-    license = licenses.lgpl2Plus;
   };
 }

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -19,14 +19,13 @@ in
 stdenv.mkDerivation rec {
   major_version = "3";
   minor_version = "17";
-  version = "v${major_version}.${minor_version}";
-  tagged_version = "${major_version}_${minor_version}";
-  name = "simgrid";
+  version = "${major_version}.${minor_version}";
+  name = "simgrid-${version}";
 
   src = fetchFromGitHub {
     owner = "simgrid";
     repo = "simgrid";
-    rev = "v3_17";
+    rev = "v${major_version}_${minor_version}";
     sha256 = "0ffs9w141qhw571jsa9sch1cnr332vs4sgj6dsiij2mc24m6wpb4";
     #rev = "master";
     #sha256 = "0qvh1jzc2lpnp8234kjx1x4g1a5kfdn6kb15vhk160qgvj98nyqm";

--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -8,7 +8,7 @@ in
   stdenv.mkDerivation {
     inherit version jarName;
 
-    name = "bfg-repo-cleaner";
+    name = "bfg-repo-cleaner-${version}";
 
     src = fetchurl {
       url = mavenUrl;

--- a/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitweb/default.nix
@@ -10,7 +10,7 @@ let
     sha256 = "0wksqma41z36dbv6w6iplkjfdm0ha3njp222fakyh4lismajr71p";
   };
 in stdenv.mkDerivation {
-  name = "gitweb";
+  name = "gitweb-${stdenv.lib.getVersion git}";
 
   src = git.gitweb;
 

--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -77,7 +77,7 @@ let
 
 # Lightworks expects some files in /usr/share/lightworks
 in buildFHSUserEnv rec {
-  name = "lightworks";
+  name = "lightworks-${stdenv.lib.getVersion lightworks}";
 
   targetPkgs = pkgs: [
       lightworks

--- a/pkgs/data/fonts/liberationsansnarrow/default.nix
+++ b/pkgs/data/fonts/liberationsansnarrow/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   pname = "liberationsansnarrow";
   version = "1.07.3";
-  name = "${pname}";
+  name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://fedorahosted.org/releases/l/i/liberation-fonts/liberation-fonts-ttf-${version}.tar.gz";

--- a/pkgs/data/fonts/meslo-lg/default.nix
+++ b/pkgs/data/fonts/meslo-lg/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   version = "1.2.1";
 
-  name = "meslo-lg";
+  name = "meslo-lg-${version}";
 
   meslo-lg = fetchurl {
     url="https://github.com/andreberg/Meslo-Font/blob/master/dist/v${version}/Meslo%20LG%20v${version}.zip?raw=true";

--- a/pkgs/data/fonts/mph-2b-damase/default.nix
+++ b/pkgs/data/fonts/mph-2b-damase/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchzip}:
 
 fetchzip {
-  name = "MPH-2B-Damase";
+  name = "MPH-2B-Damase-2";
 
   url = http://www.wazu.jp/downloads/damase_v.2.zip;
 

--- a/pkgs/development/compilers/adobe-flex-sdk/default.nix
+++ b/pkgs/development/compilers/adobe-flex-sdk/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "adobe-flex-sdk-4.0.0.14159-mpl";
+  name = "adobe-flex-sdk-4.0.0.14159";
 
   src = fetchurl {
     # This is the open source distribution

--- a/pkgs/development/compilers/emscripten/fastcomp/default.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/default.nix
@@ -15,7 +15,7 @@ let
       '';
     };
     emscriptenfastcomp = symlinkJoin {
-      name = "emscriptenfastcomp";
+      name = "emscriptenfastcomp-${stdenv.lib.getVersion self.emscriptenfastcomp-unwrapped}";
       paths = [ self.emscriptenfastcomp-wrapped self.emscriptenfastcomp-unwrapped ];
       preferLocalBuild = false;
       allowSubstitutes = true;

--- a/pkgs/development/idris-modules/with-packages.nix
+++ b/pkgs/development/idris-modules/with-packages.nix
@@ -4,9 +4,9 @@
 
 let paths = stdenv.lib.closePropagation packages;
 in
-symlinkJoin {
+stdenv.lib.appendToName "with-packages" (symlinkJoin {
 
-  name = idris.name + "-with-packages";
+  inherit (idris) name;
 
   paths = paths ++ [idris] ;
 
@@ -17,4 +17,4 @@ symlinkJoin {
       --set IDRIS_LIBRARY_PATH $out/libs
       '';
 
-}
+})

--- a/pkgs/development/libraries/c-blosc/default.nix
+++ b/pkgs/development/libraries/c-blosc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "c-blosc";
+  name = "c-blosc-${version}";
   version = "1.11.3";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/languagemachines/frog.nix
+++ b/pkgs/development/libraries/languagemachines/frog.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "frog";
+  name = "frog-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "frog-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/frogdata.nix
+++ b/pkgs/development/libraries/languagemachines/frogdata.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "frogdata";
+  name = "frogdata-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "frogdata-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/libfolia.nix
+++ b/pkgs/development/libraries/languagemachines/libfolia.nix
@@ -8,7 +8,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "libfolia";
+  name = "libfolia-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "libfolia-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/mbt.nix
+++ b/pkgs/development/libraries/languagemachines/mbt.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "mbt";
+  name = "mbt-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "mbt-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/ticcutils.nix
+++ b/pkgs/development/libraries/languagemachines/ticcutils.nix
@@ -7,7 +7,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "ticcutils";
+  name = "ticcutils-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "ticcutils-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/timbl.nix
+++ b/pkgs/development/libraries/languagemachines/timbl.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "timbl";
+  name = "timbl-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "timbl-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/timblserver.nix
+++ b/pkgs/development/libraries/languagemachines/timblserver.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "timblserver";
+  name = "timblserver-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "timblserver-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/ucto.nix
+++ b/pkgs/development/libraries/languagemachines/ucto.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "ucto";
+  name = "ucto-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "ucto-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/uctodata.nix
+++ b/pkgs/development/libraries/languagemachines/uctodata.nix
@@ -8,7 +8,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "uctodata";
+  name = "uctodata-${release.version}";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "uctodata-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/libblocksruntime/default.nix
+++ b/pkgs/development/libraries/libblocksruntime/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, clang }:
 
 stdenv.mkDerivation {
-  name = "blocksruntime";
+  name = "blocksruntime-20140624";
 
   src = fetchFromGitHub {
     owner = "mackyle";

--- a/pkgs/development/libraries/physics/nlojet/default.nix
+++ b/pkgs/development/libraries/physics/nlojet/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
-  name = "nlojet++";
+  name = "nlojet++-${version}";
   version = "4.1.3";
 
   src = fetchurl {

--- a/pkgs/development/libraries/qtinstaller/default.nix
+++ b/pkgs/development/libraries/qtinstaller/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, qtdeclarative , qttools, qtbase, qmake }:
 
 stdenv.mkDerivation rec {
-  name = "qtinstaller";
+  name = "qtinstaller-${version}";
 
   propagatedBuildInputs = [ qtdeclarative qttools ];
   nativeBuildInputs = [ qmake ];

--- a/pkgs/development/libraries/re2/default.nix
+++ b/pkgs/development/libraries/re2/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "re2";
+  name = "re2-${version}";
   version = "20140304";
 
   src = fetchurl {
-    url = "https://re2.googlecode.com/files/${name}-${version}.tgz";
+    url = "https://re2.googlecode.com/files/${name}.tgz";
     sha256 = "19wn0472c9dsxp35d0m98hlwhngx1f2xhxqgr8cb5x72gnjx3zqb";
   };
 

--- a/pkgs/development/tools/build-managers/gn/default.nix
+++ b/pkgs/development/tools/build-managers/gn/default.nix
@@ -45,8 +45,8 @@ let
     };
   };
 
-in stdenv.mkDerivation {
-  name = "gn";
+in stdenv.mkDerivation rec {
+  name = "gn-${version}";
   version = "20180423";
   sourceRoot = ".";
 

--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -2,7 +2,7 @@
 , beamPackages, z3, python27 }:
 
 stdenv.mkDerivation rec {
-  name = "cuter";
+  name = "cuter-${version}";
   version = "0.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/imatix_gsl/default.nix
+++ b/pkgs/development/tools/imatix_gsl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pcre } :
 
 stdenv.mkDerivation rec {
-  name = "imatix_gsl";
+  name = "imatix_gsl-${version}";
   version = "4.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/yuicompressor/default.nix
+++ b/pkgs/development/tools/yuicompressor/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  name = "yuicompressor";
+  name = "yuicompressor-${version}";
   version = "2.4.8";
   src = fetchurl {
-    url = "http://github.com/yui/yuicompressor/releases/download/v${version}/${name}-${version}.jar";
+    url = "http://github.com/yui/yuicompressor/releases/download/v${version}/${name}.jar";
     sha256 = "1qjxlak9hbl9zd3dl5ks0w4zx5z64wjsbk7ic73r1r45fasisdrh";
   };
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   buildCommand = ''
     mkdir -p $out/{bin,lib}
     ln -s $src $out/lib/yuicompressor.jar
-    makeWrapper ${jre}/bin/java $out/bin/${name} --add-flags \
+    makeWrapper ${jre}/bin/java $out/bin/yuicompressor --add-flags \
      "-cp $out/lib/yuicompressor.jar com.yahoo.platform.yui.compressor.YUICompressor"
   '';
 }

--- a/pkgs/development/tools/yuicompressor/default.nix
+++ b/pkgs/development/tools/yuicompressor/default.nix
@@ -3,20 +3,14 @@
 stdenv.mkDerivation rec {
   name = "yuicompressor-${version}";
   version = "2.4.8";
+  
   src = fetchurl {
     url = "http://github.com/yui/yuicompressor/releases/download/v${version}/${name}.jar";
     sha256 = "1qjxlak9hbl9zd3dl5ks0w4zx5z64wjsbk7ic73r1r45fasisdrh";
   };
 
-  buildInputs = [makeWrapper jre];
-
-  meta = {
-    description = "A JavaScript and CSS minifier";
-    maintainers = [ stdenv.lib.maintainers.jwiegley ];
-    platforms = stdenv.lib.platforms.all;
-    homepage = http://yui.github.io/yuicompressor/;
-    license = stdenv.lib.licenses.bsd3;
-  };
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre ];
 
   buildCommand = ''
     mkdir -p $out/{bin,lib}
@@ -24,4 +18,12 @@ stdenv.mkDerivation rec {
     makeWrapper ${jre}/bin/java $out/bin/yuicompressor --add-flags \
      "-cp $out/lib/yuicompressor.jar com.yahoo.platform.yui.compressor.YUICompressor"
   '';
+  
+  meta = with stdenv.lib; {
+    description = "A JavaScript and CSS minifier";
+    homepage = http://yui.github.io/yuicompressor/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jwiegley ];
+    platforms = platforms.all;
+  };
 }

--- a/pkgs/games/quake2/yquake2/wrapper.nix
+++ b/pkgs/games/quake2/yquake2/wrapper.nix
@@ -12,7 +12,7 @@ let
   };
 
 in stdenv.mkDerivation {
-  inherit name;
+  name = "${name}-${stdenv.lib.getVersion yquake2}";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -2,13 +2,14 @@
 
 stdenv.mkDerivation rec {
 
-  name = "brlaser";
+  name = "brlaser-${version}";
+  version = "4";
 
   src = fetchFromGitHub {
     owner = "pdewacht";
     repo = "brlaser";
-    rev = "a52149823373e11f918d9e6a56eda7242935c99b";
-    sha256 = "12d8g0aispdj2virf6vrvb0vx6d6ardjg3qyav75shsm1f94ids6";
+    rev = "v${version}";
+    sha256 = "1yy4mpf68c82h245srh2sd1yip29w6kx14gxk4hxkv496gf55lw5";
   };
 
   buildInputs = [ cmake zlib cups ];

--- a/pkgs/misc/cups/drivers/estudio/default.nix
+++ b/pkgs/misc/cups/drivers/estudio/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, perl }:
 
-stdenv.mkDerivation {
-  name = "cups-toshiba-estudio";
+stdenv.mkDerivation rec {
+  name = "cups-toshiba-estudio-${version}";
   version = "7.51";
 
   src = fetchurl {

--- a/pkgs/misc/lilypond/with-fonts.nix
+++ b/pkgs/misc/lilypond/with-fonts.nix
@@ -5,8 +5,8 @@
 , fonts ? openlilylib-fonts.all
 }:
 
-stdenv.mkDerivation {
-  name = "${lilypond.name}-with-fonts";
+stdenv.lib.appendToName "with-fonts" (stdenv.mkDerivation {
+  inherit (lilypond) name;
   phases = "installPhase";
   buildInputs = fonts;
   nativeBuildInputs = [ lndir ];
@@ -32,4 +32,4 @@ stdenv.mkDerivation {
         substituteInPlace $p --replace "exec -a \"${lilypond}" "exec -a \"$out"
       done
   '';
-}
+})

--- a/pkgs/misc/themes/gnome-breeze/default.nix
+++ b/pkgs/misc/themes/gnome-breeze/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation {
-  name = "gnome-breeze";
+  name = "gnome-breeze-20160526";
   src = fetchgit {
     url = "https://github.com/dirruk1/gnome-breeze";
     sha256 = "0hkk0gqlnrs1m4rb5r84f5y96qfamrbiwm09z89yc32124x1a1lm";

--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -2,7 +2,7 @@
 
 stdenv.lib.overrideDerivation systemd (p: {
   version = p.version;
-  name = "systemd-cryptsetup-generator";
+  name = "systemd-cryptsetup-generator-${p.version}";
 
   nativeBuildInputs = p.nativeBuildInputs ++ [ cryptsetup ];
   outputs = [ "out" ];

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -95,7 +95,7 @@ let
     ];
   };
 in stdenv.mkDerivation {
-  name = "xquartz";
+  name = "xquartz-${stdenv.lib.getVersion xorg.xorgserver}";
 
   buildInputs = [ ruby makeWrapper ];
 

--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -3,11 +3,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "mpDris2";
+  pname = "mpDris2";
+  name = "${pname}-${version}";
   version = "0.7";
 
   src = fetchurl {
-    url = "https://github.com/eonpatapon/${name}/archive/${version}.tar.gz";
+    url = "https://github.com/eonpatapon/${pname}/archive/${version}.tar.gz";
     sha256 = "095swrjw59lh8qiwmjjjdbxl9587axilkj4mh2sx5m0kiq929z21";
   };
 

--- a/pkgs/tools/misc/buildtorrent/default.nix
+++ b/pkgs/tools/misc/buildtorrent/default.nix
@@ -3,10 +3,10 @@
 let version = "0.8"; in
 
 stdenv.mkDerivation rec {
-	name = "buildtorrent";
+	name = "buildtorrent-${version}";
 
 	src = fetchurl {
-		url = "http://mathr.co.uk/blog/code/${name}-${version}.tar.gz";
+		url = "http://mathr.co.uk/blog/code/${name}.tar.gz";
 		sha256 = "e8e27647bdb38873ac570d46c1a9689a92b01bb67f59089d1cdd08784f7052d0";
 	};
 

--- a/pkgs/tools/misc/notify-desktop/default.nix
+++ b/pkgs/tools/misc/notify-desktop/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, dbus, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "notify-desktop";
+  name = "notify-desktop-${version}";
   version = "0.2.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/networking/dnstracer/default.nix
+++ b/pkgs/tools/networking/dnstracer/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   version = "1.9";
-  name = "dnstracer";
+  name = "dnstracer-${version}";
 
   src = fetchurl {
-    url = "http://www.mavetju.org/download/dnstracer-${version}.tar.gz";
+    url = "http://www.mavetju.org/download/${name}.tar.gz";
     sha256 = "177y58smnq2xhx9lbmj1gria371iv3r1d132l2gjvflkjsphig1f";
   };
 

--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.2.8";
-  name = "zerotierone";
+  name = "zerotierone-${version}";
 
   src = fetchurl {
     url = "https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz";

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -1,7 +1,7 @@
 { stdenv, bash-completion, cmake, fetchgit, hidapi, libusb1, pkgconfig, qt5 }:
 
 stdenv.mkDerivation rec {
-  name = "nitrokey-app";
+  name = "nitrokey-app-${version}";
   version = "1.2";
 
   # We use fetchgit instead of fetchFromGitHub because of necessary git submodules

--- a/pkgs/tools/security/nitrokey-app/udev-rules.nix
+++ b/pkgs/tools/security/nitrokey-app/udev-rules.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation {
-  name = "nitrokey-udev-rules";
+  name = "nitrokey-udev-rules-${stdenv.lib.getVersion nitrokey-app}";
 
   inherit (nitrokey-app) src;
 

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, cmake, protobuf }:
 stdenv.mkDerivation rec {
-  name = "jumanpp";
+  name = "jumanpp-${version}";
   version = "2.0.0-rc2";
 
   src = fetchurl {
-    url = "https://github.com/ku-nlp/${name}/releases/download/v${version}/${name}-${version}.tar.xz";
+    url = "https://github.com/ku-nlp/${name}/releases/download/v${version}/${name}.tar.xz";
     sha256 = "17fzmd0f5m9ayfhsr0mg7hjp3pg1mhbgknhgyd8v87x46g8bg6qp";
   };
   buildInputs = [ cmake protobuf ];

--- a/pkgs/top-level/unix-tools.nix
+++ b/pkgs/top-level/unix-tools.nix
@@ -11,9 +11,11 @@
 # input, not "procps" which requires Linux.
 
 let
+  version = "1003.1-2008";
+
   singleBinary = cmd: providers: let
       provider = "${lib.getBin providers.${hostPlatform.parsed.kernel.name}}/bin/${cmd}";
-    in runCommand cmd {
+    in runCommand "${cmd}-${version}" {
       meta.platforms = map (n: { kernel.name = n; }) (pkgs.lib.attrNames providers);
     } ''
       mkdir -p $out/bin
@@ -28,7 +30,7 @@ let
 
   # more is unavailable in darwin
   # just use less
-  more_compat = runCommand "more" {} ''
+  more_compat = runCommand "more-${version}" {} ''
     mkdir -p $out/bin
     ln -s ${pkgs.less}/bin/less $out/bin/more
   '';
@@ -131,7 +133,7 @@ let
   };
 
   makeCompat = name': value: buildEnv {
-    name = name' + "-compat";
+    name = name' + "-compat-${version}";
     paths = value;
   };
 


### PR DESCRIPTION
###### Motivation for this change
See #41007 for more details.

Most of these were found with this command:

```
nix-env -qa -f. | grep -v '\-[0-9A-Za-z.-_+]*$' | grep -v '^hook$'
```

nixpkgs-unstable:

```
$ nix-env -qa -f channel:nixpkgs-unstable | grep -v '\-[0-9A-Za-z.-_+]*$' | grep -v '^hook$' | wc -l
88
```

PR HEAD:

```
$ nix-env -qa -f https://github.com/matthewbauer/nixpkgs/archive/normalize-names.tar.gz | grep -v '\-[0-9A-Za-z.-_+]*$' | grep -v '^hook$' | wc -l
18
```