### PR TITLE
nixos/memcached: added simple set/get test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -334,6 +334,7 @@ in rec {
   #tests.logstash = callTest tests/logstash.nix {};
   tests.mathics = callTest tests/mathics.nix {};
   tests.matrix-synapse = callTest tests/matrix-synapse.nix {};
+  tests.memcached = callTest tests/memcached.nix {};
   tests.mesos = callTest tests/mesos.nix {};
   tests.misc = callTest tests/misc.nix {};
   tests.mongodb = callTest tests/mongodb.nix {};

--- a/nixos/tests/memcached.nix
+++ b/nixos/tests/memcached.nix
@@ -1,0 +1,28 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "memcached";
+
+  nodes = {
+    machine =
+      { config, pkgs, ... }:
+      {
+        imports = [ ../modules/profiles/minimal.nix ];
+        services.memcached.enable = true;
+      };
+  };
+
+  testScript = let
+    testScript = pkgs.writeScript "testScript.py" ''
+      #!${pkgs.python3.withPackages (p: [p.memcached])}/bin/python
+
+      import memcache
+      c = memcache.Client(['localhost:11211'])
+      c.set('key', 'value')
+      assert 'value' == c.get('key')
+    '';
+  in ''
+    startAll;
+    $machine->waitForUnit("memcached.service");
+    $machine->waitForOpenPort("11211");
+    $machine->succeed("${testScript}");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

Initially developed to test the bump on the stable channel this test should help use gain more confidence in package bumps of memcached regarding the core functionality.

The test ensures that the services comes up and accepts/provides values.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

