### PR TITLE
libgdiplus: fix build

### DIFF
--- a/pkgs/development/libraries/libgdiplus/default.nix
+++ b/pkgs/development/libraries/libgdiplus/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
 
   patchFlags = "-p0";
 
+  hardeningDisable = [ "format" ];
+
   buildInputs =
     [ pkgconfig glib cairo fontconfig libtiff giflib
       libjpeg libpng libXrender libexif


### PR DESCRIPTION
###### Motivation for this change

`libgdiplus` was broken after b22cc53db147cdbfe84ffbc344143bf1e8c1e515

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

