### PR TITLE
catch: add separate derivation for the catch2 branch

### DIFF
--- a/pkgs/development/libraries/catch/default.nix
+++ b/pkgs/development/libraries/catch/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, python }:
 
 stdenv.mkDerivation rec {
   name = "catch-${version}";
-  version = "1.12.0";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "catchorg";
-    repo = "Catch";
+    repo = "Catch2";
     rev = "v${version}";
-    sha256 = "0hkcmycvyyazzi9dywnyiipnmbx399iirh5xk5g957c8zl0505kd";
+    sha256 = "1v7j7rd2i79qaij0izvidjvcjximxp6drimc1ih7sinv2194j1f8";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optional doCheck python;
   cmakeFlags = [ "-DUSE_CPP14=ON" ];
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
The `catch` package issues releases for both v1 and v2 branches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

