### PR TITLE
odt2txt: 0.4 -> 0.5

### DIFF
--- a/pkgs/tools/text/odt2txt/default.nix
+++ b/pkgs/tools/text/odt2txt/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, zlib, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "odt2txt-0.4";
+  name = "odt2txt-${version}";
+  version = "0.5";
 
   src = fetchurl {
-    url = "${meta.homepage}/${name}.tar.gz";
-    sha256 = "1y36s7w2ng0r4nismxb3hb3zvsim8aimvvblz9hgnanw3kwbvx55";
+    url = "${meta.homepage}/archive/v${version}.tar.gz";
+    sha256 = "23a889109ca9087a719c638758f14cc3b867a5dcf30a6c90bf6a0985073556dd";
   };
 
   configurePhase="export makeFlags=\"DESTDIR=$out\"";
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Simple .odt to .txt converter";
-    homepage = http://stosberg.net/odt2txt;
+    homepage = https://github.com/dstosberg/odt2txt;
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.gpl2;
     maintainers = [ ];


### PR DESCRIPTION




###### Motivation for this change

Version 0.4 failed to build for me on MacOS 10.12.6 (16G1314). (Might be related to the removed libiconv-hacks.) Version 0.5 as specified builds cleanly.

Also 0.4 is from 2008 while 0.5 was released in 2014.

The old homepage now redirects to the GitHub repo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
