### PR TITLE
haskell-modules/configuration-ghc-8.4.x: bugfix - hoopl is still a core library

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -23,6 +23,7 @@ self: super: {
   ghc-prim = null;
   ghci = null;
   haskeline = null;
+  hoopl = null;
   hpc = null;
   integer-gmp = null;
   mtl = null;


### PR DESCRIPTION
Without this change, ghc84 won't build. The change is present in the 8.2.x config, but doesn't seem to have made it to 8.4.x. Trying to get `nox` working, so I can test more thoroughly.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

