### PR TITLE
singularity-tools: create mount points for image building

### DIFF
--- a/pkgs/build-support/singularity-tools/default.nix
+++ b/pkgs/build-support/singularity-tools/default.nix
@@ -96,7 +96,7 @@ rec {
             echo creating
             singularity image.create -s $((1 + size * 4 / 1024 + ${toString extraSpace})) $out
             echo importing
-            mkdir -p /var/singularity/mnt/container
+            mkdir -p /var/singularity/mnt/{container,final,overlay,session,source}
             tar -c . | singularity image.import $out
           '');
 


### PR DESCRIPTION
###### Motivation for this change

Image build was broken with latest verion of singularity due to missing mount points.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

