### PR TITLE
openshift: Fix path to mount and findmnt command

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, removeReferencesTo, which, go_1_9, go-bindata, makeWrapper, rsync
+{ stdenv, lib, fetchFromGitHub, fetchpatch, removeReferencesTo, which, go_1_9, go-bindata, makeWrapper, rsync, utillinux
 , iptables, coreutils, kerberos, clang
 , components ? [
   "cmd/oc"
@@ -37,6 +37,18 @@ in stdenv.mkDerivation rec {
 
   patchPhase = ''
     patchShebangs ./hack
+
+    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt findmnt' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/findmnt'
+
+    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mount' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
+
+    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+      --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mkdir' \
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
   '';
 
   buildPhase = ''

--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
 
     substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
       --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mkdir' \
-      'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
+      'nsenter --mount=/rootfs/proc/1/ns/mnt ${coreutils}/bin/mkdir'
   '';
 
   buildPhase = ''


### PR DESCRIPTION
Fix openshift oc cluster up mount

(cherry picked from commit fd09c3dcae0365871b9bc995a5241431a210e506)

###### Motivation for this change
Reason: The basic functionality to spin up a local cluster using "oc
cluster up" is broken due to wrong paths to mount and findmnt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

