### PR TITLE
[wip] pythonPackages.bcc-python: init at 0.5

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -211,6 +211,8 @@ in {
 
   bayespy = callPackage ../development/python-modules/bayespy { };
 
+  bcc-python = (toPythonModule (pkgs.linuxPackages.bcc.override{pythonSupport=true; inherit python;})).py;
+
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };
 
   bitcoin-price-api = callPackage ../development/python-modules/bitcoin-price-api { };


### PR DESCRIPTION
Add bcc python bindings (https://github.com/iovisor/bcc), aka tools to
play with BPF and kernel.

###### Motivation for this change
I want to load BPF programs via python.

I haven't properly tested everything yet but the bindings seemed to work (got an error when loading my bpf filter but unrelated I think)
@ragge 
@Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

