### PR TITLE
minergate-cli: init at 8.2

### DIFF
--- a/pkgs/applications/misc/minergate-cli/default.nix
+++ b/pkgs/applications/misc/minergate-cli/default.nix
@@ -1,0 +1,36 @@
+{ fetchurl, stdenv, dpkg, makeWrapper, openssl }:
+
+stdenv.mkDerivation rec {
+  version = "8.2";
+  name = "minergate-cli-${version}";
+  src = fetchurl {
+    url = "https://minergate.com/download/ubuntu-cli";
+    sha256 = "393c5ba236f6f92c449496fcda9509f4bfd3887422df98ffa59b3072124a99d8";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+    pgm=$out/opt/minergate-cli/minergate-cli
+
+    interpreter=${stdenv.glibc}/lib/ld-linux-x86-64.so.2
+    patchelf --set-interpreter "$interpreter" $pgm
+
+    wrapProgram $pgm --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl stdenv.cc.cc ]} 
+
+    rm $out/usr/bin/minergate-cli
+    mkdir -p $out/bin
+    ln -s $pgm $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Minergate CPU/GPU console client mining software";
+    homepage = https://www.minergate.com/;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ bfortz ];
+    platforms = [ "x86_64-linux" ];
+};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3373,6 +3373,8 @@ with pkgs;
 
   minergate = callPackage ../applications/misc/minergate { };
 
+  minergate-cli = callPackage ../applications/misc/minergate-cli { };
+
   minidlna = callPackage ../tools/networking/minidlna { };
 
   minisign = callPackage ../tools/security/minisign { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

