### PR TITLE
os-prober: fix dependencies for version >= 1.75

### DIFF
--- a/pkgs/tools/misc/grub/2.0x.nix
+++ b/pkgs/tools/misc/grub/2.0x.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchFromSavannah, autogen, flex, bison, python, autoconf, automake
 , gettext, ncurses, libusb, freetype, qemu, devicemapper, unifont, pkgconfig
+, fuse # only needed for grub-mount
 , zfs ? null
 , efiSupport ? false
 , zfsSupport ? true
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ bison flex python pkgconfig ];
-  buildInputs = [ ncurses libusb freetype gettext devicemapper ]
+  buildInputs = [ ncurses libusb freetype gettext devicemapper fuse ]
     ++ optional doCheck qemu
     ++ optional zfsSupport zfs;
 
@@ -83,7 +84,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-bash-completion.patch ];
 
-  configureFlags = optional zfsSupport "--enable-libzfs"
+  configureFlags = [ "--enable-grub-mount" ] # dep of os-prober
+    ++ optional zfsSupport "--enable-libzfs"
     ++ optionals efiSupport [ "--with-platform=efi" "--target=${efiSystemsBuild.${stdenv.system}.target}" "--program-prefix=" ]
     ++ optionals xenSupport [ "--with-platform=xen" "--target=${efiSystemsBuild.${stdenv.system}.target}"];
 

--- a/pkgs/tools/misc/os-prober/default.nix
+++ b/pkgs/tools/misc/os-prober/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation rec {
   version = "1.76";
   name = "os-prober-${version}";
   src = fetchurl {
-    url = "mirror://debian/pool/main/o/os-prober/os-prober_${version}.tar.xz";
-    sha256 = "1vb45i76bqivlghrq7m3n07qfmmq4wxrkplqx8gywj011rhq19fk";
+    url = "https://salsa.debian.org/philh/os-prober/-/archive/${version}/os-prober-${version}.tar.bz2";
+    sha256 = "07rw3092pckh21vx6y4hzqcn3wn4cqmwxaaiq100lncnhmszg11g";
   };
 
   buildInputs = [ makeWrapper ];

--- a/pkgs/tools/misc/os-prober/default.nix
+++ b/pkgs/tools/misc/os-prober/default.nix
@@ -56,9 +56,10 @@ stdenv.mkDerivation rec {
     done;
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Utility to detect other OSs on a set of drives";
     homepage = http://packages.debian.org/source/sid/os-prober;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ symphorien ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

os-prober's dependencies have changed since version 1.75. As a result, os-prober didn't work anymore on my system. The mechanism relying on lvm has been dropped in favor of grub-mount [1]. grub2 was not built with grub-mount enabled, so I added the relevant configure flags.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=860833#23

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) : installer.nix fails for grub1 only (I didn't touch grub1 ?!?)
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` nox-review want to rebuild os-query (why?) and fails, but this is unrelated I think
- [x] Tested execution of all binary files (usually in `./result/bin/`) (of os-prober, not grub)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

