### PR TITLE
hiawatha: GitHub -> GitLab, clean-up

### DIFF
--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -1,49 +1,49 @@
-{ stdenv, fetchurl, cmake,
-  libxslt, zlib, libxml2, openssl,
-  enableSSL ? true,
-  enableMonitor ? false,
-  enableRproxy ? true,
-  enableTomahawk ? false,
-  enableXSLT ? true,
-  enableToolkit ? true
-}:
+{ stdenv
+, fetchFromGitLab
 
-assert enableSSL -> openssl !=null;
+, cmake
+, ninja
+
+, libxslt
+, libxml2
+
+, enableSSL ? true
+, enableMonitor ? false
+, enableRproxy ? true
+, enableTomahawk ? false
+, enableXSLT ? true
+, enableToolkit ? true
+}:
 
 stdenv.mkDerivation rec {
   name = "hiawatha-${version}";
   version = "10.8.1";
 
-  src = fetchurl {
-    url = "https://github.com/hsleisink/hiawatha/archive/v${version}.tar.gz";
-    sha256 = "1f2hlw2lp98b4dx87i7pz7h66vsy2g22b5adfrlij3kj0vfv61w8";
+  src = fetchFromGitLab {
+    owner = "hsleisink";
+    repo = "hiawatha";
+    rev = "v${version}";
+    sha256 = "1428byx0xpzzwyc0j157q70sjx18dykvg6fd5vp70kj85ank0xpa";
   };
 
-  buildInputs =  [ cmake libxslt zlib libxml2 ] ++ stdenv.lib.optional enableSSL openssl ;
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ libxslt libxml2 ];
 
   prePatch = ''
     substituteInPlace CMakeLists.txt --replace SETUID ""
   '';
 
   cmakeFlags = [
-    ( if enableSSL then "-DENABLE_TLS=on" else "-DENABLE_TLS=off" )
+    (
+      # FIXME: 2018-06-08: Uses bundled library, with external ("-DUSE_SYSTEM_MBEDTLS=on") asks:
+      # ../src/tls.c:46:2: error: #error "The mbed TLS library must be compiled with MBEDTLS_THREADING_PTHREAD and MBEDTLS_THREADING_C enabled."
+      if enableSSL then "-DENABLE_TLS=on" else "-DENABLE_TLS=off" )
     ( if enableMonitor then "-DENABLE_MONITOR=on" else "-DENABLE_MONITOR=off" )
     ( if enableRproxy then "-DENABLE_RPROXY=on" else "-DENABLE_RPROXY=off" )
     ( if enableTomahawk then "-DENABLE_TOMAHAWK=on" else "-DENABLE_TOMAHAWK=off" )
     ( if enableXSLT then "-DENABLE_XSLT=on" else "-DENABLE_XSLT=off" )
     ( if enableToolkit then "-DENABLE_TOOLKIT=on" else "-DENABLE_TOOLKIT=off" )
-    "-DWEBROOT_DIR=/var/www/hiawatha"
-    "-DPID_DIR=/run"
-    "-DWORK_DIR=/var/lib/hiawatha"
-    "-DLOG_DIR=/var/log/hiawatha"
   ];
-
-  # workaround because cmake tries installs stuff outside of nix store
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
-  postInstall = ''
-    mv $out/$out/* $out
-    rm -rf $out/{var,run}
-  '';
 
   meta = with stdenv.lib; {
     description = "An advanced and secure webserver";


### PR DESCRIPTION
Developer deleted account on GitHub. As a GitLab proof - official page:
https://www.hiawatha-webserver.org/download
points to GitLab.

* Web server officially created for `mbedtls`, so use bundled
* Assert not needed
* Build with cmake/ninja
* Removed hack, no longer needed

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

