### PR TITLE
kernel: allows to be less strict on modDirVersion

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -170,8 +170,8 @@ let
         fi
         make modules_install $makeFlags "''${makeFlagsArray[@]}" \
           $installFlags "''${installFlagsArray[@]}"
-        unlink $out/lib/modules/${modDirVersion}/build
-        unlink $out/lib/modules/${modDirVersion}/source
+        unlink $out/lib/modules/$actualModDirVersion/build
+        unlink $out/lib/modules/$actualModDirVersion/source
 
         mkdir -p $dev/lib/modules/${modDirVersion}/build
         cp -dpR .. $dev/lib/modules/${modDirVersion}/source


### PR DESCRIPTION
nixos requires the nix package modDirVersion to match exactly the kernel
version else it aborts build. It might be best to leave some room for error (on minor version
for example).

###### Motivation for this change
I tweak/compile a few kernels and everytime I have to make sure that modDirVersion exactly matches. For instance compiling a kernel from the same source will need different modDirVersion depending on if they are compiled within nix-shell (a "+" will be appended https://unix.stackexchange.com/questions/370392/prevent-a-plus-sign-from-being-appended-to-linux-build) or from a nix-build.

Another example is that I run tests on a kernel via `qemu -kernel <custom_kernel>`  and some BPF scripts. BPF scripts will look for files into an $(uname -r) but I don't want to rebuild from scratch the kernel I am testing just for nixos so I configure bcc to use a stable kernel from a few commits before (with same symbols) but this doesn't work if modDir versions differ.

To summarize, current configuration of nix is good but it might be good to allow for relaxing the modDirVersion check (like ignore the suffix LOCALVERSION/EXTRAVERSION or have a fakeModDirVersion setting to warn instead of aborting build ).
For now I remove the exit in this check
https://github.com/teto/nixpkgs/blob/013dbc4d37be2e816b71f7f471d9d48c26084679/pkgs/os-specific/linux/kernel/manual-config.nix#L133
but it won't work without the current patch which doesn't change a thing for other users

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

