### PR TITLE
consul-ui: fix build

### DIFF
--- a/pkgs/servers/consul/Gemfile
+++ b/pkgs/servers/consul/Gemfile
@@ -3,4 +3,3 @@ source "https://rubygems.org"
 
 gem "uglifier"
 gem "sass"
-gem "therubyracer"

--- a/pkgs/servers/consul/Gemfile.lock
+++ b/pkgs/servers/consul/Gemfile.lock
@@ -1,22 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    execjs (2.3.0)
-    json (1.8.2)
-    libv8 (3.16.14.11)
-    ref (1.0.5)
-    sass (3.4.11)
-    therubyracer (0.12.1)
-      libv8 (~> 3.16.14.0)
-      ref
-    uglifier (2.7.0)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    execjs (2.7.0)
+    ffi (1.9.23)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    sass (3.5.6)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    uglifier (4.1.10)
+      execjs (>= 0.3.0, < 3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   sass
-  therubyracer
   uglifier
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/servers/consul/gemset.nix
+++ b/pkgs/servers/consul/gemset.nix
@@ -1,59 +1,62 @@
 {
   execjs = {
-    version = "2.3.0";
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yz55sf2nd3l666ms6xr18sm2aggcvmb8qr3v53lr4rir32y1yp1";
       type = "gem";
-      sha256 = "097v02bhmzc70j7n0yyf8j0z5wms88zcmgpmggby4hnvqxf41y1h";
     };
+    version = "2.7.0";
   };
-  json = {
-    version = "1.8.2";
+  ffi = {
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zw6pbyvmj8wafdc7l5h7w20zkp1vbr2805ql5d941g2b20pk4zr";
       type = "gem";
-      sha256 = "0zzvv25vjikavd3b1bp6lvbgj23vv9jvmnl4vpim8pv30z8p6vr5";
     };
+    version = "1.9.23";
   };
-  libv8 = {
-    version = "3.16.14.11";
+  rb-fsevent = {
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lm1k7wpz69jx7jrc92w3ggczkjyjbfziq5mg62vjnxmzs383xx8";
       type = "gem";
-      sha256 = "000vbiy78wk5r1f6p7qncab8ldg7qw5pjz7bchn3lw700gpaacxp";
     };
+    version = "0.10.3";
   };
-  ref = {
-    version = "1.0.5";
+  rb-inotify = {
+    dependencies = ["ffi"];
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yfsgw5n7pkpyky6a9wkf1g9jafxb0ja7gz0qw0y14fd2jnzfh71";
       type = "gem";
-      sha256 = "19qgpsfszwc2sfh6wixgky5agn831qq8ap854i1jqqhy1zsci3la";
     };
+    version = "0.9.10";
   };
   sass = {
-    version = "3.4.11";
+    dependencies = ["sass-listen"];
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19wyzp9qsg8hdkkxlsv713w0qmy66qrdp0shj42587ssx4qhrlag";
       type = "gem";
-      sha256 = "10dncnv7g5v8d1xpw2aaarxjjlm68f7nm02ns2kl8nf3yxi6wzdf";
     };
+    version = "3.5.6";
   };
-  therubyracer = {
-    version = "0.12.1";
+  sass-listen = {
+    dependencies = ["rb-fsevent" "rb-inotify"];
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xw3q46cmahkgyldid5hwyiwacp590zj2vmswlll68ryvmvcp7df";
       type = "gem";
-      sha256 = "106fqimqyaalh7p6czbl5m2j69z8gv7cm10mjb8bbb2p2vlmqmi6";
     };
-    dependencies = [
-      "libv8"
-      "ref"
-    ];
+    version = "4.0.0";
   };
   uglifier = {
-    version = "2.7.0";
+    dependencies = ["execjs"];
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dycp9c5xiricla6sgvg0vf22i3axs5k1v1607dvl7nv1xkkaczi";
       type = "gem";
-      sha256 = "1x1mnakx086l83a3alj690c6n8kfmb4bk243a6m6yz99s15gbxfq";
     };
-    dependencies = [
-      "execjs"
-      "json"
-    ];
+    version = "4.1.10";
   };
 }

--- a/pkgs/servers/consul/ui-no-bundle-exec.patch
+++ b/pkgs/servers/consul/ui-no-bundle-exec.patch
@@ -1,0 +1,17 @@
+diff --git a/ui/scripts/dist.sh b/ui/scripts/dist.sh
+index 0ad6e28e..db340da0 100755
+--- a/ui/scripts/dist.sh
++++ b/ui/scripts/dist.sh
+@@ -15,10 +15,9 @@ DEPLOY="../pkg/web_ui"
+ rm -rf $DEPLOY
+ mkdir -p $DEPLOY
+ 
+-bundle check >/dev/null 2>&1 || bundle install
+-bundle exec sass styles/base.scss static/base.css
++sass styles/base.scss static/base.css
+ 
+-bundle exec ruby scripts/compile.rb
++ruby scripts/compile.rb
+ 
+ # Copy into deploy
+ shopt -s dotglob

--- a/pkgs/servers/consul/ui.nix
+++ b/pkgs/servers/consul/ui.nix
@@ -1,4 +1,4 @@
-{ stdenv, consul, ruby, bundlerEnv, zip }:
+{ stdenv, consul, ruby, bundlerEnv, zip, nodejs }:
 
 let
   # `sass` et al
@@ -13,9 +13,11 @@ stdenv.mkDerivation {
 
   src = consul.src;
 
-  buildInputs = [ ruby gems zip ];
+  buildInputs = [ ruby gems zip nodejs ];
 
-  patchPhase = "patchShebangs ./ui/scripts/dist.sh";
+  patches = [ ./ui-no-bundle-exec.patch ];
+
+  postPatch = "patchShebangs ./ui/scripts/dist.sh";
 
   buildPhase = ''
     # Build ui static files


### PR DESCRIPTION
###### Motivation for this change

consul-ui is currently failing to build in 18.03 and master (#41238).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

My previous PR (#41239) was against the 18.03 branch because the fix did not work in master. This newer version works in both master and 18.03.

Update the dependencies used for building consul-ui. therubyracer is no longer required and fails to build. Instead, a nodejs binary is required to build the assets. Patch out unnecessary executions of `bundle` which can cause failures and also prevents need for patching the Gemfile.lock in the consul source, based on suggestion by @nh2.

Closes #41238