### PR TITLE
buildRustPackage: preserve output from cargo-vendor

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -58,13 +58,21 @@ in stdenv.mkDerivation (args // {
     ${setupVendorDir}
 
     mkdir .cargo
-    cat >.cargo/config <<-EOF
-      [source.crates-io]
-      registry = 'https://github.com/rust-lang/crates.io-index'
-      replace-with = 'vendored-sources'
 
-      [source.vendored-sources]
-      directory = '$(pwd)/$cargoDepsCopy'
+    if [ -f $(pwd)/$cargoDepsCopy/cargo-config ]; then 
+      # removal needed or the checksum fails
+      mv $(pwd)/$cargoDepsCopy/cargo-config .cargo/config
+      sed -i -e '/\[source\.vendored-sources\]/ { N; d; }' .cargo/config
+      sed -i -e '/\[source\.crates-io\]/ { N; d; }' .cargo/config
+    fi
+
+    cat >>.cargo/config <<-EOF
+    [source.crates-io]
+    registry = 'https://github.com/rust-lang/crates.io-index'
+    replace-with = 'vendored-sources'
+
+    [source.vendored-sources]
+    directory = '$(pwd)/$cargoDepsCopy'
     EOF
 
     unset cargoDepsCopy
@@ -97,3 +105,4 @@ in stdenv.mkDerivation (args // {
 
   passthru = { inherit cargoDeps; } // (args.passthru or {});
 })
+

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -23,9 +23,10 @@ stdenv.mkDerivation {
 
     ${cargoUpdateHook}
 
-    cargo vendor
+    cargo vendor | tee cargo-config
 
     cp -ar vendor $out
+    cp cargo-config $out
   '';
 
   outputHashAlgo = "sha256";
@@ -35,3 +36,4 @@ stdenv.mkDerivation {
   impureEnvVars = stdenv.lib.fetchers.proxyImpureEnvVars;
   preferLocalBuild = true;
 }
+


### PR DESCRIPTION
###### Motivation for this change

Dependencies specified as git repos are not working due to missing output in .cargo/config. This patch saves the output in fetchcargo and includes parts of it in the one regenerated in buildRustPackage. Note that the temporary cargo-config file must be removed prior to executing cargo update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've setup a repository to demonstrate the working configuration: https://github.com/jbboehr/nix-fetch-cargo-update

I believe this implementation is a bit brittle. A "perfect" implementation would probably use a toml parser to remove or replace the relevant sections in `.cargo/config`.

I tried running `nix-shell -p nox --run "nox-review wip"` but it crashed, maybe it affects too many packages?

Fixes #41518 