### PR TITLE
racket: use latest gtk (gtk2 -> gkt3)

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, makeFontsConf, makeWrapper
 , cairo, coreutils, fontconfig, freefont_ttf
-, glib, gmp, gtk2, libedit, libffi, libjpeg
+, glib, gmp, gtk3, libedit, libffi, libjpeg
 , libpng, libtool, mpfr, openssl, pango, poppler
 , readline, sqlite
 , disableDocs ? false
 , CoreFoundation
+, gsettings_desktop_schemas
 }:
 
 let
@@ -18,7 +19,8 @@ let
     fontconfig
     glib
     gmp
-    gtk2
+    gtk3
+    gsettings_desktop_schemas
     libedit
     libjpeg
     libpng
@@ -53,7 +55,7 @@ stdenv.mkDerivation rec {
     (stdenv.lib.optionalString stdenv.isDarwin "-framework CoreFoundation")
   ];
 
-  buildInputs = [ fontconfig libffi libtool makeWrapper sqlite ]
+  buildInputs = [ fontconfig libffi libtool makeWrapper sqlite gsettings_desktop_schemas gtk3 ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ CoreFoundation ];
 
   preConfigure = ''
@@ -74,7 +76,9 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     for p in $(ls $out/bin/) ; do
-      wrapProgram $out/bin/$p --prefix LD_LIBRARY_PATH ":" "${LD_LIBRARY_PATH}";
+      wrapProgram $out/bin/$p \
+        --prefix LD_LIBRARY_PATH ":" "${LD_LIBRARY_PATH}" \
+        --prefix XDG_DATA_DIRS ":" "$GSETTINGS_SCHEMAS_PATH";
     done
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Racket currently uses `gtk2` which is rather ugly. `gtk3` is a lot more visually appealing. This change also exhibited a problem whereby racket crashes when one opens the file search modal. This was solved by including `gsettings_desktop_schemas` and setting `XDG_DATA_DIRS`


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

