### PR TITLE
Transporter: init at 1.3.3

### DIFF
--- a/pkgs/applications/networking/transporter/default.nix
+++ b/pkgs/applications/networking/transporter/default.nix
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Simple file sharing app for elementary OS";
+    description = "Simple magic-wormhole client";
     homepage    = https://github.com/bleakgrey/Transporter;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ worldofpeace ];

--- a/pkgs/applications/networking/transporter/default.nix
+++ b/pkgs/applications/networking/transporter/default.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, granite
+, vala_0_40
+, gnome3
+, libxml2
+, gettext
+, gobjectIntrospection
+, appstream-glib
+, desktop-file-utils
+, magic-wormhole
+, wrapGAppsHook }:
+
+let
+  pname = "Transporter";
+  version = "1.3.3";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "bleakgrey";
+    repo = pname;
+    rev = version;
+    sha256 = "19zb2yqmyyhk5vgh6p278b76shlq0r8ykk1ks8zzr187nr5lf5k1";
+  };
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gettext
+    gobjectIntrospection # For setup hook
+    libxml2
+    meson
+    ninja
+    pkgconfig
+    vala_0_40
+    wrapGAppsHook
+  ];
+
+  buildInputs = with gnome3; [
+    defaultIconTheme # If I omit this there's no icons in KDE
+    glib
+    granite
+    gsettings_desktop_schemas
+    gtk3
+    libgee
+    magic-wormhole
+  ];
+
+  prePatch = ''
+  # The paths were hardcoded
+  substituteInPlace ./src/WormholeInterface.vala \
+    --replace /bin/wormhole ${magic-wormhole}/bin/wormhole
+  '';
+  
+  postPatch = ''
+    chmod +x ./meson/post_install.py
+    patchShebangs ./meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple file sharing app for elementary OS";
+    homepage    = https://github.com/bleakgrey/Transporter;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5321,6 +5321,8 @@ with pkgs;
 
   translate-shell = callPackage ../applications/misc/translate-shell { };
 
+  transporter = callPackage ../applications/networking/transporter { };
+
   trash-cli = callPackage ../tools/misc/trash-cli { };
 
   trickle = callPackage ../tools/networking/trickle {};


### PR DESCRIPTION
###### Motivation for this change
Bring a magic-wormhole gtk client to the people.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

