### PR TITLE
pythonPackages.autograd: init at 1.2

### DIFF
--- a/pkgs/development/python-modules/autograd/default.nix
+++ b/pkgs/development/python-modules/autograd/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, future, nose }:
+
+buildPythonPackage rec {
+  pname = "autograd";
+  version = "1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0zd4lhz9dpll4i63jjijbzkzbgmg8h88il7lr7kmcylvadnzm2x0";
+  };
+
+  propagatedBuildInputs = [ numpy future ];
+
+  # Currently, the PyPI tarball doesn't contain the tests. When that has been
+  # fixed, enable testing. See: https://github.com/HIPS/autograd/issues/404
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/HIPS/autograd;
+    description = "Compute derivatives of NumPy code efficiently";
+    license = licenses.mit;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -195,6 +195,8 @@ in {
     inherit (pkgs) augeas;
   };
 
+  autograd = callPackage ../development/python-modules/autograd { };
+
   automat = callPackage ../development/python-modules/automat { };
 
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };


### PR DESCRIPTION
###### Motivation for this change

Add autograd package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

