### PR TITLE
xfsprogs: swap src url to HTTPS

### DIFF
--- a/pkgs/tools/filesystems/xfsprogs/default.nix
+++ b/pkgs/tools/filesystems/xfsprogs/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   version = "4.14.0";
 
   src = fetchgit {
-    url = "git://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git";
-    rev = "refs/tags/v${version}";
+    url = "https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git";
+    rev = "v${version}";
     sha256 = "19mg3avm188xz215hqbbh7251q27qwm7g1xr8ffrjwvzmdq55rxj";
   };
 


### PR DESCRIPTION
This swaps the fetchgit call to be more consistent with the majority of other
NixPkgs fetchgit calls. Moreover, almost every network will be able to do HTTPS,
while some enterprise networks may limit external SSH access.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

