### PR TITLE
Point nix at curl 7.59.0

### DIFF
--- a/pkgs/tools/networking/curl/7_59.nix
+++ b/pkgs/tools/networking/curl/7_59.nix
@@ -1,0 +1,113 @@
+{ stdenv, lib, fetchurl, pkgconfig, perl
+, http2Support ? true, nghttp2
+, idnSupport ? false, libidn ? null
+, ldapSupport ? false, openldap ? null
+, zlibSupport ? false, zlib ? null
+, sslSupport ? false, openssl ? null
+, gnutlsSupport ? false, gnutls ? null
+, scpSupport ? false, libssh2 ? null
+, gssSupport ? false, kerberos ? null
+, c-aresSupport ? false, c-ares ? null
+, brotliSupport ? false, brotli ? null
+}:
+
+assert http2Support -> nghttp2 != null;
+assert idnSupport -> libidn != null;
+assert ldapSupport -> openldap != null;
+assert zlibSupport -> zlib != null;
+assert sslSupport -> openssl != null;
+assert !(gnutlsSupport && sslSupport);
+assert gnutlsSupport -> gnutls != null;
+assert scpSupport -> libssh2 != null;
+assert c-aresSupport -> c-ares != null;
+assert brotliSupport -> brotli != null;
+assert gssSupport -> kerberos != null;
+
+stdenv.mkDerivation rec {
+  name = "curl-7.59.0";
+
+  src = fetchurl {
+    urls = [
+      "https://github.com/curl/curl/releases/download/${lib.replaceStrings ["."] ["_"] name}/${name}.tar.bz2"
+      "https://curl.haxx.se/download/${name}.tar.bz2"
+    ];
+    sha256 = "185mazhi4bc5mc6rvhrmnc67j8l3sg7f0w2hp5gmi5ccdbyhz4mm";
+  };
+
+  outputs = [ "bin" "dev" "out" "man" "devdoc" ];
+  separateDebugInfo = stdenv.isLinux;
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkgconfig perl ];
+
+  # Zlib and OpenSSL must be propagated because `libcurl.la' contains
+  # "-lz -lssl", which aren't necessary direct build inputs of
+  # applications that use Curl.
+  propagatedBuildInputs = with stdenv.lib;
+    optional http2Support nghttp2 ++
+    optional idnSupport libidn ++
+    optional ldapSupport openldap ++
+    optional zlibSupport zlib ++
+    optional gssSupport kerberos ++
+    optional c-aresSupport c-ares ++
+    optional sslSupport openssl ++
+    optional gnutlsSupport gnutls ++
+    optional scpSupport libssh2 ++
+    optional brotliSupport brotli;
+
+  # for the second line see https://curl.haxx.se/mail/tracker-2014-03/0087.html
+  preConfigure = ''
+    sed -e 's|/usr/bin|/no-such-path|g' -i.bak configure
+    rm src/tool_hugehelp.c
+  '';
+
+  configureFlags = [
+      "--with-ca-fallback"
+      "--disable-manual"
+      ( if sslSupport then "--with-ssl=${openssl.dev}" else "--without-ssl" )
+      ( if gnutlsSupport then "--with-gnutls=${gnutls.dev}" else "--without-gnutls" )
+      ( if scpSupport then "--with-libssh2=${libssh2.dev}" else "--without-libssh2" )
+      ( if ldapSupport then "--enable-ldap" else "--disable-ldap" )
+      ( if ldapSupport then "--enable-ldaps" else "--disable-ldaps" )
+      ( if idnSupport then "--with-libidn=${libidn.dev}" else "--without-libidn" )
+      ( if brotliSupport then "--with-brotli" else "--without-brotli" )
+    ]
+    ++ stdenv.lib.optional c-aresSupport "--enable-ares=${c-ares}"
+    ++ stdenv.lib.optional gssSupport "--with-gssapi=${kerberos.dev}";
+
+  CXX = "${stdenv.cc.targetPrefix}c++";
+  CXXCPP = "${stdenv.cc.targetPrefix}c++ -E";
+
+  doCheck = false; # expensive, fails
+
+  postInstall = ''
+    moveToOutput bin/curl-config "$dev"
+    sed '/^dependency_libs/s|${libssh2.dev}|${libssh2.out}|' -i "$out"/lib/*.la
+  '' + stdenv.lib.optionalString gnutlsSupport ''
+    ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so
+    ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so.4
+    ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so.4.4.0
+  '';
+
+  crossAttrs = {
+    # We should refer to the cross built openssl
+    # For the 'urandom', maybe it should be a cross-system option
+    configureFlags = [
+        ( if sslSupport then "--with-ssl=${openssl.crossDrv}" else "--without-ssl" )
+        ( if gnutlsSupport then "--with-gnutls=${gnutls.crossDrv}" else "--without-gnutls" )
+        "--with-random /dev/urandom"
+      ];
+  };
+
+  passthru = {
+    inherit sslSupport openssl;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A command line tool for transferring files with URL syntax";
+    homepage    = https://curl.haxx.se/;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1891,6 +1891,15 @@ with pkgs;
     brotliSupport = true;
   };
 
+  curl_7_59 = callPackage ../tools/networking/curl/7_59.nix rec {
+    fetchurl = fetchurlBoot;
+    http2Support = true;
+    zlibSupport = true;
+    sslSupport = zlibSupport;
+    scpSupport = zlibSupport && !stdenv.isSunOS && !stdenv.isCygwin;
+    gssSupport = true;
+  };
+
   curl = callPackage ../tools/networking/curl rec {
     fetchurl = fetchurlBoot;
     http2Support = true;
@@ -20866,6 +20875,7 @@ with pkgs;
   inherit (callPackages ../tools/package-management/nix {
       storeDir = config.nix.storeDir or "/nix/store";
       stateDir = config.nix.stateDir or "/nix/var";
+      curl = curl_7_59;
       })
     nix
     nix1


### PR DESCRIPTION
I would consider this a temporary fix until a proper solution for #41312 has been found.
Unfortunately, NixOS on master is rather unusable without reverting the above commit.

###### Motivation for this change

All nix tools appear to be flaky and run into timeouts with curl 7.60.0
See nixos/nixpkgs#41312 for more details

Note that I created a separate `curl/7_59.nix` rather than abstracting the curl derivation to make this "fix" easily removable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

