### PR TITLE
pythonPackages.pvlib: init at 0.5.2

### DIFF
--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, pandas, pytz, six, pytest }:
+
+buildPythonPackage rec {
+  pname = "pvlib";
+  version = "0.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1897v9qq97nk5n0hfm9089yz8pffd42795mnhcyq48g9bsyap1xi";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy pandas pytz six ];
+
+  # Currently, the PyPI tarball doesn't contain the tests. When that has been
+  # fixed, enable testing. See: https://github.com/pvlib/pvlib-python/issues/473
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://pvlib-python.readthedocs.io;
+    description = "Simulate the performance of photovoltaic energy systems";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jluttine ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9888,6 +9888,8 @@ in {
     name = "${python.libPrefix}-${pkgs.kmsxx.name}";
   });
 
+  pvlib = callPackage ../development/python-modules/pvlib { };
+
   pybase64 = callPackage ../development/python-modules/pybase64 { };
 
   pylibconfig2 = callPackage ../development/python-modules/pylibconfig2 { };


### PR DESCRIPTION
###### Motivation for this change

Add pvlib Python package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

