### PR TITLE
skypeforlinux: gnome2 cleanup

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, dpkg, makeWrapper
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome2
-, libnotify, libpulseaudio, libsecret, libstdcxx5, libv4l, nspr, nss, systemd, xorg }:
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome3
+, libnotify, libpulseaudio, libsecret, libstdcxx5, libv4l, nspr, nss, pango, systemd, xorg }:
 
 let
 
@@ -22,17 +22,18 @@ let
     glibc
     libsecret
 
-    gnome2.GConf
-    gnome2.gdk_pixbuf
-    gnome2.gtk
-    gnome2.pango
+    gnome3.gconf
+    gnome3.gdk_pixbuf
+    gnome3.gtk2
+    
 
-    gnome2.gnome-keyring
+    gnome3.gnome-keyring
 
     libnotify
     libpulseaudio
     nspr
     nss
+    pango
     stdenv.cc.cc
     systemd
     libstdcxx5

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, dpkg, makeWrapper
-, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, glib, glibc, gnome3
-, libnotify, libpulseaudio, libsecret, libstdcxx5, libv4l, nspr, nss, pango, systemd, xorg }:
+, alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, glibc, gnome3
+, gtk2, libnotify, libpulseaudio, libsecret, libstdcxx5, libv4l, nspr, nss, pango, systemd, xorg }:
 
 let
 
@@ -23,8 +23,8 @@ let
     libsecret
 
     gnome3.gconf
-    gnome3.gdk_pixbuf
-    gnome3.gtk2
+    gdk_pixbuf
+    gtk2
     
 
     gnome3.gnome-keyring


### PR DESCRIPTION
###### Motivation for this change
Removed/updated gnome2 references (Part of #39976).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

