### PR TITLE
skopeo: 0.1.29 -> 0.1.30

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -52,15 +52,7 @@ rec {
       outputHashAlgo = "sha256";
       outputHash = sha256;
 
-      # One of the dependencies of Skopeo uses a hardcoded /var/tmp for storing
-      # big image files, which is not available in sandboxed builds.
-      nativeBuildInputs = lib.singleton (pkgs.skopeo.overrideAttrs (drv: {
-        postPatch = (drv.postPatch or "") + ''
-          sed -i -e 's!/var/tmp!/tmp!g' \
-            vendor/github.com/containers/image/storage/storage_image.go \
-            vendor/github.com/containers/image/internal/tmpdir/tmpdir.go
-        '';
-      }));
+      nativeBuildInputs = lib.singleton (pkgs.skopeo);
       SSL_CERT_FILE = "${pkgs.cacert.out}/etc/ssl/certs/ca-bundle.crt";
 
       sourceURL = "docker://${imageName}@${imageDigest}";

--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 
 let
-  version = "0.1.29";
+  version = "0.1.30";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "projectatomic";
     repo = "skopeo";
-    sha256 = "1lhzbyj2mm25x12s7g2jx4v8w19izjwlgx4lml13r5yy1spn65k2";
+    sha256 = "10lpiiki7mlhrp4bid40wys3lch7fars1whxsa5gy0frfgp89ghn";
   };
 
   defaultPolicyFile = runCommand "skopeo-default-policy.json" {} "cp ${src}/default-policy.json $out";
@@ -30,7 +30,11 @@ buildGoPackage rec {
   nativeBuildInputs = [ pkgconfig (lib.getBin go-md2man) ];
   buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs ostree libselinux ];
 
-  buildFlagsArray = "-ldflags= -X github.com/projectatomic/skopeo/vendor/github.com/containers/image/signature.systemDefaultPolicyPath=${defaultPolicyFile}";
+  buildFlagsArray = ''
+    -ldflags=
+    -X github.com/projectatomic/skopeo/vendor/github.com/containers/image/signature.systemDefaultPolicyPath=${defaultPolicyFile}
+    -X github.com/projectatomic/skopeo/vendor/github.com/containers/image/internal/tmpdir.unixTempDirForBigFiles=/tmp
+  '';
 
   preBuild = ''
     export CGO_CFLAGS="-I${getDev gpgme}/include -I${getDev libgpgerror}/include -I${getDev devicemapper}/include -I${getDev btrfs-progs}/include"


### PR DESCRIPTION
Skopeo used by our docker tools was patched to work in the build
sandbox (it used /var/tmp which is not available in the sandbox).
Since this temporary directory can now be set at build time, we remove
the patch from our docker tools.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

