### PR TITLE
python36Packages.cython: Disable tests on aarch64

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -11,7 +11,18 @@
 , ncurses
 }:
 
-buildPythonPackage rec {
+let
+  excludedTests = []
+    # cython's testsuite is not working very well with libc++
+    # We are however optimistic about things outside of testsuite still working
+    ++ stdenv.lib.optionals (stdenv.cc.isClang or false) [ "cpdef_extern_func" "libcpp_algo" ]
+    # Some tests in the test suite isn't working on aarch64. Disable them for
+    # now until upstream finds a workaround.
+    # Upstream issue here: https://github.com/cython/cython/issues/2308
+    ++ stdenv.lib.optionals stdenv.isAarch64 [ "numpy_memoryview" ]
+  ;
+
+in buildPythonPackage rec {
   pname = "Cython";
   version = "0.28.2";
 
@@ -29,12 +40,11 @@ buildPythonPackage rec {
   buildInputs = [ glibcLocales gdb ];
   LC_ALL = "en_US.UTF-8";
 
-  # cython's testsuite is not working very well with libc++
-  # We are however optimistic about things outside of testsuite still working
   checkPhase = ''
     export HOME="$NIX_BUILD_TOP"
     ${python.interpreter} runtests.py \
-      ${if stdenv.cc.isClang or false then ''--exclude="(cpdef_extern_func|libcpp_algo)"'' else ""}
+      ${stdenv.lib.optionalString (builtins.length excludedTests != 0)
+        ''--exclude="(${builtins.concatStringsSep "|" excludedTests})"''}
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
The tests doesn't run on aarch64 and it's reported to upstream here:
https://github.com/cython/cython/issues/2308

This would also resolve #41347 for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh @dezgeg 