### PR TITLE
minikube: bundle kvm2 driver

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -1,7 +1,15 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchurl, go-bindata, libvirt, qemu, docker-machine-kvm,
-  gpgme, makeWrapper, hostPlatform, vmnet, python }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchurl, go-bindata, libvirt, qemu
+, gpgme, makeWrapper, hostPlatform, vmnet, python, pkgconfig
+, docker-machine-kvm, docker-machine-kvm2
+, extraDrivers ? []
+}:
 
-let binPath = stdenv.lib.optionals stdenv.isLinux [ libvirt qemu docker-machine-kvm ];
+let
+  drivers = stdenv.lib.filter (d: d != null) (extraDrivers
+            ++ stdenv.lib.optionals stdenv.isLinux [ docker-machine-kvm docker-machine-kvm2 ]);
+
+  binPath = drivers
+            ++ stdenv.lib.optionals stdenv.isLinux ([ libvirt qemu ]);
 
 in buildGoPackage rec {
   pname   = "minikube";


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/issues/34448

Add a `drivers ? []` argument for bundling arbitrary binaries in the minikube `PATH`. This currently defaults to `[ docker-machine-kvm docker-machine-kvm2 ]` on Linux.

A separate effort is here: https://github.com/NixOS/nixpkgs/pull/39438

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

