### PR TITLE
procps-ng: 3.3.13 -> 3.3.15

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -1,32 +1,18 @@
-{ lib, stdenv, fetchFromGitLab, fetchpatch, ncurses, libtool, gettext, autoconf, automake, pkgconfig }:
+{ lib, stdenv, fetchFromGitLab, ncurses, libtool, gettext, autoconf, automake, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "procps-${version}";
-  version = "3.3.13";
+  version = "3.3.15";
 
   src = fetchFromGitLab {
     owner ="procps-ng";
     repo = "procps";
     rev = "v${version}";
-    sha256 = "0r3h9adhqi5fi62lx65z839fww35lfh2isnknhkaw71xndjpzr0q";
+    sha256 = "03jyjln124g60pfa47f8995w519snx3y8j6vw1rzic0153jrqa28";
   };
 
   buildInputs = [ ncurses ];
   nativeBuildInputs = [ libtool gettext autoconf automake pkgconfig ];
-
-  # https://gitlab.com/procps-ng/procps/issues/88
-  # Patches needed for musl and glibc 2.28
-  patches = [
-    (fetchpatch {
-      url = "https://gitlab.com/procps-ng/procps/uploads/f91ff094be1e4638aeffb67bdbb751ba/numa.h.diff";
-      sha256 = "16r537d2wfrvbv6dg9vyfck8n31xa58903mnssw1s4kb5ap83yd5";
-      extraPrefix = "";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/procps-ng/procps/uploads/6a7bdea4d82ba781451316fda74192ae/libio_detection.diff";
-      sha256 = "0qp0j60kiycjsv213ih10imjirmxz8zja3rk9fq5lr5xf7k2lr3p";
-    })
-  ];
 
   # autoreconfHook doesn't quite get, what procps-ng buildprocss does
   # with po/Makefile.in.in and stuff.


### PR DESCRIPTION
I can't "Tested compilation of all pkgs that depend on this change" because directly or indirectly over 1700 packages depend on this.

The patches are not necessary anymore.
Both problems were fixed in
https://gitlab.com/procps-ng/procps/commit/5576c8e4380badf262d3ee9af84404d24aae5a34

###### Motivation for this change
Update package to a newer version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

