### PR TITLE
[wip] ns3 update + Dce (direct code execution init)

### DIFF
--- a/pkgs/development/libraries/science/networking/ns3/dce.nix
+++ b/pkgs/development/libraries/science/networking/ns3/dce.nix
@@ -1,0 +1,101 @@
+# some dependencies need to be patched
+# http://code.nsnam.org/bake/file/c502b48053dc/bakeconf.xml
+{ stdenv, fetchFromGitHub, autoreconfHook, libtool, intltool, pkgconfig
+, ns-3, gcc
+, castxml ? null
+# hidden dependency of waf
+, ncurses
+, python
+, lib
+, fetchurl
+, withManual ? false
+, withQuagga ? false
+, withExamples ? false, openssl ? null, ccnd ? null, iperf2 ? null
+# shall we generate bindings
+, pythonSupport ? false
+, ...
+}:
+
+let
+  dce-version = "1.10";
+  modules = [ "core" "network" "internet" "point-to-point" "fd-net-device"
+  "point-to-point-layout" "netanim" "tap-bridge" "mobility" "flow-monitor"]
+  ++ lib.optionals withQuagga [ "internet-apps" ]
+  ;
+
+  ns3forDce = ns-3.override( { inherit modules python; });
+  pythonEnv = python.withPackages(ps:
+    stdenv.lib.optional withManual ps.sphinx
+    ++ lib.optionals pythonSupport (with ps;[ pybindgen pygccxml ])
+  );
+
+  dce = stdenv.mkDerivation rec {
+    name    = "${pname}-${version}";
+    pname   = "direct-code-execution";
+    version = dce-version;
+
+    outputs = [ "out" ] ++ lib.optional pythonSupport "py";
+
+    # with other modules
+    srcs = [
+      /home/teto/dce
+      # (fetchFromGitHub {
+      #   owner  = "direct-code-execution";
+      #   repo   = "ns-3-dce";
+      #   rev    = "dce-${version}";
+      #   sha256 = "0f2g47mql8jjzn2q6lm0cbb5fv62sdqafdvx5g8s3lqri1sca14n";
+      #   name   = "dce";
+      # })
+    ]
+    ++ lib.optional withQuagga (fetchFromGitHub {
+      owner  = "direct-code-execution";
+      repo   = "ns-3-dce-quagga";
+      rev    = "dce-${dce-version}";
+      sha256 = "1bbb1v33mv1p8isiggg9qg3a8hs0yq5s1dqz22lbdx55jrdxm7rb";
+      name   = "dce-quagga";
+    })
+    ;
+
+    postUnpack = lib.optionalString withQuagga ''
+      # mv won't work :'(
+      cp -R dce-quagga/ ${sourceRoot}/myscripts
+    '';
+
+    sourceRoot = "dce";
+
+    buildInputs = [ ns3forDce gcc pythonEnv ]
+      ++ lib.optionals pythonSupport [ castxml ncurses ]
+      ++ lib.optionals withExamples [ openssl ]
+      ;
+
+    nativeBuildInputs = [ pkgconfig ];
+
+    doCheck = false;
+
+    patchPhase = ''
+      patchShebangs test.py
+    '';
+
+
+    configureScript = "${pythonEnv.interpreter} ./waf configure";
+
+    configureFlags = with stdenv.lib; [
+      "--with-ns3=${ns3forDce}"
+      # is it really needed ?
+      "--with-python=${pythonEnv.interpreter}"
+    ]
+    ++ lib.optional (!withExamples) "--disable-examples"
+    ++ lib.optional (!doCheck) "--disable-tests"
+    ;
+
+    hardeningDisable = [ "all" ];
+
+    meta = {
+      homepage = https://www.nsnam.org/overview/projects/direct-code-execution;
+      license = stdenv.lib.licenses.gpl3;
+      description = "Run real applications/network stacks in the simulator ns-3";
+      platforms = with stdenv.lib.platforms; unix;
+    };
+  };
+in
+  dce

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -56,8 +56,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional withManual [ dia tetex ghostscript texlive.combined.scheme-medium ];
 
   propagatedBuildInputs = [
-    stdenv.cc
-    # gcc6
+    # stdenv.cc ?
     pythonEnv
   ];
 

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -21,7 +21,8 @@
 , dia, tetex ? null, ghostscript ? null, texlive ? null
 
 # generates python bindings
