### PR TITLE
bind: compile with libcap

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, openssl, libtool, perl, libxml2
+{ stdenv, lib, fetchurl
+, perl
+, libcap, libtool, libxml2, openssl
 , enablePython ? false, python3 ? null
 , enableSeccomp ? false, libseccomp ? null, buildPackages
 }:
@@ -22,7 +24,7 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional stdenv.isDarwin ./darwin-openssl-linking-fix.patch;
 
   nativeBuildInputs = [ perl ];
-  buildInputs = [ openssl libtool libxml2 ]
+  buildInputs = [ libcap libtool libxml2 openssl ]
     ++ lib.optional enableSeccomp libseccomp
     ++ lib.optional enablePython python3;
 
@@ -32,6 +34,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--localstatedir=/var"
+    "--with-libcap=${libcap.dev}"
     "--with-libtool"
     "--with-libxml2=${libxml2.dev}"
     "--with-openssl=${openssl.dev}"
@@ -43,6 +46,7 @@ stdenv.mkDerivation rec {
     "--without-idn"
     "--without-idnlib"
     "--without-lmdb"
+    "--without-libjson"
     "--without-pkcs11"
     "--without-purify"
     "--with-randomdev=/dev/random"


### PR DESCRIPTION
###### Motivation for this change

There is a bug in BIND, when compiled without libcap, which prevents it from running inside docker without granting extra capabilities: https://gitlab.isc.org/isc-projects/bind9/issues/321

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

