### PR TITLE
gitAndTools.svn-all-fast-export: 1.0.11 -> 1.0.12

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/svn-all-fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/svn-all-fast-export/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, qmake, qtbase, qttools, subversion, apr }:
 
 let
-  version = "1.0.11";
+  version = "1.0.12";
 in
 stdenv.mkDerivation {
   name = "svn-all-fast-export-${version}";
@@ -10,17 +10,8 @@ stdenv.mkDerivation {
     owner = "svn-all-fast-export";
     repo = "svn2git";
     rev = version;
-    sha256 = "0lhnw8f15j4wkpswhrjd7bp9xkhbk32zmszaxayzfhbdl0g7pzwj";
+    sha256 = "158w2ynz16dlp992g8nfk7v2f5962z88b4xyv5dyjvbl4l1v7r0v";
   };
-
-  # https://github.com/svn-all-fast-export/svn2git/pull/40
-  patches = [
-    (fetchpatch {
-      name = "pr40.patch";
-      sha256 = "0mwncklzncsifql9zlxlbj3clsif5p2v1xs8nmxrw44mqvaysjw3";
-      url = https://github.com/svn-all-fast-export/svn2git/compare/f00d5a5...flokli:nixos-20180326.patch;
-    })
-  ];
 
   nativeBuildInputs = [ qmake qttools ];
   buildInputs = [ apr.dev subversion.dev qtbase ];


### PR DESCRIPTION
patch for https://github.com/svn-all-fast-export/svn2git/pull/40 is
contained in this release, so we can drop it here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

