### PR TITLE
ocamlPackages.linenoise: init at 1.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/linenoise/default.nix
+++ b/pkgs/development/ocaml-modules/linenoise/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, ocaml, jbuilder, findlib, result }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "linenoise is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-linenoise-${version}";
+  version = "1.1.0";
+  src = fetchFromGitHub {
+    owner = "fxfactorial";
+    repo = "ocaml-linenoise";
+    rev = "v${version}";
+    sha256 = "1h6rqfgmhmd7p5z8yhk6zkbrk4yzw1v2fgwas2b7g3hqs6y0xj0q";
+  };
+
+  buildInputs = [ ocaml findlib jbuilder ];
+  propagatedBuildInputs = [ result ];
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    description = "OCaml bindings to linenoise";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -363,6 +363,8 @@ let
       then callPackage ../development/ocaml-modules/lambda-term { }
       else lambdaTerm-1_6;
 
+    linenoise = callPackage ../development/ocaml-modules/linenoise { };
+
     llvm = callPackage ../development/ocaml-modules/llvm {
       llvm = pkgs.llvm_39;
     };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

