### PR TITLE
PowerShell: init at 6.0.2

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchgit, autoPatchelfHook, fetchzip, libunwind, libuuid, icu, curl, cacert,
+  makeWrapper, less, openssl }:
+
+let platformString = if stdenv.isDarwin then "osx"
+                     else if stdenv.isLinux then "linux"
+                     else throw "unsupported platform";
+    platformSha = if stdenv.isDarwin then "1ga4p8xmrxa54v2s6i0q1q7lx2idcmp1jwm0g4jxr54fyn5ay3lf"
+                     else if stdenv.isLinux then "000mmv5iblnmwydfdvg5izli3vpb6l14xy4qy3smcikpf0h87fhl"
+                     else throw "unsupported platform";
+    platformLdLibraryPath = if stdenv.isDarwin then "DYLD_FALLBACK_LIBRARY_PATH"
+                     else if stdenv.isLinux then "LD_LIBRARY_PATH"
+                     else throw "unsupported platform";
+in
+stdenv.mkDerivation rec {
+  name = "powershell-${version}";
+  version = "6.0.2";
+
+  src = fetchzip {
+    url = "https://github.com/PowerShell/PowerShell/releases/download/v${version}/powershell-${version}-${platformString}-x64.tar.gz";
+    sha256 = platformSha;
+    stripRoot = false;
+  };
+
+  buildInputs = [ autoPatchelfHook makeWrapper ];
+  propagatedBuildInputs = [ libunwind libuuid icu curl cacert less openssl ];
+
+  # TODO: remove PAGER after upgrading to v6.1.0-preview.1 or later as it has been addressed in
+  # https://github.com/PowerShell/PowerShell/pull/6144
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/powershell
+    cp -r * $out/share/powershell
+    rm $out/share/powershell/DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
+    makeWrapper $out/share/powershell/pwsh $out/bin/pwsh --prefix ${platformLdLibraryPath} : "${stdenv.lib.makeLibraryPath [ libunwind libuuid icu openssl curl ]}" \
+                                           --set PAGER ${less}/bin/less --set TERM xterm
+  '';
+
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework";
+    homepage = https://github.com/PowerShell/PowerShell;
+    maintainers = [ maintainers.yrashk ];
+    platforms = platforms.unix;
+    license = with licenses; [ mit ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21461,4 +21461,6 @@ with pkgs;
 
   yrd = callPackage ../tools/networking/yrd { };
 
+  powershell = callPackage ../shells/powershell { };
+
 }


### PR DESCRIPTION
This is my first draft of the derivation for PowerShell. Most notable deficiency: does not (yet) support OSX. 

I'd like to gather feedback on this to see if there would be any other improvement suggestions.

###### Motivation for this change

Not present in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Further plan:

- [ ] OSX support
- [ ] Update-Help doesn't work (Update-Help : Read-only file system)