### PR TITLE
pythonPackages.aws-sam-translator: init at 1.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -393,6 +393,11 @@
     github = "andir";
     name = "Andreas Rammhold";
   };
+  andreabedini = {
+    email = "andrea@kzn.io";
+    github = "andreabedini";
+    name = "Andrea Bedini";
+  };
   andres = {
     email = "ksnixos@andres-loeh.de";
     github = "kosmikus";

--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, boto3
+, enum34
+, jsonschema
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "aws-sam-translator";
+  version = "1.5.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9d8a25e058c78d2cef5c07aec7f98cbc2070dbfc2eb6a2e102a16beafd14e3ca";
+  };
+
+  # Tests are not included in the PyPI package
+  doCheck = false;
+
+  disabled = isPy3k;
+
+  propagatedBuildInputs = [
+    boto3
+    enum34
+    jsonschema
+    six
+  ];
+
+  meta = {
+    homepage = https://github.com/awslabs/serverless-application-model;
+    description = "Python library to transform SAM templates into AWS CloudFormation templates";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.andreabedini ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -197,6 +197,8 @@ in {
 
   automat = callPackage ../development/python-modules/automat { };
 
+  aws-sam-translator = callPackage ../development/python-modules/aws-sam-translator { };
+
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };
 
   # packages defined elsewhere


### PR DESCRIPTION
###### Motivation for this change

New python package, needed for `aws-sam-cli` which I am about to submit as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

