### PR TITLE
skypeforlinux: remove libstdc++5 dependency

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, dpkg, makeWrapper
 , alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, glibc, gnome3
-, gtk2, libnotify, libpulseaudio, libsecret, libstdcxx5, libv4l, nspr, nss, pango, systemd, xorg }:
+, gtk2, libnotify, libpulseaudio, libsecret, libv4l, nspr, nss, pango, systemd, xorg }:
 
 let
 
@@ -25,7 +25,7 @@ let
     gnome3.gconf
     gdk_pixbuf
     gtk2
-    
+
 
     gnome3.gnome-keyring
 
@@ -36,7 +36,6 @@ let
     pango
     stdenv.cc.cc
     systemd
-    libstdcxx5
     libv4l
 
     xorg.libxkbfile


### PR DESCRIPTION
###### Motivation for this change

`skypeforlinux` does not require `libstdc++5` to function, and the latter is currently broken (See #41585).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

