### PR TITLE
gitaly: Cause ruby-cd to be wrapped so bundler will work

### DIFF
--- a/pkgs/applications/version-management/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitaly/default.nix
@@ -23,6 +23,8 @@ in buildGoPackage rec {
     inherit rubyEnv;
   };
 
+  buildInputs = [rubyEnv.wrappedRuby];
+
   postInstall = ''
     mkdir -p $ruby
     cp -rv $src/ruby/{bin,lib,vendor} $ruby


### PR DESCRIPTION
###### Motivation for this change

Gitaly is broken. It handles dependencies by calling bundler. ruby-cd needs to be wrapped for it to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

