### PR TITLE
qgit: 2.7 -> 2.8

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, fetchgit, cmake, qtbase }:
+{ stdenv, fetchFromGitHub, cmake, qtbase }:
 
 stdenv.mkDerivation rec {
-  name = "qgit-2.7";
+  name = "qgit-2.8";
 
-  src = fetchgit {
-    url = "http://repo.or.cz/qgit4/redivivus.git";
+  src = fetchFromGitHub {
+    owner = "tibirna";
+    repo = "qgit";
     rev = name;
-    sha256 = "0c0zxykpgkxb8gpgzz5i6b8nrzg7cdxikvpg678x7gsnxhlwjv3a";
+    sha256 = "01l6mz2f333x3zbfr68mizwpsh6sdsnadcavpasidiych1m5ry8f";
   };
 
   buildInputs = [ qtbase ];


### PR DESCRIPTION
###### Motivation for this change
New version supports HiDPI displays.

CC @peterhoeg 

###### Things done
Tested locally on a 4K display. Labels are readable now after scaling.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

