### PR TITLE
perlPackages.DBDPg: disable tests

### DIFF
--- a/pkgs/development/perl-modules/DBD-Pg/default.nix
+++ b/pkgs/development/perl-modules/DBD-Pg/default.nix
@@ -13,6 +13,9 @@ buildPerlPackage rec {
 
   makeMakerFlags = "POSTGRES_HOME=${postgresql}";
 
+  # tests freeze in a sandbox
+  doCheck = false;
+
   meta = {
     homepage = http://search.cpan.org/dist/DBD-Pg/;
     description = "DBI PostgreSQL interface";


### PR DESCRIPTION
###### Motivation for this change

Build was broken because tests freeze in sandbox, disable them. Fixes #41199.
Needs backport to 18.03

/cc @srhb 

---

