### PR TITLE
slack: 3.1.0 -> 3.2.0-beta2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchurl, dpkg
+{ stdenv, fetchurl, dpkg, makeWrapper
 , alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib
-, gnome2, libnotify, libxcb, nspr, nss, systemd, xorg }:
+, gnome3, gtk3, gdk_pixbuf, libnotify, libxcb, nspr, nss, pango
+, systemd, wget, xorg }:
 
 let
 
-  version = "3.1.0";
+  version = "3.2.0-beta25a7a50e";
 
   rpath = stdenv.lib.makeLibraryPath [
     alsaLib
@@ -17,10 +18,10 @@ let
     fontconfig
     freetype
     glib
-    gnome2.GConf
-    gnome2.gdk_pixbuf
-    gnome2.gtk
-    gnome2.pango
+    gnome3.gconf
+    gdk_pixbuf
+    gtk3
+    pango
     libnotify
     libxcb
     nspr
@@ -46,7 +47,7 @@ let
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://downloads.slack-edge.com/linux_releases/slack-desktop-${version}-amd64.deb";
-        sha256 = "1y8xxfpqvz4q6y1zkna4cp3rqi7p03w5xgr8h1cmym8z66bj7dq3";
+        sha256 = "0497794a7f0e5ac00a9421e6b1875dcc576ed93efc4a7d8c6465db641c234064";
       }
     else
       throw "Slack is not supported on ${stdenv.system}";
@@ -56,7 +57,13 @@ in stdenv.mkDerivation {
 
   inherit src;
 
-  buildInputs = [ dpkg ];
+  buildInputs = [
+    dpkg
+    gtk3  # needed for GSETTINGS_SCHEMAS_PATH
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
   unpackPhase = "true";
   buildCommand = ''
     mkdir -p $out
@@ -72,9 +79,10 @@ in stdenv.mkDerivation {
       patchelf --set-rpath ${rpath}:$out/lib/slack $file || true
     done
 
-    # Fix the symlink
+    # Replace the broken bin/slack symlink with a startup wrapper
     rm $out/bin/slack
-    ln -s $out/lib/slack/slack $out/bin/slack
+    makeWrapper $out/lib/slack/slack $out/bin/slack \
+      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/slack.desktop \


### PR DESCRIPTION
I know this says it's a beta verison, but
  - This is the version they're distributing on slack.com/download for linux
  - The previous releases were "beta" too, they just didn't mention it in the version string

###### Motivation for this change
New upstream version.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

