### PR TITLE
darwin.iproute2mac: init at 1.2.1

### DIFF
--- a/pkgs/os-specific/darwin/iproute2mac/default.nix
+++ b/pkgs/os-specific/darwin/iproute2mac/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python }:
+{ stdenv, fetchFromGitHub, darwin, python }:
 
 stdenv.mkDerivation rec {
   version = "1.2.1";
@@ -14,7 +14,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ python ];
 
   postPatch = ''
-    substituteInPlace src/ip.py --replace /usr/bin/python ${python}/bin/python
+    substituteInPlace src/ip.py \
+      --replace /usr/bin/python ${python}/bin/python \
+      --replace /sbin/ifconfig ${darwin.network_cmds}/bin/ifconfig \
+      --replace /sbin/route ${darwin.network_cmds}/bin/route \
+      --replace /usr/sbin/netstat ${darwin.network_cmds}/bin/netstat \
+      --replace /usr/sbin/ndp ${darwin.network_cmds}/bin/ndp \
+      --replace /usr/sbin/arp ${darwin.network_cmds}/bin/arp \
+      --replace /usr/sbin/networksetup ${darwin.network_cmds}/bin/networksetup
   '';
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/os-specific/darwin/iproute2mac/default.nix
+++ b/pkgs/os-specific/darwin/iproute2mac/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, python }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.1";
+  name = "iproute2mac-${version}";
+
+  src = fetchFromGitHub {
+    owner = "brona";
+    repo = "iproute2mac";
+    rev = "v${version}";
+    sha256 = "1n6la7blbxza2m79cpnywsavhzsdv4gzdxrkly4dppyidjg6jy1h";
+  };
+
+  buildInputs = [ python ];
+
+  postPatch = ''
+    substituteInPlace src/ip.py --replace /usr/bin/python ${python}/bin/python
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D -m 755 src/ip.py $out/bin/ip
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/brona/iproute2mac;
+    description = "CLI wrapper for basic network utilites on Mac OS X inspired with iproute2 on Linux systems - ip command.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flokli ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -51,8 +51,10 @@ in
     inherit (pkgs.llvmPackages) clang-unwrapped;
   };
 
+  iproute2mac = callPackage ../os-specific/darwin/iproute2mac { };
+
   libobjc = apple-source-releases.objc4;
-  
+
   lsusb = callPackage ../os-specific/darwin/lsusb { };
 
   opencflite = callPackage ../os-specific/darwin/opencflite { };


### PR DESCRIPTION
###### Motivation for this change
This adds `iproute2mac`, a CLI wrapper for basic network utilites on Mac OS X inspired with iproute2 on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @LnL7 

