### PR TITLE
compton-git: 2016-08-10 -> 2018-05-21

### DIFF
--- a/pkgs/applications/window-managers/compton/git.nix
+++ b/pkgs/applications/window-managers/compton/git.nix
@@ -3,14 +3,15 @@
   pkgconfig, libXcomposite, libXdamage, libXext, libXfixes, libXinerama,
   libXrandr, libXrender, xwininfo }:
 
-stdenv.mkDerivation {
-  name = "compton-git-2016-08-10";
+stdenv.mkDerivation rec {
+  name = "compton-git-${version}";
+  version = "2018-05-21";
 
   src = fetchFromGitHub {
-    owner  = "chjj";
+    owner  = "yshui";
     repo   = "compton";
-    rev    = "f1cd308cde0f1e1f21ec2ac8f16a3c873fa22d3a";
-    sha256 = "1ky438d1rsg4ylkcp60m82r0jck8rks3gfa869rc63k37p2nfn8p";
+    rev    = "9b24550814b7c69065f90039b0a5d0a2281b9f81";
+    sha256 = "09nn0q9lgv59chfxljips0n8vnwwxi1yz6hmcsiggsl3zvpabpxl";
   };
 
   nativeBuildInputs = [
@@ -44,7 +45,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description =
       "A fork of XCompMgr, a sample compositing manager for X servers (git version)";
-    homepage = https://github.com/chjj/compton/;
+    homepage = https://github.com/yshui/compton/;
     license = licenses.mit;
     longDescription = ''
       A fork of XCompMgr, which is a sample compositing manager for X
@@ -53,7 +54,7 @@ stdenv.mkDerivation {
       additional features, such as additional effects, and a fork at a
       well-defined and proper place.
     '';
-    maintainers = [ maintainers.ertes ];
+    maintainers = [ maintainers.ertes maintainers.twey ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bumps compton-git to a more maintained version by @yshui .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

