### PR TITLE
appimage-run: init

### DIFF
--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -1,0 +1,146 @@
+{ stdenv, writeScript, buildFHSUserEnv, coreutils
+, extraPkgs ? pkgs: [] }:
+
+buildFHSUserEnv {
+  name = "appimage-run";
+
+  # Most of the packages were taken from the Steam chroot
+  targetPkgs = pkgs: with pkgs; [
+    gtk3
+    bashInteractive
+    gnome3.zenity
+    python2
+    xorg.xrandr
+    which
+    perl
+    xdg_utils
+    iana-etc
+  ] ++ extraPkgs pkgs;
+
+  multiPkgs = pkgs: with pkgs; [
+    desktop-file-utils
+    xorg.libXcomposite
+    xorg.libXtst
+    xorg.libXrandr
+    xorg.libXext
+    xorg.libX11
+    xorg.libXfixes
+    libGL
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-ugly
+    libdrm
+    xorg.xkeyboardconfig
+    xorg.libpciaccess
+
+    glib
+    gtk2
+    bzip2
+    zlib
+    gdk_pixbuf
+
+    xorg.libXinerama
+    xorg.libXdamage
+    xorg.libXcursor
+    xorg.libXrender
+    xorg.libXScrnSaver
+    xorg.libXxf86vm
+    xorg.libXi
+    xorg.libSM
+    xorg.libICE
+    gnome2.GConf
+    freetype
+    (curl.override { gnutlsSupport = true; sslSupport = false; })
+    nspr
+    nss
+    fontconfig
+    cairo
+    pango
+    expat
+    dbus
+    cups
+    libcap
+    SDL2
+    libusb1
+    dbus-glib
+    libav
+    atk
+    libudev0-shim
+    networkmanager098
+
+    xorg.libXt
+    xorg.libXmu
+    xorg.libxcb
+    libGLU
+    libuuid
+    libogg
+    libvorbis
+    SDL
+    SDL2_image
+    glew110
+    openssl
+    libidn
+    tbb
+    wayland
+    mesa_noglu
+    libxkbcommon
+
+    flac
+    freeglut
+    libjpeg
+    libpng12
+    libsamplerate
+    libmikmod
+    libtheora
+    libtiff
+    pixman
+    speex
+    SDL_image
+    SDL_ttf
+    SDL_mixer
+    SDL2_ttf
+    SDL2_mixer
+    gstreamer
+    gst-plugins-base
+    libappindicator-gtk2
+    libcaca
+    libcanberra
+    libgcrypt
+    libvpx
+    librsvg
+    xorg.libXft
+    libvdpau
+    alsaLib
+    strace
+  ];
+
+  runScript = writeScript "appimage-exec" ''
+    #!${stdenv.shell}
+    APPIMAGE="$(realpath "$1")"
+
+    if [ ! -x "$APPIMAGE" ]; then
+      echo "fatal: $APPIMAGE is not executable"
+      exit 1
+    fi
+
+    SHA256="$(${coreutils}/bin/sha256sum "$APPIMAGE" | cut -d ' ' -f 1)"
+    SQUASHFS_ROOT="''${XDG_CACHE_HOME:-$HOME/.cache}/appimage-run/$SHA256/"
+    mkdir -p "$SQUASHFS_ROOT"
+
+    export APPDIR="$SQUASHFS_ROOT/squashfs-root"
+    if [ ! -x "$APPDIR" ]; then
+      cd "$SQUASHFS_ROOT"
+      "$APPIMAGE" --appimage-extract 2>/dev/null
+    fi
+
+    cd "$APPDIR"
+    export PATH="$PATH:$PWD/usr/bin"
+    export APPIMAGE_SILENT_INSTALL=1
+
+    if [ -n "$APPIMAGE_DEBUG_EXEC" ]; then
+      exec "$APPIMAGE_DEBUG_EXEC"
+    fi
+
+    exec ./AppRun
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -501,6 +501,8 @@ with pkgs;
     buildTools = androidenv.buildTools;
   };
 
+  appimage-run = callPackage ../tools/package-management/appimage-run {};
+
   apt-cacher-ng = callPackage ../servers/http/apt-cacher-ng { };
 
   apt-offline = callPackage ../tools/misc/apt-offline { };


### PR DESCRIPTION
###### Motivation for this change

This adds a best-effort hack to run AppImages, which currently don't
work out-of-the-box on NixOS. This is not preferable to using packaged
applications, but may help users if the application they want to run
is not in nixpkgs.

It uses the package list from the Steam chroot, but without Steam
packages.

As with steam-run, this does little sandboxing. I have an alternative
expression that uses bubblewrap to isolate the users data from
the to-be-run AppImage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

