### PR TITLE
androidndk: Fixes missing libraries for prebuilt clang

### DIFF
--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -219,7 +219,7 @@ rec {
     inherit (buildPackages)
       p7zip makeWrapper;
     inherit (pkgs)
-      stdenv fetchurl zlib ncurses lib python3
+      stdenv fetchurl zlib ncurses5 lib python3 libcxx
       coreutils file findutils gawk gnugrep gnused jdk which;
     inherit platformTools;
     version = "10e";
@@ -230,7 +230,7 @@ rec {
     inherit (buildPackages)
       p7zip makeWrapper;
     inherit (pkgs)
-      stdenv fetchurl zlib ncurses lib python3
+      stdenv fetchurl zlib ncurses5 lib python3 libcxx
       coreutils file findutils gawk gnugrep gnused jdk which;
     inherit platformTools;
     version = "16b";
@@ -241,7 +241,7 @@ rec {
     inherit (buildPackages)
       p7zip makeWrapper;
     inherit (pkgs)
-      stdenv fetchurl zlib ncurses lib python3
+      stdenv fetchurl zlib ncurses5 lib python3 libcxx
       coreutils file findutils gawk gnugrep gnused jdk which;
     inherit platformTools;
     version = "17";


### PR DESCRIPTION
###### Motivation for this change
@Ericson2314 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

