### PR TITLE
linux-hardkernel: Init at 4.14.47-139

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
+{ stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
   version = "4.14.47-139";
@@ -9,9 +9,11 @@ buildLinux (args // rec {
   # branchVersion needs to be x.y. 
   extraMeta.branch = "4.14";
 
-  src = fetchurl {
-    url = "https://github.com/hardkernel/linux/archive/${version}.tar.gz";
-    sha256 = "1n43a3rhpjq851qrn17r1dkibv6sqlmwxvl3hras4qr391x61y6n";
+  src = fetchFromGitHub {
+    owner = "hardkernel";
+    repo = "linux";
+    rev = version;
+    sha256 = "0jjgrmvi1h8zs8snnvghnjd422yfmn7jv9y1n7xikmfv4nvwqrkv";
   };
 
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,0 +1,17 @@
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, libelf, utillinux, ... } @ args:
+
+buildLinux (args // rec {
+  version = "4.14.47-139";
+
+  # modDirVersion needs to be x.y.z.
+  modDirVersion = "4.14.47";
+
+  # branchVersion needs to be x.y. 
+  extraMeta.branch = "4.14";
+
+  src = fetchurl {
+    url = "https://github.com/hardkernel/linux/archive/${version}.tar.gz";
+    sha256 = "1n43a3rhpjq851qrn17r1dkibv6sqlmwxvl3hras4qr391x61y6n";
+  };
+
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13603,6 +13603,13 @@ with pkgs;
       ];
   };
 
+  linux_hardkernel_4_14 = callPackage ../os-specific/linux/kernel/linux-hardkernel-4.14.nix {
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.modinst_arg_list_too_long
+    ];
+  };
+
   /* Linux kernel modules are inherently tied to a specific kernel.  So
      rather than provide specific instances of those packages for a
      specific kernel, we have a function that builds those packages
@@ -13825,6 +13832,11 @@ with pkgs;
   linuxPackages_samus_4_12 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_samus_4_12);
   linuxPackages_samus_latest = linuxPackages_samus_4_12;
   linux_samus_latest = linuxPackages_samus_latest.kernel;
+
+  # Hardkernel (Odroid) kernels.
+  linuxPackages_hardkernel_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_hardkernel_4_14);
+  linuxPackages_hardkernel_latest = linuxPackages_hardkernel_4_14;
+  linux_hardkernel_latest = linuxPackages_hardkernel_latest.kernel;
 
   # A function to build a manually-configured kernel
   linuxManualConfig = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {});


### PR DESCRIPTION
###### Motivation for this change
This introduces a build for the hardkernel vendor kernel tree, to support hardkernel hardware (e.g. the odroid series of SBCs).

###### Things done
I have built and tested this kernel on my Odroid HC1, using `kernelPackages = pkgs.linuxPackages_hardkernel_latest`. No problems encountered, but no further devices tested.

I just looked at existing linux kernel instances and duplicated the simplest I saw with the minimum novelty I could think of. I might definitely have missed something. Design advice is welcome.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

