### PR TITLE
adapta-kde-theme: init 2018-05-12

### DIFF
--- a/pkgs/misc/themes/adapta-kde/default.nix
+++ b/pkgs/misc/themes/adapta-kde/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "adapta-kde-theme-${version}";
+  version = "2018-05-12";
+
+  src = fetchFromGitHub {
+    owner = "PapirusDevelopmentTeam";
+    repo = "adapta-kde";
+    rev = "31eacbb64a64dbcfe6f3546f7a15b6920036c3a2";
+    sha256 = "1lgpkylhzbayk892inql16sjyy9d3v126f9i1v7qgha1203rwcji";
+  };
+
+  makeFlags = ["PREFIX=$(out)" ];
+
+  # Make this a fixed-output derivation
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  ouputHash = "ba3bd4c13e8b73c528b5adcb667e985f7d60df78d50bc58707119cb9e242bb2c";
+
+  meta = {
+    description = "A port of the adapta theme for Plasma";
+    homepage = https://git.io/adapta-kde;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.nixy ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -738,6 +738,8 @@ with pkgs;
 
   adapta-gtk-theme = callPackage ../misc/themes/adapta { };
 
+  adapta-kde-theme = callPackage ../misc/themes/adapta-kde { };
+
   aria2 = callPackage ../tools/networking/aria2 {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change
Looking to add some QT/KDE themes to NixOS so I can make my desktop pretty. Thought I would share. This seems to work out of the box.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

