### PR TITLE
p7zip: fix src URL for debian gitlab move

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -12,13 +12,13 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch rec {
       name = "CVE-2016-9296.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/p7zip.git/plain/${name}?id=4b3973f6a5d";
+      url = "https://salsa.debian.org/debian/p7zip/raw/debian/${version}+dfsg-6/debian/patches/12-${name}";
       sha256 = "09wbkzai46bwm8zmplsz0m4jck3qn7snr68i9p1gsih300zidj0m";
     })
     (fetchpatch rec {
       name = "CVE-2017-17969.patch";
-      url = "https://anonscm.debian.org/cgit/users/robert/p7zip.git/plain/debian/patches/13-${name}?h=debian/16.02%2bdfsg-5";
-      sha256 = "16lbf6rgyl7xwxfjgg1243jvi39yb3i5pgqfnxswyc0jzhxv81d7";
+      url = "https://salsa.debian.org/debian/p7zip/raw/debian/${version}+dfsg-6/debian/patches/13-${name}";
+      sha256 = "00pycdwx6gw7w591bg54ym6zhbxgn47p3zhms6mnmaycfzw09mkn";
     })
   ];
 


### PR DESCRIPTION
Another broken URL related to: https://github.com/NixOS/nixpkgs/issues/39927

Note that the patch file has legitimately changed, because ~4 months ago Debian
replaced their CVE security fix with a newer version that fixes some additional
bugs: https://salsa.debian.org/debian/p7zip/commit/d6fd3b37345489ec2907fcf70aabf0c754f5371f

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

