### PR TITLE
libevent: Pull in patches to support LibreSSL 2.7.

### DIFF
--- a/pkgs/development/libraries/libevent/default.nix
+++ b/pkgs/development/libraries/libevent/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, findutils, fixDarwinDylibNames
+{ stdenv, fetchurl, fetchpatch, findutils, fixDarwinDylibNames
 , sslSupport? true, openssl
 }:
 
@@ -12,6 +12,18 @@ stdenv.mkDerivation rec {
     url = "https://github.com/libevent/libevent/releases/download/release-${version}-stable/libevent-${version}-stable.tar.gz";
     sha256 = "1hhxnxlr0fsdv7bdmzsnhdz16fxf3jg2r6vyljcl3kj6pflcap4n";
   };
+
+  #NOTE: Patches to support libressl-2.7. These are taken from libevent upstream, and can both be dropped with the next release.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/libevent/libevent/commit/22dd14945c25600de3cf8b91000c66703b551e4f.patch";
+      sha256 = "0lbr3723chycslk1vbb7rkppwckqkcbvvl0xgh31nki612dl9xsk";
+    })
+    (fetchpatch {
+      url = "https://github.com/libevent/libevent/commit/28b8075400c70b2d2da2ce07e590c2ec6d11783d.patch";
+      sha256 = "0as1vkqwpxs4rjimgv8ap7gvljkizdh0ayl0wrq80zpfzvnrb6db";
+    })
+  ];
 
   # libevent_openssl is moved into its own output, so that openssl isn't present
   # in the default closure.


### PR DESCRIPTION
###### Motivation for this change
The current release of `libevent` does not support `libressl-2.7`. However, upstream master does have patches to support it. These are cherry-picked here.

This triggers a huge rebuild; my system seems to work perfectly since.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

