### PR TITLE
gnuradio: 3.7.11.1 -> 3.7.13.3

### DIFF
--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -6,7 +6,7 @@
 # May be able to upgrade to swig3
 , python, swig2, numpy, scipy, matplotlib
 # => grc - the gnu radio companion
-, cheetah, pygtk
+, Mako, cheetah, pygtk # Note: GR is migrating to Mako. Cheetah should be removed for GR3.8
 # => gr-wavelet: collection of wavelet blocks
 , gsl
 # => gr-qtgui: the Qt-based GUI
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnuradio-${version}";
-  version = "3.7.11.1";
+  version = "3.7.13.3";
 
   src = fetchFromGitHub {
     owner = "gnuradio";
     repo = "gnuradio";
-    rev = "6d2221196082a4954c249dc6955e33d5832a56f2";
-    sha256 = "1fkrb8cnjbriy2x94lz73q6aqxar1rkvfbafp266ykdpm29b4xgm";
+    rev = "v${version}";
+    sha256 = "0fqxn1k41xqd52i5z528zdhkn52i9z5hl6cc75ggdx9iqxhvb3jj";
     fetchSubmodules = true;
   };
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreAudio ];
 
   propagatedBuildInputs = [
-    cheetah numpy scipy matplotlib pyqt4 pygtk wxPython pyopengl
+    Mako cheetah numpy scipy matplotlib pyqt4 pygtk wxPython pyopengl
   ];
 
   enableParallelBuilding = true;
@@ -69,6 +69,8 @@ stdenv.mkDerivation rec {
   setupHook = [ grcSetupHook ];
 
   # patch wxgui and pygtk check due to python importerror in a headless environment
+  # wxgtk gui will be removed in GR3.8
+  # c++11 hack may not be necessary anymore
   preConfigure = ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-unused-variable ${stdenv.lib.optionalString (!stdenv.isDarwin) "-std=c++11"}"
     sed -i 's/.*wx\.version.*/set(WX_FOUND TRUE)/g' gr-wxgui/CMakeLists.txt

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, writeText, makeWrapper
 # Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
 # => core dependencies
-, cmake, pkgconfig, git, boost, cppunit, fftw
+, ninja, cmake, pkgconfig, git, boost, cppunit, fftw
 # => python wrappers
 # May be able to upgrade to swig3
 , python, swig2, numpy, scipy, matplotlib
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake pkgconfig git makeWrapper cppunit orc
+    cmake pkgconfig git makeWrapper cppunit orc ninja
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/rtl-sdr/default.nix
+++ b/pkgs/applications/misc/rtl-sdr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, pkgconfig, libusb1 }:
+{ stdenv, lib, fetchpatch, fetchgit, cmake, pkgconfig, libusb1 }:
 
 stdenv.mkDerivation rec {
   name = "rtl-sdr-${version}";
@@ -26,7 +26,13 @@ stdenv.mkDerivation rec {
     grep -q "Requires:" "$pcfile" && { echo "Upstream has added 'Requires:' in $(basename "$pcfile"); update nix expression."; exit 1; }
     echo "Requires: libusb-1.0" >> "$pcfile"
   '';
-
+  patches = lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "linker-fix.patch";
+      url = "https://github.com/lukeadams/rtl-sdr/commit/7a66dcf268305b5aa507d1756799942c74549b72.patch";
+      sha256 = "0cn9fyf4ay4i3shvxj1ivgyxjvfm401irk560jdjl594nzadrcsl";
+    })
+  ];
   meta = with stdenv.lib; {
     description = "Turns your Realtek RTL2832 based DVB dongle into a SDR receiver";
     homepage = http://sdr.osmocom.org/trac/wiki/rtl-sdr;

--- a/pkgs/development/libraries/libbladeRF/default.nix
+++ b/pkgs/development/libraries/libbladeRF/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, git, doxygen, help2man, tecla
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, git, doxygen, help2man, ncurses, tecla
 , libusb1, udev }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake git doxygen help2man tecla libusb1 udev ];
+  # ncurses used due to https://github.com/Nuand/bladeRF/blob/ab4fc672c8bab4f8be34e8917d3f241b1d52d0b8/host/utilities/bladeRF-cli/CMakeLists.txt#L208
+  buildInputs = [ cmake git doxygen help2man tecla libusb1 ]
+    ++ lib.optionals stdenv.isLinux [ udev ]
+    ++ lib.optionals stdenv.isDarwin [ ncurses ];
 
   # Fixup shebang
   prePatch = "patchShebangs host/utilities/bladeRF-cli/src/cmd/doc/generate.bash";
