### PR TITLE
messenger-for-desktop: gnome2 cleanup

### DIFF
--- a/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
@@ -1,6 +1,6 @@
 {
-  stdenv, fetchurl, dpkg, alsaLib, atk, cairo, cups, curl, dbus, expat,
-  fontconfig, freetype, glib, gnome2, libnotify, nspr, nss, systemd, xorg
+  stdenv, fetchurl, dpkg, alsaLib, atk, cairo, pango, cups, curl, dbus, expat,
+  fontconfig, freetype, glib, gnome3, libnotify, nspr, nss, systemd, xorg
 }:
 
 with stdenv.lib;
@@ -20,10 +20,10 @@ let
     fontconfig
     freetype
     glib
-    gnome2.GConf
-    gnome2.gdk_pixbuf
-    gnome2.gtk
-    gnome2.pango
+    gnome3.gconf
+    gnome3.gdk_pixbuf
+    gnome3.gtk2
+    pango
     libnotify
     nspr
     nss

--- a/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/messenger-for-desktop/default.nix
@@ -1,6 +1,6 @@
 {
   stdenv, fetchurl, dpkg, alsaLib, atk, cairo, pango, cups, curl, dbus, expat,
-  fontconfig, freetype, glib, gnome3, libnotify, nspr, nss, systemd, xorg
+  fontconfig, freetype, glib, gnome3, gtk2, gdk_pixbuf, libnotify, nspr, nss, systemd, xorg
 }:
 
 with stdenv.lib;
@@ -21,8 +21,8 @@ let
     freetype
     glib
     gnome3.gconf
-    gnome3.gdk_pixbuf
-    gnome3.gtk2
+    gdk_pixbuf
+    gtk2
     pango
     libnotify
     nspr


### PR DESCRIPTION
###### Motivation for this change
Removed/updated gnome2 references (Part of #39976)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

