### PR TITLE
nixos/etc: sanitize /etc setup script

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -17,11 +17,11 @@ let
     allowSubstitutes = false;
 
     /* !!! Use toXML. */
-    sources = map (x: x.source) etc';
-    targets = map (x: x.target) etc';
-    modes = map (x: x.mode) etc';
-    users  = map (x: x.user) etc';
-    groups  = map (x: x.group) etc';
+    sources = map (x: escapeShellArg x.source) etc';
+    targets = map (x: escapeShellArg x.target) etc';
+    modes = map (x: escapeShellArg x.mode) etc';
+    users  = map (x: escapeShellArg x.user) etc';
+    groups  = map (x: escapeShellArg x.group) etc';
   };
 
 in

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -17,7 +17,7 @@ let
     allowSubstitutes = false;
 
     /* !!! Use toXML. */
-    sources = map (x: escapeShellArg x.source) etc';
+    sources = map (x: x.source) etc';
     targets = map (x: escapeShellArg x.target) etc';
     modes = map (x: escapeShellArg x.mode) etc';
     users  = map (x: escapeShellArg x.user) etc';

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -17,9 +17,9 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
     if [[ "$source" =~ '*' ]]; then
 
         # If the source name contains '*', perform globbing.
-        mkdir -p $out/etc/$target
+        mkdir -p "$out/etc/$target"
         for fn in $source; do
-            ln -s "$fn" $out/etc/$target/
+            ln -s "$fn" "$out/etc/$target/"
         done
 
     else

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -3,7 +3,7 @@ source $stdenv/setup
 mkdir -p $out/etc
 
 set -f
-eval "sources_=($sources)"
+sources_=($sources)
 eval "targets_=($targets)"
 eval "modes_=($modes)"
 eval "users_=($users)"

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -14,21 +14,33 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
     source="${sources_[$i]}"
     target="${targets_[$i]}"
 
-    mkdir -p "$out/etc/$(dirname "$target")"
-    if ! [ -e "$out/etc/$target" ]; then
-        ln -s "$source" "$out/etc/$target"
-    else
-        echo "duplicate entry $target -> $source"
-        if test "$(readlink "$out/etc/$target")" != "$source"; then
-            echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $source"
-            exit 1
-        fi
-    fi
+    if [[ "$source" =~ '*' ]]; then
 
-    if test "${modes_[$i]}" != symlink; then
-        echo "${modes_[$i]}"  > "$out/etc/$target".mode
-        echo "${users_[$i]}"  > "$out/etc/$target".uid
-        echo "${groups_[$i]}" > "$out/etc/$target".gid
+        # If the source name contains '*', perform globbing.
+        mkdir -p $out/etc/$target
+        for fn in $source; do
+            ln -s "$fn" $out/etc/$target/
+        done
+
+    else
+
+        mkdir -p "$out/etc/$(dirname "$target")"
+        if ! [ -e "$out/etc/$target" ]; then
+            ln -s "$source" "$out/etc/$target"
+        else
+            echo "duplicate entry $target -> $source"
+            if test "$(readlink "$out/etc/$target")" != "$source"; then
+                echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $source"
+                exit 1
+            fi
+        fi
+
+        if test "${modes_[$i]}" != symlink; then
+            echo "${modes_[$i]}"  > "$out/etc/$target".mode
+            echo "${users_[$i]}"  > "$out/etc/$target".uid
+            echo "${groups_[$i]}" > "$out/etc/$target".gid
+        fi
+
     fi
 done
 

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -3,11 +3,11 @@ source $stdenv/setup
 mkdir -p $out/etc
 
 set -f
-sources_=($sources)
-targets_=($targets)
-modes_=($modes)
-users_=($users)
-groups_=($groups)
+eval "sources_=($sources)"
+eval "targets_=($targets)"
+eval "modes_=($modes)"
+eval "users_=($users)"
+eval "groups_=($groups)"
 set +f
 
 for ((i = 0; i < ${#targets_[@]}; i++)); do
@@ -23,24 +23,24 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
         done
 
     else
-        
-        mkdir -p $out/etc/$(dirname $target)
-        if ! [ -e $out/etc/$target ]; then
-            ln -s $source $out/etc/$target
+
+        mkdir -p "$out/etc/$(dirname "$target")"
+        if ! [ -e "$out/etc/$target" ]; then
+            ln -s "$source" "$out/etc/$target"
         else
             echo "duplicate entry $target -> $source"
-            if test "$(readlink $out/etc/$target)" != "$source"; then
-                echo "mismatched duplicate entry $(readlink $out/etc/$target) <-> $source"
+            if test "$(readlink "$out/etc/$target")" != "$source"; then
+                echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $source"
                 exit 1
             fi
         fi
-        
+
         if test "${modes_[$i]}" != symlink; then
-            echo "${modes_[$i]}"  > $out/etc/$target.mode
-            echo "${users_[$i]}"  > $out/etc/$target.uid
-            echo "${groups_[$i]}" > $out/etc/$target.gid
+            echo "${modes_[$i]}"  > "$out/etc/$target".mode
+            echo "${users_[$i]}"  > "$out/etc/$target".uid
+            echo "${groups_[$i]}" > "$out/etc/$target".gid
         fi
-        
+
     fi
 done
 

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -14,33 +14,21 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
     source="${sources_[$i]}"
     target="${targets_[$i]}"
 
-    if [[ "$source" =~ '*' ]]; then
-
-        # If the source name contains '*', perform globbing.
-        mkdir -p $out/etc/$target
-        for fn in $source; do
-            ln -s "$fn" $out/etc/$target/
-        done
-
+    mkdir -p "$out/etc/$(dirname "$target")"
+    if ! [ -e "$out/etc/$target" ]; then
+        ln -s "$source" "$out/etc/$target"
     else
-
-        mkdir -p "$out/etc/$(dirname "$target")"
-        if ! [ -e "$out/etc/$target" ]; then
-            ln -s "$source" "$out/etc/$target"
-        else
-            echo "duplicate entry $target -> $source"
-            if test "$(readlink "$out/etc/$target")" != "$source"; then
-                echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $source"
-                exit 1
-            fi
+        echo "duplicate entry $target -> $source"
+        if test "$(readlink "$out/etc/$target")" != "$source"; then
+            echo "mismatched duplicate entry $(readlink "$out/etc/$target") <-> $source"
+            exit 1
         fi
+    fi
 
-        if test "${modes_[$i]}" != symlink; then
-            echo "${modes_[$i]}"  > "$out/etc/$target".mode
-            echo "${users_[$i]}"  > "$out/etc/$target".uid
-            echo "${groups_[$i]}" > "$out/etc/$target".gid
-        fi
-
+    if test "${modes_[$i]}" != symlink; then
+        echo "${modes_[$i]}"  > "$out/etc/$target".mode
+        echo "${users_[$i]}"  > "$out/etc/$target".uid
+        echo "${groups_[$i]}" > "$out/etc/$target".gid
     fi
 done
 


### PR DESCRIPTION
Fixes #41241 

###### Motivation for this change

Variables passed to the `/etc` setup script were not shell escaped. This has been changed.
I am not entirely comfortable with the use of `eval` to construct arrays from the sanitised input, but I haven't found a better approach to convert a string of shell-escaped arguments into an array of strings in bash.

I have tested it myself, **however** I am not familiar enough with nixos tests to know which ones need to be run for something as low-level as this, and I'm well aware that any change in the `/etc` setup could break a lot. Any advice on this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

