### PR TITLE
udisks 2.1.6 -> 2.7.6

### DIFF
--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk-doc, libxslt, docbook_xsl
+, docbook_xml_dtd_43, python3, gobjectIntrospection, glib, libudev, kmod, parted
+, cryptsetup, devicemapper, dmraid, utillinux, libbytesize, libndctl, nss, volume_key
+}:
+
+let
+  version = "2.17";
+in stdenv.mkDerivation rec {
+  name = "libblockdev-${version}";
+
+  src = fetchFromGitHub {
+    owner = "storaged-project";
+    repo = "libblockdev";
+    rev = "${version}-1";
+    sha256 = "14f52cj2qcnm8i2zb57qfpdk3kij2gb3xgqkbvidmf6sjicq84z2";
+  };
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  postPatch = ''
+    patchShebangs scripts
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook pkgconfig gtk-doc libxslt docbook_xsl docbook_xml_dtd_43 python3 gobjectIntrospection
+  ];
+
+  buildInputs = [
+    glib libudev kmod parted cryptsetup devicemapper dmraid utillinux libbytesize libndctl nss volume_key
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A library for manipulating block devices";
+    homepage = http://storaged.org/libblockdev/;
+    license = licenses.lgpl2Plus; # lgpl2Plus for the library, gpl2Plus for the utils
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libbytesize/default.nix
+++ b/pkgs/development/libraries/libbytesize/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gettext
+, gtk-doc, libxslt, docbook_xml_dtd_43, docbook_xsl
+, python3, pcre, gmp, mpfr
+}:
+
+let
+  version = "1.3";
+in stdenv.mkDerivation rec {
+  name = "libbytesize-${version}";
+
+  src = fetchFromGitHub {
+    owner = "storaged-project";
+    repo = "libbytesize";
+    rev = version;
+    sha256 = "1ys5d8rya8x4q34gn1hr96z7797s9gdzah0y0d7g84x5x6k50p30";
+  };
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig gettext gtk-doc libxslt docbook_xml_dtd_43 docbook_xsl python3 ];
+
+  buildInputs = [ pcre gmp mpfr ];
+
+  meta = with stdenv.lib; {
+    description = "A tiny library providing a C “class” for working with arbitrary big sizes in bytes";
+    homepage = src.meta.homepage;
+    license = licenses.lgpl2Plus;
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/libndctl/default.nix
+++ b/pkgs/development/libraries/libndctl/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, autoconf, automake, asciidoc, docbook_xsl, docbook_xml_dtd_45, libxslt, xmlto, pkgconfig, json_c, kmod, which, systemd, utillinux
+}:
+
+let
+  version = "60.3";
+in stdenv.mkDerivation rec {
+  name = "libndctl-${version}";
+
+  src = fetchFromGitHub {
+    owner = "pmem";
+    repo = "ndctl";
+    rev = "v${version}";
+    sha256 = "0w19yh6f9skf5zy4bhdjlrn3wdx5xx9cq8j6h04cmw4nla6zj9ar";
+  };
+
+  outputs = [ "out" "man" "dev" ];
+
+  nativeBuildInputs = [
+    autoreconfHook asciidoc pkgconfig xmlto docbook_xml_dtd_45 docbook_xsl libxslt
+  ];
+
+  buildInputs = [
+    json_c kmod systemd utillinux
+  ];
+
+  preAutoreconf = ''
+    substituteInPlace configure.ac --replace "which" "${which}/bin/which"
+    substituteInPlace git-version --replace /bin/bash ${stdenv.shell}
+    substituteInPlace git-version-gen --replace /bin/sh ${stdenv.shell}
+    echo "m4_define([GIT_VERSION], [${version}])" > version.m4;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utility library for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel";
+    homepage = https://github.com/pmem/ndctl;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/volume-key/default.nix
+++ b/pkgs/development/libraries/volume-key/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchgit, fetchpatch, autoreconfHook, pkgconfig, gettext, python2
+, swig, glib, utillinux, cryptsetup, nss, gpgme
+}:
+
+let
+  version = "0.3.10";
+in stdenv.mkDerivation rec {
+  name = "volume_key-${version}";
+
+  src = fetchgit {
+    url = https://pagure.io/volume_key.git;
+    rev = "ece1ce305234da454e330905c615ec474d9781c5";
+    sha256 = "16qdi5s6ycsh0iyc362gly7ggrwamky8i0zgbd4ajp3ymk9vqdva";
+  };
+
+  outputs = [ "out" "man" "dev" ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig gettext python2 swig ];
+
+  buildInputs = [ glib cryptsetup nss utillinux gpgme ];
+
+  patches = [
+    # Use pkg-config for locating Python.h
+    # https://pagure.io/volume_key/pull-request/12
+    (fetchpatch {
+      url = https://pagure.io/fork/cathay4t/volume_key/c/8eda66d3b734ea335e37cf9d7d173b9e8ebe2fd9.patch;
+      sha256 = "01lr1zijk0imkk681zynm4w5ad3y6c9vdrmrzaib7w7ima75iczr";
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A library for manipulating storage volume encryption keys and storing them separately from volumes to handle forgotten passphrases, and the associated command-line tool";
+    homepage = https://pagure.io/volume_key/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -1,43 +1,55 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gnused
-, expat, acl, systemd, glib, libatasmart, polkit
-, libxslt, docbook_xsl, utillinux, mdadm, libgudev
-, gobjectIntrospection
+{ stdenv, fetchFromGitHub, substituteAll, libtool, pkgconfig, intltool, gnused
+, gnome3, gtk-doc, acl, systemd, glib, libatasmart, polkit, coreutils, bash
+, expat, libxslt, docbook_xsl, utillinux, mdadm, libgudev, libblockdev, parted
+, gobjectIntrospection, docbook_xml_dtd_412, docbook_xml_dtd_43
+, libxfs, f2fs-tools, dosfstools, e2fsprogs, btrfs-progs, exfat, nilfs-utils, udftools, ntfs3g
 }:
 
-stdenv.mkDerivation rec {
-  name = "udisks-2.1.8";
+let
+  version = "2.7.6";
+in stdenv.mkDerivation rec {
+  name = "udisks-${version}";
 
-  src = fetchurl {
-    url = "http://udisks.freedesktop.org/releases/${name}.tar.bz2";
-    sha256 = "1nkxhnqh39c9pzvm4zfj50rgv6apqawdx09bv3sfaxrah4a6jhfs";
+  src = fetchFromGitHub {
+    owner = "storaged-project";
+    repo = "udisks";
+    rev = name;
+    sha256 = "16kf104vv2xbk8cdgaqygszcl69d7lz9gf3vmi7ggywn7nfbp2ks";
   };
 
-  outputs = [ "out" "man" "dev" ];
+  outputs = [ "out" "man" "dev" "devdoc" ];
 
-  patches = [ ./force-path.patch ];
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      bash = "${bash}/bin/bash";
+      blkid = "${utillinux}/bin/blkid";
+      false = "${coreutils}/bin/false";
+      mdadm = "${mdadm}/bin/mdadm";
+      sed = "${gnused}/bin/sed";
+      sh = "${bash}/bin/sh";
+      sleep = "${coreutils}/bin/sleep";
+      true = "${coreutils}/bin/true";
+    })
+    (substituteAll {
+      src = ./force-path.patch;
+      path = stdenv.lib.makeBinPath [ btrfs-progs coreutils dosfstools e2fsprogs exfat f2fs-tools nilfs-utils libxfs ntfs3g parted utillinux ];
+    })
+  ];
 
-  # FIXME remove /var/run/current-system/sw/* references
-  # FIXME add references to parted, cryptsetup, etc (see the sources)
-  postPatch =
-    ''
-      substituteInPlace src/main.c --replace \
-        "@path@" \
-        "${utillinux}/bin:${mdadm}/bin:/run/current-system/sw/bin"
-      substituteInPlace data/80-udisks2.rules \
-        --replace "/bin/sh" "${stdenv.shell}" \
-        --replace "/sbin/mdadm" "${mdadm}/bin/mdadm" \
-        --replace " sed " " ${gnused}/bin/sed "
-  '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
-      substituteInPlace udisks/udisksclient.c \
-        --replace 'defined( __GNUC_PREREQ)' 1 \
-        --replace '__GNUC_PREREQ(4,6)' 1
-  '';
+  nativeBuildInputs = [
+    pkgconfig gnome3.gnome-common libtool intltool gobjectIntrospection
+    gtk-doc libxslt docbook_xml_dtd_412 docbook_xml_dtd_43 docbook_xsl
+  ];
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
+  buildInputs = [
+    expat libgudev libblockdev acl systemd glib libatasmart polkit
+  ];
 
-  buildInputs = [ libxslt docbook_xsl libgudev expat acl systemd glib libatasmart polkit ];
+  preConfigure = "./autogen.sh";
 
   configureFlags = [
+    "--enable-gtk-doc"
     "--localstatedir=/var"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-udevdir=$(out)/lib/udev"
@@ -50,9 +62,11 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails
 
-  meta = {
-    homepage = http://www.freedesktop.org/wiki/Software/udisks;
-    description = "A daemon and command-line utility for querying and manipulating storage devices";
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    description = "A daemon, tools and libraries to access and manipulate disks, storage devices and technologies";
+    homepage = https://www.freedesktop.org/wiki/Software/udisks/;
+    license = licenses.gpl2Plus; # lgpl2Plus for the library, gpl2Plus for the tools & daemon
+    maintainers = with maintainers; [];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/udisks/fix-paths.patch
+++ b/pkgs/os-specific/linux/udisks/fix-paths.patch
@@ -1,0 +1,131 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,6 +1,6 @@
+ ## Process this file with automake to produce Makefile.in
+ 
+-SHELL = /bin/bash
++SHELL = @bash@
+ .SHELLFLAGS = -o pipefail -c
+ 
+ PYTHON ?= python3
+--- a/data/80-udisks2.rules
++++ b/data/80-udisks2.rules
+@@ -17,9 +17,9 @@
+ #
+ # TODO: file bug against mdadm(8) to have --export-prefix option that can be used with e.g. UDISKS_MD_MEMBER
+ #
+-SUBSYSTEM=="block", ENV{ID_FS_USAGE}=="raid", ENV{ID_FS_TYPE}=="linux_raid_member", ENV{UDISKS_MD_MEMBER_LEVEL}=="", IMPORT{program}="/bin/sh -c '/sbin/mdadm --examine --export $tempnode | /bin/sed s/^MD_/UDISKS_MD_MEMBER_/g'"
++SUBSYSTEM=="block", ENV{ID_FS_USAGE}=="raid", ENV{ID_FS_TYPE}=="linux_raid_member", ENV{UDISKS_MD_MEMBER_LEVEL}=="", IMPORT{program}="@sh@ -c '@mdadm@ --examine --export $tempnode | @sed@ s/^MD_/UDISKS_MD_MEMBER_/g'"
+ 
+-SUBSYSTEM=="block", KERNEL=="md*", ENV{DEVTYPE}!="partition", IMPORT{program}="/bin/sh -c '/sbin/mdadm --detail --export $tempnode | /bin/sed s/^MD_/UDISKS_MD_/g'"
++SUBSYSTEM=="block", KERNEL=="md*", ENV{DEVTYPE}!="partition", IMPORT{program}="@sh@ -c '@mdadm@ --detail --export $tempnode | @sed@ s/^MD_/UDISKS_MD_/g'"
+ 
+ LABEL="udisks_probe_end"
+ 
+--- a/modules/zram/udiskslinuxmanagerzram.c
++++ b/modules/zram/udiskslinuxmanagerzram.c
+@@ -250,7 +250,7 @@
+ 
+       g_snprintf (tmp, 255, "zram%" G_GUINT64_FORMAT, i);
+       filename = g_build_filename (PACKAGE_ZRAMCONF_DIR, tmp, NULL);
+-      contents = g_strdup_printf ("#!/bin/bash\n\n"
++      contents = g_strdup_printf ("#!@bash@\n\n"
+                                   "ZRAM_NUM_STR=%" G_GUINT64_FORMAT "\n"
+                                   "ZRAM_DEV_SIZE=%" G_GUINT64_FORMAT "\n"
+                                   "SWAP=n\n",
+--- a/src/tests/install-udisks/runtest.sh
++++ b/src/tests/install-udisks/runtest.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@
+ # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+ # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ #
+--- a/src/tests/integration-test
++++ b/src/tests/integration-test
+@@ -414,7 +414,7 @@
+                 f.write('KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", '
+                         'ATTRS{model}=="scsi_debug*", '
+                         'ENV{ID_CDROM_MEDIA}=="?*", '
+-                        'IMPORT{program}="/sbin/blkid -o udev -p -u noraid $tempnode"\n')
++                        'IMPORT{program}="@blkid@ -o udev -p -u noraid $tempnode"\n')
+             # reload udev
+             subprocess.call('sync; pkill --signal HUP udevd || '
+                             'pkill --signal HUP systemd-udevd',
+@@ -1079,7 +1079,7 @@
+         self.assertFalse(os.access(f, os.X_OK))
+ 
+         f = os.path.join(mount_point, 'simple.exe')
+-        shutil.copy('/bin/bash', f)
++        shutil.copy('@bash@', f)
+         self.assertTrue(os.access(f, os.R_OK))
+         self.assertTrue(os.access(f, os.W_OK))
+         self.assertTrue(os.access(f, os.X_OK))
+@@ -1092,7 +1092,7 @@
+         self.assertFalse(os.access(f, os.X_OK))
+ 
+         f = os.path.join(mount_point, 'subdir', 'subdir.exe')
+-        shutil.copy('/bin/bash', f)
++        shutil.copy('@bash@', f)
+         self.assertTrue(os.access(f, os.R_OK))
+         self.assertTrue(os.access(f, os.W_OK))
+         self.assertTrue(os.access(f, os.X_OK))
+--- a/src/tests/storadectl/runtest.sh
++++ b/src/tests/storadectl/runtest.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash@
+ # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+ # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ #
+--- a/src/tests/test.c
++++ b/src/tests/test.c
+@@ -71,7 +71,7 @@
+ {
+   UDisksSpawnedJob *job;
+ 
+-  job = udisks_spawned_job_new ("/bin/true", NULL, getuid (), geteuid (), NULL, NULL);
++  job = udisks_spawned_job_new ("@true@", NULL, getuid (), geteuid (), NULL, NULL);
+   udisks_spawned_job_start (job);
+   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_success), NULL);
+   g_object_unref (job);
+@@ -84,10 +84,10 @@
+ {
+   UDisksSpawnedJob *job;
+ 
+-  job = udisks_spawned_job_new ("/bin/false", NULL, getuid (), geteuid (), NULL, NULL);
++  job = udisks_spawned_job_new ("@false@", NULL, getuid (), geteuid (), NULL, NULL);
+   udisks_spawned_job_start (job);
+   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
+-                             (gpointer) "Command-line `/bin/false' exited with non-zero exit status 1: ");
++                             (gpointer) "Command-line `@false@' exited with non-zero exit status 1: ");
+   g_object_unref (job);
+ }
+ 
+@@ -119,7 +119,7 @@
+ 
+   cancellable = g_cancellable_new ();
+   g_cancellable_cancel (cancellable);
+-  job = udisks_spawned_job_new ("/bin/true", NULL, getuid (), geteuid (), NULL, cancellable);
++  job = udisks_spawned_job_new ("@true@", NULL, getuid (), geteuid (), NULL, cancellable);
+   udisks_spawned_job_start (job);
+   _g_assert_signal_received (job, "completed", G_CALLBACK (on_completed_expect_failure),
+                              (gpointer) "Operation was cancelled (g-io-error-quark, 19)");
+@@ -145,7 +145,7 @@
+   GCancellable *cancellable;
+ 
+   cancellable = g_cancellable_new ();
+-  job = udisks_spawned_job_new ("/bin/sleep 0.5", NULL, getuid (), geteuid (), NULL, cancellable);
++  job = udisks_spawned_job_new ("@sleep@ 0.5", NULL, getuid (), geteuid (), NULL, cancellable);
+   udisks_spawned_job_start (job);
+   g_timeout_add (10, on_timeout, cancellable); /* 10 msec */
+   g_main_loop_run (loop);
+@@ -199,7 +199,7 @@
+ {
+   UDisksSpawnedJob *job;
+ 
+-  job = udisks_spawned_job_new ("/bin/sleep 1000", NULL, getuid (), geteuid (), NULL, NULL /* GCancellable */);
++  job = udisks_spawned_job_new ("@sleep@ 1000", NULL, getuid (), geteuid (), NULL, NULL /* GCancellable */);
+   udisks_spawned_job_start (job);
+   g_object_unref (job);
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10354,6 +10354,8 @@ with pkgs;
 
   libmx = callPackage ../development/libraries/libmx { };
 
+  libndctl = callPackage ../development/libraries/libndctl { };
+
   libnet = callPackage ../development/libraries/libnet { };
 
   libnetfilter_conntrack = callPackage ../development/libraries/libnetfilter_conntrack { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5512,6 +5512,8 @@ with pkgs;
 
   vobsub2srt = callPackage ../tools/cd-dvd/vobsub2srt { };
 
+  volume_key = callPackage ../development/libraries/volume-key { };
+
   vorbisgain = callPackage ../tools/misc/vorbisgain { };
 
   vpnc = callPackage ../tools/networking/vpnc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9790,6 +9790,8 @@ with pkgs;
 
   libbdplus = callPackage ../development/libraries/libbdplus { };
 
+  libblockdev = callPackage ../development/libraries/libblockdev { };
+
   libblocksruntime = callPackage ../development/libraries/libblocksruntime { };
 
   libbluray = callPackage ../development/libraries/libbluray { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9798,6 +9798,8 @@ with pkgs;
 
   libburn = callPackage ../development/libraries/libburn { };
 
+  libbytesize = callPackage ../development/libraries/libbytesize { };
+
   libcaca = callPackage ../development/libraries/libcaca {
     inherit (xorg) libX11 libXext;
   };


### PR DESCRIPTION
###### Motivation for this change

This bumps udisks to 2.7.6, packages new necessary dependencies, and sets udisks PATH to fix #34999.
This was already started in #35551, from which I took over now. 

required by https://github.com/NixOS/nixpkgs/pull/38382
/cc @jtojnar @jfrankenau @yegortimoshenko


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

