### PR TITLE
Remove gtk2 from gnome3 attrset

### DIFF
--- a/pkgs/applications/networking/instant-messengers/franz/default.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeDesktopItem, makeWrapper, autoPatchelfHook
-, xorg, atk, glib, pango, gdk_pixbuf, cairo, freetype, fontconfig
+, xorg, atk, glib, pango, gdk_pixbuf, cairo, freetype, fontconfig, gtk2
 , gnome3, dbus, nss, nspr, alsaLib, cups, expat, udev, libnotify, xdg_utils }:
 
 let
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     libXi libXcursor libXdamage libXrandr libXcomposite libXext libXfixes
     libXrender libX11 libXtst libXScrnSaver
   ]) ++ [
-    gnome3.gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
+    gtk2 atk glib pango gdk_pixbuf cairo freetype fontconfig dbus
     gnome3.gconf nss nspr alsaLib cups expat stdenv.cc.cc
   ];
   runtimeDependencies = [ udev.lib libnotify ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, gnome3, atk, cairo, pango, gdk_pixbuf, glib, freetype,
+{ stdenv, lib, fetchurl, dpkg, gnome3, gtk2, atk, cairo, pango, gdk_pixbuf, glib, freetype,
 fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
@@ -16,7 +16,7 @@ let
     gdk_pixbuf
     glib
     gnome3.gconf
-    gnome3.gtk2
+    gtk2
     pango
     libX11
     libXScrnSaver

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -52,7 +52,7 @@ let
     hitori gnome-taquin
   ];
 
-  inherit (pkgs) atk glib gobjectIntrospection gtk2 webkitgtk gtk3 gtkmm3 libcanberra-gtk2
+  inherit (pkgs) atk glib gobjectIntrospection webkitgtk gtk3 gtkmm3
     libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceview4
     easytag meld orca rhythmbox shotwell gnome-usage
     clutter clutter-gst clutter-gtk cogl gtkvnc libdazzle;
@@ -421,7 +421,6 @@ let
   gnome_themes_standard = gnome-themes-standard; # added 2018-02-25
   gnome-tweak-tool = gnome-tweaks; # added 2018-03-21
   gsettings_desktop_schemas = gsettings-desktop-schemas; # added 2018-02-25
-  libcanberra_gtk2 = libcanberra-gtk2; # added 2018-02-25
   libgames-support = libgnome-games-support; # added 2018-03-14
   libgnome_keyring = libgnome-keyring; # added 2018-02-25
   inherit (pkgs) rarian; # added 2018-04-25


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

