### PR TITLE
Haproxy 1.8.9

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -300,6 +300,7 @@ in rec {
   tests.grafana = callTest tests/grafana.nix {};
   tests.graphite = callTest tests/graphite.nix {};
   tests.hardened = callTest tests/hardened.nix { };
+  tests.haproxy = callTest tests/haproxy.nix {};
   tests.hibernate = callTest tests/hibernate.nix {};
   tests.hitch = callTest tests/hitch {};
   tests.home-assistant = callTest tests/home-assistant.nix { };

--- a/nixos/tests/haproxy.nix
+++ b/nixos/tests/haproxy.nix
@@ -1,0 +1,41 @@
+import ./make-test.nix ({ pkgs, ...}: {
+  name = "haproxy";
+  nodes = {
+    machine = { config, ...}: {
+      imports = [ ../modules/profiles/minimal.nix ];
+      services.haproxy = {
+        enable = true;
+        config = ''
+          defaults
+            timeout connect 10s
+
+          backend http_server
+            mode http
+            server httpd [::1]:8000
+
+          frontend http
+            bind *:80
+            mode http
+            use_backend http_server
+        '';
+      };
+      services.httpd = {
+        enable = true;
+        documentRoot = pkgs.writeTextDir "index.txt" "We are all good!";
+        adminAddr = "notme@yourhost.local";
+        listen = [{
+          ip = "::1";
+          port = 8000;
+        }];
+      };
+    };
+  };
+  testScript = ''
+    startAll;
+    $machine->waitForUnit('multi-user.target');
+    $machine->waitForUnit('haproxy.service');
+    $machine->waitForUnit('httpd.service');
+    $machine->succeed('curl -k http://localhost:80/index.txt | grep "We are all good!"');
+
+  '';
+})

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,6 +1,6 @@
 { useLua ? !stdenv.isDarwin
 , usePcre ? true
-, stdenv, fetchurl
+, stdenv, fetchurl, fetchpatch
 , openssl, zlib, lua5_3 ? null, pcre ? null
 }:
 
@@ -16,6 +16,14 @@ stdenv.mkDerivation rec {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
     sha256 = "00miblgwll3mycsgmp3gd3cn4lwsagxzgjxk5i6csnyqgj97fss3";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-11469.patch";
+      url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=17514045e5d934dede62116216c1b016fe23dd06";
+      sha256 = "0hzcvghg8qz45n3mrcgsjgvrvicvbvm52cc4hs5jbk1yb50qvls7";
+    })
+  ];
 
   buildInputs = [ openssl zlib ]
     ++ stdenv.lib.optional useLua lua5_3

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -23,7 +23,11 @@ stdenv.mkDerivation rec {
       url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=17514045e5d934dede62116216c1b016fe23dd06";
       sha256 = "0hzcvghg8qz45n3mrcgsjgvrvicvbvm52cc4hs5jbk1yb50qvls7";
     })
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
+    name = "fix-darwin-no-threads-build.patch";
+    url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=fbf09c441a4e72c4a690bc7ef25d3374767fe5c5;hp=3157ef219c493f3b01192f1b809a086a5b119a1e";
+    sha256 = "16ckzb160anf7xih7mmqy59pfz8sdywmyblxnr7lz9xix3jwk55r";
+  });
 
   buildInputs = [ openssl zlib ]
     ++ stdenv.lib.optional useLua lua5_3

--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -9,12 +9,12 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  version = "1.8.4";
+  version = "1.8.9";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
-    sha256 = "19l4i0p92ahm3vaw42gz3rmmidfivk36mvqyhir81h6ywyjb01g3";
+    sha256 = "00miblgwll3mycsgmp3gd3cn4lwsagxzgjxk5i6csnyqgj97fss3";
   };
 
   buildInputs = [ openssl zlib ]


### PR DESCRIPTION
###### Motivation for this change

