### PR TITLE
boost 1.67

### DIFF
--- a/pkgs/development/libraries/boost/1.67.nix
+++ b/pkgs/development/libraries/boost/1.67.nix
@@ -1,0 +1,13 @@
+{ stdenv, callPackage, fetchurl, hostPlatform, buildPlatform, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.67_0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/boost/boost_1_67_0.tar.bz2";
+    # SHA256 from http://www.boost.org/users/history/version_1_66_0.html
+    sha256 = "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba";
+  };
+
+  toolset = if stdenv.cc.isClang then "clang" else null;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8620,7 +8620,8 @@ with pkgs;
   boost164 = callPackage ../development/libraries/boost/1.64.nix { };
   boost165 = callPackage ../development/libraries/boost/1.65.nix { };
   boost166 = callPackage ../development/libraries/boost/1.66.nix { };
-  boost16x = boost166;
+  boost167 = callPackage ../development/libraries/boost/1.67.nix { };
+  boost16x = boost167;
   boost = boost16x;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
https://www.boost.org/users/history/version_1_67_0.html

Context/Coroutine2 changes might be interesting for Nix,
looks coroutine2 uses fibers now instead of continuations.

Also fixes failure to throw exception, FWIW.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---