### PR TITLE
treewide: fix derivation names

### DIFF
--- a/pkgs/applications/altcoins/mist.nix
+++ b/pkgs/applications/altcoins/mist.nix
@@ -56,7 +56,7 @@ let
   });
 in
 buildFHSUserEnv {
-  name = "mist-${stdenv.lib.getVersion mist}";
+  inherit name;
 
   targetPkgs = pkgs: with pkgs; [
      mist

--- a/pkgs/applications/audio/infamousPlugins/default.nix
+++ b/pkgs/applications/audio/infamousPlugins/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, cairomm, cmake, lv2, libpthreadstubs, libXdmcp, libXft, ntk, pcre, fftwFloat, zita-resampler }:
 
 stdenv.mkDerivation rec {
-  name = "infamousPlugins-v${version}";
+  name = "infamousPlugins-${version}";
   version = "0.2.04";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/swh-lv2/default.nix
+++ b/pkgs/applications/audio/swh-lv2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fftwSinglePrec, libxslt, lv2, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "swh-lv2-v${version}";
+  name = "swh-lv2-${version}";
   version = "1.0.16";
 
   src = fetchurl {

--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -1,11 +1,11 @@
 { stdenv, zlib, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
-  name = "manuskript";
+  pname = "manuskript";
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    repo = name;
+    repo = pname;
     owner = "olivierkes";
     rev = version;
     sha256 = "0bqxc4a8kyi6xz1zs0dp85wxl9h4v8lzc6073bbcsn1zg4y59ys7";
@@ -19,15 +19,15 @@ python3Packages.buildPythonApplication rec {
 
   patchPhase = ''
     substituteInPlace manuskript/ui/welcome.py \
-      --replace sample-projects $out/share/${name}/sample-projects
+      --replace sample-projects $out/share/${pname}/sample-projects
    '';
 
   buildPhase = '''';
 
   installPhase = ''
-    mkdir -p $out/share/${name}
+    mkdir -p $out/share/${pname}
     cp -av  bin/ i18n/ libs/ manuskript/ resources/ icons/ $out
-    cp -r sample-projects/ $out/share/${name}
+    cp -r sample-projects/ $out/share/${pname}
   '';
 
   doCheck = false;

--- a/pkgs/applications/editors/neovim/neovim-remote.nix
+++ b/pkgs/applications/editors/neovim/neovim-remote.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 pythonPackages.buildPythonPackage rec {
   name = "neovim-remote-${version}";
-  version = "v1.8.6";
+  version = "1.8.6";
   disabled = !pythonPackages.isPy3k;
 
   src = fetchFromGitHub {
     owner = "mhinz";
     repo = "neovim-remote";
-    rev = version;
+    rev = "v${version}";
     sha256 = "0x01zpmxi37jr7j2az2bd8902h7zhkpg6kpvc8xmll9f7703zz2l";
   };
 

--- a/pkgs/applications/editors/wxhexeditor/default.nix
+++ b/pkgs/applications/editors/wxhexeditor/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "wxHexEditor-${version}";
-  version = "v0.24";
+  version = "0.24";
 
   src = fetchFromGitHub {
     repo = "wxHexEditor";
     owner = "EUA";
-    rev = version;
+    rev = "v${version}";
     sha256 = "08xnhaif8syv1fa0k6lc3jm7yg2k50b02lyds8w0jyzh4xi5crqj";
   };
 

--- a/pkgs/applications/editors/yi/wrapper.nix
+++ b/pkgs/applications/editors/yi/wrapper.nix
@@ -8,8 +8,8 @@ let
   yiEnv = haskellPackages.ghcWithPackages
     (self: [ self.yi ] ++ extraPackages self);
 in
-stdenv.mkDerivation {
-  name = "yi-custom";
+stdenv.mkDerivation rec {
+  name = "yi-custom-${version}";
   version = "0.0.0.1";
   unpackPhase = "true";
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/graphics/exrtools/default.nix
+++ b/pkgs/applications/graphics/exrtools/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, openexr, libpng12, libjpeg }:
 
 stdenv.mkDerivation rec {
-  name = "exrtools";
+  name = "exrtools-${version}";
   version = "0.4";
 
   src = fetchurl {
-    url =  "http://scanline.ca/exrtools/${name}-${version}.tar.gz";
+    url =  "http://scanline.ca/exrtools/${name}.tar.gz";
     sha256 = "0jpkskqs1yjiighab4s91jy0c0qxcscwadfn94xy2mm2bx2qwp4z";
   };
 

--- a/pkgs/applications/graphics/gnuclad/default.nix
+++ b/pkgs/applications/graphics/gnuclad/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, lib, fetchurl, pkgconfig
 }:
 
 stdenv.mkDerivation rec {
-  name = "gnuclad";
+  name = "gnuclad-${version}";
   version = "0.2.4";
 
   src = fetchurl {
-    url = "https://launchpad.net/gnuclad/trunk/0.2/+download/${name}-${version}.tar.gz";
+    url = "https://launchpad.net/gnuclad/trunk/${lib.versions.majorMinor version}/+download/${name}.tar.gz";
     sha256 = "0ka2kscpjff7gflsargv3r9fdaxhkf3nym9mfaln3pnq6q7fwdki";
   };
 

--- a/pkgs/applications/misc/cura/lulzbot.nix
+++ b/pkgs/applications/misc/cura/lulzbot.nix
@@ -4,7 +4,7 @@ let
   py = python27Packages;
 in
 stdenv.mkDerivation rec {
-  name = "cura-lulzbot";
+  name = "cura-lulzbot-${version}";
   version = "15.02.1-1.03-5064";
 
   src =

--- a/pkgs/applications/misc/nix-tour/default.nix
+++ b/pkgs/applications/misc/nix-tour/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchgit, electron } :
 
 stdenv.mkDerivation rec {
-  name = "nix-tour";
+  name = "nix-tour-${version}";
+  version = "0.0.1";
 
   buildInputs = [ electron ];
 
-  version = "v0.0.1";
-
   src = fetchgit {
     url = "https://github.com/nixcloud/tour_of_nix";
-    rev = "refs/tags/${version}";
+    rev = "v${version}";
     sha256 = "09b1vxli4zv1nhqnj6c0vrrl51gaira94i8l7ww96fixqxjgdwvb";
   };
 

--- a/pkgs/applications/misc/xrandr-invert-colors/default.nix
+++ b/pkgs/applications/misc/xrandr-invert-colors/default.nix
@@ -1,10 +1,10 @@
 { fetchurl, stdenv, libXrandr}:
 
 stdenv.mkDerivation rec {
-  version = "v0.01";
+  version = "0.01";
   name = "xrandr-invert-colors-${version}";
   src = fetchurl {
-    url = "https://github.com/zoltanp/xrandr-invert-colors/archive/${version}.tar.gz";
+    url = "https://github.com/zoltanp/xrandr-invert-colors/archive/v${version}.tar.gz";
     sha256 = "1z4hxn56rlflvqanb8ncqa1xqawnda85b1b37w6r2iqs8rw52d75";
   };
 

--- a/pkgs/applications/networking/browsers/uzbl/default.nix
+++ b/pkgs/applications/networking/browsers/uzbl/default.nix
@@ -5,7 +5,8 @@
 # but Python 2 + packages during runtime.
 
 stdenv.mkDerivation rec {
-  name = "uzbl-v0.9.0";
+  name = "uzbl-${version}";
+  version = "0.9.0";
 
   meta = with stdenv.lib; {
     description = "Tiny externally controllable webkit browser";
@@ -16,8 +17,8 @@ stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    name = "${name}.tar.gz";
-    url = "https://github.com/uzbl/uzbl/archive/v0.9.0.tar.gz";
+    name = "uzbl-v${version}.tar.gz";
+    url = "https://github.com/uzbl/uzbl/archive/v${version}.tar.gz";
     sha256 = "0iskhv653fdm5raiidimh9fzlsw28zjqx7b5n3fl1wgbj6yz074k";
   };
 

--- a/pkgs/applications/networking/instant-messengers/coyim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/coyim/default.nix
@@ -3,7 +3,7 @@
 
 buildGoPackage rec {
   name = "coyim-${version}";
-  version = "v0.3.7_1";
+  version = "0.3.7_1";
 
   goPackagePath = "github.com/twstrike/coyim";
 

--- a/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/salut-a-toi/default.nix
@@ -9,7 +9,7 @@ let
 
 in
   stdenv.mkDerivation rec {
-    name = "salut-a-toi";
+    name = "salut-a-toi-${version}";
     version = "0.6.1";
     pname = "sat-${version}";
 

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -117,7 +117,7 @@ in if configure == null then weechat else
         ln -s $plugin $out/plugins
       done
     '';
-  in (writeScriptBin "weechat" ''
+  in (writeScriptBin weechat.name ''
     #!${stdenv.shell}
     export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
     ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}

--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation {
-  name = "gwyddion";
+  name = "gwyddion-${version}";
   version = "2.48";
   src = fetchurl {
     url = "http://sourceforge.net/projects/gwyddion/files/gwyddion/2.48/gwyddion-2.48.tar.xz";

--- a/pkgs/applications/science/math/ripser/default.nix
+++ b/pkgs/applications/science/math/ripser/default.nix
@@ -15,7 +15,7 @@ let
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation {
-  name = "ripser";
+  name = "ripser-${version}";
   version = "1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/video/dvd-slideshow/default.nix
+++ b/pkgs/applications/video/dvd-slideshow/default.nix
@@ -28,10 +28,11 @@ let
     '';
 
 in stdenv.mkDerivation rec {
-  name = "dvd-slideshow";
+  name = "dvd-slideshow-${version}";
   version = "0.8.4-2";
+
   src = fetchurl {
-    url = "mirror://sourceforge/dvd-slideshow/files/${name}-${version}.tar.gz";
+    url = "mirror://sourceforge/dvd-slideshow/files/${name}.tar.gz";
     sha256 = "17c09aqvippiji2sd0pcxjg3nb1mnh9k5nia4gn5lhcvngjcp1q5";
   };
 

--- a/pkgs/applications/video/lightworks/default.nix
+++ b/pkgs/applications/video/lightworks/default.nix
@@ -77,7 +77,7 @@ let
 
 # Lightworks expects some files in /usr/share/lightworks
 in buildFHSUserEnv rec {
-  name = "lightworks-${stdenv.lib.getVersion lightworks}";
+  name = lightworks.name;
 
   targetPkgs = pkgs: [
       lightworks

--- a/pkgs/development/compilers/eli/default.nix
+++ b/pkgs/development/compilers/eli/default.nix
@@ -28,11 +28,11 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  name = "eli";
+  name = "eli-${version}";
   version = "4.8.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/eli-project/Eli/Eli%20${version}/eli-${version}.tar.bz2";
+    url = "mirror://sourceforge/project/eli-project/Eli/Eli%20${version}/${name}.tar.bz2";
     sha256="1vran8583hbwrr5dciji4zkhz3f88w4mn8n9sdpr6zw0plpf1whj";
   };
 

--- a/pkgs/development/interpreters/red/default.nix
+++ b/pkgs/development/interpreters/red/default.nix
@@ -1,7 +1,7 @@
 { stdenv, stdenv_32bit, pkgsi686Linux, fetchFromGitHub, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "red-v${version}";
+  name = "red-${version}";
   version = "0.6.3";
   src = fetchFromGitHub {
     rev = "6a43c767fa2e85d668b83f749158a18e62c30f70";

--- a/pkgs/development/libraries/cppcms/default.nix
+++ b/pkgs/development/libraries/cppcms/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, pcre, zlib, python, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "cppcms";
+  name = "cppcms-${version}";
   version = "1.0.5";
 
   src = fetchurl {
-      url = "mirror://sourceforge/cppcms/${name}-${version}.tar.bz2";
+      url = "mirror://sourceforge/cppcms/${name}.tar.bz2";
       sha256 = "0r8qyp102sq4lw8xhrjhan0dnslhsmxj4zs9jzlw75yagfbqbdl4";
   };
 

--- a/pkgs/development/libraries/cppdb/default.nix
+++ b/pkgs/development/libraries/cppdb/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, sqlite, mysql, postgresql, unixODBC }:
 
 stdenv.mkDerivation rec {
-  name = "cppdb";
+  name = "cppdb-${version}";
   version = "0.3.1";
 
   src = fetchurl {
-      url = "mirror://sourceforge/cppcms/${name}-${version}.tar.bz2";
+      url = "mirror://sourceforge/cppcms/${name}.tar.bz2";
       sha256 = "0blr1casmxickic84dxzfmn3lm7wrsl4aa2abvpq93rdfddfy3nn";
   };
 

--- a/pkgs/development/libraries/ctpp2/default.nix
+++ b/pkgs/development/libraries/ctpp2/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "ctpp2";
+  name = "ctpp2-${version}";
   version = "2.8.3";
 
   src = fetchurl {
-    url = "http://ctpp.havoc.ru/download/ctpp2-${version}.tar.gz";
+    url = "http://ctpp.havoc.ru/download/${name}.tar.gz";
     sha256 = "1z22zfw9lb86z4hcan9hlvji49c9b7vznh7gjm95gnvsh43zsgx8";
   };
 

--- a/pkgs/development/libraries/cxxtools/default.nix
+++ b/pkgs/development/libraries/cxxtools/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   version = "2.2.1";
-  name = "cxxtools";
+  name = "cxxtools-${version}";
 
   src = fetchurl {
-    url = "http://www.tntnet.org/download/${name}-${version}.tar.gz";
+    url = "http://www.tntnet.org/download/${name}.tar.gz";
     sha256 = "0hp3qkyhidxkdf8qgkwrnqq5bpahink55mf0yz23rjd7rpbbdswc";
   };
 

--- a/pkgs/development/libraries/dleyna-connector-dbus/default.nix
+++ b/pkgs/development/libraries/dleyna-connector-dbus/default.nix
@@ -1,13 +1,14 @@
 { stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, dbus, dleyna-core, glib }:
 
 stdenv.mkDerivation rec {
-  name = "dleyna-connector-dbus";
+  pname = "dleyna-connector-dbus";
+  name = "${pname}-${version}";
   version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "01org";
-    repo = name;
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "0vziq5gwjm79yl2swch2mz6ias20nvfddf5cqgk9zbg25cb9m117";
   };
 

--- a/pkgs/development/libraries/dleyna-core/default.nix
+++ b/pkgs/development/libraries/dleyna-core/default.nix
@@ -1,12 +1,13 @@
 { stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, gupnp }:
 
 stdenv.mkDerivation rec {
-  name = "dleyna-core";
+  pname = "dleyna-core";
+  name = "${pname}-${version}";
   version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "01org";
-    repo = name;
+    repo = pname;
     rev = "v${version}";
     sha256 = "1x5vj5zfk95avyg6g3nf6gar250cfrgla2ixj2ifn8pcick2d9vq";
   };

--- a/pkgs/development/libraries/dleyna-renderer/default.nix
+++ b/pkgs/development/libraries/dleyna-renderer/default.nix
@@ -1,13 +1,14 @@
 { stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, dleyna-connector-dbus, dleyna-core, gssdp, gupnp, gupnp-av, gupnp-dlna, libsoup, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "dleyna-renderer";
+  pname = "dleyna-renderer";
+  name = "${pname}-${version}";
   version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "01org";
-    repo = name;
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "0jy54aq8hgrvzchrvfzqaj4pcn0cfhafl9bv8a9p6j82yjk4pvpp";
   };
 

--- a/pkgs/development/libraries/dleyna-server/default.nix
+++ b/pkgs/development/libraries/dleyna-server/default.nix
@@ -1,13 +1,14 @@
 { stdenv, autoreconfHook, makeWrapper, pkgconfig, fetchFromGitHub, dleyna-core, dleyna-connector-dbus, gssdp, gupnp, gupnp-av, gupnp-dlna, libsoup }:
 
 stdenv.mkDerivation rec {
-  name = "dleyna-server";
+  pname = "dleyna-server";
+  name = "${pname}-${version}";
   version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "01org";
-    repo = name;
-    rev = "${version}";
+    repo = pname;
+    rev = version;
     sha256 = "13a2i6ms27s46yxdvlh2zm7pim7jmr5cylnygzbliz53g3gxxl3j";
   };
 

--- a/pkgs/development/libraries/fastjson/default.nix
+++ b/pkgs/development/libraries/fastjson/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, libtool, autoconf, automake }:
 
 stdenv.mkDerivation rec {
-  version = "v0.99.4";
+  version = "0.99.4";
   name = "fastjson-${version}";
   src = fetchFromGitHub {
     repo = "libfastjson";

--- a/pkgs/development/libraries/libbladeRF/default.nix
+++ b/pkgs/development/libraries/libbladeRF/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.9.0";
-  name = "libbladeRF-v${version}";
+  name = "libbladeRF-${version}";
 
   src = fetchFromGitHub {
     owner = "Nuand";

--- a/pkgs/development/libraries/tntdb/default.nix
+++ b/pkgs/development/libraries/tntdb/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, cxxtools, postgresql, mysql, sqlite, zlib, openssl }:
 
 stdenv.mkDerivation rec {
+  name = "tntdb-${version}";
   version = "1.3";
-  name = "tntdb";
+
   src = fetchurl {
-    url = "http://www.tntnet.org/download/tntdb-${version}.tar.gz";
+    url = "http://www.tntnet.org/download/${name}.tar.gz";
     sha256 = "0js79dbvkic30bzw1pf26m64vs2ssw2sbj55w1dc0sy69dlv4fh9";
   };
 

--- a/pkgs/development/libraries/tntnet/default.nix
+++ b/pkgs/development/libraries/tntnet/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, cxxtools, zlib, openssl, zip }:
 
 stdenv.mkDerivation rec {
+  name = "tntnet-${version}";
   version = "2.2.1";
-  name = "tntnet";
+
   src = fetchurl {
-    url = "http://www.tntnet.org/download/tntnet-${version}.tar.gz";
+    url = "http://www.tntnet.org/download/${name}.tar.gz";
     sha256 = "08bmak9mpbamwwl3h9p8x5qzwqlm9g3jh70y0ml5hk7hiv870cf8";
   };
 

--- a/pkgs/development/python-modules/htmltreediff/default.nix
+++ b/pkgs/development/python-modules/htmltreediff/default.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage, fetchFromGitHub, isPy3k, lxml, html5lib, nose, stdenv }:
 
 buildPythonPackage rec {
-  version = "v0.1.2";
+  version = "0.1.2";
   pname = "htmltreediff";
 
   disabled = isPy3k;
@@ -9,7 +9,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "christian-oudard";
     repo = pname;
-    rev = version;
+    rev = "v${version}";
     sha256 = "16mqp2jyznrw1mgd3qzybq28h2k5wz7vmmz1m6xpgscazyjhvvd1";
   };
 

--- a/pkgs/development/python-modules/moinmoin/default.nix
+++ b/pkgs/development/python-modules/moinmoin/default.nix
@@ -3,7 +3,7 @@
 }:
 
 buildPythonPackage rec {
-  name = "moinmoin";
+  pname = "moinmoin";
   version = "1.9.9";
 
   # SyntaxError in setup.py

--- a/pkgs/development/python-modules/mt-940/default.nix
+++ b/pkgs/development/python-modules/mt-940/default.nix
@@ -3,13 +3,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "v4.10.0";
+  version = "4.10.0";
   pname = "mt940";
 
   src = fetchFromGitHub {
     owner = "WoLpH";
     repo = pname;
-    rev = version;
+    rev = "v${version}";
     sha256 = "1dsf2di8rr0iw2vaz6dppalby3y7i8x2bl0qjqvaiqacjxxvwj65";
   };
 

--- a/pkgs/development/python-modules/podcats/default.nix
+++ b/pkgs/development/python-modules/podcats/default.nix
@@ -2,13 +2,12 @@
 
 buildPythonPackage rec {
   pname = "podcats";
-  version = "v0.5.0";
-  name = "${pname}-${version}";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "jakubroztocil";
     repo = "podcats";
-    rev = version;
+    rev = "v${version}";
     sha256 = "0zjdgry5n209rv19kj9yaxy7c7zq5gxr488izrgs4sc75vdzz8xc";
   };
 

--- a/pkgs/development/python-modules/pyxml/default.nix
+++ b/pkgs/development/python-modules/pyxml/default.nix
@@ -3,10 +3,10 @@
 buildPythonPackage rec {
   pname = "PyXML";
   version = "0.8.4";
-  name = "${pname}-${pname}";
+
   format = "other";
   src = fetchurl {
-    url = "mirror://sourceforge/pyxml/${name}.tar.gz";
+    url = "mirror://sourceforge/pyxml/${pname}-${pname}.tar.gz";
     sha256 = "04wc8i7cdkibhrldy6j65qp5l75zjxf5lx6qxdxfdf2gb3wndawz";
   };
 

--- a/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
+++ b/pkgs/development/tools/ocaml/ocsigen-i18n/default.nix
@@ -2,7 +2,8 @@
 
 stdenv.mkDerivation rec
 {
-  name = "ocsigen-i18n";
+  pname = "ocsigen-i18n";
+  name = "${pname}-${version}";
   version = "3.1.0";
 
   buildInputs = with ocamlPackages; [ ocaml findlib ];
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec
   '';
 
   src = fetchurl {
-    url = "https://github.com/besport/${name}/archive/${version}.tar.gz";
+    url = "https://github.com/besport/${pname}/archive/${version}.tar.gz";
     sha256 = "0cw0mmr67wx03j4279z7ldxwb01smkqz9rbklx5lafrj5sf99178";
   };
 

--- a/pkgs/misc/screensavers/physlock/default.nix
+++ b/pkgs/misc/screensavers/physlock/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "11-dev";
-  name = "physlock-v${version}";
+  name = "physlock-${version}";
   src = fetchFromGitHub {
     owner = "muennich";
     repo = "physlock";

--- a/pkgs/servers/monitoring/bosun/default.nix
+++ b/pkgs/servers/monitoring/bosun/default.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub, buildGoPackage }:
 
 buildGoPackage rec {
-  name = "bosun";
-  rev = "0.5.0";
+  name = "bosun-${version}";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "bosun-monitor";
     repo = "bosun";
+    rev = version;
     sha256 = "1qj97wiqj6awivvac1n00k0x8wdv4ambzdj4502nmmnr5rdbqq88";
   };
 

--- a/pkgs/tools/X11/xinput_calibrator/default.nix
+++ b/pkgs/tools/X11/xinput_calibrator/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, libXi, inputproto, autoconf, automake, libtool, m4, xlibsWrapper, pkgconfig }:
 
 stdenv.mkDerivation rec {
+  pname = "xinput_calibrator";
   version = "0.7.5";
-  name = "xinput_calibrator";
+  name = "${pname}-${version}";
   src = fetchurl {
-    url = "https://github.com/tias/${name}/archive/v${version}.tar.gz";
+    url = "https://github.com/tias/${pname}/archive/v${version}.tar.gz";
     sha256 = "d8edbf84523d60f52311d086a1e3ad0f3536f448360063dd8029bf6290aa65e9";
   };
 

--- a/pkgs/tools/misc/blink1-tool/default.nix
+++ b/pkgs/tools/misc/blink1-tool/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "blink1-${version}";
-  version = "v1.98";
+  version = "1.98";
 
   src = fetchurl {
-    url = "https://github.com/todbot/blink1/archive/${version}.tar.gz";
+    url = "https://github.com/todbot/blink1/archive/v${version}.tar.gz";
     sha256 = "05hbnp20cdvyyqf6jr01waz1ycis20qzsd8hn27snmn6qd48igrb";
   };
 

--- a/pkgs/tools/misc/docker-ls/default.nix
+++ b/pkgs/tools/misc/docker-ls/default.nix
@@ -2,12 +2,12 @@
 
 buildGoPackage rec {
   name = "docker-ls-${version}";
-  version = "v0.3.1";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "mayflower";
     repo = "docker-ls";
-    rev = version;
+    rev = "v${version}";
     sha256 = "1dhadi1s3nm3r8q5a0m59fy4jdya8p7zvm22ci7ifm3mmw960xly";
   };
 

--- a/pkgs/tools/misc/profile-sync-daemon/default.nix
+++ b/pkgs/tools/misc/profile-sync-daemon/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, rsync, glibc, gawk }:
 
 stdenv.mkDerivation rec {
-  version = "v5.53";
+  version = "5.53";
   name = "profile-sync-daemon-${version}";
 
   src = fetchurl {
-    url = "http://github.com/graysky2/profile-sync-daemon/archive/${version}.tar.gz";
+    url = "http://github.com/graysky2/profile-sync-daemon/archive/v${version}.tar.gz";
     sha256 = "0m7h9l7dndqgb5k3grpc00f6dpg73p6h4q5sgkf8bvyzvcbdafwx";
   };
 

--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, ncurses }:
 
 stdenv.mkDerivation rec {
-  version = "v0.9.11";
+  version = "0.9.11";
   name = "smenu-${version}";
 
   src = fetchFromGitHub {
     owner  = "p-gen";
     repo   = "smenu";
-    rev    = version;
+    rev    = "v${version}";
     sha256 = "1va5gsxniin02casgdrqxvpzccm0vwjiql60qrsvncrq6nm6bz0d";
   };
 

--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -1,8 +1,9 @@
 { stdenv, fetchFromGitHub, pythonPackages, httpie }:
 
 pythonPackages.buildPythonApplication rec {
+  pname = "http-prompt";
   version = "0.11.1";
-  name = "http-prompt";
+  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     rev = "v${version}";
@@ -21,7 +22,7 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   checkPhase = ''
-    $out/bin/${name} --version | grep -q "${version}"
+    $out/bin/${pname} --version | grep -q "${version}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/networking/ssldump/default.nix
+++ b/pkgs/tools/networking/ssldump/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, openssl, libpcap }:
 
 stdenv.mkDerivation rec {
-  name = "ssldump";
+  name = "ssldump-${version}";
   version = "0.9b3";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/package-management/conda/default.nix
+++ b/pkgs/tools/package-management/conda/default.nix
@@ -48,7 +48,7 @@ let
     '';
 in
   buildFHSUserEnv {
-    name = "conda-shell";
+    name = "conda-shell-${version}";
     targetPkgs = pkgs: (builtins.concatLists [ [ conda ] condaDeps extraPkgs]);
     profile = ''
       # Add conda to PATH

--- a/pkgs/tools/package-management/nixops/nixops-dns.nix
+++ b/pkgs/tools/package-management/nixops/nixops-dns.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "nixops-dns";
+  name = "nixops-dns-${version}";
   version = "1.0";
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -11,19 +11,19 @@
 , gnutls }:
 
 stdenv.mkDerivation rec {
-  name = "neopg";
+  name = "neopg-${version}";
   version = "0.0.4";
 
   # no fetchFromGitHub, as repo contains submodules
   src = fetchgit {
     url = "https://github.com/das-labor/neopg.git";
-    rev = "refs/tags/v${version}";
+    rev = "v${version}";
     sha256 = "0hhkl326ff6f76k8pwggpzmivbm13fz497nlyy6ybn5bmi9xfblm";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ cmake sqlite botan2 boost164 curl gettext libusb gnutls ]; 
+  buildInputs = [ cmake sqlite botan2 boost164 curl gettext libusb gnutls ];
 
   doCheck = true;
   checkTarget = "test";

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   # We use fetchgit instead of fetchFromGitHub because of necessary git submodules
   src = fetchgit {
     url = "https://github.com/Nitrokey/nitrokey-app.git";
-    rev = "refs/tags/v${version}";
+    rev = "v${version}";
     sha256 = "0mm6vlgxlmpahmmcn4awnfpx5rx5bj8m44cywhgxlmz012x73hzi";
   };
 

--- a/pkgs/tools/security/stoken/default.nix
+++ b/pkgs/tools/security/stoken/default.nix
@@ -4,12 +4,12 @@
 
 stdenv.mkDerivation rec {
   pname = "stoken";
-  version = "v0.90";
+  version = "0.90";
   name = "${pname}-${version}";
   src = fetchFromGitHub {
     owner = "cernekee";
     repo = pname;
-    rev = version;
+    rev = "v${version}";
     sha256 = "1k7wn8pmp7dv646g938dsr99090lsphl7zy4m9x7qbh2zlnnf9af";
   };
 

--- a/pkgs/tools/text/jumanpp/default.nix
+++ b/pkgs/tools/text/jumanpp/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, cmake, protobuf }:
 stdenv.mkDerivation rec {
-  name = "jumanpp-${version}";
+  pname = "jumanpp";
+  name = "${pname}-${version}";
   version = "2.0.0-rc2";
 
   src = fetchurl {
-    url = "https://github.com/ku-nlp/${name}/releases/download/v${version}/${name}.tar.xz";
+    url = "https://github.com/ku-nlp/${pname}/releases/download/v${version}/${name}.tar.xz";
     sha256 = "17fzmd0f5m9ayfhsr0mg7hjp3pg1mhbgknhgyd8v87x46g8bg6qp";
   };
   buildInputs = [ cmake protobuf ];

--- a/pkgs/tools/text/xml/xmloscopy/default.nix
+++ b/pkgs/tools/text/xml/xmloscopy/default.nix
@@ -6,7 +6,7 @@ docbook5
 }:
 stdenv.mkDerivation rec {
   name = "xmloscopy-${version}";
-  version = "v0.1.2";
+  version = "0.1.2";
 
   buildInputs = [
     makeWrapper
@@ -27,12 +27,12 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "grahamc";
     repo = "xmloscopy";
-    rev = version;
+    rev = "v${version}";
     sha256 = "07fcnf1vv0x72lksl1v0frmlh73gca199ldqqbgdjpybjdffz456";
   };
 
   installPhase = ''
-    sed -i "s/hard to say/${version}/" ./xmloscopy
+    sed -i "s/hard to say/v${version}/" ./xmloscopy
     type -P shellcheck && shellcheck ./xmloscopy
     chmod +x ./xmloscopy
     patchShebangs ./xmloscopy

--- a/pkgs/tools/virtualization/xe-guest-utilities/default.nix
+++ b/pkgs/tools/virtualization/xe-guest-utilities/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, bzip2, lzo, zlib, xz, bash, python, gnutar, gnused, gnugrep, which }:
 
 stdenv.mkDerivation (rec {
-  name = "xe-guest-utilities";
+  pname = "xe-guest-utilities";
+  name = "${pname}-${version}";
   version = "6.2.0";
   meta = {
     description = "Citrix XenServer Tools";
@@ -17,14 +18,14 @@ stdenv.mkDerivation (rec {
   buildInputs = [ bzip2 gnutar gnused python lzo zlib xz stdenv gnugrep which ];
   patches = [ ./ip-address.patch ];
   postPatch = ''
-    tar xf "$NIX_BUILD_TOP/$name-$version/xenstore-sources.tar.bz2"
+    tar xf "$NIX_BUILD_TOP/$name/xenstore-sources.tar.bz2"
   '';
 
   buildPhase = ''
     export CC=gcc
     export CFLAGS='-Wall -Wstrict-prototypes -Wno-unused-local-typedefs -Wno-sizeof-pointer-memaccess'
     export PYTHON=python2
-    cd "$NIX_BUILD_TOP/$name-$version/uclibc-sources"
+    cd "$NIX_BUILD_TOP/$name/uclibc-sources"
     for file in Config.mk tools/libxc/Makefile tools/misc/Makefile tools/misc/lomount/Makefile tools/xenstore/Makefile; do
       substituteInPlace "$file" --replace -Werror ""
     done
@@ -39,12 +40,12 @@ stdenv.mkDerivation (rec {
       export LIBLEAFDIR_x86_64=lib
     fi
     for f in include libxc xenstore; do
-      [[ ! -d $NIX_BUILD_TOP/$name-$version/uclibc-sources/tools/$f ]] && continue
-      make -C "$NIX_BUILD_TOP/$name-$version/uclibc-sources/tools/$f" DESTDIR="$out" BINDIR=/bin SBINDIR=/bin INCLUDEDIR=/include LIBDIR=/lib install
+      [[ ! -d $NIX_BUILD_TOP/$name/uclibc-sources/tools/$f ]] && continue
+      make -C "$NIX_BUILD_TOP/$name/uclibc-sources/tools/$f" DESTDIR="$out" BINDIR=/bin SBINDIR=/bin INCLUDEDIR=/include LIBDIR=/lib install
     done
     rm -r "$out"/var
 
-    cd "$NIX_BUILD_TOP/$name-$version"
+    cd "$NIX_BUILD_TOP/$name"
     install -Dm755 xe-update-guest-attrs "$out/bin/xe-update-guest-attrs"
     install -Dm755 xe-daemon "$out/bin/xe-daemon"
     install -Dm644 xen-vcpu-hotplug.rules "$out/lib/udev/rules.d/10-xen-vcpu-hotplug.rules"

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -74,14 +74,14 @@ let
   };
 
   php_excel = assert isPhp7; buildPecl rec {
-    name = "php_excel";
+    name = "php_excel-${version}";
     version = "1.0.2";
     phpVersion = "php7";
 
     buildInputs = [ pkgs.libxl ];
 
     src = pkgs.fetchurl {
-      url = "https://github.com/iliaal/${name}/releases/download/Excel-1.0.2-PHP7/excel-${version}-${phpVersion}.tgz";
+      url = "https://github.com/iliaal/php_excel/releases/download/Excel-1.0.2-PHP7/excel-${version}-${phpVersion}.tgz";
       sha256 = "0dpvih9gpiyh1ml22zi7hi6kslkilzby00z1p8x248idylldzs2n";
     };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2819,9 +2819,10 @@ in {
   };
 
   gnutls = buildPythonPackage rec {
-    name = "python-gnutls";
+    pname = "python-gnutls";
+    version = "3.0.0";
     src = pkgs.fetchurl {
-      url = "mirror://pypi/p/python-gnutls/python-gnutls-3.0.0.tar.gz";
+      url = "mirror://pypi/p/python-gnutls/${pname}-${version}.tar.gz";
       sha256 = "1yrdxcj5rzvz8iglircz6icvyggz5fmdcd010n6w3j60yp4p84kc";
     };
 
@@ -10375,7 +10376,7 @@ in {
   };
 
   pybcrypt = buildPythonPackage rec {
-    name = "pybcrypt";
+    pname = "pybcrypt";
     version = "0.4";
 
     src = pkgs.fetchurl {


### PR DESCRIPTION
###### Motivation for this change

all these packages were being excluded from repology because their derivation names could not be parsed.

###### Things done

- [x] built all of them on NixOS