### PR TITLE
kontemplate: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/kontemplate/default.nix
+++ b/pkgs/applications/networking/cluster/kontemplate/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name          = "kontemplate-${version}";
-  version       = "1.5.0";
+  version       = "1.6.0";
   goPackagePath = "github.com/tazjin/kontemplate";
   goDeps        = ./deps.nix;
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner  = "tazjin";
     repo   = "kontemplate";
     rev    = "v${version}";
-    sha256 = "0k3yr0ypw6brj1lxqs041zsyi0r09113i0x3xfj48zv4ralq74b6";
+    sha256 = "06qcf2cxs686kd7iqccmqd5chdzxgbkav95byjim7sgvq9qjajfi";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Upstream release notes at:

https://github.com/tazjin/kontemplate/releases/tag/v1.6.0

###### Motivation for this change

A new release was made available upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
