### PR TITLE
nixos/slurm: fix default module parameters, update documenation

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -13,6 +13,7 @@ let
       ${optionalString (cfg.nodeName != null) ''nodeName=${cfg.nodeName}''}
       ${optionalString (cfg.partitionName != null) ''partitionName=${cfg.partitionName}''}
       PlugStackConfig=${plugStackConfig}
+      ProctrackType=${cfg.procTrackType}
       ${cfg.extraConfig}
     '';
 
@@ -100,6 +101,16 @@ in
           from within an interactive session or a batch job. This activates the
           slurm-spank-x11 module. Note that this requires 'services.openssh.forwardX11'
           to be enabled on the compute nodes.
+        '';
+      };
+
+      procTrackType = mkOption {
+        type = types.string;
+        default = "proctrack/linuxproc";
+        description = ''
+          Plugin to be used for process tracking on a job step basis.
+          The slurmd daemon uses this mechanism to identify all processes
+          which are children of processes it spawns for a user job step.
         '';
       };
 

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -32,12 +32,20 @@ in
     services.slurm = {
 
       server = {
-        enable = mkEnableOption "slurm control daemon";
-
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Wether to enable the slurm control daemon.
+            Note that the standard authentication method is "munge".
+            The "munge" service needs to be provided with a password file in order for
+            slurm to work properly (see <literal>services.munge.password<literal>).
+          '';
+        };
       };
 
       client = {
-        enable = mkEnableOption "slurm rlient daemon";
+        enable = mkEnableOption "slurm client daemon";
 
       };
 
@@ -160,6 +168,8 @@ in
   in mkIf (cfg.client.enable || cfg.server.enable) {
 
     environment.systemPackages = [ wrappedSlurm ];
+
+    services.munge.enable = mkDefault true;
 
     systemd.services.slurmd = mkIf (cfg.client.enable) {
       path = with pkgs; [ wrappedSlurm coreutils ]

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -383,6 +383,7 @@ in rec {
   tests.sddm = callSubTests tests/sddm.nix {};
   tests.simple = callTest tests/simple.nix {};
   tests.slim = callTest tests/slim.nix {};
+  tests.slurm = callTest tests/slurm.nix {};
   tests.smokeping = callTest tests/smokeping.nix {};
   tests.snapper = callTest tests/snapper.nix {};
   tests.statsd = callTest tests/statsd.nix {};

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -20,7 +20,6 @@ in {
         # TODO slrumd port and slurmctld port should be configurations and
         # automatically allowed by the  firewall.
         networking.firewall.enable = false;
-        services.munge.enable = true;
         services.slurm = slurmconfig;
       };
     in {
@@ -28,7 +27,6 @@ in {
       { config, pkgs, ...}:
       {
         networking.firewall.enable = false;
-        services.munge.enable = true;
         services.slurm = {
           server.enable = true;
         } // slurmconfig;


### PR DESCRIPTION
###### Motivation for this change
Slurm's default process tracking facility is now cgroups. However, the lack of the `cgroups.conf` config files, required by slurm, breaks the test. I added the option `procTrackType` to the module, setting the
default to `proctrack/linuxproc`. This enables the minimal example of the test to run again.

This PR follows the idea that a minimal setup configured through nix should be functional.
Integrating `cgroups.conf` requires an additional option in the module, since it is required
to reside in the same directory as `slurm.conf` (will be part of a future PR).


###### Things done

- New option `procTrackType`
- Refer to munge in the description (required to run in the default setting).
- [EDIT]: enable munge by default.
- [EDIT]: added slurm test to release.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
nixos/tests/slurm.nix completes successfully
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

