### PR TITLE
lua packages: add init.lua to modules search path

### DIFF
--- a/pkgs/development/lua-modules/generic/default.nix
+++ b/pkgs/development/lua-modules/generic/default.nix
@@ -29,9 +29,9 @@ else
           if [[ $LUA_PATH = *"$package_path"* ]]; then return; fi
 
           if [[ -z $LUA_PATH ]]; then
-            export LUA_PATH="$package_path/?.lua"
+            export LUA_PATH="$package_path/?.lua;$package_path/?/init.lua"
           else
-            export LUA_PATH="$LUA_PATH;$package_path/?.lua"
+            export LUA_PATH="$LUA_PATH;$package_path/?.lua;$package_path/?/init.lua"
           fi
         }
 


### PR DESCRIPTION
###### Motivation for this change

Some lua modules are loaded from directories and they need `.../?/init.lua` in LUA_PATH.

Currently luaposix is affected by this, example:

```
$ nix-shell -p luaPackages.luaposix
$ lua -e 'local posix = require "posix"'
lua: (command line):1: module 'posix' not found:
        no field package.preload['posix']
        no file '/nix/store/6ajbqh4d8gwsqc8bhhmbwh42pm8067lq-lua5.2-posix-34.0.4/share/lua/5.2/posix.lua'
        no file '/nix/store/7ri66nfliqwz9y5psnan20x7qhr79p4n-lua5.2-std.normalize-2.0.1/share/lua/5.2/posix.lua'
        no file '/nix/store/zirr21mk3bsfd5hhdcrrgfw32m2c44vb-lua5.2-std._debug-1.0/share/lua/5.2/posix.lua'
        no file '/nix/store/6ajbqh4d8gwsqc8bhhmbwh42pm8067lq-lua5.2-posix-34.0.4/lib/lua/5.2/posix.so'
        no file '/nix/store/6kqsclvf3acm3ivyf53cbq7p0j9lf114-lua5.2-bit32-5.3.0/lib/lua/5.2/posix.so'
stack traceback:
        [C]: in function 'require'
        (command line):1: in main chunk
        [C]: ?
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

