### PR TITLE
gams: move optgams and gamslice to $out/share/gams

### DIFF
--- a/pkgs/tools/misc/gams/default.nix
+++ b/pkgs/tools/misc/gams/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin" "$out/share/gams"
     cp -a * "$out/share/gams"
 
-    cp ${licenseFile} $out/share/gamslice.txt
+    cp ${licenseFile} $out/share/gams/gamslice.txt
   '' + stdenv.lib.optionalString (optgamsFile != null) ''
-    cp ${optgamsFile} $out/share/optgams.def
+    cp ${optgamsFile} $out/share/gams/optgams.def
     ln -s $out/share/gams/optgams.def $out/bin/optgams.def
   '';
 


### PR DESCRIPTION
###### Motivation for this change
GAMS was not finding the license, it needs to be placed next to the gams bin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

