### PR TITLE
python.pkgs.python-language-server: init at 0.18.0

### DIFF
--- a/pkgs/applications/science/spyder/default.nix
+++ b/pkgs/applications/science/spyder/default.nix
@@ -19,7 +19,7 @@ buildPythonApplication rec {
 
   # Somehow setuptools can't find pyqt5. Maybe because the dist-info folder is missing?
   postPatch = ''
-    substituteInPlace setup.py --replace 'pyqt5;python_version>="3"' ' '
+    sed -i -e '/pyqt5/d' setup.py
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/jedi/default.nix
+++ b/pkgs/development/python-modules/jedi/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "jedi";
-  version = "0.11.1";
+  version = "0.12.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d6e799d04d1ade9459ed0f20de47c32f2285438956a677d083d3c98def59fa97";
+    sha256 = "1bcr7csx4xil1iwmk03d79jis0bkmgi9k0kir3xa4rmwqsagcwhr";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchPypi, buildPythonApplication, lxml, typed-ast, psutil }:
+{ stdenv, fetchPypi, buildPythonPackage, lxml, typed-ast, psutil, isPy3k }:
 
-buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "mypy";
   version = "0.600";
 
@@ -11,6 +11,8 @@ buildPythonApplication rec {
     inherit pname version;
     sha256 = "1pd3kkz435wlvi9fwqbi3xag5zs59jcjqi6c9gzdjdn23friq9dw";
   };
+
+  disabled = !isPy3k;
 
   propagatedBuildInputs = [ lxml typed-ast psutil ];
 

--- a/pkgs/development/python-modules/parso/default.nix
+++ b/pkgs/development/python-modules/parso/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "parso";
-  version = "0.1.1";
+  version = "0.2.0";
   name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5815f3fe254e5665f3c5d6f54f086c2502035cb631a91341591b5a564203cffb";
+    sha256 = "0lamywk6dm5xshlkdvxxf5j6fa2k2zpi7xagf0bwidaay3vnpgb2";
   };
 
   checkInputs = [ pytest ];

--- a/pkgs/development/python-modules/pyls-isort/default.nix
+++ b/pkgs/development/python-modules/pyls-isort/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, python-language-server, isort
+}:
+
+buildPythonPackage rec {
+  pname = "pyls-isort";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "paradoxxxzero";
+    repo = "pyls-isort";
+    rev = version;
+    sha256 = "0mf8c6dw5lsj9np20p0vrhr1yfycq2awjk2pil28l579xj9nr0dc";
+  };
+
+  # no tests
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    isort python-language-server
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/palantir/python-language-server;
+    description = "An implementation of the Language Server Protocol for Python";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/pyls-mypy/default.nix
+++ b/pkgs/development/python-modules/pyls-mypy/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch
+, future, python-language-server, mypy, configparser
+, pytest, mock, isPy3k, pytestcov, coverage
+}:
+
+buildPythonPackage rec {
+  pname = "pyls-mypy";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "tomv564";
+    repo = "pyls-mypy";
+    rev = version;
+    sha256 = "0wa038a8a8yj3wmrc7q909nj4b5d3lq70ysbw7rpsnyb0x06m826";
+  };
+
+  disabled = !isPy3k;
+
+  patches = [
+    # also part of https://github.com/tomv564/pyls-mypy/pull/10
+    (fetchpatch {
+      url = "https://github.com/Mic92/pyls-mypy/commit/4c727120d2cbd8bf2825e1491cd55175f03266d2.patch";
+      sha256 = "1dgn5z742swpxwknmgvm65jpxq9zwzhggw4nl6ys7yw8r49kqgrl";
+    })
+  ];
+
+  checkPhase = ''
+    HOME=$TEMPDIR pytest
+  '';
+
+  checkInputs = [ pytest mock pytestcov coverage ];
+
+  propagatedBuildInputs = [
+    mypy python-language-server future configparser
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/palantir/python-language-server;
+    description = "An implementation of the Language Server Protocol for Python";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -1,0 +1,48 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
+, configparser, futures, future, jedi, pluggy
+, pytest, mock, pytestcov, coverage
+# The following packages are optional and
+# can be overwritten with null as your liking.
+# This also requires to disable tests.
+, rope ? null
+, mccabe ? null
+, pyflakes ? null
+, pycodestyle ? null
+, autopep8 ? null
+, yapf ? null
+, pydocstyle ? null
+}:
+
+buildPythonPackage rec {
+  pname = "python-language-server";
+  version = "0.18.0";
+
+  src = fetchFromGitHub {
+    owner = "palantir";
+    repo = "python-language-server";
+    rev = version;
+    sha256 = "0ig34bc0qm6gdj8xakmm3877lmf8ms7qg0xj8hay9gpgf8cz894s";
+  };
+
+  checkInputs = [
+    pytest mock pytestcov coverage
+    # rope is technically a dependency, but we don't add it by default since we
+    # already have jedi, which is the preferred option
+    rope
+  ];
+  checkPhase = ''
+    HOME=$TEMPDIR pytest
+  '';
+
+  propagatedBuildInputs = [
+    jedi pluggy mccabe pyflakes pycodestyle yapf pydocstyle future autopep8
+  ] ++ lib.optional (isPy27) [ configparser ]
+    ++ lib.optional (pythonOlder "3.2") [ futures ];
+
+  meta = with lib; {
+    homepage = https://github.com/palantir/python-language-server;
+    description = "An implementation of the Language Server Protocol for Python";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8492,7 +8492,7 @@ with pkgs;
 
   grabserial = callPackage ../development/tools/grabserial { };
 
-  mypy = python3Packages.callPackage ../development/tools/mypy { };
+  mypy = python3Packages.mypy;
 
   ### DEVELOPMENT / LIBRARIES
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11268,6 +11268,10 @@ in {
     buildInputs = with self; [ pyasn1 pycrypto ];
   };
 
+  python-language-server = callPackage ../development/python-modules/python-language-server {};
+
+  pyls-mypy = callPackage ../development/python-modules/pyls-mypy {};
+
   pyudev = callPackage ../development/python-modules/pyudev {
     inherit (pkgs) fetchurl systemd;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8088,6 +8088,8 @@ in {
 
   mysqlclient = callPackage ../development/python-modules/mysqlclient { };
 
+  mypy = callPackage ../development/python-modules/mypy { };
+
   mwclient = buildPythonPackage rec {
     version = "0.8.3";
     pname = "mwclient";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11272,6 +11272,8 @@ in {
 
   pyls-mypy = callPackage ../development/python-modules/pyls-mypy {};
 
+  pyls-isort = callPackage ../development/python-modules/pyls-isort {};
+
   pyudev = callPackage ../development/python-modules/pyudev {
     inherit (pkgs) fetchurl systemd;
   };


### PR DESCRIPTION
###### Motivation for this change

I use the following snippet for the plugins (put it into `environment.systemPackages` for example).

```nix
(python3.withPackages(ps: [ps.pyls-mypy ps.pyls-isort ])) 
```

and the following snippets in neovim:

```vim
let g:LanguageClient_serverCommands = {
     \ 'python': ['pyls']
     \ }
```

which is provided by the LanguageClient-neovim as shown in my dotfiles: https://github.com/Mic92/dotfiles/blob/master/nixpkgs-config/config.nix#L26

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

