### PR TITLE
wire-desktop: gnome2 cleanup

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, makeDesktopItem, gnome3, atk, cairo, pango, gdk_pixbuf, glib
+{ stdenv, lib, fetchurl, dpkg, makeDesktopItem, gnome3, gtk2, atk, cairo, pango, gdk_pixbuf, glib
 , freetype, fontconfig, dbus, libnotify, libX11, xorg, libXi, libXcursor, libXdamage
 , libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver
 , nss, nspr, alsaLib, cups, expat, udev, xdg_utils, hunspell
@@ -16,7 +16,7 @@ let
     gdk_pixbuf
     glib
     gnome3.gconf
-    gnome3.gtk2
+    gtk2
     pango
     hunspell
     libnotify

--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, makeDesktopItem, gnome2, atk, cairo, gdk_pixbuf, glib
+{ stdenv, lib, fetchurl, dpkg, makeDesktopItem, gnome3, atk, cairo, pango, gdk_pixbuf, glib
 , freetype, fontconfig, dbus, libnotify, libX11, xorg, libXi, libXcursor, libXdamage
 , libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver
 , nss, nspr, alsaLib, cups, expat, udev, xdg_utils, hunspell
@@ -15,9 +15,9 @@ let
     freetype
     gdk_pixbuf
     glib
-    gnome2.GConf
-    gnome2.gtk
-    gnome2.pango
+    gnome3.gconf
+    gnome3.gtk2
+    pango
     hunspell
     libnotify
     libX11


### PR DESCRIPTION
###### Motivation for this change
Removed/updated gnome2 references (Part of #39976)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

