### PR TITLE
Mint: 2018-05-27 -> 0.0.3

### DIFF
--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -28,13 +28,13 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  version = "2018-05-27";
+  version = "0.0.3";
   name = "mint-${version}";
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
-    rev = "a3f0c86f54b8b3a18dda5c39c2089bdb1d774b4f";
-    sha256 = "1bgs6jkwfc2ksq4gj55cl3h2l5g25f5bwlsjryiw9cbx5k4bp1kz";
+    rev = "0.0.3";
+    sha256 = "15aawhpagpaqrs64jnz3g6iw3dhq0rlqm92cvfd5a3hbwvxg7lm0";
   };
 
   buildInputs = [ crystal zlib openssl duktape ];


### PR DESCRIPTION
###### Motivation for this change

* Allow computed properties on store
* Added decode syntax for decoding primitive structures
* Always default meta charset to UTF-8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

