### PR TITLE
Revert "sqlite{,-analyzer}: use the same src (#40945)"

### DIFF
--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -1,11 +1,23 @@
-{ stdenv, tcl, sqlite }:
+{ stdenv, fetchurl, unzip, sqlite, tcl }:
+
+let
+  archiveVersion = import ./archive-version.nix stdenv.lib;
+in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  inherit (sqlite) src version;
+  version = "3.23.1";
 
-  nativeBuildInputs = [ tcl ];
+  src = assert version == sqlite.version; fetchurl {
+    url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
+    sha256 = "1z3xr8d8ds4l8ndkg34cii13d0w790nlxdkrw6virinqi7wmmd1d";
+  };
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ tcl ];
+
   makeFlags = [ "sqlite3_analyzer" ];
+
   installPhase = "install -Dt $out/bin sqlite3_analyzer";
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/sqlite/archive-version.nix
+++ b/pkgs/development/libraries/sqlite/archive-version.nix
@@ -1,0 +1,11 @@
+lib: version:
+
+with lib;
+  
+let
+  fragments = splitString "." version;
+  major = head fragments;
+  minor = concatMapStrings (fixedWidthNumber 2) (tail fragments);
+in
+
+major + minor + "00"


### PR DESCRIPTION
This reverts commit e28a586f94e77f22d943288ad84f88be23c587f8.


autoconf doesn't set things the same way,
and as a result it seems that Nix built against this
is prone to crashing.

Quick comparison of the build logs and output artifacts:

on master (and after this PR):
* -D_REENTRANT=1
* references __assert_fail so asserts are probably enabled.
  * (good thing IMO)
* references posix_fallocate64, strerror_r (glibc variant, and happily the posix/xsi variant as provided by musl)
* Nix built against it no longer crashes \o/

current staging (without this PR):
* nicer expression
* picks up malloc_usable_size, strchrnul, utime
* Nix built against this crashes

It's likely we can get the "best of both" with some effort/investigation,
but for now I suggest reverting this so it builds a working Nix again :).



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---