### PR TITLE
udiskie: 1.7.4 -> 1.7.5

### DIFF
--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonApplication rec {
   name = "udiskie-${version}";
-  version = "1.7.4";
+  version = "1.7.5";
 
   src = fetchFromGitHub {
     owner = "coldfix";
     repo = "udiskie";
     rev = version;
-    sha256 = "0r3m8y6ppkl8p1lhr89sfk9v2la1zn0rbmr6hy860j7b22yvnkrn";
+    sha256 = "1mcdn8ha5d5nsmrzk6xnnsqrmk94rdrzym9sqm38zk5r8gpyl1k4";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

`udiskie` breaks for me with the following error when using 1.7.4:

```
Traceback (most recent call last):
  File "/nix/store/cqa72mqgm5gi0xpqp5r8csdizv3p3ajr-udiskie-1.7.4/lib/python3.6/site-packages/udiskie/cli.py", line 307, in _start_async_tasks
    results = yield self._init()
  File "/nix/store/cqa72mqgm5gi0xpqp5r8csdizv3p3ajr-udiskie-1.7.4/lib/python3.6/site-packages/udiskie/cli.py", line 495, in _init
    tasks.append(Async())
NameError: name 'Async' is not defined
```

The error has been confirmed by the Debian issue tracker, so it's
obviously not related to NixOS.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=899419 for further
reference.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

