### PR TITLE
ihaskell: Do not unset $PATH in the wrapper

### DIFF
--- a/pkgs/development/tools/haskell/ihaskell/wrapper.nix
+++ b/pkgs/development/tools/haskell/ihaskell/wrapper.nix
@@ -9,7 +9,7 @@ let
   ihaskellSh = writeScriptBin "ihaskell-notebook" ''
     #! ${stdenv.shell}
     export GHC_PACKAGE_PATH="$(echo ${ihaskellEnv}/lib/*/package.conf.d| tr ' ' ':'):$GHC_PACKAGE_PATH"
-    export PATH="${stdenv.lib.makeBinPath ([ ihaskellEnv jupyter ])}"
+    export PATH="${stdenv.lib.makeBinPath ([ ihaskellEnv jupyter ])}\${PATH:+':'}$PATH"
     ${ihaskellEnv}/bin/ihaskell install -l $(${ihaskellEnv}/bin/ghc --print-libdir) && ${jupyter}/bin/jupyter notebook
   '';
 in


### PR DESCRIPTION
If there is no specific reason to unset `$PATH` then it’s probably better not to unset it.
This PR fixes browser auto-start on macOS (which needs `osascript`).