### PR TITLE
Add missing ios triples to bfd

### DIFF
--- a/pkgs/development/tools/misc/binutils/support-ios.patch
+++ b/pkgs/development/tools/misc/binutils/support-ios.patch
@@ -1,5 +1,5 @@
 diff --git a/bfd/config.bfd b/bfd/config.bfd
-index f04a993f06..3357022f35 100644
+index f04a993f06..1e24a9d030 100644
 --- a/bfd/config.bfd
 +++ b/bfd/config.bfd
 @@ -238,7 +238,7 @@ case "${targ}" in
@@ -20,8 +20,35 @@ index f04a993f06..3357022f35 100644
      targ_defvec=arm_mach_o_vec
      targ_selvecs="mach_o_le_vec mach_o_be_vec mach_o_fat_vec"
      targ_archs="$targ_archs bfd_i386_arch bfd_powerpc_arch bfd_rs6000_arch"
+@@ -678,7 +678,7 @@ case "${targ}" in
+   i[3-7]86-*-aix*)
+     targ_defvec=i386_coff_vec
+     ;;
+-  i[3-7]86-*-darwin* | i[3-7]86-*-macos10* | i[3-7]86-*-rhapsody*)
++  i[3-7]86-*-darwin* | i[3-7]86-*-ios* | i[3-7]86-*-macos10* | i[3-7]86-*-rhapsody*)
+     targ_defvec=i386_mach_o_vec
+     targ_selvecs="mach_o_le_vec mach_o_be_vec mach_o_fat_vec pef_vec pef_xlib_vec sym_vec"
+     targ64_selvecs=x86_64_mach_o_vec
+@@ -762,7 +762,7 @@ case "${targ}" in
+     targ_defvec=x86_64_elf64_cloudabi_vec
+     want64=true
+     ;;
+-  x86_64-*-darwin*)
++  x86_64-*-darwin* | x86_64-*-ios*)
+     targ_defvec=x86_64_mach_o_vec
+     targ_selvecs="i386_mach_o_vec mach_o_le_vec mach_o_be_vec mach_o_fat_vec pef_vec pef_xlib_vec sym_vec"
+     targ_archs="$targ_archs bfd_powerpc_arch bfd_rs6000_arch"
+@@ -1402,7 +1402,7 @@ case "${targ}" in
+     targ_selvecs="powerpc_elf32_le_vec powerpc_boot_vec"
+     targ64_selvecs="powerpc_elf64_vec powerpc_elf64_le_vec"
+     ;;
+-  powerpc-*-darwin* | powerpc-*-macos10* | powerpc-*-rhapsody*)
++  powerpc-*-darwin* | powerpc-*-ios* | powerpc-*-macos10* | powerpc-*-rhapsody*)
+     targ_defvec=mach_o_be_vec
+     targ_selvecs="mach_o_be_vec mach_o_le_vec mach_o_fat_vec pef_vec pef_xlib_vec sym_vec"
+     targ_archs="$targ_archs bfd_i386_arch"
 diff --git a/configure.ac b/configure.ac
-index aae94501e4..4b1121e0d1 100644
+index aae94501e4..2cceb4dad4 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -510,7 +510,7 @@ if test x$enable_libgomp = x ; then
@@ -33,9 +60,18 @@ index aae94501e4..4b1121e0d1 100644
  	;;
      nvptx*-*-*)
  	;;
-@@ -706,7 +706,7 @@ case "${target}" in
+@@ -700,13 +700,13 @@ esac
+ 
+ # Disable libffi for some systems.
+ case "${target}" in
+-  powerpc-*-darwin*)
++  powerpc-*-darwin* | powerpc-*-ios*)
      ;;
