### PR TITLE
dep2nix: init at 0.0.1

### DIFF
--- a/pkgs/development/tools/dep2nix/default.nix
+++ b/pkgs/development/tools/dep2nix/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, buildGoPackage
+, makeWrapper, nix-prefetch-git }:
+
+buildGoPackage rec {
+  name = "dep2nix-${version}";
+  version = "0.0.1";
+
+  goPackagePath = "github.com/nixcloud/dep2nix";
+
+  src = fetchFromGitHub {
+    owner = "nixcloud";
+    repo = "dep2nix";
+    rev = version;
+    sha256 = "05b06wgcy88fb5ccqwq3mfhrhcblr1akpxgsf44kgbdwf5nzz87g";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postFixup = ''
+    wrapProgram $bin/bin/dep2nix \
+      --prefix PATH : ${nix-prefetch-git}/bin
+  '';
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Convert `Gopkg.lock` files from golang dep into `deps.nix`";
+    license = licenses.bsd3;
+    homepage = https://github.com/nixcloud/dep2nix;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/tools/dep2nix/deps.nix
+++ b/pkgs/development/tools/dep2nix/deps.nix
@@ -1,0 +1,145 @@
+
+  # file automatically generated from Gopkg.lock with https://github.com/nixcloud/dep2nix (golang dep)
+  [
+  
+    {
+      goPackagePath  = "github.com/Masterminds/semver";
+      fetch = {
+        type = "git";
+        url = "https://github.com/Masterminds/semver";
+        rev =  "a93e51b5a57ef416dac8bb02d11407b6f55d8929";
+        sha256 = "1rd3p135r7iw0lvaa6vk7afxna87chq61a7a0wqnxd3xgpnpa9ik";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/Masterminds/vcs";
+      fetch = {
+        type = "git";
+        url = "https://github.com/Masterminds/vcs";
+        rev =  "6f1c6d150500e452704e9863f68c2559f58616bf";
+        sha256 = "02bpyzccazw9lwqchcz349al4vlxnz4m5gzwigk02zg2qpa1j53j";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/armon/go-radix";
+      fetch = {
+        type = "git";
+        url = "https://github.com/armon/go-radix";
+        rev =  "1fca145dffbcaa8fe914309b1ec0cfc67500fe61";
+        sha256 = "19jws9ngncpbhghzcy7biyb4r8jh14mzknyk67cvq6ln7kh1qyic";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/boltdb/bolt";
+      fetch = {
+        type = "git";
+        url = "https://github.com/boltdb/bolt";
+        rev =  "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8";
+        sha256 = "0z7j06lijfi4y30ggf2znak2zf2srv2m6c68ar712wd2ys44qb3r";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/golang/dep";
+      fetch = {
+        type = "git";
+        url = "https://github.com/CrushedPixel/dep";
+        rev =  "fa9f32339c8855ebe7e7bc66e549036a7e06d37a";
+        sha256 = "1knaxs1ji1b0b68393f24r8qzvahxz9x7rqwc8jsjlshvpz0hlm6";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/golang/protobuf";
+      fetch = {
+        type = "git";
+        url = "https://github.com/golang/protobuf";
+        rev =  "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175";
+        sha256 = "1pyli3dcagi7jzpiazph4fhkz7a3z4bhd25nwbb7g0iy69b8z1g4";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/jmank88/nuts";
+      fetch = {
+        type = "git";
+        url = "https://github.com/jmank88/nuts";
+        rev =  "8b28145dffc87104e66d074f62ea8080edfad7c8";
+        sha256 = "1d0xj1dj1lfalq3pg15h0c645n84lf122xx3zkm7hawq9zri6n5k";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/nightlyone/lockfile";
+      fetch = {
+        type = "git";
+        url = "https://github.com/nightlyone/lockfile";
+        rev =  "6a197d5ea61168f2ac821de2b7f011b250904900";
+        sha256 = "03znnf6rzyyi4h4qj81py1xpfs3pnfm39j4bfc9qzakz5j9y1gdl";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/pelletier/go-toml";
+      fetch = {
+        type = "git";
+        url = "https://github.com/pelletier/go-toml";
+        rev =  "acdc4509485b587f5e675510c4f2c63e90ff68a8";
+        sha256 = "1y5m9pngxhsfzcnxh8ma5nsllx74wn0jr47p2n6i3inrjqxr12xh";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/pkg/errors";
+      fetch = {
+        type = "git";
+        url = "https://github.com/pkg/errors";
+        rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+        sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+      };
+    }
+    
+    {
+      goPackagePath  = "github.com/sdboyer/constext";
+      fetch = {
+        type = "git";
+        url = "https://github.com/sdboyer/constext";
+        rev =  "836a144573533ea4da4e6929c235fd348aed1c80";
+        sha256 = "0055yw73di4spa1wwpa2pyb708wmh9r3xd8dcv8pn81dba94if1w";
+      };
+    }
+    
+    {
+      goPackagePath  = "golang.org/x/net";
+      fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/net";
+        rev =  "dc948dff8834a7fe1ca525f8d04e261c2b56e70d";
+        sha256 = "0gkw1am63agb1rgpxr2qhns9npr99mzwrxg7px88qq8h93zzd4kg";
+      };
+    }
+    
+    {
+      goPackagePath  = "golang.org/x/sync";
+      fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/sync";
+        rev =  "fd80eb99c8f653c847d294a001bdf2a3a6f768f5";
+        sha256 = "12lzldlj1cqc1babp1hkkn76fglzn5abkqvmbpr4f2j95mf9x836";
+      };
+    }
+    
+    {
+      goPackagePath  = "golang.org/x/sys";
+      fetch = {
+        type = "git";
+        url = "https://go.googlesource.com/sys";
+        rev =  "37707fdb30a5b38865cfb95e5aab41707daec7fd";
+        sha256 = "1abrr2507a737hdqv4q7pw7hv6ls9pdiq9crhdi52r3gcz6hvizg";
+      };
+    }
+    
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13869,6 +13869,8 @@ with pkgs;
 
   dep = callPackage ../development/tools/dep { };
 
+  dep2nix = callPackage ../development/tools/dep2nix { };
+
   easyjson = callPackage ../development/tools/easyjson { };
 
   go-bindata = callPackage ../development/tools/go-bindata { };


### PR DESCRIPTION
###### Motivation for this change

cc @qknight 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

