### PR TITLE
rpcs3: 0.0.4-8032 -> 0.0.5-6980

### DIFF
--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -1,22 +1,31 @@
-{ stdenv, lib, fetchgit, cmake, pkgconfig, git
-, qt5, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python27
-, pulseaudioSupport ? true, libpulseaudio
-, waylandSupport ? true, wayland
-, alsaSupport ? true, alsaLib
-}:
-
-stdenv.mkDerivation rec {
-  name = "rpcs3-${version}";
-  version = "0.0.5-6938";
-
-  src = fetchgit {
-    url = "https://github.com/RPCS3/rpcs3";
-    rev = "4db0cf005bbd030dc001b41e480a739db77db601";
-    sha256 = "1hcafhlz6y1hkbfklszf4hbdiciwgswkwwdpw9j3kvyvgs2bwhfl";
-    branchName = "master";  # Prevent default 'fetchgit' branch from appearing in version info
-    deepClone = true;       # Required for git describe to return commit count in version info
-    leaveDotGit = true;     # Required for version header file generation
-  };
+{ stdenv, lib, fetchgit, cmake, pkgconfig, git                                                                      
+, qt5, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python27                                              
+, pulseaudioSupport ? true, libpulseaudio                                                                           
+, waylandSupport ? true, wayland                                                                                    
+, alsaSupport ? true, alsaLib                                                                                       
+}:                                                                                                                  
+                                                                                                                    
+let                                                                                                                 
+  majorVersion = "0.0.5";                                                                                           
+  gitVersion = "6980-81e5f3b7f"; # echo $(git rev-list HEAD --count)-$(git rev-parse --short HEAD)                  
+in                                                                                                                  
+stdenv.mkDerivation rec {                                                                                           
+  name = "rpcs3-${version}";                                                                                        
+  version = "${majorVersion}-${gitVersion}";                                                                        
+                                                                                                                    
+  src = fetchgit {                                                                                                  
+    url = "https://github.com/RPCS3/rpcs3";                                                                         
+    rev = "81e5f3b7f299942f56bcfdde54edd09c722b32d8";                                                               
+    sha256 = "0czj6ga1nccqgcvi58sjnv1cc4k7qvwijp4warml463hpsmbd9r0";                                                
+  };                                                                                                                
+                                                                                                                    
+  preConfigure = ''                                                                                                 
+    cat > ./rpcs3/git-version.h <<EOF                                                                               
+    #define RPCS3_GIT_VERSION "${gitVersion}"                                                                       
+    #define RPCS3_GIT_BRANCH "HEAD"                                                                                 
+    #define RPCS3_GIT_VERSION_NO_UPDATE 1                                                                           
+    EOF
+  '';
 
   cmakeFlags = [
     "-DUSE_SYSTEM_LIBPNG=ON"

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchgit, cmake, pkgconfig
-, qtbase, openal, glew, llvm_4, vulkan-loader, libpng, ffmpeg, libevdev
+{ stdenv, lib, fetchgit, cmake, pkgconfig, git
+, qt5, openal, glew, vulkan-loader, libpng, ffmpeg, libevdev, python27
 , pulseaudioSupport ? true, libpulseaudio
 , waylandSupport ? true, wayland
 , alsaSupport ? true, alsaLib
@@ -7,12 +7,15 @@
 
 stdenv.mkDerivation rec {
   name = "rpcs3-${version}";
-  version = "2018-02-23";
+  version = "0.0.5-6884";
 
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
-    rev = "41bd07274f15b8f1be2475d73c3c75ada913dabb";
-    sha256 = "1v28m64ahakzj4jzjkmdd7y8q75pn9wjs03vprbnl0z6wqavqn0x";
+    rev = "dcd7f442fac3b9b45ecaddf5460ecb8f7238df2e";
+    sha256 = "0fqdwd6lr5yb4lffmvw4abhdfr70bl4jfdc95cmpc0zzdld0lb0a";
+    branchName = "master";  # Prevent default 'fetchgit' branch from appearing in version info
+    deepClone = true;       # Required for git describe to return commit count in version info
+    leaveDotGit = true;     # Required for version header file generation
   };
 
   cmakeFlags = [
@@ -21,10 +24,10 @@ stdenv.mkDerivation rec {
     "-DUSE_NATIVE_INSTRUCTIONS=OFF"
   ];
 
-  nativeBuildInputs = [ cmake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig git ];
 
   buildInputs = [
-    qtbase openal glew llvm_4 vulkan-loader libpng ffmpeg libevdev
+    qt5.qtbase qt5.qtquickcontrols openal glew vulkan-loader libpng ffmpeg libevdev python27
   ] ++ lib.optional pulseaudioSupport libpulseaudio
     ++ lib.optional alsaSupport alsaLib
     ++ lib.optional waylandSupport wayland;
@@ -34,7 +37,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "PS3 emulator/debugger";
     homepage = "https://rpcs3.net/";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar nocent ];
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   name = "rpcs3-${version}";
-  version = "0.0.5-6925";
+  version = "0.0.5-6938";
 
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
-    rev = "db9a6113d7155eb14cb2770bbd6af46b26797fd9";
-    sha256 = "0jyj9z1x44vi86gabmryigggbsmm0vfvivw4krppxxqiirgr8bli";
+    rev = "4db0cf005bbd030dc001b41e480a739db77db601";
+    sha256 = "1hcafhlz6y1hkbfklszf4hbdiciwgswkwwdpw9j3kvyvgs2bwhfl";
     branchName = "master";  # Prevent default 'fetchgit' branch from appearing in version info
     deepClone = true;       # Required for git describe to return commit count in version info
     leaveDotGit = true;     # Required for version header file generation

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -7,12 +7,12 @@
 
 stdenv.mkDerivation rec {
   name = "rpcs3-${version}";
-  version = "0.0.5-6884";
+  version = "0.0.5-6925";
 
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
-    rev = "dcd7f442fac3b9b45ecaddf5460ecb8f7238df2e";
-    sha256 = "1zjkv7vj110r19vjwhnzqz9l92cv00z02vkwi2fhi26m7avbhr3y";
+    rev = "db9a6113d7155eb14cb2770bbd6af46b26797fd9";
+    sha256 = "0jyj9z1x44vi86gabmryigggbsmm0vfvivw4krppxxqiirgr8bli";
     branchName = "master";  # Prevent default 'fetchgit' branch from appearing in version info
     deepClone = true;       # Required for git describe to return commit count in version info
     leaveDotGit = true;     # Required for version header file generation

--- a/pkgs/misc/emulators/rpcs3/default.nix
+++ b/pkgs/misc/emulators/rpcs3/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://github.com/RPCS3/rpcs3";
     rev = "dcd7f442fac3b9b45ecaddf5460ecb8f7238df2e";
-    sha256 = "0fqdwd6lr5yb4lffmvw4abhdfr70bl4jfdc95cmpc0zzdld0lb0a";
+    sha256 = "1zjkv7vj110r19vjwhnzqz9l92cv00z02vkwi2fhi26m7avbhr3y";
     branchName = "master";  # Prevent default 'fetchgit' branch from appearing in version info
     deepClone = true;       # Required for git describe to return commit count in version info
     leaveDotGit = true;     # Required for version header file generation


### PR DESCRIPTION
###### Motivation for this change
- Uses the [LLVM fork of rpcs3](https://github.com/RPCS3/llvm) instead of upstream LLVM.
- ~~Enable leaveDotGit to report correct version info (branch name and commit count). Let me know if this causes some problems (see #8567).~~
- Manually write version info to header file

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

