### PR TITLE
Add an additional dependency for home-assistant

### DIFF
--- a/pkgs/development/python-modules/voluptuous-serialize/default.nix
+++ b/pkgs/development/python-modules/voluptuous-serialize/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, voluptuous, pytest }:
+
+buildPythonPackage rec  {
+  pname = "voluptuous-serialize";
+  version = "2018-03-10";
+
+  disabled = !isPy3k;
+
+  # no tests in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "balloob";
+    repo = pname;
+    rev = "567f0d96f928cf6c30c9f1b8bdee729e651aac82";
+    sha256 = "0b16f1bxlqyvi1hy8wmzp2k0rzqcycmdhs8zwsyx0swnvkgwnv50";
+  };
+
+  propagatedBuildInputs = [
+    voluptuous
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/balloob/voluptuous-serialize;
+    license = licenses.asl20;
+    description = "Convert Voluptuous schemas to dictionaries so they can be serialized";
+    maintainers = with maintainers; [ etu ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -402,7 +402,7 @@
     "http.real_ip" = ps: with ps; [  ];
     "http.static" = ps: with ps; [  ];
     "http.view" = ps: with ps; [  ];
-    "hue" = ps: with ps; [ aiohue ];
+    "hue" = ps: with ps; [ aiohue voluptuous-serialize ];
     "hue.bridge" = ps: with ps; [  ];
     "hue.config_flow" = ps: with ps; [  ];
     "hue.const" = ps: with ps; [  ];
@@ -459,7 +459,7 @@
     "light.hive" = ps: with ps; [  ];
     "light.homekit_controller" = ps: with ps; [  ];
     "light.homematic" = ps: with ps; [ pyhomematic ];
-    "light.hue" = ps: with ps; [ aiohue ];
+    "light.hue" = ps: with ps; [ aiohue voluptuous-serialize ];
     "light.hyperion" = ps: with ps; [  ];
     "light.iglo" = ps: with ps; [  ];
     "light.ihc" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18129,6 +18129,8 @@ EOF
 
   voluptuous = callPackage ../development/python-modules/voluptuous { };
 
+  voluptuous-serialize = callPackage ../development/python-modules/voluptuous-serialize { };
+
   pysigset = callPackage ../development/python-modules/pysigset { };
 
   us = callPackage ../development/python-modules/us { };


### PR DESCRIPTION
###### Motivation for this change
I've tried to set up my hue bridge with home-assistant but it failed. But then I've packaged this dep and now it works:

![image](https://user-images.githubusercontent.com/461970/40804833-b94cb038-651c-11e8-88f5-aa18e614d29d.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dotlambda @f-breidenstein 