### PR TITLE
Add Bazel buildtools

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3930,6 +3930,11 @@
     github = "uralbash";
     name = "Svintsov Dmitry";
   };
+  uri-canva = {
+    email = "uri@canva.com";
+    github = "uri-canva";
+    name = "Uri Baghin";
+  };
   utdemir = {
     email = "me@utdemir.com";
     github = "utdemir";

--- a/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "bazel-buildtools";
+  version = "2018-05-24";
+
+  goPackagePath = "github.com/bazelbuild/buildtools";
+
+  src = fetchFromGitHub {
+    owner = "bazelbuild";
+    repo = "buildtools";
+    rev = "588d90030bc8054b550967aa45a8a8d170deba0b";
+    sha256 = "18q1z138545kh4s5k0jcqwhpzc1w7il4x00l7yzv9wq8bg1vn1rv";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "This derivation contains developer tools for working with Google's bazel buildtool.";
+    homepage = https://github.com/bazelbuild/buildtools;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ uri-canva ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/bazel/buildtools/deps.nix
+++ b/pkgs/development/tools/build-managers/bazel/buildtools/deps.nix
@@ -1,0 +1,29 @@
+[
+  {
+    goPackagePath = "github.com/bazelbuild/buildtools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bazelbuild/buildtools";
+      rev = "588d90030bc8054b550967aa45a8a8d170deba0b";
+      sha256 = "18q1z138545kh4s5k0jcqwhpzc1w7il4x00l7yzv9wq8bg1vn1rv";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "3a3da3a4e26776cc22a79ef46d5d58477532dede";
+      sha256 = "05l0kjgk6ss98qii7vpjj2bqszyd16h448w47sv4422mp2xbni40";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/skylark";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/skylark";
+      rev = "572cea2bd78e2f1de8f3e136db9413cf02f097eb";
+      sha256 = "0hc7gwvqsw421if06nlfdl86h6jl8wgjx1j2x2mzpnzdh1r03w92";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7647,6 +7647,11 @@ with pkgs;
   bazel_0_4 = callPackage ../development/tools/build-managers/bazel/0.4.nix { };
   bazel = callPackage ../development/tools/build-managers/bazel { };
 
+  bazel-buildtools = callPackage ../development/tools/build-managers/bazel/buildtools { };
+  buildifier = bazel-buildtools;
+  buildozer = bazel-buildtools;
+  unused_deps = bazel-buildtools;
+
   buildBazelPackage = callPackage ../build-support/build-bazel-package { };
 
   bear = callPackage ../development/tools/build-managers/bear { };


### PR DESCRIPTION
###### Motivation for this change
Adds three new derivations for https://github.com/bazelbuild/buildtools .

These are added as three completely separate derivations, even though they're all carbon copies of each other, because the three are independent, so they can be updated independently, and in fact in some cases will have to be updated independently, as a certain version of one of the tools might be incompatible with the other tools built on the same commit.

Still the repetition is pretty ugly, so I'm open to suggestions on how to refactor it.

Also open to suggestions on what the commit message should be, as I don't think the one I've put now is quite in line with the guidelines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
