### PR TITLE
pythonPackages.jira: fix build

### DIFF
--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -1,10 +1,14 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k
 , pytest, pytestrunner, pbr, glibcLocales , pytestcov
-, requests, requests_oauthlib, requests_toolbelt, defusedxml }:
+, requests, requests_oauthlib, requests_toolbelt, defusedxml
+, ipython
+}:
 
 buildPythonPackage rec {
   pname = "jira";
   version = "1.0.15";
+
+  PBR_VERSION = version;
 
   src = fetchPypi {
     inherit pname version;
@@ -12,18 +16,20 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ glibcLocales pytest pytestcov pytestrunner pbr ];
-  propagatedBuildInputs = [ requests requests_oauthlib requests_toolbelt defusedxml ];
+  propagatedBuildInputs = [ requests requests_oauthlib requests_toolbelt defusedxml pbr ipython ];
+
+  # impure tests because of connectivity attempts to jira servers
+  doCheck = false;
+
+  patches = [ ./sphinx-fix.patch ];
 
   LC_ALL = "en_US.utf8";
 
   disabled = !isPy3k;
 
-  # no tests in release tarball
-  doCheck = false;
-
   meta = with lib; {
     description = "This library eases the use of the JIRA REST API from Python.";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ globin ];
+    maintainers = with maintainers; [ globin ma27 ];
   };
 }

--- a/pkgs/development/python-modules/jira/sphinx-fix.patch
+++ b/pkgs/development/python-modules/jira/sphinx-fix.patch
@@ -1,0 +1,11 @@
+diff --git a/setup.py b/setup.py
+index c49a24d..31aeec2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -11,5 +11,5 @@ except ImportError:
+ 
+ 
+ setuptools.setup(
+-    setup_requires=['pbr>=3.0.0', 'setuptools>=17.1', 'pytest-runner', 'sphinx>=1.6.5'],
++    setup_requires=['pbr>=3.0.0', 'setuptools>=17.1', 'pytest-runner'],
+     pbr=True)


### PR DESCRIPTION
###### Motivation for this change

The build for `pythonPackages.jira` failed with the following error:

```
Download error on https://pypi.python.org/simple/sphinx/: [Errno -2] Name or service not known -- Some packages may not be found!
Couldn't find index page for 'sphinx' (maybe misspelled?)
Download error on https://pypi.python.org/simple/: [Errno -2] Name or service not known -- Some packages may not be found!
No local packages or working download links found for sphinx>=1.6.5
Traceback (most recent call last):
  ...
  File "/nix/store/bp4dillg6xxblpf00v8d9nxfx3bnggfy-python3.6-bootstrapped-pip-10.0.1/lib/python3.6/site-packages/setuptools/command/easy_install.py", line 667, in easy_install
    raise DistutilsError(msg)
distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('sphinx>=1.6.5')
builder for '/nix/store/8dv7mpspyk6kxwnzqb43rzm4q5j14xp0-python3.6-jira-1.0.15.drv' failed with exit code 1
```

The root issue is most likely caused by some docs fixes upstream
(https://github.com/pycontribs/jira/commit/519183d874fde26e676a75aa53496968643aaac0)
which were released in 1.0.15. The bump (without the fix) has been
performed in 7a6bf668fb73cd4d1096fa1c0162d9c6009f1d7e.

See https://hydra.nixos.org/build/75004048 for further reference

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

