### PR TITLE
synapse-bt: init at 2018-06-04

### DIFF
--- a/pkgs/applications/networking/p2p/synapse-bt/default.nix
+++ b/pkgs/applications/networking/p2p/synapse-bt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl }:
+
+rustPlatform.buildRustPackage rec {
+  name = "synapse-bt-unstable-${version}";
+  version = "2018-06-04";
+
+  src = fetchFromGitHub {
+    owner = "Luminarys";
+    repo = "synapse";
+    rev = "ec8f23a14af21426ab0c4f8953dd954f747850ab";
+    sha256 = "0d1rrwnk333zz9g8s40i75xgdkpz6a1j01ajsh32yvzvbi045zkw";
+  };
+
+  cargoSha256 = "1psrmgf6ddzqwx7gf301rx84asfnvxpsvkx2fan453v65819k960";
+
+  buildInputs = [ pkgconfig openssl ];
+
+  cargoBuildFlags = [ "--all" ];
+
+  meta = with stdenv.lib; {
+    description = "Flexible and fast BitTorrent daemon";
+    homepage = https://synapse-bt.org/;
+    license = licenses.isc;
+    maintainers = with maintainers; [ dywedir ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17116,6 +17116,8 @@ with pkgs;
     inherit (gnome3) libgee;
   };
 
+  synapse-bt = callPackage ../applications/networking/p2p/synapse-bt { };
+
   synfigstudio = callPackage ../applications/graphics/synfigstudio {
     fontsConf = makeFontsConf { fontDirectories = [ freefont_ttf ]; };
     inherit (gnome3) defaultIconTheme;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

