### PR TITLE
etherape: 0.9.13 -> 0.9.17

### DIFF
--- a/pkgs/applications/networking/sniffers/etherape/default.nix
+++ b/pkgs/applications/networking/sniffers/etherape/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchurl, pkgconfig, libtool, gtk2, libpcap, libglade, libgnome, libgnomeui
-, gnomedocutils, scrollkeeper, libxslt }:
+{ stdenv, fetchurl, pkgconfig, libtool, gtk2, libpcap, libglade,
+libgnomecanvas, popt, itstool }:
 
 stdenv.mkDerivation rec {
-  name = "etherape-0.9.13";
+  name = "etherape-0.9.17";
   src = fetchurl {
     url = "mirror://sourceforge/etherape/${name}.tar.gz";
-    sha256 = "1xq93k1slyak8mgwrw5kymq0xn0kl8chvfcvaablgki4p0l2lg9a";
+    sha256 = "1n66dw9nsl7zz0qfkb74ncgch3lzms2ssw8dq2bzbk3q1ilad3p6";
   };
 
-  configureFlags = [ "--disable-scrollkeeper" ];
-
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ itstool pkgconfig ];
   buildInputs = [
-    libtool gtk2 libpcap libglade libgnome libgnomeui gnomedocutils
-    scrollkeeper libxslt
+    libtool gtk2 libpcap libglade libgnomecanvas popt
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://etherape.sourceforge.net/;
     license = stdenv.lib.licenses.gpl2Plus;
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ symphorien ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15709,7 +15709,7 @@ with pkgs;
   eterm = callPackage ../applications/misc/eterm { };
 
   etherape = callPackage ../applications/networking/sniffers/etherape {
-    inherit (gnome2) gnomedocutils libgnome libglade libgnomeui scrollkeeper;
+    inherit (gnome2) libgnomecanvas libglade;
   };
 
   evilvte = callPackage ../applications/misc/evilvte {


### PR DESCRIPTION

###### Motivation for this change

fixes startup. The current version crashes on startup with `ERROR:diagram.c:211:addref_canvas_obj: assertion failed: (obj) `

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

