### PR TITLE
linkchecker: use the default requests package

### DIFF
--- a/pkgs/tools/networking/linkchecker/default.nix
+++ b/pkgs/tools/networking/linkchecker/default.nix
@@ -1,19 +1,5 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, python2, gettext }:
-let
-  # pin requests version until next release.
-  # see: https://github.com/linkcheck/linkchecker/issues/76
-  python2Packages = (python2.override {
-    packageOverrides = self: super: {   
-      requests = super.requests.overridePythonAttrs(oldAttrs: rec {
-        version = "2.14.2";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0lyi82a0ijs1m7k9w1mqwbmq1qjsac35fazx7xqyh8ws76xanx52";
-        };
-      });
-    };
-  }).pkgs;
-in
+
 python2Packages.buildPythonApplication rec {
   pname = "LinkChecker";
   version = "9.3.1";


### PR DESCRIPTION
Fixes SSL issues.

###### Motivation for this change

Before this patch:
`linkchecker https://google.com` 

Fails with this error:
```
  File "/nix/store/zfs78yih9xm6s9p2n58flz3m0slnmfph-LinkChecker-9.3/lib/python2.7/site-packages/linkcheck/checker/httpurl.py", line 184, in _get_ssl_sock
    line: if raw_connection.sock is None:
    locals:
      raw_connection = <local> None
      raw_connection.sock = <local> !AttributeError: 'NoneType' object has no attribute 'sock'
      None = <builtin> None
AttributeError: 'NoneType' object has no attribute 'sock'
```
With the patch, it works as expected.


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

