### PR TITLE
memcached: 1.5.5 -> 1.5.8

### DIFF
--- a/pkgs/servers/memcached/default.nix
+++ b/pkgs/servers/memcached/default.nix
@@ -1,12 +1,12 @@
 {stdenv, fetchurl, cyrus_sasl, libevent}:
 
 stdenv.mkDerivation rec {
-  version = "1.5.5";
+  version = "1.5.8";
   name = "memcached-${version}";
 
   src = fetchurl {
     url = "http://memcached.org/files/${name}.tar.gz";
-    sha256 = "1v87gvhxih5jav20cp9zdddna31s968xdm2iskc9mqzb5li6di72";
+    sha256 = "1ppnhsqv9047vm0rrmqla56y972f8qqjdb780iz6v922jjcc723k";
   };
 
   buildInputs = [cyrus_sasl libevent];


### PR DESCRIPTION
###### Motivation for this change

Backport of the (automated) version bump to address the famous UDP
amplification CVE-2018-1000115. While the issue only manifests on localhost (with our
default nixos configuration) the issue might be more relevant for people
that expose it to other hosts and only restrict the TCP access. UDP was
enabled per default, it had to be disabled. The NixOS module does only
configures the TCP port.

(cherry picked from commit 7e30cfff780bccd454b3ae956552dce37bf749b6)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

