### PR TITLE
[staging] perlPackages: convert some modules to aliases

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1464,21 +1464,7 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
-  CatalystPluginUnicodeEncoding = buildPerlPackage {
-    name = "Catalyst-Plugin-Unicode-Encoding-1.9";
-    src = fetchurl {
-      url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Unicode-Encoding-1.9.tar.gz;
-      sha256 = "1glxkh79zz71bmgk44hnhsi37z2mgxcwf7bkmwlnwv3jh1iaz0ah";
-    };
-    buildInputs = [ HTTPMessage IOStringy ];
-    propagatedBuildInputs = [ CatalystRuntime ClassDataInheritable LWP TryTiny URI ];
-    meta = {
-      description = "Unicode aware Catalyst";
-      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
-      maintainers = with maintainers; [ ];
-      platforms   = stdenv.lib.platforms.unix;
-    };
-  };
+  CatalystPluginUnicodeEncoding = CatalystRuntime;
 
   CatalystPluginHTMLWidget = buildPerlPackage rec {
     name = "Catalyst-Plugin-HTML-Widget-1.1";


### PR DESCRIPTION
###### Motivation for this change

These modules have been included into other packages and do not have own packages anymore:
https://metacpan.org/pod/Catalyst::Plugin::Unicode::Encoding

forgotten in https://github.com/NixOS/nixpkgs/pull/41454

