### PR TITLE
lib: Fix `nix-env -qaP -f . --xml --meta`

### DIFF
--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -3,6 +3,8 @@ let
   inherit (lib.systems) parse;
   inherit (lib.systems.inspect) patterns;
 
+  abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) parse.abis;
+
 in rec {
   all     = [ {} ]; # `{}` matches anything
   none    = [];
@@ -19,7 +21,7 @@ in rec {
   darwin  = [ patterns.isDarwin ];
   freebsd = [ patterns.isFreeBSD ];
   # Should be better, but MinGW is unclear, and HURD is bit-rotted.
-  gnu     = [ { kernel = parse.kernels.linux; abi = parse.abis.gnu; } ];
+  gnu     = [ { kernel = parse.kernels.linux; abi = abis.gnu; } ];
   illumos = [ patterns.isSunOS ];
   linux   = [ patterns.isLinux ];
   netbsd  = [ patterns.isNetBSD ];


### PR DESCRIPTION
###### Motivation for this change

The function value cannot be serialized so nix-env was mad. Turns out we can
just remove it like we do in `lib/systems/inspect.nix`.

@peti This is the fix. Sorry I didn't have it earlier. Hope the disruption wasn't too terrible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

