### PR TITLE
i3lock-pixeled: github -> gitlab

### DIFF
--- a/pkgs/misc/screensavers/i3lock-pixeled/default.nix
+++ b/pkgs/misc/screensavers/i3lock-pixeled/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, pkgs, fetchurl }:
+{ stdenv, i3lock, imagemagick, scrot, playerctl, fetchFromGitLab }:
 
 stdenv.mkDerivation rec {
   name = "i3lock-pixeled-${version}";
   version = "1.2.0";
 
-  src = fetchurl {
-    url = "https://github.com/Ma27/i3lock-pixeled/archive/${version}.tar.gz";
-    sha256 = "0vlynm833fk1mmdnkcgh4hwqmfypn22zskhysm110k39zvikif0h";
+  src = fetchFromGitLab {
+    owner = "Ma27";
+    repo = "i3lock-pixeled";
+    rev = version;
+    sha256 = "0pysx9sv4i3nnjvpqkrxkxaqja2a2dw5f2r1bzjcgg3c3c5qv74b";
   };
 
-  propagatedBuildInputs = with pkgs; [
+  propagatedBuildInputs = [
     i3lock
     imagemagick
     scrot
@@ -22,15 +24,15 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     substituteInPlace i3lock-pixeled \
-       --replace i3lock    "${pkgs.i3lock}/bin/i3lock" \
-       --replace convert   "${pkgs.imagemagick}/bin/convert" \
-       --replace scrot     "${pkgs.scrot}/bin/scrot" \
-       --replace playerctl "${pkgs.playerctl}/bin/playerctl"
+       --replace i3lock    "${i3lock}/bin/i3lock" \
+       --replace convert   "${imagemagick}/bin/convert" \
+       --replace scrot     "${scrot}/bin/scrot" \
+       --replace playerctl "${playerctl}/bin/playerctl"
   '';
 
   meta = with stdenv.lib; {
     description = "Simple i3lock helper which pixels a screenshot by scaling it down and up to get a pixeled version of the screen when the lock is active.";
-    homepage = https://github.com/Ma27/i3lock-pixeled;
+    homepage = https://gitlab.com/Ma27/i3lock-pixeled;
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ ma27 ];


### PR DESCRIPTION
###### Motivation for this change

`i3lock-pixeled` is now hosted at GitLab.

Additionally `pkgs` has been removed which makes possible overrides
*way* easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

