### PR TITLE
18.03-intltool-debian-patch - fix "error: cannot download perl-5.22.p…

### DIFF
--- a/pkgs/development/tools/misc/intltool/default.nix
+++ b/pkgs/development/tools/misc/intltool/default.nix
@@ -11,10 +11,10 @@ stdenv.mkDerivation rec {
 
   # fix "unescaped left brace" errors when using intltool in some cases
   patches = [(fetchpatch {
-    name = "perl-5.22.patch";
-    url = "https://anonscm.debian.org/viewvc/pkg-gnome/desktop/unstable/intltool"
-      + "/debian/patches/perl5.22-regex-fixes?revision=47258&view=co&pathrev=47258";
-    sha256 = "17clqczb9fky7hp8czxa0fy82b5478irvz4f3fnans3sqxl95hx3";
+    name = "perl5.26-regex-fixes.patch";
+    url = "https://sources.debian.org/data/main/i/intltool/0.51.0-5"
+      + "/debian/patches/perl5.26-regex-fixes.patch";
+    sha256 = "12q2140867r5d0dysly72khi7b0mm2gd7nlm1k81iyg7fxgnyz45";
   })];
 
   propagatedBuildInputs = [ gettext perl perlXMLParser ];


### PR DESCRIPTION
…atch from any mirror"

###### Motivation for this change
following `nixos-unstable-small`: `error: cannot download perl-5.22.patch from any mirror`

patch source: https://sources.debian.org/patches/intltool/

pull request for `master`: https://github.com/NixOS/nixpkgs/pull/41611

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

