### PR TITLE
pony-stable: 0.1.1 -> 0.1.2

### DIFF
--- a/pkgs/development/compilers/ponyc/pony-stable.nix
+++ b/pkgs/development/compilers/ponyc/pony-stable.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pony-stable-${version}";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "pony-stable";
     rev = version;
-    sha256 = "0v4039iijjv93m89s3dsikcbp1y0hml6g1agj44s6w2g4m8kiiw3";
+    sha256 = "1g0508r66qjx857cb1cycq98b0gw7s1zn1l7bplyj1psk8mqh7kz";
   };
 
   buildInputs = [ ponyc ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "A simple dependency manager for the Pony language.";
     homepage = https://www.ponylang.org;
     license = stdenv.lib.licenses.bsd2;
-    maintainers = with stdenv.lib.maintainers; [ dipinhora kamilchm ];
+    maintainers = with stdenv.lib.maintainers; [ dipinhora kamilchm patternspandemic ];
     platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

