### PR TITLE
Revert "itstool: 2.0.2 -> 2.0.4"

### DIFF
--- a/pkgs/development/tools/misc/itstool/default.nix
+++ b/pkgs/development/tools/misc/itstool/default.nix
@@ -2,11 +2,13 @@
 # We need the same Python as is used to build libxml2Python
 
 stdenv.mkDerivation rec {
-  name = "itstool-2.0.4";
+  # 2.0.3+ breaks the build of gnome3.gnome-desktop
+  # https://github.com/itstool/itstool/issues/17
+  name = "itstool-2.0.2";
 
   src = fetchurl {
     url = "http://files.itstool.org/itstool/${name}.tar.bz2";
-    sha256 = "0q7b4qrc758zfx3adsgvz0r93swdbxjr42w37rahngm33nshihlp";
+    sha256 = "bf909fb59b11a646681a8534d5700fec99be83bb2c57badf8c1844512227033a";
   };
 
   buildInputs = [ python2 libxml2Python ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#37028

There is an upstream bug https://github.com/itstool/itstool/issues/17, breaking gnome, gnumeric and others.

cc @matthewbauer @ryantm 