### PR TITLE
fcitx-table-extra: init at 0.3.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2176,6 +2176,11 @@
     github = "limeytexan";
     name = "Michael Brantley";
   };
+  linc01n = {
+    email = "git@lincoln.hk";
+    github = "linc01n";
+    name = "Lincoln Lee";
+  };
   linquize = {
     email = "linquize@yahoo.com.hk";
     github = "linquize";

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-extra/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-extra/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, cmake, fcitx, gettext }:
+
+stdenv.mkDerivation rec {
+  name = "fcitx-table-extra-${version}";
+  version = "0.3.8";
+
+  src = fetchurl {
+    url = "http://download.fcitx-im.org/fcitx-table-extra/${name}.tar.xz";
+    sha256 = "c91bb19c1a7b53c5339bf2f75ae83839020d337990f237a8b9bc0f4416c120ef";
+  };
+
+  buildInputs = [ cmake fcitx gettext ];
+
+  preInstall = ''
+   substituteInPlace tables/cmake_install.cmake \
+      --replace ${fcitx} $out
+  '';
+
+  meta = with stdenv.lib; {
+    isFcitxEngine = true;
+    homepage      = "https://github.com/fcitx/fcitx-table-extra";
+    downloadPage  = "http://download.fcitx-im.org/fcitx-table-extra/";
+    description   = "Provides extra table for Fcitx, including Boshiamy, Zhengma, Cangjie, and Quick";
+    license       = licenses.gpl2Plus;
+    platforms     = platforms.linux;
+    maintainers   = with maintainers; [ linc01n ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2315,6 +2315,8 @@ with pkgs;
       protobuf = pkgs.protobuf.overrideDerivation (oldAttrs: { stdenv = clangStdenv; });
     };
 
+    table-extra = callPackage ../tools/inputmethods/fcitx-engines/fcitx-table-extra { };
+
     table-other = callPackage ../tools/inputmethods/fcitx-engines/fcitx-table-other { };
 
     cloudpinyin = callPackage ../tools/inputmethods/fcitx-engines/fcitx-cloudpinyin { };


### PR DESCRIPTION
###### Motivation for this change
Add extra table for fcitx.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

