### PR TITLE
php71: 7.1.17 -> 7.1.18

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -348,8 +348,8 @@ in {
   };
 
   php71 = generic {
-    version = "7.1.17";
-    sha256 = "1kyvg1dvn2zddlc7apl8c74wlwz45rxx10fr1s4z6l1cannf6971";
+    version = "7.1.18";
+    sha256 = "13mz8baknpydswjgqzfqqqjv426x4pnc04rfv2k33s7d2makf3jq";
   };
 
   php72 = generic {


### PR DESCRIPTION
###### Motivation for this change
Changelog: http://www.php.net/ChangeLog-7.php#7.1.18

It doesn't seem to be any security related changes this time. So I don't see much need for backporting. Backporting is common with the PHP packages. But this time it doesn't seem to be required :smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

