### PR TITLE
raspberrypiWirelessFirmware: init

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -38,7 +38,8 @@ in {
         firmwareLinuxNonfree
         intel2200BGFirmware
         rtl8192su-firmware
-      ] ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "4.13") [
+      ] ++ optional (pkgs.stdenv.isAarch32 || pkgs.stdenv.isAarch64) raspberrypiWirelessFirmware
+        ++ optionals (versionOlder config.boot.kernelPackages.kernel.version "4.13") [
         rtl8723bs-firmware
       ];
     })

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "raspberrypi-wireless-firmware-${version}";
+  version = "2018-05-30";
+
+  srcs = [
+    (fetchurl {
+      url = "https://archive.raspberrypi.org/debian/pool/main/b/bluez-firmware/bluez-firmware_1.2-3+rpt5.debian.tar.xz";
+      sha256 = "06zpyrz6frkgjy26hr3998klnhjdqxwashgjgvj9rgbcqy70nkxg";
+    })
+    (fetchurl {
+      url = "https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20161130-3+rpt3_all.deb";
+      sha256 = "10l74ac28baprnsiylf2vy4pkxgb3crixid90ngs6si9smm7rn6z";
+    })
+  ];
+
+  sourceRoot = ".";
+  dontBuild = true;
+  # Firmware blobs do not need fixing and should not be modified
+  dontFixup = true;
+
+  # Unpack the debian package
+  unpackCmd = ''
+    if ! [[ "$curSrc" =~ \.deb$ ]]; then return 1; fi
+    ar -xf "$curSrc"
+    tar -xf data.tar.xz
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib/firmware/brcm"
+
+    # Wifi firmware
+    for filename in lib/firmware/brcm/brcmfmac434??-sdio.*; do
+      cp "$filename" "$out/lib/firmware/brcm"
+    done
+
+    # Bluetooth firmware
+    cp broadcom/*.hcd "$out/lib/firmware/brcm"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3 and Zero W";
+    homepage = https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/;
+    license = licenses.unfreeRedistributableFirmware;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14013,6 +14013,8 @@ with pkgs;
   radeontop = callPackage ../os-specific/linux/radeontop { };
 
   raspberrypifw = callPackage ../os-specific/linux/firmware/raspberrypi {};
+  raspberrypiWirelessFirmware = callPackage ../os-specific/linux/firmware/raspberrypi-wireless { };
+
   raspberrypi-tools = callPackage ../os-specific/linux/firmware/raspberrypi/tools.nix {};
 
   regionset = callPackage ../os-specific/linux/regionset { };


### PR DESCRIPTION
###### Motivation for this change

The builtin wifi and bluetooth radios do not currently work in NixOS on the RaspberryPi 3 and Raspberry Pi Zero W, because some firmware files are missing.

###### Things done

This PR adds a package containing the missing wifi and bluetooth firmware and adds it to `enableRedistributableFirmware`. Some of the firmware files also exist in `firmwareLinuxNonfree`, but this package contains newer versions. Therefore, it must be placed later it the list to overwrite the files from `firmwareLinuxNonfree`.

I have not actually tested bluetooth, but wifi now works out of the box with this PR.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

