### PR TITLE
freecad: 0.16.6712 -> 0.17

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -1,19 +1,23 @@
 { stdenv, fetchurl, cmake, coin3d, xercesc, ode, eigen, qt4, opencascade, gts
-, boost, zlib, python27Packages, swig, gfortran, soqt, libf2c, makeWrapper, makeDesktopItem }:
+, hdf5, vtk, medfile, boost, zlib, python27Packages, swig, gfortran
+, soqt, libf2c, makeWrapper, makeDesktopItem
+, mpi ? null }:
+
+assert mpi != null;
 
 let
   pythonPackages = python27Packages;
 in stdenv.mkDerivation rec {
   name = "freecad-${version}";
-  version = "0.16.6712";
+  version = "0.17";
 
   src = fetchurl {
     url = "https://github.com/FreeCAD/FreeCAD/archive/${version}.tar.gz";
-    sha256 = "14hs26gvv7gbg9misxq34v4nrds2sbxjhj4yyw5kq3zbvl517alp";
+    sha256 = "1yv6abdzlpn4wxy315943xwrnbywxqfgkjib37qwfvbb8y9p60df";
   };
 
   buildInputs = with pythonPackages; [ cmake coin3d xercesc ode eigen qt4 opencascade gts boost
-    zlib python swig gfortran soqt libf2c makeWrapper matplotlib
+    zlib python swig gfortran soqt libf2c makeWrapper matplotlib mpi vtk hdf5 medfile
     pycollada pyside pysideShiboken pysideTools pivy
   ];
 

--- a/pkgs/development/libraries/medfile/default.nix
+++ b/pkgs/development/libraries/medfile/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, cmake, hdf5 }:
+
+stdenv.mkDerivation rec {
+  name = "medfile-${version}";
+  version = "3.3.1";
+
+  src = fetchurl {
+    url = "http://files.salome-platform.org/Salome/other/med-${version}.tar.gz";
+    sha256 = "1215sal10xp6xirgggdszay2bmx0sxhn9pgh7x0wg2w32gw1wqyx";
+  };
+
+  buildInputs = [ cmake hdf5 ];
+
+  checkPhase = "make test";
+
+  postInstall = "rm -r $out/bin/testc";
+
+  meta = with stdenv.lib; {
+    description = "Library to read and write MED files";
+    homepage = http://salome-platform.org/;
+    platforms = platforms.linux;
+    license = licenses.lgpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16021,7 +16021,7 @@ with pkgs;
 
   fomp = callPackage ../applications/audio/fomp { };
 
-  freecad = callPackage ../applications/graphics/freecad { };
+  freecad = callPackage ../applications/graphics/freecad { mpi = openmpi; };
 
   freemind = callPackage ../applications/misc/freemind { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3369,6 +3369,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  medfile = callPackage ../development/libraries/medfile {
+    hdf5 = hdf5_1_8;
+  };
+
   memtester = callPackage ../tools/system/memtester { };
 
   minergate = callPackage ../applications/misc/minergate { };


### PR DESCRIPTION
FreeCAD 0.17 now needs vtk, (open-)mpi, hdf5 and MEDFile for the FEM feature. 

MEDFile (from http://salome-platform.org/downloads/current-version) has been packaged in this PR.

I also haven't checked if dependencies have been dropped or whether the PYTHONPATH patch/hack is still needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

