### PR TITLE
pythonPackages.amazon_kclpy: init at 1.5.0

### DIFF
--- a/pkgs/development/python-modules/amazon_kclpy/default.nix
+++ b/pkgs/development/python-modules/amazon_kclpy/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, python, mock, boto, pytest }:
+
+buildPythonPackage rec {
+  pname = "amazon_kclpy";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "amazon-kinesis-client-python";
+    rev = "v${version}";
+    sha256 = "1qg86y9172gm5592ja7lr6w7kfnx668j99bf3ijklpk5yshxwr9m";
+  };
+
+  # argparse is just required for python2.6
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "'argparse'," ""
+  '';
+
+  propagatedBuildInputs =  [ mock boto ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    ${python.interpreter} -m pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Amazon Kinesis Client Library for Python";
+    homepage = https://github.com/awslabs/amazon-kinesis-client-python;
+    license = licenses.asl;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}

--- a/pkgs/development/python-modules/amazon_kclpy/default.nix
+++ b/pkgs/development/python-modules/amazon_kclpy/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Amazon Kinesis Client Library for Python";
     homepage = https://github.com/awslabs/amazon-kinesis-client-python;
-    license = licenses.asl;
+    license = licenses.amazonsl;
     maintainers = with maintainers; [ psyanticy ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -201,6 +201,8 @@ in {
 
   # packages defined elsewhere
 
+  amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };
+
   backports_csv = callPackage ../development/python-modules/backports_csv {};
 
   bap = callPackage ../development/python-modules/bap {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

