### PR TITLE
Update python-dateutil 2.6.1 -> 2.7.3

### DIFF
--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [ six setuptools_scm ];
 
   meta = with stdenv.lib; {
     description = "Powerful extensions to the standard datetime module";

--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, six }:
+{ stdenv, buildPythonPackage, fetchPypi, six, setuptools_scm }:
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "python-dateutil";

--- a/pkgs/development/python-modules/dateutil/default.nix
+++ b/pkgs/development/python-modules/dateutil/default.nix
@@ -2,11 +2,11 @@
 buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "python-dateutil";
-  version = "2.6.1";
+  version = "2.7.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1jkahssf0ir5ssxc3ydbp8cpv77limn8d4s77szb2nrgl2r3h749";
+    sha256 = "e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8";
   };
 
   propagatedBuildInputs = [ six ];


### PR DESCRIPTION
###### Motivation for this change
Various bugfixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

