### PR TITLE
altcoins.aeon: 0.9.14.0 -> 0.12.0.0

### DIFF
--- a/pkgs/applications/altcoins/aeon/default.nix
+++ b/pkgs/applications/altcoins/aeon/default.nix
@@ -1,7 +1,10 @@
-{ stdenv, fetchFromGitHub, cmake, boost, miniupnpc, openssl, pkgconfig, unbound }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, git, doxygen, graphviz
+, boost, miniupnpc, openssl, unbound, cppzmq
+, zeromq, pcsclite, readline
+}:
 
 let
-  version = "0.9.14.0";
+  version = "0.12.0.0";
 in
 stdenv.mkDerivation {
   name = "aeon-${version}";
@@ -10,19 +13,24 @@ stdenv.mkDerivation {
     owner = "aeonix";
     repo = "aeon";
     rev = "v${version}";
-    sha256 = "0pl9nfhihj0wsdgvvpv5f14k4m2ikk8s3xw6nd8ymbnpxfzyxynr";
+    fetchSubmodules = true;
+    sha256 = "1schzlscslhqq7zcd68b1smqlaf7k789x1rwpplm7qi5iz9a8cfr";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig git doxygen graphviz ];
 
-  buildInputs = [ boost miniupnpc openssl unbound ];
+  buildInputs = [
+    boost miniupnpc openssl unbound
+    cppzmq zeromq pcsclite readline
+  ];
 
-  installPhase = ''
-    install -D src/aeond "$out/bin/aeond"
-    install src/simpleminer "$out/bin/aeon-simpleminer"
-    install src/simplewallet "$out/bin/aeon-simplewallet"
-    install src/connectivity_tool "$out/bin/aeon-connectivity-tool"
-  '';
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_GUI_DEPS=ON"
+    "-DReadline_ROOT_DIR=${readline.dev}"
+  ];
+
+  hardeningDisable = [ "fortify" ];
 
   meta = with stdenv.lib; {
     description = "Private, secure, untraceable currency";


### PR DESCRIPTION
Aeon was rebased onto a recent version of monero, so
aeon/default.nix now more closely matches monero/default.nix.

###### Motivation for this change

Upcoming hardfork (PoW change)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

