### PR TITLE
pass-audit: init at 0.1

### DIFF
--- a/pkgs/tools/security/pass/extensions/audit.nix
+++ b/pkgs/tools/security/pass/extensions/audit.nix
@@ -1,0 +1,42 @@
+{ stdenv, pass, fetchFromGitHub, pythonPackages, makeWrapper }:
+
+let
+  pythonEnv = pythonPackages.python.withPackages (p: [ p.requests ]);
+
+in stdenv.mkDerivation rec {
+  name = "pass-audit-${version}";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "roddhjav";
+    repo = "pass-audit";
+    rev = "v${version}";
+    sha256 = "0v0db8bzpcaa7zqz17syn3c78mgvw4mpg8qg1gh5rmbjsjfxw6sm";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ pythonEnv ];
+
+  patchPhase = ''
+    sed -i -e "s|/usr/lib|$out/lib|" audit.bash
+    sed -i -e 's|$0|${pass}/bin/pass|' audit.bash
+  '';
+
+  dontBuild = true;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    wrapProgram $out/lib/password-store/extensions/audit.bash \
+      --prefix PATH : "${pythonEnv}/bin" \
+      --run "export PREFIX"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pass extension for auditing your password repository.";
+    homepage = https://github.com/roddhjav/pass-audit;
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/pass/extensions/default.nix
+++ b/pkgs/tools/security/pass/extensions/default.nix
@@ -3,6 +3,9 @@
 with pkgs;
 
 {
+  pass-audit = callPackage ./audit.nix {
+    pythonPackages = python3Packages;
+  };
   pass-import = callPackage ./import.nix {
     pythonPackages = python3Packages;
   };


### PR DESCRIPTION
###### Motivation for this change

Adds the `pass-audit` extension for `pass` password manager.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

