### PR TITLE
hyper: gnome2 cleanup

### DIFF
--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, lib, fetchurl, dpkg, gtk2, atk, glib, pango, gdk_pixbuf, cairo
+{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk_pixbuf, gnome3, cairo
 , freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
 , libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
 , libxcb
-, GConf, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
+, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
 
 let
   libPath = stdenv.lib.makeLibraryPath [
-    stdenv.cc.cc gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
+    stdenv.cc.cc gnome3.gtk2 gnome3.gconf atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
-    libXrender libX11 libXtst libXScrnSaver GConf nss nspr alsaLib cups expat libudev libpulseaudio
+    libXrender libX11 libXtst libXScrnSaver nss nspr alsaLib cups expat libudev libpulseaudio
   ];
 in
 stdenv.mkDerivation rec {

--- a/pkgs/applications/misc/hyper/default.nix
+++ b/pkgs/applications/misc/hyper/default.nix
@@ -1,12 +1,11 @@
-{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk_pixbuf, gnome3, cairo
+{ stdenv, lib, fetchurl, dpkg, atk, glib, pango, gdk_pixbuf, gnome3, gtk2, cairo
 , freetype, fontconfig, dbus, libXi, libXcursor, libXdamage, libXrandr
 , libXcomposite, libXext, libXfixes, libXrender, libX11, libXtst, libXScrnSaver
-, libxcb
-, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
+, libxcb, nss, nspr, alsaLib, cups, expat, libudev, libpulseaudio }:
 
 let
   libPath = stdenv.lib.makeLibraryPath [
-    stdenv.cc.cc gnome3.gtk2 gnome3.gconf atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
+    stdenv.cc.cc gtk2 gnome3.gconf atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes libxcb
     libXrender libX11 libXtst libXScrnSaver nss nspr alsaLib cups expat libudev libpulseaudio
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16321,8 +16321,7 @@ with pkgs;
 
   hydrogen = callPackage ../applications/audio/hydrogen { };
 
-  hyper = callPackage ../applications/misc/hyper { inherit (gnome2) GConf; };
-  hyperterm = self.hyper;
+  hyper = callPackage ../applications/misc/hyper { };
 
   hyper-haskell-server-with-packages = callPackage ../development/tools/haskell/hyper-haskell/server.nix {
     inherit (haskellPackages) ghcWithPackages;


### PR DESCRIPTION
###### Motivation for this change
Removed/updated gnome2 references (Part of #39976).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Notes
There was this in the all-packages.nix
```nix
hyperterm = self.hyper;
```
Seemed uneeded to me so I removed it.
