### PR TITLE
aescrypt: fix darwin build

### DIFF
--- a/pkgs/tools/misc/aescrypt/default.nix
+++ b/pkgs/tools/misc/aescrypt/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1a1rs7xmbxh355qg3v02rln3gshvy3j6wkx4g9ir72l22mp6zkc7";
   };
 
+  NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-liconv";
+
   preBuild = ''
+    substituteInPlace src/Makefile --replace "CC=gcc" "CC?=gcc"
     cd src
   '';
 
@@ -27,6 +30,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 qknight ];
     platforms   = stdenv.lib.platforms.all;
-    hydraPlatforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This addresses two issues:
1. the Makefile hardcodes CC=gcc so the patch updates this to ~~`CC:=gcc`~~ `CC?=gcc` - I will be emailing the author to update upstream after which I'll remove this patch
2. after I fixed that, I got a `libiconv` error which looked pretty much like the one at https://github.com/NixOS/nixpkgs/issues/2486#issue-32756599 - based on advice on irc I added `NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-liconv";`

cc @LnL7  

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

