### PR TITLE
spl, zfs: 0.7.8 -> 0.7.9, unstable to latest

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -62,15 +62,15 @@ in
   assert kernel != null;
 {
     splStable = common {
-      version = "0.7.8";
-      sha256 = "0ypyy7ij280n7rly6ifrvna9k55gxwdx9a7lalf4r1ka714379fi";
-      patches = [ ./install_prefix-0.7.8.patch ];
+      version = "0.7.9";
+      sha256 = "0540m1dv9jvrzk9kw61glg0h0cwj976mr9zb42y3nh17k47ywff0";
+      patches = [ ./install_prefix-0.7.9.patch ];
     };
 
     splUnstable = common {
-      version = "2018-04-10";
-      rev = "9125f8f5bdb36bfbd2d816d30b6b29b9f89ae3d8";
-      sha256 = "00zrbca906rzjd62m4khiw3sdv8x18dapcmvkyaawripwvzc4iri";
+      version = "2018-05-07";
+      rev = "1149b62d20b7ed9d8ae25d5da7a06213d79b7602";
+      sha256 = "07qlx7l23y696gzyy7ynly7n1141w66y21gkmxiia2xwldj8klkx";
       patches = [ ./install_prefix.patch ];
     };
 

--- a/pkgs/os-specific/linux/spl/install_prefix-0.7.9.patch
+++ b/pkgs/os-specific/linux/spl/install_prefix-0.7.9.patch
@@ -112,18 +112,6 @@ index 581083e..0c35fb7 100644
 +kerneldir = @prefix@/libexec/spl/include/sys/fs
  kernel_HEADERS = $(KERNEL_H)
  endif
-diff --git a/include/sys/sysevent/Makefile.am b/include/sys/sysevent/Makefile.am
-index 63d9af3..de1aa18 100644
---- a/include/sys/sysevent/Makefile.am
-+++ b/include/sys/sysevent/Makefile.am
-@@ -8,6 +8,6 @@ USER_H =
- EXTRA_DIST = $(COMMON_H) $(KERNEL_H) $(USER_H)
- 
- if CONFIG_KERNEL
--kerneldir = @prefix@/src/spl-$(VERSION)/include/sys/sysevent
-+kerneldir = @prefix@/libexec/spl/include/sys/sysevent
- kernel_HEADERS = $(KERNEL_H)
- endif
 diff --git a/include/util/Makefile.am b/include/util/Makefile.am
 index e2bf09f..3f5d6ce 100644
 --- a/include/util/Makefile.am

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -156,9 +156,9 @@ in {
     incompatibleKernelVersion = "4.16";
 
     # this package should point to the latest release.
-    version = "0.7.8";
+    version = "0.7.9";
 
-    sha256 = "0m7j5cpz81lqcfbh4w3wvqjjka07wickl27klgy1zplv6vr0baix";
+    sha256 = "0krpxrvnda2jx6l71xhw9fsksyp2a6h9l9asppac3szsd1n7fp9n";
 
     extraPatches = [
       (fetchpatch {
@@ -175,10 +175,10 @@ in {
     incompatibleKernelVersion = "4.16";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2018-04-10";
+    version = "2018-05-22";
 
-    rev = "74df0c5e251a920a1966a011c16f960cd7ba562e";
-    sha256 = "1x3mipj3ryznnd7kx84r3n607hv6jqs66mb61g3zcdmvk6al4yq4";
+    rev = "ba863d0be4cbfbea938b10e49fb6ff459ac9ec20";
+    sha256 = "11dhigw1gybalwg2m6si148b6w195dj2lw38snqf6576wb5zndd0";
     isUnstable = true;
 
     extraPatches = [


### PR DESCRIPTION
###### Motivation for this change

Updates ZFS on Linux to the latest version. It is still broken with Linux 4.16.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

