### PR TITLE
check-mssql-health: init at 2.6.4.14

### DIFF
--- a/pkgs/development/perl-modules/DBD-sybase/default.nix
+++ b/pkgs/development/perl-modules/DBD-sybase/default.nix
@@ -1,0 +1,17 @@
+{ fetchurl, buildPerlPackage, DBI, freetds }:
+
+buildPerlPackage rec {
+  name = "DBD-Sybase-1.16";
+
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/M/ME/MEWP/${name}.tar.gz";
+    sha256 = "1k6n261nrrcll9wxn5xwi4ibpavqv1il96687k62mbpznzl2gx37";
+  };
+
+  SYBASE = freetds;
+
+  buildInputs = [ freetds ] ;
+  propagatedBuildInputs = [ DBI ];
+
+  doCheck = false;
+}

--- a/pkgs/servers/monitoring/plugins/labs_consol_de.nix
+++ b/pkgs/servers/monitoring/plugins/labs_consol_de.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, fetchurl, buildPerlPackage, autoreconfHook, makeWrapper
-, perl, NetSNMP, coreutils, gnused, gnugrep }:
+, perl, DBDsybase, NetSNMP, coreutils, gnused, gnugrep }:
 
 let
   glplugin = fetchFromGitHub {
@@ -9,11 +9,10 @@ let
     sha256 = "0wb55a9pmgbilfffx0wkiikg9830qd66j635ypczqp4basslpq5b";
   };
 
-  generic = { pname, version, sha256, description, ... } @ attrs:
+  generic = { pname, version, sha256, description, buildInputs, ... }:
   let
-    attrs' = builtins.removeAttrs attrs [ "pname" "version" "rev" "sha256"];
     name' = "${stdenv.lib.replaceStrings [ "-" ] [ "_" ] "${pname}"}-${version}";
-  in perl.stdenv.mkDerivation rec {
+  in perl.stdenv.mkDerivation {
     name = "${pname}-${version}";
 
     src = fetchurl {
@@ -21,7 +20,7 @@ let
       inherit sha256;
     };
 
-    buildInputs = [ perl NetSNMP ];
+    buildInputs = [ perl ] ++ buildInputs;
 
     nativeBuildInputs = [ autoreconfHook makeWrapper ];
 
@@ -54,11 +53,20 @@ let
   };
 
 in {
+  check-mssql-health = generic {
+    pname       = "check_mssql_health";
+    version     = "2.6.4.14";
+    sha256      = "0w6gybrs7imx169l8740s0ax3adya867fw0abrampx59mnsj5pm1";
+    description = "Check plugin for Microsoft SQL Server.";
+    buildInputs = [ DBDsybase ];
+  };
+
   check-nwc-health = generic {
     pname       = "check_nwc_health";
     version     = "7.0.1.3";
     sha256      = "0rgd6zgd7kplx3z72n8zbzwkh8vnd83361sk9ibh6ng78sds1sl5";
     description = "Check plugin for network equipment.";
+    buildInputs = [ NetSNMP ];
   };
 
   check-ups-health = generic {
@@ -66,5 +74,6 @@ in {
     version     = "2.8.2.2";
     sha256      = "1gc2wjsymay2vk5ywc1jj9cvrbhs0fs851x8l4nc75df2g75v521";
     description = "Check plugin for UPSs.";
+    buildInputs = [ NetSNMP ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12811,7 +12811,8 @@ with pkgs;
   monitoring-plugins = callPackage ../servers/monitoring/plugins { };
   nagiosPluginsOfficial = monitoring-plugins;
 
-  inherit (callPackage ../servers/monitoring/plugins/labs_consol_de.nix { inherit (perlPackages) NetSNMP; })
+  inherit (callPackage ../servers/monitoring/plugins/labs_consol_de.nix { inherit (perlPackages) DBDsybase NetSNMP; })
+    check-mssql-health
     check-nwc-health
     check-ups-health;
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4100,6 +4100,11 @@ let self = _self // overrides; _self = with self; {
     inherit (pkgs) postgresql;
   };
 
+  DBDsybase = import ../development/perl-modules/DBD-sybase {
+    inherit fetchurl buildPerlPackage DBI;
+    inherit (pkgs) freetds;
+  };
+
   DBFile = import ../development/perl-modules/DB_File {
     inherit fetchurl buildPerlPackage;
     inherit (pkgs) db;


### PR DESCRIPTION
###### Motivation for this change

MSSQL check for use by sensu (and nagios and icinga and the rest of them).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

