### PR TITLE
lib: bitAnd, bitOr, bitXor

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,10 +56,10 @@ let
       hasAttr head isAttrs isBool isInt isList isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail;
-    inherit (trivial) id const concat or and boolToString mergeAttrs
-      flip mapNullable inNixShell min max importJSON warn info
-      nixpkgsVersion version mod compare splitByAndCompare
-      functionArgs setFunctionArgs isFunction;
+    inherit (trivial) id const concat or and bitAnd bitOr bitXor
+      boolToString mergeAttrs flip mapNullable inNixShell min max
+      importJSON warn info nixpkgsVersion version mod compare
+      splitByAndCompare functionArgs setFunctionArgs isFunction;
 
     inherit (fixedPoints) fix fix' extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -45,6 +45,21 @@ runTests {
     expected = true;
   };
 
+  testBitAnd = {
+    expr = (bitAnd 3 10);
+    expected = 2;
+  };
+
+  testBitOr = {
+    expr = (bitOr 3 10);
+    expected = 11;
+  };
+
+  testBitXor = {
+    expr = (bitXor 3 10);
+    expected = 9;
+  };
+
 # STRINGS
 
   testConcatMapStrings = {


### PR DESCRIPTION
###### Motivation for this change

Add ```bitAnd```, ```bitOr```, ```bitXor``` recently introduced to Nix as builtins (https://github.com/NixOS/nix/pull/2157) with fallback version for old versions of Nix

Example use case https://github.com/NixOS/nixpkgs/issues/41251#issuecomment-393664755