### PR TITLE
obs-linuxbrowser: init at 0.3.1

### DIFF
--- a/pkgs/applications/video/obs-studio/linuxbrowser.nix
+++ b/pkgs/applications/video/obs-studio/linuxbrowser.nix
@@ -1,0 +1,48 @@
+# We don't have a wrapper which can supply obs-studio plugins so you have to
+# somewhat manually install this:
+
+# nix-env -f . -iA obs-linuxbrowser
+# mkdir -p ~/.config/obs-studio/plugins
+# ln -s ~/.nix-profile/share/obs/obs-plugins/obs-linuxbrowser ~/.config/obs-studio/plugins/
+
+{ stdenv, fetchFromGitHub, obs-studio, cmake, libcef
+}:
+
+stdenv.mkDerivation rec {
+  name = "obs-linuxbrowser-${version}";
+  version = "0.3.1";
+  src = fetchFromGitHub {
+    owner = "bazukas";
+    repo = "obs-linuxbrowser";
+    rev = version;
+    sha256 = "0dql7wxyhksqa08j1dn5d09v2jwhgywc1p7psifhhvh97rkp4z7j";
+  };
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ obs-studio ];
+  postUnpack = ''
+    mkdir -p cef/Release cef/Resources cef/libcef_dll_wrapper/
+    for i in ${libcef}/share/cef/*; do
+      ln -s $i cef/Release/
+      ln -s $i cef/Resources/
+    done
+    ln -s ${libcef}/lib/libcef.so cef/Release/
+    ln -s ${libcef}/lib/libcef_dll_wrapper.a cef/libcef_dll_wrapper/
+    ln -s ${libcef}/include cef/
+  '';
+  cmakeFlags = [
+    "-DCEF_DIR=../../cef"
+    "-DOBS_INCLUDE=${obs-studio}/include/obs"
+  ];
+  installPhase = ''
+    mkdir -p $out/share/obs/obs-plugins
+    cp -r build/obs-linuxbrowser $out/share/obs/obs-plugins/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Browser source plugin for obs-studio based on Chromium Embedded Framework";
+    homepage = https://github.com/bazukas/obs-linuxbrowser;
+    maintainers = with maintainers; [ puffnfresh ];
+    license = licenses.gpl2;
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, cmake, alsaLib, atk, cairo, cups, dbus, expat, fontconfig
+, GConf, gdk_pixbuf, glib, gtk2, libX11, libxcb, libXcomposite, libXcursor
+, libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXScrnSaver
+, libXtst, nspr, nss, pango, libpulseaudio, systemd }:
+
+let
+  libPath =
+    stdenv.lib.makeLibraryPath [
+      alsaLib atk cairo cups dbus expat fontconfig GConf gdk_pixbuf glib gtk2
+      libX11 libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXi
+      libXrandr libXrender libXScrnSaver libXtst nspr nss pango libpulseaudio
+      systemd
+    ];
+in
+stdenv.mkDerivation rec {
+  name = "cef-binary-${version}";
+  # Not very recent but more recent versions have problems:
+  # https://github.com/bazukas/obs-linuxbrowser/issues/63
+  version = "3.3325.1750.gaabe4c4";
+  src = fetchurl {
+    url = "http://opensource.spotify.com/cefbuilds/cef_binary_${version}_linux64.tar.bz2";
+    sha256 = "06pj1ci1lwammz1vwmbgw2fri7gkvbpv4iw67pqckd9xz0cfhwzr";
+  };
+  nativeBuildInputs = [ cmake ];
+  makeFlags = "libcef_dll_wrapper";
+  dontStrip = true;
+  dontPatchELF = true;
+  installPhase = ''
+    mkdir -p $out/lib/ $out/share/cef/
+    cp libcef_dll_wrapper/libcef_dll_wrapper.a $out/lib/
+    cp ../Release/libcef.so $out/lib/
+    patchelf --set-rpath "${libPath}" $out/lib/libcef.so
+    cp ../Release/*.bin $out/share/cef/
+    cp -r ../Resources/* $out/share/cef/
+    cp -r ../include $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple framework for embedding Chromium-based browsers in other applications";
+    homepage = http://opensource.spotify.com/cefbuilds/index.html;
+    maintainers = with maintainers; [ puffnfresh ];
+    license = licenses.bsd3;
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9752,6 +9752,8 @@ with pkgs;
   libcec = callPackage ../development/libraries/libcec { };
   libcec_platform = callPackage ../development/libraries/libcec/platform.nix { };
 
+  libcef = callPackage ../development/libraries/libcef { inherit (gnome2) GConf; };
+
   libcello = callPackage ../development/libraries/libcello {};
 
   libcerf = callPackage ../development/libraries/libcerf {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17204,6 +17204,8 @@ with pkgs;
 
   oblogout = callPackage ../tools/X11/oblogout { };
 
+  obs-linuxbrowser = callPackage ../applications/video/obs-studio/linuxbrowser.nix { };
+
   obs-studio = libsForQt5.callPackage ../applications/video/obs-studio {
     alsaSupport = stdenv.isLinux;
     pulseaudioSupport = config.pulseaudio or true;


### PR DESCRIPTION
###### Motivation for this change

I use obs-studio to make videos. I'd like to have a browser overlay. I managed to get [obs-linuxbrowser](https://github.com/bazukas/obs-linuxbrowser) to work, with some effort.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

