### PR TITLE
mbedtls: cmake&ninja, threading, clean-up; hiawatha: options, Nix mbedtls

### DIFF
--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -1,7 +1,16 @@
-{ stdenv, fetchFromGitHub, perl }:
+{ stdenv
+, fetchFromGitHub
+
+, cmake
+, ninja
+, perl # Project uses Perl for scripting and testing
+
+, enableThreading ? true
+}:
 
 stdenv.mkDerivation rec {
-  name = "mbedtls-2.11.0";
+  name = "mbedtls-${version}";
+  version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "ARMmbed";
@@ -10,26 +19,21 @@ stdenv.mkDerivation rec {
     sha256 = "1d4a0jc08q3h051amv8hhh3hmqp4f1rk5z7ffyfs2g8dassm78ir";
   };
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ cmake ninja perl ];
 
-  postPatch = ''
-    patchShebangs .
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace library/Makefile --replace "-soname" "-install_name"
     substituteInPlace tests/scripts/run-test-suites.pl --replace "LD_LIBRARY_PATH" "DYLD_LIBRARY_PATH"
     # Necessary for install_name_tool below
     echo "LOCAL_LDFLAGS += -headerpad_max_install_names" >> programs/Makefile
   '';
 
-  makeFlags = [
-    "SHARED=1"
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    "DLEXT=dylib"
-  ];
+  postConfigure = stdenv.lib.optionals enableThreading ''
+    perl scripts/config.pl set MBEDTLS_THREADING_C    # Threading abstraction layer
+    perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD    # POSIX thread wrapper layer for the threading layer.
+  '';
 
-  installFlags = [
-    "DESTDIR=\${out}"
-  ];
+  cmakeFlags = [ "-DUSE_SHARED_MBEDTLS_LIBRARY=on" ];
 
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     install_name_tool -change libmbedcrypto.dylib $out/lib/libmbedcrypto.dylib $out/lib/libmbedtls.dylib
@@ -45,12 +49,10 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  doCheck = true;
-
   meta = with stdenv.lib; {
     homepage = https://tls.mbed.org/;
-    description = "Portable cryptographic and SSL/TLS library, aka polarssl";
-    license = licenses.gpl3;
+    description = "Portable cryptographic and TLS library, formerly known as PolarSSL";
+    license = licenses.asl20;
     platforms = platforms.all;
     maintainers = with maintainers; [ wkennington fpletz ];
   };

--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -3,16 +3,16 @@
 
 , cmake
 , ninja
+, mbedtls
 
-, libxslt
-, libxml2
-
-, enableSSL ? true
-, enableMonitor ? false
-, enableRproxy ? true
-, enableTomahawk ? false
-, enableXSLT ? true
-, enableToolkit ? true
+, enableCache     ? true     # Internal cache support.
+, enableIpV6      ? true
+, enableTls       ? true
+, enableMonitor   ? false    # Support for the Hiawatha Monitor.
+, enableRproxy    ? true     # Reverse proxy support.
+, enableTomahawk  ? false    # Tomahawk, the Hiawatha command shell.
+, enableXslt      ? true, libxml2 ? null, libxslt ? null
+, enableToolkit   ? true     # The URL Toolkit.
 }:
 
 stdenv.mkDerivation rec {
@@ -27,28 +27,29 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ libxslt libxml2 ];
+  buildInputs = [ mbedtls ] ++ stdenv.lib.optionals enableXslt [ libxslt libxml2 ];
 
   prePatch = ''
     substituteInPlace CMakeLists.txt --replace SETUID ""
   '';
 
   cmakeFlags = [
-    (
-      # FIXME: 2018-06-08: Uses bundled library, with external ("-DUSE_SYSTEM_MBEDTLS=on") asks:
-      # ../src/tls.c:46:2: error: #error "The mbed TLS library must be compiled with MBEDTLS_THREADING_PTHREAD and MBEDTLS_THREADING_C enabled."
-      if enableSSL then "-DENABLE_TLS=on" else "-DENABLE_TLS=off" )
-    ( if enableMonitor then "-DENABLE_MONITOR=on" else "-DENABLE_MONITOR=off" )
-    ( if enableRproxy then "-DENABLE_RPROXY=on" else "-DENABLE_RPROXY=off" )
-    ( if enableTomahawk then "-DENABLE_TOMAHAWK=on" else "-DENABLE_TOMAHAWK=off" )
-    ( if enableXSLT then "-DENABLE_XSLT=on" else "-DENABLE_XSLT=off" )
-    ( if enableToolkit then "-DENABLE_TOOLKIT=on" else "-DENABLE_TOOLKIT=off" )
+    "-DUSE_SYSTEM_MBEDTLS=on" # Policy to use Nix deps, and Nix uses up to date deps
+    ( if enableCache     then "-DENABLE_CACHE=on"       else "-DENABLE_CACHE=off"       )
+    ( if enableIpV6      then "-DENABLE_IPV6=on"        else "-DENABLE_IPV6=off"        )
+    ( if enableTls       then "-DENABLE_TLS=on"         else "-DENABLE_TLS=off"         )
+    ( if enableMonitor   then "-DENABLE_MONITOR=on"     else "-DENABLE_MONITOR=off"     )
+    ( if enableRproxy    then "-DENABLE_RPROXY=on"      else "-DENABLE_RPROXY=off"      )
+    ( if enableTomahawk  then "-DENABLE_TOMAHAWK=on"    else "-DENABLE_TOMAHAWK=off"    )
+    ( if enableXslt      then "-DENABLE_XSLT=on"        else "-DENABLE_XSLT=off"        )
+    ( if enableToolkit   then "-DENABLE_TOOLKIT=on"     else "-DENABLE_TOOLKIT=off"     )
   ];
 
   meta = with stdenv.lib; {
+    homepage = https://www.hiawatha-webserver.org;
     description = "An advanced and secure webserver";
     license = licenses.gpl2;
-    homepage = https://www.hiawatha-webserver.org;
+    platforms = platforms.unix;    # "Hiawatha runs perfectly on Linux, BSD and MacOS X"
     maintainers = [ maintainers.ndowens ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

