### PR TITLE
pdf-redact-tools: init -> 0.1.2

### DIFF
--- a/pkgs/tools/graphics/pdfredacttools/default.nix
+++ b/pkgs/tools/graphics/pdfredacttools/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pythonPackages, imagemagick, exiftool, file, ghostscript }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "pdf-redact-tools";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "firstlookmedia";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01vs1bc0pfgk6x2m36vwra605fg59yc31d0hl9jmj86n8q6wwvss";
+  };
+
+  patchPhase = ''substituteInPlace pdf-redact-tools      \
+    --replace \'convert\' \'${imagemagick}/bin/convert\' \
+    --replace \'exiftool\' \'${exiftool}/bin/exiftool\'  \
+    --replace \'file\' \'${file}/bin/file\'
+   '';
+
+  propagatedBuildInputs = [ imagemagick exiftool ghostscript ];
+
+  meta = with stdenv.lib; {
+    description = "Redact and strip metadata from documents before publishing";
+    longDescription = ''
+	PDF Redact Tools helps with securely redacting and stripping metadata
+	from documents before publishing. Note that this is not a security tool.
+        It uses ImageMagick to parse PDFs.  While ImageMagick is a versatile tool, it has
+        a history of several security bugs. A malicious PDF could exploit a bug in
+        ImageMagick to take over your computer. If you're working with potentially
+        malicious PDFs, it's safest to run them through PDF Redact Tools in an isolated
+        environment, such as a virtual machine, or by using a tool such as the Qubes
+        PDF Converter instead.
+    '';
+    platforms = platforms.all;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4363,6 +4363,8 @@ with pkgs;
 
   pdf2odt = callPackage ../tools/typesetting/pdf2odt { };
 
+  pdf-redact-tools = callPackage ../tools/graphics/pdfredacttools { };
+
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };
 
   fmodex = callPackage ../games/zandronum/fmod.nix { };


### PR DESCRIPTION
###### Motivation for this change

A tool which is very useful for dissidents, journalists, whistleblowers etc. It flattens PDF's and allows for easy conversion to images and back for manual touch-ups.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