-, pythonSupport ? false, ncurses ? null
+# TODO turn false afterwards
+, pythonSupport ? true, ncurses ? null
 
 # All modules can be enabled by choosing 'all_modules'.
 # we include here the DCE mandatory ones

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -75,10 +75,14 @@ stdenv.mkDerivation rec {
       "--with-python=${pythonEnv.interpreter}"
   ]
   ++ optional (build_profile != null) "--build-profile=${build_profile}"
-  ++ optional pythonSupport "--apiscan=all"
+  # maybe do it afterwards ? not needed , it's done automatically
+  # ++ optional pythonSupport "--apiscan=all"
   ++ optional withExamples " --enable-examples "
   ++ optional doCheck " --enable-tests "
   ;
+
+  # to prevent fatal error: 'backward_warning.h' file not found
+  CXXFLAGS = "-D_GLIBCXX_PERMIT_BACKWARD_HASH";
 
   postBuild = with stdenv.lib; let flags = concatStringsSep ";" (
       optional enableDoxygen "./waf doxygen"
@@ -95,7 +99,8 @@ stdenv.mkDerivation rec {
     ${pythonEnv.interpreter} ./test.py
   '';
 
-  hardeningDisable = [ "fortify" ];
+  # strictoverflow prevents clang from discovering pyembed when bindings
+  hardeningDisable = [ "fortify" "strictoverflow"];
 
   meta = {
     homepage = http://www.nsnam.org;

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -21,7 +21,7 @@
 , dia, tetex ? null, ghostscript ? null, texlive ? null
 
 # generates python bindings
-, generateBindings ? false, ncurses ? null
+, pythonSupport ? false, ncurses ? null
 
 # All modules can be enabled by choosing 'all_modules'.
 # we include here the DCE mandatory ones
@@ -33,7 +33,7 @@
 let
   pythonEnv = python.withPackages(ps:
     stdenv.lib.optional withManual ps.sphinx
-    ++ stdenv.lib.optionals generateBindings (with ps;[ pybindgen pygccxml ])
+    ++ stdenv.lib.optionals pythonSupport (with ps;[ pybindgen pygccxml ])
   );
 in
 stdenv.mkDerivation rec {
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   };
 
   # ncurses is a hidden dependency of waf when checking python
-  buildInputs = lib.optionals generateBindings [ castxml ncurses ]
+  buildInputs = lib.optionals pythonSupport [ castxml ncurses ]
     ++ stdenv.lib.optional enableDoxygen [ doxygen graphviz imagemagick ]
     ++ stdenv.lib.optional withManual [ dia tetex ghostscript texlive.combined.scheme-medium ];
 
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
       "--with-python=${pythonEnv.interpreter}"
   ]
   ++ optional (build_profile != null) "--build-profile=${build_profile}"
-  ++ optional generateBindings "--apiscan=all"
+  ++ optional pythonSupport "--apiscan=all"
   ++ optional withExamples " --enable-examples "
   ++ optional doCheck " --enable-tests "
   ;

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -62,14 +62,14 @@ stdenv.mkDerivation rec {
     patchShebangs doc/ns3_html_theme/get_version.sh
   '';
 
-  configureScript = "${python.interpreter} ./waf configure";
+  configureScript = "${pythonEnv.interpreter} ./waf configure";
 
   configureFlags = with stdenv.lib; [
       "--enable-modules=${stdenv.lib.concatStringsSep "," modules}"
       "--with-python=${pythonEnv.interpreter}"
   ]
   ++ optional (build_profile != null) "--build-profile=${build_profile}"
-  ++ optional generateBindings [  ]
+  ++ optional generateBindings "--apiscan=all"
   ++ optional withExamples " --enable-examples "
   ++ optional doCheck " --enable-tests "
   ;

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -59,6 +59,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     # stdenv.cc ?
     pythonEnv
+    # llvmPackages.libcxx
   ];
 
 

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -55,7 +55,13 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional enableDoxygen [ doxygen graphviz imagemagick ]
     ++ stdenv.lib.optional withManual [ dia tetex ghostscript texlive.combined.scheme-medium ];
 
-  propagatedBuildInputs = [ gcc6 pythonEnv ];
+  propagatedBuildInputs = [
+    stdenv.cc
+    # gcc6
+    pythonEnv
+  ];
+
+
 
   postPatch = ''
     patchShebangs ./waf

--- a/pkgs/development/python-modules/cxxfilt/default.nix
+++ b/pkgs/development/python-modules/cxxfilt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchPypi, buildPythonPackage, setuptools_scm
+, pytest
+}:
+buildPythonPackage rec {
+  pname = "cxxfilt";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mkxiaw8p9vwmk7np63hjnmkb327454jyrg8lcfbwfahmqk1zi3v";
+  };
+
+  buildInputs = [ setuptools_scm ];
+  # propagatedBuildInputs = [ cxxfilt pygccxml ];
+
+  checkInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/afg984/python-cxxfilt;
+    description = "Demangling C++ symbols in Python";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ teto ];
+  };
+}
+
+
+

