### PR TITLE
libarchive: pull in patch to support LibresSSL-2.7.

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -1,5 +1,5 @@
 {
-  fetchurl, stdenv, pkgconfig,
+  fetchurl, fetchpatch, stdenv, pkgconfig,
   acl, attr, bzip2, e2fsprogs, libxml2, lzo, openssl, sharutils, xz, zlib,
 
   # Optional but increases closure only negligibly.
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
   patches = [
     ./CVE-2017-14166.patch
     ./CVE-2017-14502.patch
+
+    # LibreSSL patch; this is from upstream, and can be removed when the next release is made.
+    (fetchpatch {
+      url = "https://github.com/libarchive/libarchive/commit/5da00ad75b09e262774ec3675bbe4d5a4502a852.patch";
+      sha256 = "1r5n09dqhs5f8jx4iyqy06f0ryrxnbz60ww9aiww0j4gp5fs77qk";
+    })
   ];
 
   outputs = [ "out" "lib" "dev" ];


### PR DESCRIPTION
###### Motivation for this change
The current release of `libarchive` does not support `libressl-2.7`. This patch from upstream adds support.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

