### PR TITLE
eigen3_3: Fix darwin build

### DIFF
--- a/pkgs/development/libraries/eigen/3.3.nix
+++ b/pkgs/development/libraries/eigen/3.3.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, cmake}:
+{stdenv, fetchurl, fetchpatch, cmake}:
 
 let
   version = "3.3.4";
@@ -11,6 +11,15 @@ stdenv.mkDerivation {
     name = "eigen-${version}.tar.gz";
     sha256 = "1q85bgd6hnsgn0kq73wa4jwh4qdwklfg73pgqrz4zmxvzbqyi1j2";
   };
+
+  patches = [
+    # Remove for > 3.3.4
+    # Upstream commit from 6 Apr 2018 "Fix cmake scripts with no fortran compiler"
+    (fetchpatch {
+      url    = "https://bitbucket.org/eigen/eigen/commits/ba14974d054ae9ae4ba88e5e58012fa6c2729c32/raw";
+      sha256 = "0fskiy9sbzvp693fcyv3pfq8kxxx3d3mgmaqvjbl5bpfjivij8l1";
+    })
+  ];
   
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
###### Motivation for this change
This fixes the darwin build of eigen3_3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

