### PR TITLE
xearth : init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2289,6 +2289,11 @@
     github = "madjar";
     name = "Georges Dubus";
   };
+  mafo = {
+    email = "Marc.Fontaine@gmx.de";
+    github = "MarcFontaine";
+    name = "Marc Fontaine";
+  };
   magnetophon = {
     email = "bart@magnetophon.nl";
     github = "magnetophon";

--- a/pkgs/applications/science/astronomy/xearth/default.nix
+++ b/pkgs/applications/science/astronomy/xearth/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, xorg }:
+stdenv.mkDerivation rec {
+  name = "xearth-${version}";
+  version = "1.1";
+  
+  src = fetchurl {
+    url = "http://xearth.org/${name}.tar.gz";
+    sha256 = "bcb1407cc35b3f6dd3606b2c6072273b6a912cbd9ed1ae22fb2d26694541309c";
+  };
+
+  buildInputs = with xorg; [  imake libXt libXext ];
+
+  dontAddPrefix = true;
+  configureScript="xmkmf";
+
+  installFlags=[ "DESTDIR=$(out)/" "BINDIR=bin" "MANDIR=man/man1"];
+  installTargets="install install.man";
+  
+  meta = with stdenv.lib; {
+    description = "sets the X root window to an image of the Earth";
+    homepage = "http://xplanet.org";
+    longDescription =
+      '' Xearth  sets  the X root window to an image of the Earth, as seen from your favorite vantage point in space,
+         correctly shaded for the current position of the Sun.
+	 By default, xearth updates the displayed image every  five  minutes.
+      '';
+    maintainers = [ maintainers.mafo ];
+    license = "xearth";
+    platforms=platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20569,6 +20569,7 @@ with pkgs;
 
   vite = callPackage ../applications/science/misc/vite { };
 
+  xearth = callPackage ../applications/science/astronomy/xearth { };
   xplanet = callPackage ../applications/science/astronomy/xplanet { };
 
   ### SCIENCE / PHYSICS


### PR DESCRIPTION
###### Motivation for this change
I would like to add the xearth package to nixpkgs

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

