### PR TITLE
openjdk: fix truststore-from-env patch for jdk10

### DIFF
--- a/pkgs/development/compilers/openjdk/read-truststore-from-env-jdk10.patch
+++ b/pkgs/development/compilers/openjdk/read-truststore-from-env-jdk10.patch
@@ -8,12 +8,22 @@
       *    jssecacerts
       *    cacerts
       */
-@@ -144,6 +145,9 @@
+@@ -132,7 +133,8 @@
+                 public TrustStoreDescriptor run() {
+                     // Get the system properties for trust store.
+                     String storePropName = System.getProperty(
+-                            "javax.net.ssl.trustStore", jsseDefaultStore);
++                            "javax.net.ssl.trustStore",
++                            System.getenv("JAVAX_NET_SSL_TRUSTSTORE"));
+                     String storePropType = System.getProperty(
+                             "javax.net.ssl.trustStoreType",
+                             KeyStore.getDefaultType());
+@@ -144,6 +146,9 @@
                      String temporaryName = "";
                      File temporaryFile = null;
                      long temporaryTime = 0L;
-+                    if (storePropName == null){
-+                        storePropName = System.getenv("JAVAX_NET_SSL_TRUSTSTORE");
++                    if (storePropName == null) {
++                        storePropName = jsseDefaultStore;
 +                    }
                      if (!"NONE".equals(storePropName)) {
                          String[] fileNames =


### PR DESCRIPTION
###### Motivation for this change
read-truststore-from-env-jdk10.patch does not work.

storePropName will be jsseDefaultStore if the property isn't present, and jsseDefaultStore is never null, so the branch to use the environment variable will never be taken.

Easy way to test if it is working correctly from shell (should output NONE):

```
echo 'var c = Class.forName("sun.security.ssl.TrustStoreManager$TrustStoreDescriptor"); var ci = c.getDeclaredMethod("createInstance"); var n = c.getDeclaredField("storeName"); ci.setAccessible(true); n.setAccessible(true); System.out.println(n.get(ci.invoke(null)));' | JAVAX_NET_SSL_TRUSTSTORE=NONE jshell -
```

This functionality seems necessary to make clojure work after 5a53b98, because the cert for  https://repo.clojars.org isn't trusted by the included cacerts.

###### Things done

The env var is supposed to be preferred to jssecacerts, so we can use it as the default in the call to System.getProperty instead, and use the null check to fall back on jsseDefaultStore.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

