### PR TITLE
(WIP) terminfo-extra: init

### DIFF
--- a/pkgs/data/misc/terminfo-extra/default.nix
+++ b/pkgs/data/misc/terminfo-extra/default.nix
@@ -1,0 +1,12 @@
+{ rxvt_unicode, st, runCommandNoCC, ncurses }:
+runCommandNoCC "terminfo-extra" {
+  nativeBuildInputs = [ ncurses ];
+  srcs = [ rxvt_unicode.src st.src ];
+  sourceRoot = ".";
+} ''
+  unpackPhase
+
+  mkdir -p $out/share/terminfo
+  tic -xo $out/share/terminfo */doc/etc/rxvt-unicode.terminfo
+  tic -xo $out/share/terminfo */st.info
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14667,6 +14667,8 @@ with pkgs;
 
   stix-two = callPackage ../data/fonts/stix-two { };
 
+  terminfo-extra = callPackage ../data/misc/terminfo-extra { };
+
   inherit (callPackages ../data/fonts/gdouros { })
     symbola aegyptus akkadian anatolian maya unidings musica analecta textfonts aegan abydos;
 


### PR DESCRIPTION
###### Motivation for this change
Headless systems may need extra terminfo definitions, but users would prefer not to have all the X11 baggage that the terminal emulators bring with them, making "just install the terminal" an unattractive option. This is a possible solution.

Marked as WIP because I'm not sure of the approach and would appreciate some feedback.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

