### PR TITLE
bulletml: fix build failure due to -Wformat-security

### DIFF
--- a/pkgs/development/libraries/bulletml/default.nix
+++ b/pkgs/development/libraries/bulletml/default.nix
@@ -38,6 +38,7 @@ in stdenv.mkDerivation {
     "-C src"
   ];
   nativeBuildInputs = [ bison perl ];
+  hardeningDisable = [ "format" ];
 
   installPhase = ''
     install -D -m 644 src/bulletml.d "$out"/include/d/bulletml.d


### PR DESCRIPTION
###### Motivation for this change

Some files are built with -Wno-format, which is not compatible with the
default hardening setting of -Wformat-security in Nixpkgs.

I forgot to rebuild after rebase in the last pr, so bulletml got merged in a broken state.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

