### PR TITLE
dbeaver: 5.0.5 -> 5.0.6

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "5.0.5";
+  version = "5.0.6";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "1rcskrv8d3rjcfcn1sxzcaxnvmzgdsbjc9m11li8i4rln712ysza";
+    sha256 = "12crrazlfzvr1c6y33z7v4z7ip9pjbzki8cw15v5d2irkpa710ky";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

 * [Updates dbeaver 5.0.6](https://dbeaver.io/2018/05/27/dbeaver-5-0-6/).

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> *As a side note, #34182 is still open and I will still gladly accept any help in figuring out how to build this using the source release.*