### PR TITLE
gtkd: dontStrip as a workaround for binutils strip problem

### DIFF
--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -84,6 +84,10 @@ stdenv.mkDerivation rec {
 
   installFlags = "prefix=$(out)";
 
+  # Workaround for https://github.com/NixOS/nixpkgs/issues/40397
+  # Remove after update to binutils 2.31
+  dontStrip = true;
+
   inherit atk cairo gdk_pixbuf librsvg pango;
   inherit (gnome3) glib gtk3 gtksourceview libgda libpeas vte;
   inherit (gst_all_1) gstreamer;


### PR DESCRIPTION
###### Motivation for this change

This fixes https://github.com/NixOS/nixpkgs/issues/41188 and is needed because binutils won't be fixed till 2.31 is released. See https://github.com/NixOS/nixpkgs/issues/40397.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

