### PR TITLE
ninja: build manual with docbook

### DIFF
--- a/pkgs/development/tools/build-managers/ninja/default.nix
+++ b/pkgs/development/tools/build-managers/ninja/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python, asciidoc, re2c }:
+{ stdenv, fetchFromGitHub, python, asciidoc, docbook_xml_dtd_45, docbook_xsl, libxslt, re2c }:
 
 stdenv.mkDerivation rec {
   name = "ninja-${version}";
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "16scq9hcq6c5ap6sy8j4qi75qps1zvrf3p79j1vbrvnqzp928i5f";
   };
 
-  nativeBuildInputs = [ python asciidoc re2c ];
+  nativeBuildInputs = [ python asciidoc docbook_xml_dtd_45 docbook_xsl libxslt.bin re2c ];
 
   buildPhase = ''
     python configure.py --bootstrap
-    asciidoc doc/manual.asciidoc
+    ./ninja manual
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

It is not meant to be built with asciidoc alone: it lacks the table of contents
and styles. See  https://github.com/ninja-build/ninja/blob/v1.8.2/doc/README.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).