### PR TITLE
Fix GHCJS 8.4/8.2 in sandboxed builds

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
+++ b/pkgs/development/compilers/ghcjs-ng/configured-ghcjs-src.nix
@@ -6,6 +6,8 @@
 , cabal-install
 , gmp
 , runCommand
+, lib
+, stdenv
 
 , ghc
 , happy
@@ -20,15 +22,18 @@ runCommand "configured-ghcjs-src" {
     autoconf
     automake
     python3
-    gcc
     ghc
     happy
     alex
     cabal-install
+  ] ++ lib.optionals stdenv.isDarwin [
+    gcc # https://github.com/ghcjs/ghcjs/issues/663
   ];
   inherit ghcjsSrc;
 } ''
   export HOME=$(pwd)
+  mkdir $HOME/.cabal
+  touch $HOME/.cabal/config
   cp -r "$ghcjsSrc" "$out"
   chmod -R +w "$out"
   cd "$out"

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -50,13 +50,10 @@ let
   };
 
   bootGhcjs = haskellLib.justStaticExecutables passthru.bootPkgs.ghcjs;
-  libexec =
-    if builtins.compareVersions bootGhcjs.version "8.3" <= 0
-      then "${bootGhcjs}/bin"
-      else "${bootGhcjs}/libexec/${builtins.replaceStrings ["darwin"] ["osx"] stdenv.system}-${passthru.bootPkgs.ghc.name}/${bootGhcjs.name}";
+  libexec = "${bootGhcjs}/libexec/${builtins.replaceStrings ["darwin"] ["osx"] stdenv.system}-${passthru.bootPkgs.ghc.name}/${bootGhcjs.name}";
 
 in stdenv.mkDerivation {
-    name = "ghcjs";
+    name = bootGhcjs.name;
     src = passthru.configuredSrc;
     nativeBuildInputs = [
       bootGhcjs
@@ -73,6 +70,8 @@ in stdenv.mkDerivation {
     phases = ["unpackPhase" "buildPhase"];
     buildPhase = ''
       export HOME=$TMP
+      mkdir $HOME/.cabal
+      touch $HOME/.cabal/config
       cd lib/boot
 
       mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

`cabal` previously tried to contact hackage.haskell.org, which it definitely does not need to do. Instead we create a nearly empty `.cabal/config` file.

As a side benefit, we also get to fix cabal looking for `gcc` when it should be using `$CC`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
