### PR TITLE
nwipe: init at 0.24

### DIFF
--- a/pkgs/tools/security/nwipe/default.nix
+++ b/pkgs/tools/security/nwipe/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, ncurses, parted, automake, autoconf, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  version = "0.24";
+  name = "nwipe-${version}";
+  src = fetchFromGitHub {
+    owner = "martijnvanbrummelen";
+    repo = "nwipe";
+    rev = "v${version}";
+    sha256 = "0zminjngz98b4jl1ii6ssa7pkmf4xw6mmk8apxz3xr68cps12ls0";
+  };
+  nativeBuildInputs = [ automake autoconf ncurses parted pkgconfig ];
+  preConfigure = "sh init.sh || :";
+  meta = with stdenv.lib; {
+    description = "Securely erase disks";
+    homepage = https://github.com/martijnvanbrummelen/nwipe;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.woffs ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/security/nwipe/default.nix
+++ b/pkgs/tools/security/nwipe/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0zminjngz98b4jl1ii6ssa7pkmf4xw6mmk8apxz3xr68cps12ls0";
   };
-  nativeBuildInputs = [ automake autoconf ncurses parted pkgconfig ];
+  nativeBuildInputs = [ automake autoconf pkgconfig ];
+  buildInputs = [ ncurses parted ];
   preConfigure = "sh init.sh || :";
   meta = with stdenv.lib; {
     description = "Securely erase disks";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1384,6 +1384,8 @@ with pkgs;
 
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
+  nwipe = callPackage ../tools/security/nwipe { };
+
   onboard = callPackage ../applications/misc/onboard { };
 
   optar = callPackage ../tools/graphics/optar {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

