### PR TITLE
ocamlPackages: use opaline instead of opam-installer

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/0.9.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/0.9.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline }:
 
 let
   pname = "cmdliner";
@@ -17,17 +17,12 @@ stdenv.mkDerivation rec {
   };
 
   unpackCmd = "tar xjf $src";
-  nativeBuildInputs = [ ocamlbuild opam ];
+  nativeBuildInputs = [ ocamlbuild opaline ];
   buildInputs = [ ocaml findlib ];
-
-  createFindlibDestdir = true;
 
   configurePhase = "ocaml pkg/git.ml";
   buildPhase     = "ocaml pkg/build.ml native=true native-dynlink=true";
-  installPhase   = ''
-    opam-installer --script --prefix=$out | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${ocaml.version}/site-lib/
-  '';
+  installPhase   = "opaline -libdir $OCAMLFIND_DESTDIR";
 
   meta = with stdenv.lib; {
     homepage = http://erratique.ch/software/cmdliner;

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, which, ocsigen_server, ocsigen_deriving, ocaml, camlp4,
   js_of_ocaml, lwt_react, cryptokit,
   ipaddr, ocamlnet, lwt_ssl, ocaml_pcre,
-  opam, ppx_tools, ppx_deriving, findlib
+  opaline, ppx_tools, ppx_deriving, findlib
 , js_of_ocaml-ocamlbuild, js_of_ocaml-ppx, js_of_ocaml-ppx_deriving_json
 , js_of_ocaml-lwt
 , js_of_ocaml-tyxml
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec
 
   patches = [ ./camlp4.patch ];
 
-  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opam ppx_tools
+  buildInputs = [ ocaml which findlib js_of_ocaml-ocamlbuild js_of_ocaml-ppx_deriving_json opaline ppx_tools
     ocsigen_deriving
   ];
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec
     ppx_deriving
   ];
 
-  installPhase = "opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
+  installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   setupHook = [ ./setup-hook.sh ];
 

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline }:
 
 let
   inherit (stdenv.lib) getVersion versionAtLeast;
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0czj41sr8jsivl3z8wyblf9k971j3kx2wc3s0c1nhzcc8allg9i2";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam ];
+  buildInputs = [ ocaml findlib ocamlbuild opaline ];
 
   createFindlibDestdir = true;
 
@@ -27,10 +27,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
 
