### PR TITLE
gnome2.gtksourceview: fix build on darwin

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -1,6 +1,6 @@
 {stdenv, fetchpatch, fetchurl, autoreconfHook, pkgconfig, atk, cairo, glib
 , gnome-common, gtk, pango
-, libxml2Python, perl, intltool, gettext, gtk-mac-integration }:
+, libxml2Python, perl, intltool, gettext, gtk-mac-integration-gtk2 }:
 
 with stdenv.lib;
 
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     pango libxml2Python perl intltool
     gettext
   ] ++ optionals stdenv.isDarwin [
-    autoreconfHook gnome-common gtk-mac-integration
+    autoreconfHook gnome-common gtk-mac-integration-gtk2
   ];
 
   preConfigure = optionalString stdenv.isDarwin ''


### PR DESCRIPTION
###### Motivation for this change

`gnome2.gtksourceview` currently fails to build on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

