### PR TITLE
atom, atom-beta: 1.27.1 -> 1.27.2, 1.28.0-beta1 -> 1.28.0-beta2

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -58,12 +58,12 @@ let
   };
 in stdenv.lib.mapAttrs common {
   atom = {
-    version = "1.27.1";
-    sha256 = "08slv8s90wz2jcdrcqh2d815wfbrkwcdx9c3qbx8cml04hz8p2gx";
+    version = "1.27.2";
+    sha256 = "0xriv142asc82mjxzkqsafaqalxa3icz4781z2fsgyfkkw6zbz2v";
   };
 
   atom-beta = {
-    version = "1.28.0-beta1";
-    sha256 = "1mkxq2a7sylj9jx1bs2v1pmgrwc10cgh810qic1lncq9jzpaik0n";
+    version = "1.28.0-beta2";
+    sha256 = "0fc9j1l776hv057dirw2bv9wmvhcaba5c4nq1cgs5rb5whxir2n6";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

New version! :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

