### PR TITLE
lib: Fix platforms issues with `nix-env -qaP -f . --xml --meta`

### DIFF
--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -22,9 +22,9 @@ in rec {
   freebsd = [ patterns.isFreeBSD ];
   # Should be better, but MinGW is unclear, and HURD is bit-rotted.
   gnu     = [
-    { kernel = parse.kernels.linux; abi = parse.abis.gnu; }
-    { kernel = parse.kernels.linux; abi = parse.abis.gnueabi; }
-    { kernel = parse.kernels.linux; abi = parse.abis.gnueabihf; }
+    { kernel = parse.kernels.linux; abi = abis.gnu; }
+    { kernel = parse.kernels.linux; abi = abis.gnueabi; }
+    { kernel = parse.kernels.linux; abi = abis.gnueabihf; }
   ];
   illumos = [ patterns.isSunOS ];
   linux   = [ patterns.isLinux ];


### PR DESCRIPTION
###### Motivation for this change

A merge undid my fix in d437f2c365a12fb3894eb87f52decf53c745f475.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

