### PR TITLE
noto-fonts: separate package for unusual weights

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -1,47 +1,59 @@
 { stdenv, fetchzip, fetchFromGitHub, optipng, cairo, unzip, pythonPackages, pkgconfig, pngquant, which, imagemagick }:
 
-rec {
-  # 18MB
-  noto-fonts = let version = "2017-10-24-phase3-second-cleanup"; in fetchzip {
-    name = "noto-fonts-${version}";
-
-    url = "https://github.com/googlei18n/noto-fonts/archive/v${version}.zip";
-    postFetch = ''
-      unzip $downloadedFile
-
-      mkdir -p $out/share/fonts/noto
-      cp noto-fonts-*/hinted/*.ttf $out/share/fonts/noto
-      # Also copy unhinted & alpha fonts for better glyph coverage,
-      # if they don't have a hinted version
-      # (see https://groups.google.com/d/msg/noto-font/ZJSkZta4n5Y/tZBnLcPdbS0J)
-      cp -n noto-fonts-*/unhinted/*.ttf $out/share/fonts/noto
-      cp -n noto-fonts-*/alpha/*.ttf $out/share/fonts/noto
-    '';
-    sha256 = "013l816cq9svdji266sccscm9sf9pfn472gq9lnqkzlwaxx9qrrl";
-
-    meta = with stdenv.lib; {
-      inherit version;
-      description = "Beautiful and free fonts for many languages";
-      homepage = https://www.google.com/get/noto/;
-      longDescription =
-      ''
-        When text is rendered by a computer, sometimes characters are displayed as
-        “tofu”. They are little boxes to indicate your device doesn’t have a font to
-        display the text.
-
-        Google has been developing a font family called Noto, which aims to support all
-        languages with a harmonious look and feel. Noto is Google’s answer to tofu. The
-        name noto is to convey the idea that Google’s goal is to see “no more tofu”.
-        Noto has multiple styles and weights, and freely available to all.
-
-        This package also includes the Arimo, Cousine, and Tinos fonts.
+let
+  mkNoto = { name, weights, sha256, }:
+    let version = "2017-10-24-phase3-second-cleanup"; in
+    fetchzip {
+      name = "${name}-${version}";
+      inherit sha256;
+      url = "https://github.com/googlei18n/noto-fonts/archive/v${version}.zip";
+      postFetch = ''
+        unzip $downloadedFile
+        mkdir -p $out/share/fonts/noto
+        # Also copy unhinted & alpha fonts for better glyph coverage,
+        # if they don't have a hinted version
+        # (see https://groups.google.com/d/msg/noto-font/ZJSkZta4n5Y/tZBnLcPdbS0J)
+        for ttf in noto-fonts-*/{hinted,unhinted,alpha}/*-${weights}.ttf
+        do
+            cp -n "$ttf" -t "$out/share/fonts/noto"
+        done
       '';
-      license = licenses.asl20;
-      platforms = platforms.all;
-      maintainers = with maintainers; [ mathnerd314 ];
+      meta = with stdenv.lib; {
+        inherit version;
+        description = "Beautiful and free fonts for many languages";
+        homepage = https://www.google.com/get/noto/;
+        longDescription =
+        ''
+          When text is rendered by a computer, sometimes characters are
+          displayed as “tofu”. They are little boxes to indicate your device
+          doesn’t have a font to display the text.
+
+          Google has been developing a font family called Noto, which aims to
+          support all languages with a harmonious look and feel. Noto is
+          Google’s answer to tofu. The name noto is to convey the idea that
+          Google’s goal is to see “no more tofu”.  Noto has multiple styles and
+          weights, and freely available to all.
+
+          This package also includes the Arimo, Cousine, and Tinos fonts.
+        '';
+        license = licenses.asl20;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ mathnerd314 ];
+      };
     };
+in
+
+rec {
+  noto-fonts = mkNoto {
+    name = "noto-fonts";
+    weights = "{Regular,Bold,Light,Italic,BoldItalic,LightItalic}";
+    sha256 = "1dmarbsfank6xzzx31h5jdv6n99rzblqyb1iqjkpll6dl3627pnb";
   };
-  # 89MB
+  noto-fonts-extra = mkNoto {
+    name = "noto-fonts-extra";
+    weights = "{Black,Condensed,Extra,Medium,Semi,Thin}*";
+    sha256 = "1lih49bqmsmblczvbl7qb1bhn0bq8v5xkr991b3gjghpdkx584bc";
+  };
   noto-fonts-cjk = let version = "1.004"; in fetchzip {
     name = "noto-fonts-cjk-${version}";
 
@@ -74,7 +86,6 @@ rec {
       maintainers = with maintainers; [ mathnerd314 ];
     };
   };
-  # 12MB
   noto-fonts-emoji = let version = "2017-09-13-design-refresh"; in stdenv.mkDerivation {
     name = "noto-fonts-emoji-${version}";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14516,7 +14516,7 @@ with pkgs;
   nafees = callPackage ../data/fonts/nafees { };
 
   inherit (callPackages ../data/fonts/noto-fonts {})
-    noto-fonts noto-fonts-cjk noto-fonts-emoji;
+    noto-fonts noto-fonts-cjk noto-fonts-emoji noto-fonts-extra;
 
   nullmailer = callPackage ../servers/mail/nullmailer {
     stdenv = gccStdenv;


### PR DESCRIPTION
### Motivation

Noto provides a large number of unusual font weights so that the complete
package of fonts is more than 300 MB in size. Most of these weights are moved
into noto-fonts-extra; noto-fonts retains the ordinary weights and styles.

See also: #31543

### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

