### PR TITLE
python27Packages.cython, python36Packages.cython: Disable tests on i686

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -20,6 +20,7 @@ let
     # now until upstream finds a workaround.
     # Upstream issue here: https://github.com/cython/cython/issues/2308
     ++ stdenv.lib.optionals stdenv.isAarch64 [ "numpy_memoryview" ]
+    ++ stdenv.lib.optionals stdenv.isi686 [ "future_division" "overflow_check_longlong" ]
   ;
 
 in buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Follow up #41453 "python36Packages.cython: Disable tests on aarch64"

some tests are failing on ```i686-linux```