### PR TITLE
librarian-puppet-go: update license

### DIFF
--- a/pkgs/development/tools/librarian-puppet-go/default.nix
+++ b/pkgs/development/tools/librarian-puppet-go/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
   meta = with lib; {
     inherit (src.meta) homepage;
     description = "librarian-puppet implementation in go.";
-    license = licenses.unfree; # still unspecified https://github.com/tmtk75/librarian-puppet-go/issues/5
+    license = licenses.mit;
     maintainers = with maintainers; [ womfoo ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
Issue closed and upstream notes it's under MIT.

###### Motivation for this change
I just happened to be crawling through the packages and saw the source author defined the license.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

