### PR TITLE
fix opam tool support

### DIFF
--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -71,8 +71,12 @@ in stdenv.mkDerivation rec {
   # Dirty, but apparently ocp-build requires a TERM
   makeFlags = ["TERM=screen"];
 
+  # change argv0 to "opam" as a workaround for
+  # https://github.com/ocaml/opam/issues/2142
   postInstall = ''
-    wrapProgram $out/bin/opam \
+    mv $out/bin/opam $out/bin/.opam-wrapped
+    makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
+      --argv0 "opam" \
       --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin
   '';
 


### PR DESCRIPTION
###### Motivation for this change

opam extension tools like 'opam depext' don't work because of interaction of wrap-program with https://github.com/ocaml/opam/issues/2142 ...

###### Things done

Changed wrap-program to a more explicit makeWrapper use that avoids using an absolute path for argv0.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

