### PR TITLE
uboot: add support for the Raspberry Pi Zero W

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -200,6 +200,12 @@ in rec {
     filesToInstall = ["u-boot.bin"];
   };
 
+  ubootRaspberryPiZeroW = buildUBoot rec {
+    defconfig = "rpi_0_w_defconfig";
+    extraMeta.platforms = ["armv6l-linux"];
+    filesToInstall = ["u-boot.bin"];
+  };
+
   ubootRaspberryPi2 = buildUBoot rec {
     defconfig = "rpi_2_defconfig";
     extraMeta.platforms = ["armv7l-linux"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14155,6 +14155,7 @@ with pkgs;
     ubootQemuAarch64
     ubootQemuArm
     ubootRaspberryPi
+    ubootRaspberryPiZeroW
     ubootRaspberryPi2
     ubootRaspberryPi3_32bit
     ubootRaspberryPi3_64bit


### PR DESCRIPTION
###### Motivation for this change

Even thought the hardware is very similar to the Raspberry Pi 1, U-Boot has a separate config for the Raspberry Pi Zero W. The main difference seems to be a different pin for the LED.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

