### PR TITLE
pythonPackages.pdfminer: replacing pdfminer with pdfminer_six

### DIFF
--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, pycryptodome, chardet, nose, pytest }:
+
+buildPythonPackage rec {
+  pname = "pdfminer_six";
+  version = "20170720";
+
+  src = fetchFromGitHub {
+    owner = "pdfminer";
+    repo = "pdfminer.six";
+    rev = "${version}";
+    sha256 = "0vax5k0a8qn8x86ybpzqydk7x3hajsk8b6xf3y610j19mgag6wvs";
+  };
+
+  propagatedBuildInputs = [ six pycryptodome chardet ];
+  
+  checkInputs = [ nose pytest ];
+  checkPhase = ''
+    # some crappy hack to ensure the test do not fail for python3
+    # for some reason importing from the folder tools fails :\
+    cp tools/dumppdf.py tests/
+    cp tools/pdf2txt.py tests/
+    sed -i '/from tools import dumppdf/c\    import dumppdf' tests/test_tools_dumppdf.py
+    sed -i '/import tools.pdf2txt as pdf2txt/c\import pdf2txt as pdf2txt' tests/test_tools_pdf2txt.py
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "fork of PDFMiner using six for Python 2+3 compatibility";
+    homepage = https://github.com/pdfminer/pdfminer.six;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, six, pycryptodome, chardet, nose, pytest }:
+{ stdenv, buildPythonPackage, python, fetchFromGitHub, six, pycryptodome, chardet, nose, pytest }:
 
 buildPythonPackage rec {
   pname = "pdfminer_six";
@@ -15,13 +15,7 @@ buildPythonPackage rec {
   
   checkInputs = [ nose pytest ];
   checkPhase = ''
-    # some crappy hack to ensure the test do not fail for python3
-    # for some reason importing from the folder tools fails :\
-    cp tools/dumppdf.py tests/
-    cp tools/pdf2txt.py tests/
-    sed -i '/from tools import dumppdf/c\    import dumppdf' tests/test_tools_dumppdf.py
-    sed -i '/import tools.pdf2txt as pdf2txt/c\import pdf2txt as pdf2txt' tests/test_tools_pdf2txt.py
-    pytest
+    ${python.interpreter} -m pytest
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -311,6 +311,8 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
+  pdfminer_six = callPackage ../development/python-modules/pdfminer_six { };
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -311,7 +311,7 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
-  pdfminer_six = callPackage ../development/python-modules/pdfminer_six { };
+  pdfminer = callPackage ../development/python-modules/pdfminer_six { };
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
@@ -3781,28 +3781,6 @@ in {
       homepage = https://github.com/joeyespo/path-and-address;
       license = licenses.mit;
       maintainers = with maintainers; [ koral];
-    };
-  };
-
-
-  pdfminer = buildPythonPackage rec {
-    version = "20140328";
-    name = "pdfminer-${version}";
-
-    disabled = ! isPy27;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pdfminer/pdfminer-${version}.tar.gz";
-      sha256 = "0qpjv4b776dwvpf5a7v19g41qsz97bv0qqsyvm7a31k50n9pn65s";
-    };
-
-    propagatedBuildInputs = with self; [  ];
-
-    meta = {
-      description = "Tool for extracting information from PDF documents";
-      homepage = http://euske.github.io/pdfminer/index.html;
-      license = licenses.mit;
-      maintainers = with maintainers; [ ];
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

PDFMiner.six is a fork of PDFMiner using six for Python 2+3 compatibility. I think it safe to remove the old pdfminer and only keep pdfminer.six (tested building weboob which as far as i know the only package that depends on pdfminer using the new pdfminer_six and it was successful) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

