### PR TITLE
shadowsocks-libev: supports darwin

### DIFF
--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -24,6 +24,19 @@ stdenv.mkDerivation rec {
     cp lib/* $out/lib
     chmod +x $out/bin/*
     mv $out/pkgconfig $out/lib
+
+    ${stdenv.lib.optionalString stdenv.isDarwin ''
+      install_name_tool -change libcork.dylib $out/lib/libcork.dylib $out/lib/libipset.dylib
+      install_name_tool -change libbloom.dylib $out/lib/libbloom.dylib $out/lib/libipset.dylib
+
+      for exe in $out/bin/*; do
+        install_name_tool -change libmbedtls.dylib ${mbedtls}/lib/libmbedtls.dylib $exe
+        install_name_tool -change libmbedcrypto.dylib ${mbedtls}/lib/libmbedcrypto.dylib $exe
+        install_name_tool -change libcork.dylib $out/lib/libcork.dylib $exe
+        install_name_tool -change libipset.dylib $out/lib/libipset.dylib $exe
+        install_name_tool -change libbloom.dylib $out/lib/libbloom.dylib $exe
+      done
+    ''}
   '';
 
   meta = with stdenv.lib; {
@@ -35,6 +48,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/shadowsocks/shadowsocks-libev;
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.nfjinjing ];
-    platforms = platforms.linux;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
shadowsocks-libev is [supported on darwin](https://github.com/shadowsocks/shadowsocks-libev#installation)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

