### PR TITLE
docker-machine-kvm2: init at 0.27.0

### DIFF
--- a/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
+++ b/pkgs/applications/networking/cluster/docker-machine/kvm2.nix
@@ -1,0 +1,36 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, libvirt, pkgconfig }:
+
+buildGoPackage rec {
+  pname = "docker-machine-kvm2";
+  name = "${pname}-${version}";
+  version = "0.27.0";
+
+  goPackagePath = "k8s.io/minikube";
+  subPackages = [ "cmd/drivers/kvm" ];
+
+  src = fetchFromGitHub {
+    owner = "kubernetes";
+    repo = "minikube";
+    rev = "v${version}";
+    sha256 = "00gj8x5p0vxwy0y0g5nnddmq049h7zxvhb73lb4gii5mghr9mkws";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libvirt ];
+
+  preBuild = ''
+    export buildFlagsArray=(-ldflags="-X k8s.io/minikube/pkg/drivers/kvm/version.VERSION=v${version}")
+  '';
+
+  postInstall = ''
+    mv $bin/bin/kvm $bin/bin/docker-machine-driver-kvm2
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/kubernetes/minikube/blob/master/docs/drivers.md;
+    description = "KVM2 driver for docker-machine.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tadfisher ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15362,6 +15362,7 @@ with pkgs;
 
   docker-machine = callPackage ../applications/networking/cluster/docker-machine { };
   docker-machine-kvm = callPackage ../applications/networking/cluster/docker-machine/kvm.nix { };
+  docker-machine-kvm2 = callPackage ../applications/networking/cluster/docker-machine/kvm2.nix { };
   docker-machine-xhyve = callPackage ../applications/networking/cluster/docker-machine/xhyve.nix {
     inherit (darwin.apple_sdk.frameworks) Hypervisor vmnet;
   };


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/34448

Add a derivation for `docker-machine-driver-kvm2`.

Another attempt was made in https://github.com/NixOS/nixpkgs/pull/39438 but it looks like that is stalled.

A PR to integrate with `minikube` is forthcoming.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

