### PR TITLE
barrier: init at 2.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2968,6 +2968,11 @@
     github = "phreedom";
     name = "Evgeny Egorochkin";
   };
+  phryneas = {
+    email = "mail@lenzw.de";
+    github = "phryneas";
+    name = "Lenz Weber";
+  };
   phunehehe = {
     email = "phunehehe@gmail.com";
     github = "phunehehe";

--- a/pkgs/applications/misc/barrier/default.nix
+++ b/pkgs/applications/misc/barrier/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, cmake, curl, xorg, avahi, qt5,
+  avahiWithLibdnssdCompat ? avahi.override { withLibdnssdCompat = true; }
+}:
+
+stdenv.mkDerivation rec {
+  name = "barrier-${version}";
+  version = "2.1.1";
+  src = fetchurl {
+    url = "https://github.com/debauchee/barrier/archive/v${version}.tar.gz";
+    sha256 = "0x17as5ikfx2r5hawr368a9risvcavyc8zv5g724s709nr6m0pbp";
+  };
+
+  buildInputs = [ cmake curl xorg.libX11 xorg.libXext xorg.libXtst avahiWithLibdnssdCompat ];
+  propagatedBuildInputs = with qt5; [ qtbase ];
+
+  postFixup = ''
+      substituteInPlace "$out/share/applications/barrier.desktop" --replace "Exec=barrier" "Exec=$out/bin/barrier"
+    '';
+
+  meta = {
+    description = "Open-source KVM software";
+    longDescription = ''
+      Barrier is KVM software forked from Symless's synergy 1.9 codebase.
+      Synergy was a commercialized reimplementation of the original
+      CosmoSynergy written by Chris Schoeneman.
+    '';
+    homepage = https://github.com/debauchee/barrier;
+    downloadPage = https://github.com/debauchee/barrier/releases;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.phryneas ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14943,6 +14943,8 @@ with pkgs;
     ffmpeg = ffmpeg_1;
   };
 
+  barrier = callPackage ../applications/misc/barrier {};
+
   banshee = callPackage ../applications/audio/banshee {
     gconf = pkgs.gnome2.GConf;
     libgpod = pkgs.libgpod.override { monoSupport = true; };


### PR DESCRIPTION
###### Motivation for this change

This adds barrier, a fork of synergy 1.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

