### PR TITLE
tiscamera: Init at 0.9.1

### DIFF
--- a/pkgs/os-specific/linux/tiscamera/allow-pipeline-stop-in-trigger-mode.patch
+++ b/pkgs/os-specific/linux/tiscamera/allow-pipeline-stop-in-trigger-mode.patch
@@ -1,0 +1,48 @@
+diff --git a/src/gstreamer-1.0/gsttcamsrc.cpp b/src/gstreamer-1.0/gsttcamsrc.cpp
+index d482e1e..e36afd8 100644
+--- a/src/gstreamer-1.0/gsttcamsrc.cpp
++++ b/src/gstreamer-1.0/gsttcamsrc.cpp
+@@ -1112,6 +1112,7 @@ bool gst_tcam_src_init_camera (GstTcamSrc* self)
+ 
+ static void gst_tcam_src_close_camera (GstTcamSrc* self)
+ {
++    GST_INFO("Closing device");
+     if (self->device != NULL)
+     {
+         self->device->dev->stop_stream();
+@@ -1156,7 +1157,7 @@ static gboolean gst_tcam_src_stop (GstBaseSrc* src)
+ 
+     self->device->dev->stop_stream();
+     gst_element_send_event(GST_ELEMENT(self), gst_event_new_eos());
+-    GST_DEBUG_OBJECT (self, "Stopped acquisition");
++    GST_DEBUG("Stopped acquisition");
+ 
+     return TRUE;
+ }
+@@ -1556,6 +1557,18 @@ static void gst_tcam_src_get_property (GObject* object,
+ }
+ 
+ 
++static gboolean gst_tcam_src_unlock (GstBaseSrc* src)
++{
++    GstTcamSrc* self = GST_TCAM_SRC(src);
++
++    self->is_running = FALSE;
++
++    self->cv.notify_all();
++
++    return TRUE;
++}
++
++
+ static void gst_tcam_src_class_init (GstTcamSrcClass* klass)
+ {
+     GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+@@ -1616,6 +1629,7 @@ static void gst_tcam_src_class_init (GstTcamSrcClass* klass)
+     gstbasesrc_class->fixate = gst_tcam_src_fixate_caps;
+     gstbasesrc_class->start = gst_tcam_src_start;
+     gstbasesrc_class->stop = gst_tcam_src_stop;
++    gstbasesrc_class->unlock = gst_tcam_src_unlock;
+     gstbasesrc_class->negotiate = gst_tcam_src_negotiate;
+     gstbasesrc_class->get_times = gst_tcam_src_get_times;
+ 

--- a/pkgs/os-specific/linux/tiscamera/default.nix
+++ b/pkgs/os-specific/linux/tiscamera/default.nix
@@ -1,0 +1,98 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, pcre
+, tinyxml
+, libusb1
+, libzip
+, glib
+, gobjectIntrospection
+, gst_all_1
+, libwebcam
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tiscamera";
+  version = "0.9.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "TheImagingSource";
+    repo = pname;
+    rev = "v-${name}";
+    sha256 = "143yp6bpzj3rqfnrcnlrcwggay37fg6rkphh4w9y9v7v4wllzf87";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+  ];
+
+  buildInputs = [
+    pcre
+    tinyxml
+    libusb1
+    libzip
+    glib
+    gobjectIntrospection
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    libwebcam
+  ];
+
+
+  cmakeFlags = [
+    "-DBUILD_ARAVIS=OFF" # For GigE support. Won't need it as our camera is usb.
+    "-DBUILD_GST_1_0=ON"
+    "-DBUILD_TOOLS=ON"
+    "-DBUILD_V4L2=ON"
+    "-DBUILD_LIBUSB=ON"
+  ];
+
+
+  patches = [
+    ./allow-pipeline-stop-in-trigger-mode.patch # To be removed next release.
+  ];
+
+  postPatch = ''
+    substituteInPlace ./data/udev/80-theimagingsource-cameras.rules \
+      --replace "/usr/bin/uvcdynctrl" "${libwebcam}/bin/uvcdynctrl" \
+      --replace "/path/to/tiscamera/uvc-extensions" "$out/share/uvcdynctrl/data/199e"
+
+    substituteInPlace ./src/BackendLoader.cpp \
+      --replace '"libtcam-v4l2.so"' "\"$out/lib/tcam-0/libtcam-v4l2.so\"" \
+      --replace '"libtcam-aravis.so"' "\"$out/lib/tcam-0/libtcam-aravis.so\"" \
+      --replace '"libtcam-libusb.so"' "\"$out/lib/tcam-0/libtcam-libusb.so\""
+  '';
+
+  preConfigure = ''
+    cmakeFlagsArray=(
+      $cmakeFlagsArray
+      "-DCMAKE_INSTALL_PREFIX=$out"
+      "-DTCAM_INSTALL_UDEV=$out/lib/udev/rules.d"
+      "-DTCAM_INSTALL_UVCDYNCTRL=$out/share/uvcdynctrl/data/199e"
+      "-DTCAM_INSTALL_GST_1_0=$out/lib/gstreamer-1.0"
+      "-DTCAM_INSTALL_GIR=$out/share/gir-1.0"
+      "-DTCAM_INSTALL_TYPELIB=$out/lib/girepository-1.0"
+      "-DTCAM_INSTALL_SYSTEMD=$out/etc/systemd/system"
+    )
+  '';
+
+
+  # There are gobject introspection commands launched as part of the build. Those have a runtime
+  # dependency on `libtcam` (which itself is built as part of this build). In order to allow
+  # that, we set the dynamic linker's path to point on the build time location of the library.
+  preBuild = ''
+    export LD_LIBRARY_PATH=$PWD/src:$LD_LIBRARY_PATH
+  '';
+
+  meta = with lib; {
+    description = "The Linux sources and UVC firmwares for The Imaging Source cameras";
+    homepage = https://github.com/TheImagingSource/tiscamera;
+    license = with licenses; [ asl20 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11818,6 +11818,8 @@ with pkgs;
 
   tinyxml-2 = callPackage ../development/libraries/tinyxml-2 { };
 
+  tiscamera = callPackage ../os-specific/linux/tiscamera { };
+
   tivodecode = callPackage ../applications/video/tivodecode { };
 
   tix = callPackage ../development/libraries/tix { };


### PR DESCRIPTION
###### Motivation for this change

Linux uvc drivers for the imaging source camera. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

