### PR TITLE
drone: 0.5 -> 0.8.5

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -2,66 +2,25 @@
 
 buildGoPackage rec {
   name = "drone.io-${version}";
-  version = "0.5-20161104-${stdenv.lib.strings.substring 0 7 revision}";
-  revision = "232df356afeeb4aec5e2959fa54b084dcadb267f";
+  version = "0.8.5-20180329-${stdenv.lib.strings.substring 0 7 revision}";
+  revision = "81103a98208b0bfc76be5b07194f359fbc80183b";
   goPackagePath = "github.com/drone/drone";
 
   # These dependencies pulled (in `drone` buildprocess) via Makefile,
   # so I extracted them here, all revisions pinned by same date, as ${version}
-  extraSrcs = [ 
-    {
-      goPackagePath = "github.com/drone/drone-ui";
-      src = fetchFromGitHub {
-        owner = "drone";
-        repo = "drone-ui";
-        rev = "e66df33b4620917a2e7b59760887cc3eed543664";
-        sha256 = "0d50xdzkh9akpf5c0sqgcgy11v2vz858l36jp5snr94zkrdkv0n1";
-      };
-    }
-    {
-      goPackagePath = "github.com/drone/mq";
-      src = fetchFromGitHub {
-        owner = "drone";
-        repo = "mq";
-        rev = "0f296601feeed952dabd038793864acdbefe6dbe";
-        sha256 = "1k7439c90l4w29g7wyixfmpbkap7bn8yh8zynbjyjf9qjzwsnw97";
-      };
-    }
-    {
-      goPackagePath = "github.com/tidwall/redlog";
-      src = fetchFromGitHub {
-        owner = "tidwall";
-        repo = "redlog";
-        rev = "54086c8553cd23aba652513a87d2b085ea961541";
-        sha256 = "12a7mk6r8figjinzkbisxcaly6sasggy62m8zs4cf35lpq2lhffq";
-      };
-    }
-    {
-      goPackagePath = "golang.org/x/crypto";
-      src = fetchFromGitHub {
-        owner = "golang";
-        repo = "crypto";
-        rev = "9477e0b78b9ac3d0b03822fd95422e2fe07627cd";
-        sha256 = "1qcqai6nf1q50z9ga7r4ljnrh1qz49kwlcqpri4bknx732lqq0v5";
-      };
-    }
-  ];
-  nativeBuildInputs = [ go-bindata go-bindata-assetfs ];
+  goDeps= ./deps.nix;
 
-  preBuild = ''
-    go generate github.com/drone/drone/server/template
-    go generate github.com/drone/drone/store/datastore/ddl
-  '';
+  nativeBuildInputs = [ go-bindata go-bindata-assetfs ];
 
   src = fetchFromGitHub {
     owner = "drone";
     repo = "drone";
     rev = revision;
-    sha256 = "0xrijcrlv3ag9n2kywkrhdkxyhxc8fs6zqn0hyav6a6jpqnsahg3";
+    sha256 = "1890bwhxr62adv261v4kn1azhq7qvcj2zpll68i9nsvjib8a52bq";
   };
 
   meta = with stdenv.lib; {
-    maintainers = with maintainers; [ avnik ];
+    maintainers = with maintainers; [ avnik vdemeester ];
     license = licenses.asl20;
     description = "Continuous Integration platform built on container technology";
   };

--- a/pkgs/development/tools/continuous-integration/drone/deps.nix
+++ b/pkgs/development/tools/continuous-integration/drone/deps.nix
@@ -1,0 +1,38 @@
+[
+  {
+    goPackagePath = "github.com/drone/drone-ui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/drone/drone-ui";
+      rev = "5a497bd6cd5c3c17c53b00d40bcda1bf6f68f475";
+      sha256 = "1666xlz3dg468izfwprg17sgb3f4ppn5sj5klds3wgdfrjjm4v57";
+    };
+  }
+  {
+    goPackagePath = "github.com/drone/mq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/drone/mq";
+      rev = "280af2a3b9c7d9ce90d625150dfff972c6c190b8";
+      sha256 = "10a24yq3ya8mvs7j6m7lqhyws7jd923rnih75ciq1g327qxf743s";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/net";
+      rev = "dfa909b99c79129e1100513e5cd36307665e5723";
+      sha256 = "0nsansy1yqy1kzh5wpv3zi85s0chxfq0ha8knhgnfa0wj0k8q0il";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "b4deda0973fb4c70b50d226b1af49f3da59f5265";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+]


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump version of drone (https://drone.io) to `v0.8.5`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

