### PR TITLE
imagemagick: depend on fftw for fft feature

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -101,5 +101,6 @@ stdenv.mkDerivation rec {
     description = "A software suite to create, edit, compose, or convert bitmap images";
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ the-kenny wkennington ];
+    license = licenses.asl20;
   };
 }

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, pkgconfig, libtool
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg
-, lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp
+, lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp, fftw
 , ApplicationServices
 , buildPlatform, hostPlatform
 }:
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin ApplicationServices;
 
   propagatedBuildInputs =
-    [ bzip2 freetype libjpeg lcms2 ]
+    [ bzip2 freetype libjpeg lcms2 fftw ]
     ++ lib.optionals (!hostPlatform.isMinGW)
       [ libX11 libXext libXt libwebp ]
     ;


### PR DESCRIPTION
###### Motivation for this change

Be able to use the [`-fft`](https://www.imagemagick.org/Usage/fourier) feature of Imagemagick.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

