### PR TITLE
stdenv.cc: use libc++ as default c++ standard library on darwin

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -126,9 +126,9 @@ fi
 
 if [[ "$isCpp" = 1 ]]; then
     if [[ "$cppInclude" = 1 ]]; then
-        NIX_@infixSalt@_CFLAGS_COMPILE+=" ${NIX_@infixSalt@_CXXSTDLIB_COMPILE-@default_cxx_stdlib_compile@}"
+        NIX_@infixSalt@_CFLAGS_COMPILE+=" ${NIX_@infixSalt@_CXXSTDLIB_COMPILE:-@default_cxx_stdlib_compile@}"
     fi
-    NIX_@infixSalt@_CFLAGS_LINK+=" $NIX_@infixSalt@_CXXSTDLIB_LINK"
+    NIX_@infixSalt@_CFLAGS_LINK+=" ${NIX_@infixSalt@_CXXSTDLIB_LINK:-@default_cxx_stdlib_link@}"
 fi
 
 source @out@/nix-support/add-hardening.sh

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -360,6 +360,7 @@ in rec {
       cc       = pkgs.llvmPackages.clang-unwrapped;
       bintools = pkgs.darwin.binutils;
       libc     = pkgs.darwin.Libsystem;
+      libcxx   = pkgs.libcxx;
       extraPackages = [ pkgs.libcxx ];
     };
 


### PR DESCRIPTION
###### Motivation for this change

When installing clang on darwin the default c++ standard library isn't set up as it is for gcc on Linux, so compiling c++ code will fail unless include and link flags for the standard library as specified explicitly, which is counter intuitive as the compiler will add them automatically in a traditional installation unless `-nostdlib` or similar is used.

In fact the derivation of gcc does take care of this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

