### PR TITLE
Revert "lib: bitAnd, bitOr, bitXor"

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,10 +56,10 @@ let
       hasAttr head isAttrs isBool isInt isList isString length
       lessThan listToAttrs pathExists readFile replaceStrings seq
       stringLength sub substring tail;
-    inherit (trivial) id const concat or and bitAnd bitOr bitXor
-      boolToString mergeAttrs flip mapNullable inNixShell min max
-      importJSON warn info nixpkgsVersion version mod compare
-      splitByAndCompare functionArgs setFunctionArgs isFunction;
+    inherit (trivial) id const concat or and boolToString mergeAttrs
+      flip mapNullable inNixShell min max importJSON warn info
+      nixpkgsVersion version mod compare splitByAndCompare
+      functionArgs setFunctionArgs isFunction;
 
     inherit (fixedPoints) fix fix' extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -45,21 +45,6 @@ runTests {
     expected = true;
   };
 
-  testBitAnd = {
-    expr = (bitAnd 3 10);
-    expected = 2;
-  };
-
-  testBitOr = {
-    expr = (bitOr 3 10);
-    expected = 11;
-  };
-
-  testBitXor = {
-    expr = (bitXor 3 10);
-    expected = 9;
-  };
-
 # STRINGS
 
   testConcatMapStrings = {

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1,38 +1,4 @@
 { lib }:
-let
-  zipIntBits = f: x: y:
-    let
-      # (intToBits 6) -> [ 0 1 1 ]
-      intToBits = x:
-        if x==0 then
-          []
-        else
-          let
-            headbit  = if (x / 2) * 2 != x then 1 else 0;                          # x & 1
-            tailbits = if x < 0 then 9223372036854775807 + ((x+1) / 2) else x / 2; # x >>> 1
-          in
-            [headbit] ++ (intToBits tailbits);
-
-      # (bitsToInt [ 0 1 1 ]) -> 6
-      bitsToInt = l:
-        if l==[] then
-          0
-        else
-          (builtins.head l) + (2 * (bitsToInt (builtins.tail l)));
-
-      zipListsWith' = fst: snd:
-        if fst==[] && snd==[] then
-          []
-        else if fst==[] then
-          [(f 0                   (builtins.head snd))] ++ (zipListsWith' []                  (builtins.tail snd))
-        else if snd==[] then
-          [(f (builtins.head fst) 0                  )] ++ (zipListsWith' (builtins.tail fst) []                 )
-        else
-          [(f (builtins.head fst) (builtins.head snd))] ++ (zipListsWith' (builtins.tail fst) (builtins.tail snd));
-    in
-      assert (builtins.isInt x) && (builtins.isInt y);
-      bitsToInt (zipListsWith' (intToBits x) (intToBits y));
-in
 rec {
 
   /* The identity function
@@ -64,15 +30,6 @@ rec {
 
   /* boolean “and” */
   and = x: y: x && y;
-
-  /* bitwise “and” */
-  bitAnd = builtins.bitAnd or zipIntBits (a: b: if a==1 && b==1 then 1 else 0);
-
-  /* bitwise “or” */
-  bitOr = builtins.bitOr or zipIntBits (a: b: if a==1 || b==1 then 1 else 0);
-
-  /* bitwise “xor” */
-  bitXor = builtins.bitXor or zipIntBits (a: b: if a!=b then 1 else 0);
 
   /* Convert a boolean to a string.
      Note that toString on a bool returns "1" and "".


### PR DESCRIPTION
Reverts NixOS/nixpkgs#41373

The literal 64 bit integer `9223372036854775807` breaks 32 bit nix installations (the integer doesn’t parse there).