--- a/pkgs/development/python-modules/cxxfilt/default.nix
+++ b/pkgs/development/python-modules/cxxfilt/default.nix
@@ -10,8 +10,18 @@ buildPythonPackage rec {
     sha256 = "1mkxiaw8p9vwmk7np63hjnmkb327454jyrg8lcfbwfahmqk1zi3v";
   };
 
+
+  # see https://github.com/NixOS/nixpkgs/issues/7307
+  patchPhase = stdenv.lib.optionalString stdenv.isLinux ''
+      substituteInPlace cxxfilt/__init__.py --replace \
+        "find_any_library('c')" "'${stdenv.glibc}/lib/libc.so.6'"
+
+      substituteInPlace cxxfilt/__init__.py --replace \
+        "find_any_library('c++', 'stdc++')" "'${stdenv.cc.cc.lib}/lib/libstdc++.so.6'"
+  '';
+
+
   buildInputs = [ setuptools_scm ];
-  # propagatedBuildInputs = [ cxxfilt pygccxml ];
 
   checkInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pybindgen/default.nix
+++ b/pkgs/development/python-modules/pybindgen/default.nix
@@ -9,6 +9,7 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ cxxfilt pygccxml ];
 
   checkInputs = [ pygccxml ];
 

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -24,11 +24,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cmake
-    llvmPackages.clang-unwrapped
+    # need to keep it for cmake to find the LLVM_DIR
     llvmPackages.llvm
   ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
 
