### PR TITLE
wireguard-go: 0.0.20180519 -> 0.0.20180531

### DIFF
--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -22,7 +22,7 @@ buildGoPackage rec {
     description = "Userspace Go implementation of WireGuard";
     homepage = https://git.zx2c4.com/wireguard-go/about/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ kirelagin zx2c4 ];
+    maintainers = with maintainers; [ kirelagin yegortimoshenko zx2c4 ];
     platforms = platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "wireguard-go-${version}";
-  version = "0.0.20180519";
+  version = "0.0.20180531";
 
-  goPackagePath = "wireguard-go";
+  goPackagePath = "git.zx2c4.com/wireguard-go";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-    sha256 = "0b3wpc0ccf24567fjafv1sjs3yqq1xjam3gpfp37avxqy9789nb7";
+    sha256 = "1vs11kr5a2s99v0g7079nfrfvmjfh1p2lnkj2icjyn2cb0s1vqiy";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/networking/wireguard-go/deps.nix
+++ b/pkgs/tools/networking/wireguard-go/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "1a580b3eff7814fc9b40602fd35256c63b50f491";
-      sha256 = "11adgxc6fzcb3dxr5v2g4nk6ggrz04qnx633hzgmzfh2wv3blgv7";
+      rev =  "8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9";
+      sha256 = "0vg0dfpv1wgj5imlakpma763yfd67aqbiy0fcklq3cw46qmfbzf1";
     };
   }
   {
@@ -14,8 +14,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev =  "2491c5de3490fced2f6cff376127c667efeed857";
-      sha256 = "1wmijnrxi9p2rv8g6clqkzdihn5ncv29j0s4s1bz9ksncdr36ll3";
+      rev =  "1e491301e022f8f977054da4c2d852decd59571f";
+      sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
     };
   }
   {
@@ -23,8 +23,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b";
-      sha256 = "03fhkng37rczqwfgah5hd7d373jps3hcfx79dmky2fh62yvpcyn3";
+      rev =  "9527bec2660bd847c050fda93a0f0c6dee0800bb";
+      sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

Update wireguard-go to the latest release to sync with wireguard-tools, also assume maintainership.

@zx2c4: is there a low-volume Atom/RSS feed or mailing list I could follow for updates?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

