### PR TITLE
haskell generic-builder: Use strictDeps always

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -5,7 +5,7 @@
 # stripLen acts as the -p parameter when applying a patch.
 
 { lib, fetchurl, patchutils }:
-{ stripLen ? 0, extraPrefix ? null, excludes ? [], ... }@args:
+{ stripLen ? 0, extraPrefix ? null, excludes ? [], includes ? [], ... }@args:
 
 fetchurl ({
   postFetch = ''
@@ -24,7 +24,9 @@ fetchurl ({
     ${patchutils}/bin/filterdiff \
       -p1 \
       ${builtins.toString (builtins.map (x: "-x ${x}") excludes)} \
+      ${builtins.toString (builtins.map (x: "-i ${x}") includes)} \
       "$tmpfile" > "$out"
     ${args.postFetch or ""}
   '';
-} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "postFetch"])
+  meta.broken = excludes != [] && includes != [];
+} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "includes" "postFetch"])

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -47,7 +47,7 @@ self: super: {
   hoogleLocal = { packages ? [] }: self.callPackage ./hoogle.nix { inherit packages; };
 
   # Break infinite recursions.
-  attoparsec-varword = super.attoparsec-varword.override { bytestring-builder-varword = dontCheck self.bytestring-builder-varword; };
+  attoparsec-varword = addTestToolDepend (super.attoparsec-varword.override { bytestring-builder-varword = dontCheck self.bytestring-builder-varword; }) self.hspec-discover;
   clock = dontCheck super.clock;
   Dust-crypto = dontCheck super.Dust-crypto;
   hasql-postgres = dontCheck super.hasql-postgres;
@@ -341,7 +341,7 @@ self: super: {
   hsbencher = dontCheck super.hsbencher;
   hsexif = dontCheck super.hsexif;
   hspec-server = dontCheck super.hspec-server;
-  HTF = dontCheck super.HTF;
+  HTF = addTestToolDepend (dontCheck super.HTF) self.cpphs;
   htsn = dontCheck super.htsn;
   htsn-import = dontCheck super.htsn-import;
   http-link-header = dontCheck super.http-link-header; # non deterministic failure https://hydra.nixos.org/build/75041105
@@ -559,9 +559,6 @@ self: super: {
   # https://ghc.haskell.org/trac/ghc/ticket/9825
   vimus = overrideCabal super.vimus (drv: { broken = pkgs.stdenv.isLinux && pkgs.stdenv.isi686; });
 
-  # https://github.com/hspec/mockery/issues/6
-  mockery = overrideCabal super.mockery (drv: { preCheck = "export TRAVIS=true"; });
-
   # https://github.com/alphaHeavy/lzma-conduit/issues/5
   lzma-conduit = dontCheck super.lzma-conduit;
 
@@ -661,9 +658,9 @@ self: super: {
   }));
 
   # Need newer versions of their dependencies than the ones we have in LTS-11.x.
-  cabal2nix = super.cabal2nix.overrideScope (self: super: { hpack = self.hpack_0_28_2; hackage-db = self.hackage-db_2_0_1; });
+  cabal2nix = super.cabal2nix.overrideScope (self: super: { hpack = addTestToolDepend (self.hpack_0_28_2) self.hspec-discover; hackage-db = self.hackage-db_2_0_1; });
   dbus-hslogger = super.dbus-hslogger.overrideScope (self: super: { dbus = self.dbus_1_0_1; });
-  graphviz = (addBuildTool super.graphviz pkgs.graphviz).overrideScope (self: super: { wl-pprint-text = self.wl-pprint-text_1_2_0_0; base-compat = self.base-compat_0_10_1; });
+  graphviz = (addBuildTool (addTestToolDepend super.graphviz self.hspec-discover) pkgs.graphviz).overrideScope (self: super: { wl-pprint-text = self.wl-pprint-text_1_2_0_0; base-compat = self.base-compat_0_10_1; });
   status-notifier-item = super.status-notifier-item.overrideScope (self: super: { dbus = self.dbus_1_0_1; });
 
   # https://github.com/bos/configurator/issues/22
@@ -819,7 +816,7 @@ self: super: {
   http-api-data = dontCheck super.http-api-data;
 
   # https://github.com/snoyberg/yaml/issues/106
-  yaml = disableCabalFlag super.yaml "system-libyaml";
+  yaml = addTestToolDepend (disableCabalFlag super.yaml "system-libyaml") self.hspec-discover;
 
   # https://github.com/diagrams/diagrams-lib/issues/288
   diagrams-lib = overrideCabal super.diagrams-lib (drv: { doCheck = !pkgs.stdenv.isi686; });
@@ -1074,38 +1071,77 @@ self: super: {
   #
   #   2. https://github.com/hspec/hspec/pull/355 The buildTool will be properly
   #      cabal2nixed when run on the patched cabal file.
-  #
-  #   3. Force 2.5.1 as only it has patch for proper build-tool-depends deps.
-  hspec_2_5_1 = let
-    breakCycles = super.hspec_2_5_1.override { stringbuilder = dontCheck self.stringbuilder; };
-  in appendPatch (addTestToolDepend breakCycles self.hspec-meta) (pkgs.fetchpatch {
-    url = "https://github.com/hspec/hspec/commit/8007227da5c8f2e294c1455a9f2c9855917dc461.diff";
-    includes = [ "hspec.cabal" ];
-    sha256 = "0qk7lsg7s1j42mf9zbh4ga1ca5qbh1qsnsidvlp4rjjifw6jq3vz";
-  });
-  hspec-core_2_5_1 = let
-    breakCycles = super.hspec-core_2_5_1.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
-  in appendPatch (addTestToolDepend breakCycles self.hspec-meta) (pkgs.fetchpatch {
-    url = "https://github.com/hspec/hspec/commit/8007227da5c8f2e294c1455a9f2c9855917dc461.diff";
-    includes = [ "hspec-core.cabal" ];
-    sha256 = "0rwlz24mqh67gpkcrnhm8js594783v4gikzmdwi148w0h6hw2435";
-    stripLen = 1;
-  });
-  hspec-discover_2_5_1 = appendPatch (addTestToolDepend super.hspec-discover_2_5_1 self.hspec-meta) (pkgs.fetchpatch {
-    url = "https://github.com/hspec/hspec/commit/8007227da5c8f2e294c1455a9f2c9855917dc461.diff";
-    includes = [ "hspec-discover.cabal" ];
-    sha256 = "1c343flwxaq7cpnwyjf4y1c5smqs5q90i48sda9kyhl88mslq63b";
-    stripLen = 1;
-  });
-  hspec = self.hspec_2_5_1;
-  hspec-core = self.hspec-core_2_5_1;
-  hspec-discover = self.hspec-discover_2_5_1;
-  hspec-smallcheck = self.hspec-smallcheck_0_5_2;
+  hspec = let
+    breakCycles = super.hspec.override { stringbuilder = dontCheck self.stringbuilder; };
+  in addTestToolDepend breakCycles self.hspec-meta;
+  hspec-core = let
+    breakCycles = super.hspec-core.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
+  in addTestToolDepend breakCycles self.hspec-meta;
+  hspec-discover = addTestToolDepend super.hspec-discover self.hspec-meta;
+  hspec-smallcheck = addTestToolDepend super.hspec-smallcheck self.hspec-meta;
+  hspec-attoparsec = addTestToolDepend super.hspec-attoparsec self.hspec-meta;
+  hspec-contrib = addTestToolDepend super.hspec-contrib self.hspec-meta;
 
   # The build-tool-depends this hacks around has been added on master.
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
   with-location = addTestToolDepend super.with-location self.hspec-discover;
   text-conversions = addTestToolDepend super.text-conversions self.hspec-discover;
+  logging-facade = addTestToolDepend super.logging-facade self.hspec-discover;
+  distributive = addTestToolDepend super.distributive self.hspec-discover;
+  doctest = addTestToolDepend super.doctest self.hspec-discover;
+  http-types = addTestToolDepend super.http-types self.hspec-discover;
+  interpolate = addTestToolDepend super.interpolate self.hspec-discover;
+  mockery = addTestToolDepend super.mockery self.hspec-discover;
+  slim = addTestToolDepend super.slim self.hspec-discover;
+  string-conversions = addTestToolDepend super.string-conversions self.hspec-discover;
+  catamorphism = addTestToolDepend super.catamorphism self.hspec-discover;
+  unliftio = addTestToolDepend super.unliftio self.hspec-discover;
+  word8 = addTestToolDepend super.word8 self.hspec-discover;
+  iproute = addTestToolDepend super.iproute self.hspec-discover;
+  mime-mail = addTestToolDepend super.mime-mail self.hspec-discover;
+  unix-time = addTestToolDepend super.unix-time self.hspec-discover;
+  ClustalParser = addTestToolDepend super.ClustalParser self.hspec-discover;
+  ascii-progress = addTestToolDepend super.ascii-progress self.hspec-discover;
+  safe-exceptions = addTestToolDepend super.safe-exceptions self.hspec-discover;
+  markdown-unlit = addTestToolDepend super.markdown-unlit self.hspec-discover;
+  rio = addTestToolDepend super.rio self.hspec-discover;
+  conduit-extra = addTestToolDepend super.conduit-extra self.hspec-discover;
+  http-date = addTestToolDepend super.http-date self.hspec-discover;
+  ip = addTestToolDepend super.ip self.hspec-discover;
+  megaparsec = addTestToolDepend super.megaparsec self.hspec-discover;
+  text-zipper = addTestToolDepend super.text-zipper self.hspec-discover;
+  yi-rope = addTestToolDepend super.yi-rope self.hspec-discover;
+  yate = addTestToolDepend super.yate self.hspec-discover;
+  bitset-word8 = addTestToolDepend super.bitset-word8 self.hspec-discover;
+  io-choice = addTestToolDepend super.io-choice self.hspec-discover;
+  th-utilities = addTestToolDepend super.th-utilities self.hspec-discover;
+  sum-type-boilerplace = addTestToolDepend super.sum-type-boilerplate self.hspec-discover;
+  ViennaRNAParser = addTestToolDepend super.ViennaRNAParser self.hspec-discover;
+  base58string = addTestToolDepend super.base58string self.hspec-discover;
+  hpack = addTestToolDepend super.hpack self.hspec-discover;
+  fast-logger = addTestToolDepend super.fast-logger self.hspec-discover;
+  bitcoin-script = addTestToolDepend super.bitcoin-script self.hspec-discover;
+  hexstring = addTestToolDepend super.hexstring self.hspec-discover;
+  language-docker = addTestToolDepend super.language-docker self.hspec-discover;
+  say = addTestToolDepend super.say self.hspec-discover;
+  prometheus-client = addTestToolDepend super.prometheus-client self.hspec-discover;
+  Parallel-Arrows-BaseSpec = addTestToolDepend super.Parallel-Arrows-BaseSpec self.hspec-discover;
+  http2 = addTestToolDepend super.http2 self.hspec-discover;
+  wai-extra = addTestToolDepend super.wai-extra self.hspec-discover;
+  aeson-qq = addTestToolDepend super.aeson-qq self.hspec-discover;
+  shakespeare = addTestToolDepend super.shakespeare self.hspec-discover;
+  elm-export = addTestToolDepend super.elm-export self.hspec-discover;
+  fold-debounce = addTestToolDepend super.fold-debounce self.hspec-discover;
+  bitcoin-types = addTestToolDepend super.bitcoin-types self.hspec-discover;
+  quickcheck-arbitrary-adt = addTestToolDepend super.quickcheck-arbitrary-adt self.hspec-discover;
+  haddock-library = addTestToolDepend super.haddock-library self.hspec-discover;
+  sum-type-boilerplate = addTestToolDepend super.sum-type-boilerplate self.hspec-discover;
+  eve = addTestToolDepend super.eve self.hspec-discover;
+  jvm = addTestToolDepend super.jvm self.hspec-discover;
+  xmobar = addTestToolDepend super.xmobar self.hspec-discover;
+  wild-bind = addTestToolDepend super.wild-bind self.hspec-discover;
+  test-fixture = addTestToolDepend super.test-fixture self.hspec-discover;
+  streaming-binary = addTestToolDepend super.streaming-binary self.hspec-discover;
 }
 
 //
@@ -1113,7 +1149,7 @@ self: super: {
 (let
   amazonkaOverrides = self: super: {
     conduit = self.conduit_1_2_13_1;
-    conduit-extra = self.conduit-extra_1_2_3_2;
+    conduit-extra = addTestToolDepend super.conduit-extra_1_2_3_2 self.hspec-discover;
     resourcet = self.resourcet_1_1_11;
     xml-conduit = self.xml-conduit_1_7_1_2;
     http-conduit = self.http-conduit_2_2_4;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1105,6 +1105,7 @@ self: super: {
   # The build-tool-depends this hacks around has been added on master.
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
   with-location = addTestToolDepend super.with-location self.hspec-discover;
+  text-conversions = addTestToolDepend super.text-conversions self.hspec-discover;
 }
 
 //

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1084,6 +1084,7 @@ self: super: {
 
   # The build-tool-depends this hacks around has been added on master.
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
+  # https://github.com/sol/with-location/pull/1
   with-location = addTestToolDepend super.with-location self.hspec-discover;
   text-conversions = addTestToolDepend super.text-conversions self.hspec-discover;
   logging-facade = addTestToolDepend super.logging-facade self.hspec-discover;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1082,6 +1082,7 @@ self: super: {
   hspec-attoparsec = addTestToolDepend super.hspec-attoparsec self.hspec-meta;
   hspec-contrib = addTestToolDepend super.hspec-contrib self.hspec-meta;
   hspec-wai = addTestToolDepend super.hspec-wai self.hspec-meta;
+  hspec-checkers = addTestToolDepend super.hspec-checkers self.hspec-meta;
 
   # The build-tool-depends this hacks around has been added on master.
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
@@ -1157,16 +1158,27 @@ self: super: {
   typenums = addTestToolDepend super.typenums self.hspec-discover;
   type-assertions = addTestToolDepend super.type-assertions self.hspec-discover;
   tsne = addTestToolDepend super.tsne self.hspec-discover;
-  tiphys = addTestToolDepend super.tipys self.hspec-discover;
+  tiphys = addTestToolDepend super.tiphys self.hspec-discover;
   ticker = addTestToolDepend super.ticker self.hspec-discover;
   thread-hierarchy = addTestToolDepend super.thread-hierarchy self.hspec-discover;
   th-to-exp = addTestToolDepend super.th-to-exp self.hspec-discover;
-  th-nowq = addTestToolDepend super.th-to-exp self.markdown-unlit;
+  th-nowq = addTestToolDepend super.th-nowq self.markdown-unlit;
   text-regex-replace = addTestToolDepend super.text-regex-replace self.hspec-discover;
   system-extra = addTestToolDepend super.system-extra self.hspec-discover;
   t3-game = addTestToolDepend super.t3-game self.hspec-discover;
   modern-uri = addTestToolDepend super.modern-uri self.hspec-discover;
-  heist = addTestToolDepend super.heist pkgs.pandoc;
+  dimensional = addTestToolDepend super.dimensional self.hspec-discover;
+  eventful-core = addTestToolDepend super.eventful-core self.hspec-discover;
+  gridbox = addTestToolDepend super.gridbox self.hspec-discover;
+  greskell-core = addTestToolDepend super.greskell-core self.hspec-discover;
+  dns = addTestToolDepend super.dns self.hspec-discover;
+  hapistrano = addTestToolDepend super.hapistrano self.hspec-discover;
+  hw-hspec-hedgehog = addTestToolDepend super.hw-hspec-hedgehog self.hspec-discover;
+  update-repos = addTestToolDepend super.update-repos self.hspec-discover;
+  invariant = addTestToolDepend super.invariant self.hspec-discover;
+  ulid = addTestToolDepend super.ulid self.hspec-discover;
+  matrix-market-attoparsec = addTestToolDepend super.matrix-market-attoparsec self.hspec-discover;
+  paymill = addTestToolDepend super.paymill self.hspec-discover;
 
 }
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1150,6 +1150,7 @@ self: super: {
   test-fixture = addTestToolDepend super.test-fixture self.hspec-discover;
   streaming-binary = addTestToolDepend super.streaming-binary self.hspec-discover;
   yesod-persistent = addTestToolDepend super.yesod-persistent self.hspec-discover;
+  yesod-persistent_1_4_3 = addTestToolDepend super.yesod-persistent_1_4_3 self.hspec-discover;
   wss-client = addTestToolDepend super.wss-client self.hspec-discover;
   word-trie = addTestToolDepend super.word-trie self.hspec-discover;
   woot = addTestToolDepend super.woot self.hspec-discover;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1036,7 +1036,7 @@ self: super: {
 
   # The test suite does not know how to find the 'alex' binary.
   alex = overrideCabal super.alex (drv: {
-    testToolDepends = (drv.testSystemDepends or []) ++ [ buildPackages.which ];
+    testToolDepends = (drv.testToolDepends or []) ++ [ buildPackages.which ];
     preCheck = ''export PATH="$PWD/dist/build/alex:$PATH"'';
   });
 
@@ -1104,6 +1104,7 @@ self: super: {
 
   # The build-tool-depends this hacks around has been added on master.
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
+  with-location = addTestToolDepend super.with-location self.hspec-discover;
 }
 
 //

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1139,6 +1139,9 @@ self: super: {
   bitcoin-types = addTestToolDepend super.bitcoin-types self.hspec-discover;
   quickcheck-arbitrary-adt = addTestToolDepend super.quickcheck-arbitrary-adt self.hspec-discover;
   haddock-library = addTestToolDepend super.haddock-library self.hspec-discover;
+  haddock-library_1_2_1 = addTestToolDepend super.haddock-library_1_2_1 self.hspec-discover;
+  haddock-library_1_4_3 = addTestToolDepend super.haddock-library_1_4_3 self.hspec-discover;
+  haddock-api_2_17_4 = addTestToolDepend super.haddock-api_2_17_4 self.hspec-discover;
   sum-type-boilerplate = addTestToolDepend super.sum-type-boilerplate self.hspec-discover;
   eve = addTestToolDepend super.eve self.hspec-discover;
   jvm = addTestToolDepend super.jvm self.hspec-discover;
@@ -1179,6 +1182,12 @@ self: super: {
   ulid = addTestToolDepend super.ulid self.hspec-discover;
   matrix-market-attoparsec = addTestToolDepend super.matrix-market-attoparsec self.hspec-discover;
   paymill = addTestToolDepend super.paymill self.hspec-discover;
+  bitcoin-tx = addTestToolDepend super.bitcoin-tx self.hspec-discover;
+  conduit-extra_1_2_3_2 = addTestToolDepend super.conduit-extra_1_2_3_2 self.hspec-discover;
+  algolia = addTestToolDepend super.algolia self.tasty-discover;
+  clckwrks = addTestToolDepend super.clckwrks self.hsx2hs;
+  HasBigDecimal = addTestToolDepend super.HasBigDecimal self.hspec-discover;
+  classy-prelude-conduit = addTestToolDepend super.classy-prelude-conduit self.hspec-discover;
 
 }
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1093,7 +1093,7 @@ self: super: {
   doctest = addTestToolDepend super.doctest self.hspec-discover;
   http-types = addTestToolDepend super.http-types self.hspec-discover;
   interpolate = addTestToolDepend super.interpolate self.hspec-discover;
-  mockery = addTestToolDepend super.mockery self.hspec-discover;
+  mockery = addTestToolDepend (overrideCabal super.mockery (drv: { preCheck = "export TRAVIS=true"; })) self.hspec-discover;
   slim = addTestToolDepend super.slim self.hspec-discover;
   string-conversions = addTestToolDepend super.string-conversions self.hspec-discover;
   catamorphism = addTestToolDepend super.catamorphism self.hspec-discover;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1086,6 +1086,7 @@ self: super: {
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
   # https://github.com/sol/with-location/pull/1
   with-location = addTestToolDepend super.with-location self.hspec-discover;
+  # https://github.com/cjdev/text-conversions/pull/6
   text-conversions = addTestToolDepend super.text-conversions self.hspec-discover;
   logging-facade = addTestToolDepend super.logging-facade self.hspec-discover;
   distributive = addTestToolDepend super.distributive self.hspec-discover;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -51,8 +51,6 @@ self: super: {
   clock = dontCheck super.clock;
   Dust-crypto = dontCheck super.Dust-crypto;
   hasql-postgres = dontCheck super.hasql-postgres;
-  hspec = super.hspec.override { stringbuilder = dontCheck self.stringbuilder; };
-  hspec-core = super.hspec-core.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
   hspec-expectations = dontCheck super.hspec-expectations;
   HTTP = dontCheck super.HTTP;
   http-streams = dontCheck super.http-streams;
@@ -1070,6 +1068,39 @@ self: super: {
     base-compat = super.base-compat_0_10_1;
   };
 
+  # A few things for hspec*:
+  #
+  #   1. Break cycles for test
+  #
+  #   2. https://github.com/hspec/hspec/pull/355 The buildTool will be properly
+  #      cabal2nixed when run on the patched cabal file.
+  #
+  #   3. Force 2.5.1 as only it has patch for proper build-tool-depends deps.
+  hspec_2_5_1 = let
+    breakCycles = super.hspec_2_5_1.override { stringbuilder = dontCheck self.stringbuilder; };
+  in appendPatch (addTestToolDepend breakCycles self.hspec-meta) (pkgs.fetchpatch {
+    url = "https://github.com/hspec/hspec/commit/8007227da5c8f2e294c1455a9f2c9855917dc461.diff";
+    includes = [ "hspec.cabal" ];
+    sha256 = "0qk7lsg7s1j42mf9zbh4ga1ca5qbh1qsnsidvlp4rjjifw6jq3vz";
+  });
+  hspec-core_2_5_1 = let
+    breakCycles = super.hspec-core_2_5_1.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
+  in appendPatch (addTestToolDepend breakCycles self.hspec-meta) (pkgs.fetchpatch {
+    url = "https://github.com/hspec/hspec/commit/8007227da5c8f2e294c1455a9f2c9855917dc461.diff";
+    includes = [ "hspec-core.cabal" ];
+    sha256 = "0rwlz24mqh67gpkcrnhm8js594783v4gikzmdwi148w0h6hw2435";
+    stripLen = 1;
+  });
+  hspec-discover_2_5_1 = appendPatch (addTestToolDepend super.hspec-discover_2_5_1 self.hspec-meta) (pkgs.fetchpatch {
+    url = "https://github.com/hspec/hspec/commit/8007227da5c8f2e294c1455a9f2c9855917dc461.diff";
+    includes = [ "hspec-discover.cabal" ];
+    sha256 = "1c343flwxaq7cpnwyjf4y1c5smqs5q90i48sda9kyhl88mslq63b";
+    stripLen = 1;
+  });
+  hspec = self.hspec_2_5_1;
+  hspec-core = self.hspec-core_2_5_1;
+  hspec-discover = self.hspec-discover_2_5_1;
+  hspec-smallcheck = self.hspec-smallcheck_0_5_2;
 }
 
 //

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1101,6 +1101,9 @@ self: super: {
   hspec-core = self.hspec-core_2_5_1;
   hspec-discover = self.hspec-discover_2_5_1;
   hspec-smallcheck = self.hspec-smallcheck_0_5_2;
+
+  # The build-tool-depends this hacks around has been added on master.
+  base-compat = addTestToolDepend super.base-compat self.hspec-discover;
 }
 
 //

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1166,6 +1166,7 @@ self: super: {
   system-extra = addTestToolDepend super.system-extra self.hspec-discover;
   t3-game = addTestToolDepend super.t3-game self.hspec-discover;
   modern-uri = addTestToolDepend super.modern-uri self.hspec-discover;
+  heist = addTestToolDepend super.heist pkgs.pandoc;
 
 }
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -9,7 +9,7 @@
 #
 # See comment at the top of configuration-nix.nix for more information about this
 # distinction.
-{ pkgs, haskellLib }:
+{ buildPackages, pkgs, haskellLib }:
 
 with haskellLib;
 
@@ -1036,7 +1036,7 @@ self: super: {
 
   # The test suite does not know how to find the 'alex' binary.
   alex = overrideCabal super.alex (drv: {
-    testSystemDepends = (drv.testSystemDepends or []) ++ [pkgs.which];
+    testToolDepends = (drv.testSystemDepends or []) ++ [ buildPackages.which ];
     preCheck = ''export PATH="$PWD/dist/build/alex:$PATH"'';
   });
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1081,6 +1081,7 @@ self: super: {
   hspec-smallcheck = addTestToolDepend super.hspec-smallcheck self.hspec-meta;
   hspec-attoparsec = addTestToolDepend super.hspec-attoparsec self.hspec-meta;
   hspec-contrib = addTestToolDepend super.hspec-contrib self.hspec-meta;
+  hspec-wai = addTestToolDepend super.hspec-wai self.hspec-meta;
 
   # The build-tool-depends this hacks around has been added on master.
   base-compat = addTestToolDepend super.base-compat self.hspec-discover;
@@ -1144,6 +1145,27 @@ self: super: {
   wild-bind = addTestToolDepend super.wild-bind self.hspec-discover;
   test-fixture = addTestToolDepend super.test-fixture self.hspec-discover;
   streaming-binary = addTestToolDepend super.streaming-binary self.hspec-discover;
+  yesod-persistent = addTestToolDepend super.yesod-persistent self.hspec-discover;
+  wss-client = addTestToolDepend super.wss-client self.hspec-discover;
+  word-trie = addTestToolDepend super.word-trie self.hspec-discover;
+  woot = addTestToolDepend super.woot self.hspec-discover;
+  wikicfp-scraper = addTestToolDepend super.wikicfp-scraper self.hspec-discover;
+  hopfli = addTestToolDepend super.hopfli self.hspec-discover;
+  webex-teams-api = addTestToolDepend super.webex-teams-api self.hspec-discover;
+  wave = addTestToolDepend super.wave self.hspec-discover;
+  clay = addTestToolDepend super.clay self.hspec-discover;
+  typenums = addTestToolDepend super.typenums self.hspec-discover;
+  type-assertions = addTestToolDepend super.type-assertions self.hspec-discover;
+  tsne = addTestToolDepend super.tsne self.hspec-discover;
+  tiphys = addTestToolDepend super.tipys self.hspec-discover;
+  ticker = addTestToolDepend super.ticker self.hspec-discover;
+  thread-hierarchy = addTestToolDepend super.thread-hierarchy self.hspec-discover;
+  th-to-exp = addTestToolDepend super.th-to-exp self.hspec-discover;
+  th-nowq = addTestToolDepend super.th-to-exp self.markdown-unlit;
+  text-regex-replace = addTestToolDepend super.text-regex-replace self.hspec-discover;
+  system-extra = addTestToolDepend super.system-extra self.hspec-discover;
+  t3-game = addTestToolDepend super.t3-game self.hspec-discover;
+
 }
 
 //

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1165,6 +1165,7 @@ self: super: {
   text-regex-replace = addTestToolDepend super.text-regex-replace self.hspec-discover;
   system-extra = addTestToolDepend super.system-extra self.hspec-discover;
   t3-game = addTestToolDepend super.t3-game self.hspec-discover;
+  modern-uri = addTestToolDepend super.modern-uri self.hspec-discover;
 
 }
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1056,12 +1056,6 @@ self: super: {
   # Work around overspecified constraint on github ==0.18.
   github-backup = doJailbreak super.github-backup;
 
-  # Work around large number of repeated arguments
-  # https://github.com/NixOS/nixpkgs/issues/40013
-  taffybar = super.taffybar.overrideDerivation (drv: {
-    strictDeps = true;
-  });
-
   # dhall-json requires a very particular dhall version
   dhall-json_1_2_1 = super.dhall-json_1_2_1.override { dhall = self.dhall_1_15_0; };
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -341,7 +341,7 @@ self: super: {
   hsbencher = dontCheck super.hsbencher;
   hsexif = dontCheck super.hsexif;
   hspec-server = dontCheck super.hspec-server;
-  HTF = addTestToolDepend (dontCheck super.HTF) self.cpphs;
+  HTF = addBuildTool (dontCheck super.HTF) self.cpphs;
   htsn = dontCheck super.htsn;
   htsn-import = dontCheck super.htsn-import;
   http-link-header = dontCheck super.http-link-header; # non deterministic failure https://hydra.nixos.org/build/75041105

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -25,6 +25,22 @@ self: super: {
   haskeline = null;
   hoopl = self.hoopl_3_10_2_2;   # no longer a core library in GHC 8.4.x
   hpc = null;
+
+  # A few things for hspec*:
+  #
+  #   1. Break cycles for test
+  #
+  #   2. https://github.com/hspec/hspec/pull/355 The buildTool will be properly
+  #      cabal2nixed when run on the patched cabal file.
+  hspec = let
+    breakCycles = super.hspec_2_5_1.override { stringbuilder = dontCheck self.stringbuilder; };
+  in addTestToolDepend breakCycles self.hspec-meta;
+  hspec-core = let
+    breakCycles = super.hspec-core_2_5_1.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
+  in addTestToolDepend breakCycles self.hspec-meta;
+  hspec-discover = addTestToolDepend super.hspec-discover_2_5_1 self.hspec-meta;
+  hspec-smallcheck = addTestToolDepend self.hspec-smallcheck_0_5_2 self.hspec-meta;
+
   integer-gmp = null;
   mtl = null;
   parsec = null;
@@ -396,7 +412,7 @@ self: super: {
   dhall = self.dhall_1_14_0;
   dhall_1_13_0 = doJailbreak super.dhall_1_14_0;  # support ansi-terminal 0.8.x
   HaTeX = self.HaTeX_3_19_0_0;
-  hpack = self.hpack_0_28_2;
+  hpack = addTestBuildDepend self.hpack_0_28_2 super.hspec-discover;
   matrix = self.matrix_0_3_6_1;
   pandoc = self.pandoc_2_2_1;
   pandoc-types = self.pandoc-types_1_17_5_1;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -397,10 +397,6 @@ self: super: {
   dhall_1_13_0 = doJailbreak super.dhall_1_14_0;  # support ansi-terminal 0.8.x
   HaTeX = self.HaTeX_3_19_0_0;
   hpack = self.hpack_0_28_2;
-  hspec = dontCheck super.hspec_2_5_3;
-  hspec-core = dontCheck super.hspec-core_2_5_3;
-  hspec-discover = self.hspec-discover_2_5_3;
-  hspec-smallcheck = self.hspec-smallcheck_0_5_2;
   matrix = self.matrix_0_3_6_1;
   pandoc = self.pandoc_2_2_1;
   pandoc-types = self.pandoc-types_1_17_5_1;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -33,12 +33,12 @@ self: super: {
   #   2. https://github.com/hspec/hspec/pull/355 The buildTool will be properly
   #      cabal2nixed when run on the patched cabal file.
   hspec = let
-    breakCycles = super.hspec_2_5_1.override { stringbuilder = dontCheck self.stringbuilder; };
+    breakCycles = super.hspec_2_5_3.override { stringbuilder = dontCheck self.stringbuilder; };
   in addTestToolDepend breakCycles self.hspec-meta;
   hspec-core = let
-    breakCycles = super.hspec-core_2_5_1.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
+    breakCycles = super.hspec-core_2_5_3.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
   in addTestToolDepend breakCycles self.hspec-meta;
-  hspec-discover = addTestToolDepend super.hspec-discover_2_5_1 self.hspec-meta;
+  hspec-discover = addTestToolDepend super.hspec-discover_2_5_3 self.hspec-meta;
   hspec-smallcheck = addTestToolDepend self.hspec-smallcheck_0_5_2 self.hspec-meta;
 
   integer-gmp = null;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -53,7 +53,7 @@ self: super: builtins.intersectAttrs super {
 
   # Use the default version of mysql to build this package (which is actually mariadb).
   # test phase requires networking
-  mysql = dontCheck (super.mysql.override { mysql = pkgs.mysql.connector-c; });
+  mysql = dontCheck (addBuildTool (super.mysql.override { mysql = pkgs.mysql.connector-c; }) pkgs.mysql);
 
   # CUDA needs help finding the SDK headers and libraries.
   cuda = overrideCabal super.cuda (drv: {
@@ -516,4 +516,15 @@ self: super: builtins.intersectAttrs super {
   # Tests require a browser: https://github.com/ku-fpg/blank-canvas/issues/73
   blank-canvas = dontCheck super.blank-canvas;
   blank-canvas_0_6_2 = dontCheck super.blank-canvas_0_6_2;
+
+  # cabal2nix generates a dependency on base-compat, which is the wrong version
+  base-compat-batteries = super.base-compat-batteries.override {
+    base-compat = super.base-compat_0_10_1;
+  };
+
+  # Custom setup needs pg_config
+  HDBC-postgresql = addBuildTool super.HDBC-postgresql pkgs.postgresql;
+
+  # Custom setup needs sdl-config
+  SDL = addBuildTool super.SDL pkgs.SDL;
 }

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -517,14 +517,11 @@ self: super: builtins.intersectAttrs super {
   blank-canvas = dontCheck super.blank-canvas;
   blank-canvas_0_6_2 = dontCheck super.blank-canvas_0_6_2;
 
-  # cabal2nix generates a dependency on base-compat, which is the wrong version
-  base-compat-batteries = super.base-compat-batteries.override {
-    base-compat = super.base-compat_0_10_1;
-  };
-
   # Custom setup needs pg_config
   HDBC-postgresql = addBuildTool super.HDBC-postgresql pkgs.postgresql;
 
   # Custom setup needs sdl-config
   SDL = addBuildTool super.SDL pkgs.SDL;
+  neat-interpolation = addBuildTool super.neat-interpolation self.HTF;
+  hnix = addBuildTool super.hnix pkgs.nix;
 }

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, lib, haskellLib, ghc, all-cabal-hashes
+{ buildPackages, pkgs, stdenv, lib, haskellLib, ghc, all-cabal-hashes
 , buildHaskellPackages
 , compilerConfig ? (self: super: {})
 , packageSetConfig ? (self: super: {})
@@ -18,7 +18,7 @@ let
     inherit stdenv haskellLib ghc buildHaskellPackages extensible-self all-cabal-hashes;
   };
 
-  commonConfiguration = configurationCommon { inherit pkgs haskellLib; };
+  commonConfiguration = configurationCommon { inherit buildPackages pkgs haskellLib; };
   nixConfiguration = configurationNix { inherit pkgs haskellLib; };
 
   extensible-self = makeExtensible

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -182,12 +182,14 @@ let
   depsBuildBuild = [ nativeGhc ];
   nativeBuildInputs = [ ghc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
                       setupHaskellDepends ++
-                      buildTools ++ libraryToolDepends ++ executableToolDepends;
+                      buildTools ++ libraryToolDepends ++ executableToolDepends ++
+                      optionals doCheck testToolDepends ++
+                      optionals doBenchmark benchmarkToolDepends;
   propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends ++ libraryFrameworkDepends;
   otherBuildInputs = extraLibraries ++ librarySystemDepends ++ executableSystemDepends ++ executableFrameworkDepends ++
                      allPkgconfigDepends ++
-                     optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testToolDepends ++ testFrameworkDepends) ++
-                     optionals doBenchmark (benchmarkDepends ++ benchmarkHaskellDepends ++ benchmarkSystemDepends ++ benchmarkToolDepends ++ benchmarkFrameworkDepends);
+                     optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testFrameworkDepends) ++
+                     optionals doBenchmark (benchmarkDepends ++ benchmarkHaskellDepends ++ benchmarkSystemDepends ++ benchmarkFrameworkDepends);
 
   allBuildInputs = propagatedBuildInputs ++ otherBuildInputs;
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -233,6 +233,7 @@ stdenv.mkDerivation ({
 
   inherit src;
 
+  strictDeps = true;
   inherit depsBuildBuild nativeBuildInputs;
   buildInputs = otherBuildInputs ++ optionals (!hasActiveLibrary) propagatedBuildInputs;
   propagatedBuildInputs = optionals hasActiveLibrary propagatedBuildInputs;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -143,6 +143,12 @@ rec {
   addBuildTool = drv: x: addBuildTools drv [x];
   addBuildTools = drv: xs: overrideCabal drv (drv: { buildTools = (drv.buildTools or []) ++ xs; });
 
+  addTestToolDepend = drv: x: addTestToolDepends drv [x];
+  addTestToolDepends = drv: xs: overrideCabal drv (drv: { testToolDepends = (drv.testToolDepends or []) ++ xs; });
+
+  addBenchmarkToolDepend = drv: x: addBenchmarkToolDepends drv [x];
+  addBenchmarkToolDepends = drv: xs: overrideCabal drv (drv: { benchmarkToolDepends = (drv.benchmarkToolDepends or []) ++ xs; });
+
   addExtraLibrary = drv: x: addExtraLibraries drv [x];
   addExtraLibraries = drv: xs: overrideCabal drv (drv: { extraLibraries = (drv.extraLibraries or []) ++ xs; });
 


### PR DESCRIPTION
###### Motivation for this change

This helps avoid the `ARG_MAX` issues we've been having, and is generally a good idea to ensure cross comparability anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

