### PR TITLE
python.pkgs.bokeh: fix name format

### DIFF
--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -33,7 +33,6 @@
 
 buildPythonPackage rec {
   pname = "bokeh";
-  name = "${pname}${version}";
   version = "0.12.15";
 
   src = fetchPypi {


### PR DESCRIPTION
###### Motivation for this change

the derivation name format was inconsistent