### PR TITLE
git: 2.16.2 -> 2.16.4 (for release-18.03)

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "2.16.2";
+  version = "2.16.4";
   svn = subversionClient.override { perlBindings = true; };
 in
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "05y7480f2p7fkncbhf08zz56jbykcp0ia5gl6y3djs0lsa5mfq2m";
+    sha256 = "0cnmidjvbdf81mybcvxvl0c2r2x2nvq2jj2dl59dmrc7qklv0sbf";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -6,15 +6,15 @@
 
 -# First decide what scheme to use...
 -GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
--if test -n "@@USE_GETTEXT_SCHEME@@"
+-if test -n "$GIT_GETTEXT_POISON"
+-then
+-	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
+-elif test -n "@@USE_GETTEXT_SCHEME@@"
 -then
 -	GIT_INTERNAL_GETTEXT_SH_SCHEME="@@USE_GETTEXT_SCHEME@@"
 -elif test -n "$GIT_INTERNAL_GETTEXT_TEST_FALLBACKS"
 -then
 -	: no probing necessary
--elif test -n "$GIT_GETTEXT_POISON"
--then
--	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
 -elif type gettext.sh >/dev/null 2>&1
 -then
 -	# GNU libintl's gettext.sh


### PR DESCRIPTION
###### Motivation for this change

This is a security update, see [1].

It is not backported from master because master is at 2.17.0 after #38636 and 2.17.1 after #41223.

[1] https://github.com/git/git/blob/master/Documentation/RelNotes/2.17.1.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
