### PR TITLE
dotty: 0.6.0-RC1 -> 0.8.0-RC1

### DIFF
--- a/pkgs/development/compilers/scala/dotty-bare.nix
+++ b/pkgs/development/compilers/scala/dotty-bare.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  version = "0.6.0-RC1";
+  version = "0.8.0-RC1";
   name = "dotty-bare-${version}";
 
   src = fetchurl {
     url = "https://github.com/lampepfl/dotty/releases/download/${version}/dotty-${version}.tar.gz";
-    sha256 = "de1f5e72fb0e0b4c377d6cec93f565eff49769698cd8be01b420705fe8475ca4";
+    sha256 = "e5b7a9bb6f1007146a440ddfff871cc312075e5d69b9ab7e279ad7c3514f7065";
   };
 
   propagatedBuildInputs = [ jre ] ;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/lampepfl/dotty/releases

New features :
- [0.7.0](https://github.com/lampepfl/dotty/releases/tag/0.7.0)
  -  Enum Simplification lampepfl/dotty/pull/3872
  -  Erased terms lampepfl/dotty/pull/3342
  -  Improved IDE support lampepfl/dotty/pull/3960
  -  Improved GADT support lampepfl/dotty/pull/3918, lampepfl/dotty/pull/3990, lampepfl/dotty/pull/4034
- [0.8.0](https://github.com/lampepfl/dotty/releases/tag/0.8.0-RC1)
  - sbt 1 support lampepfl/dotty/pull/3872
  -  Unchecked warnings lampepfl/dotty/pull/4045
  -  Kind Polymorphism lampepfl/dotty/pull/4108
  -  Improved support for SAM type lampepfl/dotty/pull/4152

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

