### PR TITLE
dd-agent: fix compatibility issue with iostat

### DIFF
--- a/pkgs/tools/networking/dd-agent/40103-iostat-fix.patch
+++ b/pkgs/tools/networking/dd-agent/40103-iostat-fix.patch
@@ -1,0 +1,30 @@
+diff --git a/checks/system/unix.py b/checks/system/unix.py
+index c37af3c3..58c72626 100644
+--- a/checks/system/unix.py
++++ b/checks/system/unix.py
+@@ -39,7 +39,7 @@ class IO(Check):
+         self.value_re = re.compile(r'\d+\.\d+')
+ 
+     def _parse_linux2(self, output):
+-        recentStats = output.split('Device:')[2].split('\n')
++        recentStats = output.split('Device')[2].split('\n')
+         header = recentStats[0]
+         headerNames = re.findall(self.header_re, header)
+         device = None
+@@ -123,14 +123,14 @@ class IO(Check):
+ 
+                 #                 Linux 2.6.32-343-ec2 (ip-10-35-95-10)   12/11/2012      _x86_64_        (2 CPU)
+                 #
+-                # Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
++                # Device         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
+                 # sda1              0.00    17.61    0.26   32.63     4.23   201.04    12.48     0.16    4.81   0.53   1.73
+                 # sdb               0.00     2.68    0.19    3.84     5.79    26.07    15.82     0.02    4.93   0.22   0.09
+                 # sdg               0.00     0.13    2.29    3.84   100.53    30.61    42.78     0.05    8.41   0.88   0.54
+                 # sdf               0.00     0.13    2.30    3.84   100.54    30.61    42.78     0.06    9.12   0.90   0.55
+                 # md0               0.00     0.00    0.05    3.37     1.41    30.01    18.35     0.00    0.00   0.00   0.00
+                 #
+-                # Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
++                # Device         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
+                 # sda1              0.00     0.00    0.00   10.89     0.00    43.56     8.00     0.03    2.73   2.73   2.97
+                 # sdb               0.00     0.00    0.00    2.97     0.00    11.88     8.00     0.00    0.00   0.00   0.00
+                 # sdg               0.00     0.00    0.00    0.00     0.00     0.00     0.00     0.00    0.00   0.00   0.00

--- a/pkgs/tools/networking/dd-agent/default.nix
+++ b/pkgs/tools/networking/dd-agent/default.nix
@@ -38,6 +38,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1iqxvgpsqibqw3vk79158l2pnb6y4pjhjp2d6724lm5rpz4825lx";
   };
 
+  patches = [ ./40103-iostat-fix.patch ];
+
   buildInputs = [
     python
     unzip
@@ -59,6 +61,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -R $src $out/agent
     chmod u+w -R $out
+    (cd $out/agent; patchPhase)
     PYTHONPATH=$out/agent:$PYTHONPATH
     ln -s $out/agent/agent.py $out/bin/dd-agent
     ln -s $out/agent/dogstatsd.py $out/bin/dogstatsd


### PR DESCRIPTION
###### Motivation for this change

Applies a patch to the dd-agent derivation that fixes a compatibility
issue with the current version of iostat, which no longer contains a
colon after its table headers.

This patch is applied in order for the fix to be backportable to
existing stable releases. A final "proper" fix will be an upgrade to a
newer version of dd-agent, but that requires several other changes.

This fixes #40103.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

------

cc: @bflyblue