### PR TITLE
libtiff: 4.0.9 update patches

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -13,12 +13,12 @@ stdenv.mkDerivation rec {
 
   prePatch = let
       debian = fetchurl {
-        url = http://snapshot.debian.org/archive/debian-debug/20180128T155203Z//pool/main/t/tiff/tiff_4.0.9-3.debian.tar.xz;
-        sha256 = "0wya42y7kcq093g3h7ca10cm5sns1mgnkjmdd2qdi59v8arga4y4";
+        url = http://http.debian.net/debian/pool/main/t/tiff/tiff_4.0.9-5.debian.tar.xz;
+        sha256 = "15lwcsd46gini27akms2ngyxnwi1hs2yskrv5x2wazs5fw5ii62w";
       };
     in ''
-      tar xf '${debian}'
-      patches="$patches $(cat debian/patches/series | sed 's|^|debian/patches/|')"
+      tar xf ${debian}
+      patches="$patches $(sed 's|^|debian/patches/|' < debian/patches/series)"
     '';
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];


### PR DESCRIPTION
###### Motivation for this change

Get libtiff on the same patch level as Debian. The imported patch file contains:

CVE-2017-9935
CVE-2017-11613
CVE-2017-17095
CVE-2017-18013
CVE-2018-5784
CVE-2018-7456

Re #41748 (master)
Re #41749 (release-18.03 - needs to be cherry-picked)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

