### PR TITLE
mysql55: 5.5.58 -> 5.5.60; mysql57: 5.7.20 -> 5.7.22

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -368,7 +368,6 @@ rec {
 
   # MySQL mirrors
   mysql = [
-    http://mysql.mirrors.pair.com/Downloads/
     http://cdn.mysql.com/Downloads/
   ];
 

--- a/pkgs/development/libraries/qt-5/modules/qtlocation.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtlocation.nix
@@ -4,8 +4,6 @@ qtModule {
   name = "qtlocation";
   qtInputs = [ qtbase qtmultimedia ];
   outputs = [ "bin" "out" "dev" ];
-  # Linking with -lclipper fails with parallel build enabled
-  enableParallelBuilding = false;
   qmakeFlags = stdenv.lib.optional stdenv.isDarwin [
      # boost uses std::auto_ptr which has been disabled in clang with libcxx
      # This flag re-enables this feature

--- a/pkgs/servers/sql/mysql/5.5.x.nix
+++ b/pkgs/servers/sql/mysql/5.5.x.nix
@@ -6,11 +6,11 @@
 let
 self = stdenv.mkDerivation rec {
   name = "mysql-${version}";
-  version = "5.5.58";
+  version = "5.5.60";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.5/${name}.tar.gz";
-    sha256 = "1f890376ld1qapl038sjh2ialdizys3sj96vfn4mqmb1ybx14scv";
+    sha256 = "071xaamqkbscybqzm79gf2w3bkr9lqlzwafis3gzc8w8fkhi4hd3";
   };
 
   patches = if stdenv.isCygwin then [
@@ -47,6 +47,8 @@ self = stdenv.mkDerivation rec {
     "-DINSTALL_MYSQLSHAREDIR=share/mysql"
     "-DINSTALL_DOCDIR=share/mysql/docs"
     "-DINSTALL_SHAREDIR=share/mysql"
+    "-DINSTALL_MYSQLTESTDIR="
+    "-DINSTALL_SQLBENCHDIR="
   ];
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ]; # since gcc-7
@@ -57,8 +59,7 @@ self = stdenv.mkDerivation rec {
   '';
   postInstall = ''
     sed -i -e "s|basedir=\"\"|basedir=\"$out\"|" $out/bin/mysql_install_db
-    rm -r $out/mysql-test $out/sql-bench $out/data "$out"/lib/*.a
-    rm $out/share/man/man1/mysql-test-run.pl.1
+    rm -r $out/data "$out"/lib/*.a
   '';
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

Latest updates. (See commit messages for details.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of ~all~ some binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