-   x86_64-*-darwin[[912]]*)
+-  i[[3456789]]86-*-darwin*)
++  i[[3456789]]86-*-darwin* | i[[3456789]]86-*-ios*)
+     ;;
+-  x86_64-*-darwin[[912]]*)
++  x86_64-*-darwin[[912]]* | x86_64-*-ios[[912]]*)
      ;;
 -  *-*-darwin*)
 +  *-*-darwin* | *-*-ios*)
@@ -60,7 +96,7 @@ index aae94501e4..4b1121e0d1 100644
  	# PR 46986
  	noconfigdirs="$noconfigdirs target-libgo"
  	;;
-@@ -916,11 +916,11 @@ esac
+@@ -916,27 +916,27 @@ esac
  case "${target}" in
    *-*-chorusos)
      ;;
@@ -74,7 +110,18 @@ index aae94501e4..4b1121e0d1 100644
      noconfigdirs="$noconfigdirs ld gas gdb gprof"
      noconfigdirs="$noconfigdirs sim target-rda"
      ;;
-@@ -936,7 +936,7 @@ case "${target}" in
+-  powerpc-*-darwin*)
++  powerpc-*-darwin* | powerpc-*-ios*)
+     noconfigdirs="$noconfigdirs ld gas gdb gprof"
+     noconfigdirs="$noconfigdirs sim target-rda"
+     ;;
+-  i[[3456789]]86-*-darwin*)
++  i[[3456789]]86-*-darwin* | i[[3456789]]86-*-ios*)
+     noconfigdirs="$noconfigdirs ld gprof"
+     noconfigdirs="$noconfigdirs sim target-rda"
+     ;;
+-  x86_64-*-darwin[[912]]*)
++  x86_64-*-darwin[[912]]* | x86_64-*-ios[[912]]*)
      noconfigdirs="$noconfigdirs ld gas gprof"
      noconfigdirs="$noconfigdirs sim target-rda"
      ;;
@@ -92,6 +139,15 @@ index aae94501e4..4b1121e0d1 100644
      host_makefile_frag="config/mh-darwin"
      ;;
    powerpc-*-aix*)
+@@ -1697,7 +1697,7 @@ ACX_ELF_TARGET_IFELSE([# ELF platforms build the lto-plugin always.
+   build_lto_plugin=yes
+ ],[if test x"$default_enable_lto" = x"yes" ; then
+     case $target in
+-      *-apple-darwin[[912]]* | *-cygwin* | *-mingw* | *djgpp*) ;;
++      *-apple-darwin[[912]]* | *-apple-ios[[912]]* | *-cygwin* | *-mingw* | *djgpp*) ;;
+       # On other non-ELF platforms, LTO has yet to be validated.
+       *) enable_lto=no ;;
+     esac
 @@ -1708,7 +1708,7 @@ ACX_ELF_TARGET_IFELSE([# ELF platforms build the lto-plugin always.
    # warn during gcc/ subconfigure; unless you're bootstrapping with
    # -flto it won't be needed until after installation anyway.


### PR DESCRIPTION
Using the [new triples](https://github.com/NixOS/nixpkgs/blob/master/lib/systems/examples.nix#L97) for iPhoneSimulator builds currently fails on `binutils`, that is

```
`nix-build --show-trace  -E '(import ./. { system = "x86_64-darwin"; crossSystem = { config = "x86_64-apple-ios"; useiOSPrebuilt = true; sdkVer = "10.2"; isiPhoneSimulator = true; }; }).hello'`
```
yields
```
checking linker --as-needed support... no
*** BFD does not support target x86_64-apple-ios.
*** Look in bfd/config.bfd for supported targets.
make[1]: *** [Makefile:2667: configure-bfd] Error 1
make[1]: Leaving directory '/private/tmp/nix-build-x86_64-apple-ios-binutils-2.30.drv-0/binutils-2.30'
make: *** [Makefile:878: all] Error 2
builder for '/nix/store/k7vqw9fw35917fb7yf3qkg1dh877s8lw-x86_64-apple-ios-binutils-2.30.drv' failed with exit code 2
```