### PR TITLE
dwarf-therapist: fix build

### DIFF
--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -11,23 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0b5y7800nzydn0jcc0vglgi9mzkj8f3qhw16wd872cf5396xnag9";
   };
 
-  outputs = [ "out" "layouts" ];
   buildInputs = [ qtbase qtdeclarative ];
   nativeBuildInputs = [ texlive cmake ninja ];
-
-  configurePhase = ''
-    cmake -GNinja
-  '';
-
-  buildPhase = ''
-    ninja -j$NIX_BUILD_CORES
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp ./DwarfTherapist $out/bin/DwarfTherapist
-    cp -r ./share/memory_layouts $layouts
-  '';
 
   meta = with stdenv.lib; {
     description = "Tool to manage dwarves in in a running game of Dwarf Fortress";

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -18,7 +18,7 @@ in symlinkJoin {
   postBuild = ''
     # DwarfTherapist assumes it's run in $out/share/dwarftherapist and
     # therefore uses many relative paths.
-    wrapProgram $out/bin/DwarfTherapist \
+    wrapProgram $out/bin/dwarftherapist \
       --run "cd $out/share/dwarftherapist"
 
     rm -rf $out/share/dwarftherapist/memory_layouts/linux
@@ -26,7 +26,7 @@ in symlinkJoin {
     origmd5=$(cat "${dfHashFile}.orig" | cut -c1-8)
     patchedmd5=$(cat "${dfHashFile}" | cut -c1-8)
     substitute \
-      ${dt.layouts}/${inifile} \
+      ${dt}/share/dwarftherapist/memory_layouts/${inifile} \
       $out/share/dwarftherapist/memory_layouts/${inifile} \
       --replace "$origmd5" "$patchedmd5"
   '';


### PR DESCRIPTION
###### Motivation for this change

Update for dfc4744afd82b2d26a8df71b05ffacf05230af50 (https://hydra.nixos.org/build/75634919). `DwarfTherapist` has been renamed to `dwarftherapist` upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

/cc @matthewbauer, maintainers @the-kenny @abbradar @bendlas