### PR TITLE
spectral-cube: init at 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3536,6 +3536,11 @@
     github = "sleexyz";
     name = "Sean Lee";
   };
+  smaret = {
+    email = "sebastien.maret@icloud.com";
+    github = "smaret";
+    name = "Sébastien Maret";
+  };
   smironov = {
     email = "grrwlf@gmail.com";
     github = "grwlf";

--- a/pkgs/development/python-modules/radio_beam/default.nix
+++ b/pkgs/development/python-modules/radio_beam/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, astropy }:
+
+buildPythonPackage rec {
+  pname = "radio_beam";
+  version = "0.2";
+
+  doCheck = false; # the tests requires several pytest plugins that are not in nixpkgs
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gbnwnk89n8z0xwn41rc7wpr0fwrzkvxficyki3dyqbxq7y3qfrv";
+  };
+
+  propagatedBuildInputs = [ astropy ];
+
+  meta = {
+    description = "Tools for Beam IO and Manipulation";
+    homepage = http://radio-astro-tools.github.io;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ smaret ];
+  };
+}
+
+

--- a/pkgs/development/python-modules/spectral-cube/default.nix
+++ b/pkgs/development/python-modules/spectral-cube/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, astropy
+, radio_beam
+, pytest }:
+
+buildPythonPackage rec {
+  pname = "spectral-cube";
+  version = "0.4.3";
+
+  doCheck = false; # the tests requires several pytest plugins that are not in nixpkgs
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "057g3mzlg5cy4wg2hh3p6gssn93rs6i7pswzhldvcq4k8m8hsl3b";
+  };
+
+  propagatedBuildInputs = [ astropy radio_beam pytest ];
+
+  meta = {
+    description = "Library for reading and analyzing astrophysical spectral data cubes";
+    homepage = http://radio-astro-tools.github.io;
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ smaret ];
+  };
+}
+
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18171,6 +18171,8 @@ EOF
 
   radio_beam = callPackage ../development/python-modules/radio_beam { };
 
+  spectral-cube = callPackage ../development/python-modules/spectral-cube { };
+
 });
 
 in fix' (extends overrides packages)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18168,6 +18168,9 @@ EOF
   pyogg = callPackage ../development/python-modules/pyogg { };
 
   rubymarshal = callPackage ../development/python-modules/rubymarshal { };
+
+  radio_beam = callPackage ../development/python-modules/radio_beam { };
+
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change

This PR provides a package for`spectral-cube`, a Python module for reading and analyzing astrophysical spectral data cubes. It also provides a package for `radio_beam`, on which `spectral-cube` depends.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
