### PR TITLE
pythonPackages.pdf2image: init at 0.1.13

### DIFF
--- a/pkgs/development/python-modules/pdf2image/default.nix
+++ b/pkgs/development/python-modules/pdf2image/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildPythonPackage, fetchPypi, pillow, poppler_utils }:
+
+buildPythonPackage rec {
+  pname = "pdf2image";
+  version = "0.1.13";
+
+  buildInputs = [ pillow poppler_utils ];
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "784928038588059e00c7f97e5608047cb754b6ec8fd10e7551e7ad0f40d2cd56";
+  };
+
+  meta = with stdenv.lib; {
+    description = "A python module that wraps the pdftoppm utility to convert PDF to PIL Image object";
+    homepage = https://github.com/Belval/pdf2image;
+    license = licenses.mit;
+    maintainers = with maintainers; [ gerschtli ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -315,6 +315,8 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
+  pdf2image = callPackage ../development/python-modules/pdf2image { };
+
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
###### Motivation for this change

Inits python package `pdf2image` at version 0.1.13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

