### PR TITLE
loadwatch: init at 1.1

### DIFF
--- a/pkgs/tools/system/loadwatch/default.nix
+++ b/pkgs/tools/system/loadwatch/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, fetchurl, ... }:
+{ stdenv, fetchgit, ... }:
 
 stdenv.mkDerivation {
-  name = "loadwatch-1.1";
-  src = fetchurl {
-    url = "mirror://debian/pool/main/l/loadwatch/loadwatch_1.0+1.1alpha1.orig.tar.gz";
-    sha256 = "1abjl3cy4sa4ivdm7wghv9rq93h8kix4wjbiv7pb906rdqs4881a";
+  name = "loadwatch-1.1-1-g6d2544c";
+  src = fetchgit {
+    url = "git://woffs.de/git/fd/loadwatch.git";
+    sha256 = "1bhw5ywvhyb6snidsnllfpdi1migy73wg2gchhsfbcpm8aaz9c9b";
+    rev = "6d2544c0caaa8a64bbafc3f851e06b8056c30e6e";
   };
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/tools/system/loadwatch/default.nix
+++ b/pkgs/tools/system/loadwatch/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, ... }:
+
+stdenv.mkDerivation {
+  name = "loadwatch-1.1";
+  src = fetchurl {
+    url = "mirror://debian/pool/main/l/loadwatch/loadwatch_1.0+1.1alpha1.orig.tar.gz";
+    sha256 = "1abjl3cy4sa4ivdm7wghv9rq93h8kix4wjbiv7pb906rdqs4881a";
+  };
+  installPhase = ''
+    mkdir -p $out/bin
+    install loadwatch lw-ctl $out/bin
+  '';
+  meta = with stdenv.lib; {
+    description = "Run a program using only idle cycles";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ woffs ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1338,6 +1338,8 @@ with pkgs;
 
   languagetool = callPackage ../tools/text/languagetool {  };
 
+  loadwatch = callPackage ../tools/system/loadwatch { };
+
   loccount = callPackage ../development/tools/misc/loccount { };
 
   long-shebang = callPackage ../misc/long-shebang {};


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

