### PR TITLE
detox: fix missing safe.tbl

### DIFF
--- a/pkgs/tools/misc/detox/default.nix
+++ b/pkgs/tools/misc/detox/default.nix
@@ -12,6 +12,10 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
+  postInstall = ''
+    install -m644 safe.tbl $out/share/detox/
+  '';
+
   meta = with stdenv.lib; {
     homepage = http://detox.sourceforge.net/;
     description = "Utility designed to clean up filenames";


### PR DESCRIPTION
###### Motivation for this change
detox was not working. For unknown reasons, safe.tbl got not installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

