### PR TITLE
binutils: Apply patches from 2.30 branch 

### DIFF
--- a/pkgs/development/tools/misc/binutils/PR22741-objcopy-segfault-on-fuzzed-COFF-object.patch
+++ b/pkgs/development/tools/misc/binutils/PR22741-objcopy-segfault-on-fuzzed-COFF-object.patch
@@ -1,0 +1,28 @@
+From eb77f6a4621795367a39cdd30957903af9dbb815 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Sat, 27 Jan 2018 08:19:33 +1030
+Subject: [PATCH] PR22741, objcopy segfault on fuzzed COFF object
+
+	PR 22741
+	* coffgen.c (coff_pointerize_aux): Ensure auxent tagndx is in
+	range before converting to a symbol table pointer.
+---
+ bfd/coffgen.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/coffgen.c b/bfd/coffgen.c
+index b2410873d0..4f90eaddd9 100644
+--- a/bfd/coffgen.c
++++ b/bfd/coffgen.c
+@@ -1555,7 +1555,8 @@ coff_pointerize_aux (bfd *abfd,
+     }
+   /* A negative tagndx is meaningless, but the SCO 3.2v4 cc can
+      generate one, so we must be careful to ignore it.  */
+-  if (auxent->u.auxent.x_sym.x_tagndx.l > 0)
++  if ((unsigned long) auxent->u.auxent.x_sym.x_tagndx.l
++      < obj_raw_syment_count (abfd))
+     {
+       auxent->u.auxent.x_sym.x_tagndx.p =
+ 	table_base + auxent->u.auxent.x_sym.x_tagndx.l;
+-- 
+2.16.2

--- a/pkgs/development/tools/misc/binutils/PR22829-objcopy-strip-removes-PT_GNU_RELRO-from-lld.patch
+++ b/pkgs/development/tools/misc/binutils/PR22829-objcopy-strip-removes-PT_GNU_RELRO-from-lld.patch
@@ -1,0 +1,144 @@
+From 3b56a1358768563d9cf320559ebdedfb30f122dd Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 12 Feb 2018 13:06:07 +1030
+Subject: [PATCH] PR22829, objcopy/strip removes PT_GNU_RELRO from lld binaries
+
+lld lays out the relro segment differently to GNU ld, not bothering to
+include the first few bytes of .got.plt and padding out to a page at
+the end of the segment.  This patch teaches binutils to recognize the
+different (and somewhat inferior) layout as valid.
+
+bfd/
+	PR 22829
+	* elf.c (assign_file_positions_for_non_load_sections): Rewrite
+	PT_GNU_RELRO setup.
+ld/
+	* testsuite/ld-x86-64/pr14207.d: Adjust relro p_filesz.
+
+(cherry picked from commit f2731e0c374e5323ce4cdae2bcc7b7fe22da1a6f)
+---
+ bfd/elf.c                        | 78 ++++++++++++++++++++++++++--------------
+ ld/testsuite/ld-x86-64/pr14207.d |  2 +-
+ 2 files changed, 52 insertions(+), 28 deletions(-)
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index bbaab26918..f5a230cd77 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -5826,50 +5826,74 @@ assign_file_positions_for_non_load_sections (bfd *abfd,
+     {
+       if (p->p_type == PT_GNU_RELRO)
+ 	{
+-	  const Elf_Internal_Phdr *lp;
+-	  struct elf_segment_map *lm;
++	  bfd_vma start, end;
+ 
+ 	  if (link_info != NULL)
+ 	    {
+ 	      /* During linking the range of the RELRO segment is passed
+-		 in link_info.  */
++		 in link_info.  Note that there may be padding between
++		 relro_start and the first RELRO section.  */
++	      start = link_info->relro_start;
++	      end = link_info->relro_end;
++	    }
++	  else if (m->count != 0)
++	    {
++	      if (!m->p_size_valid)
++		abort ();
++	      start = m->sections[0]->vma;
++	      end = start + m->p_size;
++	    }
++	  else
++	    {
++	      start = 0;
++	      end = 0;
++	    }
++
++	  if (start < end)
++	    {
++	      struct elf_segment_map *lm;
++	      const Elf_Internal_Phdr *lp;
++	      unsigned int i;
++
++	      /* Find a LOAD segment containing a section in the RELRO
++		 segment.  */
+ 	      for (lm = elf_seg_map (abfd), lp = phdrs;
+ 		   lm != NULL;
+ 		   lm = lm->next, lp++)
+ 		{
+ 		  if (lp->p_type == PT_LOAD
+-		      && lp->p_vaddr < link_info->relro_end
+ 		      && lm->count != 0
+-		      && lm->sections[0]->vma >= link_info->relro_start)
++		      && lm->sections[lm->count - 1]->vma >= start
++		      && lm->sections[0]->vma < end)
+ 		    break;
+ 		}
+-
+ 	      BFD_ASSERT (lm != NULL);
+-	    }
+-	  else
+-	    {
+-	      /* Otherwise we are copying an executable or shared
+-		 library, but we need to use the same linker logic.  */
+-	      for (lp = phdrs; lp < phdrs + count; ++lp)
++
++	      /* Find the section starting the RELRO segment.  */
++	      for (i = 0; i < lm->count; i++)
+ 		{
+-		  if (lp->p_type == PT_LOAD
+-		      && lp->p_paddr == p->p_paddr)
++		  asection *s = lm->sections[i];
++		  if (s->vma >= start
++		      && s->vma < end
++		      && s->size != 0)
+ 		    break;
+ 		}
+-	    }
++	      BFD_ASSERT (i < lm->count);
++
++	      p->p_vaddr = lm->sections[i]->vma;
++	      p->p_paddr = lm->sections[i]->lma;
++	      p->p_offset = lm->sections[i]->filepos;
++	      p->p_memsz = end - p->p_vaddr;
++	      p->p_filesz = p->p_memsz;
++
++	      /* The RELRO segment typically ends a few bytes into
++		 .got.plt but other layouts are possible.  In cases
++		 where the end does not match any loaded section (for
++		 instance is in file padding), trim p_filesz back to
++		 correspond to the end of loaded section contents.  */
++	      if (p->p_filesz > lp->p_vaddr + lp->p_filesz - p->p_vaddr)
++		p->p_filesz = lp->p_vaddr + lp->p_filesz - p->p_vaddr;
+ 
+-	  if (lp < phdrs + count)
+-	    {
+-	      p->p_vaddr = lp->p_vaddr;
+-	      p->p_paddr = lp->p_paddr;
+-	      p->p_offset = lp->p_offset;
+-	      if (link_info != NULL)
+-		p->p_filesz = link_info->relro_end - lp->p_vaddr;
+-	      else if (m->p_size_valid)
+-		p->p_filesz = m->p_size;
+-	      else
+-		abort ();
+-	      p->p_memsz = p->p_filesz;
+ 	      /* Preserve the alignment and flags if they are valid. The
+ 	         gold linker generates RW/4 for the PT_GNU_RELRO section.
+ 		 It is better for objcopy/strip to honor these attributes
+diff --git a/ld/testsuite/ld-x86-64/pr14207.d b/ld/testsuite/ld-x86-64/pr14207.d
+index f6558e7cd7..41f92b8bd8 100644
+--- a/ld/testsuite/ld-x86-64/pr14207.d
++++ b/ld/testsuite/ld-x86-64/pr14207.d
+@@ -13,7 +13,7 @@ Program Headers:
+   LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x0001c8 0x0001c8 R   0x200000
+   LOAD           0x000b.8 0x0000000000200b.8 0x0000000000200b.8 0x0004.0 0x000c.8 RW  0x200000
+   DYNAMIC        0x000b.0 0x0000000000200b.0 0x0000000000200b.0 0x0001.0 0x0001.0 RW  0x8
+-  GNU_RELRO      0x000b.8 0x0000000000200b.8 0x0000000000200b.8 0x0004.8 0x0004.8 R   0x1
++  GNU_RELRO      0x000b.8 0x0000000000200b.8 0x0000000000200b.8 0x0004.0 0x0004.8 R   0x1
+ 
+  Section to Segment mapping:
+   Segment Sections...
+-- 
+2.16.2

--- a/pkgs/development/tools/misc/binutils/PR22836-r-s-doesnt-work-with-g3-using-GCC-7.patch
+++ b/pkgs/development/tools/misc/binutils/PR22836-r-s-doesnt-work-with-g3-using-GCC-7.patch
@@ -1,0 +1,232 @@
+From d957f81cb38d7e82ae546cd03265ee3087ba8a85 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Tue, 13 Feb 2018 14:09:48 +1030
+Subject: [PATCH] PR22836, "-r -s" doesn't work with -g3 using GCC 7
+
+This fixes the case where all of a group is removed with ld -r, the
+situation in the PR, and failures where part of a group is removed
+that contain relocs.
+
+bfd/
+	PR 22836
+	* elf.c (_bfd_elf_fixup_group_sections): Account for removed
+	relocation sections.  If size reduces to just the flag word,
+	remove that too and mark with SEC_EXCLUDE.
+	* elflink.c (bfd_elf_final_link): Strip empty group sections.
+binutils/
+	* testsuite/binutils-all/group-7.s,
+	* testsuite/binutils-all/group-7a.d,
+	* testsuite/binutils-all/group-7b.d,
+	* testsuite/binutils-all/group-7c.d: New tests.
+	* testsuite/binutils-all/objcopy.exp: Run them.
+ld/
+	* testsuite/ld-elf/pr22836-2.d,
+	* testsuite/ld-elf/pr22836-2.s: New test.
+
+(cherry picked from commit 6e5e9d58c1eeef5677c90886578a895cb8c164c5)
+---
+ bfd/ChangeLog                               | 11 +++++++++++
+ bfd/elf.c                                   | 25 +++++++++++++++++++++----
+ bfd/elflink.c                               |  7 +++++++
+ binutils/ChangeLog                          | 12 ++++++++++++
+ binutils/testsuite/binutils-all/group-7.s   |  6 ++++++
+ binutils/testsuite/binutils-all/group-7a.d  | 16 ++++++++++++++++
+ binutils/testsuite/binutils-all/group-7b.d  | 19 +++++++++++++++++++
+ binutils/testsuite/binutils-all/group-7c.d  |  8 ++++++++
+ binutils/testsuite/binutils-all/objcopy.exp |  3 +++
+ ld/ChangeLog                                |  9 +++++++++
+ ld/testsuite/ld-elf/pr22836-2.d             |  7 +++++++
+ ld/testsuite/ld-elf/pr22836-2.s             |  7 +++++++
+ 12 files changed, 126 insertions(+), 4 deletions(-)
+ create mode 100644 binutils/testsuite/binutils-all/group-7.s
+ create mode 100644 binutils/testsuite/binutils-all/group-7a.d
+ create mode 100644 binutils/testsuite/binutils-all/group-7b.d
+ create mode 100644 binutils/testsuite/binutils-all/group-7c.d
+ create mode 100644 ld/testsuite/ld-elf/pr22836-2.d
+ create mode 100644 ld/testsuite/ld-elf/pr22836-2.s
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index 325bdd5..e95c8a9 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -7579,7 +7579,16 @@ _bfd_elf_fixup_group_sections (bfd *ibfd, asection *discarded)
+ 	       but the SHT_GROUP section is, then adjust its size.  */
+ 	    else if (s->output_section == discarded
+ 		     && isec->output_section != discarded)
+-	      removed += 4;
++	      {
++		struct bfd_elf_section_data *elf_sec = elf_section_data (s);
++		removed += 4;
++		if (elf_sec->rel.hdr != NULL
++		    && (elf_sec->rel.hdr->sh_flags & SHF_GROUP) != 0)
++		  removed += 4;
++		if (elf_sec->rela.hdr != NULL
++		    && (elf_sec->rela.hdr->sh_flags & SHF_GROUP) != 0)
++		  removed += 4;
++	      }
+ 	    s = elf_next_in_group (s);
+ 	    if (s == first)
+ 	      break;
+@@ -7589,18 +7598,26 @@ _bfd_elf_fixup_group_sections (bfd *ibfd, asection *discarded)
+ 	    if (discarded != NULL)
+ 	      {
+ 		/* If we've been called for ld -r, then we need to
+-		   adjust the input section size.  This function may
+-		   be called multiple times, so save the original
+-		   size.  */
++		   adjust the input section size.  */
+ 		if (isec->rawsize == 0)
+ 		  isec->rawsize = isec->size;
+ 		isec->size = isec->rawsize - removed;
++		if (isec->size <= 4)
++		  {
++		    isec->size = 0;
++		    isec->flags |= SEC_EXCLUDE;
++		  }
+ 	      }
+ 	    else
+ 	      {
+ 		/* Adjust the output section size when called from
+ 		   objcopy. */
+ 		isec->output_section->size -= removed;
++		if (isec->output_section->size <= 4)
++		  {
++		    isec->output_section->size = 0;
++		    isec->output_section->flags |= SEC_EXCLUDE;
++		  }
+ 	      }
+ 	  }
+       }
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 72aa3ac..69cb5ab 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -11618,6 +11618,13 @@ bfd_elf_final_link (bfd *abfd, struct bfd_link_info *info)
+ 	  else
+ 	    o->flags |= SEC_EXCLUDE;
+ 	}
++      else if ((o->flags & SEC_GROUP) != 0 && o->size == 0)
++	{
++	  /* Remove empty group section from linker output.  */
++	  o->flags |= SEC_EXCLUDE;
++	  bfd_section_list_remove (abfd, o);
++	  abfd->section_count--;
++	}
+     }
+ 
+   /* Count up the number of relocations we will output for each output
+diff --git a/binutils/testsuite/binutils-all/group-7.s b/binutils/testsuite/binutils-all/group-7.s
+new file mode 100644
+index 0000000..5028afc
+--- /dev/null
++++ b/binutils/testsuite/binutils-all/group-7.s
+@@ -0,0 +1,6 @@
++	.section        .data.foo,"awG",%progbits,foo,comdat
++here:
++	.dc.a	here
++
++	.section        .data2.foo,"awG",%progbits,foo,comdat
++	.dc.a	0
+diff --git a/binutils/testsuite/binutils-all/group-7a.d b/binutils/testsuite/binutils-all/group-7a.d
+new file mode 100644
+index 0000000..fa8db60
+--- /dev/null
++++ b/binutils/testsuite/binutils-all/group-7a.d
+@@ -0,0 +1,16 @@
++#name: copy removing reloc group member
++#source: group-7.s
++#PROG: objcopy
++#DUMPPROG: readelf
++#objcopy: --remove-section .data.foo
++#readelf: -Sg --wide
++
++#...
++  \[[ 0-9]+\] \.group[ \t]+GROUP[ \t]+.*
++#...
++  \[[ 0-9]+\] \.data2\.foo[ \t]+PROGBITS[ \t0-9a-f]+WAG.*
++#...
++COMDAT group section \[[ 0-9]+\] `\.group' \[foo\] contains 1 section.*
++   \[Index\]    Name
++   \[[ 0-9]+\]   \.data2\.foo
++#pass
+diff --git a/binutils/testsuite/binutils-all/group-7b.d b/binutils/testsuite/binutils-all/group-7b.d
+new file mode 100644
+index 0000000..b674545
+--- /dev/null
++++ b/binutils/testsuite/binutils-all/group-7b.d
+@@ -0,0 +1,19 @@
++#name: copy removing non-reloc group member
++#source: group-7.s
++#PROG: objcopy
++#DUMPPROG: readelf
++#objcopy: --remove-section .data2.foo
++#readelf: -Sg --wide
++
++#...
++  \[[ 0-9]+\] \.group[ \t]+GROUP[ \t]+.*
++#...
++  \[[ 0-9]+\] \.data\.foo[ \t]+PROGBITS[ \t0-9a-f]+WAG.*
++#...
++  \[[ 0-9]+\] \.rela?\.data\.foo[ \t]+RELA?[ \t0-9a-f]+IG.*
++#...
++COMDAT group section \[[ 0-9]+\] `\.group' \[foo\] contains 2 sections:
++   \[Index\]    Name
++   \[[ 0-9]+\]   \.data\.foo
++   \[[ 0-9]+\]   \.rela?\.data\.foo
++#pass
+diff --git a/binutils/testsuite/binutils-all/group-7c.d b/binutils/testsuite/binutils-all/group-7c.d
+new file mode 100644
+index 0000000..83e9115
+--- /dev/null
++++ b/binutils/testsuite/binutils-all/group-7c.d
+@@ -0,0 +1,8 @@
++#name: copy removing reloc and non-reloc group member
++#source: group-7.s
++#PROG: objcopy
++#DUMPPROG: readelf
++#objcopy: -R .data.foo -R .data2.foo
++#readelf: -g --wide
++
++There are no section groups in this file\.
+diff --git a/binutils/testsuite/binutils-all/objcopy.exp b/binutils/testsuite/binutils-all/objcopy.exp
+index 377f88c..f4a7692 100644
+--- a/binutils/testsuite/binutils-all/objcopy.exp
++++ b/binutils/testsuite/binutils-all/objcopy.exp
+@@ -1051,6 +1051,9 @@ if [is_elf_format] {
+     objcopy_test_readelf "GNU_MBIND section" mbind1.s
+     run_dump_test "group-5"
+     run_dump_test "group-6"
++    run_dump_test "group-7a"
++    run_dump_test "group-7b"
++    run_dump_test "group-7c"
+     run_dump_test "copy-1"
+     run_dump_test "note-1"
+     if [is_elf64 tmpdir/bintest.o] {
+diff --git a/ld/testsuite/ld-elf/pr22836-2.d b/ld/testsuite/ld-elf/pr22836-2.d
+new file mode 100644
+index 0000000..10133e4
+--- /dev/null
++++ b/ld/testsuite/ld-elf/pr22836-2.d
+@@ -0,0 +1,7 @@
++#source: pr22836-2.s
++#ld: -r -S
++#readelf: -g --wide
++
++group section \[[ 0-9]+\] `\.group' \[foo\] contains 1 section.*
++   \[Index\]    Name
++   \[[ 0-9]+\]   \.comment
+diff --git a/ld/testsuite/ld-elf/pr22836-2.s b/ld/testsuite/ld-elf/pr22836-2.s
+new file mode 100644
+index 0000000..77cd83a
+--- /dev/null
++++ b/ld/testsuite/ld-elf/pr22836-2.s
+@@ -0,0 +1,7 @@
++	.section	.debug_macro,"G",%progbits,foo
++	.long	.LASF0
++.LASF0:
++	.string	"__STDC__ 1"
++
++	.section	.comment,"G",%progbits,foo
++	.asciz "hi"
+-- 
+2.9.3

--- a/pkgs/development/tools/misc/binutils/PR23199-invalid-SHT_group-entry-leads-to-group-confusion.patch
+++ b/pkgs/development/tools/misc/binutils/PR23199-invalid-SHT_group-entry-leads-to-group-confusion.patch
@@ -1,0 +1,68 @@
+From e3d435293f0dd45247e8057574389f322f5fe5a2 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Fri, 18 May 2018 17:09:45 +0930
+Subject: [PATCH] PR23199, Invalid SHT_GROUP entry leads to group confusion
+
+This patch prevents elf_next_in_group list pointer confusion when
+SHT_GROUP sections specify other SHT_GROUP sections in their list of
+group sections.
+
+	PR 23199
+	* elf.c (setup_group): Formatting.  Check that SHT_GROUP entries
+	don't point at other SHT_GROUP sections.  Set shdr corresponding
+	to invalid entry, to NULL rather than section 0.  Identify
+	SHT_GROUP section index when reporting an error.  Cope with NULL
+	shdr pointer.
+
+(cherry picked from commit 4bba0fb1c6d391a217c25e44398a7e1c7090155f)
+---
+ bfd/elf.c     | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index e95c8a9..f657ec4 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -627,7 +627,8 @@ setup_group (bfd *abfd, Elf_Internal_Shdr *hdr, asection *newsect)
+ 	      bfd_alloc2 (abfd, num_group, sizeof (Elf_Internal_Shdr *));
+ 	  if (elf_tdata (abfd)->group_sect_ptr == NULL)
+ 	    return FALSE;
+-	  memset (elf_tdata (abfd)->group_sect_ptr, 0, num_group * sizeof (Elf_Internal_Shdr *));
++	  memset (elf_tdata (abfd)->group_sect_ptr, 0,
++		  num_group * sizeof (Elf_Internal_Shdr *));
+ 	  num_group = 0;
+ 
+ 	  for (i = 0; i < shnum; i++)
+@@ -706,13 +707,16 @@ setup_group (bfd *abfd, Elf_Internal_Shdr *hdr, asection *newsect)
+ 			      |= SEC_LINK_ONCE | SEC_LINK_DUPLICATES_DISCARD;
+ 			  break;
+ 			}
+-		      if (idx >= shnum)
++		      if (idx < shnum)
++			dest->shdr = elf_elfsections (abfd)[idx];
++		      if (idx >= shnum
++			  || dest->shdr->sh_type == SHT_GROUP)
+ 			{
+ 			  _bfd_error_handler
+-			    (_("%B: invalid SHT_GROUP entry"), abfd);
+-			  idx = 0;
++			    (_("%B: invalid entry in SHT_GROUP section [%u]"),
++			     abfd, i);
++			  dest->shdr = NULL;
+ 			}
+-		      dest->shdr = elf_elfsections (abfd)[idx];
+ 		    }
+ 		}
+ 	    }
+@@ -778,7 +782,8 @@ setup_group (bfd *abfd, Elf_Internal_Shdr *hdr, asection *newsect)
+ 		idx = (Elf_Internal_Group *) shdr->contents;
+ 		n_elt = shdr->sh_size / 4;
+ 		while (--n_elt != 0)
+-		  if ((s = (++idx)->shdr->bfd_section) != NULL
++		  if ((++idx)->shdr != NULL
++		      && (s = idx->shdr->bfd_section) != NULL
+ 		      && elf_next_in_group (s) != NULL)
+ 		    break;
+ 		if (n_elt != 0)
+-- 
+2.9.3

--- a/pkgs/development/tools/misc/binutils/PR23199-mark-section-in-a-section-group-with-SHF_GROUP.patch
+++ b/pkgs/development/tools/misc/binutils/PR23199-mark-section-in-a-section-group-with-SHF_GROUP.patch
@@ -1,0 +1,41 @@
+From e2bcabadb8bc02d971b30644d91a70ec4c4b825d Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Mon, 21 May 2018 19:25:19 -0700
+Subject: [PATCH] Mark section in a section group with SHF_GROUP
+
+All sections in a section group should be marked with SHF_GROUP.  But
+some tools generate broken objects without SHF_GROUP.  This patch fixes
+them up for objcopy and strip.
+
+	PR binutils/23199
+	* elf.c (setup_group): Mark section in a section group with
+	SHF_GROUP.
+
+(cherry picked from commit bae363f1146378207e1dffe5f23845644a1d0b7a)
+---
+ bfd/elf.c     | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index f657ec4..3f76640 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -708,7 +708,15 @@ setup_group (bfd *abfd, Elf_Internal_Shdr *hdr, asection *newsect)
+ 			  break;
+ 			}
+ 		      if (idx < shnum)
+-			dest->shdr = elf_elfsections (abfd)[idx];
++			{
++			  dest->shdr = elf_elfsections (abfd)[idx];
++			  /* PR binutils/23199: All sections in a
++			     section group should be marked with
++			     SHF_GROUP.  But some tools generate
++			     broken objects without SHF_GROUP.  Fix
++			     them up here.  */
++			  dest->shdr->sh_flags |= SHF_GROUP;
++			}
+ 		      if (idx >= shnum
+ 			  || dest->shdr->sh_type == SHT_GROUP)
+ 			{
+-- 
+2.9.3

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -64,6 +64,21 @@ stdenv.mkDerivation rec {
 
     # https://sourceware.org/bugzilla/show_bug.cgi?id=22868
     ./gold-symbol-visibility.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=22741
+    ./PR22741-objcopy-segfault-on-fuzzed-COFF-object.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=22829
+    ./PR22829-objcopy-strip-removes-PT_GNU_RELRO-from-lld.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=22836
+    ./PR22836-r-s-doesnt-work-with-g3-using-GCC-7.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=23199
+    ./PR23199-invalid-SHT_group-entry-leads-to-group-confusion.patch
+
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=23199
+    ./PR23199-mark-section-in-a-section-group-with-SHF_GROUP.patch
   ] ++ stdenv.lib.optional targetPlatform.isiOS ./support-ios.patch
     ++ stdenv.lib.optionals targetPlatform.isAarch64 [
     # Version 2.30 introduced strict requirements on ELF relocations which cannot


### PR DESCRIPTION

###### Motivation for this change

This fixes https://github.com/NixOS/nixpkgs/issues/40397.
Because I already had those other patches I thought it is better to commit them with the two patches which fix the strip issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