-  propagatedbuildInputs = [ llvmPackages.libclang
+  propagatedbuildInputs = [
+    llvmPackages.libclang
     llvmPackages.libcxx
   ];
 

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
 
   propagatedbuildInputs = [
     llvmPackages.libclang
-    llvmPackages.libcxx
   ];
 
   # 97% tests passed, 96 tests failed out of 2866

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -28,7 +28,9 @@ stdenv.mkDerivation rec {
     llvmPackages.llvm
   ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
 
-  propagatedbuildInputs = [ llvmPackages.libclang ];
+  propagatedbuildInputs = [ llvmPackages.libclang
+    llvmPackages.libcxx
+  ];
 
   # 97% tests passed, 96 tests failed out of 2866
   # mostly because it checks command line and nix append -isystem and all

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21719,10 +21719,12 @@ with pkgs;
 
   megam = callPackage ../applications/science/misc/megam { };
 
-  ns-3 = callPackage ../development/libraries/science/networking/ns3 {
+  ns-3 = callPackage ../development/libraries/science/networking/ns3 { };
+
+  ns3clang = ns-3.override {
     # can't find pyembed with it
     # stdenv = llvmPackages.libcxxStdenv; # fails
-    # stdenv = clangStdenv;
+    stdenv = clangStdenv;
   };
 
   root = callPackage ../applications/science/misc/root {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21719,12 +21719,14 @@ with pkgs;
 
   megam = callPackage ../applications/science/misc/megam { };
 
-  ns-3 = callPackage ../development/libraries/science/networking/ns3 { };
+  ns-3 = callPackage ../development/libraries/science/networking/ns3 {
+    modules = [ "core" "network" "internet" "point-to-point"];
+  };
 
   ns3clang = ns-3.override {
     # can't find pyembed with it
-    # stdenv = llvmPackages.libcxxStdenv; # fails
-    stdenv = clangStdenv;
+    stdenv = llvmPackages.libcxxStdenv; # fails
+    # stdenv = clangStdenv;
   };
 
   root = callPackage ../applications/science/misc/root {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -112,7 +112,9 @@ with pkgs;
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
-  castxml = callPackage ../development/tools/castxml { };
+  castxml = callPackage ../development/tools/castxml {
+     stdenv = clangStdenv;
+  };
 
   cmark = callPackage ../development/libraries/cmark { };
 
@@ -21716,7 +21718,14 @@ with pkgs;
 
   megam = callPackage ../applications/science/misc/megam { };
 
-  ns-3 = callPackage ../development/libraries/science/networking/ns3 { };
+  ns-3 = callPackage ../development/libraries/science/networking/ns3 {
+    # generates
+#/nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/ext/hash_map:60:10: fatal error: 'backward_warning.h' file not found
+##include "backward_warning.h"
+#         ^~~~~~~~~~~~~~~~~~~~
+
+#        stdenv = clangStdenv;
+  };
 
   root = callPackage ../applications/science/misc/root {
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21720,13 +21720,9 @@ with pkgs;
   megam = callPackage ../applications/science/misc/megam { };
 
   ns-3 = callPackage ../development/libraries/science/networking/ns3 {
-    # generates
-#/nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/ext/hash_map:60:10: fatal error: 'backward_warning.h' file not found
-##include "backward_warning.h"
-#         ^~~~~~~~~~~~~~~~~~~~
-    stdenv = llvmPackages.libcxxStdenv; # fails
-
-       # stdenv = clangStdenv;
+    # can't find pyembed with it
+    # stdenv = llvmPackages.libcxxStdenv; # fails
+    # stdenv = clangStdenv;
   };
 
   root = callPackage ../applications/science/misc/root {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -113,7 +113,8 @@ with pkgs;
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
   castxml = callPackage ../development/tools/castxml {
-     stdenv = clangStdenv;
+    # stdenv = llvmPackages.libcxxStdenv; # fails
+    stdenv = clangStdenv;
   };
 
   cmark = callPackage ../development/libraries/cmark { };
@@ -21723,8 +21724,9 @@ with pkgs;
 #/nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/ext/hash_map:60:10: fatal error: 'backward_warning.h' file not found
 ##include "backward_warning.h"
 #         ^~~~~~~~~~~~~~~~~~~~
+    stdenv = llvmPackages.libcxxStdenv; # fails
 
-#        stdenv = clangStdenv;
+       # stdenv = clangStdenv;
   };
 
   root = callPackage ../applications/science/misc/root {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21763,6 +21763,12 @@ with pkgs;
 
   cernlib = callPackage ../development/libraries/physics/cernlib { };
 
+  dce = callPackage ../development/libraries/science/networking/ns3/dce.nix {
+    # python=python3;
+  };
+
+  dce-quagga = dce.override { withQuagga = true; };
+
   g4py = callPackage ../development/libraries/physics/geant4/g4py { };
 
   hepmc = callPackage ../development/libraries/physics/hepmc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -282,6 +282,8 @@ in {
 
   cozy = callPackage ../development/python-modules/cozy { };
 
+  cxxfilt = callPackage ../development/python-modules/cxxfilt { };
+
   dendropy = callPackage ../development/python-modules/dendropy { };
 
   dependency-injector = callPackage ../development/python-modules/dependency-injector { };


### PR DESCRIPTION
###### Motivation for this change
It's a bit messy at the moment but I share because I have some trouble generating the python bindings, castxml can't find standard headers such as stddef.h. I've read a few issues about it and tried a few things to no avail. 
```
./waf --apiscan=all --no32bit-scan -v
Waf: Entering directory `/home/teto/scratch/source/build'
Modules to scan:  ['antenna', 'applications', 'bridge', 'buildings', 'config-store', 'core', 'csma', 'energy', 'fd-net-device', 'internet', 'lr-wpan', 'lte', 'mobility', 'mpi', 'network', 'point-to-point', 'point-to-point-layout', 'propagation', 'spectrum', 'stats', 'traffic-control', 'uan', 'virtual-net-device', 'wave', 'wifi', 'wimax']
api-scan-gcc_LP64
api-scan-gcc_LP64
api-scan-gcc_LP64
api-scan-gcc_LP64
<ns3modulegen_core_customizations.SmartPointerTransformation object at 0x7f92fba03dd0>
<ns3modulegen_core_customizations.SmartPointerTransformation object at 0x7f5c4c9b5dd0>
<ns3modulegen_core_customizations.SmartPointerTransformation object at 0x7fe54ff56dd0>
INFO Parsing source file "/home/teto/scratch/source/build/ns3/antenna-module.h" ... 
INFO Parsing source file "/home/teto/scratch/source/build/ns3/buildings-module.h" ... 
INFO Parsing source file "/home/teto/scratch/source/build/ns3/bridge-module.h" ... 
warning: argument unused during compilation: '-nostdlibinc' [-Wunused-command-line-argument]
<ns3modulegen_core_customizations.SmartPointerTransformation object at 0x7f2470e35dd0>
warning: argument unused during compilation: '-nostdlibinc' [-Wunused-command-line-argument]
warning: argument unused during compilation: '-nostdlibinc' [-Wunused-command-line-argument]
In file included from /home/teto/scratch/source/build/ns3/bridge-module.h:10:
In file included from /home/teto/scratch/source/build/ns3/bridge-channel.h:21:
In file included from /home/teto/scratch/source/build/ns3/net-device.h:25:
In file included from /home/teto/scratch/source/build/ns3/callback.h:24:
In file included from /home/teto/scratch/source/build/ns3/ptr.h:24:
In file included from /nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/iostream:39:
In file included from /nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/ostream:38:
In file included from /nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/ios:38:
In file included from /nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/iosfwd:40:
In file included from /nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/bits/postypes.h:40:
In file included from /nix/store/ng5kbr6kmh979qaachifbsbblydrcmqc-gcc-7.3.0/include/c++/7.3.0/cwchar:44:
/nix/store/lb3kkvyylnbcxn5jad9i11szxlhkpkjq-glibc-2.27-dev/include/wchar.h:35:10: fatal error: 
      'stddef.h' file not found
#include <stddef.h>
         ^~~~~~~~~~
```

To reproduce the problem:

```
nix-shell -E 'with (import <nixpkgs> {}); ns3clang.override { pythonSupport=true; }
$ unpackPhase
$ cd source
$ configurePhase
$ buildPhase
$ ./waf --apiscan=all --no32bit-scan -v
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

