### PR TITLE
at-spi2-atk, at-spi2-core, clutter-gtk, fribidi: updates, build with meson, adding updareScript

### DIFF
--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -1,14 +1,24 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig
-, at-spi2-core, atk, dbus, glib, libxml2 }:
+{ stdenv
+, fetchurl
+
+, meson
+, ninja
+, pkgconfig
+
+, at-spi2-core
+, atk
+, dbus
+, glib
+, libxml2
+}:
 
 stdenv.mkDerivation rec {
-  name = "${moduleName}-${versionMajor}.${versionMinor}";
-  moduleName   = "at-spi2-atk";
-  versionMajor = "2.26";
-  versionMinor = "2";
+  name = "${moduleName}-${version}";
+  moduleName = "at-spi2-atk";
+  version = "2.26.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${moduleName}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0vkan52ab9vrkknnv8y4f1cspk8x7xd10qx92xk9ys71p851z2b1";
   };
 
@@ -17,8 +27,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "D-Bus bridge for Assistive Technology Service Provider Interface (AT-SPI) and Accessibility Toolkit (ATK)";
-    homepage = "https://gitlab.gnome.org/GNOME/at-spi2-atk";
+    homepage = https://gitlab.gnome.org/GNOME/at-spi2-atk;
+    license = licenses.lgpl2Plus; # NOTE: 2018-06-06: Please check the license when upstream sorts-out licensing: https://gitlab.gnome.org/GNOME/at-spi2-atk/issues/2
+    maintainers = with maintainers; [ jtojnar gnome3.maintainers ];
     platforms = platforms.unix;
-
   };
 }

--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -1,25 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, meson, ninja, libxml2
-, python, popt, atk, libX11, libICE, xorg, libXi
-, intltool, dbus-glib, at-spi2-core, libSM }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig
+, at-spi2-core, atk, dbus, glib, libxml2 }:
 
 stdenv.mkDerivation rec {
-  versionMajor = "2.26";
-  versionMinor = "1";
-  moduleName   = "at-spi2-atk";
   name = "${moduleName}-${versionMajor}.${versionMinor}";
+  moduleName   = "at-spi2-atk";
+  versionMajor = "2.26";
+  versionMinor = "2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
-    sha256 = "0x9vc99ni46fg5dzlx67vbw0zqffr24gz8jvbdxbmzyvc5xw5w5l";
+    sha256 = "0vkan52ab9vrkknnv8y4f1cspk8x7xd10qx92xk9ys71p851z2b1";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig intltool ];
-  buildInputs = [ python popt atk libX11 libICE xorg.libXtst libXi
-                  dbus-glib at-spi2-core libSM libxml2 ];
-
-  doCheck = false; # needs dbus daemon
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [ at-spi2-core atk dbus glib libxml2 ];
 
   meta = with stdenv.lib; {
+    description = "D-Bus bridge for Assistive Technology Service Provider Interface (AT-SPI) and Accessibility Toolkit (ATK)";
+    homepage = "https://gitlab.gnome.org/GNOME/at-spi2-atk";
     platforms = platforms.unix;
+
   };
 }

--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -10,20 +10,28 @@
 , dbus
 , glib
 , libxml2