@@ -24,19 +27,19 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Debug"
+    "-DBUILD_DOCUMENTATION=ON"
+  ] ++ lib.optionals stdenv.isLinux [
     "-DUDEV_RULES_PATH=etc/udev/rules.d"
     "-DINSTALL_UDEV_RULES=ON"
-    "-DBUILD_DOCUMENTATION=ON"
   ];
 
   hardeningDisable = [ "fortify" ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://nuand.com/libbladeRF-doc;
     description = "Supporting library of the BladeRF SDR opensource hardware";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ funfunctor ];
-    platforms = with platforms; linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libbladeRF/default.nix
+++ b/pkgs/development/libraries/libbladeRF/default.nix
@@ -30,8 +30,10 @@ stdenv.mkDerivation rec {
     "-DBUILD_DOCUMENTATION=ON"
   ];
 
+  hardeningDisable = [ "fortify" ];
+
   meta = with stdenv.lib; {
-    homepage = https://www.nuand.com/;
+    homepage = https://nuand.com/libbladeRF-doc;
     description = "Supporting library of the BladeRF SDR opensource hardware";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ funfunctor ];

--- a/pkgs/development/tools/misc/uhd/default.nix
+++ b/pkgs/development/tools/misc/uhd/default.nix
@@ -9,17 +9,15 @@
 
 let
   uhdVer = "v" + version;
-  ImgVer = "uhd-images_3.11.0.git-227-g9277fc58.tar.xz";
 
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf... style keeps changing
-  version = "3.11.0.0";
+  version = "3.12.0.0";
 
-  # Firmware images are downloaded (pre-built) from:
-  # http://files.ettus.com/binaries/images/
+  # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
-    url = "http://files.ettus.com/binaries/images/${ImgVer}";
-    sha256 = "1z8isnlxc5h0168jjpdvdv7rkd55x4dkfh14m8pc501zsf8azd6z";
+    url = "https://github.com/EttusResearch/uhd/releases/download/${uhdVer}/uhd-images_${version}.tar.xz";
+    sha256 = "1glf2qay4asajbl92fy432idqk0sj5h603najr8sgkbdyyyr933p";
   };
 
 in stdenv.mkDerivation {
@@ -29,7 +27,7 @@ in stdenv.mkDerivation {
     owner = "EttusResearch";
     repo = "uhd";
     rev = "${uhdVer}";
-    sha256 = "1ilx1a8k5zygfq7acm9yk2fi368b1a1l7ll21kmmxjv6ifz8ds5q";
+    sha256 = "0m7vw7dmvn7d01kkzphayzi0bk50m5v9a17rpnxhn0bqhw282ksv";
   };
 
   enableParallelBuilding = true;
@@ -49,8 +47,10 @@ in stdenv.mkDerivation {
 
   postPhases = [ "installFirmware" ];
 
+  # UHD expects images in `$CMAKE_INSTALL_PREFIX/share/uhd/images`
   installFirmware = ''
-    tar --strip-components=1 -xvf "${uhdImagesSrc}" -C "$out"
+    mkdir -p "$out/share/uhd/images"
+    tar --strip-components=1 -xvf "${uhdImagesSrc}" -C "$out/share/uhd/images"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15928,7 +15928,7 @@ with pkgs;
   gnss-sdr = callPackage ../applications/misc/gnss-sdr { };
 
   gnuradio = callPackage ../applications/misc/gnuradio {
-    inherit (python2Packages) cheetah lxml matplotlib numpy python pyopengl pyqt4 scipy wxPython pygtk;
+    inherit (python2Packages) cheetah lxml Mako matplotlib numpy python pyopengl pyqt4 scipy wxPython pygtk;
     inherit (darwin.apple_sdk.frameworks) CoreAudio;
     fftw = fftwFloat;
     qwt = qwt6_qt4;


### PR DESCRIPTION
###### Motivation for this change
* gnuradio: version bump and use ninja
* rtl-sdr: fix weird linker error
* libbladerf: disable fortify to fix build, enable it on darwin
* uhd: 3.11.0.0 -> 3.12.0.0 (fixes Darwin build with newer Boost)
nox-review completed successfully
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

