### PR TITLE
[RFC/RDY] flent: add manpage + init http-getter

### DIFF
--- a/pkgs/applications/networking/flent/default.nix
+++ b/pkgs/applications/networking/flent/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, buildPythonApplication, fetchFromGitHub, matplotlib, netperf, procps, pyqt5 }:
+{ stdenv, buildPythonApplication, fetchFromGitHub, matplotlib, procps, pyqt5
+, sphinx
+}:
 
 buildPythonApplication rec {
   pname = "flent";
@@ -10,7 +12,8 @@ buildPythonApplication rec {
     sha256 = "1llcdakk0nk9xlpjjz7mv4a80yq4sjnbqhaqvyj9m6lbcxgssh2r";
   };
 
-  buildInputs = [ netperf ];
+  buildInputs = [ sphinx ];
+
   propagatedBuildInputs = [
     matplotlib
     procps

--- a/pkgs/applications/networking/flent/http-getter.nix
+++ b/pkgs/applications/networking/flent/http-getter.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake
+, curl, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "http-getter";
+  version = "20180606";
+
+  src = fetchFromGitHub {
+    owner = "tohojo";
+    repo = "http-getter";
+    rev = "79bcccce721825a745f089d0c347bbaf2e6e12f4";
+    sha256 = "1zxk52s1h5qx62idil237zdpj8agrry0w1xwkfx05wvv9sw4ld35";
+  };
+
+  buildInputs = [ cmake pkgconfig curl ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/tohojo/http-getter;
+    description = "Simple getter for HTTP URLs using cURL";
+    platforms = platforms.unix;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3020,6 +3020,8 @@ with pkgs;
 
   http-prompt = callPackage ../tools/networking/http-prompt { };
 
+  http-getter = callPackage ../applications/networking/flent/http-getter.nix { };
+
   httpie = callPackage ../tools/networking/httpie { };
 
   httping = callPackage ../tools/networking/httping {};


### PR DESCRIPTION
###### Motivation for this change
without at least netperf the program is useless since it is an interface to netperf.
http-getter is a small utility used just by flent so I addded it to the flent default.nix.

NB: for those testing it, I kept the stable release but there is a nasty bug that was solved there
https://github.com/tohojo/flent/issues/137 so you might need to override the src to sthg more recent.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

