### PR TITLE
ctags: fix source url

### DIFF
--- a/pkgs/development/tools/misc/ctags/default.nix
+++ b/pkgs/development/tools/misc/ctags/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchsvn, autoreconfHook }:
+{ stdenv, fetchurl, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "ctags-${revision}";
-  revision = "816";
+  name = "ctags-${version}";
+  version = "5.8";
 
-  src = fetchsvn {
-    url = "https://ctags.svn.sourceforge.net/svnroot/ctags/trunk";
-    rev = revision;
-    sha256 = "0jmbkrmscbl64j71qffcc39x005jrmphx8kirs1g2ws44wil39hf";
+  src = fetchurl {
+    url = "mirror://sourceforge/ctags/ctags-${version}.tar.gz";
+    sha256 = "1iwrkrpdcmzbjmrv6b8169fvw6pq8v1307mipc5rx5myr9fv8i0f";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  # don't use $T(E)MP which is set to the build directory
-  configureFlags= [ "--enable-tmpdir=/tmp" ];
+  # lregex.c:411:4: error: format not a string literal and no format arguments [-Werror=format-security]
+  hardeningDisable = [ "format" ];
 
   meta = with stdenv.lib; {
     description = "A tool for fast source code browsing (exuberant ctags)";

--- a/pkgs/development/tools/misc/ctags/default.nix
+++ b/pkgs/development/tools/misc/ctags/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchurl, autoreconfHook }:
+{ stdenv, fetchsvn, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "ctags-${version}";
-  version = "5.8";
+  name = "ctags-${revision}";
+  revision = "816";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/ctags/ctags-${version}.tar.gz";
-    sha256 = "1iwrkrpdcmzbjmrv6b8169fvw6pq8v1307mipc5rx5myr9fv8i0f";
+  src = fetchsvn {
+    url = https://svn.code.sf.net/p/ctags/code/trunk;
+    rev = revision;
+    sha256 = "0jmbkrmscbl64j71qffcc39x005jrmphx8kirs1g2ws44wil39hf";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  # lregex.c:411:4: error: format not a string literal and no format arguments [-Werror=format-security]
-  hardeningDisable = [ "format" ];
+  # don't use $T(E)MP which is set to the build directory
+  configureFlags= [ "--enable-tmpdir=/tmp" ];
 
   meta = with stdenv.lib; {
     description = "A tool for fast source code browsing (exuberant ctags)";


### PR DESCRIPTION
The upstream SVN appears to no longer exist:
```
svn: E170013: Unable to connect to a repository at URL 'https://ctags.svn.sourceforge.net/svnroot/ctags/trunk'
svn: E160013: '/svnroot/ctags/trunk' path not found
```

The download homepage just references the sourceforge download:
http://ctags.sourceforge.net/
which is version 5.8.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

