### PR TITLE
matrix-synapse: 0.30.0 -> 0.31.1

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -26,13 +26,13 @@ let
   };
 in pythonPackages.buildPythonApplication rec {
   name = "matrix-synapse-${version}";
-  version = "0.30.0";
+  version = "0.31.1";
 
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "synapse";
     rev = "v${version}";
-    sha256 = "10ggv7669ngxs8py82k8z24874ga0ldcxvpp7xhjpbr1s0gw8zv8";
+    sha256 = "1lrbjqa9rxn2prbnha9aghnwyi4z1rpfd7bk0bjsjixjl389d6d8";
   };
 
   patches = [
@@ -42,7 +42,7 @@ in pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [
     blist canonicaljson daemonize dateutil frozendict pillow pyasn1
     pydenticon pymacaroons-pynacl pynacl pyopenssl pysaml2 pytz requests
-    signedjson systemd twisted ujson unpaddedbase64 pyyaml
+    signedjson systemd twisted ujson unpaddedbase64 pyyaml prometheus_client
     matrix-angular-sdk bleach netaddr jinja2 psycopg2
     psutil msgpack-python lxml matrix-synapse-ldap3
     phonenumbers jsonschema affinity bcrypt


### PR DESCRIPTION
###### Motivation for this change
[v0.31.1](https://matrix.org/blog/2018/06/08/synapse-0-31-1-released/) fixes a security bug where the rules for message visibility were not correctly applied over federation, I interpret this as other matrix servers federating with yours could request a specific message despite no user of that other homeserver should have access to that message.

[v0.30.0](https://matrix.org/blog/2018/06/06/synapse-v0-31-0-released/)'s main change:

> Most notable change from v0.30.0 is to switch to python prometheus library to improve system stats reporting. WARNING this changes a number of prometheus metrics in a backwards-incompatible manner.

Not totally sure whether I should advise to backport to stable, the security bug really isn't nice and probably quite easy to exploit, but private conversations are hopefully using e2e encryption to protect from this. Backporting this will quite certainly break the setups of people using the prometheus monitoring system to monitor their matrix instance, but on the other hand, the intersection between NixOS, matrix and prometheus users might be near zero, or at least much less than there are people using synapse on NixOS in general.

*NOTE*: As of #41038, I can't run the synapse tests myself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

