### PR TITLE
ctmg: add 1.2

### DIFF
--- a/pkgs/tools/security/ctmg/default.nix
+++ b/pkgs/tools/security/ctmg/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, ...  }:
+
+stdenv.mkDerivation rec {
+  name    = "ctmg-${version}";
+  version = "1.2";
+
+  src = fetchurl {
+    url    = "https://git.zx2c4.com/ctmg/snapshot/ctmg-${version}.tar.xz";
+    sha256 = "1djxrf66abl63cybxfgjshr8avbp6nq158d0jx4mlfa3pdj32kv9";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ctmg.sh $out/bin/ctmg
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An encrypted container manager for Linux using cryptsetup";
+    homepage    = https://git.zx2c4.com/ctmg/about/;
+    license     = licenses.free;
+    maintainers = with maintainers; [ mrVanDalo ];
+    platforms   = platforms.linux;
+  };
+}
+

--- a/pkgs/tools/security/ctmg/default.nix
+++ b/pkgs/tools/security/ctmg/default.nix
@@ -1,25 +1,21 @@
-{ stdenv, fetchurl, ...  }:
+{ stdenv, fetchzip }:
 
 stdenv.mkDerivation rec {
-  name    = "ctmg-${version}";
+  name = "ctmg-${version}";
   version = "1.2";
 
-  src = fetchurl {
-    url    = "https://git.zx2c4.com/ctmg/snapshot/ctmg-${version}.tar.xz";
-    sha256 = "1djxrf66abl63cybxfgjshr8avbp6nq158d0jx4mlfa3pdj32kv9";
+  src = fetchzip {
+    url = "https://git.zx2c4.com/ctmg/snapshot/ctmg-${version}.tar.xz";
+    sha256 = "1i4v8sriwjrmj3yizbl1ysckb711yl9qsn9x45jq0ij1apsydhyc";
   };
 
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ctmg.sh $out/bin/ctmg
-  '';
+  installPhase = "install -D ctmg.sh $out/bin/ctmg";
 
   meta = with stdenv.lib; {
     description = "An encrypted container manager for Linux using cryptsetup";
-    homepage    = https://git.zx2c4.com/ctmg/about/;
-    license     = licenses.free;
+    homepage = https://git.zx2c4.com/ctmg/about/;
+    license = licenses.isc;
     maintainers = with maintainers; [ mrVanDalo ];
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }
-

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7816,6 +7816,8 @@ with pkgs;
 
   ctodo = callPackage ../applications/misc/ctodo { };
 
+  ctmg = callPackage ../tools/security/ctmg { };
+
   cmake_2_8 = callPackage ../development/tools/build-managers/cmake/2.8.nix { };
 
   cmake = libsForQt5.callPackage ../development/tools/build-managers/cmake { };


### PR DESCRIPTION
###### Motivation for this change

[ctmg](https://git.zx2c4.com/ctmg/about/) is awesome!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

