### PR TITLE
 gdk-pixbuf: fix loader.cache on darwin 

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     "-Djasper=true"
     "-Dx11=true"
     "-Dgir=${if gobjectIntrospection != null then "true" else "false"}"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "-Dbuiltin_loaders=all";
+  ];
 
   postPatch = ''
     chmod +x build-aux/* # patchShebangs only applies to executables

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -82,12 +82,8 @@ stdenv.mkDerivation rec {
       $dev/bin/gdk-pixbuf-query-loaders --update-cache
     '';
 
-  # The fixDarwinDylibNames hook doesn't patch library references or binaries.
+  # The fixDarwinDylibNames hook doesn't patch binaries.
   preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
-    for f in $(find $out/lib -name '*.dylib'); do
-        install_name_tool -change @rpath/libgdk_pixbuf-2.0.0.dylib $out/lib/libgdk_pixbuf-2.0.0.dylib $f
-    done
-
     for f in $out/bin/* $dev/bin/*; do
         install_name_tool -change @rpath/libgdk_pixbuf-2.0.0.dylib $out/lib/libgdk_pixbuf-2.0.0.dylib $f
     done

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -73,8 +73,16 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall =
-    # All except one utility seem to be only useful during building.
+    # meson erroneously installs loaders with .dylib extension on Darwin.
+    # Their @rpath has to be replaced before gdk-pixbuf-query-loaders looks at them.
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      for f in $out/${passthru.moduleDir}/*.dylib; do
+          install_name_tool -change @rpath/libgdk_pixbuf-2.0.0.dylib $out/lib/libgdk_pixbuf-2.0.0.dylib $f
+          mv $f ''${f%.dylib}.so
+      done
     ''
+    # All except one utility seem to be only useful during building.
+    + ''
       moveToOutput "bin" "$dev"
       moveToOutput "bin/gdk-pixbuf-thumbnailer" "$out"
 


### PR DESCRIPTION
###### Motivation for this change

gdk-pixbuf-query-loaders looks for .so files even on darwin, but after the switch to meson the loaders are installed with .dylib extension.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested compilation of `gdk_pixbuf`, `gtk2` (reported to fail in #41314).