### PR TITLE
make-wrapper.sh: Add --export flag

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -13,8 +13,9 @@ assertExecutable() {
 # ARGS:
 # --argv0 NAME      : set name of executed process to NAME
 #                     (otherwise it’s called …-wrapped)
-# --set   VAR VAL   : add VAR with value VAL to the executable’s environment
-# --unset VAR       : remove VAR from the environment
+# --set    VAR VAL  : add VAR with value VAL to the executable’s environment
+# --unset  VAR      : remove VAR from the environment
+# --export VAR      : export VAR
 # --run   COMMAND   : run command before the executable
 #                     The command can push extra flags to a magic list variable
 #                     extraFlagsArray, which are then added to the invocation
@@ -57,6 +58,10 @@ makeWrapper() {
             varName="${params[$((n + 1))]}"
             n=$((n + 1))
             echo "unset $varName" >> "$wrapper"
+        elif [[ "$p" == "--export" ]]; then
+            varName="${params[$((n+1))]}"
+            n=$((n + 1))
+            echo "export $varName" >> "$wrapper"
         elif [[ "$p" == "--run" ]]; then
             command="${params[$((n + 1))]}"
             n=$((n + 1))


### PR DESCRIPTION
###### Motivation for this change

Adds an `--export` flag to `make-wrapper.sh` to export previously unexported variables. This is important because the wrapped program is called using `exec`, so any unexported variables will not be visible to the wrapped program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
I'm having trouble testing this locally because it triggers a TON of rebuilds.
