### PR TITLE
gnome3.vinagre: fix build

### DIFF
--- a/pkgs/desktops/gnome-3/apps/vinagre/default.nix
+++ b/pkgs/desktops/gnome-3/apps/vinagre/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ gtk3 vte libxml2 gtkvnc intltool libsecret
                   itstool makeWrapper gnome3.defaultIconTheme librsvg ];
 
+  NIX_CFLAGS_COMPILE = "-Wno-format-nonliteral";
+
   preFixup = ''
     wrapProgram "$out/bin/vinagre" \
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:$out/share"


### PR DESCRIPTION
Currently, vinagre fails to build with the following message:

```
vinagre/vinagre-utils.c: In function 'vinagre_utils_request_credential':
vinagre/vinagre-utils.c:686:2: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  _tmp12_ = g_strdup_printf (_tmp10_, _tmp11_);
  ^~~~~~~
```

vinagre-utils.c seems to be generated from vinagre-utils.vala. I
couldn't find anything weird in here, so let's disable
-Werror=format-nonliteral for now as done elsewhere, too.

###### Motivation for this change
vinagre didn't build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