-  installPhase = ''
-    opam-installer --script --prefix=$out ${pname}.install | sh
-    ln -s $out/lib/${pname} $out/lib/ocaml/${getVersion ocaml}/site-lib/${pname}
-  '';
+  installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";
 
   meta = with stdenv.lib; {
     description = "Basic types for computer graphics in OCaml";

--- a/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
+++ b/pkgs/development/ocaml-modules/janestreet/buildOcamlJane.nix
@@ -1,4 +1,4 @@
-{ buildOcaml, opam, js_build_tools, ocaml_oasis, fetchurl } :
+{ buildOcaml, opaline, js_build_tools, ocaml_oasis, fetchurl } :
 
 { name, version ? "113.33.03", buildInputs ? [],
   hash ? "",
@@ -14,7 +14,7 @@ buildOcaml (args // {
 
   hasSharedObjects = true;
 
-  buildInputs = [ ocaml_oasis js_build_tools opam ] ++ buildInputs;
+  buildInputs = [ ocaml_oasis js_build_tools opaline ] ++ buildInputs;
 
   dontAddPrefix = true;
 
@@ -22,14 +22,6 @@ buildOcaml (args // {
 
   buildPhase = "OCAML_TOPLEVEL_PATH=`ocamlfind query findlib`/.. make";
 
-  installPhase = ''
-    opam-installer -i --prefix $prefix --libdir `ocamlfind printconf destdir` --stubsdir `ocamlfind printconf destdir`/${name} ${name}.install
-    if [ -d $out/lib/${name} ]
-      then if [ "$(ls -A $out/lib/${name})" ]
-        then mv $out/lib/${name}/* `ocamlfind printconf destdir`/${name}
-      fi
-      rmdir $out/lib/${name}
-    fi
-  '';
+  installPhase = "opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR ${name}.install";
 
 })

--- a/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
+++ b/pkgs/development/ocaml-modules/janestreet/js-build-tools.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, fetchurl, ocaml_oasis, opam }:
+{ stdenv, buildOcaml, fetchurl, ocaml_oasis, opaline }:
 
 buildOcaml rec {
   name = "js-build-tools";
@@ -13,11 +13,11 @@ buildOcaml rec {
 
   hasSharedObjects = true;
 
-  buildInputs = [ ocaml_oasis opam ];
+  buildInputs = [ ocaml_oasis opaline ];
 
   dontAddPrefix = true;
   configurePhase = "./configure --prefix $prefix";
-  installPhase = "opam-installer -i --prefix $prefix --libdir `ocamlfind printconf destdir` ${name}.install";
+  installPhase = "opaline -prefix $prefix -libdir $OCAMLFIND_DESTDIR ${name}.install";
 
   patches = [ ./js-build-tools-darwin.patch ];
 

--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -17,10 +17,7 @@ buildOcaml rec {
 
   buildPhase = "jbuilder build -p lambda-term";
 
-  installPhase = ''
-    ${jbuilder.installPhase}
-    mv $out/lib/ocaml/${ocaml.version}/site-lib/{stubslibs,lambda-term}/dlllambda_term_stubs.so
-  '';
+  inherit (jbuilder) installPhase;
 
   hasSharedObjects = true;
 

--- a/pkgs/development/ocaml-modules/mstruct/default.nix
+++ b/pkgs/development/ocaml-modules/mstruct/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, opam
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder
 , cstruct
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 		sha256 = "1p4ygwzs3n1fj4apfib0z0sabpph21bkq1dgjk4bsa59pq4prncm";
 	};
 
-	buildInputs = [ ocaml findlib jbuilder opam ];
+	buildInputs = [ ocaml findlib jbuilder ];
 
 	propagatedBuildInputs = [ cstruct ];
 

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -22,10 +22,7 @@ stdenv.mkDerivation rec {
     ppx_sexp_conv ];
   propagatedBuildInputs = [ cstruct zarith sexplib ] ++ optional withLwt cstruct-lwt;
 
-  buildPhase = ''
-    LD_LIBRARY_PATH=${cpuid}/lib/ocaml/${ocaml.version}/site-lib/stubslibs/ \
-    ${topkg.buildPhase} --with-lwt ${boolToString withLwt}
-  '';
+  buildPhase = "${topkg.buildPhase} --with-lwt ${boolToString withLwt}";
   inherit (topkg) installPhase;
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, buildOcaml, ocaml, opam
+{ stdenv, fetchurl, buildOcaml, ocaml, opaline
 , calendar, eliom, js_of_ocaml-ppx_deriving_json
 }:
 
@@ -8,13 +8,13 @@ buildOcaml rec
  version = "1.1.0";
 
  propagatedBuildInputs = [ calendar eliom js_of_ocaml-ppx_deriving_json ];
- buildInputs = [ opam ];
+ buildInputs = [ opaline ];
 
  installPhase =
   ''
     export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH
     make install
-    opam-installer --prefix=$out
+    opaline -prefix $out
   '';
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, buildOcaml, ocaml, opam,
+{stdenv, fetchFromGitHub, buildOcaml, ocaml, opaline,
  cppo, ppx_tools, ounit, ppx_deriving}:
 
 buildOcaml rec {
@@ -15,15 +15,12 @@ buildOcaml rec {
     sha256 = "14c2lp7r9080c4hsb1y1drbxxx3v44b7ib5wfh3kkh3f1jfsjwbk";
   };
 
-  buildInputs = [ cppo ounit ppx_deriving opam ];
+  buildInputs = [ cppo ounit ppx_deriving opaline ];
 
   doCheck = true;
   checkTarget = "test";
 
-  installPhase = ''
-    opam-installer --script --prefix=$out ppx_import.install | sh
-    ln -s $out/lib/ppx_import $out/lib/ocaml/${ocaml.version}/site-lib
-  '';
+  installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   meta = with stdenv.lib; {
     description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";

--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, react, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, react, opaline }:
 
 assert stdenv.lib.versionAtLeast ocaml.version "3.11";
 
@@ -9,12 +9,12 @@ stdenv.mkDerivation {
     sha256 = "0wcs0z50nia1cpk8mh6i5qbc6sff9cc8x7s7q1q89d7m73bnv4vf";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opam ];
+  buildInputs = [ ocaml findlib ocamlbuild opaline ];
   propagatedBuildInputs = [ react ];
 
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
 
-  installPhase = "opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
+  installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   meta = with stdenv.lib; {
     description = "An OCaml module for functional reactive programming (FRP) based on React";

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -5,7 +5,7 @@ The `buildPhase` and `installPhase` attributes can be reused directly
 in many cases. When more fine-grained control on how to run the “topkg”
 build system is required, the attribute `run` can be used.
 */
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, result, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, result, opaline }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.01"
 then throw "topkg is not available for OCaml ${ocaml.version}"
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   unpackCmd = "tar xjf ${src}";
   buildPhase = "${run} build";
   createFindlibDestdir = true;
-  installPhase = "${opam}/bin/opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
+  installPhase = "${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   passthru = { inherit run; };
 

--- a/pkgs/development/ocaml-modules/uchar/default.nix
+++ b/pkgs/development/ocaml-modules/uchar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, ocamlbuild, opam }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline }:
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-uchar-0.0.2";
@@ -9,15 +9,9 @@ stdenv.mkDerivation {
   };
 
   unpackCmd = "tar xjf $src";
-  buildInputs = [ ocaml ocamlbuild opam ];
+  buildInputs = [ ocaml ocamlbuild findlib opaline ];
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
-  installPhase = ''
-    opam-installer --script --prefix=$out uchar.install > install.sh
-    sh install.sh
-    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/
-    ln -s $out/lib/uchar $out/lib/ocaml/${ocaml.version}/site-lib/
-  '';
-
+  installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";
 
   meta = {
     description = "Compatibility library for OCaml’s Uchar module";

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -4,38 +4,24 @@ let
   webpage = "http://erratique.ch/software/${pname}";
 in
 
-assert stdenv.lib.versionAtLeast ocaml.version "3.12";
-
-let param =
-  if stdenv.lib.versionAtLeast ocaml.version "4.02"
-  then {
-    version = "1.3.0";
-    sha256 = "1rrdxg5kh9zaqmgapy9bhdqyxbbvxxib3bdfg1vhw4rrkp1z0x8n";
-    buildInputs = [ topkg ];
-    inherit (topkg) buildPhase;
-  } else {
-    version = "1.2.0";
-    sha256 = "1jywcrwn5z3gkgvicr004cxmdaqfmq8wh72f81jqz56iyn5024nh";
-    buildInputs = [];
-    buildPhase = "./pkg/build true";
-  };
-in
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "xmlm is not available for OCaml ${ocaml.version}"
+else
 
 stdenv.mkDerivation rec {
-  name = "ocaml-${pname}-${version}";
-  inherit (param) version;
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+  version = "1.3.0";
 
   src = fetchurl {
     url = "${webpage}/releases/${pname}-${version}.tbz";
-    inherit (param) sha256;
+    sha256 = "1rrdxg5kh9zaqmgapy9bhdqyxbbvxxib3bdfg1vhw4rrkp1z0x8n";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ] ++ param.buildInputs;
+  buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
   unpackCmd = "tar xjf $src";
 
-  inherit (param) buildPhase;
-  inherit (topkg) installPhase;
+  inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
     description = "An OCaml streaming codec to decode and encode the XML data format";

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -50,8 +50,8 @@ stdenv.mkDerivation rec {
         if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib"; then
             export OCAMLPATH="''${OCAMLPATH}''${OCAMLPATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/"
         fi
-        if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib/stubslibs"; then
-            export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/stubslibs"
+        if test -d "''$1/lib/ocaml/${ocaml.version}/site-lib/stublibs"; then
+            export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/stublibs"
         fi
         export OCAMLFIND_DESTDIR="''$out/lib/ocaml/${ocaml.version}/site-lib/"
         if test -n "$createFindlibDestdir"; then

--- a/pkgs/development/tools/ocaml/jbuilder/default.nix
+++ b/pkgs/development/tools/ocaml/jbuilder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, opam }:
+{ stdenv, fetchFromGitHub, ocamlPackages, opaline }:
 
 stdenv.mkDerivation rec {
   name = "jbuilder-${version}";
@@ -10,11 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "0571lzm8caq6wnia7imgy4a27x5l2bvxiflg0jrwwml0ylnii65f";
   };
 
-  buildInputs = [ ocaml ];
+  buildInputs = with ocamlPackages; [ ocaml findlib ];
 
   dontAddPrefix = true;
 
-  installPhase = "${opam}/bin/opam-installer -i --prefix=$out --libdir=$OCAMLFIND_DESTDIR";
+  installPhase = "${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 
   preFixup = "rm -rf $out/jbuilder";
 
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     description = "Fast, portable and opinionated build system";
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     license = stdenv.lib.licenses.asl20;
-    inherit (ocaml.meta) platforms;
+    inherit (ocamlPackages.ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The `opam` package which provides the `opam-installer` tool does not currently build on aarch64 and has too many dependencies.

The `opaline` tool provides similar functionality to `opam-installer`, without the drawbacks listed above.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

