### PR TITLE
Bumping dhall

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -483,8 +483,8 @@ default-package-overrides:
   - deque ==0.2.1
   - deriving-compat ==0.4.2
   - descriptive ==0.9.4
-  - dhall ==1.11.1
-  - dhall-json ==1.0.13
+  - dhall ==1.14.0
+  - dhall-json ==1.2.0
   - dice ==0.1
   - dictionaries ==0.2.0.4
   - Diff ==0.3.4


### PR DESCRIPTION
###### Motivation for this change

There's a new feature in dhall-json that permits a wide variety of use cases (see https://github.com/dhall-lang/dhall-json/issues/27 )

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm unsure how to test this, but I'm willing to do the work. I was unable to find consistent documentation other than some references to "Hydra just builds things automatically".