### PR TITLE
lib/recursiveUpdateUntil: fix code to match documentation

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -383,11 +383,12 @@ rec {
   recursiveUpdateUntil = pred: lhs: rhs:
     let f = attrPath:
       zipAttrsWith (n: values:
+        let here = attrPath ++ [n]; in
         if tail values == []
-        || pred attrPath (head (tail values)) (head values) then
+        || pred here (head (tail values)) (head values) then
           head values
         else
-          f (attrPath ++ [n]) values
+          f here values
       );
     in f [] [rhs lhs];
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -198,6 +198,30 @@ runTests {
   };
 
 
+# ATTRSETS
+
+  # code from the example
+  testRecursiveUpdateUntil = {
+    expr = recursiveUpdateUntil (path: l: r: path == ["foo"]) {
+      # first attribute set
+      foo.bar = 1;
+      foo.baz = 2;
+      bar = 3;
+    } {
+      #second attribute set
+      foo.bar = 1;
+      foo.quz = 2;
+      baz = 4;
+    };
+    expected = {
+      foo.bar = 1; # 'foo.*' from the second set
+      foo.quz = 2; #
+      bar = 3;     # 'bar' from the first set
+      baz = 4;     # 'baz' from the second set
+    };
+  };
+
+
 # GENERATORS
 # these tests assume attributes are converted to lists
 # in alphabetical order

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -191,11 +191,20 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
      <literal>lib.traceCallXml</literal> has been deprecated. Please complain
      if you use the function regularly.
     </para>
+   </listitem>
+   <listitem>
     <para>
      The attribute <literal>lib.nixpkgsVersion</literal> has been deprecated in
      favor of <literal>lib.version</literal>. Please refer to the discussion in
      <link xlink:href="https://github.com/NixOS/nixpkgs/pull/39416#discussion_r183845745">NixOS/nixpkgs#39416</link>
      for further reference.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <literal>lib.recursiveUpdateUntil</literal> was not acting according to its
+     specification. It has been fixed to act according to the docstring, and a
+     test has been added.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
###### Motivation for this change

The function `recursiveUpdateUntil` did not produce the expected result for the exact example given in the documentation.

This fixes that and makes the function useable for any predicate that actually looks at the path argument. In current nixpkgs, there is only 1 location that touches this functionality:
https://github.com/NixOS/nixpkgs/blob/75601e10cb30d5220c09c5d0cf2c8ee55fc4b34a/nixos/maintainers/option-usages.nix#L128-L131

I'm not fully sure what that is all about, but since it's maintainer-only I do not expect issues will arise because of this fix, as they probably just assumed this function worked as advertised as well.

```
$ nix repl lib
Welcome to Nix version 2.0.2. Type :? for help.

Loading 'lib'...
Added 350 variables.

-- this is the exact example from the function's documentation:
nix-repl> recursiveUpdateUntil (path: l: r: path == ["foo"]) {
                   # first attribute set
                   foo.bar = 1;
                   foo.baz = 2;
                   bar = 3;
                 } {
                   #second attribute set
                   foo.bar = 1;
                   foo.quz = 2;
                   baz = 4;
                 }
{ bar = 3; baz = 4; foo = { bar = 1; baz = 2; quz = 2; }; }

-- although the documentation says:
{
    foo.bar = 1; # 'foo.*' from the second set
    foo.quz = 2; #
    bar = 3;     # 'bar' from the first set
    baz = 4;     # 'baz' from the second set
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

