### PR TITLE
18.03-pcsc-lite-not-found - alioth.debian.org decommissioned:

### DIFF
--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     # This URL changes in unpredictable ways, so it is not sensible
     # to put a version variable in there.
     url = "https://pcsclite.apdu.fr/files/pcsc-lite-1.8.23.tar.bz2";
-    sha256 = "09b7a79hjkgiyvhyvwf8gpxaf8b7wd0342hx6zrpd269hhfbjvwy";
+    sha256 = "1jc9ws5ra6v3plwraqixin0w0wfxj64drahrbkyrrwzghqjjc9ss";
   };
 
   patches = [ ./no-dropdir-literals.patch ];

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     # This URL changes in unpredictable ways, so it is not sensible
     # to put a version variable in there.
-    url = "https://alioth.debian.org/frs/download.php/file/4235/pcsc-lite-1.8.23.tar.bz2";
-    sha256 = "1jc9ws5ra6v3plwraqixin0w0wfxj64drahrbkyrrwzghqjjc9ss";
+    url = "https://pcsclite.apdu.fr/files/pcsc-lite-1.8.23.tar.bz2";
+    sha256 = "09b7a79hjkgiyvhyvwf8gpxaf8b7wd0342hx6zrpd269hhfbjvwy";
   };
 
   patches = [ ./no-dropdir-literals.patch ];


### PR DESCRIPTION
https://reproducible-builds.org/blog/posts/162/

PR on `master`: https://github.com/NixOS/nixpkgs/pull/41790

###### Motivation for this change
"The deprecated Alioth Debian server is now gone and has been replaced with Salsa"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

