### PR TITLE
gdal: Fix darwin build

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, libjpeg, libtiff, zlib
+{ stdenv, fetchurl, fetchpatch, unzip, libjpeg, libtiff, zlib
 , postgresql, mysql, libgeotiff, pythonPackages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4
 , libiconv
@@ -15,6 +15,16 @@ stdenv.mkDerivation rec {
     url = "http://download.osgeo.org/gdal/${version}/${name}.tar.xz";
     sha256 = "18iaamzkn0lipizynvspf3bs5qzgcy36hn6bbi941q8dlfdf8xbg";
   };
+
+  patches = [
+    # fix build with recent Poppler
+    (fetchpatch {
+      url    = "https://github.com/OSGeo/gdal/commit/124f0343436d1267319ac627fc220530091b41ea.diff";
+      stripLen = 2;
+      extraPrefix = "";
+      sha256 = "1v6iiy4cgrdcfas3iva5swh9446pqfjh5p6bcab6y49hyjhpsgfy";
+    })
+  ];
 
   buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite
     libspatialite poppler hdf4 ]


### PR DESCRIPTION
###### Motivation for this change
This should fix the darwin build of gdal.
See https://github.com/OSGeo/gdal/pull/573


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

