### PR TITLE
nixos/programs.mosh: refactor

### DIFF
--- a/nixos/modules/programs/mosh.nix
+++ b/nixos/modules/programs/mosh.nix
@@ -16,10 +16,28 @@ in
       default = false;
       type = lib.types.bool;
     };
+    withUtempter = mkOption {
+      description = ''
+        Whether to enable libutempter for mosh.
+        This is required so that mosh can write to /var/run/utmp (which can be queried with `who` to display currently connected user sessions).
+        Note, this will add a guid wrapper for the group utmp!
+      '';
+      default = true;
+      type = lib.types.bool;
+    };
   };
 
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [ mosh ];
     networking.firewall.allowedUDPPortRanges = [ { from = 60000; to = 61000; } ];
+    security.wrappers = mkIf cfg.withUtempter {
+      utempter = {
+        source = "${pkgs.libutempter}/lib/utempter/utempter";
+        owner = "nobody";
+        group = "utmp";
+        setuid = false;
+        setgid = true;
+      };
+    };
   };
 }

--- a/pkgs/development/libraries/libutempter/default.nix
+++ b/pkgs/development/libraries/libutempter/default.nix
@@ -13,11 +13,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib ];
 
+  patches = [ ./exec_path.patch ];
+
   prePatch = ''
     substituteInPlace Makefile --replace 2711 0711
   '';
 
-  installFlags = [
+  makeFlags = [
     "libdir=\${out}/lib"
     "libexecdir=\${out}/lib"
     "includedir=\${out}/include"
@@ -26,6 +28,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files";
+    longDescription = ''
+      The bundled utempter binary must be able to run as a user belonging to group utmp.
+      On NixOS systems, this can be achieved by creating a setguid wrapper.
+    '';
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.msteen ];

--- a/pkgs/development/libraries/libutempter/exec_path.patch
+++ b/pkgs/development/libraries/libutempter/exec_path.patch
@@ -1,0 +1,25 @@
+diff -ur libutempter-1.1.6/iface.c libutempter-1.1.6.patched/iface.c
+--- libutempter-1.1.6/iface.c	2010-11-04 18:14:53.000000000 +0100
++++ libutempter-1.1.6.patched/iface.c	2018-06-06 15:09:11.417755549 +0200
+@@ -60,9 +60,9 @@
+ 		_exit(EXIT_FAILURE);
+ 	}
+ 
+-	execv(path, argv);
++	execvp(path, argv);
+ #ifdef	UTEMPTER_DEBUG
+-	fprintf(stderr, "libutempter: execv: %s\n", strerror(errno));
++	fprintf(stderr, "libutempter: execvp: %s\n", strerror(errno));
+ #endif
+ 
+ 	while (EACCES == errno)
+@@ -79,7 +79,7 @@
+ 		if (setgid(sgid))
+ 			break;
+ 
+-		(void) execv(path, argv);
++		(void) execvp(path, argv);
+ 		break;
+ 	}
+ 
+Only in libutempter-1.1.6.patched: result

--- a/pkgs/tools/networking/mosh/default.nix
+++ b/pkgs/tools/networking/mosh/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig, IOTty
-, makeWrapper, perl, openssl, autoreconfHook, openssh, bash-completion }:
+{ lib, stdenv, fetchurl, zlib, protobuf, ncurses, pkgconfig, IOTty
+, makeWrapper, perl, openssl, autoreconfHook, openssh, bash-completion
+, libutempter ? null, withUtempter ? stdenv.isLinux }:
 
 stdenv.mkDerivation rec {
   name = "mosh-1.3.2";
@@ -10,15 +11,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ protobuf ncurses zlib IOTty makeWrapper perl openssl bash-completion ];
+  buildInputs = [ protobuf ncurses zlib IOTty makeWrapper perl openssl bash-completion ] ++ lib.optional withUtempter libutempter;
 
-  patches = [ ./ssh_path.patch ];
+  patches = [ ./ssh_path.patch ./utempter_path.patch ];
   postPatch = ''
     substituteInPlace scripts/mosh.pl \
         --subst-var-by ssh "${openssh}/bin/ssh"
   '';
 
-  configureFlags = [ "--enable-completion" ];
+  configureFlags = [ "--enable-completion" ] ++ lib.optional withUtempter "--with-utempter";
 
   postInstall = ''
       wrapProgram $out/bin/mosh --prefix PERL5LIB : $PERL5LIB

--- a/pkgs/tools/networking/mosh/utempter_path.patch
+++ b/pkgs/tools/networking/mosh/utempter_path.patch
@@ -1,0 +1,14 @@
+diff -ur mosh-1.3.2/src/frontend/mosh-server.cc mosh-1.3.2.patched/src/frontend/mosh-server.cc
+--- mosh-1.3.2/src/frontend/mosh-server.cc	2017-07-22 23:14:53.000000000 +0200
++++ mosh-1.3.2.patched/src/frontend/mosh-server.cc	2018-06-06 10:45:50.725352804 +0200
+@@ -351,6 +351,10 @@
+     }
+   }
+ 
++#ifdef HAVE_UTEMPTER
++    utempter_set_helper( "utempter" );
++#endif
++
+   try {
+     return run_server( desired_ip, desired_port, command_path, command_argv, colors, verbose, with_motd );
+   } catch ( const Network::NetworkException &e ) {


### PR DESCRIPTION
Adds programs.mosh.withUtempter (default: true).

###### Motivation for this change

The option enables --with-utempter for mosh, allowing it to write to
/var/run/utmp and thus making connected sessions appear in the output
of `who -a`.

###### Things done

For that, a guid-wrapper is required. Also, the path to the `utempter` was
hardcoded in the resulting binary until now (so it could never been found),
thus, libutempter was patched accordingly to point to
/run/wrappers/bin/utempter which at least works when the wrapper is
configured.

I wrote it this way so that installing the package `mosh` by itself still is compiled without utempter as usually a user just installing the mosh package most likely just wants to use the client and will not have the wrapper installed.

In any case: compiling against utempter without having the wrapper in place has no negative consequences. /var/run/utmp will not be written, but mosh continues working.


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

