### PR TITLE
busybox: 1.28.3 -> 1.28.4, fix fsck exit code

### DIFF
--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -33,14 +33,14 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "busybox-1.28.3";
+  name = "busybox-1.28.4";
 
   # Note to whoever is updating busybox: please verify that:
   # nix-build pkgs/stdenv/linux/make-bootstrap-tools.nix -A test
   # still builds after the update.
   src = fetchurl {
     url = "http://busybox.net/downloads/${name}.tar.bz2";
-    sha256 = "0via6faqj9xcyi8r39r4n0wxlk8r2292yk0slzwrdri37w1j43dd";
+    sha256 = "0smfn8hlds6nx8war62kyaykg3n7mxbjjfcpsgz84znwk4v4mhg3";
   };
 
   hardeningDisable = [ "format" ] ++ lib.optionals enableStatic [ "fortify" ];

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -47,6 +47,13 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./busybox-in-store.patch
+
+    # Fix fsck wrapper issue using upstream patch.
+    # Issue:
+    #   https://github.com/NixOS/nixpkgs/issues/40174
+    # Submitted upstream:
+    #   http://lists.busybox.net/pipermail/busybox/2018-May/086417.html
+    ./fsck-fix-incorrect-handling-of-child-exit.patch
   ];
 
   postPatch = "patchShebangs .";

--- a/pkgs/os-specific/linux/busybox/fsck-fix-incorrect-handling-of-child-exit.patch
+++ b/pkgs/os-specific/linux/busybox/fsck-fix-incorrect-handling-of-child-exit.patch
@@ -1,0 +1,89 @@
+From ccb8e4bc4fb74701d0d323d61e9359d8597a4272 Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Thu, 24 May 2018 15:26:28 +0200
+Subject: [PATCH] fsck: fix incorrect handling of child exit
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In commit
+
+  c4fb8c6a - fsck: do not use statics
+
+not only statics were changed but also a couple of
+statics-unrelated changes were made.
+
+This included the handling of the child termination status
+as follows:
+
+    - if (WIFEXITED(status))
+    -   status = WEXITSTATUS(status);
+    - else if (WIFSIGNALED(status)) {
+    + status = WEXITSTATUS(status);
+    + if (WIFSIGNALED(status)) {
+
+This is wrong, should have used a different variable to hold exit code.
+
+Reported by Niklas Hambüchen <mail@nh2.me>.
+
+function                                             old     new   delta
+wait_one                                             294     282     -12
+
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ e2fsprogs/fsck.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/e2fsprogs/fsck.c b/e2fsprogs/fsck.c
+index 1c285bb92..f5aa3dbe4 100644
+--- a/e2fsprogs/fsck.c
++++ b/e2fsprogs/fsck.c
+@@ -414,7 +414,7 @@ static void kill_all_if_got_signal(void)
+ static int wait_one(int flags)
+ {
+ 	int status;
+-	int sig;
++	int exitcode;
+ 	struct fsck_instance *inst, *prev;
+ 	pid_t pid;
+ 
+@@ -448,15 +448,16 @@ static int wait_one(int flags)
+ 	}
+  child_died:
+ 
+-	status = WEXITSTATUS(status);
++	exitcode = WEXITSTATUS(status);
+ 	if (WIFSIGNALED(status)) {
++		unsigned sig;
+ 		sig = WTERMSIG(status);
+-		status = EXIT_UNCORRECTED;
++		exitcode = EXIT_UNCORRECTED;
+ 		if (sig != SIGINT) {
+ 			printf("Warning: %s %s terminated "
+-				"by signal %d\n",
++				"by signal %u\n",
+ 				inst->prog, inst->device, sig);
+-			status = EXIT_ERROR;
++			exitcode = EXIT_ERROR;
+ 		}
+ 	}
+ 
+@@ -492,12 +493,12 @@ static int wait_one(int flags)
+ 	else
+ 		G.instance_list = inst->next;
+ 	if (G.verbose > 1)
+-		printf("Finished with %s (exit status %d)\n",
+-			inst->device, status);
++		printf("Finished with %s (exit status %u)\n",
++			inst->device, exitcode);
+ 	G.num_running--;
+ 	free_instance(inst);
+ 
+-	return status;
++	return exitcode;
+ }
+ 
+ /*
+-- 
+2.17.0
+


### PR DESCRIPTION
Update and add fix for #40174 from upstream.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---