### PR TITLE
mininet: init at 2.3.0d4

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -102,6 +102,7 @@
   ./programs/less.nix
   ./programs/light.nix
   ./programs/mosh.nix
+  ./programs/mininet.nix
   ./programs/mtr.nix
   ./programs/nano.nix
   ./programs/npm.nix

--- a/nixos/modules/programs/mininet.nix
+++ b/nixos/modules/programs/mininet.nix
@@ -1,0 +1,40 @@
+# Global configuration for mininet
+# kernel must have NETNS/VETH/SCHED
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg  = config.programs.mininet;
+
+  generatedPath = with pkgs; makeSearchPath "bin"  [
+    iperf ethtool iproute socat
+  ];
+
+  pyEnv = pkgs.python.withPackages(ps: [ ps.mininet-python ]);
+
+  mnexecWrapped = pkgs.runCommand "mnexec-wrapper"
+    { buildInputs = [ pkgs.makeWrapper pkgs.pythonPackages.wrapPython ]; }
+    ''
+      makeWrapper ${pkgs.mininet}/bin/mnexec \
+        $out/bin/mnexec \
+        --prefix PATH : "${generatedPath}"
+
+      makeWrapper ${pyEnv}/bin/mn $out/bin/mn
+
+      # mn errors out without a telnet binary
+      # pkgs.telnet brings an undesired ifconfig into PATH see #43105
+      # so we wrap it here instead
+      makeWrapper ${pkgs.telnet}/bin/telnet $out/bin/telnet
+    '';
+in
+{
+  options.programs.mininet.enable = mkEnableOption "Mininet";
+
+  config = mkIf cfg.enable {
+
+    virtualisation.vswitch.enable = true;
+
+    environment.systemPackages = [ mnexecWrapped ];
+  };
+}

--- a/nixos/modules/programs/mininet.nix
+++ b/nixos/modules/programs/mininet.nix
@@ -20,12 +20,11 @@ let
         $out/bin/mnexec \
         --prefix PATH : "${generatedPath}"
 
-      makeWrapper ${pyEnv}/bin/mn $out/bin/mn
+      ln -s ${pyEnv}/bin/mn $out/bin/mn
 
       # mn errors out without a telnet binary
       # pkgs.telnet brings an undesired ifconfig into PATH see #43105
-      # so we wrap it here instead
-      makeWrapper ${pkgs.telnet}/bin/telnet $out/bin/telnet
+      ln -s ${pkgs.telnet}/bin/telnet $out/bin/telnet
     '';
 in
 {

--- a/pkgs/tools/virtualization/mininet/default.nix
+++ b/pkgs/tools/virtualization/mininet/default.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation rec {
   buildFlags = [ "mnexec" ];
   makeFlags = [ "PREFIX=$(out)" ];
 
+  pythonPath = [ python.pkgs.setuptools ];
+  buildInputs = [ python which help2man ];
+
   installTargets = [ "install-mnexec" "install-manpages" ];
 
   preInstall = ''
@@ -33,7 +36,6 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  buildInputs = [ python.pkgs.wrapPython which help2man pyEnv ];
 
   meta = with lib; {
     description = "Emulator for rapid prototyping of Software Defined Networks";

--- a/pkgs/tools/virtualization/mininet/default.nix
+++ b/pkgs/tools/virtualization/mininet/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchFromGitHub
+, which
+, python
+, help2man
+}:
+
+let
+  pyEnv = python.withPackages(ps: [ ps.setuptools ]);
+in
+stdenv.mkDerivation rec {
+  name = "mininet-${version}";
+  version = "2.3.0d4";
+
+  outputs = [ "out" "py" ];
+
+  src = fetchFromGitHub {
+    owner = "mininet";
+    repo = "mininet";
+    rev = version;
+    sha256 = "02hsqa7r5ykj8m1ycl32xwn1agjrw78wkq87xif0dl2vkzln41i4";
+  };
+
+  buildFlags = [ "mnexec" ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  installTargets = [ "install-mnexec" "install-manpages" ];
+
+  preInstall = ''
+    mkdir -p $out $py
+    # without --root, install fails
+    ${pyEnv.interpreter} setup.py install --root="/" --prefix=$py
+  '';
+
+  doCheck = false;
+
+  buildInputs = [ python.pkgs.wrapPython which help2man pyEnv ];
+
+  meta = with lib; {
+    description = "Emulator for rapid prototyping of Software Defined Networks";
+    license = {
+      fullName = "Mininet 2.3.0d4 License";
+    };
+    homepage = https://github.com/mininet/mininet;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21709,6 +21709,8 @@ with pkgs;
     flex = flex_2_5_35;
   };
 
+  mininet = callPackage ../tools/virtualization/mininet { };
+
   msieve = callPackage ../applications/science/math/msieve { };
 
   weka = callPackage ../applications/science/math/weka { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -406,6 +406,8 @@ in {
 
   monty = callPackage ../development/python-modules/monty { };
 
+  mininet-python = (toPythonModule (pkgs.mininet.override{ inherit python; })).py;
+
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;
   };


### PR DESCRIPTION
Mininet (https://github.com/mininet/mininet) is a popular network emulator that
glues several components such as network namespaces, traffic control
commands into a set of python bindings. It is then "easy" to describe a
topology and run experiments on it.

To test it, you should rebuild with    `programs.mininet.enable = true;`
Then you can run 
`nix-shell -p 'python.withPackages(ps: [ps.mininet-python])' --verbose` and launch your own scripts or just `sudo mn`

###### Motivation for this change
I use it for experimentation

###### Things done
The current Makefile is very limiting so I submitted this PR https://github.com/mininet/mininet/pull/803 but there is only one maintainer so it might take time for the patch to get in so I embedded it in nixpkgs.

Mininet can work with several openflow controllers. I have written nix packages for  https://github.com/CPqD/ofsoftswitch13 (and its netbee dependency) but it didn't work so I fell back on openvswitch.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

