### PR TITLE
dwm-status: init at 0.4.0

### DIFF
--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -1,0 +1,30 @@
+{ stdenv, rustPlatform, fetchFromGitHub, dbus, gdk_pixbuf, libnotify, pkgconfig }:
+
+rustPlatform.buildRustPackage rec {
+  name = "dwm-status-${version}";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Gerschtli";
+    repo = "dwm-status";
+    rev = version;
+    sha256 = "0nw0iz78mnrmgpc471yjv7yzsaf7346mwjp6hm5kbsdclvrdq9d7";
+  };
+
+  buildInputs = [
+    dbus
+    gdk_pixbuf
+    libnotify
+    pkgconfig
+  ];
+
+  cargoSha256 = "0169k91pb7ipvi0m71cmkppp1klgp5ghampa7x0fxkyrvrf0dvqg";
+
+  meta = with stdenv.lib; {
+    description = "DWM status service which dynamically updates when needed";
+    homepage = https://github.com/Gerschtli/dwm-status;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ gerschtli ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15429,6 +15429,8 @@ with pkgs;
     patches = config.dwm.patches or [];
   };
 
+  dwm-status = callPackage ../applications/window-managers/dwm/dwm-status.nix { };
+
   dynamips = callPackage ../applications/virtualization/dynamips { };
 
   evilwm = callPackage ../applications/window-managers/evilwm {


### PR DESCRIPTION
###### Motivation for this change

Inits my own `dwm-status` package at version 0.4.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

