### PR TITLE
pass-import: fix environment bugs

### DIFF
--- a/pkgs/tools/security/pass/extensions/import.nix
+++ b/pkgs/tools/security/pass/extensions/import.nix
@@ -18,13 +18,18 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ pythonEnv ];
 
+  patchPhase = ''
+    sed -i -e 's|$0|${pass}/bin/pass|' import.bash
+  '';
+
   dontBuild = true;
 
   installFlags = [ "PREFIX=$(out)" ];
 
   postFixup = ''
     wrapProgram $out/lib/password-store/extensions/import.bash \
-      --prefix PATH : "${pythonEnv}/bin"
+      --prefix PATH : "${pythonEnv}/bin" \
+      --run "export PREFIX"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes #41323.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

