### PR TITLE
ocamlPackages.opam-file-format: init at 2.0.0-rc2

### DIFF
--- a/pkgs/development/ocaml-modules/opam-file-format/default.nix
+++ b/pkgs/development/ocaml-modules/opam-file-format/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.0-rc2";
+  name = "ocaml${ocaml.version}-opam-file-format-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "opam-file-format";
+    rev = "${version}";
+    sha256 = "05g0pikmifmfkwyws5x82fglgsz3d317yfn6nrz7zmpn22cirvir";
+  };
+
+  buildInputs = [ ocaml findlib ];
+
+  installFlags = [ "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
+
+  meta = {
+    description = "Parser and printer for the opam file syntax";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -519,6 +519,8 @@ let
 
     omd = callPackage ../development/ocaml-modules/omd { };
 
+    opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otr = callPackage ../development/ocaml-modules/otr { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

