### PR TITLE
 pkgs/qemu: tell qemu where to find smbd

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -15,6 +15,7 @@
 , xenSupport ? false, xen
 , openGLSupport ? sdlSupport, mesa_noglu, epoxy, libdrm
 , virglSupport ? openGLSupport, virglrenderer
+, smbdSupport ? false, samba
 , hostCpuOnly ? false
 , nixosTestRunner ? false
 }:
@@ -63,7 +64,8 @@ stdenv.mkDerivation rec {
     ++ optionals stdenv.isLinux [ alsaLib libaio libcap_ng libcap attr ]
     ++ optionals xenSupport [ xen ]
     ++ optionals openGLSupport [ mesa_noglu epoxy libdrm ]
-    ++ optionals virglSupport [ virglrenderer ];
+    ++ optionals virglSupport [ virglrenderer ]
+    ++ optionals smbdSupport [ samba ];
 
   enableParallelBuilding = true;
 
@@ -100,8 +102,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags =
-    [ "--smbd=smbd" # use `smbd' from $PATH
-      "--audio-drv-list=${audio}"
+    [ "--audio-drv-list=${audio}"
       "--sysconfdir=/etc"
       "--localstatedir=/var"
     ]
@@ -117,7 +118,8 @@ stdenv.mkDerivation rec {
     ++ optional gtkSupport "--enable-gtk"
     ++ optional xenSupport "--enable-xen"
     ++ optional openGLSupport "--enable-opengl"
-    ++ optional virglSupport "--enable-virglrenderer";
+    ++ optional virglSupport "--enable-virglrenderer"
+    ++ optional smbdSupport "--smbd=${samba}/bin/smbd";
 
   doCheck = false; # tries to access /dev
 


### PR DESCRIPTION
###### Motivation for this change

QEMU is able to start a Samba server to facilitate sharing files between the guest and host, but it needs to be told where the `smbd` binary is at compile time.

Before this change, QEMU threw an error if run with `-net user,smb=/path/to/shared/folder` even if `smbd` was in `$PATH`:

```
qemu-system-x86_64: Could not find 'smbd', please install it
```

Despite the comment on this line, it doesn't appear to have worked:

https://github.com/NixOS/nixpkgs/blob/f5b0d6d88963b77659348805f5347bb6655ec713/pkgs/applications/virtualization/qemu/default.nix#L103

This change fixes that if built with `smbdSupport = true`.

###### Things done

Note that I didn't test all the binaries because there's a lot of them, but I did test `qemu-system-x86_64`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