This fixes CVE-2018-10184 a potential remote denial of service in the
http/2 module and CVE-2018-11469. The version bump also includes various other changes that
are described in the changelog [1]:
```
2018/05/18 : 1.8.9
    - BUG/MINOR: pattern: Add a missing HA_SPIN_INIT() in pat_ref_newid()
    - BUG/MAJOR: channel: Fix crash when trying to read from a closed socket
    - BUG/MINOR: log: t_idle (%Ti) is not set for some requests
    - BUG/MEDIUM: lua: Fix segmentation fault if a Lua task exits
    - MINOR: h2: detect presence of CONNECT and/or content-length
    - BUG/MEDIUM: h2: implement missing support for chunked encoded uploads
    - BUG/MINOR: lua/threads: Make lua's tasks sticky to the current thread
    - BUG/MINOR: config: disable http-reuse on TCP proxies
    - BUG/MINOR: checks: Fix check->health computation for flapping servers
    - BUG/MEDIUM: threads: Fix the sync point for more than 32 threads
    - BUG/MINOR: lua: Put tasks to sleep when waiting for data
    - DOC/MINOR: clean up LUA documentation re: servers & array/table.
    - BUG/MINOR: map: correctly track reference to the last ref_elt being dumped
    - BUG/MEDIUM: task: Don't free a task that is about to be run.
    - BUG/MINOR: lua: schedule socket task upon lua connect()
    - BUG/MINOR: lua: ensure large proxy IDs can be represented
    - BUG/MEDIUM: http: don't always abort transfers on CF_SHUTR
    - BUG/MEDIUM: pollers: Use a global list for fd shared between threads.
    - BUG/MEDIUM: ssl: properly protect SSL cert generation
    - BUG/MINOR: spoe: Mistake in error message about SPOE configuration

2018/04/19 : 1.8.8
    - BUG/MEDIUM: threads: Fix the max/min calculation because of name clashes
    - BUG/MEDIUM: connection: Make sure we have a mux before calling detach().
    - BUG/MINOR: http: Return an error in proxy mode when url2sa fails
    - BUG/MEDIUM: kqueue: When adding new events, provide an output to get errors.
    - BUG/MINOR: cli: Guard against NULL messages when using CLI_ST_PRINT_FREE
    - MINOR: cli: Ensure the CLI always outputs an error when it should
    - DOC: lua: update the links to the config and Lua API
    - BUG/CRITICAL: h2: fix incorrect frame length check

2018/04/07 : 1.8.7
    - BUG/MAJOR: cache: always initialize newly created objects
    - MINOR: servers: Support alphanumeric characters for the server templates names

2018/04/05 : 1.8.6
    - BUG/MINOR: lua: the function returns anything
    - BUG/MINOR: lua funtion hlua_socket_settimeout don't check negative values
    - BUILD/MINOR: fix build when USE_THREAD is not defined
    - MINOR: cli/threads: make "show fd" report thread_sync_io_handler instead of "unknown"
    - MINOR: cli: make "show fd" report the mux and mux_ctx pointers when available
    - BUILD/MINOR: cli: fix a build warning introduced by last commit
    - BUG/MINOR: hpack: fix harmless use of uninitialized value in hpack_dht_insert
    - CLEANUP: h2: rename misleading h2c_stream_close() to h2s_close()
    - MINOR: h2: provide and use h2s_detach() and h2s_free()
    - BUG/MAJOR: h2: remove orphaned streams from the send list before closing
    - MINOR: h2: always call h2s_detach() in h2_detach()
    - MINOR: h2: fuse h2s_detach() and h2s_free() into h2s_destroy()
    - BUG/MEDIUM: h2/threads: never release the task outside of the task handler
    - BUG/MEDIUM: h2: don't consider pending data on detach if connection is in error
    - BUILD/MINOR: threads: always export thread_sync_io_handler()
    - BUG/MEDIUM: h2: always add a stream to the send or fctl list when blocked
    - BUG/MINOR: checks: check the conn_stream's readiness and not the connection
    - BUG/MINOR: email-alert: Set the mailer port during alert initialization
    - BUG/MINOR: cache: fix "show cache" output
    - BUG/MINOR: fd: Don't clear the update_mask in fd_insert.
    - BUG/MAJOR: cache: fix random crashes caused by incorrect delete() on non-first blocks
    - BUG/MINOR: spoe: Initialize variables used during conf parsing before any check
    - BUG/MINOR: spoe: Don't release the context buffer in .check_timeouts callbaclk

2018/03/23 : 1.8.5
    - BUG/MINOR: threads: fix missing thread lock labels for 1.8
    - BUG/MEDIUM: ssl: Don't always treat SSL_ERROR_SYSCALL as unrecovarable.
    - BUG/MEDIUM: ssl: Shutdown the connection for reading on SSL_ERROR_SYSCALL
    - BUG/MINOR: init: Add missing brackets in the code parsing -sf/-st
    - BUG/MINOR: ssl/threads: Make management of the TLS ticket keys files thread-safe
    - BUG/MEDIUM: http: Switch the HTTP response in tunnel mode as earlier as possible
    - BUG/MEDIUM: ssl/sample: ssl_bc_* fetch keywords are broken.
    - DOC: lua: new prototype for function "register_action()"
    - DOC: cfgparse: Warn on option (tcp|http)log in backend
    - BUG/MINOR: debug/pools: properly handle out-of-memory when building with DEBUG_UAF
    - MINOR: debug/pools: make DEBUG_UAF also detect underflows
    - BUG/MINOR: h2: Set the target of dbuf_wait to h2c
    - MINOR: stats: display the number of threads in the statistics.
    - BUG/MEDIUM: h2: always consume any trailing data after end of output buffers
    - BUG/MEDIUM: buffer: Fix the wrapping case in bo_putblk
    - BUG/MEDIUM: buffer: Fix the wrapping case in bi_putblk
    - Revert "BUG/MINOR: send-proxy-v2: string size must include ('\0')"
    - MINOR: systemd: Add section for SystemD sandboxing to unit file
    - MINOR: systemd: Add SystemD's Protect*= options to the unit file
    - MINOR: systemd: Add SystemD's SystemCallFilter option to the unit file
    - MINOR/BUILD: fix Lua build on Mac OS X
    - BUILD/MINOR: fix Lua build on Mac OS X (again)
    - BUG/MINOR: session: Fix tcp-request session failure if handshake.
    - CLEANUP: .gitignore: Ignore binaries from the contrib directory
    - BUG/MINOR: unix: Don't mess up when removing the socket from the xfer_sock_list.
    - BUG/MEDIUM: h2: also arm the h2 timeout when sending
    - BUG/MINOR: cli: Fix a crash when passing a negative or too large value to "show fd"
    - CLEANUP: ssl: Remove a duplicated #include
    - CLEANUP: cli: Remove a leftover debug message
    - BUG/MINOR: cli: Fix a typo in the 'set rate-limit' usage
    - BUG/MEDIUM: fix a 100% cpu usage with cpu-map and nbthread/nbproc
    - BUG/MINOR: force-persist and ignore-persist only apply to backends
    - BUG/MEDIUM: spoe: Remove idle applets from idle list when HAProxy is stopping
    - BUG/MEDIUM: threads/unix: Fix a deadlock when a listener is temporarily disabled
    - BUG/MAJOR: threads/queue: Fix thread-safety issues on the queues management
    - BUG/MINOR: dns: don't downgrade DNS accepted payload size automatically
    - BUG/MINOR: seemless reload: Fix crash when an interface is specified.
    - BUG/MINOR: cli: Fix a crash when sending a command with too many arguments
    - BUILD: ssl: Fix build with OpenSSL without NPN capability
    - BUG/MINOR: spoa-example: unexpected behavior for more than 127 args
    - BUG/MINOR: lua: return bad error messages
    - BUG/MEDIUM: tcp-check: single connect rule can't detect DOWN servers
    - BUG/MINOR: tcp-check: use the server's service port as a fallback
    - BUG/MEDIUM: threads/queue: wake up other threads upon dequeue
    - MINOR: log: stop emitting alerts when it's not possible to write on the socket
    - BUILD/BUG: enable -fno-strict-overflow by default
    - DOC: log: more than 2 log servers are allowed
    - DOC: don't suggest using http-server-close
    - BUG/MEDIUM: h2: properly account for DATA padding in flow control
    - BUG/MINOR: h2: ensure we can never send an RST_STREAM in response to an RST_STREAM
    - BUG/MINOR: listener: Don't decrease actconn twice when a new session is rejected
```
[1] haproxy.org/download/1.8/src/CHANGELOG

Probably obsoletes #37998 as soon as the Darwin build succeeds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

