### PR TITLE
 frostwire: 6.6.3 -> 6.6.7

### DIFF
--- a/pkgs/applications/networking/p2p/frostwire/default.nix
+++ b/pkgs/applications/networking/p2p/frostwire/default.nix
@@ -1,14 +1,14 @@
 { stdenv, lib, fetchFromGitHub, gradle, perl, jre, makeWrapper, makeDesktopItem, mplayer }:
 
 let
-  version = "6.6.3-build-253";
+  version = "6.6.7-build-529";
   name = "frostwire-desktop-${version}";
 
   src = fetchFromGitHub {
     owner = "frostwire";
     repo = "frostwire";
     rev = name;
-    sha256 = "1bqv942hfz12i3b3nm1pfwdp7f58nzjxg44h31f3q47719hh8kd7";
+    sha256 = "03wdj2kr8akzx8m1scvg98132zbaxh81qjdsxn2645b3gahjwz0m";
   };
 
   desktopItem = makeDesktopItem {
@@ -40,7 +40,7 @@ let
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0p279i41q7pn6nss8vndv3g4qzrvj3pmhdxq50kymwkyp2kly3lc";
+    outputHash = "11zd98g0d0fdgls4lsskkagwfxyh26spfd6c6g9cahl89czvlg3c";
   };
 
 in stdenv.mkDerivation {

--- a/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
+++ b/pkgs/applications/networking/p2p/frostwire/frostwire-bin.nix
@@ -3,12 +3,12 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "6.6.5";
+  version = "6.6.7";
   name = "frostwire-${version}";
 
   src = fetchurl {
     url = "http://dl.frostwire.com/frostwire/${version}/frostwire-${version}.noarch.tar.gz";
-    sha256 = "0qxh5288mxd7ksd3zl0i8avkyzh8lj06x3jqya8znfq1c1wg0fph";
+    sha256 = "01ah0cwr3ahihfz1xxs0irw4rsa7wjgnlkcqfyg5q9rmzwbnxkyh";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

