### PR TITLE
cc-wrapper, bintools-wrapper: unbreak include/link paths when cross-compiling

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -13,7 +13,7 @@ set -u
 bintoolsWrapper_addLDVars () {
     # See ../setup-hooks/role.bash
     local role_post role_pre
-    getTargetRoleEnvHook
+    getHostRoleEnvHook
 
     if [[ -d "$1/lib64" && ! -L "$1/lib64" ]]; then
         export NIX_${role_pre}LDFLAGS+=" -L$1/lib64"

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -68,7 +68,7 @@ set -u
 ccWrapper_addCVars () {
     # See ../setup-hooks/role.bash
     local role_post role_pre
-    getTargetRoleEnvHook
+    getHostRoleEnvHook
 
     if [[ -d "$1/include" ]]; then
         export NIX_${role_pre}CFLAGS_COMPILE+=" ${ccIncludeFlag:--isystem} $1/include"


### PR DESCRIPTION
###### Motivation for this change

2110c0bd3009279ceec291f07bfbf063cb5ba6a0 refactored `cc-wrapper` and `bintools-wrapper` to use [pkgs/build-support/setup-hooks/role.bash](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/role.bash). There appears to have been a small mistake in how this was done, which caused dependencies to be added `NIX_TARGET_CFLAGS/LDFLAGS` instead of `NIX_CFLAGS/LDFLAGS` when cross-compiling.

I discovered this when attempting to cross compile `tmon`, which failed because it was unable to find its `ncurses` dependency. With this PR, it successfully compiles.

###### Things done

Use `getHostRoleEnvHook` instead of `getTargetRoleEnvHook`, which looks at `$depHostOffset` instead of `$depTargetOffset`.

cc @Ericson2314 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

