### PR TITLE
invoice2data: init at 0.2.93

### DIFF
--- a/pkgs/tools/text/invoice2data/default.nix
+++ b/pkgs/tools/text/invoice2data/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, python3Packages, xpdf, imagemagick, tesseract }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "invoice2data";
+  version = "0.2.93";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1phz0a8jxg074k0im7shrrdfvdps7bn1fa4zwcf8q3sa2iig26l4";
+  };
+
+  makeWrapperArgs = ["--prefix" "PATH" ":" "${stdenv.lib.makeBinPath [ imagemagick xpdf tesseract ]}" ];
+
+  propagatedBuildInputs = with python3Packages; [ unidecode dateparser pyyaml pillow chardet pdfminer ];
+
+  # Tests fails even when ran manually on my ubuntu machine !!
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Data extractor for PDF invoices";
+    homepage = https://github.com/invoice-x/invoice2data;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3099,6 +3099,8 @@ with pkgs;
 
   intecture-cli = callPackage ../tools/admin/intecture/cli.nix { };
 
+  invoice2data  = callPackage ../tools/text/invoice2data  { };
+
   iodine = callPackage ../tools/networking/iodine { };
 
   ioping = callPackage ../tools/system/ioping { };


### PR DESCRIPTION
###### Motivation for this change
This is to resume working on #40925 to include pdfminer after it got merged( I messed up the other branch ).
cc @FRidh  @flokli 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

