### PR TITLE
opaline: init at 0.3.1

### DIFF
--- a/pkgs/development/tools/ocaml/opaline/default.nix
+++ b/pkgs/development/tools/ocaml/opaline/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocamlPackages }:
+
+stdenv.mkDerivation rec {
+  version = "0.3.1";
+  name = "opaline-${version}";
+
+  src = fetchFromGitHub {
+    owner = "jaapb";
+    repo = "opaline";
+    rev = "v${version}";
+    sha256 = "0vd5xaf272hk4iqfj347jvbppy7my5p5gz8yqpkvl1d1i6lzh08v";
+  };
+
+  buildInputs = with ocamlPackages; [ ocaml findlib ocamlbuild opam-file-format ];
+
+  preInstall = "mkdir -p $out/bin";
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    description = "OPAm Light INstaller Engine";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocamlPackages.ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6873,6 +6873,8 @@ with pkgs;
     ocamlPackages = ocamlPackages_4_02;
   };
 
+  opaline = callPackage ../development/tools/ocaml/opaline { };
+
   opam = callPackage ../development/tools/ocaml/opam { };
 
   picat = callPackage ../development/compilers/picat {


### PR DESCRIPTION
Opaline is a lightweight replacement for opam-installer.

Homepage: https://github.com/jaapb/opaline

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

