### PR TITLE
[WIP] netbsd.compat: fix build with musl

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, hostPlatform, fetchcvs, lib, groff, mandoc, zlib, coreutils
+{ stdenv, hostPlatform, fetchcvs, lib, groff, mandoc, zlib, buildPackages
 , yacc, flex, libressl, bash, less, writeText }:
 
 let
@@ -178,7 +178,7 @@ let
 
     # temporarily use gnuinstall for bootstrapping
     # bsdinstall will be built later
-    makeFlags = [ "INSTALL=${coreutils}/bin/install" ];
+    makeFlags = [ "INSTALL=${buildPackages.coreutils}/bin/install" ];
     installFlags = [];
     RENAME = "-D";
 


### PR DESCRIPTION
I am trying to make this succeed:
```
nix-build --arg crossSystem '(import <nixpkgs/lib>).systems.examples.musl64' -A netbsd.compat
```

The first issue I encountered is that coreutils don't build for musl, but luckily they are only needed for the build platform. Here:
```
nativeBuildInputs = [ makeMinimal ];
makeFlags = [ "INSTALL=${coreutils}/bin/install" ];
```
I could have added `coreutils` to `nativeBuildInputs` and deleted `makeFlags`, but the definition seems to be making a point of using them only for `install`, so I have qualified them with `buildPackages`.

The next issue is that `netbsd.compat` configure fails to find `zlib.h`. From `config.log`:
```
configure:2220: checking for zlib.h
configure:2230: x86_64-unknown-linux-musl-gcc -E  conftest.c
configure:2227:10: fatal error: zlib.h: No such file or directory
 #include "confdefs.h"
          ^~~~~~~~
compilation terminated.
configure:2236: $? = 1
configure: failed program was:
#line 2226 "configure"
#include "confdefs.h"
#include <zlib.h>
configure:2255: result: no
configure:2260: error: zlib must be installed in a compiler-visible path
```
My test using the environment of the failed build:
```
$ echo '#include <zlib.h>' > test.c
$ x86_64-unknown-linux-musl-gcc -c test.c
test.c:1:10: fatal error: zlib.h: No such file or directory
 #include <zlib.h>
          ^~~~~~~~
compilation terminated.
$ env | grep zlib
NIX_TARGET_LDFLAGS= -L/nix/store/n1gw5s811sz37c8b9204nbmrpiqql2sr-zlib-1.2.11-x86_64-unknown-linux-musl-dev/lib -L/nix/store/64nyx4j4h1947vrvyn92ja3jchyq1g0b-zlib-1.2.11-x86_64-unknown-linux-musl/lib
NIX_TARGET_CFLAGS_COMPILE= -isystem /nix/store/n1gw5s811sz37c8b9204nbmrpiqql2sr-zlib-1.2.11-x86_64-unknown-linux-musl-dev/include
buildInputs=/nix/store/n1gw5s811sz37c8b9204nbmrpiqql2sr-zlib-1.2.11-x86_64-unknown-linux-musl-dev
```
So the issue is that `x86_64-unknown-linux-musl-gcc` is not using `NIX_TARGET_CFLAGS_COMPILE`, but I am not sure what exactly goes wrong.