### PR TITLE
[nixos-18.03] haskellPackages.http-link-header: disable tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -301,6 +301,7 @@ self: super: {
   HTF = dontCheck super.HTF;
   htsn = dontCheck super.htsn;
   htsn-import = dontCheck super.htsn-import;
+  http-link-header = dontCheck super.http-link-header; # non deterministic failure https://hydra.nixos.org/build/75041105
   ihaskell = dontCheck super.ihaskell;
   influxdb = dontCheck super.influxdb;
   itanium-abi = dontCheck super.itanium-abi;


### PR DESCRIPTION
The test

  `Network.HTTP.Link, writeLinkHeader → parseLinkHeader, roundtrips successfully`

seems to flap, as I cannot reproduce the failure locally, but it occured on
Hydra [0]. Also upstream is aware of the problem [1].

[0] https://hydra.nixos.org/build/75041105
[1] https://github.com/myfreeweb/http-link-header/issues/7

###### Motivation for this change

As the Hydra build failed, I needed to build `haskellPackages.github-backup` by myself, as it depends on the package in question. As the local build was successful without this patch, it seems to me like

* the test suite of `http-link-header` is flapping
* the local build could be avoided by disabling the test suite

###### Things done

Disabled tests on `haskellPackages.http-link-header`.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

