### PR TITLE
nixos/tests/gnome3: switch to lightdm

### DIFF
--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -11,8 +11,9 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       services.xserver.enable = true;
 
-      services.xserver.displayManager.auto.enable = true;
-      services.xserver.displayManager.auto.user = "alice";
+      services.xserver.displayManager.lightdm.enable = true;
+      services.xserver.displayManager.lightdm.autoLogin.enable = true;
+      services.xserver.displayManager.lightdm.autoLogin.user = "alice";
       services.xserver.desktopManager.gnome3.enable = true;
 
       virtualisation.memorySize = 1024;
@@ -21,7 +22,9 @@ import ./make-test.nix ({ pkgs, ...} : {
   testScript =
     ''
       $machine->waitForX;
-      $machine->sleep(15);
+
+      # wait for alice to be logged in
+      $machine->waitForUnit("default.target","alice");
 
       # Check that logging in has given the user ownership of devices.
       $machine->succeed("getfacl /dev/snd/timer | grep -q alice");


### PR DESCRIPTION
###### Motivation for this change

#41616. The test failed because the the `slim` display manager doesn't start the gnome3 session correctly. Switch it to `lightdm`. (`slim` is unmaintained since 2014 and shouldn't be the default anymore, see #30890. For `gdm` we already have  a separate test `gnome3-gdm`.)

/cc @jtojnar and listed maintainers @domenkozar  @eelco @chaoflow @lethalman 

###### Things done

Test succeeds on local machine.