### PR TITLE
alsa: setup mirrors for src downloads

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -405,4 +405,12 @@ rec {
     http://repo1.maven.org/maven2/
     http://central.maven.org/maven2/
   ];
+
+  # Alsa Project
+  alsa = [
+     ftp://ftp.alsa-project.org/pub/
+     http://alsa.cybermirror.org/
+     http://www.mirrorservice.org/sites/ftp.alsa-project.org/pub/
+     http://alsa.mirror.fr/
+  ];
 }

--- a/pkgs/os-specific/linux/alsa-firmware/default.nix
+++ b/pkgs/os-specific/linux/alsa-firmware/default.nix
@@ -4,10 +4,7 @@ stdenv.mkDerivation rec {
   name = "alsa-firmware-1.0.29";
 
   src = fetchurl {
-    urls = [
-      "ftp://ftp.alsa-project.org/pub/firmware/${name}.tar.bz2"
-      "http://alsa.cybermirror.org/firmware/${name}.tar.bz2"
-    ];
+    url = "mirror://alsa/firmware/${name}.tar.bz2";
     sha256 = "0gfcyj5anckjn030wcxx5v2xk2s219nyf99s9m833275b5wz2piw";
   };
 
@@ -28,7 +25,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.alsa-project.org/main/index.php/Main_Page;
+    homepage = http://www.alsa-project.org/;
     description = "Soundcard firmwares from the alsa project";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/os-specific/linux/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-lib/default.nix
@@ -4,10 +4,7 @@ stdenv.mkDerivation rec {
   name = "alsa-lib-1.1.6";
 
   src = fetchurl {
-    urls = [
-     "ftp://ftp.alsa-project.org/pub/lib/${name}.tar.bz2"
-     "http://alsa.cybermirror.org/lib/${name}.tar.bz2"
-    ];
+    url = "mirror://alsa/lib/${name}.tar.bz2";
     sha256 = "096pwrnhj36yndldvs2pj4r871zhcgisks0is78f1jkjn9sd4b2z";
   };
 

--- a/pkgs/os-specific/linux/alsa-oss/default.nix
+++ b/pkgs/os-specific/linux/alsa-oss/default.nix
@@ -4,10 +4,7 @@ stdenv.mkDerivation rec {
   name = "alsa-oss-1.1.6";
 
   src = fetchurl {
-    urls = [
-      "ftp://ftp.alsa-project.org/pub/oss-lib/${name}.tar.bz2"
-      "http://alsa.cybermirror.org/oss-lib/${name}.tar.bz2"
-    ];
+    url = "mirror://alsa/oss-lib/${name}.tar.bz2";
     sha256 = "1sj512wyci5qv8cisps96xngh7y9r5mv18ybqnazy18zwr1zgly3";
   };
 

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -4,10 +4,7 @@ stdenv.mkDerivation rec {
   name = "alsa-plugins-1.1.6";
 
   src = fetchurl {
-    urls = [
-      "ftp://ftp.alsa-project.org/pub/plugins/${name}.tar.bz2"
-      "http://alsa.cybermirror.org/plugins/${name}.tar.bz2"
-    ];
+    url = "mirror://alsa/plugins/${name}.tar.bz2";
     sha256 = "04qcwkisbh0d6lnh0rw1k6n869fbs6zbfq6yvb41rymiwgmk27bg";
   };
 

--- a/pkgs/os-specific/linux/alsa-tools/default.nix
+++ b/pkgs/os-specific/linux/alsa-tools/default.nix
@@ -7,10 +7,7 @@ stdenv.mkDerivation rec {
   version = "1.1.6";
 
   src = fetchurl {
-    urls = [
-      "ftp://ftp.alsa-project.org/pub/tools/${name}.tar.bz2"
-      "http://alsa.cybermirror.org/tools/${name}.tar.bz2"
-    ];
+    url = "mirror://alsa/tools/${name}.tar.bz2";
     sha256 = "09rjb6hw1mn9y1jfdfj5djncgc2cr5wfps83k56rf6k4zg14v76n";
   };
 

--- a/pkgs/os-specific/linux/alsa-utils/default.nix
+++ b/pkgs/os-specific/linux/alsa-utils/default.nix
@@ -5,10 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.1.6";
 
   src = fetchurl {
-    urls = [
-      "ftp://ftp.alsa-project.org/pub/utils/${name}.tar.bz2"
-      "http://alsa.cybermirror.org/utils/${name}.tar.bz2"
-    ];
+    url = "mirror://alsa/utils/${name}.tar.bz2";
     sha256 = "0vnkyymgwj9rfdb11nvab30dnfrylmakdfildxl0y8mj836awp0m";
   };
 
@@ -27,7 +24,6 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.alsa-project.org/;
     description = "ALSA, the Advanced Linux Sound Architecture utils";
-
     longDescription = ''
       The Advanced Linux Sound Architecture (ALSA) provides audio and
       MIDI functionality to the Linux-based operating system.


### PR DESCRIPTION
This commit adds a list of supported mirrors for all alsa projects, as described
on the download section of the alsa-project hompage:
http://alsa-project.org/main/index.php/Download

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

