### PR TITLE
nixos/systemd: Allow to override serviceConfig

### DIFF
--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -78,10 +78,16 @@ in rec {
     optional (badFields != [ ])
       "Systemd ${group} has extra fields [${concatStringsSep " " badFields}].";
 
-  checkUnitConfig = group: checks: v:
-    let errors = concatMap (c: c group v) checks; in
-    if errors == [] then true
-      else builtins.trace (concatStringsSep "\n" errors) false;
+  checkUnitConfig = group: checks: attrs: let
+    # We're applied at the top-level type (attrsOf unitOption), so the actual
+    # unit options might contain attributes from mkOverride that we need to
+    # convert into single values before checking them.
+    defs = mapAttrs (const (v:
+      if v._type or "" == "override" then v.content else v
+    )) attrs;
+    errors = concatMap (c: c group defs) checks;
+  in if errors == [] then true
+     else builtins.trace (concatStringsSep "\n" errors) false;
 
   toOption = x:
     if x == true then "true"


### PR DESCRIPTION
This has been reported by @qknight in his Stack Overflow question:

https://stackoverflow.com/q/50678639

The correct way to override a single value would be to use something like this:

```nix
{ systemd.services.nagios.serviceConfig.Restart = lib.mkForce "no"; }
```

However, this doesn't work because the check is applied for the `attrsOf` type and thus the attribute values might still contain the attribute set created by `mkOverride`.

The `unitOption` type however did already account for this, but at this stage it's already too late.

So now the actual value is unpacked while checking the values of the attribute set, which should allow us to override values in `serviceConfig`.

Cc: @edolstra, @qknight