### PR TITLE
iasl: integrate upstream patch for acpica/acpica#387

### DIFF
--- a/pkgs/development/compilers/iasl/default.nix
+++ b/pkgs/development/compilers/iasl/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, bison, flex}:
+{stdenv, fetchurl, fetchpatch, bison, flex}:
 
 stdenv.mkDerivation rec {
   name = "iasl-${version}";
@@ -11,13 +11,17 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = [
     "-O3"
-    # See: https://github.com/acpica/acpica/issues/387:
-    "-Wno-error=format-overflow"
   ];
 
   buildFlags = "iasl";
 
   buildInputs = [ bison flex ];
+
+  patches = fetchpatch {
+    /* https://github.com/acpica/acpica/pull/389 */
+    url = "https://github.com/acpica/acpica/commit/935ca65f7806a3ef9bd02a947e50f3a1f586ac67.patch";
+    sha256 = "0jz4bakifphm425shbd1j99hldgy71m7scl8mwibm441d56l3ydf";
+  };
 
   installPhase =
     ''


### PR DESCRIPTION
###### Motivation for this change

See: 
 - https://github.com/acpica/acpica/issues/387

~~Probably want to wait until https://github.com/acpica/acpica/pull/389 is merged.~~ :heavy_check_mark: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

