### PR TITLE
pythonPackages.pykdtree: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/pykdtree/default.nix
+++ b/pkgs/development/python-modules/pykdtree/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage rec {
     sha256 = "79351b79087f473f83fb27a5cd552bd1056f2dfa7acec5d4a68f35a7cbea6776";
   };
 
+  preInstall = ''export USE_OMP=0'';
+
   propagatedBuildInputs = [ numpy ];
 
   checkInputs = [ nose ];

--- a/pkgs/development/python-modules/pykdtree/default.nix
+++ b/pkgs/development/python-modules/pykdtree/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, nose }:
+
+buildPythonPackage rec {
+  pname = "pykdtree";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "79351b79087f473f83fb27a5cd552bd1056f2dfa7acec5d4a68f35a7cbea6776";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  checkInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    description = "kd-tree implementation for fast nearest neighbour search in Python";
+    homepage = https://github.com/storpipfugl/pykdtree;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/development/python-modules/pykdtree/default.nix
+++ b/pkgs/development/python-modules/pykdtree/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, nose }:
+{ stdenv, buildPythonPackage, fetchPypi, numpy, nose, openmp }:
 
 buildPythonPackage rec {
   pname = "pykdtree";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "79351b79087f473f83fb27a5cd552bd1056f2dfa7acec5d4a68f35a7cbea6776";
   };
 
-  preInstall = ''export USE_OMP=0'';
+  buildInputs = [ openmp ];
 
   propagatedBuildInputs = [ numpy ];
 
@@ -22,4 +22,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ psyanticy ];
   };
 }
-

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -382,6 +382,8 @@ in {
     callPackage = pkgs.callPackage;
   };
 
+  pykdtree = callPackage ../development/python-modules/pykdtree { };
+
   pyparser = callPackage ../development/python-modules/pyparser { };
 
   pyqt4 = callPackage ../development/python-modules/pyqt/4.x.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -382,7 +382,9 @@ in {
     callPackage = pkgs.callPackage;
   };
 
-  pykdtree = callPackage ../development/python-modules/pykdtree { };
+  pykdtree = callPackage ../development/python-modules/pykdtree {
+    inherit (pkgs.llvmPackages) openmp;
+  };
 
   pyparser = callPackage ../development/python-modules/pyparser { };
 


### PR DESCRIPTION
###### Motivation for this change

pykdtree is a kd-tree implementation for fast nearest neighbour search in Python. The aim is to be the fastest implementation around for common use cases (low dimensions and low number of neighbours) for both tree construction and queries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

