### PR TITLE
[WIP] nixos: make several modules not run as root

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -511,12 +511,7 @@ in {
         openssh
         gitlab-workhorse
       ];
-      preStart = ''
-        mkdir -p /run/gitlab
-        chown ${cfg.user}:${cfg.group} /run/gitlab
-      '';
       serviceConfig = {
-        PermissionsStartOnly = true; # preStart must be run as root
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
@@ -568,7 +563,6 @@ in {
         # The uploads directory is hardcoded somewhere deep in rails. It is
         # symlinked in the gitlab package to /run/gitlab/uploads to make it
         # configurable
-        mkdir -p /run/gitlab
         mkdir -p ${cfg.statePath}/{log,uploads}
         ln -sf ${cfg.statePath}/log /run/gitlab/log
         ln -sf ${cfg.statePath}/uploads /run/gitlab/uploads
@@ -645,6 +639,7 @@ in {
       '';
 
       serviceConfig = {
+        RuntimeDirectory = "gitlab";
         PermissionsStartOnly = true; # preStart must be run as root
         Type = "simple";
         User = cfg.user;

--- a/nixos/modules/services/monitoring/apcupsd.nix
+++ b/nixos/modules/services/monitoring/apcupsd.nix
@@ -150,8 +150,8 @@ in
     systemd.services.apcupsd = {
       description = "APC UPS Daemon";
       wantedBy = [ "multi-user.target" ];
-      preStart = "mkdir -p /run/apcupsd/";
       serviceConfig = {
+        RuntimeDirectory = "apcupsd";
         ExecStart = "${pkgs.apcupsd}/bin/apcupsd -b -f ${configFile} -d1";
         # TODO: When apcupsd has initiated a shutdown, systemd always ends up
         # waiting for it to stop ("A stop job is running for UPS daemon"). This

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -57,12 +57,6 @@ let
     --nodaemon --syslog --prefix=${name} --pidfile /run/${name}/${name}.pid ${name}
   '';
 
-  mkPidFileDir = name: ''
-    mkdir -p /run/${name}
-    chmod 0700 /run/${name}
-    chown -R graphite:graphite /run/${name}
-  '';
-
   carbonEnv = {
     PYTHONPATH = let
       cenv = pkgs.python.buildEnv.override {
@@ -412,18 +406,16 @@ in {
         after = [ "network.target" ];
         environment = carbonEnv;
         serviceConfig = {
+          RuntimeDirectory = name;
           ExecStart = "${pkgs.pythonPackages.twisted}/bin/twistd ${carbonOpts name}";
           User = "graphite";
           Group = "graphite";
           PermissionsStartOnly = true;
           PIDFile="/run/${name}/${name}.pid";
         };
-        preStart = mkPidFileDir name + ''
-
-          mkdir -p ${cfg.dataDir}/whisper
-          chmod 0700 ${cfg.dataDir}/whisper
-          chown graphite:graphite ${cfg.dataDir}
-          chown graphite:graphite ${cfg.dataDir}/whisper
+        preStart = ''
+          install -dm0700 -o graphite -g graphite ${cfg.dataDir}
+          install -dm0700 -o graphite -g graphite ${cfg.dataDir}/whisper
         '';
       };
     })
@@ -436,12 +428,12 @@ in {
         after = [ "network.target" ];
         environment = carbonEnv;
         serviceConfig = {
+          RuntimeDirectory = name;
           ExecStart = "${pkgs.pythonPackages.twisted}/bin/twistd ${carbonOpts name}";
           User = "graphite";
           Group = "graphite";
           PIDFile="/run/${name}/${name}.pid";
         };
-        preStart = mkPidFileDir name;
       };
     })
 
@@ -452,12 +444,12 @@ in {
         after = [ "network.target" ];
         environment = carbonEnv;
         serviceConfig = {
+          RuntimeDirectory = name;
           ExecStart = "${pkgs.pythonPackages.twisted}/bin/twistd ${carbonOpts name}";
           User = "graphite";
           Group = "graphite";
           PIDFile="/run/${name}/${name}.pid";
         };
-        preStart = mkPidFileDir name;
       };
     })
 

--- a/nixos/modules/services/security/munge.nix
+++ b/nixos/modules/services/security/munge.nix
@@ -35,20 +35,21 @@ in
 
     environment.systemPackages = [ pkgs.munge ];
 
-    systemd.services.munged = { 
+    systemd.services.munged = {
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      path = [ pkgs.munge pkgs.coreutils ];
+      path = with pkgs; [ munge coreutils ];
 
       preStart = ''
         chmod 0700 ${cfg.password}
-        mkdir -p /var/lib/munge -m 0711
-        mkdir -p /var/log/munge -m 0700
-        mkdir -p /run/munge -m 0755
       '';
 
       serviceConfig = {
+        RuntimeDirectory = "munge";
+        StateDirectory = "munge";
+        LogDirectory = "munge";
+        Type = "forking";
         ExecStart = "${pkgs.munge}/bin/munged --syslog --key-file ${cfg.password}";
         PIDFile = "/run/munge/munged.pid";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";

--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -74,8 +74,6 @@ let
     pkgs.writeText "lighttpd.conf" ''
       server.document-root = "${cfg.document-root}"
       server.port = ${toString cfg.port}
-      server.username = "lighttpd"
-      server.groupname = "lighttpd"
 
       # As for why all modules are loaded here, instead of having small
       # server.modules += () entries in each sub-service extraConfig snippet,
@@ -240,7 +238,13 @@ in
       description = "Lighttpd Web Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig.ExecStart = "${pkgs.lighttpd}/sbin/lighttpd -D -f ${configFile}";
+      serviceConfig = {
+        RuntimeDirectory = "lighttpd";
+        User = "lighttpd";
+        Group = "lighttpd";
+        ExecStart = "${pkgs.lighttpd}/sbin/lighttpd -D -f ${configFile}";
+        AmbientCapabilities = if (cfg.port < 1024) then "cap_net_bind_service" else "";
+      };
       # SIGINT => graceful shutdown
       serviceConfig.KillSignal = "SIGINT";
     };

--- a/nixos/modules/services/web-servers/lighttpd/inginious.nix
+++ b/nixos/modules/services/web-servers/lighttpd/inginious.nix
@@ -249,11 +249,6 @@ in
           }
         '';
 
-        systemd.services.lighttpd.preStart = ''
-          mkdir -p /run/lighttpd
-          chown lighttpd.lighttpd /run/lighttpd
-        '';
-
         systemd.services.lighttpd.wants = [ "mongodb.service" "docker.service" ];
         systemd.services.lighttpd.after = [ "mongodb.service" "docker.service" ];
       }


### PR DESCRIPTION
###### Motivation for this change

A number of services are currently run as root because they need to create various directories. We can have systemd do that for us so they can start as regular users.

This isn't tested yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

