### PR TITLE
scdoc: init at 1.3.3

### DIFF
--- a/pkgs/tools/typesetting/scdoc/default.nix
+++ b/pkgs/tools/typesetting/scdoc/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "scdoc-${version}";
+  version = "1.3.3";
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~sircmpwn/scdoc/snapshot/scdoc-${version}.tar.xz";
+    sha256 = "1xkfsrzpbm68522b1dml9dghnwb5dlwpf91c1i4y51rgv3hdgwdj";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "VERSION=1.2.3" "VERSION=${version}" \
+      --replace "-static" "" \
+      --replace "/usr/local" "$out"
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "A simple man page generator";
+    longDescription = ''
+      scdoc is a simple man page generator written for POSIX systems written in
+      C99.
+    '';
+    homepage = https://git.sr.ht/~sircmpwn/scdoc/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4853,6 +4853,8 @@ with pkgs;
 
   scanbd = callPackage ../tools/graphics/scanbd { };
 
+  scdoc = callPackage ../tools/typesetting/scdoc { };
+
   screen = callPackage ../tools/misc/screen {
     inherit (darwin.apple_sdk.libs) utmp;
   };


### PR DESCRIPTION
We'll need this to build the man pages of sway 1.0 (sway 1.0-alpha.2:
"This release replaces the asciidoc dependency with scdoc." [0]).

[0]: https://github.com/swaywm/sway/releases/tag/1.0-alpha.2

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

