### PR TITLE
sequeler: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/applications/misc/sequeler/default.nix
+++ b/pkgs/applications/misc/sequeler/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchFromGitHub
-, cmake, ninja, pkgconfig, vala, gobjectIntrospection, gettext, wrapGAppsHook
-, gtk3, glib, granite, libgee, libgda, gtksourceview, libxml2 }:
+, meson, ninja, pkgconfig, vala, gobjectIntrospection, gettext, wrapGAppsHook
+, gtk3, glib, granite, libgee, libgda, gtksourceview, libxml2, libsecret }:
 
 
 let
-  version = "0.5.4";
+  version = "0.5.5";
   sqlGda = libgda.override {
     mysqlSupport = true;
     postgresSupport = true;
@@ -17,12 +17,17 @@ in stdenv.mkDerivation rec {
     owner = "Alecaddd";
     repo = "sequeler";
     rev = "v${version}";
-    sha256 = "05c7y6xdyq3h9bn90pbz03jhy9kabmgpxi4zz0i26q0qphljskbx";
+    sha256 = "0jv7nx9k1qw2i3cmg0vnahz4qfam03xypas975x40icqd3bhfgj3";
   };
 
-  nativeBuildInputs = [ cmake ninja pkgconfig vala gobjectIntrospection gettext wrapGAppsHook ];
+  nativeBuildInputs = [ meson ninja pkgconfig vala gobjectIntrospection gettext wrapGAppsHook ];
 
-  buildInputs = [ gtk3 glib granite libgee sqlGda gtksourceview libxml2 ];
+  buildInputs = [ gtk3 glib granite libgee sqlGda gtksourceview libxml2 libsecret ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
 
   meta = with stdenv.lib; {
     description = "Friendly SQL Client";


### PR DESCRIPTION
###### Motivation for this change
Changelog: https://github.com/Alecaddd/sequeler/releases/tag/v0.5.5

They also happened to switch away from cmake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jtojnar 