### PR TITLE
steam: add optional extraProfile

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -3,6 +3,7 @@
 , withJava ? false
 , withPrimus ? false
 , extraPkgs ? pkgs: [ ] # extra packages to add to targetPkgs
+, extraProfile ? "" # string to append to profile
 , nativeOnly ? false
 , runtimeOnly ? false
 }:
@@ -178,7 +179,7 @@ in buildFHSUserEnv rec {
 
   profile = ''
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}
-  '';
+  '' + extraProfile;
 
   runScript = writeScript "steam-wrapper.sh" ''
     #!${stdenv.shell}


### PR DESCRIPTION
###### Motivation for this change
Personally, I have a pulseaudio setup where I have all my clients connect to a remote server.
This can be easily achieved by setting the PULSE_SERVER environmental variable.

I would say this is a general enough approach to solve my problem, that it might be useful for other users and other purposes, like settings environmental variables to tell your GPU driver to do something non-default.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

