### PR TITLE
zoom-us: update && added new field to `meta` attributes

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -14,7 +14,7 @@ meta = with stdenv.lib; {
     GNU Hello is a program that prints "Hello, world!" when you run it.
     It is fully customizable.
   '';
-  homepage = http://www.gnu.org/software/hello/manual/;
+  homepage = https://www.gnu.org/software/hello/manual/;
   license = licenses.gpl3Plus;
   maintainers = [ maintainers.eelco ];
   platforms = platforms.all;
@@ -35,11 +35,11 @@ $ nix-env -qa hello --json
     "hello": {
         "meta": {
             "description": "A program that produces a familiar, friendly greeting",
-            "homepage": "http://www.gnu.org/software/hello/manual/",
+            "homepage": "https://www.gnu.org/software/hello/manual/",
             "license": {
                 "fullName": "GNU General Public License version 3 or later",
                 "shortName": "GPLv3+",
-                "url": "http://www.fsf.org/licensing/licenses/gpl.html"
+                "url": "https://www.fsf.org/licensing/licenses/gpl.html"
             },
             "longDescription": "GNU Hello is a program that prints \"Hello, world!\" when you run it.\nIt is fully customizable.\n",
             "maintainers": [
@@ -131,7 +131,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
     <listitem>
      <para>
       The package’s homepage. Example:
-      <literal>http://www.gnu.org/software/hello/manual/</literal>
+      <literal>https://www.gnu.org/software/hello/</literal>
      </para>
     </listitem>
    </varlistentry>
@@ -141,7 +141,17 @@ hello-2.3  A program that produces a familiar, friendly greeting
     <listitem>
      <para>
       The page where a link to the current version can be found. Example:
-      <literal>http://ftp.gnu.org/gnu/hello/</literal>
+      <literal>https://ftp.gnu.org/gnu/hello/</literal>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><varname>releaseNews</varname>
+    </term>
+    <listitem>
+     <para>
+      The package’s release news page. May be a link to RSS news feed. Example:
+      <literal>https://savannah.gnu.org/news/atom.php?group=hello</literal>
      </para>
     </listitem>
    </varlistentry>

--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -131,7 +131,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
     <listitem>
      <para>
       The package’s homepage. Example:
-      <literal>https://www.gnu.org/software/hello/</literal>
+      <literal>https://www.gnu.org/software/hello/manual/</literal>
      </para>
     </listitem>
    </varlistentry>

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -1,19 +1,21 @@
 { stdenv, fetchurl, system, makeWrapper, makeDesktopItem,
   alsaLib, dbus, glib, fontconfig, freetype, libpulseaudio,
-  utillinux, zlib, xorg, udev, sqlite, expat, libv4l, procps, libGL }:
+  utillinux, zlib, xorg, udev, sqlite, expat, libv4l, procps, libGL,
+  nss, nspr }:
 
 let
 
-  version = "2.0.123200.0405";
+  version = "2.1.103753.0521";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${version}/zoom_x86_64.tar.xz";
-      sha256 = "1ifwa2xf5mw1ll2j1f39qd7mpyxpc6xj3650dmlnxf525dsm573z";
+      sha256 = "17ph0gi8x4h24afczvfj9dvcy737mjq7zzblh6ysfdqzbqb1bpjj";
     };
   };
 
 in stdenv.mkDerivation {
   name = "zoom-us-${version}";
+  inherit version;
 
   src = srcs.${system};
 
@@ -32,6 +34,8 @@ in stdenv.mkDerivation {
     sqlite
     utillinux
     udev
+    nspr
+    nss
 
     xorg.libX11
     xorg.libSM

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -104,6 +104,7 @@ in stdenv.mkDerivation {
 
   meta = {
     homepage = https://zoom.us/;
+    releaseNews = "https://support.zoom.us/hc/en-us/articles/205759689-New-Updates-for-Linux";
     description = "zoom.us video conferencing application";
     license = stdenv.lib.licenses.unfree;
     platforms = builtins.attrNames srcs;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -151,6 +151,7 @@ let
     platforms = listOf (either str lib.systems.parsedPlatform.types.system);
     hydraPlatforms = listOf str;
     broken = bool;
+    releaseNews = str;
 
     # Weirder stuff that doesn't appear in the documentation?
     knownVulnerabilities = listOf str;


### PR DESCRIPTION
###### Motivation for this change
zoom-us upgrade.

Second commit adds `releaseNews` meta-attribute. If it is controversial or unwanted, that commit may be dropped. Personally, I often find it hard to find the release news link in google, so I propose to document found one in nixpkgs.

And made meta.nix doc more secure (!) by making all links to GNU hello https://

And fixed homepage link for GNU hello - previously it was a link to manual, not homepage.
EDIT: reverted this change, there are plenty of references, need to change them all, but this is out of scope for this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

