### PR TITLE
haskell generic-builder: Limit usage of --extra-framework-dirs on Darwin for compat

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -212,6 +212,9 @@ let
     if [ -d "$p/lib" ]; then
       configureFlags+=" --extra-lib-dirs=$p/lib"
     fi
+  ''
+  # It is not clear why --extra-framework-dirs does work fine on Linux
+  + optionalString (!buildPlatform.isDarwin || versionAtLeast nativeGhc.version "8.0") ''
     if [[ -d "$p/Library/Frameworks" ]]; then
       configureFlags+=" --extra-framework-dirs=$p/Library/Frameworks"
     fi


### PR DESCRIPTION
###### Motivation for this change

I have no idea why this appears  to be  a Darwin only thing. It would be nice to investigate that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

