### PR TITLE
Fix gnome urls

### DIFF
--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "0.97.3.20170622";
 
   src = fetchgit {
-    url = git://git.gnome.org/dia;
+    url = https://gitlab.gnome.org/GNOME/dia.git;
     rev = "b86085dfe2b048a2d37d587adf8ceba6fb8bc43c";
     sha256 = "1fyxfrzdcs6blxhkw3bcgkksaf3byrsj4cbyrqgb4869k3ynap96";
   };

--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -16,7 +16,7 @@ in stdenv.mkDerivation {
   name = "planner-${version}";
 
   src = fetchgit {
-    url = "https://git.gnome.org/browse/planner";
+    url = https://gitlab.gnome.org/GNOME/planner.git;
     rev = "6a79647e5711b2b8d7435cacc3452e643d2f05e6";
     sha256 = "18k40s0f665qclrzvkgyfqmvjk0nqdc8aj3m8n4ky85di4qbqlwd";
   };

--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
   patches = optionals stdenv.isDarwin [
     (fetchpatch {
       name = "change-igemacintegration-to-gtkosxapplication.patch";
-      url = "https://git.gnome.org/browse/gtksourceview/patch/?id=e88357c5f210a8796104505c090fb6a04c213902";
+      url = "https://gitlab.gnome.org/GNOME/gtksourceview/commit/e88357c5f210a8796104505c090fb6a04c213902.patch";
       sha256 = "0h5q79q9dqbg46zcyay71xn1pm4aji925gjd5j93v4wqn41wj5m7";
     })
     (fetchpatch {
       name = "update-to-gtk-mac-integration-2.0-api.patch";
-      url = "https://git.gnome.org/browse/gtksourceview/patch/?id=ab46e552e1d0dae73f72adac8d578e40bdadaf95";
+      url = "https://gitlab.gnome.org/GNOME/gtksourceview/commit/ab46e552e1d0dae73f72adac8d578e40bdadaf95.patch";
       sha256 = "0qzrbv4hpa0v8qbmpi2vp575n13lkrvp3cgllwrd2pslw1v9q3aj";
     })
   ];

--- a/pkgs/desktops/gnome-2/desktop/vte/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/vte/default.nix
@@ -18,12 +18,12 @@ in stdenv.mkDerivation rec {
     # fixed in upstream version 0.32.2
     (fetchpatch{
       name = "CVE-2012-2738-1.patch";
-      url = https://git.gnome.org/browse/vte/patch/?id=feeee4b5832b17641e505b7083e0d299fdae318e;
+      url = https://gitlab.gnome.org/GNOME/vte/commit/feeee4b5832b17641e505b7083e0d299fdae318e.patch;
       sha256 = "1455i6zxcx4rj2cz639s8qdc04z2nshprwl7k00mcsw49gv3hk5n";
     })
     (fetchpatch{
       name = "CVE-2012-2738-2.patch";
-      url = https://git.gnome.org/browse/vte/patch/?id=98ce2f265f986fb88c38d508286bb5e3716b9e74;
+      url = https://gitlab.gnome.org/GNOME/vte/commit/98ce2f265f986fb88c38d508286bb5e3716b9e74.patch;
       sha256 = "0n24vw49h89w085ggq23iwlnnb6ajllfh2dg4vsar21d82jxc0sn";
     })
   ];

--- a/pkgs/desktops/gnome-3/core/libcroco/default.nix
+++ b/pkgs/desktops/gnome-3/core/libcroco/default.nix
@@ -13,12 +13,12 @@ in stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "CVE-2017-7960.patch";
-      url = "https://git.gnome.org/browse/libcroco/patch/?id=898e3a8c8c0314d2e6b106809a8e3e93cf9d4394";
+      url = https://gitlab.gnome.org/GNOME/libcroco/commit/898e3a8c8c0314d2e6b106809a8e3e93cf9d4394.patch;
       sha256 = "1xjwdqijxf4b7mhdp3kkgnb6c14y0bn3b3gg79kyrm82x696d94l";
     })
     (fetchpatch {
       name = "CVE-2017-7961.patch";
-      url = "https://git.gnome.org/browse/libcroco/patch/?id=9ad72875e9f08e4c519ef63d44cdbd94aa9504f7";
+      url = https://gitlab.gnome.org/GNOME/libcroco/commit/9ad72875e9f08e4c519ef63d44cdbd94aa9504f7.patch;
       sha256 = "0zakd72ynzjgzskwyvqglqiznsb93j1bkvc1lgyrzgv9rwrbwv9s";
     })
   ];
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GNOME CSS2 parsing and manipulation toolkit";
-    homepage = https://git.gnome.org/browse/libcroco;
+    homepage = https://gitlab.gnome.org/GNOME/libcroco;
     license = licenses.lgpl2;
     platforms = platforms.unix;
   };

