### PR TITLE
[WIP/RFC] make-derivation: default name if pname and version are both set

### DIFF
--- a/pkgs/applications/altcoins/aeon/default.nix
+++ b/pkgs/applications/altcoins/aeon/default.nix
@@ -3,11 +3,9 @@
 , zeromq, pcsclite, readline
 }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "aeon";
   version = "0.12.0.0";
-in
-stdenv.mkDerivation {
-  name = "aeon-${version}";
 
   src = fetchFromGitHub {
     owner = "aeonix";

--- a/pkgs/applications/altcoins/dapp.nix
+++ b/pkgs/applications/altcoins/dapp.nix
@@ -2,7 +2,7 @@
 , seth, git, solc, shellcheck, nodejs, hevm }:
 
 stdenv.mkDerivation rec {
-  name = "dapp-${version}";
+  pname = "dapp";
   version = "0.5.7";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/dashpay.nix
+++ b/pkgs/applications/altcoins/dashpay.nix
@@ -8,7 +8,7 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  name = "dashpay-${version}";
+  pname = "dashpay";
   version = "0.12.2.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/dero.nix
+++ b/pkgs/applications/altcoins/dero.nix
@@ -2,7 +2,7 @@
 , libunwind, lmdb, miniupnpc, readline }:
 
 stdenv.mkDerivation rec {
-  name = "dero-${version}";
+  pname = "dero";
   version = "0.11.6";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/freicoin.nix
+++ b/pkgs/applications/altcoins/freicoin.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.8.6-2";
-  name = "freicoin-${version}";
+  pname = "freicoin";
 
   src = fetchFromGitHub {
     owner = "freicoin";

--- a/pkgs/applications/altcoins/masari.nix
+++ b/pkgs/applications/altcoins/masari.nix
@@ -2,7 +2,7 @@
 , lmdb, miniupnpc, readline }:
 
 stdenv.mkDerivation rec {
-  name = "masari-${version}";
+  pname = "masari";
   version = "0.1.4.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -11,7 +11,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "monero-gui-${version}";
+  pname = "monero-gui";
   version = "0.12.0.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/nano-wallet/default.nix
+++ b/pkgs/applications/altcoins/nano-wallet/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
 
-  name = "nano-wallet-${version}";
+  pname = "nano-wallet";
   version = "12.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/particl/particl-core.nix
+++ b/pkgs/applications/altcoins/particl/particl-core.nix
@@ -18,7 +18,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "particl-core-${version}";
+  pname = "particl-core";
   version     = "0.16.0.5";
 
   src = fetchurl {

--- a/pkgs/applications/altcoins/seth.nix
+++ b/pkgs/applications/altcoins/seth.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "seth-${version}";
+  pname = "seth";
   version = "0.6.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/altcoins/stellar-core.nix
+++ b/pkgs/applications/altcoins/stellar-core.nix
@@ -1,12 +1,9 @@
 { stdenv, lib, fetchgit, autoconf, libtool, automake, pkgconfig, git
 , bison, flex, postgresql }:
 
-let
+stdenv.mkDerivation rec {
   pname = "stellar-core";
   version = "0.5.1";
-
-in stdenv.mkDerivation {
-  name = "${pname}-${version}";
 
   src = fetchgit {
     url = "https://github.com/stellar/stellar-core.git";

--- a/pkgs/applications/altcoins/sumokoin.nix
+++ b/pkgs/applications/altcoins/sumokoin.nix
@@ -2,7 +2,7 @@
 , libunwind, lmdb, miniupnpc }:
 
 stdenv.mkDerivation rec {
-  name = "sumokoin-${version}";
+  pname = "sumokoin";
   version = "0.2.0.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/MMA/default.nix
+++ b/pkgs/applications/audio/MMA/default.nix
@@ -2,7 +2,7 @@
 
   stdenv.mkDerivation rec {
   version = "16.06";
-  name = "mma-${version}";
+  pname = "mma";
 
   src = fetchurl {
     url = "http://www.mellowood.ca/mma/mma-bin-${version}.tar.gz";

--- a/pkgs/applications/audio/a2jmidid/default.nix
+++ b/pkgs/applications/audio/a2jmidid/default.nix
@@ -4,7 +4,7 @@
 let
   inherit (python2Packages) python dbus-python;
 in stdenv.mkDerivation rec {
-  name = "a2jmidid-${version}";
+  pname = "a2jmidid";
   version = "8";
 
   src = fetchurl {

--- a/pkgs/applications/audio/abcde/default.nix
+++ b/pkgs/applications/audio/abcde/default.nix
@@ -3,60 +3,59 @@
 , perl, DigestSHA, MusicBrainz, MusicBrainzDiscID
 , makeWrapper }:
 
-let version = "2.8.1";
-in
-  stdenv.mkDerivation {
-    name = "abcde-${version}";
-    src = fetchurl {
-      url = "http://abcde.einval.com/download/abcde-${version}.tar.gz";
-      sha256 = "0f9bjs0phk23vry7gvh0cll9vl6kmc1y4fwwh762scfdvpbp3774";
-    };
+stdenv.mkDerivation rec {
+  pname = "abcde";
+  version = "2.8.1";
+  src = fetchurl {
+    url = "http://abcde.einval.com/download/abcde-${version}.tar.gz";
+    sha256 = "0f9bjs0phk23vry7gvh0cll9vl6kmc1y4fwwh762scfdvpbp3774";
+  };
 
-    # FIXME: This package does not support `distmp3', `eject', etc.
+  # FIXME: This package does not support `distmp3', `eject', etc.
 
-    patches = [ ./abcde.patch ];
+  patches = [ ./abcde.patch ];
 
-    configurePhase = ''
-      sed -i "s|^[[:blank:]]*prefix *=.*$|prefix = $out|g ;
-              s|^[[:blank:]]*etcdir *=.*$|etcdir = $out/etc|g ;
-              s|^[[:blank:]]*INSTALL *=.*$|INSTALL = install -c|g" \
-        "Makefile";
+  configurePhase = ''
+    sed -i "s|^[[:blank:]]*prefix *=.*$|prefix = $out|g ;
+            s|^[[:blank:]]*etcdir *=.*$|etcdir = $out/etc|g ;
+            s|^[[:blank:]]*INSTALL *=.*$|INSTALL = install -c|g" \
+      "Makefile";
 
-      # We use `cd-paranoia' from GNU libcdio, which contains a hyphen
-      # in its name, unlike Xiph's cdparanoia.
-      sed -i "s|^[[:blank:]]*CDPARANOIA=.*$|CDPARANOIA=cd-paranoia|g ;
-              s|^[[:blank:]]*DEFAULT_CDROMREADERS=.*$|DEFAULT_CDROMREADERS=\"cd-paranoia cdda2wav\"|g" \
-        "abcde"
+    # We use `cd-paranoia' from GNU libcdio, which contains a hyphen
+    # in its name, unlike Xiph's cdparanoia.
+    sed -i "s|^[[:blank:]]*CDPARANOIA=.*$|CDPARANOIA=cd-paranoia|g ;
+            s|^[[:blank:]]*DEFAULT_CDROMREADERS=.*$|DEFAULT_CDROMREADERS=\"cd-paranoia cdda2wav\"|g" \
+      "abcde"
 
-      substituteInPlace "abcde" \
-        --replace "/etc/abcde.conf" "$out/etc/abcde.conf"
+    substituteInPlace "abcde" \
+      --replace "/etc/abcde.conf" "$out/etc/abcde.conf"
 
+  '';
+
+  buildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = [ perl DigestSHA MusicBrainz MusicBrainzDiscID ];
+
+  installFlags = [ "sysconfdir=$(out)/etc" ];
+
+  postFixup = ''
+    for cmd in abcde cddb-tool abcde-musicbrainz-tool; do
+      wrapProgram "$out/bin/$cmd" --prefix PATH ":" \
+        ${stdenv.lib.makeBinPath [ "$out" which libcdio-paranoia cddiscid wget vorbis-tools id3v2 eyeD3 lame flac glyr ]}
+    done
+  '';
+
+  meta = {
+    homepage = http://abcde.einval.com/wiki/;
+    license = stdenv.lib.licenses.gpl2Plus;
+    description = "Command-line audio CD ripper";
+
+    longDescription = ''
+      abcde is a front-end command-line utility (actually, a shell
+      script) that grabs tracks off a CD, encodes them to
+      Ogg/Vorbis, MP3, FLAC, Ogg/Speex and/or MPP/MP+ (Musepack)
+      format, and tags them, all in one go.
     '';
-
-    buildInputs = [ makeWrapper ];
-
-    propagatedBuildInputs = [ perl DigestSHA MusicBrainz MusicBrainzDiscID ];
-
-    installFlags = [ "sysconfdir=$(out)/etc" ];
-
-    postFixup = ''
-      for cmd in abcde cddb-tool abcde-musicbrainz-tool; do
-        wrapProgram "$out/bin/$cmd" --prefix PATH ":" \
-          ${stdenv.lib.makeBinPath [ "$out" which libcdio-paranoia cddiscid wget vorbis-tools id3v2 eyeD3 lame flac glyr ]}
-      done
-    '';
-
-    meta = {
-      homepage = http://abcde.einval.com/wiki/;
-      license = stdenv.lib.licenses.gpl2Plus;
-      description = "Command-line audio CD ripper";
-
-      longDescription = ''
-        abcde is a front-end command-line utility (actually, a shell
-        script) that grabs tracks off a CD, encodes them to
-        Ogg/Vorbis, MP3, FLAC, Ogg/Speex and/or MPP/MP+ (Musepack)
-        format, and tags them, all in one go.
-      '';
-      platforms = stdenv.lib.platforms.linux;
-    };
-  }
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -37,7 +37,8 @@ let
 in
 
 multiStdenv.mkDerivation {
-  name = "airwave-${version}";
+  pname = "airwave";
+  inherit version;
 
   src = airwave-src;
 

--- a/pkgs/applications/audio/ams-lv2/default.nix
+++ b/pkgs/applications/audio/ams-lv2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cairo, fftw, gtkmm2, lv2, lvtk, pkgconfig, python }:
 
 stdenv.mkDerivation  rec {
-  name = "ams-lv2-${version}";
+  pname = "ams-lv2";
   version = "1.2.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/artyFX/default.nix
+++ b/pkgs/applications/audio/artyFX/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub , cairomm, cmake, libjack2, libpthreadstubs, libXdmcp, libxshmfence, libsndfile, lv2, ntk, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "artyFX-${version}";
+  pname = "artyFX";
   version = "1.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -7,7 +7,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "audacious-${version}";
+  pname = "audacious";
   version = "3.9";
 
   src = fetchurl {

--- a/pkgs/applications/audio/audacious/qt-5.nix
+++ b/pkgs/applications/audio/audacious/qt-5.nix
@@ -31,7 +31,7 @@ in
 
 mkDerivation {
   inherit version;
-  name = "audacious-qt5-${version}";
+  pname = "audacious-qt5";
 
   sourceFiles = lib.attrValues sources;
   sourceRoots = lib.attrNames sources;

--- a/pkgs/applications/audio/audacity/default.nix
+++ b/pkgs/applications/audio/audacity/default.nix
@@ -8,7 +8,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   version = "2.2.2";
-  name = "audacity-${version}";
+  pname = "audacity";
 
   src = fetchurl {
     url = "https://github.com/audacity/audacity/archive/Audacity-${version}.tar.gz";

--- a/pkgs/applications/audio/axoloti/default.nix
+++ b/pkgs/applications/audio/axoloti/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.0.12-1";
-  name = "axoloti-${version}";
+  pname = "axoloti";
 
   src = fetchFromGitHub {
     owner = "axoloti";

--- a/pkgs/applications/audio/banshee/default.nix
+++ b/pkgs/applications/audio/banshee/default.nix
@@ -5,7 +5,7 @@
 , libmtp, libgpod, mono-zeroconf }:
 
 stdenv.mkDerivation rec {
-  name = "banshee-${version}";
+  pname = "banshee";
   version = "2.6.2";
 
   src = fetchurl {

--- a/pkgs/applications/audio/baudline/default.nix
+++ b/pkgs/applications/audio/baudline/default.nix
@@ -7,7 +7,7 @@ let
     [ libXmu libXt libX11 libXext libXxf86vm libjack2 ];
 in
 stdenv.mkDerivation rec {
-  name = "baudline-${version}";
+  pname = "baudline";
   version = "1.08";
 
   src =

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -6,7 +6,7 @@
 , xdg_utils, zenity, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "bitwig-studio-${version}";
+  pname = "bitwig-studio";
   version = "1.3.16";
 
   src = fetchurl {

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio2.nix
@@ -2,7 +2,7 @@
   xdg_utils, zenity, ffmpeg }:
 
 bitwig-studio1.overrideAttrs (oldAttrs: rec {
-  name = "bitwig-studio-${version}";
+  pname = "bitwig-studio";
   version = "2.3.2";
 
   src = fetchurl {

--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -28,19 +28,18 @@ assert withOnlineServices -> withTaglib;
 assert withReplaygain -> withTaglib;
 
 let
-  version = "2.2.0";
-  pname = "cantata";
   fstat = x: fn: "-DENABLE_" + fn + "=" + (if x then "ON" else "OFF");
   fstats = x: map (fstat x);
 
   withUdisks = (withTaglib && withDevices);
 
 in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "2.2.0";
+  pname = "cantata";
 
   src = fetchFromGitHub {
     owner  = "CDrummond";
-    repo   = "cantata";
+    repo   = pname;
     rev    = "v${version}";
     sha256 = "1b633chgfs8rya78bzzck5zijna15d1y4nmrz4dcjp862ks5y5q6";
   };

--- a/pkgs/applications/audio/caps/default.nix
+++ b/pkgs/applications/audio/caps/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl }:
 stdenv.mkDerivation rec {
-  name = "caps-${version}";
+  pname = "caps";
   version = "0.9.24";
   src = fetchurl {
     url = "http://www.quitte.de/dsp/caps_${version}.tar.bz2";

--- a/pkgs/applications/audio/caudec/default.nix
+++ b/pkgs/applications/audio/caudec/default.nix
@@ -1,11 +1,8 @@
 { stdenv, fetchurl, makeWrapper, bash, bc, findutils, flac, lame, opusTools, procps, sox }:
 
-let
-  version = "1.7.5";
-in
-
 stdenv.mkDerivation rec {
-  name = "caudec-${version}";
+  pname = "caudec";
+  version = "1.7.5";
 
   src = fetchurl {
     url = "http://caudec.net/downloads/caudec-${version}.tar.gz";

--- a/pkgs/applications/audio/cava/default.nix
+++ b/pkgs/applications/audio/cava/default.nix
@@ -2,7 +2,7 @@
   libpulseaudio, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "cava-${version}";
+  pname = "cava";
   version = "0.6.1";
 
   buildInputs = [

--- a/pkgs/applications/audio/chuck/default.nix
+++ b/pkgs/applications/audio/chuck/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.3.5.2";
-  name = "chuck-${version}";
+  pname = "chuck";
 
   src = fetchurl {
     url = "http://chuck.cs.princeton.edu/release/files/chuck-${version}.tgz";

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -21,7 +21,7 @@ let
 
   patches = [
     ./clementine-spotify-blob.patch
-    # Required so as to avoid adding libspotify as a build dependency (as it is 
+    # Required so as to avoid adding libspotify as a build dependency (as it is
     # unfree and thus would prevent us from having a free package).
     ./clementine-spotify-blob-remove-from-build.patch
     (fetchpatch {
@@ -69,8 +69,8 @@ let
   '';
 
   free = stdenv.mkDerivation {
-    name = "clementine-free-${version}";
-    inherit src patches nativeBuildInputs postPatch;
+    pname = "clementine-free";
+    inherit version src patches nativeBuildInputs postPatch;
 
     buildInputs = buildInputs ++ [ makeWrapper ];
 
@@ -96,9 +96,9 @@ let
 
   # Unfree Spotify blob for Clementine
   unfree = stdenv.mkDerivation {
-    name = "clementine-blob-${version}";
+    pname = "clementine-blob";
     # Use the same patches and sources as Clementine
-    inherit src nativeBuildInputs postPatch;
+    inherit version src nativeBuildInputs postPatch;
 
     patches = [
       ./clementine-spotify-blob.patch

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -99,7 +99,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "cmus-${version}";
+  pname = "cmus";
   version = "2.7.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -13,7 +13,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "csound-${version}";
+  pname = "csound";
   version = "6.11.0";
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/deadbeef/plugins/opus.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/opus.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromBitbucket, opusfile, libopus, libogg, openssl, deadbeef }:
 
 stdenv.mkDerivation rec {
-  name = "deadbeef-opus-plugin-${version}";
+  pname = "deadbeef-opus-plugin";
   version = "0.8";
 
   src = fetchFromBitbucket {

--- a/pkgs/applications/audio/denemo/default.nix
+++ b/pkgs/applications/audio/denemo/default.nix
@@ -5,7 +5,7 @@
 , portaudio, portmidi, fftw, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "denemo-${version}";
+  pname = "denemo";
   version = "2.2.0";
 
   src = fetchurl {

--- a/pkgs/applications/audio/dfasma/default.nix
+++ b/pkgs/applications/audio/dfasma/default.nix
@@ -27,7 +27,7 @@ let
   };
 
 in stdenv.mkDerivation rec {
-  name = "dfasma-${version}";
+  pname = "dfasma";
   version = "1.4.5";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/dr14_tmeter/default.nix
+++ b/pkgs/applications/audio/dr14_tmeter/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python3Packages, pkgs }:
 
 python3Packages.buildPythonApplication rec {
-  name = "dr14_tmeter-${version}";
+  pname = "dr14_tmeter";
   version = "1.0.16";
 
   disabled = !python3Packages.isPy3k;

--- a/pkgs/applications/audio/ecasound/default.nix
+++ b/pkgs/applications/audio/ecasound/default.nix
@@ -14,7 +14,7 @@
 # TODO: fix readline, ncurses, lilv, liblo, liboil and python. See configure log.
 
 stdenv.mkDerivation rec {
-  name = "ecasound-${version}";
+  pname = "ecasound";
   version = "2.9.1";
 
   src = fetchurl {

--- a/pkgs/applications/audio/elisa/default.nix
+++ b/pkgs/applications/audio/elisa/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation rec {
-  name = "elisa-${version}";
+  pname = "elisa";
   version = "0.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -4,7 +4,7 @@
 , sonicSupport ? true, sonic }:
 
 stdenv.mkDerivation rec {
-  name = "espeak-ng-${version}";
+  pname = "espeak-ng";
   version = "1.49.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/faust/faust1.nix
+++ b/pkgs/applications/audio/faust/faust1.nix
@@ -25,7 +25,8 @@ let
   };
 
   faust = stdenv.mkDerivation {
-    name = "faust-${version}";
+    pname = "faust";
+    inherit version;
 
     inherit src;
 

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -36,9 +36,9 @@ let
 
   faust = stdenv.mkDerivation {
 
-    name = "faust-${version}";
+    pname = "faust";
 
-    inherit src;
+    inherit version src;
 
     nativeBuildInputs = [ makeWrapper pkgconfig vim ];
     buildInputs = [ llvm emscripten openssl libsndfile libmicrohttpd ];

--- a/pkgs/applications/audio/flacon/default.nix
+++ b/pkgs/applications/audio/flacon/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "flacon-${version}";
+  pname = "flacon";
   version = "4.1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/fluidsynth/default.nix
+++ b/pkgs/applications/audio/fluidsynth/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation  rec {
-  name = "fluidsynth-${version}";
+  pname = "fluidsynth";
   version = "1.1.10";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/fmit/default.nix
+++ b/pkgs/applications/audio/fmit/default.nix
@@ -10,7 +10,7 @@ assert portaudioSupport -> portaudio != null;
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "fmit-${version}";
+  pname = "fmit";
   version = "1.1.14";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/fmsynth/default.nix
+++ b/pkgs/applications/audio/fmsynth/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, gtkmm2, lv2, lvtk, pkgconfig }:
 stdenv.mkDerivation rec {
-  name = "fmsynth-unstable-${version}";
+  pname = "fmsynth-unstable";
   version = "2015-02-07";
   src = fetchFromGitHub {
     owner = "Themaister";

--- a/pkgs/applications/audio/foo-yc20/default.nix
+++ b/pkgs/applications/audio/foo-yc20/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "git-2015-05-21";
-  name = "foo-yc20-${version}";
+  pname = "foo-yc20";
   src = fetchFromGitHub {
     owner = "sampov2";
     repo = "foo-yc20";

--- a/pkgs/applications/audio/freewheeling/default.nix
+++ b/pkgs/applications/audio/freewheeling/default.nix
@@ -7,7 +7,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "freewheeling-${version}";
+  pname = "freewheeling";
   version = "0.6.4";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/gmpc/default.nix
+++ b/pkgs/applications/audio/gmpc/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gmpc-${version}";
+  pname = "gmpc";
   version = "11.8.16";
 
   libmpd = stdenv.mkDerivation {

--- a/pkgs/applications/audio/google-play-music-desktop-player/default.nix
+++ b/pkgs/applications/audio/google-play-music-desktop-player/default.nix
@@ -4,8 +4,6 @@
 }:
 
 let
-  version = "4.5.0";
-
   deps = [
     alsaLib
     atk
@@ -41,8 +39,9 @@ let
 
 in
 
-stdenv.mkDerivation {
-  name = "google-play-music-desktop-player-${version}";
+stdenv.mkDerivation rec {
+  pname = "google-play-music-desktop-player";
+  version = "4.5.0";
 
   src = fetchurl {
     url = "https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/releases/download/v${version}/google-play-music-desktop-player_${version}_amd64.deb";

--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -4,7 +4,7 @@
 }:
 
 python3Packages.buildPythonApplication rec {
-  name = "gpodder-${version}";
+  pname = "gpodder";
   version = "3.10.1";
 
   format = "other";

--- a/pkgs/applications/audio/gradio/default.nix
+++ b/pkgs/applications/audio/gradio/default.nix
@@ -16,11 +16,10 @@
 , gst_all_1
 , gst_plugins ? with gst_all_1; [ gst-plugins-good gst-plugins-ugly ]
 }:
-let
-  version = "7.1";
 
-in stdenv.mkDerivation rec {
-  name = "gradio-${version}";
+stdenv.mkDerivation rec {
+  pname = "gradio";
+  version = "7.1";
 
   src = fetchFromGitHub {
     owner = "haecker-felix";

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -11,7 +11,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "guitarix-${version}";
+  pname = "guitarix";
   version = "0.37.0";
 
   src = fetchurl {

--- a/pkgs/applications/audio/helm/default.nix
+++ b/pkgs/applications/audio/helm/default.nix
@@ -3,7 +3,7 @@
 
   stdenv.mkDerivation rec {
   version = "0.9.0";
-  name = "helm-${version}";
+  pname = "helm";
 
   src = fetchFromGitHub {
     owner = "mtytel";

--- a/pkgs/applications/audio/hydrogen/default.nix
+++ b/pkgs/applications/audio/hydrogen/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.9.7";
-  name = "hydrogen-${version}";
+  pname = "hydrogen";
 
   src = fetchurl {
     url = "https://github.com/hydrogen-music/hydrogen/archive/${version}.tar.gz";

--- a/pkgs/applications/audio/i-score/default.nix
+++ b/pkgs/applications/audio/i-score/default.nix
@@ -27,7 +27,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.0.0-b31";
-  name = "i-score-${version}";
+  pname = "i-score";
 
   src = fetchFromGitHub {
     owner = "OSSIA";

--- a/pkgs/applications/audio/iannix/default.nix
+++ b/pkgs/applications/audio/iannix/default.nix
@@ -2,7 +2,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "iannix-${version}";
+  pname = "iannix";
   version = "2016-01-31";
   src = fetchFromGitHub {
     owner = "iannix";

--- a/pkgs/applications/audio/infamousPlugins/default.nix
+++ b/pkgs/applications/audio/infamousPlugins/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, cairomm, cmake, lv2, libpthreadstubs, libXdmcp, libXft, ntk, pcre, fftwFloat, zita-resampler }:
 
 stdenv.mkDerivation rec {
-  name = "infamousPlugins-${version}";
+  pname = "infamousPlugins";
   version = "0.2.04";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/keyfinder-cli/default.nix
+++ b/pkgs/applications/audio/keyfinder-cli/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, libav, libkeyfinder }:
 
 stdenv.mkDerivation rec {
-  name = "keyfinder-cli-${version}";
+  pname = "keyfinder-cli";
   version = "2015-09-13";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/keyfinder/default.nix
+++ b/pkgs/applications/audio/keyfinder/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, libav_0_8, libkeyfinder, qtbase, qtxmlpatterns, qmake, taglib }:
 
 stdenv.mkDerivation rec {
-  name = "keyfinder-${version}";
+  pname = "keyfinder";
   version = "2.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/ladspa-plugins/default.nix
+++ b/pkgs/applications/audio/ladspa-plugins/default.nix
@@ -2,7 +2,7 @@
 , perlPackages }:
 
 stdenv.mkDerivation rec {
-  name = "swh-plugins-${version}";
+  pname = "swh-plugins";
   version = "0.4.17";
 
 

--- a/pkgs/applications/audio/ladspa-sdk/default.nix
+++ b/pkgs/applications/audio/ladspa-sdk/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl }:
 stdenv.mkDerivation rec {
-  name = "ladspa-sdk-${version}";
+  pname = "ladspa-sdk";
   version = "1.13";
   src = fetchurl {
     url = "http://www.ladspa.org/download/ladspa_sdk_${version}.tgz";

--- a/pkgs/applications/audio/lastfmsubmitd/default.nix
+++ b/pkgs/applications/audio/lastfmsubmitd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pythonPackages }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "lastfmsubmitd-${version}";
+  pname = "lastfmsubmitd";
   namePrefix = ""; 
   version = "1.0.6";
 

--- a/pkgs/applications/audio/lastwatch/default.nix
+++ b/pkgs/applications/audio/lastwatch/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "lastwatch-${version}";
+  pname = "lastwatch";
   namePrefix = "";
   version = "0.4.1";
 

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -4,7 +4,7 @@
 , qtbase, qttools, SDL ? null }:
 
 stdenv.mkDerivation rec {
-  name = "lmms-${version}";
+  pname = "lmms";
   version = "1.2.0-rc4";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/lv2bm/default.nix
+++ b/pkgs/applications/audio/lv2bm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, glib, lilv, lv2, pkgconfig, serd, sord, sratom }:
 
 stdenv.mkDerivation rec {
-  name = "lv2bm-${version}";
+  pname = "lv2bm";
   version = "git-2015-11-29";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "CharacterCompressor-${version}";
+  pname = "CharacterCompressor";
   version = "0.3.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "CompBus-${version}";
+  pname = "CompBus";
   version = "1.1.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "constant-detune-chorus-${version}";
+  pname = "constant-detune-chorus";
   version = "0.1.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "LazyLimiter-${version}";
+  pname = "LazyLimiter";
   version = "0.3.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "MBdistortion-${version}";
+  pname = "MBdistortion";
   version = "1.1.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "RhythmDelay-${version}";
+  pname = "RhythmDelay";
   version = "2.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
@@ -1,6 +1,6 @@
 { stdenv, pkgs, callPackage, fetchFromGitHub, faust2jack, faust2lv2, helmholtz, mrpeach, puredata-with-plugins }:
 stdenv.mkDerivation rec {
-  name = "VoiceOfFaust-${version}";
+  pname = "VoiceOfFaust";
   version = "1.1.4";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "pluginUtils-${version}";
+  pname = "pluginUtils";
   version = "1.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
 stdenv.mkDerivation rec {
-  name = "shelfMultiBand-${version}";
+  pname = "shelfMultiBand";
   version = "0.6.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/mhwaveedit/default.nix
+++ b/pkgs/applications/audio/mhwaveedit/default.nix
@@ -3,7 +3,7 @@
 , vorbis-tools }:
 
 stdenv.mkDerivation  rec {
-  name = "mhwaveedit-${version}";
+  pname = "mhwaveedit";
   version = "1.4.23";
 
   src = fetchurl {

--- a/pkgs/applications/audio/milkytracker/default.nix
+++ b/pkgs/applications/audio/milkytracker/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.01";
-  name = "milkytracker-${version}";
+  pname = "milkytracker";
 
   src = fetchurl {
     url = "https://github.com/milkytracker/MilkyTracker/archive/v${version}.00.tar.gz";

--- a/pkgs/applications/audio/mimms/default.nix
+++ b/pkgs/applications/audio/mimms/default.nix
@@ -1,31 +1,30 @@
 { fetchurl, stdenv, pythonPackages, libmms }:
 
-let version = "3.2";
-in
-  pythonPackages.buildPythonApplication {
-    name = "mimms-${version}";
-    src = fetchurl {
-      url = "http://download.savannah.gnu.org/releases/mimms/mimms-${version}.tar.bz2";
-      sha256 = "0zmcd670mpq85cs3nvdq3i805ba0d1alqahfy1m9cpf7kxrivfml";
-    };
+pythonPackages.buildPythonApplication rec {
+  pname = "mimms";
+  version = "3.2";
+  src = fetchurl {
+    url = "http://download.savannah.gnu.org/releases/mimms/mimms-${version}.tar.bz2";
+    sha256 = "0zmcd670mpq85cs3nvdq3i805ba0d1alqahfy1m9cpf7kxrivfml";
+  };
 
-    postInstall = ''
-      wrapProgram $out/bin/mimms \
-        --prefix LD_LIBRARY_PATH : ${libmms}/lib
+  postInstall = ''
+    wrapProgram $out/bin/mimms \
+      --prefix LD_LIBRARY_PATH : ${libmms}/lib
+  '';
+
+  meta = {
+    homepage = https://savannah.nongnu.org/projects/mimms/;
+    license = stdenv.lib.licenses.gpl3;
+    description = "An mms (e.g. mms://) stream downloader";
+
+    longDescription = ''
+      mimms is a program designed to allow you to download streams
+      using the MMS protocol and save them to your computer, as
+      opposed to watching them live. Similar functionality is
+      available in full media player suites such as Xine, MPlayer,
+      and VLC, but mimms is quick and easy to use and, for the time
+      being, remains a useful program.
     '';
-
-    meta = {
-      homepage = https://savannah.nongnu.org/projects/mimms/;
-      license = stdenv.lib.licenses.gpl3;
-      description = "An mms (e.g. mms://) stream downloader";
-
-      longDescription = ''
-        mimms is a program designed to allow you to download streams
-        using the MMS protocol and save them to your computer, as
-        opposed to watching them live. Similar functionality is
-        available in full media player suites such as Xine, MPlayer,
-        and VLC, but mimms is quick and easy to use and, for the time
-        being, remains a useful program.
-      '';
-    };
-  }
+  };
+}

--- a/pkgs/applications/audio/minimodem/default.nix
+++ b/pkgs/applications/audio/minimodem/default.nix
@@ -5,7 +5,6 @@
 stdenv.mkDerivation rec {
   version = "0.24-1";
   pname = "minimodem";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "kamalmostafa";
@@ -39,4 +38,3 @@ stdenv.mkDerivation rec {
     maintainers = with stdenv.lib.maintainers; [ relrod ];
   };
 }
-

--- a/pkgs/applications/audio/moc/default.nix
+++ b/pkgs/applications/audio/moc/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "moc-${version}";
+  pname = "moc";
   version = "2.5.2";
 
   src = fetchurl {

--- a/pkgs/applications/audio/mod-distortion/default.nix
+++ b/pkgs/applications/audio/mod-distortion/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, lv2 }:
 
 stdenv.mkDerivation rec {
-  name = "mod-distortion-git-${version}";
+  pname = "mod-distortion-git";
   version = "2016-08-19";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -3,7 +3,7 @@
 }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-${version}";
+  pname = "mopidy";
 
   version = "2.1.0";
 

--- a/pkgs/applications/audio/mopidy/gmusic.nix
+++ b/pkgs/applications/audio/mopidy/gmusic.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-gmusic-${version}";
+  pname = "mopidy-gmusic";
   version = "2.0.0";
 
   src = fetchurl {

--- a/pkgs/applications/audio/mopidy/local-images.nix
+++ b/pkgs/applications/audio/mopidy/local-images.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy, gobjectIntrospection }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-local-images-${version}";
+  pname = "mopidy-local-images";
 
   version = "1.0.0";
 

--- a/pkgs/applications/audio/mopidy/local-sqlite.nix
+++ b/pkgs/applications/audio/mopidy/local-sqlite.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-local-sqlite-${version}";
+  pname = "mopidy-local-sqlite";
 
   version = "1.0.0";
 

--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-musicbox-webclient-${version}";
+  pname = "mopidy-musicbox-webclient";
 
   version = "2.3.0";
 

--- a/pkgs/applications/audio/mopidy/soundcloud.nix
+++ b/pkgs/applications/audio/mopidy/soundcloud.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-soundcloud-${version}";
+  pname = "mopidy-soundcloud";
 
   version = "2.0.2";
 

--- a/pkgs/applications/audio/mopidy/spotify-tunigo.nix
+++ b/pkgs/applications/audio/mopidy/spotify-tunigo.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy, mopidy-spotify }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-spotify-tunigo-${version}";
+  pname = "mopidy-spotify-tunigo";
 
   version = "1.0.0";
 

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-spotify-${version}";
+  pname = "mopidy-spotify";
   version = "3.1.0";
 
   src = fetchurl {

--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pythonPackages, mopidy }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "mopidy-youtube-${version}";
+  pname = "mopidy-youtube";
 
   version = "2.0.2";
 

--- a/pkgs/applications/audio/morituri/default.nix
+++ b/pkgs/applications/audio/morituri/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (pythonPackages) python;
 in stdenv.mkDerivation rec {
-  name = "morituri-${version}";
+  pname = "morituri";
   version = "0.2.3.20151109";
   namePrefix = "";
 

--- a/pkgs/applications/audio/mp3blaster/default.nix
+++ b/pkgs/applications/audio/mp3blaster/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
 
   version = "3.2.6";
 
-  name = "mp3blaster-${version}";
+  pname = "mp3blaster";
 
   src = fetchFromGitHub {
     owner = "stragulus";

--- a/pkgs/applications/audio/mpc/default.nix
+++ b/pkgs/applications/audio/mpc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, mpd_clientlib }:
 
 stdenv.mkDerivation rec {
-  name = "mpc-${version}";
+  pname = "mpc";
   version = "0.28";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/mpg321/default.nix
+++ b/pkgs/applications/audio/mpg321/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "mpg321-${version}";
+  pname = "mpg321";
   version = "0.3.2";
 
   src = fetchurl {

--- a/pkgs/applications/audio/musescore/darwin.nix
+++ b/pkgs/applications/audio/musescore/darwin.nix
@@ -8,7 +8,7 @@ in
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "musescore-darwin-${version}";
+  pname = "musescore-darwin";
   version = "${concatStringsSep "." versionComponents}";
 
   src = fetchurl {

--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "musescore-${version}";
+  pname = "musescore";
   version = "2.2.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/ncmpc/default.nix
+++ b/pkgs/applications/audio/ncmpc/default.nix
@@ -2,7 +2,7 @@
 , mpd_clientlib, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "ncmpc-${version}";
+  pname = "ncmpc";
   version = "0.30";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/ncpamixer/default.nix
+++ b/pkgs/applications/audio/ncpamixer/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
 
-  name = "ncpamixer-${version}";
+  pname = "ncpamixer";
   version = "1.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/non/default.nix
+++ b/pkgs/applications/audio/non/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "non-${version}";
+  pname = "non";
   version = "2018-02-15";
   src = fetchFromGitHub {
     owner = "original-male";

--- a/pkgs/applications/audio/nova-filters/default.nix
+++ b/pkgs/applications/audio/nova-filters/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.2-2";
-  name = "nova-filters-${version}";
+  pname = "nova-filters";
 
   src = fetchurl {
     url = http://klingt.org/~tim/nova-filters/nova-filters_0.2-2.tar.gz;

--- a/pkgs/applications/audio/openmpt123/default.nix
+++ b/pkgs/applications/audio/openmpt123/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchurl, SDL2, pkgconfig, flac, libsndfile }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "openmpt123";
   version = "0.2.7025-beta20.1";
-in stdenv.mkDerivation rec {
-  name = "openmpt123-${version}";
   src = fetchurl {
     url = "https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}.tar.gz";
     sha256 = "0qp2nnz6pnl1d7yv9hcjyim7q6yax5881k1jxm8jfgjqagmz5k6p";

--- a/pkgs/applications/audio/pamix/default.nix
+++ b/pkgs/applications/audio/pamix/default.nix
@@ -3,7 +3,7 @@
 , libpulseaudio, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "pamix-${version}";
+  pname = "pamix";
   version = "1.6";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/pamixer/default.nix
+++ b/pkgs/applications/audio/pamixer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, fetchpatch, boost, libpulseaudio }:
 
 stdenv.mkDerivation rec {
-  name = "pamixer-${version}";
+  pname = "pamixer";
   version = "1.3.1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/patchage/default.nix
+++ b/pkgs/applications/audio/patchage/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "patchage-${version}";
+  pname = "patchage";
   version = "1.0.1";
   src = fetchsvn {
     url = http://svn.drobilla.net/lad/trunk/patchage/;

--- a/pkgs/applications/audio/pd-plugins/cyclone/default.nix
+++ b/pkgs/applications/audio/pd-plugins/cyclone/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, puredata }:
 
 stdenv.mkDerivation rec {
-  name = "cyclone-${version}";
+  pname = "cyclone";
   version = "0.3beta-2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/pd-plugins/maxlib/default.nix
+++ b/pkgs/applications/audio/pd-plugins/maxlib/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, puredata }:
 
 stdenv.mkDerivation rec {
-  name = "maxlib-${version}";
+  pname = "maxlib";
   version = "1.5.7";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/pd-plugins/mrpeach/default.nix
+++ b/pkgs/applications/audio/pd-plugins/mrpeach/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, puredata }:
 
 stdenv.mkDerivation rec {
-  name = "mrpeach-${version}";
+  pname = "mrpeach";
   version = "1.1";
 
   # this was to only usable url I could find:

--- a/pkgs/applications/audio/pd-plugins/puremapping/default.nix
+++ b/pkgs/applications/audio/pd-plugins/puremapping/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, unzip, puredata }:
 
 stdenv.mkDerivation rec {
-  name = "puremapping-${version}";
+  pname = "puremapping";
   version = "20160130";
 
   src = fetchurl {

--- a/pkgs/applications/audio/pd-plugins/timbreid/default.nix
+++ b/pkgs/applications/audio/pd-plugins/timbreid/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.7.0";
-  name = "timbreid-${version}";
+  pname = "timbreid";
 
   src = fetchurl {
     url = "http://williambrent.conflations.com/pd/timbreID-${version}-src.zip";

--- a/pkgs/applications/audio/pianobooster/default.nix
+++ b/pkgs/applications/audio/pianobooster/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, alsaLib, cmake, libGLU_combined, makeWrapper, qt4 }:
 
 stdenv.mkDerivation  rec {
-  name = "pianobooster-${version}";
+  pname = "pianobooster";
   version = "0.6.4b";
 
   src = fetchurl {

--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -1,10 +1,10 @@
 { stdenv, python2Packages, fetchurl, gettext, chromaprint }:
 
 let
-  version = "1.4.2";
   pythonPackages = python2Packages;
-in pythonPackages.buildPythonApplication {
-  name = "picard-${version}";
+in pythonPackages.buildPythonApplication rec {
+  pname = "picard";
+  version = "1.4.2";
   namePrefix = "";
 
   src = fetchurl {

--- a/pkgs/applications/audio/pithos/default.nix
+++ b/pkgs/applications/audio/pithos/default.nix
@@ -4,7 +4,6 @@
 pythonPackages.buildPythonApplication rec {
   pname = "pithos";
   version = "1.1.2";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = pname;

--- a/pkgs/applications/audio/playbar2/default.nix
+++ b/pkgs/applications/audio/playbar2/default.nix
@@ -7,7 +7,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "playbar2-${version}";
+  pname = "playbar2";
   version = "2.5";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/plugin-torture/default.nix
+++ b/pkgs/applications/audio/plugin-torture/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, boost, ladspaH, lilv, lv2, pkgconfig, serd, sord, sratom }:
 
 stdenv.mkDerivation rec {
-  name = "plugin-torture-${version}";
+  pname = "plugin-torture";
   version = "2016-07-25";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/pmidi/default.nix
+++ b/pkgs/applications/audio/pmidi/default.nix
@@ -3,7 +3,8 @@
 , sourceSha256 ? "051mv6f13c8y13c1iv3279k1hhzpz4fm9sfczhgp9sim2bjdj055"
 }:
 stdenv.mkDerivation {
-  name = "pmidi-${version}";
+  pname = "pmidi";
+  inherit version;
 
   src = fetchurl {
     url = "mirror://sourceforge/pmidi/${version}/pmidi-${version}.tar.gz";

--- a/pkgs/applications/audio/ponymix/default.nix
+++ b/pkgs/applications/audio/ponymix/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, libpulseaudio, libnotify, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "ponymix-${version}";
+  pname = "ponymix";
   version = "5";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/praat/default.nix
+++ b/pkgs/applications/audio/praat/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, alsaLib, gtk2, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "praat-${version}";
+  pname = "praat";
   version = "6.0.40";
 
   src = fetchurl {

--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, python2Packages, makeWrapper, chromaprint }:
 
 python2Packages.buildPythonApplication rec {
-  name = "puddletag-${version}";
+  pname = "puddletag";
   version = "1.2.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/pulseaudio-ctl/default.nix
+++ b/pkgs/applications/audio/pulseaudio-ctl/default.nix
@@ -3,10 +3,9 @@
 
 let
   path = stdenv.lib.makeBinPath [ bc dbus gawk gnused libnotify pulseaudioLight ];
-  pname = "pulseaudio-ctl";
 
 in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "pulseaudio-ctl";
   version = "1.66";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/puredata/default.nix
+++ b/pkgs/applications/audio/puredata/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation  rec {
-  name = "puredata-${version}";
+  pname = "puredata";
   version = "0.48-0";
 
   src = fetchurl {

--- a/pkgs/applications/audio/qtscrobbler/default.nix
+++ b/pkgs/applications/audio/qtscrobbler/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, withMtp ? true, libmtp, pkgconfig, which, qt4, qmake4Hook }:
 
 stdenv.mkDerivation rec {
-  name = "qtscrobbler-${version}";
+  pname = "qtscrobbler";
   version = "0.11";
 
   src = fetchurl {

--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -39,7 +39,7 @@ let
   pythonInputs = with python2.pkgs; [ python2 lxml ];
 in
 stdenv.mkDerivation rec {
-  name = "radiotray-ng-${version}";
+  pname = "radiotray-ng";
   version = "0.2.2";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -13,7 +13,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "renoise-${version}";
+  pname = "renoise";
   version = "3.1.0";
 
   src =

--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -1,10 +1,9 @@
 { stdenv, lib, pkgconfig, fetchFromGitHub, scons, python, glibmm, libpulseaudio, libao
 }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "rhvoice";
   version = "unstable-2018-02-10";
-in stdenv.mkDerivation rec {
-  name = "rhvoice-${version}";
 
   src = fetchFromGitHub {
     owner = "Olga-Yakovleva";

--- a/pkgs/applications/audio/rubyripper/default.nix
+++ b/pkgs/applications/audio/rubyripper/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, ruby, cdparanoia, makeWrapper }:
 stdenv.mkDerivation rec {
   version = "0.6.2";
-  name = "rubyripper-${version}";
+  pname = "rubyripper";
   src = fetchurl {
     url = "https://rubyripper.googlecode.com/files/rubyripper-${version}.tar.bz2";
     sha256 = "1fwyk3y0f45l2vi3a481qd7drsy82ccqdb8g2flakv58m45q0yl1";

--- a/pkgs/applications/audio/sayonara/default.nix
+++ b/pkgs/applications/audio/sayonara/default.nix
@@ -1,10 +1,8 @@
 { stdenv, fetchurl, cmake, qt5, zlib, taglib, pkgconfig, pcre, gst_all_1 }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "sayonara-player";
   version = "1.0.0-git5-20180115";
-in
-stdenv.mkDerivation {
-  name = "sayonara-player-${version}";
 
   src = fetchurl {
     url = "https://sayonara-player.com/sw/sayonara-player-${version}.tar.gz";

--- a/pkgs/applications/audio/setbfree/default.nix
+++ b/pkgs/applications/audio/setbfree/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation  rec {
-  name = "setbfree-${version}";
+  pname = "setbfree";
   version = "0.8.5";
 
   src = fetchurl {

--- a/pkgs/applications/audio/shntool/default.nix
+++ b/pkgs/applications/audio/shntool/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "3.0.10";
-  name = "shntool-${version}";
+  pname = "shntool";
 
   src = fetchurl {
     url = http://www.etree.org/shnutils/shntool/dist/src/shntool-3.0.10.tar.gz;

--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -4,7 +4,7 @@
 let
   inherit (python3Packages) buildPythonApplication python isPy3k dbus-python pygobject3 mpd2;
 in buildPythonApplication rec {
-  name = "sonata-${version}";
+  pname = "sonata";
   version = "1.7b1";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -21,7 +21,7 @@ let
 
 in stdenv.mkDerivation rec {
   version = "3.0.1";
-  name = "sonic-pi-${version}";
+  pname = "sonic-pi";
 
   src = fetchFromGitHub {
     owner = "samaaron";

--- a/pkgs/applications/audio/sooperlooper/default.nix
+++ b/pkgs/applications/audio/sooperlooper/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "sooperlooper-git-${version}";
+  pname = "sooperlooper-git";
   version = "2016-07-19";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/sorcer/default.nix
+++ b/pkgs/applications/audio/sorcer/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub , boost, cairomm, cmake, libsndfile, lv2, ntk, pkgconfig, python }:
 
 stdenv.mkDerivation rec {
-  name = "sorcer-${version}";
+  pname = "sorcer";
   version = "1.1.3";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/soundscape-renderer/default.nix
+++ b/pkgs/applications/audio/soundscape-renderer/default.nix
@@ -15,7 +15,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "soundscape-renderer-unstable-${version}";
+  pname = "soundscape-renderer-unstable";
 
   version = "2016-11-03";
 

--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -47,7 +47,8 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "spotify-${version}";
+  pname = "spotify";
+  inherit version;
 
   src = fetchurl {
     url = "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}_amd64.deb";

--- a/pkgs/applications/audio/ssrc/default.nix
+++ b/pkgs/applications/audio/ssrc/default.nix
@@ -2,7 +2,6 @@
 
 stdenv.mkDerivation rec {
   pname = "ssrc";
-  name = "${pname}-${version}";
   version = "1.33";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/sunvox/default.nix
+++ b/pkgs/applications/audio/sunvox/default.nix
@@ -12,7 +12,7 @@ let
     else "x86";
 in
 stdenv.mkDerivation rec {
-  name = "SunVox-${version}";
+  pname = "SunVox";
   version = "1.9.3b";
 
   src = fetchurl {

--- a/pkgs/applications/audio/svox/default.nix
+++ b/pkgs/applications/audio/svox/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
-  name = "svox-${version}";
+  pname = "svox";
   version = "2017-07-18";
 
   src = fetchgit {

--- a/pkgs/applications/audio/swh-lv2/default.nix
+++ b/pkgs/applications/audio/swh-lv2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fftwSinglePrec, libxslt, lv2, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "swh-lv2-${version}";
+  pname = "swh-lv2";
   version = "1.0.16";
 
   src = fetchurl {

--- a/pkgs/applications/audio/timemachine/default.nix
+++ b/pkgs/applications/audio/timemachine/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "timemachine-${version}";
+  pname = "timemachine";
   version = "0.3.1";
   src = fetchFromGitHub {
     owner = "swh";

--- a/pkgs/applications/audio/transcribe/default.nix
+++ b/pkgs/applications/audio/transcribe/default.nix
@@ -4,7 +4,7 @@
 , libpng12, pango, zlib }:
 
 stdenv.mkDerivation rec {
-  name = "transcribe-${version}";
+  pname = "transcribe";
   version = "8.40";
 
   src = if stdenv.system == "i686-linux" then

--- a/pkgs/applications/audio/uade123/default.nix
+++ b/pkgs/applications/audio/uade123/default.nix
@@ -1,9 +1,8 @@
 { stdenv, fetchurl, which, libao, pkgconfig }:
 
-let
+stdenv.mkDerivation rec {
+  pname = "uade123";
   version = "2.13";
-in stdenv.mkDerivation rec {
-  name = "uade123-${version}";
   src = fetchurl {
     url = "http://zakalwe.fi/uade/uade2/uade-${version}.tar.bz2";
     sha256 = "04nn5li7xy4g5ysyjjngmv5d3ibxppkbb86m10vrvadzxdd4w69v";

--- a/pkgs/applications/audio/vimpc/default.nix
+++ b/pkgs/applications/audio/vimpc/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.09.1";
-  name = "vimpc-${version}";
+  pname = "vimpc";
 
   src = fetchFromGitHub {
     owner = "boysetsfrog";

--- a/pkgs/applications/audio/ympd/default.nix
+++ b/pkgs/applications/audio/ympd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, llvmPackages, pkgconfig, mpd_clientlib, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "ympd-${version}";
+  pname = "ympd";
   version = "1.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/zam-plugins/default.nix
+++ b/pkgs/applications/audio/zam-plugins/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit , boost, libX11, libGLU_combined, liblo, libjack2, ladspaH, lv2, pkgconfig, rubberband, libsndfile, fftwFloat, libsamplerate }:
 
 stdenv.mkDerivation rec {
-  name = "zam-plugins-${version}";
+  pname = "zam-plugins";
   version = "3.10";
 
   src = fetchgit {

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation  rec {
-  name = "zynaddsubfx-${version}";
+  pname = "zynaddsubfx";
   version = "3.0.3";
 
   src = fetchurl {

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -36,8 +36,7 @@
 
 let
   androidStudio = stdenv.mkDerivation {
-    name = "${pname}-${version}";
-
+    inherit pname version;
     src = fetchurl {
       url = "https://dl.google.com/dl/android/studio/ide-zips/${version}/android-studio-ide-${build}-linux.zip";
       sha256 = sha256Hash;

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -2,12 +2,10 @@
 
 let
   common = pname: {version, sha256}: stdenv.mkDerivation rec {
-    name = "${pname}-${version}";
-    inherit version;
+    inherit pname version;
 
     src = fetchurl {
       url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
-      name = "${name}.deb";
       inherit sha256;
     };
 

--- a/pkgs/applications/editors/bonzomatic/default.nix
+++ b/pkgs/applications/editors/bonzomatic/default.nix
@@ -1,7 +1,6 @@
 { stdenv, makeWrapper, fetchFromGitHub, cmake, alsaLib, mesa_glu, libXcursor, libXinerama, libXrandr, xorgserver }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "bonzomatic";
   version = "2018-03-29";
 

--- a/pkgs/applications/editors/emacs-modes/idris/default.nix
+++ b/pkgs/applications/editors/emacs-modes/idris/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchurl, emacs }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "idris-mode";
   version = "0.9.18";
 

--- a/pkgs/applications/editors/ghostwriter/default.nix
+++ b/pkgs/applications/editors/ghostwriter/default.nix
@@ -3,7 +3,6 @@
 stdenv.mkDerivation rec {
   pname = "ghostwriter";
   version = "1.6.2";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "wereturtle";

--- a/pkgs/applications/editors/texmacs/default.nix
+++ b/pkgs/applications/editors/texmacs/default.nix
@@ -9,17 +9,16 @@
   koreanFonts ? false }:
 
 let
-  pname = "TeXmacs";
-  version = "1.99.2";
   common = callPackage ./common.nix {
     inherit tex extraFonts chineseFonts japaneseFonts koreanFonts;
   };
 in
-stdenv.mkDerivation {
-  name = "${pname}-${version}";
+stdenv.mkDerivation rec {
+  pname = "TeXmacs";
+  version = "1.99.2";
 
   src = fetchurl {
-    url = "http://www.texmacs.org/Download/ftp/tmftp/source/TeXmacs-${version}-src.tar.gz";
+    url = "http://www.texmacs.org/Download/ftp/tmftp/source/${pname}-${version}-src.tar.gz";
     sha256 = "0l48g9746igiaxw657shm8g3xxk565vzsviajlrxqyljbh6py0fs";
   };
 
@@ -34,7 +33,7 @@ stdenv.mkDerivation {
   inherit (common) postPatch;
 
   postFixup = ''
-    bin="$out/libexec/TeXmacs/bin/texmacs.bin"
+    bin="$out/libexec/${pname}/bin/texmacs.bin"
     rpath=$(patchelf --print-rpath "$bin")
     patchelf --set-rpath "$rpath:${zlib.out}/lib" "$bin"
   '';

--- a/pkgs/applications/editors/texstudio/default.nix
+++ b/pkgs/applications/editors/texstudio/default.nix
@@ -3,7 +3,6 @@
 stdenv.mkDerivation rec {
   pname = "texstudio";
   version = "2.12.8";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "${pname}-org";

--- a/pkgs/applications/graphics/dosage/default.nix
+++ b/pkgs/applications/graphics/dosage/default.nix
@@ -1,7 +1,6 @@
 { stdenv, pythonPackages, fetchFromGitHub }:
 
 pythonPackages.buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "dosage";
   version = "2018.04.08";
   PBR_VERSION = version;

--- a/pkgs/applications/misc/jrnl/default.nix
+++ b/pkgs/applications/misc/jrnl/default.nix
@@ -7,7 +7,6 @@ with python.pkgs;
 buildPythonApplication rec {
   pname = "jrnl";
   version = "1.9.8";
-  name = "${pname}-${version}";
   disabled = isPy3k;
 
   src = fetchPypi {

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -3,7 +3,6 @@
 with python3Packages;
 
 buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "khal";
   version = "0.9.9";
 

--- a/pkgs/applications/misc/tzupdate/default.nix
+++ b/pkgs/applications/misc/tzupdate/default.nix
@@ -4,7 +4,6 @@ let
   inherit (python.pkgs) buildPythonApplication fetchPypi requests;
 in
 buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "tzupdate";
   version = "1.2.0";
 

--- a/pkgs/applications/networking/feedreaders/feedreader/default.nix
+++ b/pkgs/applications/networking/feedreaders/feedreader/default.nix
@@ -3,11 +3,9 @@
 , curl, glib, gnome3, gst_all_1, json-glib, libnotify, libsecret, sqlite
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "FeedReader";
   version = "2.2";
-in stdenv.mkDerivation {
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "jangernert";

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -6,7 +6,6 @@ in
 buildPythonApplication rec {
   pname = "fava";
   version = "1.7";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
@@ -26,4 +25,3 @@ buildPythonApplication rec {
     maintainers = with stdenv.lib.maintainers; [ ];
   };
 }
-

--- a/pkgs/applications/science/biology/raxml/default.nix
+++ b/pkgs/applications/science/biology/raxml/default.nix
@@ -8,7 +8,6 @@
 stdenv.mkDerivation rec {
   pname = "RAxML";
   version = "8.2.11";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "stamatak";

--- a/pkgs/applications/science/logic/hol/default.nix
+++ b/pkgs/applications/science/logic/hol/default.nix
@@ -20,7 +20,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "${pname}-${version}";
+  inherit pname version;
 
   src = fetchurl {
     url = "mirror://sourceforge/hol/hol/${longVersion}/${holsubdir}.tar.gz";

--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   # newer versions (4.9.0) are available, but still considered beta (https://github.com/gap-system/gap/wiki/GAP-4.9-release-notes)
   version = "4r8p10";
   pkgVer = "2018_01_15-13_02";
-  name = "${pname}-${version}";
 
   src = let
     # 4r8p10 -> 48

--- a/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitflow/default.nix
@@ -5,7 +5,6 @@ with pkgs.lib;
 stdenv.mkDerivation rec {
   pname = "gitflow";
   version = "1.11.0";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "petervanderdoes";

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -15,7 +15,13 @@ let
 
   # Convert a version to branch (3.26.18 → 3.26)
   # Used for finding packages on GNOME mirrors
-  versionBranch = version: builtins.concatStringsSep "." (lib.take 2 (lib.splitString "." version));
+  versionBranch = lib.versions.majorMinor;
+
+  fetchGnomeSource = {pname, version, sha256, name ? "${pname}-${version}"}:
+    pkgs.fetchurl {
+      inherit sha256;
+      url = "mirror://gnome/sources/${pname}/${versionBranch version}/${name}.tar.xz";
+    };
 
   updateScript = callPackage ./update.nix { };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -17,10 +17,13 @@ let
   # Used for finding packages on GNOME mirrors
   versionBranch = lib.versions.majorMinor;
 
-  fetchGnomeSource = {pname, version, sha256, name ? "${pname}-${version}"}:
+  fetchGnomeSource = {pname, version, sha256, name ? "${pname}-${version}", shortenVersion ? true}:
+    let
+      shortVersion = if shortenVersion then versionBranch version else version;
+    in
     pkgs.fetchurl {
       inherit sha256;
-      url = "mirror://gnome/sources/${pname}/${versionBranch version}/${name}.tar.xz";
+      url = "mirror://gnome/sources/${pname}/${shortVersion}/${name}.tar.xz";
     };
 
   updateScript = callPackage ./update.nix { };

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -65,7 +65,7 @@ then throw "${name} not supported for interpreter ${python.executable}"
 else
 
 toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
-    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts"
+    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "pname" "version"
   ] // {
 
   name = namePrefix + name;

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -65,7 +65,7 @@ then throw "${name} not supported for interpreter ${python.executable}"
 else
 
 toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
-    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "pname"
+    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts"
   ] // {
 
   name = namePrefix + name;

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -65,7 +65,7 @@ then throw "${name} not supported for interpreter ${python.executable}"
 else
 
 toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
-    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "pname" "version"
+    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "pname"
   ] // {
 
   name = namePrefix + name;

--- a/pkgs/development/libraries/libdazzle/default.nix
+++ b/pkgs/development/libraries/libdazzle/default.nix
@@ -1,12 +1,9 @@
 { stdenv, pkgs, fetchurl, ninja, meson, pkgconfig, vala, gobjectIntrospection, libxml2
 , gtk-doc, docbook_xsl, dbus, xvfb_run, glib, gtk3, gnome3 }:
 
-let
+stdenv.mkDerivation rec {
   version = "3.28.1";
   pname = "libdazzle";
-in
-stdenv.mkDerivation {
-  name = "${pname}-${version}";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -12,7 +12,6 @@
 , withSage ? false # sage support
 }:
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "linbox";
   version = "1.5.2";
 

--- a/pkgs/development/libraries/science/math/lcalc/default.nix
+++ b/pkgs/development/libraries/science/math/lcalc/default.nix
@@ -7,7 +7,6 @@
 stdenv.mkDerivation rec {
   version = "1.23";
   pname = "lcalc";
-  name = "${pname}-${version}";
 
   src = fetchurl {
     # original at http://oto.math.uwaterloo.ca/~mrubinst/L_function_public/CODE/L-${version}.tar.gz, no longer available

--- a/pkgs/development/libraries/science/math/rubiks/default.nix
+++ b/pkgs/development/libraries/science/math/rubiks/default.nix
@@ -7,10 +7,9 @@
 stdenv.mkDerivation rec {
   pname = "rubiks";
   version = "20070912";
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "http://mirrors.mit.edu/sage/spkg/upstream/rubiks/rubiks-${version}.tar.bz2";
+    url = "http://mirrors.mit.edu/sage/spkg/upstream/${pname}/${pname}-${version}.tar.bz2";
     sha256 = "0zdmkb0j1kyspdpsszzb2k3279xij79jkx0dxd9f3ix1yyyg3yfq";
   };
 
@@ -29,19 +28,19 @@ stdenv.mkDerivation rec {
     # Fix makefiles which use all the variables in all the wrong ways and
     # hardcode values for some variables.
     (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/rubiks/patches/dietz-cu2-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/${pname}/patches/dietz-cu2-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "1ry3w1mk9q4jqd91zlaa1bdiiplld4hpfjaldbhlmzlgrrc99qmq";
     })
     (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/rubiks/patches/dietz-mcube-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/${pname}/patches/dietz-mcube-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "0zsbh6k3kqdg82fv0kzghr1x7pafisv943gmssqscp107bhg77bz";
     })
     (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/rubiks/patches/dietz-solver-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/${pname}/patches/dietz-solver-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "0vhw70ylnmydgjhwx8jjlb2slccj4pfqn6vzirkyz1wp8apsmfhp";
     })
     (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/rubiks/patches/reid-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/${pname}/patches/reid-Makefile.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "1r311sn012xs135s0d21qwsig2kld7rdcq19nm0zbnklviid57df";
     })
   ];

--- a/pkgs/development/python-modules/bootstrapped-pip/default.nix
+++ b/pkgs/development/python-modules/bootstrapped-pip/default.nix
@@ -14,9 +14,9 @@ let
     sha256 = "8fca9275c89964f13da985c3656cb00ba029d7f3916b37990927ffdf264e7926";
   };
 
-in stdenv.mkDerivation rec {
   pname = "pip";
   version = "10.0.1";
+in stdenv.mkDerivation rec {
   name = "${python.libPrefix}-bootstrapped-${pname}-${version}";
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/gssapi/default.nix
+++ b/pkgs/development/python-modules/gssapi/default.nix
@@ -4,7 +4,6 @@ nose, shouldbe, gss, krb5Full, which, darwin }:
 buildPythonPackage rec {
   pname = "gssapi";
   version = "1.4.1";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/html5-parser/default.nix
+++ b/pkgs/development/python-modules/html5-parser/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "html5-parser";
   version = "0.4.5";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/markdownsuperscript/default.nix
+++ b/pkgs/development/python-modules/markdownsuperscript/default.nix
@@ -3,7 +3,6 @@
 buildPythonPackage rec {
   pname = "MarkdownSuperscript";
   version = "2.0.0";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/pelican/default.nix
+++ b/pkgs/development/python-modules/pelican/default.nix
@@ -6,7 +6,6 @@
 
 buildPythonPackage rec {
   pname = "pelican";
-  name = "${pname}-${version}";
   version = "3.7.1";
   disabled = isPy26;
 

--- a/pkgs/development/python-modules/persistent/default.nix
+++ b/pkgs/development/python-modules/persistent/default.nix
@@ -7,7 +7,6 @@
 buildPythonPackage rec {
   pname = "persistent";
   version = "4.2.4.2";
-  name = "${pname}-${version}";
 
   propagatedBuildInputs = [ zope_interface ];
 

--- a/pkgs/development/python-modules/pycrypto/default.nix
+++ b/pkgs/development/python-modules/pycrypto/default.nix
@@ -6,7 +6,6 @@
 buildPythonPackage rec {
   version = pycryptodome.version;
   pname = "pycrypto";
-  name = "${pname}-${version}";
 
   # Cannot build wheel otherwise (zip 1980 issue)
   SOURCE_DATE_EPOCH=315532800;

--- a/pkgs/development/python-modules/pyfftw/default.nix
+++ b/pkgs/development/python-modules/pyfftw/default.nix
@@ -4,7 +4,6 @@
 buildPythonPackage rec {
   version = "0.10.4";
   pname = "pyFFTW";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/requests_download/default.nix
+++ b/pkgs/development/python-modules/requests_download/default.nix
@@ -7,7 +7,6 @@
 buildPythonPackage rec {
   pname = "requests_download";
   version = "0.1.1";
-  name = "${pname}-${version}";
 
   format = "wheel";
 

--- a/pkgs/development/python-modules/scikitlearn/default.nix
+++ b/pkgs/development/python-modules/scikitlearn/default.nix
@@ -7,7 +7,6 @@
 buildPythonPackage rec {
   pname = "scikit-learn";
   version = "0.19.1";
-  name = "${pname}-${version}";
   disabled = stdenv.isi686;  # https://github.com/scikit-learn/scikit-learn/issues/5534
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/setuptools/default.nix
+++ b/pkgs/development/python-modules/setuptools/default.nix
@@ -6,9 +6,10 @@
 }:
 
 # Should use buildPythonPackage here somehow
-stdenv.mkDerivation rec {
+let
   pname = "setuptools";
   version = "39.0.1";
+in stdenv.mkDerivation rec {
   name = "${python.libPrefix}-${pname}-${version}";
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/smart_open/default.nix
+++ b/pkgs/development/python-modules/smart_open/default.nix
@@ -13,7 +13,6 @@
 
 buildPythonPackage rec {
   pname = "smart_open";
-  name = "${pname}-${version}";
   version = "1.5.7";
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -25,7 +25,6 @@
 }:
 
 buildPythonPackage rec {
-  name = "${pname}-${version}";
   pname = "Sphinx";
   version = "1.7.4";
   src = fetchPypi {

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -4,7 +4,6 @@
 in python3Packages.buildPythonApplication rec {
   version = "0.46.1";
   pname = "meson";
-  name = "${pname}-${version}";
 
   src = python3Packages.fetchPypi {
     inherit pname version;

--- a/pkgs/development/tools/flootty/default.nix
+++ b/pkgs/development/tools/flootty/default.nix
@@ -7,7 +7,6 @@ in
 buildPythonApplication rec {
   pname = "Flootty";
   version = "3.2.1";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -3,7 +3,6 @@ let
   deps = import ./requirements.nix { inherit pkgs; };
 in
 python27Packages.buildPythonApplication rec {
-  name = "${pname}-${version}";
   pname = "gdbgui";
   version = "0.11.1.2";
 

--- a/pkgs/development/tools/misc/lit/default.nix
+++ b/pkgs/development/tools/misc/lit/default.nix
@@ -3,7 +3,6 @@
 python2.pkgs.buildPythonApplication rec {
   pname = "lit";
   version = "0.5.1";
-  name = "${pname}-${version}";
 
   src = python2.pkgs.fetchPypi {
     inherit pname version;

--- a/pkgs/misc/themes/arc/default.nix
+++ b/pkgs/misc/themes/arc/default.nix
@@ -3,11 +3,10 @@
 let
   # treat versions newer than 3.22 as 3.22
   gnomeVersion = if stdenv.lib.versionOlder "3.22" gnome3.version then "3.22" else gnome3.version;
-  pname = "arc-theme";
 in
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "arc-theme";
   version = "2017-05-12";
 
   src = fetchFromGitHub {

--- a/pkgs/misc/themes/blackbird/default.nix
+++ b/pkgs/misc/themes/blackbird/default.nix
@@ -3,10 +3,9 @@
 stdenv.mkDerivation rec {
   pname = "Blackbird";
   version = "2017-12-13";
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
-    repo = "${pname}";
+    repo = pname;
     owner = "shimmerproject";
     rev = "a1c5674c0ec38b4cc8ba41d2c0e6187987ae7eb4";
     sha256 = "0xskcw36ci2ykra5gir5pkrawh2qkcv18p4fp2kxivssbd20d4jw";

--- a/pkgs/misc/themes/greybird/default.nix
+++ b/pkgs/misc/themes/greybird/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchFromGitHub, autoreconfHook, sass, glib, libxml2, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "greybird";
   version = "3.22.7";
 
   src = fetchFromGitHub {
     owner = "shimmerproject";
-    repo = "${pname}";
+    repo = pname;
     rev = "v${version}";
     sha256 = "118k0bb780h54i2vn5my5r6vbkk134899xwp4aigw5a289xzryvb";
   };

--- a/pkgs/misc/themes/vertex/default.nix
+++ b/pkgs/misc/themes/vertex/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gnome3, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "theme-vertex";
   version = "20170128";
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -83,7 +83,7 @@ rec {
 
     # Check that the name is consistent with pname and version:
     assert lib.lists.all (name: builtins.hasAttr name attrs) ["name" "pname" "version"]
-      -> attrs.name == "${attrs.pname}-${attrs.version}";
+      -> lib.strings.hasSuffix "${attrs.pname}-${attrs.version}" attrs.name;
 
     # TODO(@Ericson2314): Make this more modular, and not O(n^2).
     let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -66,6 +66,8 @@ rec {
     , pos ? # position used in error messages and for meta.position
         (if attrs.meta.description or null != null
           then builtins.unsafeGetAttrPos "description" attrs.meta
+          else if attrs.version or null != null
+          then builtins.unsafeGetAttrPos "version" attrs
           else builtins.unsafeGetAttrPos "name" attrs)
     , separateDebugInfo ? false
     , outputs ? [ "out" ]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -12,7 +12,9 @@ rec {
   # * https://nixos.org/nix/manual/#ssec-derivation
   #   Explanation about derivations in general
   mkDerivation =
-    { name ? ""
+    { name ? if builtins.hasAttr "pname" attrs && builtins.hasAttr "version" attrs
+        then "${attrs.pname}-${attrs.version}"
+        else ""
 
     # These types of dependencies are all exhaustively documented in
     # the "Specifying Dependencies" section of the "Standard

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -81,6 +81,10 @@ rec {
 
     , ... } @ attrs:
 
+    # Check that the name is consistent with pname and version:
+    assert lib.lists.all (name: builtins.hasAttr name attrs) ["name" "pname" "version"]
+      -> attrs.name == "${attrs.pname}-${attrs.version}";
+
     # TODO(@Ericson2314): Make this more modular, and not O(n^2).
     let
       supportedHardeningFlags = [ "fortify" "stackprotector" "pie" "pic" "strictoverflow" "format" "relro" "bindnow" ];

--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -7,7 +7,6 @@ with python.pkgs;
 buildPythonApplication rec {
   pname = "mycli";
   version = "1.6.0";
-  name = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-anthy/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-anthy/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, fcitx, anthy, gettext, pkgconfig }:
+{ stdenv, fetchFcitxSource, cmake, fcitx, anthy, gettext, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-anthy-${version}";
+  pname = "fcitx-anthy";
   version = "0.2.2";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-anthy/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "0ayrzfx95670k86y19bzl6i6w98haaln3x8dxpb39a5dwgz59pf8";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-chewing/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-chewing/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext, libchewing, pkgconfig }:
+{ stdenv, fetchFcitxSource, cmake, fcitx, gettext, libchewing, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-chewing-${version}";
+  pname = "fcitx-chewing";
   version = "0.2.2";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-chewing/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "0l548xdx2fvjya1ixp37pn382yak0m4kwfh9lgh7l3y2sblqw9zs";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-cloudpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-cloudpinyin/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, curl }:
+{ stdenv, fetchFcitxSource, cmake, pkgconfig, fcitx, gettext, curl }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-cloudpinyin-${version}";
+  pname = "fcitx-cloudpinyin";
   version = "0.3.4";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-cloudpinyin/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "143x9gbswzfngvgfy77zskrzrpywj8qg2d19kisgfwfisk7yhcf1";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-hangul/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-hangul/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, fcitx, libhangul, gettext, pkgconfig }:
+{ stdenv, fetchFcitxSource, cmake, fcitx, libhangul, gettext, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-hangul-${version}";
+  pname = "fcitx-hangul";
   version = "0.3.0";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-hangul/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "1jq78nczliw6pnhfac8hspffybrry6syk17y0wwcq05j3r3nd2lp";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFcitxSource, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
+{ stdenv, fetchFcitxSource, fetchurl, cmake, pkgconfig, fcitx, gettext
+, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
 
 stdenv.mkDerivation rec {
   pname = "fcitx-libpinyin";
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
 
   preBuild = let
     ZHUYIN_DATA_FILE_NAME = "model.text.20161206.tar.gz";
-    store_path = fetchFcitxSource {
+    store_path = fetchurl {
       url = "https://download.fcitx-im.org/data/${ZHUYIN_DATA_FILE_NAME}";
       sha256 = "017p11si1b7bkwx36xaybq5a9icq1pd7x1jbymqw92akfgjj8w2w";
     };

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
+{ stdenv, fetchFcitxSource, cmake, pkgconfig, fcitx, gettext, libpinyin, glib, pcre, dbus, qtwebengine, qtbase, fcitx-qt5 }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-libpinyin-${version}";
+  pname = "fcitx-libpinyin";
   version = "0.5.3";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-libpinyin/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "196c229ckib3xvafkk4n3n3jk9rpksfcjsbbwka6a9k2f34qrjj6";
   };
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   preBuild = let
     ZHUYIN_DATA_FILE_NAME = "model.text.20161206.tar.gz";
-    store_path = fetchurl {
+    store_path = fetchFcitxSource {
       url = "https://download.fcitx-im.org/data/${ZHUYIN_DATA_FILE_NAME}";
       sha256 = "017p11si1b7bkwx36xaybq5a9icq1pd7x1jbymqw92akfgjj8w2w";
     };

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-m17n/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-m17n/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext, m17n_lib, m17n_db, pkgconfig }:
+{ stdenv, fetchFcitxSource, cmake, fcitx, gettext, m17n_lib, m17n_db, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-m17n-${version}";
+  pname = "fcitx-m17n";
   version = "0.2.3";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-m17n/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "0ffyhsg7bc6525k94kfhnja1h6ajlfprq72d286dp54cksnakyc4";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
@@ -1,4 +1,4 @@
-{ clangStdenv, fetchFromGitHub, fetchFcitxSource, fetchpatch, gyp, which, ninja,
+{ clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, gyp, which, ninja,
   python, pkgconfig, protobuf, gtk2, zinnia, qt5, libxcb, tegaki-zinnia-japanese,
   fcitx, gettext }:
 let
@@ -8,12 +8,12 @@ let
     rev    = "e5b3425575734c323e1d947009dd74709437b684";
     sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
   };
-  icons = fetchFcitxSource {
+  icons = fetchurl {
     url    = "http://download.fcitx-im.org/fcitx-mozc/fcitx-mozc-icon.tar.gz";
     sha256 = "10bdjn481jsh32vll7r756l392anz44h6207vjqwby3rplk31np1";
   };
 in clangStdenv.mkDerivation rec {
-  name    = "fcitx-mozc-${version}";
+  pname    = "fcitx-mozc";
   version = "2.20.2673.102";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-mozc/default.nix
@@ -1,4 +1,4 @@
-{ clangStdenv, fetchFromGitHub, fetchurl, fetchpatch, gyp, which, ninja,
+{ clangStdenv, fetchFromGitHub, fetchFcitxSource, fetchpatch, gyp, which, ninja,
   python, pkgconfig, protobuf, gtk2, zinnia, qt5, libxcb, tegaki-zinnia-japanese,
   fcitx, gettext }:
 let
@@ -8,7 +8,7 @@ let
     rev    = "e5b3425575734c323e1d947009dd74709437b684";
     sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
   };
-  icons = fetchurl {
+  icons = fetchFcitxSource {
     url    = "http://download.fcitx-im.org/fcitx-mozc/fcitx-mozc-icon.tar.gz";
     sha256 = "10bdjn481jsh32vll7r756l392anz44h6207vjqwby3rplk31np1";
   };

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-rime/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, pkgconfig, fcitx, librime, brise, hicolor-icon-theme }:
+{ stdenv, fetchFcitxSource, cmake, pkgconfig, fcitx, librime, brise, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-rime-${version}";
+  pname = "fcitx-rime";
   version = "0.3.2";
 
-  src = fetchurl {
-    url = "https://download.fcitx-im.org/fcitx-rime/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "0bd8snfa6jr8dhnm0s0z021iryh5pbaf7p15rhkgbigw2pssczpr";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-skk/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-skk/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, fcitx, libskk, skk-dicts }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-skk-${version}";
+  pname = "fcitx-skk";
   version = "0.1.4";
   src = fetchFromGitHub {
     owner = "fcitx";

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-table-other/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext }:
+{ stdenv, fetchFcitxSource, cmake, fcitx, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-table-other-${version}";
+  pname = "fcitx-table-other";
   version = "0.2.4";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-table-other/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "1di60lr6l5k2sdwi3yrc0hl89j2k0yipayrsn803vd040w1fgfhq";
   };
 

--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-unikey/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, cmake, fcitx, gettext, pkgconfig }:
+{ stdenv, fetchFcitxSource, cmake, fcitx, gettext, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-unikey-${version}";
+  pname = "fcitx-unikey";
   version = "0.2.5";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-unikey/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "063vc29v7ycaai98v3z4q319sv9sm91my17pmhblw1vifxnw02wf";
   };
 

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFcitxSource, makeWrapper, pkgconfig, cmake, fcitx, gtk3, isocodes, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-configtool-0.4.9";
+  pname = "fcitx-configtool";
+  version = "0.4.9";
 
   meta = with stdenv.lib; {
     description = "GTK-based config tool for Fcitx";

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, cmake, fcitx, gtk3, isocodes, gnome3 }:
+{ stdenv, fetchFcitxSource, makeWrapper, pkgconfig, cmake, fcitx, gtk3, isocodes, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-configtool-0.4.9";
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ cdepillabout ];
   };
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-configtool/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "1ypr2jr3vzs2shqfrvhqy69xvagrn9x507180i9wxy14hb97a82r";
   };
 
@@ -24,4 +24,3 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS";
   '';
 }
-

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFcitxSource, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules }:
 
 stdenv.mkDerivation rec {
-  name = "fcitx-qt5-${version}";
+  pname = "fcitx-qt5";
   version = "1.2.1";
 
   src = fetchFcitxSource {

--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -1,11 +1,11 @@
-{ stdenv, lib, fetchurl, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules }:
+{ stdenv, lib, fetchFcitxSource, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules }:
 
 stdenv.mkDerivation rec {
   name = "fcitx-qt5-${version}";
   version = "1.2.1";
 
-  src = fetchurl {
-    url = "http://download.fcitx-im.org/fcitx-qt5/${name}.tar.xz";
+  src = fetchFcitxSource {
+    inherit pname version;
     sha256 = "0z8ax0dxk88byic41mfaiahjdv1k8ciwn97xfjkkgr4ijgscdr8c";
   };
 

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
@@ -1,10 +1,17 @@
-{ stdenv, fetchurl, intltool, pkgconfig
+{ stdenv, fetchFromGitHub, intltool, pkgconfig
 , anthy, ibus, glib, gobjectIntrospection, gtk3, python3
 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-anthy-${version}";
+  pname = "ibus-anthy";
   version = "1.5.10";
+
+  src = fetchFromGitHub {
+    owner = "ibus";
+    repo = pname;
+    rev = version;
+    sha256 = "07qyfdra2lc91jn35inraxbjqzni6yzx59a17k968pspx8lzdx02";
+  };
 
   meta = with stdenv.lib; {
     isIbusEngine = true;
@@ -27,9 +34,4 @@ stdenv.mkDerivation rec {
     wrapPythonPrograms
     substituteInPlace $out/share/ibus/component/anthy.xml --replace \$\{exec_prefix\} $out
   '';
-
-  src = fetchurl {
-    url = "https://github.com/ibus/ibus-anthy/releases/download/${version}/${name}.tar.gz";
-    sha256 = "0jpqz7pb9brlqiwrbr3i6wvj3b39a9bs9lljl3qa3r77mz8y0cyc";
-  };
 }

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-hangul/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-hangul/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, intltool, pkgconfig
+{ stdenv, fetchFromGitHub, intltool, pkgconfig
 , gtk3, ibus, libhangul, librsvg, python3
 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-hangul-${version}";
+  pname = "ibus-hangul";
   version = "1.5.0";
 
-  src = fetchurl {
-    url = "https://github.com/choehwanjin/ibus-hangul/releases/download/${version}/${name}.tar.gz";
-    sha256 = "120p9w7za6hi521hz8q235fkl4i3p1qqr8nqm4a3kxr0pcq40bd2";
+  src = fetchFromGitHub {
+    owner = "choehwanjin";
+    repo = pname;
+    rev = version;
+    sha256 = "12l2spr32biqdbz01bzkamgq5gskbi6cd7ai343wqyy1ibjlkmp8";
   };
 
   buildInputs = [ gtk3 ibus libhangul python3 ];

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-kkc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-kkc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchFromGitHub
 , vala, intltool, pkgconfig
 , libkkc, ibus, skk-dicts
 , gtk3
@@ -7,11 +7,12 @@
 stdenv.mkDerivation rec {
   pname = "ibus-kkc";
   version = "1.5.22";
-  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "${meta.homepage}/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "1kj74c9zy9yxkjx7pz96mzqc13cf10yfmlgprr8sfd4ay192bzi2";
+  src = fetchFromGitHub {
+    owner = "ueno";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1w5dpska0ps3jwqnhvxic7lmhlba2vyj85nkfngj84b9agpf7f3r";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -4,12 +4,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-libpinyin-${version}";
+  pname = "ibus-libpinyin";
   version = "1.10.0";
 
   src = fetchFromGitHub {
     owner  = "libpinyin";
-    repo   = "ibus-libpinyin";
+    repo   = pname;
     rev    = version;
     sha256 = "0zkzz6ig74nws8phqxbsggnpf5g5f2hxi0mdyn2m3s4nm14q3ma6";
   };

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
@@ -4,12 +4,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-m17n-${version}";
+  pname = "ibus-m17n";
   version = "1.3.4";
 
   src = fetchFromGitHub {
     owner  = "ibus";
-    repo   = "ibus-m17n";
+    repo   = pname;
     rev    = version;
     sha256 = "1n0bvgc4jyksgvzrw5zs2pxcpxcn3gcc0j2kasbznm34fpv3frsr";
   };

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -9,7 +9,7 @@ let
     sha256 = "0pyrpz9c8nxccwpgyr36w314mi8h132cis8ijvlqmmhqxwsi30hm";
   };
 in clangStdenv.mkDerivation rec {
-  name = "ibus-mozc-${version}";
+  pname = "ibus-mozc";
   version = "2.20.2673.102";
 
   meta = with clangStdenv.lib; {

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table-others/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, ibus, ibus-table, pkgconfig, python3 }:
+{ stdenv, fetchFromGitHub, ibus, ibus-table, pkgconfig, python3 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-table-others-${version}";
+  pname = "ibus-table-others";
   version = "1.3.9";
 
-  src = fetchurl {
-    url = "https://github.com/moebiuscurve/ibus-table-others/releases/download/${version}/${name}.tar.gz";
-    sha256 = "0270a9njyzb1f8nw5w9ghwxcl3m6f13d8p8a01fjm8rnjs04mcb3";
+  src = fetchFromGitHub {
+    owner = "moebiuscurve";
+    repo = pname;
+    rev = version;
+    sha256 = "0iyhfb9261q4g1ldvddiqsf03fhpagailbxw3a7pig1858v15izf";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-table/default.nix
@@ -4,7 +4,7 @@
 , ibus, python3 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-table-${version}";
+  pname = "ibus-table";
   version = "1.9.20";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-uniemoji/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-uniemoji/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-uniemoji-${version}";
+  pname = "ibus-uniemoji";
   version = "0.6.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -39,7 +39,7 @@ let
     '';
   };
   cldrEmojiAnnotation = stdenv.mkDerivation rec {
-    name = "cldr-emoji-annotation-${version}";
+    pname = "cldr-emoji-annotation";
     version = "31.90.0_1";
     src = fetchFromGitHub {
       owner = "fujiwarat";
@@ -61,7 +61,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "ibus-${version}";
+  pname = "ibus";
   version = "1.5.17";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/inputmethods/ibus/ibus-qt.nix
+++ b/pkgs/tools/inputmethods/ibus/ibus-qt.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, ibus, cmake, pkgconfig, qt4, icu, doxygen }:
+{ stdenv, fetchFromGitHub, ibus, cmake, pkgconfig, qt4, icu, doxygen }:
 
 stdenv.mkDerivation rec {
-  name = "ibus-qt-${version}";
+  pname = "ibus-qt";
   version = "1.3.3";
 
-  src = fetchurl {
-    url = "https://github.com/ibus/ibus-qt/releases/download/${version}/${name}-Source.tar.gz";
-    sha256 = "1q9g7qghpcf07valc2ni7yf994xqx2pmdffknj7scxfidav6p19g";
+  src = fetchFromGitHub {
+    owner = "ibus";
+    repo = pname;
+    rev = version;
+    sha256 = "1q3p4p1harzn920j8anwmq9ag60nwvlavl01vl2icd2nd110717s";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  name = "ibus-with-plugins-" + (builtins.parseDrvName ibus.name).version;
+  name = "ibus-with-plugins-" + ibus.version;
   env = {
     buildInputs = [ ibus ] ++ plugins;
     nativeBuildInputs = [ lndir makeWrapper ];

--- a/pkgs/tools/misc/bepasty/default.nix
+++ b/pkgs/tools/misc/bepasty/default.nix
@@ -10,7 +10,6 @@ with python.pkgs;
 buildPythonPackage rec {
   pname = "bepasty";
   version = "0.4.0";
-  name = "${pname}-${version}";
 
   propagatedBuildInputs = [
     flask

--- a/pkgs/tools/package-management/nix-bundle/default.nix
+++ b/pkgs/tools/package-management/nix-bundle/default.nix
@@ -2,7 +2,6 @@
 
 stdenv.mkDerivation rec {
   pname = "nix-bundle";
-  name = "${pname}-${version}";
   version = "0.2.0";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/security/krunner-pass/default.nix
+++ b/pkgs/tools/security/krunner-pass/default.nix
@@ -4,12 +4,10 @@
 
   pass, pass-otp ? null, krunner,
 }:
-let
+
+mkDerivation rec {
   pname = "krunner-pass";
   version = "1.3.0";
-in
-mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "akermu";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2295,6 +2295,12 @@ with pkgs;
     plugins = [];
   };
 
+  fetchFcitxSource = {pname, version, sha256}:
+    fetchurl {
+      inherit sha256;
+      url = "http://download.fcitx-im.org/${pname}/${pname}-${version}.tar.xz";
+    };
+
   fcitx-engines = recurseIntoAttrs {
 
     anthy = callPackage ../tools/inputmethods/fcitx-engines/fcitx-anthy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19789,6 +19789,7 @@ with pkgs;
   });
 
   gnome3 = recurseIntoAttrs (callPackage ../desktops/gnome-3 { });
+  inherit (gnome3) fetchGnomeSource;
 
   gnomeExtensions = recurseIntoAttrs {
     appindicator = callPackage ../desktops/gnome-3/extensions/appindicator { };


### PR DESCRIPTION
###### Motivation for this change

This is done in, for example, `buildPythonPackage`

###### TODO

- [x] The basic change (c313e07) 
- [x] Remove `name = "${pname}-${version}"` from packages that define it that way (ef6ece0) 
- [ ] Update a lot of Gnome packages such that they don't use `${name}` in the `fetchUrl` anymore (see
af1b4f4)
- [ ] Change `name = "foobar-${version}"` for to `pname = "foobar"` for packages that define it that way (WIP on my machine, will give a lot of pings once I push it: there are 3k+ packages that use this method.)
- [ ] Documentation:
    - [ ] Document that this exists
    - [ ] Recommend it as the default way of defining packages?
- [ ] Cleanup:
    - [ ] Remove `rec` from packages that don't need it anymore
    - [ ] Squash/reorder a few commits in this pr
- [ ] A full build to check that I didn't make any mistakes.

---

