### PR TITLE
consul: 0.9.3 -> 1.0.6; also upgrade python-consul...

### DIFF
--- a/pkgs/development/python-modules/consul/default.nix
+++ b/pkgs/development/python-modules/consul/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "python-consul";
-  version = "0.7.2";
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ef0b7c8a2d8efba5f9602f45aadbe5035e22a511d245624ed732af81223a6571";
+    sha256 = "1i0pf3yvga7kvzzkj378hhmn9qs0y0iyhs28xflvz6w6nqa7msqg";
   };
 
   buildInputs = [ requests six pytest ];

--- a/pkgs/servers/consul/Gemfile.lock
+++ b/pkgs/servers/consul/Gemfile.lock
@@ -2,8 +2,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     execjs (2.3.0)
-    json (1.8.2)
-    libv8 (3.16.14.11)
+    json (1.8.5)
+    libv8 (3.16.14.15)
     ref (1.0.5)
     sass (3.4.11)
     therubyracer (0.12.1)
@@ -20,3 +20,6 @@ DEPENDENCIES
   sass
   therubyracer
   uglifier
+
+BUNDLED WITH
+   1.12.5

--- a/pkgs/servers/consul/README.md
+++ b/pkgs/servers/consul/README.md
@@ -1,0 +1,14 @@
+# Updating consul
+
+When updating consul, you must also update `consul-ui`'s Ruby dependencies.
+
+Do so by downloading the source code, `cd ui`, and run
+
+```bash
+cd TEMP_DIR_WITH_CONSUL_SOURCE
+cd ui
+$(nix-build '<nixpkgs>' -A bundix --no-out-link)/bin/bundix --magic
+cp gemset.nix Gemfile Gemfile.lock THIS_DIRECTORY
+```
+
+(As described in https://nixos.org/nixpkgs/manual/#sec-language-ruby)

--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "consul-${version}";
-  version = "0.9.3";
+  version = "1.0.6";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "consul";
     inherit rev;
-    sha256 = "1176frp7kimpycsmz9wrbizf46jgxr8jq7hz5w4q1x90lswvrxv3";
+    sha256 = "06isx7y6nc3305d9bw61738jfmyyh0czshgfdn8dvhdhvxjs5pp2";
   };
 
   # Keep consul.ui for backward compatability

--- a/pkgs/servers/consul/gemset.nix
+++ b/pkgs/servers/consul/gemset.nix
@@ -1,59 +1,60 @@
 {
   execjs = {
-    version = "2.3.0";
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "097v02bhmzc70j7n0yyf8j0z5wms88zcmgpmggby4hnvqxf41y1h";
+      type = "gem";
     };
+    version = "2.3.0";
   };
   json = {
-    version = "1.8.2";
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "0zzvv25vjikavd3b1bp6lvbgj23vv9jvmnl4vpim8pv30z8p6vr5";
+      type = "gem";
     };
+    version = "1.8.5";
   };
   libv8 = {
-    version = "3.16.14.11";
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1j5x22v7rqdk1047k0sz4k1xhf6hkdw6h1nl7xsw694hfjdb0vyx";
       type = "gem";
-      sha256 = "000vbiy78wk5r1f6p7qncab8ldg7qw5pjz7bchn3lw700gpaacxp";
     };
+    version = "3.16.14.15";
   };
   ref = {
-    version = "1.0.5";
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "19qgpsfszwc2sfh6wixgky5agn831qq8ap854i1jqqhy1zsci3la";
+      type = "gem";
     };
+    version = "1.0.5";
   };
   sass = {
-    version = "3.4.11";
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "10dncnv7g5v8d1xpw2aaarxjjlm68f7nm02ns2kl8nf3yxi6wzdf";
+      type = "gem";
     };
+    version = "3.4.11";
   };
   therubyracer = {
-    version = "0.12.1";
+    dependencies = ["libv8" "ref"];
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "106fqimqyaalh7p6czbl5m2j69z8gv7cm10mjb8bbb2p2vlmqmi6";
+      type = "gem";
     };
-    dependencies = [
-      "libv8"
-      "ref"
-    ];
+    version = "0.12.1";
   };
   uglifier = {
-    version = "2.7.0";
+    dependencies = ["execjs" "json"];
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "1x1mnakx086l83a3alj690c6n8kfmb4bk243a6m6yz99s15gbxfq";
+      type = "gem";
     };
-    dependencies = [
-      "execjs"
-      "json"
-    ];
+    version = "2.7.0";
   };
 }

--- a/pkgs/servers/consul/ui.nix
+++ b/pkgs/servers/consul/ui.nix
@@ -15,7 +15,21 @@ stdenv.mkDerivation {
 
   buildInputs = [ ruby gems zip ];
 
-  patchPhase = "patchShebangs ./ui/scripts/dist.sh";
+  patchPhase = ''
+    patchShebangs ./ui/scripts/dist.sh
+  '' +
+  # Patch out upstream's habit of checking if all deps are available,
+  # hiding all error messages and installing them with `bundle install`
+  # if they aren't.
+  # That way we can easily see when upstream's deps changed but
+  # `bundix` wasn't run to reflect that in nixpkgs.
+  # This will have to be updated if
+  # https://github.com/hashicorp/consul/pull/4176 is merged
+  # (we still want to patch `bundle install` out to make the error
+  # message more obvious).
+  ''
+    sed -i 's:bundle check >/dev/null 2>&1 || bundle install:bundle check:g' ui/scripts/dist.sh
+  '';
 
   buildPhase = ''
     # Build ui static files


### PR DESCRIPTION
... to a version that can handle Consul >= 1.0.

See https://github.com/NixOS/nixpkgs/pull/35602#issuecomment-368486246

Upgrading consul also requires upgrading the Ruby deps, see
https://github.com/NixOS/nixpkgs/pull/41239#issuecomment-393000879

Also add instructions on how to do that, and a small patch
to improve the error message when it is forgotten.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is intended to replace and improve upon PRs #35602 and #41239.

First check with their corresponding authors that they agree, then merge this one.