### PR TITLE
haskell: fix overriding haskellPackages using haskell.packageOverrides

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6460,7 +6460,7 @@ with pkgs;
   haskell = callPackage ./haskell-packages.nix { };
 
   haskellPackages = haskell.packages.ghc822.override {
-    overrides = config.haskellPackageOverrides or (self: super: {});
+    overrides = config.haskellPackageOverrides or haskell.packageOverrides;
   };
 
   inherit (haskellPackages) ghc;


### PR DESCRIPTION
###### Motivation for this change

@peti I just discovered that overriding `haskellPackages` by overriding `haskell.packageOverrides` was not working. This patch fixes that.

###### Things done

Tested using:

```
$ nix-build -E '(import ./. { overlays = [(final : previous : { haskell = previous.haskell // { packageOverrides = self : super : {blablabla = super.scientific;};};})];}).haskellPackages.blablabla'
/nix/store/s75xbfhn88187jk8238h4ii2ap9kg4m2-scientific-0.3.6.2
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

