### PR TITLE
GCE image: properly remove the temporary ssh host keys files/directory

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -253,12 +253,11 @@ in
               mv -f $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key* /etc/ssh/
               chmod 600 /etc/ssh/ssh_host_ed25519_key
               chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
-              rm $SSH_HOST_KEYS_DIR/*
           else
               echo "Setup of ssh host keys from http://metadata.google.internal/computeMetadata/v1/instance/attributes/ failed."
               false
           fi
-          rm -r $SSH_HOST_KEYS_DIR
+          rm -rf $SSH_HOST_KEYS_DIR
         '';
       serviceConfig.Type = "oneshot";
       serviceConfig.RemainAfterExit = true;

--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -253,11 +253,12 @@ in
               mv -f $SSH_HOST_KEYS_DIR/ssh_host_ed25519_key* /etc/ssh/
               chmod 600 /etc/ssh/ssh_host_ed25519_key
               chmod 644 /etc/ssh/ssh_host_ed25519_key.pub
+              rm $SSH_HOST_KEYS_DIR/*
           else
               echo "Setup of ssh host keys from http://metadata.google.internal/computeMetadata/v1/instance/attributes/ failed."
               false
           fi
-          rm -f $SSH_HOST_KEYS_DIR
+          rm -r $SSH_HOST_KEYS_DIR
         '';
       serviceConfig.Type = "oneshot";
       serviceConfig.RemainAfterExit = true;


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

