### PR TITLE
sqlite: do not contaminate dependent libtool-based projects with sqlite dependencies

### DIFF
--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -66,6 +66,11 @@ stdenv.mkDerivation rec {
     echo ""
   '';
 
+  postInstall = ''
+    # Do not contaminate dependent libtool-based projects with sqlite dependencies.
+    sed -i $out/lib/libsqlite3.la -e "s/dependency_libs=.*/dependency_libs='''/"
+  '';
+
   meta = {
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
     downloadPage = http://sqlite.org/download.html;

--- a/pkgs/development/libraries/vsqlite/default.nix
+++ b/pkgs/development/libraries/vsqlite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, boost, sqlite, zlib }:
+{ stdenv, fetchurl, boost, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "vsqlite-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "17fkj0d2jh0xkjpcayhs1xvbnh1d69f026i7vs1zqnbiwbkpz237";
   };
 
-  buildInputs = [ boost sqlite zlib ];
+  buildInputs = [ boost sqlite ];
 
   prePatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace Makefile.in \


### PR DESCRIPTION
###### Motivation for this change

sqlite is built as a shared library, but libtool nevertheless adds `-lz` into the
link commands of the dependent projects, which fail to link if they do not
directly depend on libz.  Fix this by clearing dependency_libs in libsqlite3.la.

sqlite was made dependent on libz in #40626 and reached `master` in b22cc53db147cdbfe84ffbc344143bf1e8c1e515. It seems better to merge this PR into master to stabilize it and prevent such workarounds as e89414ff699ddd0689a696db7889b6e5654c847d.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

