### PR TITLE
libbluray: fix Java build

### DIFF
--- a/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
+++ b/pkgs/development/libraries/libbluray/BDJ-JARFILE-path.patch
@@ -1,21 +1,26 @@
-diff -ru3 libbluray-0.8.0/configure.ac libbluray-0.8.0-new/configure.ac
---- libbluray-0.8.0/configure.ac	2015-04-10 09:48:23.000000000 +0300
-+++ libbluray-0.8.0-new/configure.ac	2015-05-18 14:22:01.002075482 +0300
-@@ -231,6 +231,7 @@
-   AC_DEFINE([USING_BDJAVA], [1], ["Define to 1 if using BD-Java"])
-   AC_DEFINE_UNQUOTED([JAVA_ARCH], ["$java_arch"], ["Defines the architecture of the java vm."])
-   AC_DEFINE_UNQUOTED([JDK_HOME], ["$JDK_HOME"], [""])
-+  CPPFLAGS="${CPPFLAGS} -DJARDIR='\"\$(datadir)/java\"'"
+diff --git a/configure.ac b/configure.ac
+index 5fd3c8de..7ae343e0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -228,6 +228,10 @@ if test "x$use_bdjava_jar" = "xyes" && test "x$HAVE_ANT" = "xno"; then
+     AC_MSG_ERROR([BD-J requires ANT, but ant was not found. Please install it.])
  fi
- AM_CONDITIONAL([USING_BDJAVA], [ test $use_bdjava = "yes" ])
  
-diff -ru3 libbluray-0.8.0/src/libbluray/bdj/bdj.c libbluray-0.8.0-new/src/libbluray/bdj/bdj.c
---- libbluray-0.8.0/src/libbluray/bdj/bdj.c	2015-04-06 19:25:09.000000000 +0300
-+++ libbluray-0.8.0-new/src/libbluray/bdj/bdj.c	2015-05-18 14:22:59.241312808 +0300
-@@ -228,6 +228,7 @@
- #ifdef _WIN32
-         "" BDJ_JARFILE,
- #else
++if test "x$use_bdjava_jar" = "xyes"; then
++  CPPFLAGS="${CPPFLAGS} -DJARDIR='\"\$(datadir)/java\"'"
++fi
++
+ AC_DEFINE_UNQUOTED([JAVA_ARCH], ["$java_arch"], ["Defines the architecture of the java vm."])
+ AC_DEFINE_UNQUOTED([JDK_HOME], ["$JDK_HOME"], [""])
+ AM_CONDITIONAL([USING_BDJAVA_BUILD_JAR], [ test $use_bdjava_jar = "yes" ])
+diff --git a/src/libbluray/bdj/bdj.c b/src/libbluray/bdj/bdj.c
+index 511ad533..e273b9e0 100644
+--- a/src/libbluray/bdj/bdj.c
++++ b/src/libbluray/bdj/bdj.c
+@@ -478,6 +478,7 @@ static const char *_find_libbluray_jar(BDJ_STORAGE *storage)
+     // pre-defined search paths for libbluray.jar
+     static const char * const jar_paths[] = {
+ #ifndef _WIN32
 +        JARDIR "/" BDJ_JARFILE,
          "/usr/share/java/" BDJ_JARFILE,
          "/usr/share/libbluray/lib/" BDJ_JARFILE,


### PR DESCRIPTION
###### Motivation for this change

The following command currently fails to build:

```bash
nix-build -E 'with import <nixpkgs> { }; libbluray.override { withJava = true; }'
```

That is, enabling the `withJava` option in libbluray fails to build, due to a patch that fails to apply. This PR updates the patch so it successfully applies to the source for libbluray v1.0.2. This patch is only applied when `withJava` is true.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @abbradar