### PR TITLE
schema2ldif: Init at 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -58,6 +58,11 @@
     github = "DamienCassou";
     name = "Damien Cassou";
   };
+  das_j = {
+    email = "janne@hess.ooo";
+    github = "dasJ";
+    name = "Janne Heß";
+  };
   DerGuteMoritz = {
     email = "moritz@twoticketsplease.de";
     github = "DerGuteMoritz";

--- a/pkgs/servers/dns/dnsdist/default.nix
+++ b/pkgs/servers/dns/dnsdist/default.nix
@@ -30,5 +30,6 @@
     description = "DNS Loadbalancer";
     homepage = "https://dnsdist.org";
     license = licenses.gpl2;
+    maintainers = with maintainers; [ das_j ];
   };
 }

--- a/pkgs/tools/text/schema2ldif/default.nix
+++ b/pkgs/tools/text/schema2ldif/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, makeWrapper, perl, perlPackages }: stdenv.mkDerivation rec {
+  name = "schema2ldif-${version}";
+  version = "1.3";
+
+  src = fetchurl {
+    url = "https://repos.fusiondirectory.org/sources/schema2ldif/schema2ldif-${version}.tar.gz";
+    sha256 = "00cd9xx9g0mnnfn5lvay3vg166z84jla0ya1x34ljdc8bflxsr9a";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+
+    cp bin/{schema2ldif,ldap-schema-manager} $out/bin
+    gzip -c man/schema2ldif.1 > $out/share/man/man1/schema2ldif.1.gz
+    gzip -c man/ldap-schema-manager.1 > $out/share/man/man1/ldap-schema-manager.1.gz
+
+    wrapProgram $out/bin/schema2ldif \
+       --prefix PERL5PATH : "${stdenv.lib.makePerlPath [ perlPackages.GetoptLong perlPackages.PodUsage ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utilities to manage schema in .schema and .ldif format";
+    homepage = "https://www.fusiondirectory.org/schema2ldif-project-and-components/";
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4911,6 +4911,8 @@ with pkgs;
 
   sharutils = callPackage ../tools/archivers/sharutils { };
 
+  schema2ldif = callPackage ../tools/text/schema2ldif { };
+
   shocco = callPackage ../tools/text/shocco { };
 
   shotwell = callPackage ../applications/graphics/shotwell { };


### PR DESCRIPTION
###### Motivation for this change

schema2ldif was not available yet

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

