### PR TITLE
elmer: init at version 8.3

### DIFF
--- a/pkgs/applications/science/physics/elmer/default.nix
+++ b/pkgs/applications/science/physics/elmer/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, cmake, gfortran, openmpi, blas, liblapack, qt4}:
+
+stdenv.mkDerivation rec {
+  name = "elmer-${version}";
+  version = "8.3";
+  src = fetchFromGitHub {
+    owner = "elmercsc";
+    repo = "elmerfem";
+    rev = "release-${version}";
+    sha256 = "0lkzalag41f3rrd0p4ym14arng4phc7x9zbhgd3qmhfbc93a7bq7";
+  };
+
+  buildInputs = [ cmake gfortran openmpi blas liblapack qt4 ];
+  configurePhase = ''
+    mkdir build
+    cd build
+    cmake -DWITH_ELMERGUI:BOOL=TRUE \
+          -DWITH_MPI:BOOL=TRUE \
+          -DCMAKE_INSTALL_PREFIX=$out ../
+  '';
+  hardeningDisable = [ "format" ];
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "An open source multiphysical simulation software";
+    longDescription = ''
+      Elmer includes physical models of fluid dynamics, structural mechanics, electromagnetics, heat transfer and acoustics, for example.
+      These are described by partial differential equations which Elmer solves by the Finite Element Method (FEM).
+    '';
+    homepage = http://www.elmerfem.org/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.wucke13 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20093,6 +20093,8 @@ with pkgs;
 
   ### PHYSICS
 
+  elmer = callPackage ../applications/science/physics/elmer { };
+
   sacrifice = callPackage ../applications/science/physics/sacrifice {};
 
   sherpa = callPackage ../applications/science/physics/sherpa {};


### PR DESCRIPTION
Having a FEM tool could be handy.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

