### PR TITLE
nixos/tests/iftop: fix non-deterministic failure

### DIFF
--- a/nixos/tests/iftop.nix
+++ b/nixos/tests/iftop.nix
@@ -9,22 +9,26 @@ with lib;
   nodes = {
     withIftop = {
       imports = [ ./common/user-account.nix ];
-
       programs.iftop.enable = true;
     };
     withoutIftop = {
       imports = [ ./common/user-account.nix ];
+      environment.systemPackages = [ pkgs.iftop ];
     };
   };
 
   testScript = ''
     subtest "machine with iftop enabled", sub {
-      $withIftop->start;
-      $withIftop->succeed("su -l alice -c 'iftop -t -s 1'");
+      $withIftop->waitForUnit("default.target");
+      # limit to eth1 (eth0 is the test driver's control interface)
+      # and don't try name lookups
+      $withIftop->succeed("su -l alice -c 'iftop -t -s 1 -n -i eth1'");
     };
     subtest "machine without iftop", sub {
-      $withoutIftop->start;
-      $withoutIftop->mustFail("su -l alice -c 'iftop -t -s 1'");
+      $withoutIftop->waitForUnit("default.target");
+      # check that iftop is there but user alice lacks capabilities
+      $withoutIftop->succeed("iftop -t -s 1 -n -i eth1");
+      $withoutIftop->fail("su -l alice -c 'iftop -t -s 1 -n -i eth1'");
     };
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Non-deterministic test failure: https://hydra.nixos.org/build/74650732 . The test needs to wait until machines are fully booted before sending commands. ~~Also, `iftop` should be run as root.~~

/cc @Ma27

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

