### PR TITLE
Revert "curl: 7.59.0 -> 7.60.0"

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -24,14 +24,14 @@ assert brotliSupport -> brotli != null;
 assert gssSupport -> kerberos != null;
 
 stdenv.mkDerivation rec {
-  name = "curl-7.60.0";
+  name = "curl-7.59.0";
 
   src = fetchurl {
     urls = [
       "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] name}/${name}.tar.bz2"
       "https://curl.haxx.se/download/${name}.tar.bz2"
     ];
-    sha256 = "16qyhy9alq2wk6zgqhh5dchr45f6nxaqzy3rh8rbx6dx0hignzc9";
+    sha256 = "185mazhi4bc5mc6rvhrmnc67j8l3sg7f0w2hp5gmi5ccdbyhz4mm";
   };
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
This reverts commit 44101ee9d67095af06a977eb7f64ba72a2faa66a.

I would consider this a temporary fix until a proper solution for #41312 has been found.
Unfortunately, NixOS on master is rather unusable without reverting the above commit.

###### Motivation for this change

All nix tools appear to be flaky and run into timeouts with curl 7.60.0
See nixos/nixpkgs#41312 for more details


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

