### PR TITLE
pythonPackages.keyrings-alt: 2.3 -> 3.1

### DIFF
--- a/pkgs/development/python-modules/keyrings-alt/default.nix
+++ b/pkgs/development/python-modules/keyrings-alt/default.nix
@@ -1,15 +1,17 @@
 { stdenv, buildPythonPackage, fetchPypi, six
-, pytest, unittest2, mock, keyring
+, pytest, unittest2, mock, keyring, setuptools_scm
 }:
 
 buildPythonPackage rec {
   pname = "keyrings.alt";
-  version = "2.3";
+  version = "3.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "5cb9b6cdb5ce5e8216533e342d3e1b418ddd210466834061966d7dc1a4736f2d";
+    sha256 = "0nnva8g03dv6gdhjk1ihn2qw7g15232fyj8shipah9whgfv8d75m";
   };
+
+  nativeBuildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ six ];
 
   # Fails with "ImportError: cannot import name mock"

--- a/pkgs/development/python-modules/keyrings-alt/default.nix
+++ b/pkgs/development/python-modules/keyrings-alt/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, buildPythonPackage, fetchPypi, six
-, pytest, unittest2, mock, keyring, setuptools_scm
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, six
+, pytest, pytest-flake8, backports_unittest-mock, keyring, setuptools_scm
 }:
 
 buildPythonPackage rec {
@@ -15,8 +15,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ six ];
 
   # Fails with "ImportError: cannot import name mock"
-  doCheck = false;
-  checkInputs = [ pytest unittest2 mock keyring ];
+  #doCheck = false;
+  checkInputs = [ pytest pytest-flake8 keyring ] ++ stdenv.lib.optional (pythonOlder "3.3") backports_unittest-mock;
+
+  checkPhase = ''
+    py.test
+  '';
 
   meta = with stdenv.lib; {
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change
Bumps to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