--- a/pkgs/desktops/gnome-3/devtools/nemiver/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/nemiver/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./bool_slot.patch ./safe_ptr.patch
     (fetchpatch {
-      url = "https://git.gnome.org/browse/nemiver/patch/src/persp/dbgperspective/nmv-dbg-perspective.cc?id=262cf9657f9c2727a816972b348692adcc666008";
+      url = https://gitlab.gnome.org/GNOME/nemiver/commit/262cf9657f9c2727a816972b348692adcc666008.patch;
       sha256 = "03jv6z54b8nzvplplapk4aj206zl1gvnv6iz0mad19g6yvfbw7a7";
     })
   ];

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   #   sha256 = "0d534ysa6n9prd17wwzisq7mj6qkhwh8wcf8qgin1ar3hbs5ry7z";
   # };
   src = fetchgit {
-    url = https://git.gnome.org/browse/gdk-pixbuf;
+    url = https://gitlab.gnome.org/GNOME/gdk-pixbuf.git;
     rev = version;
     sha256 = "18lwqg63vyap2m1mw049rnb8fm869429xbf7636a2n21gs3d3jwv";
   };
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
     # Add missing test file bug753605-atsize.jpg
     (fetchpatch {
-      url = https://git.gnome.org/browse/gdk-pixbuf/patch/?id=87f8f4bf01dfb9982c1ef991e4060a5e19fdb7a7;
+      url = https://gitlab.gnome.org/GNOME/gdk-pixbuf/commit/87f8f4bf01dfb9982c1ef991e4060a5e19fdb7a7.patch;
       sha256 = "1slzywwnrzfx3zjzdsxrvp4g2q4skmv50pdfmyccp41j7bfyb2j0";
     })
 

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Use GNUTLS system trust for certificates
     (fetchpatch {
-      url = https://git.gnome.org/browse/glib-networking/patch/?id=f1c8feee014007cc913b71357acb609f8d1200df;
+      url = https://gitlab.gnome.org/GNOME/glib-networking/commit/f1c8feee014007cc913b71357acb609f8d1200df.patch;
       sha256 = "1rbxqsrcb5if3xs2d18pqzd9xnjysdj715ijc41n5w326fsawg7i";
     })
   ];

--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library to use HTTPSEverywhere in desktop applications";
-    homepage = https://git.gnome.org/browse/libhttpseverywhere;
+    homepage = https://gitlab.gnome.org/GNOME/libhttpseverywhere;
     license = licenses.lgpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ sternenseemann ] ++ gnome3.maintainers;

--- a/pkgs/development/tools/gnome-desktop-testing/default.nix
+++ b/pkgs/development/tools/gnome-desktop-testing/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   name = "gnome-desktop-testing-${version}";
 
   src = fetchgit {
-    url = https://git.gnome.org/browse/gnome-desktop-testing;
+    url = https://gitlab.gnome.org/GNOME/gnome-desktop-testing.git;
     rev = "v${version}";
     sha256 = "1bcd8v101ynsv2p5swh30hnajjf6z8dxzd89h9racp847hgjgyxc";
   };


### PR DESCRIPTION
###### Motivation for this change
GNOME migrated most of the repos to GitLab but for some URLs, redirects were not estabilished.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

