### PR TITLE
minio: Output server logs & startup in json format

### DIFF
--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -85,7 +85,7 @@ in
       '';
       serviceConfig = {
         PermissionsStartOnly = true;
-        ExecStart = "${cfg.package}/bin/minio server --address ${cfg.listenAddress} --config-dir=${cfg.configDir} ${cfg.dataDir}";
+        ExecStart = "${cfg.package}/bin/minio server --json --address ${cfg.listenAddress} --config-dir=${cfg.configDir} ${cfg.dataDir}";
         Type = "simple";
         User = "minio";
         Group = "minio";


### PR DESCRIPTION
Currently minio logs with enhanced tty data and journalctl does not include anything useful as a result:

```
Jun 08 11:03:28 alpha minio[17813]: [78B blob data]
Jun 08 11:03:28 alpha minio[17813]: [49B blob data]
Jun 08 11:03:28 alpha minio[17813]: [19B blob data]
Jun 08 11:03:28 alpha minio[17813]: [88B blob data]
Jun 08 11:03:28 alpha minio[17813]: [45B blob data]
Jun 08 11:03:28 alpha minio[17813]: [44B blob data]
Jun 08 11:03:28 alpha minio[17813]: [57B blob data]
```

Indicating that it detected some binary output.  With the `--json` flag it logs:

```
Jun 08 11:14:58 alpha minio[18573]: {"level":"FATAL","time":"2018-06-07T23:14:58.770637778Z","error":{"message":"--address input is invalid: address 127.0.0.1: missing port in address","source":["/build/go/src/github.com/minio/minio/cmd/server-main.go:121:cmd.serverHandleCmdArgs()"]}}
```

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

