### PR TITLE
qt5.qtlocation: enable parallel building

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -4,8 +4,6 @@ qtModule {
   name = "qtlocation";
   qtInputs = [ qtbase qtmultimedia ];
   outputs = [ "bin" "out" "dev" ];
-  # Linking with -lclipper fails with parallel build enabled
-  enableParallelBuilding = false;
   qmakeFlags = stdenv.lib.optional stdenv.isDarwin [
      # boost uses std::auto_ptr which has been disabled in clang with libcxx
      # This flag re-enables this feature


### PR DESCRIPTION
###### Motivation for this change

Parallel building was fixed in [1] which is part of 5.9.2, 5.10.0.

[1] https://github.com/qt/qtlocation/commit/3ac051c4549575634cecc706175b019f4ed4c3bf and https://github.com/qt/qtlocation/commit/b4ca6fea977e35e60d40d12c0e93d1c44fac5b5f

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).