### PR TITLE
some overrideDerivation cleanups

### DIFF
--- a/pkgs/applications/window-managers/i3/gaps.nix
+++ b/pkgs/applications/window-managers/i3/gaps.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, i3, autoreconfHook }:
 
-i3.overrideDerivation (super : rec {
+i3.overrideAttrs (oldAttrs : rec {
 
   name = "i3-gaps-${version}";
   version = "4.15.0.1";
@@ -11,7 +11,7 @@ i3.overrideDerivation (super : rec {
     sha256 = "16s6bink8yj3zix4vww64b745d5drf2vqjg8vz3pwzrark09hfal";
   };
 
-  nativeBuildInputs = super.nativeBuildInputs ++ [ autoreconfHook ];
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ autoreconfHook ];
 
   postUnpack = ''
       echo -n "${version} (${releaseDate})" > ./i3-${version}/I3_VERSION
@@ -19,7 +19,6 @@ i3.overrideDerivation (super : rec {
 
   # fatal error: GENERATED_config_enums.h: No such file or directory
   enableParallelBuilding = false;
-}) // {
 
   meta = with stdenv.lib; {
     description = "A fork of the i3 tiling window manager with some additional features";
@@ -36,5 +35,4 @@ i3.overrideDerivation (super : rec {
       Configured via plain text file. Multi-monitor. UTF-8 clean.
     '';
   };
-
-}
+})

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -7,10 +7,8 @@ rec {
     version = "2.0.5";
     isStable = true;
     sha256 = "0yg9q4q6v028bgh85317ykc9whgxgysp76qzaqgq55y6jy11yjw7";
-  } // {
-    # 64-bit ARM isn't supported upstream
-    meta = meta // {
-      platforms = lib.filter (p: p != "aarch64-linux") meta.platforms;
+    meta = genericMeta // {
+      platforms = lib.filter (p: p != "aarch64-linux") genericMeta.platforms;
     };
   };
 
@@ -20,13 +18,12 @@ rec {
     sha256 = "1hyrhpkwjqsv54hnnx4cl8vk44h9d6c9w0fz1jfjz00w255y7lhs";
   };
 
-
-  meta = with stdenv.lib; {
+  genericMeta = with stdenv.lib; {
     description = "High-performance JIT compiler for Lua 5.1";
     homepage    = http://luajit.org;
     license     = licenses.mit;
     platforms   = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers ; [ thoughtpolice smironov vcunat andir ];
+    maintainers = with maintainers; [ thoughtpolice smironov vcunat andir ];
   };
 
   generic =
@@ -37,6 +34,7 @@ rec {
         url = "http://luajit.org/download/LuaJIT-${version}.tar.gz";
         inherit sha256;
       })
+    , meta ? genericMeta
     }:
 
     stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, collectd }:
 with stdenv.lib;
 
-overrideDerivation collectd (oldAttrs: {
+collectd.overrideAttrs (oldAttrs: {
   name = "libcollectdclient-${collectd.version}";
   buildInputs = [ ];
 
@@ -16,7 +16,6 @@ overrideDerivation collectd (oldAttrs: {
 
   postInstall = "rm -rf $out/{bin,etc,sbin,share}";
 
-}) // {
   meta = with stdenv.lib; {
     description = "C Library for collectd, a daemon which collects system performance statistics periodically";
     homepage = http://collectd.org;
@@ -24,4 +23,4 @@ overrideDerivation collectd (oldAttrs: {
     platforms = platforms.linux; # TODO: collectd may be linux but the C client may be more portable?
     maintainers = [ maintainers.sheenobu maintainers.bjornfor ];
   };
-}
+})

--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -1,9 +1,8 @@
-
 { stdenv, wayland, wayland-protocols, xorgserver, xkbcomp, xkeyboard_config, epoxy, libxslt, libunwind, makeWrapper }:
 
 with stdenv.lib;
 
-overrideDerivation xorgserver (oldAttrs: {
+xorgserver.overrideAttrs (oldAttrs: {
 
   name = "xwayland-${xorgserver.version}";
   propagatedBuildInputs = oldAttrs.propagatedBuildInputs
@@ -28,14 +27,10 @@ overrideDerivation xorgserver (oldAttrs: {
     rm -fr $out/share/X11/xkb/compiled
   '';
 
-}) // {
   meta = {
     description = "An X server for interfacing X11 apps with the Wayland protocol";
     homepage = http://wayland.freedesktop.org/xserver.html;
     license = licenses.mit;
     platforms = platforms.linux;
   };
-}
-
-
-
+})


### PR DESCRIPTION
These four top-level packages were the only ones that didn't have the
meta.position attribute automagically set. This commit fixes this.

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

