### PR TITLE
haskellPackages.hnix: dont jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -250,7 +250,7 @@ self: super: {
   digit = doJailbreak super.digit;
 
   # https://github.com/jwiegley/hnix/issues/98 - tied to an older deriving-compat
-  hnix = doJailbreak (overrideCabal super.hnix (old: {
+  hnix = (overrideCabal super.hnix (old: {
     patches = old.patches or [] ++ [
       # should land in hnix-5.2
       (pkgs.fetchpatch {


### PR DESCRIPTION
The jailbreak itself produces a broken cabal file, and with the current
haskellPackages hnix builds just fine.