+
+, gnome3 # To pass updateScript
 }:
 
 stdenv.mkDerivation rec {
-  name = "${moduleName}-${version}";
-  moduleName = "at-spi2-atk";
+  name = "${pname}-${version}";
+  pname = "at-spi2-atk";
   version = "2.26.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${moduleName}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0vkan52ab9vrkknnv8y4f1cspk8x7xd10qx92xk9ys71p851z2b1";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];
   buildInputs = [ at-spi2-core atk dbus glib libxml2 ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "D-Bus bridge for Assistive Technology Service Provider Interface (AT-SPI) and Accessibility Toolkit (ATK)";

--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, python, pkgconfig, popt, atk, libX11, libICE, xorg, libXi
+{ stdenv, fetchurl, pkgconfig, meson, ninja, libxml2
+, python, popt, atk, libX11, libICE, xorg, libXi
 , intltool, dbus-glib, at-spi2-core, libSM }:
 
 stdenv.mkDerivation rec {
@@ -12,9 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0x9vc99ni46fg5dzlx67vbw0zqffr24gz8jvbdxbmzyvc5xw5w5l";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ meson ninja pkgconfig intltool ];
   buildInputs = [ python popt atk libX11 libICE xorg.libXtst libXi
-                  dbus-glib at-spi2-core libSM ];
+                  dbus-glib at-spi2-core libSM libxml2 ];
 
   doCheck = false; # needs dbus daemon
 

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, python, pkgconfig, popt, gettext, dbus-glib
+{ stdenv, fetchurl, pkgconfig, gettext, meson, ninja
+, python, popt, dbus-glib
 , libX11, xextproto, libSM, libICE, libXtst, libXi, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
@@ -14,14 +15,11 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig gettext gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
   buildInputs = [
     python popt dbus-glib
     libX11 xextproto libSM libICE libXtst libXi
   ];
-
-  # ToDo: on non-NixOS we create a symlink from there?
-  configureFlags = "--with-dbus-daemondir=/run/current-system/sw/bin/";
 
   doCheck = false; # needs dbus daemon
 

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -1,29 +1,38 @@
-{ stdenv, fetchurl, pkgconfig, gettext, meson, ninja
-, python, popt, dbus-glib
-, libX11, xextproto, libSM, libICE, libXtst, libXi, gobjectIntrospection }:
+{ stdenv
+, fetchurl
+
+, meson
+, ninja
+, pkgconfig
+, gobjectIntrospection
+
+, dbus
+, glib
+, libX11
+, libXtst # at-spi2-core can be build with custom option not to support X, but due to it is a aplication client-side library, GUI-less usage is a very rare case
+, libXi
+}:
 
 stdenv.mkDerivation rec {
-  versionMajor = "2.28";
-  versionMinor = "0";
+  name = "${moduleName}-${version}";
   moduleName   = "at-spi2-core";
-  name = "${moduleName}-${versionMajor}.${versionMinor}";
+  version = "2.28.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${moduleName}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "11qwdxxx4jm0zj04xydlwah41axiz276dckkiql3rr0wn5x4i8j2";
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext gobjectIntrospection ];
-  buildInputs = [
-    python popt dbus-glib
-    libX11 xextproto libSM libICE libXtst libXi
-  ];
-
-  doCheck = false; # needs dbus daemon
+  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
+  buildInputs = [ dbus glib libX11 libXtst libXi ];
 
   meta = with stdenv.lib; {
+    description = "Assistive Technology Service Provider Interface protocol definitions and daemon for D-Bus";
+    homepage = https://gitlab.gnome.org/GNOME/at-spi2-core;
+    license = licenses.lgpl2Plus; # NOTE: 2018-06-06: Please check the license when upstream sorts-out licensing: https://gitlab.gnome.org/GNOME/at-spi2-core/issues/2
+    maintainers = with maintainers; [ jtojnar gnome3.maintainers ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -9,17 +9,19 @@
 , dbus
 , glib
 , libX11
-, libXtst # at-spi2-core can be build with custom option not to support X, but due to it is a aplication client-side library, GUI-less usage is a very rare case
+, libXtst # at-spi2-core can be build without X support, but due it is a client-side library, GUI-less usage is a very rare case
 , libXi
+
+, gnome3 # To pass updateScript
 }:
 
 stdenv.mkDerivation rec {
-  name = "${moduleName}-${version}";
-  moduleName   = "at-spi2-core";
+  name = "${pname}-${version}";
+  pname = "at-spi2-core";
   version = "2.28.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${moduleName}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "11qwdxxx4jm0zj04xydlwah41axiz276dckkiql3rr0wn5x4i8j2";
   };
 
@@ -27,6 +29,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
   buildInputs = [ dbus glib libX11 libXtst libXi ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Assistive Technology Service Provider Interface protocol definitions and daemon for D-Bus";

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -3,14 +3,14 @@
 , libX11, xextproto, libSM, libICE, libXtst, libXi, gobjectIntrospection }:
 
 stdenv.mkDerivation rec {
-  versionMajor = "2.26";
-  versionMinor = "2";
+  versionMajor = "2.28";
+  versionMinor = "0";
   moduleName   = "at-spi2-core";
   name = "${moduleName}-${versionMajor}.${versionMinor}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${moduleName}/${versionMajor}/${name}.tar.xz";
-    sha256 = "0596ghkamkxgv08r4a1pdhm06qd5zzgcfqsv64038w9xbvghq3n8";
+    sha256 = "11qwdxxx4jm0zj04xydlwah41axiz276dckkiql3rr0wn5x4i8j2";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/clutter-gtk/default.nix
+++ b/pkgs/development/libraries/clutter-gtk/default.nix
@@ -1,8 +1,11 @@
-{ fetchurl, stdenv, pkgconfig, gobjectIntrospection, clutter, gtk3, gnome3 }:
+{ fetchurl, stdenv, pkgconfig, meson, ninja
+, gobjectIntrospection, clutter, gtk3, gnome3 }:
+
 let
   pname = "clutter-gtk";
   version = "1.8.4";
 in
+
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
@@ -12,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ clutter gtk3 ];
-  nativeBuildInputs = [ pkgconfig gobjectIntrospection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobjectIntrospection ];
 
   postBuild = "rm -rf $out/share/gtk-doc";
 

--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig }:
+{ stdenv
+, fetchurl
+
+, meson
+, ninja
+, pkgconfig
+}:
 
 stdenv.mkDerivation rec {
-  name = "fribidi-${version}";
-  version = "1.0.3";
+  name = "${pname}-${version}";
+  pname = "fribidi";
+  version = "1.0.4";
 
-  src = fetchFromGitHub {
-    owner = "fribidi";
-    repo = "fribidi";
-    rev = "v${version}";
-    sha256 = "02483nscxc695j9b92clcdf0xb7xkfjry09kqdkkhkzl3vdcj039";
+  # NOTE: 2018-06-06 v1.0.4: Only URL tarball has "Have pre-generated man pages: true", which works-around upstream usage of some rare ancient `c2man` fossil application.
+  src = fetchurl {
+    url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${name}.tar.bz2";
+    sha256 = "1gipy8fjyn6i4qrhima02x8xs493d21f22dijp88nk807razxgcl";
   };
 
-  # FIXME: Please build with Meson after https://github.com/fribidi/fribidi/issues/79 solved
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-
-  # Configure script checks for glib, but it is only used for tests.
+  nativeBuildInputs = [ meson ninja pkgconfig ];
 
   outputs = [ "out" "devdoc" ];
 

--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -2,15 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "fribidi-${version}";
-  version = "0.19.7";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "fribidi";
     repo = "fribidi";
-    rev = version;
-    sha256 = "10q5jfch5qzrj2w4fbkr086ank66plx8hp7ra9a01irj80pbk96d";
+    rev = "v${version}";
+    sha256 = "02483nscxc695j9b92clcdf0xb7xkfjry09kqdkkhkzl3vdcj039";
   };
 
+  # FIXME: Please build with Meson after https://github.com/fribidi/fribidi/issues/79 solved
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
   # Configure script checks for glib, but it is only used for tests.


### PR DESCRIPTION
Please, let's merge this progress.
I gathered information and would open new pull request on new work.

###### Motivation for this change

- [x] Number of projects support Meson builds.
  This would make Hydra rebuilds faster for this packages. 

- [x] Also doing version updates on these packages.

- [x] Light linting of this packages

- [x] Since  many of these packages are under GNOME umbrella - migrating them to use fresh GNOME GitLab.

### Packages
- [x] `at-spi2-atk` (GNOME)
  - [x] Meson build
  - [x] updateScript hook
- [x] `at-spi2-core` (GNOME)
  - [x] Meson build
  - [x] 2.26.2 -> 2.28.0
  - [x] updateScript hook
- [x] `clutter-gtk` (GNOME)
  - [x] Meson build
- [x] `fribidi`
  - [x] 0.19.7 -> 1.0.3
  - [x] Made bug report to fix meson build: https://github.com/fribidi/fribidi/issues/79
  - [x] Meson build (disabled documentation generation)
---
#### Notes on encountered bugs
- [ ] `gnome-logs` (GNOME)
  - [ ] Can not find `meson.build` with `fetchurl`
  - [ ] Upon migration on GitLab AND Meson:
  ```
  Running custom install script '/usr/bin/env python3 /build/source/meson_post_install.py'
  Failed to run install script '/usr/bin/env python3 /build/source/meson_post_install.py'
  FAILED: meson-install
  /nix/store/yshj6nmgf5zl9yyhw9qxdjkfmz0k1ijh-python3-3.6.5/bin/python3.6m /nix/store  /ayjq6cvqm0a3yd615ksv3va2a455vq5b-meson-0.46.1/bin/meson --internal install /build/source/build/meson-private/install.dat
  ninja: build stopped: subcommand failed.
  ```
- [ ] `gnome-nettool` (GNOME)
  - [ ] Meson build not seen stable release
- [ ] `grilo` (GNOME)
  - [ ] Can not find `meson.build` with `fetchurl`
  - [x] Made bugreport: https://gitlab.gnome.org/GNOME/grilo/issues/4
- [ ] `pango`
  - [ ] Can not find `meson.build` with `fetchurl`
- [ ] `gnome3.gtk`
  - [ ] Can not find `meson.build` with `fetchurl`

#### For later work
- [ ] `grilo-plugins` (GNOME)
- [ ] `hexchat`
- [ ] `intel-gpu-tools`
- [ ] `jsoncpp`
- [ ] `libdrm`
- [ ] `libmediaart` (GNOME)
- [ ] `mesa`
- [ ] `mpc`
- [ ] `orc`
- [ ] `rofi`
- [ ] `seahorse` (GNOME)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

