### PR TITLE
platforms/raspberrypi: enable kernelAutoModules

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -170,7 +170,8 @@ rec {
     kernelBaseConfig = "bcm2835_defconfig";
     kernelDTB = true;
     kernelArch = "arm";
-    kernelAutoModules = false;
+    kernelAutoModules = true;
+    kernelPreferBuiltin = true;
     kernelExtraConfig = ''
       # Disable OABI to have seccomp_filter (required for systemd)
       # https://github.com/raspberrypi/firmware/issues/651


### PR DESCRIPTION
###### Motivation for this change

`armv7l-hf-multiplatform` and `aarch64-multiplatform` platforms enable the `kernelAutoModules` option, which enables support for lots of miscellaneous hardware and features. This was missing from the `raspberrypi` platform.

###### Things done

This PR adds the options `kernelAutoModules=true` and `kernelPreferBuiltin=true` to the `raspberrypi` platform bringing it in line with the others. Both the mainline and rpi kernels build and run correctly with these options.

cc @dezgeg 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

