### PR TITLE
python2Packages.pyezminc: init at 1.2

### DIFF
--- a/pkgs/development/python-modules/pyezminc/default.nix
+++ b/pkgs/development/python-modules/pyezminc/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage, isPy3k, fetchFromGitHub, stdenv,
+  netcdf, hdf5, libminc, ezminc,
+  cython, numpy, scipy
+}:
+
+buildPythonPackage rec {
+  pname = "pyezminc";
+  version = "1.2.01";
+ 
+  disabled = isPy3k;
+
+  src = fetchFromGitHub {
+    owner  = "BIC-MNI";
+    repo   = "pyezminc";
+    rev    = "release-${version}";
+    sha256 = "13smvramacisbwj8qsl160dnvv6ynngn1jmqwhvy146nmadphyv1";
+  };
+
+  nativeBuildInputs = [ cython ];
+  buildInputs = [ netcdf hdf5 libminc ezminc ];
+  propagatedBuildInputs = [ numpy scipy ];
+
+  NIX_CFLAGS_COMPILE = "-fpermissive";
+
+  doCheck = false;  # e.g., expects test data in /opt
+
+  meta = {
+    homepage = https://github.com/BIC-MNI/pyezminc;
+    description = "Python API for libminc using EZMINC";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1240,6 +1240,8 @@ in {
 
   pyechonest = callPackage ../development/python-modules/pyechonest { };
 
+  pyezminc = callPackage ../development/python-modules/pyezminc { };
+
   billiard = callPackage ../development/python-modules/billiard { };
 
   binaryornot = callPackage ../development/python-modules/binaryornot { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

