### PR TITLE
configuration-ghc-8.4.x: bump to dhall_1_14_0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -408,8 +408,8 @@ self: super: {
   # Older versions don't compile.
   base-compat = self.base-compat_0_10_1;
   brick = self.brick_0_37_1;
-  dhall = self.dhall_1_13_0;
-  dhall_1_13_0 = doJailbreak super.dhall_1_13_0;  # support ansi-terminal 0.8.x
+  dhall = self.dhall_1_14_0;
+  dhall_1_13_0 = doJailbreak super.dhall_1_14_0;  # support ansi-terminal 0.8.x
   HaTeX = self.HaTeX_3_19_0_0;
   hpack = self.hpack_0_28_2;
   hspec = dontCheck super.hspec_2_5_1;


### PR DESCRIPTION
###### Motivation for this change
The `dhall_1_13_0` attribute doesn't exist, anymore.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Additionally, what's the process for library versions becoming the default? For this instance, what's preventing `dhall` just pointing at 1.14.0, rather than using a versioned attribute?