### PR TITLE
ocamlPackages.functory: 0.5 -> 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -1,14 +1,24 @@
-{stdenv, fetchurl, ocaml, findlib}:
+{ stdenv, fetchurl, ocaml, findlib }:
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.11";
 
+let param =
+  if stdenv.lib.versionAtLeast ocaml.version "4.02" then {
+    version = "0.6";
+    sha256 = "18wpyxblz9jh5bfp0hpffnd0q8cq1b0dqp0f36vhqydfknlnpx8y";
+  } else {
+    version = "0.5";
+    sha256 = "1j17rhifdjv1z262dma148ywg34x0zjn8vczdrnkwajsm4qg1hw3";
+  };
+in
+
 stdenv.mkDerivation {
 
-  name = "ocaml-functory-0.5";
+  name = "ocaml${ocaml.version}-functory-${param.version}";
 
   src = fetchurl {
-    url = https://www.lri.fr/~filliatr/functory/download/functory-0.5.tar.gz;
-    sha256 = "1j17rhifdjv1z262dma148ywg34x0zjn8vczdrnkwajsm4qg1hw3";
+    url = "https://www.lri.fr/~filliatr/functory/download/functory-${param.version}.tar.gz";
+    inherit (param) sha256;
   };
 
   buildInputs = [ ocaml findlib ];


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml ≥ 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

