### PR TITLE
nixos/autosuggestions: add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -127,6 +127,7 @@
   ./programs/zsh/oh-my-zsh.nix
   ./programs/zsh/zsh.nix
   ./programs/zsh/zsh-autoenv.nix
+  ./programs/zsh/zsh-autosuggestions.nix
   ./programs/zsh/zsh-syntax-highlighting.nix
   ./rename.nix
   ./security/acme.nix

--- a/nixos/modules/programs/zsh/zsh-autosuggestions.nix
+++ b/nixos/modules/programs/zsh/zsh-autosuggestions.nix
@@ -1,0 +1,60 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.zsh.autosuggestions;
+in
+{
+  options.programs.zsh.autosuggestions = {
+
+    enable = mkEnableOption "zsh-autosuggestions";
+
+    highlightStyle = mkOption {
+      type = types.str;
+      default = "fg=8"; # https://github.com/zsh-users/zsh-autosuggestions/tree/v0.4.3#suggestion-highlight-style
+      description = "Highlight style for suggestions ({fore,back}ground color)";
+      example = "fg=cyan";
+    };
+
+    strategy = mkOption {
+      type = types.enum [ "default" "match_prev_cmd" ];
+      default = "default";
+      description = ''
+        Set ZSH_AUTOSUGGEST_STRATEGY to choose the strategy for generating suggestions.
+        There are currently two to choose from:
+
+          * default: Chooses the most recent match.
+          * match_prev_cmd: Chooses the most recent match whose preceding history item matches
+            the most recently executed command (more info). Note that this strategy won't work as
+            expected with ZSH options that don't preserve the history order such as
+            HIST_IGNORE_ALL_DUPS or HIST_EXPIRE_DUPS_FIRST.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = with types; attrsOf str;
+      default = {};
+      description = "Attribute set with additional configuration values";
+      example = literalExample ''
+        {
+          "ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" = "20";
+        }
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    programs.zsh.interactiveShellInit = ''
+      source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+      export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="${cfg.highlightStyle}"
+      export ZSH_AUTOSUGGEST_STRATEGY="${cfg.strategy}"
+
+      ${concatStringsSep "\n" (mapAttrsToList (key: value: ''export ${key}="${value}"'') cfg.extraConfig)}
+    '';
+
+  };
+}

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -87,13 +87,6 @@ in
         type = types.bool;
       };
 
-      enableAutosuggestions = mkOption {
-        default = false;
-        description = ''
-          Enable zsh-autosuggestions
-        '';
-        type = types.bool;
-      };
     };
 
   };
@@ -167,10 +160,6 @@ in
         done
 
         ${optionalString cfg.enableCompletion "autoload -U compinit && compinit"}
-
-        ${optionalString (cfg.enableAutosuggestions)
-          "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-        }
 
         ${cfge.interactiveShellInit}
 

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -247,6 +247,8 @@ with lib;
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "custom" ] [ "programs" "zsh" "ohMyZsh" "custom" ])
     (mkRenamedOptionModule [ "programs" "zsh" "oh-my-zsh" "plugins" ] [ "programs" "zsh" "ohMyZsh" "plugins" ])
 
+    (mkRenamedOptionModule [ "programs" "zsh" "enableAutosuggestions" ] [ "programs" "zsh" "autosuggestions" "enable" ])
+
     # Xen
     (mkRenamedOptionModule [ "virtualisation" "xen" "qemu-package" ] [ "virtualisation" "xen" "package-qemu" ])
 


### PR DESCRIPTION
###### Motivation for this change

The `zsh-autosuggestions` package provides several configuration options
such as a different highlight style (like `fg=cyan` which is easier to
read).

With `rename.nix` the old `programs.zsh.enableAutosuggestions` is still
functional, but yields the following warning like this during evaluation:

```
trace: warning: The option `programs.zsh.enableAutosuggestions' defined in `<unknown-file>' has been renamed to `programs.zsh.autosuggestions.enable'.
```

The module provides the most common `zsh-autosuggestions` (highlight
style and strategy) as options that will be written into the interactive
shell init (`/etc/zshrc` by default). Further configuration options can
be declared using the `extraConfig` attr set:

```
{
  programs.zsh.autosuggestions.extraConfig = {
    "ZSH_AUTOSUGGEST_BUFFER_MAX_SIZE" = "buffer_size";
  };
}
```

A full list of available configuration options for `zsh-autosuggestions`
can be viewed here: https://github.com/zsh-users/zsh-autosuggestions/blob/v0.4.3/README.md


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

