### PR TITLE
kde-applications: 18.04.1 -> 18.04.2

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.04.1/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/applications/18.04.2/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1699 +3,1699 @@
 
 {
   akonadi = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-18.04.1.tar.xz";
-      sha256 = "0dg0r49angzkp5b09zbxjygjaxn1d50db15rwm7v9xsnz6fmc6hv";
-      name = "akonadi-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-18.04.2.tar.xz";
+      sha256 = "1kwaq91kimvpv4hr0n8bavfpwnd3c80z7bi3wc0hw07r86plxg35";
+      name = "akonadi-18.04.2.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-calendar-18.04.1.tar.xz";
-      sha256 = "0anmy67dc85afc0aq6y813c6xjr0jnkzsh56889zyz8z7k9xpg2q";
-      name = "akonadi-calendar-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-calendar-18.04.2.tar.xz";
+      sha256 = "0sbdkfd5n9apdw65nhl028k6s4qml25lqif6gg01z228ibwr63h2";
+      name = "akonadi-calendar-18.04.2.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-calendar-tools-18.04.1.tar.xz";
-      sha256 = "1935d5nwq2s8ijc9nzp7rdsmbyl2b42xwx0vj7cz1835y4w3k2vn";
-      name = "akonadi-calendar-tools-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-calendar-tools-18.04.2.tar.xz";
+      sha256 = "1xa33lc95brpc73y0464x9a4vx90np85r9k5pb8489mqhh1nmhf2";
+      name = "akonadi-calendar-tools-18.04.2.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadiconsole-18.04.1.tar.xz";
-      sha256 = "032r5r5ksifigx8bk82yygvhji1xjx3dd6i7z7mpx5qlc1zmqjpk";
-      name = "akonadiconsole-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadiconsole-18.04.2.tar.xz";
+      sha256 = "1njyncsn3icgjsw73a3hylaqfw049pxjqv7rnaw1qzwpk2sz8rfd";
+      name = "akonadiconsole-18.04.2.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-contacts-18.04.1.tar.xz";
-      sha256 = "1y1qcndsrdphii048cpwnfnd185mywcaw1h1szq71q2ww2aapcmp";
-      name = "akonadi-contacts-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-contacts-18.04.2.tar.xz";
+      sha256 = "04v9ncy0vmx1zl345z8sx8asb0spnzzh7qrrqa59wypqki7ndhbr";
+      name = "akonadi-contacts-18.04.2.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-import-wizard-18.04.1.tar.xz";
-      sha256 = "150i8m7ngb6kdyixvzfgnjwyrs2xpsd53gy2x28091kg2kqb0nl4";
-      name = "akonadi-import-wizard-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-import-wizard-18.04.2.tar.xz";
+      sha256 = "0yg3w34j3c0pcxsffpwz2f3fpsy1wg0jd8j9s0nvlq1cmmlglsh9";
+      name = "akonadi-import-wizard-18.04.2.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-mime-18.04.1.tar.xz";
-      sha256 = "0ypfbrr8h2nypdyg8xxs4d53qlbq4kd3ph2yhafp80577xwhqgmw";
-      name = "akonadi-mime-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-mime-18.04.2.tar.xz";
+      sha256 = "1rsymy2fljriwzwiacwxnmkgwm95hmhnbhg8rbrxblyinbnyrjhy";
+      name = "akonadi-mime-18.04.2.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-notes-18.04.1.tar.xz";
-      sha256 = "0f4q6ls7z5ikf46v7m0wazdczay8y3yvscw1lnmq5qwnvdfyqcpd";
-      name = "akonadi-notes-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-notes-18.04.2.tar.xz";
+      sha256 = "1pa109cq2nl9fbxc4d0p2dybby70six6nbfcfsxmi42yskc107sw";
+      name = "akonadi-notes-18.04.2.tar.xz";
     };
   };
   akonadi-search = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akonadi-search-18.04.1.tar.xz";
-      sha256 = "01mfj7s3kx5kcjbvj4hljfrmsbpfmfiq0r87cgzg6734c4mzjqsl";
-      name = "akonadi-search-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akonadi-search-18.04.2.tar.xz";
+      sha256 = "0kjcmg2yyfx3qs140rmwjajwc197l6b3c1d3d0ryh00incmd4j9k";
+      name = "akonadi-search-18.04.2.tar.xz";
     };
   };
   akregator = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/akregator-18.04.1.tar.xz";
-      sha256 = "0h5pdbrwxa3n086yywqsm0m8x9p1s5jy2hgjivdilxgwnqcj6zpv";
-      name = "akregator-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/akregator-18.04.2.tar.xz";
+      sha256 = "1fdgnrl9pbrrpfj73rsvz0xhp67lzr88px4dkkh8msczq7cv3wrc";
+      name = "akregator-18.04.2.tar.xz";
     };
   };
   analitza = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/analitza-18.04.1.tar.xz";
-      sha256 = "09y3zz6zn3cs5nn0i0dcx71jrm0lzz3g8af6nz118m6rz71wndnq";
-      name = "analitza-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/analitza-18.04.2.tar.xz";
+      sha256 = "1m9zg2axi9fnkpl3lqn9s9hmvjh2zcafc5mpgk3lfd2v1v410nd3";
+      name = "analitza-18.04.2.tar.xz";
     };
   };
   ark = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ark-18.04.1.tar.xz";
-      sha256 = "10gpm90zsssygl65280z4p43ma75qjswiyv4drlrksydakxvvxk3";
-      name = "ark-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ark-18.04.2.tar.xz";
+      sha256 = "08ld389whnp94p27m4bh9y65ja02502gc4n05h1cwjx8rkl1z2q8";
+      name = "ark-18.04.2.tar.xz";
     };
   };
   artikulate = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/artikulate-18.04.1.tar.xz";
-      sha256 = "0brpb7ijqib7qp5ypvz9gkai7mwdxf915a7makklgzg80mdqnxpv";
-      name = "artikulate-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/artikulate-18.04.2.tar.xz";
+      sha256 = "1k41jmczw55difdsqq8rwlmpshli8ckxq969yinysy59c8b29c4a";
+      name = "artikulate-18.04.2.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/audiocd-kio-18.04.1.tar.xz";
-      sha256 = "1g3waj7xb14fgb75b0zzhbai93yqv5r1p0n0j3rwhfg9bvkgqgpa";
-      name = "audiocd-kio-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/audiocd-kio-18.04.2.tar.xz";
+      sha256 = "0hvlg3vricnn3shrqzr71im7c3ixzidrqv5cm0c189mir3ys5965";
+      name = "audiocd-kio-18.04.2.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/baloo-widgets-18.04.1.tar.xz";
-      sha256 = "1bq2n7lpldi2qiwdgx6l78m41whdjd41n1247985d1cr62bsn5cq";
-      name = "baloo-widgets-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/baloo-widgets-18.04.2.tar.xz";
+      sha256 = "0hsrc1vf4mscf0yxhafbh775lidyrq3ihlcb018j1gnk190b3pxr";
+      name = "baloo-widgets-18.04.2.tar.xz";
     };
   };
   blinken = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/blinken-18.04.1.tar.xz";
-      sha256 = "0sgaipxfzwjfikyj2r47vp0192s8v0zll2x61i9z6p6lzq7glw0j";
-      name = "blinken-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/blinken-18.04.2.tar.xz";
+      sha256 = "0fq3ai0ymxlz4jrn9h0nd3kgc0dnzih058jmdwnar42r85dhb9cy";
+      name = "blinken-18.04.2.tar.xz";
     };
   };
   bomber = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/bomber-18.04.1.tar.xz";
-      sha256 = "13ivb42jq2864vdpajds3cwjhhml7ikww66z1r6j4wp8mlmdlnal";
-      name = "bomber-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/bomber-18.04.2.tar.xz";
+      sha256 = "194bqr0rk2v62ax1blxvjzyr8qs61h0z8vzcwzh92mws0dbd3zyz";
+      name = "bomber-18.04.2.tar.xz";
     };
   };
   bovo = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/bovo-18.04.1.tar.xz";
-      sha256 = "1lm465vcmf4glql9krxl36sr6msgayqkzinammw9ian1wmih9qbn";
-      name = "bovo-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/bovo-18.04.2.tar.xz";
+      sha256 = "0f5v8gcb0kj5bcrir2697v10pj0xzjyc1ynq3djbj2k9n76nd85p";
+      name = "bovo-18.04.2.tar.xz";
     };
   };
   calendarsupport = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/calendarsupport-18.04.1.tar.xz";
-      sha256 = "02zw1hyqwy031bg0nyxjvayjfamm0z9iw9v9f71hfrsi9siyf77a";
-      name = "calendarsupport-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/calendarsupport-18.04.2.tar.xz";
+      sha256 = "1jp9bkabq267kznjn2dd9h6a33rynlcaak9i2s07jvm0r2wpp8ka";
+      name = "calendarsupport-18.04.2.tar.xz";
     };
   };
   cantor = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/cantor-18.04.1.tar.xz";
-      sha256 = "1hcdf755yzs8kz6qbxan47gn622pg137sqabfbvqjflnphzz7f08";
-      name = "cantor-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/cantor-18.04.2.tar.xz";
+      sha256 = "039jphc9l6sh85j348hjld09ls2wd0dm784c52pzmpf32bjnmfda";
+      name = "cantor-18.04.2.tar.xz";
     };
   };
   cervisia = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/cervisia-18.04.1.tar.xz";
-      sha256 = "03slkk30k747f73dk98q4b930m7w1cimim053hl9y50n1c63n021";
-      name = "cervisia-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/cervisia-18.04.2.tar.xz";
+      sha256 = "0p80prz7ql14pgfa9mj34i78qa1jm7dbyjdvqv3f7d5dfqnqd3m9";
+      name = "cervisia-18.04.2.tar.xz";
     };
   };
   dolphin = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/dolphin-18.04.1.tar.xz";
-      sha256 = "11wm2wqmkni798xj6g8z7r6qyfy6db9k7xwnp90k2g1qb5n0xnsh";
-      name = "dolphin-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/dolphin-18.04.2.tar.xz";
+      sha256 = "0gk8m05xfpp8fal7rhw51nx03y39sj1z2ngx5s7xhf26hv2cyzmj";
+      name = "dolphin-18.04.2.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/dolphin-plugins-18.04.1.tar.xz";
-      sha256 = "00azpyy8xh0d62vayj04l3cbwxgxax430wh35jbv828vng3d2pfc";
-      name = "dolphin-plugins-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/dolphin-plugins-18.04.2.tar.xz";
+      sha256 = "11mqb0jcjm5lr9jqr8nlm1316mirl5sls45p1fa6gyyqbxps2iyv";
+      name = "dolphin-plugins-18.04.2.tar.xz";
     };
   };
   dragon = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/dragon-18.04.1.tar.xz";
-      sha256 = "1phrgssp3x11dmg07yvyi1hsmigfw8q6bblsizr9xm0pvmgrdjl0";
-      name = "dragon-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/dragon-18.04.2.tar.xz";
+      sha256 = "0zcg6k9bqcvld2hjf3aa4fh7xm7nikf9xk739wp9dln67lrbw2hm";
+      name = "dragon-18.04.2.tar.xz";
     };
   };
   eventviews = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/eventviews-18.04.1.tar.xz";
-      sha256 = "0jq1adi764a4w1kszhbdm49dylbwai4ipasjyrkqnf85xly48g40";
-      name = "eventviews-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/eventviews-18.04.2.tar.xz";
+      sha256 = "1ffd7lxs48jypjj6q46p8lzw4ppc5xa2f16cxhnaflkdkdnmp8gl";
+      name = "eventviews-18.04.2.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ffmpegthumbs-18.04.1.tar.xz";
-      sha256 = "06ls31wxgvnc4c7bc3ba14w4w64b9x37q3zmcnslyydghhnr0qnn";
-      name = "ffmpegthumbs-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ffmpegthumbs-18.04.2.tar.xz";
+      sha256 = "01law0kav378y7id85717y456lwbn4p7ymjp23k5psh12yd6m3k7";
+      name = "ffmpegthumbs-18.04.2.tar.xz";
     };
   };
   filelight = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/filelight-18.04.1.tar.xz";
-      sha256 = "1w169433m5823h1axn4ami9hk4rimi87ypiqagyyl13bncb7s6as";
-      name = "filelight-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/filelight-18.04.2.tar.xz";
+      sha256 = "1i0wzfwl4gqvpzd13m1aa135laq5f5vkf5sji2ld8f4xa97ipgy2";
+      name = "filelight-18.04.2.tar.xz";
     };
   };
   granatier = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/granatier-18.04.1.tar.xz";
-      sha256 = "0q5a2w2bz40qnk7jpcknsc4758k91cd1rh3rxa4v4wlq51id7lzz";
-      name = "granatier-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/granatier-18.04.2.tar.xz";
+      sha256 = "1kkh06slfs5g1gzlzlmw4fi8ma4nbkk3qnb4f46m8qzczymcj68y";
+      name = "granatier-18.04.2.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/grantlee-editor-18.04.1.tar.xz";
-      sha256 = "0ysirk51y993jxvvk98h2r9awsc4zyijavfja6zl0gsnvwwrjnjs";
-      name = "grantlee-editor-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/grantlee-editor-18.04.2.tar.xz";
+      sha256 = "0niky7v12s00x954zvmlqg6833hmvabr36a7b7i85w7k5qs9r2gq";
+      name = "grantlee-editor-18.04.2.tar.xz";
     };
   };
   grantleetheme = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/grantleetheme-18.04.1.tar.xz";
-      sha256 = "0gzsxxywaqs6lc111hsw736p6gz55xs77v9bpk48igk37r9a0rs8";
-      name = "grantleetheme-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/grantleetheme-18.04.2.tar.xz";
+      sha256 = "09d0yy3b7d3d64r46hwq21n5ik8ksn385i41biqr85cnl4is7pd7";
+      name = "grantleetheme-18.04.2.tar.xz";
     };
   };
   gwenview = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/gwenview-18.04.1.tar.xz";
-      sha256 = "0wyxwqsf2nynz4h87lgy1xla8nj7mi94b997pmp70jzy4936l8bi";
-      name = "gwenview-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/gwenview-18.04.2.tar.xz";
+      sha256 = "1kic82x3ixy0jrxf37aaxb2dncxvwagmw6c3hc1zyb8fi0n9hhw4";
+      name = "gwenview-18.04.2.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/incidenceeditor-18.04.1.tar.xz";
-      sha256 = "0kc18pml59mhn9bn0g96mw46dmxq7crgn4033dxsfczak0kdr474";
-      name = "incidenceeditor-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/incidenceeditor-18.04.2.tar.xz";
+      sha256 = "00dd6qnhwf153d14jpv8idnfw55hyfwqfxj13wzaqpkv7pgip56a";
+      name = "incidenceeditor-18.04.2.tar.xz";
     };
   };
   juk = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/juk-18.04.1.tar.xz";
-      sha256 = "01zgxxx00hxag29883xfgw4r0m4j66iwr83bap55ni018xgkf4c3";
-      name = "juk-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/juk-18.04.2.tar.xz";
+      sha256 = "0p73xmymjkzi9pab9lia3bkz4xk0lcdnjgr9kkx4n0rrwj2dccpd";
+      name = "juk-18.04.2.tar.xz";
     };
   };
   k3b = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/k3b-18.04.1.tar.xz";
-      sha256 = "0py84q63r40mh8pp0r70gzwidfxv9kj5firvr7pp59rk9fsxznl7";
-      name = "k3b-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/k3b-18.04.2.tar.xz";
+      sha256 = "1yy6i9ca4y04vzb1ykdvvbmds5gb15a1hrsib3qj294mw8gfrhyn";
+      name = "k3b-18.04.2.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kaccounts-integration-18.04.1.tar.xz";
-      sha256 = "1abyhaa7gj2admk6kf555sbwzc7yha3ql41dhw4j3k6kpzkqk9zj";
-      name = "kaccounts-integration-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kaccounts-integration-18.04.2.tar.xz";
+      sha256 = "1ijsjaxdiqkd0jjj6wkaf4y1a064mx0xch1prqvjjfx5g2ja2k1b";
+      name = "kaccounts-integration-18.04.2.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kaccounts-providers-18.04.1.tar.xz";
-      sha256 = "15ygghq434qkj1z5iislm8fz0m8z6rkpiyrcjbmqs0cw4s0mqzp6";
-      name = "kaccounts-providers-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kaccounts-providers-18.04.2.tar.xz";
+      sha256 = "1hpn7vpdpj7swm9xkdc1kr7qhbcljbswl87c1nrg39lfw44w0iyw";
+      name = "kaccounts-providers-18.04.2.tar.xz";
     };
   };
   kaddressbook = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kaddressbook-18.04.1.tar.xz";
-      sha256 = "0w02gc9l8jhzf15ljig83ddbkzf430k1qbqp821b3rz5s20gg4m5";
-      name = "kaddressbook-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kaddressbook-18.04.2.tar.xz";
+      sha256 = "0mg1g5x5hg3cdpxg5qf08l1d0ds3q5dm6xmkrripq5adgz77mqgr";
+      name = "kaddressbook-18.04.2.tar.xz";
     };
   };
   kajongg = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kajongg-18.04.1.tar.xz";
-      sha256 = "1vpkj42ylzpakrqy84hkp0hvj4q4x7wnarwwqqj8xp4xi40na481";
-      name = "kajongg-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kajongg-18.04.2.tar.xz";
+      sha256 = "1zv5g7q8sjhjzb16f52k2129awz5v5m15vkj06rnn3yvhhm694kn";
+      name = "kajongg-18.04.2.tar.xz";
     };
   };
   kalarm = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kalarm-18.04.1.tar.xz";
-      sha256 = "0v6maszs79959jkciy5j9xnqggr9ymjzvsibr1j5s30kynlzpxkm";
-      name = "kalarm-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kalarm-18.04.2.tar.xz";
+      sha256 = "18mh380kwg4pgphk0854san2v3iccra5fsydyjlh9g3mi4wkf6fj";
+      name = "kalarm-18.04.2.tar.xz";
     };
   };
   kalarmcal = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kalarmcal-18.04.1.tar.xz";
-      sha256 = "1j04wdb6vg2896hb8y28lm8sna0lil8021i2kw97crfhramldvjk";
-      name = "kalarmcal-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kalarmcal-18.04.2.tar.xz";
+      sha256 = "0ks9k5yrf8nld5x31hlfhdhypy7hi7h62kyqp707kpijhbjb32r6";
+      name = "kalarmcal-18.04.2.tar.xz";
     };
   };
   kalgebra = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kalgebra-18.04.1.tar.xz";
-      sha256 = "0gg1fb4cgnnrxyrm554847kpa1bs57zgi9ia8f9wmcivyd35vvyf";
-      name = "kalgebra-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kalgebra-18.04.2.tar.xz";
+      sha256 = "1vn3qcw8af32njpvg4gpqxx5k0v9wzs67c43var0pa190b6bsjhw";
+      name = "kalgebra-18.04.2.tar.xz";
     };
   };
   kalzium = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kalzium-18.04.1.tar.xz";
-      sha256 = "00x2jql639rmbvcfj72yjmfb98f9msfwi2g2mqyww43ja3c835ic";
-      name = "kalzium-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kalzium-18.04.2.tar.xz";
+      sha256 = "12qivsw7pq85z09100bbzca24ag7wdl5ywjf8whi3m1w05xasl61";
+      name = "kalzium-18.04.2.tar.xz";
     };
   };
   kamera = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kamera-18.04.1.tar.xz";
-      sha256 = "1ra7hdvs6fnkbzqvm5sryk6ymlgj0ngsg98yhznda0qvrrkgfahg";
-      name = "kamera-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kamera-18.04.2.tar.xz";
+      sha256 = "02c7nf9f43lxzk88i4y5laj60m7b4062n7lz5jvdiwvlsd9hqkm8";
+      name = "kamera-18.04.2.tar.xz";
     };
   };
   kamoso = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kamoso-18.04.1.tar.xz";
-      sha256 = "1rd08647zx2k7xq8jclxsk0dgjgdaih6fxmnrd7awzjmj0qh89a7";
-      name = "kamoso-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kamoso-18.04.2.tar.xz";
+      sha256 = "1gwq6gairy4zm8vqdq3x9r3rx81ybq5rg7cncyrxhyiyk65w4fb6";
+      name = "kamoso-18.04.2.tar.xz";
     };
   };
   kanagram = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kanagram-18.04.1.tar.xz";
-      sha256 = "0g4zmr10jq9vw92z9nbfvigz6pbjg1p1zc1aspwlh38ajk8sr3gb";
-      name = "kanagram-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kanagram-18.04.2.tar.xz";
+      sha256 = "09l9inx079hbhil47k3w7gkx455z42nqy4jisvs7m8l7c7d7ns3x";
+      name = "kanagram-18.04.2.tar.xz";
     };
   };
   kapman = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kapman-18.04.1.tar.xz";
-      sha256 = "14s2kg50r9nlg53vsi1x59kc8z1rgnqcq028a6zwfnv0sdsa7pw5";
-      name = "kapman-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kapman-18.04.2.tar.xz";
+      sha256 = "0bj6zd6jyjwj4lswn7xyq2gl09ki8iykrjjpy2m1ywm339x8q96v";
+      name = "kapman-18.04.2.tar.xz";
     };
   };
   kapptemplate = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kapptemplate-18.04.1.tar.xz";
-      sha256 = "064pw1fkbm52pkcg9hyay8mkraw3fdlycgx306p9brahvxb9xjsb";
-      name = "kapptemplate-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kapptemplate-18.04.2.tar.xz";
+      sha256 = "1d5z2ghwlkkz7i7hfpsybrblcadini0m1lml2iyiyb75hl1fprmc";
+      name = "kapptemplate-18.04.2.tar.xz";
     };
   };
   kate = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kate-18.04.1.tar.xz";
-      sha256 = "1xbckjsp5imxcda8vrdb5flgb5sjmdylwy1yr5v01nilmqgpmwa8";
-      name = "kate-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kate-18.04.2.tar.xz";
+      sha256 = "10684wzvzm7mrr69lrnpk3dnjkhqwrxv0mimq0927c1ln76sqy0n";
+      name = "kate-18.04.2.tar.xz";
     };
   };
   katomic = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/katomic-18.04.1.tar.xz";
-      sha256 = "0g3kkibgnxkg5zxgja7rqad57fpw28qapf8rlbczkmxls581ifw6";
-      name = "katomic-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/katomic-18.04.2.tar.xz";
+      sha256 = "0v000v98xsy9x9ka5w1maprgj4pma97v3y07x39l2a96wkinh1k0";
+      name = "katomic-18.04.2.tar.xz";
     };
   };
   kbackup = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kbackup-18.04.1.tar.xz";
-      sha256 = "1gv5m4d6zcadamcicllfp8smm7k4846a2qy4pgm006lhk390bsyz";
-      name = "kbackup-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kbackup-18.04.2.tar.xz";
+      sha256 = "1py7b2mjf1lhpg3hpwy8agjh7wcql67myv3jx2j6r660ni8rbf66";
+      name = "kbackup-18.04.2.tar.xz";
     };
   };
   kblackbox = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kblackbox-18.04.1.tar.xz";
-      sha256 = "0hv6ziw2dy88fbc1z0vlflagsrr7x97r9c5l4w9v4acr0ih7ms7h";
-      name = "kblackbox-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kblackbox-18.04.2.tar.xz";
+      sha256 = "1xllh7sds3pm8hjs1l88i8w7xzizl3kv9bdvznih0f61mwrwhwph";
+      name = "kblackbox-18.04.2.tar.xz";
     };
   };
   kblocks = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kblocks-18.04.1.tar.xz";
-      sha256 = "12339f1g73h3qg9a21kqmkqp6ywiw1gvnwdww45dzflf4w931lsw";
-      name = "kblocks-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kblocks-18.04.2.tar.xz";
+      sha256 = "0gnj8lflm7jmqz8i5ymy5gmb11d0v1483bpllvmhsjylk7v7qzal";
+      name = "kblocks-18.04.2.tar.xz";
     };
   };
   kblog = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kblog-18.04.1.tar.xz";
-      sha256 = "1gndfvny1zh2w1daxmpix5sn2wlbc2430m3a21lvgp3qmhb5rwkr";
-      name = "kblog-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kblog-18.04.2.tar.xz";
+      sha256 = "17yh6599k50nayw2b0lx80hkkz7c46xwn389g674c0zyj768pbxl";
+      name = "kblog-18.04.2.tar.xz";
     };
   };
   kbounce = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kbounce-18.04.1.tar.xz";
-      sha256 = "0qjbzmjgcvxbpvbqxyyh02pk5hr6z871n13awsq770xwbr1pdnwc";
-      name = "kbounce-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kbounce-18.04.2.tar.xz";
+      sha256 = "10bipg1ny6997xyqh8d7346xf1j7g4p9bzzmappzs6mx1bsm7hgl";
+      name = "kbounce-18.04.2.tar.xz";
     };
   };
   kbreakout = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kbreakout-18.04.1.tar.xz";
-      sha256 = "0yr9hwlwdp1fi2parzniyq5rfv4fxbxxs63xfggaz7ndbm1h8bif";
-      name = "kbreakout-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kbreakout-18.04.2.tar.xz";
+      sha256 = "0y40d36ms3xzch4c2f30gfawr12zzmjgdfh603yy52x81z866svf";
+      name = "kbreakout-18.04.2.tar.xz";
     };
   };
   kbruch = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kbruch-18.04.1.tar.xz";
-      sha256 = "08wb7f2jhz3dkx22sj2k4sairl715nrk7c2swd88dcaskcy411nk";
-      name = "kbruch-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kbruch-18.04.2.tar.xz";
+      sha256 = "1xr6rwdsnxq6as8f1yc48l2997795xgc2py80df84v1gpk0hhm2n";
+      name = "kbruch-18.04.2.tar.xz";
     };
   };
   kcachegrind = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcachegrind-18.04.1.tar.xz";
-      sha256 = "1mig7xm67w3vwslymbfm51w8w9cnqzk41kqp998j6g7dfrh8476g";
-      name = "kcachegrind-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcachegrind-18.04.2.tar.xz";
+      sha256 = "1bkqb39a0q0di17j0qxg907fm47002vj24j19pmg94qm6nl4b2i4";
+      name = "kcachegrind-18.04.2.tar.xz";
     };
   };
   kcalc = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcalc-18.04.1.tar.xz";
-      sha256 = "14j2w9w31cqmsls3zrgifywbz5bxkzkryggfd1jxiz9q526ylpxy";
-      name = "kcalc-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcalc-18.04.2.tar.xz";
+      sha256 = "19ryii9jvyssa6676an2m09mgdz18340p6jv067qscg0sw5ka3fv";
+      name = "kcalc-18.04.2.tar.xz";
     };
   };
   kcalcore = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcalcore-18.04.1.tar.xz";
-      sha256 = "0q23pb9pkii6czk3angl3xzlzc90fck1pwc05695rz90iwbxq62x";
-      name = "kcalcore-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcalcore-18.04.2.tar.xz";
+      sha256 = "0ailxkviabv5qg02wl2phfx06znbs5dxncb6nzl87qrzck4myj31";
+      name = "kcalcore-18.04.2.tar.xz";
     };
   };
   kcalutils = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcalutils-18.04.1.tar.xz";
-      sha256 = "05ma56f0ly8nq62p6nlzkscdq5m93142kakhqrsl17c902bvkcmm";
-      name = "kcalutils-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcalutils-18.04.2.tar.xz";
+      sha256 = "1z3bzx78n4p88p0a3w1m2a984pcqmi8aph28d3h2isiinlfwgak2";
+      name = "kcalutils-18.04.2.tar.xz";
     };
   };
   kcharselect = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcharselect-18.04.1.tar.xz";
-      sha256 = "0pv22v1x3n73rxzpihsxz5xxy1c37lq72jcscwylwmwfyszmvdwx";
-      name = "kcharselect-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcharselect-18.04.2.tar.xz";
+      sha256 = "0n71jy1a6hsabzzhvrg46067drb97aa095159bxma1x9xjgbdq14";
+      name = "kcharselect-18.04.2.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcolorchooser-18.04.1.tar.xz";
-      sha256 = "1wzy9a3pz0jwwmgbqxqlfii0faascrxnxq398wzrnx955shlksbm";
-      name = "kcolorchooser-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcolorchooser-18.04.2.tar.xz";
+      sha256 = "0m0izh28h2n0dja5rwdqg88g0v9v9nz8gmv73zhz72mi4p7vq2h2";
+      name = "kcolorchooser-18.04.2.tar.xz";
     };
   };
   kcontacts = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcontacts-18.04.1.tar.xz";
-      sha256 = "0725cad646qzpgpvxl0vyb1a4hpbk0b6zb3wbdim4al56y7x1rxh";
-      name = "kcontacts-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcontacts-18.04.2.tar.xz";
+      sha256 = "03mzacymwxj50873vs0rla2bxm29kfc9d7sv692nzmccv00r21mj";
+      name = "kcontacts-18.04.2.tar.xz";
     };
   };
   kcron = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kcron-18.04.1.tar.xz";
-      sha256 = "1wlk36s6i53vk4crrvijbfmagh5d8sjbmcacdwdcf4vlb56kxphr";
-      name = "kcron-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kcron-18.04.2.tar.xz";
+      sha256 = "1nwpsq4qhrlggdcn9snfl124g355h3c69360ngziwj66dnnwwcm7";
+      name = "kcron-18.04.2.tar.xz";
     };
   };
   kdav = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdav-18.04.1.tar.xz";
-      sha256 = "16abp767h4rs35yj0j8kgmhm4k09cidnsmh1ihx2b53ya1ivmv9b";
-      name = "kdav-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdav-18.04.2.tar.xz";
+      sha256 = "0m3lf2mjmcblnlqsp9jrv508c8nkhvbrbpcp0hw9sdw8qaplb6x3";
+      name = "kdav-18.04.2.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdebugsettings-18.04.1.tar.xz";
-      sha256 = "1bz5wcap6kqjv6164zm7wcm31q634785lqlarsc5hqld5xjgr7ig";
-      name = "kdebugsettings-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdebugsettings-18.04.2.tar.xz";
+      sha256 = "0k60nld8r7g5wxj8l14m5pdkzwjhyqgznd4kjfx3vn63xx002ysp";
+      name = "kdebugsettings-18.04.2.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kde-dev-scripts-18.04.1.tar.xz";
-      sha256 = "08wsj1h44lmvvv43k9l3mxvi2hr498hz3d22z0bwcdjaqgvy60r5";
-      name = "kde-dev-scripts-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kde-dev-scripts-18.04.2.tar.xz";
+      sha256 = "08a9d9ib8wcqgi4kyfh8adzrnf804vjlcdha97wkypz4qk6bilw2";
+      name = "kde-dev-scripts-18.04.2.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kde-dev-utils-18.04.1.tar.xz";
-      sha256 = "13wpa4xrkm3711vdwjkklibaf7as64klw4hpq9s9vx33ma73sf9a";
-      name = "kde-dev-utils-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kde-dev-utils-18.04.2.tar.xz";
+      sha256 = "0cwfh0innaskb3wipij3pzcx4a6dvgjq1slvz2kvcp7cqx9bmhhs";
+      name = "kde-dev-utils-18.04.2.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdeedu-data-18.04.1.tar.xz";
-      sha256 = "1ccf8bjd2fc2chgf63bwg91c0r4acxf40w81rssi83wjvnhg4d5j";
-      name = "kdeedu-data-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdeedu-data-18.04.2.tar.xz";
+      sha256 = "03qklcwvjqdgmh8gdz9l98dqmn2yvvs48ha5qlj141jw0cla8lss";
+      name = "kdeedu-data-18.04.2.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdegraphics-mobipocket-18.04.1.tar.xz";
-      sha256 = "1y9bjnpbpriyhs007wli7m0q5g9wv2d7izp0qxk4xzmrrw7k5v51";
-      name = "kdegraphics-mobipocket-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdegraphics-mobipocket-18.04.2.tar.xz";
+      sha256 = "1pmqxwlaxxabv8vl6rq7zch1zlizcijvamxfdil49h603jrpspqm";
+      name = "kdegraphics-mobipocket-18.04.2.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdegraphics-thumbnailers-18.04.1.tar.xz";
-      sha256 = "06798hwxyd2xvf3aiigwzd53frzi0mqxsbxliznqxxjvk5lcp1ha";
-      name = "kdegraphics-thumbnailers-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdegraphics-thumbnailers-18.04.2.tar.xz";
+      sha256 = "1n5a43d80qdm7gp8k58h3kkp5kbbwg532arj66gfglcimvyw7ybl";
+      name = "kdegraphics-thumbnailers-18.04.2.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdenetwork-filesharing-18.04.1.tar.xz";
-      sha256 = "18dilp18312v1zbrfq5rq223s6cy2lmdmgvp2hg5a25rmldw1yiw";
-      name = "kdenetwork-filesharing-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdenetwork-filesharing-18.04.2.tar.xz";
+      sha256 = "08rg7lw07xi9iskqi09nkw00kgim437a9wm7svcm1nhwnln45bas";
+      name = "kdenetwork-filesharing-18.04.2.tar.xz";
     };
   };
   kdenlive = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdenlive-18.04.1.tar.xz";
-      sha256 = "059xqybn3r1w432mbnxx5ds1whj5x23ym2lm90wg23b9hmmmhxl3";
-      name = "kdenlive-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdenlive-18.04.2.tar.xz";
+      sha256 = "08dy8fww0aq1g69pznwach2yykj7izyp2z8axx724drmqh4jifri";
+      name = "kdenlive-18.04.2.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdepim-addons-18.04.1.tar.xz";
-      sha256 = "1qninnlhwmkw6nxxymjww1x7krm87nz5m6p66y3ghrgyl0q16k7b";
-      name = "kdepim-addons-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdepim-addons-18.04.2.tar.xz";
+      sha256 = "0g3rbq8129pa1qq2vrxlh049nfqrl7k3zqnqbhavb9kggvgfx151";
+      name = "kdepim-addons-18.04.2.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdepim-apps-libs-18.04.1.tar.xz";
-      sha256 = "1a41km8nhgrc24qlgh64560p8il6q9dlcmy25x92s1xmpn1zg1lc";
-      name = "kdepim-apps-libs-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdepim-apps-libs-18.04.2.tar.xz";
+      sha256 = "000qgbr3lvpcx4p42r0f7bl8wlhf3sc320svf2mx4vpgbi28fm7y";
+      name = "kdepim-apps-libs-18.04.2.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdepim-runtime-18.04.1.tar.xz";
-      sha256 = "0gl2wkkaxpz13rg6zyclcjkc0i7qwqwxcvamgb3cl6l6qkp869w1";
-      name = "kdepim-runtime-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdepim-runtime-18.04.2.tar.xz";
+      sha256 = "18sxzdm2drn16zk0wmsa1sxabag04x50sn72x4arjr32b9pgr8fp";
+      name = "kdepim-runtime-18.04.2.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdesdk-kioslaves-18.04.1.tar.xz";
-      sha256 = "1mx3pg36mx0b6v2kq3a3spxm40rdk4bgkhzzjwphppqkxc57bgln";
-      name = "kdesdk-kioslaves-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdesdk-kioslaves-18.04.2.tar.xz";
+      sha256 = "1csvzwq4hd9r36w5kms7w4zadwd8g10p1mhaq5p9afdg531x5zza";
+      name = "kdesdk-kioslaves-18.04.2.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdesdk-thumbnailers-18.04.1.tar.xz";
-      sha256 = "0s07h5kfl2h2w0qarz28362n92jdbbq7iw4cy93p949mp6jz1xij";
-      name = "kdesdk-thumbnailers-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdesdk-thumbnailers-18.04.2.tar.xz";
+      sha256 = "0k797w3qm4phvfmaqvhqds79sx340frli9jklsjjkmb1zv3yzz3f";
+      name = "kdesdk-thumbnailers-18.04.2.tar.xz";
     };
   };
   kdf = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdf-18.04.1.tar.xz";
-      sha256 = "1hmq92vglivs9q536g3qx0b7v3g7nlvkly81p8brqs55cw0npf8d";
-      name = "kdf-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdf-18.04.2.tar.xz";
+      sha256 = "1dwvn5rb3jpz4vl2msxm88a1lcb7sb72v0s2161hxrk8xhnxngr3";
+      name = "kdf-18.04.2.tar.xz";
     };
   };
   kdialog = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdialog-18.04.1.tar.xz";
-      sha256 = "0xmdzwawa43xfv9a2sm2rijiiik7b0cvpbcxvwf7s37gwrw5fk05";
-      name = "kdialog-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdialog-18.04.2.tar.xz";
+      sha256 = "0bfvndacp7hbmgkq33kxl64c5kgi4a7m5i4bb5r5bw7d5mdqzrkn";
+      name = "kdialog-18.04.2.tar.xz";
     };
   };
   kdiamond = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kdiamond-18.04.1.tar.xz";
-      sha256 = "12z0v4w8adlzsnymn5dsc1fpgqx2w3hx38chwc7l2l5bvgx5ycc1";
-      name = "kdiamond-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kdiamond-18.04.2.tar.xz";
+      sha256 = "0hqkbjdc0ndflwiqg2m1f4zzvz3cgwmxkxc8zxyavl50br471aji";
+      name = "kdiamond-18.04.2.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/keditbookmarks-18.04.1.tar.xz";
-      sha256 = "1qi8y5j9s9d4i6vqvw5h29b55q73zfgj4v76dxdl1z85ghcv0my4";
-      name = "keditbookmarks-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/keditbookmarks-18.04.2.tar.xz";
+      sha256 = "1dfc97vvknywb833ndxilynhxhna6qsfq9rd2fapz5jwk0y7cdnj";
+      name = "keditbookmarks-18.04.2.tar.xz";
     };
   };
   kfind = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kfind-18.04.1.tar.xz";
-      sha256 = "15fha4k00s88n0k7ad0bnw9iyyjyxlhjmnlcr84hfbh6wiwn4l4k";
-      name = "kfind-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kfind-18.04.2.tar.xz";
+      sha256 = "0j5awrlyf6f9z9xybssq0s4yvygxni90zsmqi35rm4vjd38rixjd";
+      name = "kfind-18.04.2.tar.xz";
     };
   };
   kfloppy = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kfloppy-18.04.1.tar.xz";
-      sha256 = "0rw3r09zil7121ssms1mvccw435nmmgmz0zx0rmfvpk6bks0cim9";
-      name = "kfloppy-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kfloppy-18.04.2.tar.xz";
+      sha256 = "08pd9qq9syw7mf5d21y1306k0l540zk5dqjn380mng7rmiddnchb";
+      name = "kfloppy-18.04.2.tar.xz";
     };
   };
   kfourinline = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kfourinline-18.04.1.tar.xz";
-      sha256 = "0gm8s8gi9nnilcvmnz4gk26wrszjg7y8xfq4dyqw87axwaqcv2z6";
-      name = "kfourinline-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kfourinline-18.04.2.tar.xz";
+      sha256 = "02dsip9cjbygjc7palb1dr9w4g32c4n5krhwf3p0mnmwyhnqbqv3";
+      name = "kfourinline-18.04.2.tar.xz";
     };
   };
   kgeography = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kgeography-18.04.1.tar.xz";
-      sha256 = "16c2gidj8jc4xr35ph392gh4r75vfiqw7n07lpv30d6v3h1mq2jy";
-      name = "kgeography-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kgeography-18.04.2.tar.xz";
+      sha256 = "0sm6sw1ibmsf8n704a114244dbj0387bzjrcblfa0j1zcyf6k9bg";
+      name = "kgeography-18.04.2.tar.xz";
     };
   };
   kget = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kget-18.04.1.tar.xz";
-      sha256 = "1kzvalb1a27bn9ac4iqkgar7fydspd9bhva3n0v9gzz34p3lv1f7";
-      name = "kget-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kget-18.04.2.tar.xz";
+      sha256 = "0i01z7nic11qh9g41dva9vsip02qy0r7axysj53p5yx1syf5brwi";
+      name = "kget-18.04.2.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kgoldrunner-18.04.1.tar.xz";
-      sha256 = "0w1vppp0r1prciz6gg5srlj0z05m5wcbpp3wwz6wxh2vnpbm2lc1";
-      name = "kgoldrunner-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kgoldrunner-18.04.2.tar.xz";
+      sha256 = "1rangxnzfs83f0hx6k39dc9yiaqn1jr6yznf51zdzb23k4jcczm4";
+      name = "kgoldrunner-18.04.2.tar.xz";
     };
   };
   kgpg = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kgpg-18.04.1.tar.xz";
-      sha256 = "0b2kngq4dqs3qxkvxny72sfm2xlbsmhb986zmpp0wsm09gd6lhyh";
-      name = "kgpg-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kgpg-18.04.2.tar.xz";
+      sha256 = "1r2jsm1klgnzprx342qlj429jbvpa4gnk69b9bfxz8la0lfv71n4";
+      name = "kgpg-18.04.2.tar.xz";
     };
   };
   khangman = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/khangman-18.04.1.tar.xz";
-      sha256 = "1vcr5gp3gz0dygkn8dhkg3fpyqny8vc61nymwii4v247znhg7hw4";
-      name = "khangman-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/khangman-18.04.2.tar.xz";
+      sha256 = "1vyim621gqbfq3wmlr864nm7c4mrn01bpz2m0sn33n7hbnpzb1rw";
+      name = "khangman-18.04.2.tar.xz";
     };
   };
   khelpcenter = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/khelpcenter-18.04.1.tar.xz";
-      sha256 = "00p3s5zmql82dwr4lmfy3yqyyn7h2209lhf49cajh01hd2nasig1";
-      name = "khelpcenter-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/khelpcenter-18.04.2.tar.xz";
+      sha256 = "13va6h9z0s21dm7jgddka0x7i5llrr398mk7v4kmdr9zbzd6727c";
+      name = "khelpcenter-18.04.2.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kidentitymanagement-18.04.1.tar.xz";
-      sha256 = "1lb1vl3r7avj45lfrlabbbkq0f7anpx04g20ajn2n8ajfgjpns9q";
-      name = "kidentitymanagement-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kidentitymanagement-18.04.2.tar.xz";
+      sha256 = "1rjmafsbblchqpl865ah7m7arf5kz30cc8sk2z4ps5c8lqzn8gql";
+      name = "kidentitymanagement-18.04.2.tar.xz";
     };
   };
   kig = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kig-18.04.1.tar.xz";
-      sha256 = "1ry2rgmy7y4wyxwwz2f7qrj5aw5sjgv46vs4x5203v514p625nzw";
-      name = "kig-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kig-18.04.2.tar.xz";
+      sha256 = "0i8jkbaxskgxwvsnjqysvmdm5a6yq3v0w6h3fmrk9jsp5gf120gw";
+      name = "kig-18.04.2.tar.xz";
     };
   };
   kigo = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kigo-18.04.1.tar.xz";
-      sha256 = "1l2bdxjv5kiz6f0gmqwd43jghps5l2cvw8228ay4l7r4r9wp0ihr";
-      name = "kigo-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kigo-18.04.2.tar.xz";
+      sha256 = "1fkrx9fhxijw0sd861pn2ihphspyhx6i79z2816gv3riqa0a9j51";
+      name = "kigo-18.04.2.tar.xz";
     };
   };
   killbots = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/killbots-18.04.1.tar.xz";
-      sha256 = "06vqgahirw01zfbhr2dj5z7fd2jay3kizvl04wwwp1fr8jsw3plw";
-      name = "killbots-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/killbots-18.04.2.tar.xz";
+      sha256 = "0ppg1n2m5cd3rgl0ixvga7i9j0f2v97cfxzpwqhbymwz4970cxqz";
+      name = "killbots-18.04.2.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kimagemapeditor-18.04.1.tar.xz";
-      sha256 = "1144z9zasc3x678q8xnk98nn5y0bzaal0lxc6xb51ib4q8q2lhn1";
-      name = "kimagemapeditor-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kimagemapeditor-18.04.2.tar.xz";
+      sha256 = "1nl0am3kww53bg0wds1p8bmw8hbn79zrnh06bhk9f6p0n5n817jc";
+      name = "kimagemapeditor-18.04.2.tar.xz";
     };
   };
   kimap = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kimap-18.04.1.tar.xz";
-      sha256 = "03y1n4rf7xdxb82716wijz196dk0rg8d50rs9kycymys9sgq5y0h";
-      name = "kimap-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kimap-18.04.2.tar.xz";
+      sha256 = "0fxx24nxm055vkdgyisfx648n2ayxrgacmkv519bham9v9qg32zd";
+      name = "kimap-18.04.2.tar.xz";
     };
   };
   kio-extras = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kio-extras-18.04.1.tar.xz";
-      sha256 = "0635iam41i5afjspw08x99irqfsj7pa1w8wz4nfbx9yv2iclq1rh";
-      name = "kio-extras-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kio-extras-18.04.2.tar.xz";
+      sha256 = "1kmnfxh5dbgxismz03rbkf7pdgl187ddnr5k3gr547fdid9caphn";
+      name = "kio-extras-18.04.2.tar.xz";
     };
   };
   kiriki = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kiriki-18.04.1.tar.xz";
-      sha256 = "0n258bvhd5cgb978zqqkig6is5fb9idvwa7n860q1r2nimsnch5y";
-      name = "kiriki-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kiriki-18.04.2.tar.xz";
+      sha256 = "0apaa8ki57i3n1lnmgkqjccdx8vp4bwf020nvyxx7vwm8kqpm1hy";
+      name = "kiriki-18.04.2.tar.xz";
     };
   };
   kiten = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kiten-18.04.1.tar.xz";
-      sha256 = "1f6z5assiz6gxvhcp08x71qk3hyc36ib2sr6bmq0q7cbb7xlhbac";
-      name = "kiten-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kiten-18.04.2.tar.xz";
+      sha256 = "0bj6fb00wnvza5hwlxk6b2vhpp7vwsna184ghizx03cl242ig1c9";
+      name = "kiten-18.04.2.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kjumpingcube-18.04.1.tar.xz";
-      sha256 = "0p4manwh4pndhdnb45fczllpsvswwwgvz1wk8grx2axq0x6pjjln";
-      name = "kjumpingcube-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kjumpingcube-18.04.2.tar.xz";
+      sha256 = "0ll38kbm8yf2pnph3rbhh9ydx4ms7mr49y95k6azkxjbvn8hf4wg";
+      name = "kjumpingcube-18.04.2.tar.xz";
     };
   };
   kldap = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kldap-18.04.1.tar.xz";
-      sha256 = "0arriibg2flqr8rvd4fa8xd4rgr1rl3pwhxxskpfi4i3rl8w1a2i";
-      name = "kldap-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kldap-18.04.2.tar.xz";
+      sha256 = "1jlqr06y0bs3mzzbqf49hzwqyavs39rwc61mzgydm0951kalh2zs";
+      name = "kldap-18.04.2.tar.xz";
     };
   };
   kleopatra = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kleopatra-18.04.1.tar.xz";
-      sha256 = "0ayjxvm6sdg1waf44nw360nh740vi29c7m6frq2jyfbxn401x7p3";
-      name = "kleopatra-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kleopatra-18.04.2.tar.xz";
+      sha256 = "0c66j35zjg2hfknc3fqqh6x5ynfw0whgzi1q74hiv9225zbzb80a";
+      name = "kleopatra-18.04.2.tar.xz";
     };
   };
   klettres = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/klettres-18.04.1.tar.xz";
-      sha256 = "1vzr8pf6m24ng3kg44ld5hiap7qqfp2w1q7npyr6sq28rrm8jilb";
-      name = "klettres-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/klettres-18.04.2.tar.xz";
+      sha256 = "0wilxlfhgyj8pbq87kl4vx97f39kc9bpqcchc09qgc3ack40rakv";
+      name = "klettres-18.04.2.tar.xz";
     };
   };
   klickety = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/klickety-18.04.1.tar.xz";
-      sha256 = "1wk6g4a8gmd1z8qqgy30s3f2zgq651dv38gnbk3949j81k92084m";
-      name = "klickety-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/klickety-18.04.2.tar.xz";
+      sha256 = "0w9ajwqsklq2chj491rmph05vg4y4ibvbjwic9l99i8ybp89x00k";
+      name = "klickety-18.04.2.tar.xz";
     };
   };
   klines = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/klines-18.04.1.tar.xz";
-      sha256 = "0zslagiphj37i79896k71j40125nz74qknx75sp3iv2wafy0akgf";
-      name = "klines-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/klines-18.04.2.tar.xz";
+      sha256 = "1wdn3s4r3301ps84v7mw61zmwvlb8rdsvfgxbgrs46am052dszgg";
+      name = "klines-18.04.2.tar.xz";
     };
   };
   kmag = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmag-18.04.1.tar.xz";
-      sha256 = "163i0axbnxkyqhbri6k48x9jsb5l5ll8hl0zvcsw0srh8bzswvgd";
-      name = "kmag-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmag-18.04.2.tar.xz";
+      sha256 = "1fikna4rrsbzgdq9qiwpp1j48rimpf0frrnzgnjq8lnc61csfcjn";
+      name = "kmag-18.04.2.tar.xz";
     };
   };
   kmahjongg = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmahjongg-18.04.1.tar.xz";
-      sha256 = "1zl1mr8pg6sz2ydqilgdbh3758vw13af37s9g8pi7axva8adf0fp";
-      name = "kmahjongg-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmahjongg-18.04.2.tar.xz";
+      sha256 = "1a19r3kbysx7pzy96wl9sq8c03lwp105nqf9gzbhabm0kyx945hc";
+      name = "kmahjongg-18.04.2.tar.xz";
     };
   };
   kmail = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmail-18.04.1.tar.xz";
-      sha256 = "057727gsrdf0pkn5n17km5ryjiw5rimxixff0dax939d9403qwfg";
-      name = "kmail-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmail-18.04.2.tar.xz";
+      sha256 = "0miqwi55rc1zq1zfz75r8pzz4q3c81z61wp6w53zjhib50caa66i";
+      name = "kmail-18.04.2.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmail-account-wizard-18.04.1.tar.xz";
-      sha256 = "0qky1a0lrmy8mfiq0dqhrd8j7m1lc9p34ivx9vy4rr82r9g3y5jw";
-      name = "kmail-account-wizard-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmail-account-wizard-18.04.2.tar.xz";
+      sha256 = "1vj0bn0z4il34v3nadbw4ldp15yd0afisdriiw3nsyq5v8yp75h9";
+      name = "kmail-account-wizard-18.04.2.tar.xz";
     };
   };
   kmailtransport = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmailtransport-18.04.1.tar.xz";
-      sha256 = "09l79049dpkzc3iqdxv4jvglpynrq976gvr8n38k63mr5sajwg72";
-      name = "kmailtransport-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmailtransport-18.04.2.tar.xz";
+      sha256 = "1zc1q19xdb59pcqc2n850f4fh107b3f5nj31mhii8496mzz1nk0j";
+      name = "kmailtransport-18.04.2.tar.xz";
     };
   };
   kmbox = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmbox-18.04.1.tar.xz";
-      sha256 = "05zcnykb7asamqf8iqs63bl7jk5myywdqydhxz56jr19fw32lyqq";
-      name = "kmbox-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmbox-18.04.2.tar.xz";
+      sha256 = "0dwd7mkflggj4xdk65qpjlvzb15k6agz6pfmbx426xgpm0dq4bwc";
+      name = "kmbox-18.04.2.tar.xz";
     };
   };
   kmime = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmime-18.04.1.tar.xz";
-      sha256 = "1jlhlxw31c9g7z6yhqjsp76xm85ywrr0in4qazidwb9k8lkqxa7g";
-      name = "kmime-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmime-18.04.2.tar.xz";
+      sha256 = "02h2bpcf4mz4wfv1r2lj9xm01bbglwz23r4ay7373gilxjgcxx5h";
+      name = "kmime-18.04.2.tar.xz";
     };
   };
   kmines = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmines-18.04.1.tar.xz";
-      sha256 = "0i88pc7j18xighw8ii6gh5gxq9k2zy372ggdyany91dcjgmwhgw7";
-      name = "kmines-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmines-18.04.2.tar.xz";
+      sha256 = "0p1hg5nvpkyijl6nzshp136chiqvkwbbmniq7w9gdmf3ch7hr7ba";
+      name = "kmines-18.04.2.tar.xz";
     };
   };
   kmix = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmix-18.04.1.tar.xz";
-      sha256 = "1jq71pgnlz95na5fbm504pkrrahiclqbb0cwsqpbpi10m2nzcrwd";
-      name = "kmix-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmix-18.04.2.tar.xz";
+      sha256 = "1l2gqwxrhnbm9hxyyb0bsn8dxv2c52ha3576j5h62j4rwxzh5mm7";
+      name = "kmix-18.04.2.tar.xz";
     };
   };
   kmousetool = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmousetool-18.04.1.tar.xz";
-      sha256 = "08g5k9yfd5wrh47zp99hgq634vd9r23gjlr77xg86jqn8dj2lgqx";
-      name = "kmousetool-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmousetool-18.04.2.tar.xz";
+      sha256 = "0ivhdrdpn8fkws9lghj4iakd3qdrvyd6mp0v3zacdi2mccgcsclg";
+      name = "kmousetool-18.04.2.tar.xz";
     };
   };
   kmouth = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmouth-18.04.1.tar.xz";
-      sha256 = "08m5r9vd0gb06izav2g21qkfmg1gjpj0kn0nh785bbhs0bbngrci";
-      name = "kmouth-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmouth-18.04.2.tar.xz";
+      sha256 = "0zyjh1fbjkg2p0wwc5nw8mh26wbngm0c2vacxv1zx1xdhdwa4mbw";
+      name = "kmouth-18.04.2.tar.xz";
     };
   };
   kmplot = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kmplot-18.04.1.tar.xz";
-      sha256 = "01rxnc45jc6swsm2h8bw45n96lsalgbfzww18hlq1qpyjr20181h";
-      name = "kmplot-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kmplot-18.04.2.tar.xz";
+      sha256 = "0k2qpcwd6s34zx049na1i429ans8js6bgwynkz7fmva0fpc1kgwh";
+      name = "kmplot-18.04.2.tar.xz";
     };
   };
   knavalbattle = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/knavalbattle-18.04.1.tar.xz";
-      sha256 = "1kr37qmb4577i12wghc0qcbbqpxr2wzww1cqv0wcd9jmjd3mq1xw";
-      name = "knavalbattle-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/knavalbattle-18.04.2.tar.xz";
+      sha256 = "1l846gak5gb3r4sf38410c7lfpwna89x285ql5fhlgzr311xkhqm";
+      name = "knavalbattle-18.04.2.tar.xz";
     };
   };
   knetwalk = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/knetwalk-18.04.1.tar.xz";
-      sha256 = "02zpndbbyffakdxxswpmb1hrszh78a3ip6mfr8bqwnwbvzh80cjy";
-      name = "knetwalk-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/knetwalk-18.04.2.tar.xz";
+      sha256 = "0vvc2kkn9szgknxhcc5mphbsk0h121i0kaljr0330ggpxj0n6kfi";
+      name = "knetwalk-18.04.2.tar.xz";
     };
   };
   knotes = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/knotes-18.04.1.tar.xz";
-      sha256 = "0jc9mpnwgrbh8pra75gsiy9wm0aylm9a0ssw8bhfivb77dmqr44c";
-      name = "knotes-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/knotes-18.04.2.tar.xz";
+      sha256 = "0x20j9ln4gmi407avmkpn5snhsjfa70q7ica2z4l15yb43ds2viv";
+      name = "knotes-18.04.2.tar.xz";
     };
   };
   kolf = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kolf-18.04.1.tar.xz";
-      sha256 = "1bahv98dskknyy8rxpnjxywpcw09x58bsdg0aqgh5xdm0ym992ik";
-      name = "kolf-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kolf-18.04.2.tar.xz";
+      sha256 = "0cbl5as62qidi1i2902767apy8yyx7lkpbwm4hp681v8m34kwi6y";
+      name = "kolf-18.04.2.tar.xz";
     };
   };
   kollision = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kollision-18.04.1.tar.xz";
-      sha256 = "0pr4f9inxp77d761byis30jski642bhcfvbpcpnj9fi3k1cgzcna";
-      name = "kollision-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kollision-18.04.2.tar.xz";
+      sha256 = "0065p658792n03n0q0fmmgs6h2h31sczff25y0ka7xyky49452vs";
+      name = "kollision-18.04.2.tar.xz";
     };
   };
   kolourpaint = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kolourpaint-18.04.1.tar.xz";
-      sha256 = "1lfvmk9vhwa8j454pfh0x1klqb360zlsyydiiqm5a4dhc4wvcwzy";
-      name = "kolourpaint-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kolourpaint-18.04.2.tar.xz";
+      sha256 = "03rrhy1idhj39wfncxpbnrj7wji8lv39msv80zw1k394wdxz713r";
+      name = "kolourpaint-18.04.2.tar.xz";
     };
   };
   kompare = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kompare-18.04.1.tar.xz";
-      sha256 = "0kmf245fbm32hdgmyiv51ham3py7jhc3zpwfcfxbjyi94ikx4n79";
-      name = "kompare-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kompare-18.04.2.tar.xz";
+      sha256 = "0b90varbdq87apsxmp7rk8nbwk57wy6ivl2xc5cpi2p0r09f5bc9";
+      name = "kompare-18.04.2.tar.xz";
     };
   };
   konqueror = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/konqueror-18.04.1.tar.xz";
-      sha256 = "0798z1pm7sxi93xy4jibzhff8k37q88l59kyz524kl7m8wnw5scj";
-      name = "konqueror-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/konqueror-18.04.2.tar.xz";
+      sha256 = "1wy2gf20p7jlsq3dw1xf72pssfhmsbg50wgvbndsr9a9mylj3d4h";
+      name = "konqueror-18.04.2.tar.xz";
     };
   };
   konquest = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/konquest-18.04.1.tar.xz";
-      sha256 = "0h637lpmdsascp178fi5mpl9825n83r094ff8l5k4dnfks5imgv4";
-      name = "konquest-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/konquest-18.04.2.tar.xz";
+      sha256 = "07pdakv1snnwy0q0afc1qydy26vw65c7wy2dbh0hl57df9m095i4";
+      name = "konquest-18.04.2.tar.xz";
     };
   };
   konsole = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/konsole-18.04.1.tar.xz";
-      sha256 = "0hnyi5361glmal69brqc9h6zcv8z4l8va6nv0hc2siafmj21yhw6";
-      name = "konsole-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/konsole-18.04.2.tar.xz";
+      sha256 = "0rqrb9xdp6m2fyknk346iqbfcgz5qizdsa7n450gwinjki14yksx";
+      name = "konsole-18.04.2.tar.xz";
     };
   };
   kontact = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kontact-18.04.1.tar.xz";
-      sha256 = "00xaizfnfvh39xnxq2jp9n9cl7f0a22hlndamjfhw126ji0mz052";
-      name = "kontact-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kontact-18.04.2.tar.xz";
+      sha256 = "0g2sz9rmzscwwm6frxz2x5z17imwh5h9kb64iz0lffjzg8d9fjmq";
+      name = "kontact-18.04.2.tar.xz";
     };
   };
   kontactinterface = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kontactinterface-18.04.1.tar.xz";
-      sha256 = "1zywgcrwzgw56vx2x0f2f0235bs2aikvn2qfizv4m5ac7ydihnyd";
-      name = "kontactinterface-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kontactinterface-18.04.2.tar.xz";
+      sha256 = "076pbxxsr38q2h0s3xcgszpvdsgfrx7njh37zrv3frn5ns928dxw";
+      name = "kontactinterface-18.04.2.tar.xz";
     };
   };
   kopete = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kopete-18.04.1.tar.xz";
-      sha256 = "1isxabxxx48vjzihycv80fapx69qrvv5zlyfrdg42s9qxqkcgvi8";
-      name = "kopete-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kopete-18.04.2.tar.xz";
+      sha256 = "1s6js1xbm6n7prcjz66rk21lyzj7l76hhghvby0aak6rd77qdhpd";
+      name = "kopete-18.04.2.tar.xz";
     };
   };
   korganizer = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/korganizer-18.04.1.tar.xz";
-      sha256 = "1x3n03200j79xrj4y7046l3sa3qqfys3z2d2b1nl22v8g3l8gyx2";
-      name = "korganizer-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/korganizer-18.04.2.tar.xz";
+      sha256 = "06n4npcwf76nwrzbzjqr14pcmrqn46sriyasgqzd1iqmx1120lb5";
+      name = "korganizer-18.04.2.tar.xz";
     };
   };
   kpat = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kpat-18.04.1.tar.xz";
-      sha256 = "1fly7cd895v6k991hjvq4cv22dibzsvihzcj9cl9pzc7dk9vp70v";
-      name = "kpat-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kpat-18.04.2.tar.xz";
+      sha256 = "0nqgqd4i459m0z0bhavx08igap9lqx4rcc6yx63ina67nbx114k6";
+      name = "kpat-18.04.2.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kpimtextedit-18.04.1.tar.xz";
-      sha256 = "09513fv0kaa7x01lsnpm18vvxijcwb68hdglbw08n5f7135k79mn";
-      name = "kpimtextedit-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kpimtextedit-18.04.2.tar.xz";
+      sha256 = "1scd58mzh3mddp0nsjp7wjfclz2ylvxqksa4q4md9rbxnc3zl6fn";
+      name = "kpimtextedit-18.04.2.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kqtquickcharts-18.04.1.tar.xz";
-      sha256 = "08y0nc070pjmf07yifkfd6dm3frma752c42m3ms0ysz96l1x2gr1";
-      name = "kqtquickcharts-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kqtquickcharts-18.04.2.tar.xz";
+      sha256 = "1pxaj7wpnkwygilkj0bg4sd5m2w6jlpc2yaliaswzfy3vshrb2nl";
+      name = "kqtquickcharts-18.04.2.tar.xz";
     };
   };
   krdc = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/krdc-18.04.1.tar.xz";
-      sha256 = "166990llgfkbysahrfralc6n2g7ix7h4w1fpzss0axfigz5ink1x";
-      name = "krdc-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/krdc-18.04.2.tar.xz";
+      sha256 = "0aziq34snf0bbp9zzbag9hjv9an4b24qslmxkn002ifq9c1jww7k";
+      name = "krdc-18.04.2.tar.xz";
     };
   };
   kreversi = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kreversi-18.04.1.tar.xz";
-      sha256 = "0g6jc7s54i4gzb5q9cg4qczwx9i4zir52zqnjl5akr1w9v8d2m34";
-      name = "kreversi-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kreversi-18.04.2.tar.xz";
+      sha256 = "1436cr72snpn6aqjsc9nm3arc7ycdimlliky922mzdsl4n3absg2";
+      name = "kreversi-18.04.2.tar.xz";
     };
   };
   krfb = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/krfb-18.04.1.tar.xz";
-      sha256 = "1zd3rgp4265r1fi1kc2s09rrzpa22b9j56cq3l50mzkb80kyi6vl";
-      name = "krfb-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/krfb-18.04.2.tar.xz";
+      sha256 = "1niwg04ziqwyphw3r54909rwcqc39iv6ni8aqqsm1wfx5iqyg1sa";
+      name = "krfb-18.04.2.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kross-interpreters-18.04.1.tar.xz";
-      sha256 = "1gybf7diq2amaqs7xaikfh1kp40iwfvxz4bms16b6flck8sja8va";
-      name = "kross-interpreters-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kross-interpreters-18.04.2.tar.xz";
+      sha256 = "1n6r1wn6qw9rf1zrszq30sqkavn46b1151ak99kf3nc3c6fk225q";
+      name = "kross-interpreters-18.04.2.tar.xz";
     };
   };
   kruler = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kruler-18.04.1.tar.xz";
-      sha256 = "0bkf1cm23582hwz4j3xygrwqwbfq27qycvnf2mqw921j08axa376";
-      name = "kruler-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kruler-18.04.2.tar.xz";
+      sha256 = "0ynq8vvgbmrgc8na0bj7nf98qr0kis59wrq8jygllgybrvm8wxb4";
+      name = "kruler-18.04.2.tar.xz";
     };
   };
   kshisen = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kshisen-18.04.1.tar.xz";
-      sha256 = "098qqzii4wk0pv5388yighy381k5ffrb8wy4z461yxgxc75d77f7";
-      name = "kshisen-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kshisen-18.04.2.tar.xz";
+      sha256 = "1psvdcylr8c81252cmd7ky1f62bh82kpnbvfcvwkg2kfwwr9ril3";
+      name = "kshisen-18.04.2.tar.xz";
     };
   };
   ksirk = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ksirk-18.04.1.tar.xz";
-      sha256 = "0mxj4vp6da535ghnxisk6j7akhis0fh16kj6bycw8fxxl5jiy0sq";
-      name = "ksirk-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ksirk-18.04.2.tar.xz";
+      sha256 = "1zl5riig9rmcs3sn4fj51fhxlcgs709x4ahdgcjrncafvxb9b1xg";
+      name = "ksirk-18.04.2.tar.xz";
     };
   };
   ksmtp = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ksmtp-18.04.1.tar.xz";
-      sha256 = "0imfcaisvh78s18x2w4iizr4vn6sndr1nk9585vs9dr8wcwbfrl3";
-      name = "ksmtp-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ksmtp-18.04.2.tar.xz";
+      sha256 = "16q7f5b87mxzz05d8vfra3m2fj0n2h62askcmp5p8zfc9am07991";
+      name = "ksmtp-18.04.2.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ksnakeduel-18.04.1.tar.xz";
-      sha256 = "07p9nil9x3cyzzxcr59h3rj9h6g1lfssrsi6iqwq0hpdc6h2zl73";
-      name = "ksnakeduel-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ksnakeduel-18.04.2.tar.xz";
+      sha256 = "119jgihx1qdk6aa8xkjh5q3zcqsybbs8vn3hjnwcy2dzkyc04v7a";
+      name = "ksnakeduel-18.04.2.tar.xz";
     };
   };
   kspaceduel = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kspaceduel-18.04.1.tar.xz";
-      sha256 = "0aar147l5bq1ij40ng5wbdixg91678r3d07lrnmdffb47wa1ly7n";
-      name = "kspaceduel-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kspaceduel-18.04.2.tar.xz";
+      sha256 = "08g1h7j1bl7sfiz2vk05df16yjp0dwzvdn7ymr74il6m6ln65a9w";
+      name = "kspaceduel-18.04.2.tar.xz";
     };
   };
   ksquares = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ksquares-18.04.1.tar.xz";
-      sha256 = "1vr9xdi0jfrjwvq5y04djmnax7q4d5amj8a7mzvvqq427zl6xc3c";
-      name = "ksquares-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ksquares-18.04.2.tar.xz";
+      sha256 = "1xc82gc4bszsfd3y7xgfaxj4flnflr1v0wv8m1jgk3xzka889wq2";
+      name = "ksquares-18.04.2.tar.xz";
     };
   };
   ksudoku = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ksudoku-18.04.1.tar.xz";
-      sha256 = "0habss3w7m3x8mhh70qq38nymynvihar9clpxmlp6pbyw8sl9v6n";
-      name = "ksudoku-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ksudoku-18.04.2.tar.xz";
+      sha256 = "0fhbf7d3bb7cad7wd44hslx7ak5l6nx1d0r3dh38y51c7jwwy2nl";
+      name = "ksudoku-18.04.2.tar.xz";
     };
   };
   ksystemlog = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ksystemlog-18.04.1.tar.xz";
-      sha256 = "1yyrbdzjxrlf96l3bvj675fsbn6440lxr1nd5j4rs09d3fyvl6p1";
-      name = "ksystemlog-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ksystemlog-18.04.2.tar.xz";
+      sha256 = "0qx1wg4a8cpp3vd89xqcbfl7hzg3frcv37bsmdc44l988m9l44x3";
+      name = "ksystemlog-18.04.2.tar.xz";
     };
   };
   kteatime = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kteatime-18.04.1.tar.xz";
-      sha256 = "02849i02h0zmsc3wifzgq9s0mgfdyzdrm61ngq944r260anizxhd";
-      name = "kteatime-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kteatime-18.04.2.tar.xz";
+      sha256 = "1bmirc40prg5f4rlyrz8xbgwrm8nrcxvmbpk8399szb41m3p031c";
+      name = "kteatime-18.04.2.tar.xz";
     };
   };
   ktimer = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktimer-18.04.1.tar.xz";
-      sha256 = "13k0wmjh925sj7l8n4kc0adva1vfbgs6admh80ch0xwk8mmsdjvp";
-      name = "ktimer-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktimer-18.04.2.tar.xz";
+      sha256 = "1djb5r7wwrc0hzv76lqf602gy9ijz4zw1j1z6n19yhvy9baz5ix6";
+      name = "ktimer-18.04.2.tar.xz";
     };
   };
   ktnef = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktnef-18.04.1.tar.xz";
-      sha256 = "1m6nbsnbh8apyqaw2kivkzhk7fp9y2xphmrblqdpf49qpbh6jqlq";
-      name = "ktnef-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktnef-18.04.2.tar.xz";
+      sha256 = "03m7gqgz8bpjig8xh04pmzs3yyfiajksqq43hsh3hlck1fmycmvq";
+      name = "ktnef-18.04.2.tar.xz";
     };
   };
   ktouch = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktouch-18.04.1.tar.xz";
-      sha256 = "18piwwdq4hl8yaln7s7p4bw0lwkyjwnw8lknirj1352npycvq2n1";
-      name = "ktouch-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktouch-18.04.2.tar.xz";
+      sha256 = "0x16m27l8hc2kk2bfc7r98y45vwkdqs7mk3g1i7ys4rf4rdcf62h";
+      name = "ktouch-18.04.2.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-accounts-kcm-18.04.1.tar.xz";
-      sha256 = "1ihxvngg6cp1vzhpf4hkf2zwxpa5gnlq11lc1ffnhy7fm7ig28nx";
-      name = "ktp-accounts-kcm-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-accounts-kcm-18.04.2.tar.xz";
+      sha256 = "1wfy4p8w1rzq6mnq9axcx6b0v0hsjjlzysn7gvgqnyvnqzfn31gg";
+      name = "ktp-accounts-kcm-18.04.2.tar.xz";
     };
   };
   ktp-approver = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-approver-18.04.1.tar.xz";
-      sha256 = "1749l1zklk1q7i3z4mbk24566vps74hj3as4ijybgymczr4rd3gz";
-      name = "ktp-approver-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-approver-18.04.2.tar.xz";
+      sha256 = "1irhid13c2nblfs1qkkpkiwk7559zd3hh4397v9d9h2952gadf2r";
+      name = "ktp-approver-18.04.2.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-auth-handler-18.04.1.tar.xz";
-      sha256 = "0llkw1yqi91s8iqdqz8pskccinmjsgbp1081pngpkqcg1iy7bara";
-      name = "ktp-auth-handler-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-auth-handler-18.04.2.tar.xz";
+      sha256 = "01wmnd63zjc37yknfjqqsgninqpwrh2w6df4rydxbk3p1mqv1g6x";
+      name = "ktp-auth-handler-18.04.2.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-call-ui-18.04.1.tar.xz";
-      sha256 = "1pji4z8h7bk5npl279x5g9hx7zgdhnjdrv669nrd1gi9m20n6vi7";
-      name = "ktp-call-ui-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-call-ui-18.04.2.tar.xz";
+      sha256 = "1q9h89ng2r85is18lkxpsbapd0j0ac4gb8jyq333c7lahflr6qfw";
+      name = "ktp-call-ui-18.04.2.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-common-internals-18.04.1.tar.xz";
-      sha256 = "0jwkwznqcrk39k07srl7c0yznj9p9dp70lkfhjg3syscwm8drydv";
-      name = "ktp-common-internals-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-common-internals-18.04.2.tar.xz";
+      sha256 = "13mi1l8xwhr7h5sc332b91nsrq211q2m8xxvdizmlmyf4kss02b2";
+      name = "ktp-common-internals-18.04.2.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-contact-list-18.04.1.tar.xz";
-      sha256 = "1806fapr0pv15dmpqb0khdlgrmk9bsf45s1ab7x9pdnghnawn132";
-      name = "ktp-contact-list-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-contact-list-18.04.2.tar.xz";
+      sha256 = "0n8aj9m7vq62amrv1smfq39lmbjzlbcz4zdbk529j0iqryvm4ycr";
+      name = "ktp-contact-list-18.04.2.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-contact-runner-18.04.1.tar.xz";
-      sha256 = "0b9xm5p9w5kd67sh13h9caxqj89jzia79hfk9fzxpjbf0kifj72s";
-      name = "ktp-contact-runner-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-contact-runner-18.04.2.tar.xz";
+      sha256 = "0zjsvsxdd2w4vijj9bqifl88wf0bkkdiqrpzpdm71zwvpp8dp6pj";
+      name = "ktp-contact-runner-18.04.2.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-desktop-applets-18.04.1.tar.xz";
-      sha256 = "0jrdz8ccgrbwpb6k73wvsix3h3h16dxzgqy19lykd5igckq1v2qh";
-      name = "ktp-desktop-applets-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-desktop-applets-18.04.2.tar.xz";
+      sha256 = "19qdpgp6qqfzqv5xli1jk63d2nz1pr8kaggssfxmygc02vjq39wg";
+      name = "ktp-desktop-applets-18.04.2.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-filetransfer-handler-18.04.1.tar.xz";
-      sha256 = "03v0wgac6knprqi7mfzc3w1rrdkf9lgi2gpscc3k910dyswh1802";
-      name = "ktp-filetransfer-handler-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-filetransfer-handler-18.04.2.tar.xz";
+      sha256 = "1ygnm5n9sykyr9vi9c131xhrbrb54s9qbm4kmvxnrw8bl40vpdj5";
+      name = "ktp-filetransfer-handler-18.04.2.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-kded-module-18.04.1.tar.xz";
-      sha256 = "0d3vv1ngsbh87wxijvyd2hzhdzwr0r5vx5h3jdl3znjh9ysifwm4";
-      name = "ktp-kded-module-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-kded-module-18.04.2.tar.xz";
+      sha256 = "11x559k1cqgzhpm7b44ybi47n1086jmd38pw0nmivj0j0qgssypm";
+      name = "ktp-kded-module-18.04.2.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-send-file-18.04.1.tar.xz";
-      sha256 = "1p3vgbsmam687bzp1h6xxv2qr2f6jz6mjbpk5jxjvvz66aq4dj8y";
-      name = "ktp-send-file-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-send-file-18.04.2.tar.xz";
+      sha256 = "15izy3ziwm2170lg5c4irvypyafzwa4idxjr1pvf1j5z4rs0vj29";
+      name = "ktp-send-file-18.04.2.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktp-text-ui-18.04.1.tar.xz";
-      sha256 = "1zsxyizm9vdlrxicxvgmy5irqi914szxkd38xrgspp2vdi4bnvb6";
-      name = "ktp-text-ui-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktp-text-ui-18.04.2.tar.xz";
+      sha256 = "0vfi1dsax99gr7qzpk40vpa0da4hqncxjgwxa6h1srf5l0hbvc1r";
+      name = "ktp-text-ui-18.04.2.tar.xz";
     };
   };
   ktuberling = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/ktuberling-18.04.1.tar.xz";
-      sha256 = "1rpval4rl63dfy2p6aq5902ifvv14x1zg8mzzci26kqq8k38jasc";
-      name = "ktuberling-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/ktuberling-18.04.2.tar.xz";
+      sha256 = "1c82gnjlsp1dblmdavhrz43yzv2h3nvjafna7f53js6d5ggsxm2q";
+      name = "ktuberling-18.04.2.tar.xz";
     };
   };
   kturtle = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kturtle-18.04.1.tar.xz";
-      sha256 = "1s2n46nlzc63108gc43h14yjrcd12h93bvbg08ynhfaq26pqz1jk";
-      name = "kturtle-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kturtle-18.04.2.tar.xz";
+      sha256 = "09fy1q40iwj7ds521ffzc5hmsbh7qb481ykq6ixfqbxzys4yjxm8";
+      name = "kturtle-18.04.2.tar.xz";
     };
   };
   kubrick = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kubrick-18.04.1.tar.xz";
-      sha256 = "1gqnfc8gnl96gz5i3ak7swhm36c9dv7n0c4b5f70pnsi5n7klbxr";
-      name = "kubrick-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kubrick-18.04.2.tar.xz";
+      sha256 = "1z7yym9sc2i35sw32sjc5qqip99vmf5grwxmha50ra6qvxqgljmq";
+      name = "kubrick-18.04.2.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kwalletmanager-18.04.1.tar.xz";
-      sha256 = "0vj0ch1dk265v6x8xzvskpv5mc564p10pn8m9jjv79wk2xy1vsjz";
-      name = "kwalletmanager-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kwalletmanager-18.04.2.tar.xz";
+      sha256 = "0lijv2s9213d0wnk0j23qfd1f7f77kdypj2b9pmpi4ng1sf77bwp";
+      name = "kwalletmanager-18.04.2.tar.xz";
     };
   };
   kwave = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kwave-18.04.1.tar.xz";
-      sha256 = "0avbyyrhvzfxdib0d80rk7m6gk6kq9rjvv640s08y237m68fncap";
-      name = "kwave-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kwave-18.04.2.tar.xz";
+      sha256 = "04crj0qkbnzc7abfa920s9csdpy4rhw49qq1x3sq09mqagbd04fw";
+      name = "kwave-18.04.2.tar.xz";
     };
   };
   kwordquiz = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/kwordquiz-18.04.1.tar.xz";
-      sha256 = "1yqynfmlargfwk7nlfzhlxd1df462ssw7qj3pdhym8277jfch58r";
-      name = "kwordquiz-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/kwordquiz-18.04.2.tar.xz";
+      sha256 = "07dyzq9l4v2bymkc8jjm1i76y3nka98py2nf4ids0lpgxvkdx197";
+      name = "kwordquiz-18.04.2.tar.xz";
     };
   };
   libgravatar = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libgravatar-18.04.1.tar.xz";
-      sha256 = "19xrc70yh6baxg5jlr3v3d3af46vms28jzvkpgda5ffacnn3xnrj";
-      name = "libgravatar-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libgravatar-18.04.2.tar.xz";
+      sha256 = "1yzai7azdqa16vndifj7smzxkw2sdkx1j8jfbcqsrs1rmn4p8f0f";
+      name = "libgravatar-18.04.2.tar.xz";
     };
   };
   libkcddb = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkcddb-18.04.1.tar.xz";
-      sha256 = "1nn80sflfgzd3d2kc4d4zwa09ix498svrinn27b9h8x3w3gsbg8f";
-      name = "libkcddb-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkcddb-18.04.2.tar.xz";
+      sha256 = "053dgcxva3qphifhk08146gmnnnxnkay64p81bcrxgjbd5lf7vak";
+      name = "libkcddb-18.04.2.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkcompactdisc-18.04.1.tar.xz";
-      sha256 = "12zb39zwvl8y2b48vjn34dxj4f65laswd67w5f7m4g0nczq218v1";
-      name = "libkcompactdisc-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkcompactdisc-18.04.2.tar.xz";
+      sha256 = "0l3nd8px0w0bl0kjr5gk1rbakzgff8bbzvqrfhqfswx7iqdghlav";
+      name = "libkcompactdisc-18.04.2.tar.xz";
     };
   };
   libkdcraw = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkdcraw-18.04.1.tar.xz";
-      sha256 = "011q982rx5m8609i1zd6q186xw3ps81fnvhjk69hxy5w8pp44m6i";
-      name = "libkdcraw-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkdcraw-18.04.2.tar.xz";
+      sha256 = "116db7f69972kbjc3p5mh81cv3iq76y9a53v965idx1manw6p17b";
+      name = "libkdcraw-18.04.2.tar.xz";
     };
   };
   libkdegames = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkdegames-18.04.1.tar.xz";
-      sha256 = "03afnypmn8bz1cgc4lgfmid2hszsq564hsf9m5s57a29vfswnp6m";
-      name = "libkdegames-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkdegames-18.04.2.tar.xz";
+      sha256 = "130fj578bgkwg6anm0sbnhvw9wvlwv5m5mmqnfnw9aha16yd6w12";
+      name = "libkdegames-18.04.2.tar.xz";
     };
   };
   libkdepim = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkdepim-18.04.1.tar.xz";
-      sha256 = "02wrkn1h662dqzp7kyrhhhiyahhkgqz75jcd59haxyj66amlgcx6";
-      name = "libkdepim-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkdepim-18.04.2.tar.xz";
+      sha256 = "1rsyd06dqkfhx1s1zjzlg3n75pkhw754iai2758a8rxzs6bq6plg";
+      name = "libkdepim-18.04.2.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkeduvocdocument-18.04.1.tar.xz";
-      sha256 = "14i25wjfak39bz0y5rkg25mvjxnzpak76sf5w163dmwx2hd7spzr";
-      name = "libkeduvocdocument-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkeduvocdocument-18.04.2.tar.xz";
+      sha256 = "17bgsj9jf1a0108nrm17cp0fjli9jpbsci28yllda2kavcdr1izm";
+      name = "libkeduvocdocument-18.04.2.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkexiv2-18.04.1.tar.xz";
-      sha256 = "0q6hmghivdj0aq00pg3z5i6mfdj3xgpdd6yw0vr9i4jnk0rfb349";
-      name = "libkexiv2-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkexiv2-18.04.2.tar.xz";
+      sha256 = "1cqp8cbqmqxnjkhiv8yjd047vppnym5dqy3yr01ppv9jlivyqzpk";
+      name = "libkexiv2-18.04.2.tar.xz";
     };
   };
   libkgapi = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkgapi-18.04.1.tar.xz";
-      sha256 = "0wpxn7qyf56rckarx52ic3yyhv8r043dxjir4f2yf05vkddwkshv";
-      name = "libkgapi-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkgapi-18.04.2.tar.xz";
+      sha256 = "1axnn3634h2cjiky1km8c88ip8wnascxc1z4rdbxwk013hkbd4fh";
+      name = "libkgapi-18.04.2.tar.xz";
     };
   };
   libkgeomap = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkgeomap-18.04.1.tar.xz";
-      sha256 = "16rzw8r1i7isfh86rg86a0h25zwa8h3hnxbzf3fjmdn6mmdkp2va";
-      name = "libkgeomap-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkgeomap-18.04.2.tar.xz";
+      sha256 = "1rx2ksp07nsny4dr7dmjlbd5v9agnnnnz38r4kf4cqdr7w3ymhhd";
+      name = "libkgeomap-18.04.2.tar.xz";
     };
   };
   libkipi = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkipi-18.04.1.tar.xz";
-      sha256 = "09rx85phr259anznvxyfp4rb51jsid76jrbcgv52vy9cfd7rr8pk";
-      name = "libkipi-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkipi-18.04.2.tar.xz";
+      sha256 = "1bddsblrq45v7id41cr8bxss9sdlznk50mwkc03nc9xq1dlhsw0n";
+      name = "libkipi-18.04.2.tar.xz";
     };
   };
   libkleo = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkleo-18.04.1.tar.xz";
-      sha256 = "06kyiv9bshyf2q0k7g7pm1ja35sxddgrzb5ayxnx03na86dm67j9";
-      name = "libkleo-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkleo-18.04.2.tar.xz";
+      sha256 = "0m57klq8dlmibw5j8ah14q18cxl4sy7kjkrckmaydkhi45lc6j8m";
+      name = "libkleo-18.04.2.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkmahjongg-18.04.1.tar.xz";
-      sha256 = "09sqi1xyd8hk3x6w5ix6sa191ihil3zjq1qd6j50fr2rpqzfnbm0";
-      name = "libkmahjongg-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkmahjongg-18.04.2.tar.xz";
+      sha256 = "0gbzrsc837h5xh72c89zj98ydly08799kl3g4fpai7w2ak1hmcf4";
+      name = "libkmahjongg-18.04.2.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libkomparediff2-18.04.1.tar.xz";
-      sha256 = "0d00r0h1fbmhkdn791f3i87ckc4l8wd5rljlm4lfzcr95lbmpzyv";
-      name = "libkomparediff2-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libkomparediff2-18.04.2.tar.xz";
+      sha256 = "0m3r45mzipvglv6llkmfryr023yya07xilkxksp672lb46w8x047";
+      name = "libkomparediff2-18.04.2.tar.xz";
     };
   };
   libksane = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libksane-18.04.1.tar.xz";
-      sha256 = "1k1ffki9gcgah7xymyzbwza00gw3dvkfghcbyy4dpvbb0q4ayw7c";
-      name = "libksane-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libksane-18.04.2.tar.xz";
+      sha256 = "0flc1azdjjby27lbi5kgcghh7imry4m37jxsnnwyhnhdfm3py1dy";
+      name = "libksane-18.04.2.tar.xz";
     };
   };
   libksieve = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/libksieve-18.04.1.tar.xz";
-      sha256 = "0dsb1lj155y32avlgw6clxpbv00z3nrc7a7nlfh29l0wjl09mr50";
-      name = "libksieve-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/libksieve-18.04.2.tar.xz";
+      sha256 = "0sml8x0462s13g4wjrvsswsz5fl97zyz1ps9c6v8prc0hyann81p";
+      name = "libksieve-18.04.2.tar.xz";
     };
   };
   lokalize = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/lokalize-18.04.1.tar.xz";
-      sha256 = "1svwl30abycdq2jc4a688lbb4yk28dqscchi1zshdii6w00bcys9";
-      name = "lokalize-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/lokalize-18.04.2.tar.xz";
+      sha256 = "0nzrvbbv61nl3mxgnx2kv4qc9pgky85jxgw7i9w4alizz491xzlp";
+      name = "lokalize-18.04.2.tar.xz";
     };
   };
   lskat = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/lskat-18.04.1.tar.xz";
-      sha256 = "0isy9ibk93i4b72cdv5210n8gfwiydrw4i0bax2pkyxqymyfr5lj";
-      name = "lskat-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/lskat-18.04.2.tar.xz";
+      sha256 = "0qywkf6bl8mgjwhmcpmhrlfk316ds3afyf2ibgcb15cixv72amw1";
+      name = "lskat-18.04.2.tar.xz";
     };
   };
   mailcommon = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/mailcommon-18.04.1.tar.xz";
-      sha256 = "0s0c4swm1q331hzqg0fqb2r9dwx4aamwan3s5p71vjnibxzbmqck";
-      name = "mailcommon-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/mailcommon-18.04.2.tar.xz";
+      sha256 = "1aszv65xp07gvx98sx2j8dp6m429c1a5g71n825lvj42j2v4221p";
+      name = "mailcommon-18.04.2.tar.xz";
     };
   };
   mailimporter = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/mailimporter-18.04.1.tar.xz";
-      sha256 = "1qzc7yjjscbxkinby9carp02wqppx95hirq0m5ihly7avn5cn6dz";
-      name = "mailimporter-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/mailimporter-18.04.2.tar.xz";
+      sha256 = "17fvrnwmd3bs7r87ysab6blnwn3p7vanlbwb1zzlhqw8m4q8f015";
+      name = "mailimporter-18.04.2.tar.xz";
     };
   };
   marble = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/marble-18.04.1.tar.xz";
-      sha256 = "04aa32qnr585lq3s3hmxqlwqranr3wr1zr1xm99pbsb32k2yyyjn";
-      name = "marble-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/marble-18.04.2.tar.xz";
+      sha256 = "0a4i8jbkibjm24zcldzn1nsr3d2kqwjdzj4anchyhfzyk22ac8hd";
+      name = "marble-18.04.2.tar.xz";
     };
   };
   mbox-importer = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/mbox-importer-18.04.1.tar.xz";
-      sha256 = "06735201365rpp3lr877pqdkz9206zfzhvbbr432fvg6lx3p5z4s";
-      name = "mbox-importer-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/mbox-importer-18.04.2.tar.xz";
+      sha256 = "1ymmwgc7m5k2bg99zfik319zdmx2dw8ni56cqjid1yx5iqmghyl6";
+      name = "mbox-importer-18.04.2.tar.xz";
     };
   };
   messagelib = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/messagelib-18.04.1.tar.xz";
-      sha256 = "1fznlxl1j1n5pbg3v7rmd4lhfjhr1r95b62gyqydlrrwgzzs92b2";
-      name = "messagelib-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/messagelib-18.04.2.tar.xz";
+      sha256 = "0hjk08na1w943y3pi65a7g8q7m66r7scabbs8cvj3sp31c2f9hfw";
+      name = "messagelib-18.04.2.tar.xz";
     };
   };
   minuet = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/minuet-18.04.1.tar.xz";
-      sha256 = "0fans0fpghdckmp6ww8api4d7kfna1w20yjgssvfqxgyxxni0vps";
-      name = "minuet-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/minuet-18.04.2.tar.xz";
+      sha256 = "039la5ifyhv1h7kr1g8zgrkkgvi522d32snxx3cqchyj0dy22ays";
+      name = "minuet-18.04.2.tar.xz";
     };
   };
   okular = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/okular-18.04.1.tar.xz";
-      sha256 = "0fhfbjlwa4xzf2q2wnidprj7qqizs26i959k61k4j66y66d2za0g";
-      name = "okular-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/okular-18.04.2.tar.xz";
+      sha256 = "1jcrk6czwgpbfi4l6cvsnyxcf0s4jnkiw0py7np7yvycwsf4x7mz";
+      name = "okular-18.04.2.tar.xz";
     };
   };
   palapeli = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/palapeli-18.04.1.tar.xz";
-      sha256 = "01p1xipacb8w7lcd3n8387c7axjxswvv62rn7sphp736l23wri5c";
-      name = "palapeli-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/palapeli-18.04.2.tar.xz";
+      sha256 = "0fbn1sv6pznl2s3ps1g2f4y400zjxk9ia42120rz1i695v9xcp2f";
+      name = "palapeli-18.04.2.tar.xz";
     };
   };
   parley = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/parley-18.04.1.tar.xz";
-      sha256 = "1qh7bg38bvq8drnd7plkdxxqsl6rgd37g3iqnxwljxf723s6hcz5";
-      name = "parley-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/parley-18.04.2.tar.xz";
+      sha256 = "0cbab4kqh80gfqvm4iihf78shbkkryg59q3qb5h8m86i22kzf0hv";
+      name = "parley-18.04.2.tar.xz";
     };
   };
   picmi = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/picmi-18.04.1.tar.xz";
-      sha256 = "095xm4nkd0kg0pvbbp3vasll1lfpk491frspk2463q0zhd04hpmi";
-      name = "picmi-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/picmi-18.04.2.tar.xz";
+      sha256 = "0xs4a0dv3kyl2rkl8whlrhfhs05wzvab2q3k9bdmjn3vkcg6w3kc";
+      name = "picmi-18.04.2.tar.xz";
     };
   };
   pimcommon = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/pimcommon-18.04.1.tar.xz";
-      sha256 = "0zyd0ja6ir6nbkvf4hk6hi93qr19kns8hgww15y2xmdhdcyf52ja";
-      name = "pimcommon-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/pimcommon-18.04.2.tar.xz";
+      sha256 = "0xdng2vrv0mdzxnlcysrhrjkbkv9vmkck20xc9p3kr2qzjl4v4n3";
+      name = "pimcommon-18.04.2.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/pim-data-exporter-18.04.1.tar.xz";
-      sha256 = "0k69nmjp0n2mmg1nsghghk2ybnvyr01gnrhqwvknpbncb2cnkgcg";
-      name = "pim-data-exporter-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/pim-data-exporter-18.04.2.tar.xz";
+      sha256 = "0si2wss4la5d8w0axcv4j8gnx1x4cy0ja8raz77m2ffnwi27rj43";
+      name = "pim-data-exporter-18.04.2.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/pim-sieve-editor-18.04.1.tar.xz";
-      sha256 = "076hzkia8l61nn3gwma88lsx02d1fb6d00jbibvghqp7raa9f0fx";
-      name = "pim-sieve-editor-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/pim-sieve-editor-18.04.2.tar.xz";
+      sha256 = "152qrdi48kcjnfhnhk7pa2950bmlww7w2i840zngfr3q7s09kacs";
+      name = "pim-sieve-editor-18.04.2.tar.xz";
     };
   };
   poxml = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/poxml-18.04.1.tar.xz";
-      sha256 = "1ha1dy5j40269nv5ygb0idd9kkizni3zq4vz64i2y29lvbrqdgh1";
-      name = "poxml-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/poxml-18.04.2.tar.xz";
+      sha256 = "15nhdkrmyqqcs2lh9c6xn3ny5rb40b97igmicyxw677divlc0aib";
+      name = "poxml-18.04.2.tar.xz";
     };
   };
   print-manager = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/print-manager-18.04.1.tar.xz";
-      sha256 = "10l2w1fyym4nflmqnfsxdnnbllvliwyx7z7ylmi4i4rkcpaafyqx";
-      name = "print-manager-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/print-manager-18.04.2.tar.xz";
+      sha256 = "1kd7mj9qrf1a24lna9jl7rgc1889hgpr97wasq8542g1wdqwdng9";
+      name = "print-manager-18.04.2.tar.xz";
     };
   };
   rocs = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/rocs-18.04.1.tar.xz";
-      sha256 = "1bsm1kjkp9x2rh4n682kjyljisri7mniw5yap4ifksq5lk2vbn8z";
-      name = "rocs-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/rocs-18.04.2.tar.xz";
+      sha256 = "1c0rixfxama65rdd120njgvjan2hj32j5zc7y012yvns495mai5p";
+      name = "rocs-18.04.2.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/signon-kwallet-extension-18.04.1.tar.xz";
-      sha256 = "0xhvah1xq60wiz6pyjkc66sxsz1v3vdzjbjdr5kklpr98pg9xlib";
-      name = "signon-kwallet-extension-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/signon-kwallet-extension-18.04.2.tar.xz";
+      sha256 = "1q2nmprypaybpk59m1r5qxj9daycw1dxj62x6cc4gj4cxkw9q0bw";
+      name = "signon-kwallet-extension-18.04.2.tar.xz";
     };
   };
   spectacle = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/spectacle-18.04.1.tar.xz";
-      sha256 = "0k8vl79gwm4sj0f5pshz99l6cq323hk7a4r1jqzkdmbdv1mc0rgc";
-      name = "spectacle-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/spectacle-18.04.2.tar.xz";
+      sha256 = "1dyzpqkswl4dlc9ch38r7qh346vm0bj5vb173yf1x40dy4yp2q1n";
+      name = "spectacle-18.04.2.tar.xz";
     };
   };
   step = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/step-18.04.1.tar.xz";
-      sha256 = "1zwxjsjv72wjvzwj7cdz3lclw92bp9306bcpm4bpfrlcnr3xny1z";
-      name = "step-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/step-18.04.2.tar.xz";
+      sha256 = "0z4k9qaxv066dqmbfwxjfwkc3c8jvl77y6gix8qq181hrz71wcw4";
+      name = "step-18.04.2.tar.xz";
     };
   };
   svgpart = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/svgpart-18.04.1.tar.xz";
-      sha256 = "14qf9xfgvgk8d49qz6vhfivzw8hsmj6q2scjk6vg3i16y62qlym9";
-      name = "svgpart-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/svgpart-18.04.2.tar.xz";
+      sha256 = "1pny7rljyig2fpdxfydnv7i2mja40v0xi9z87w52q43jgnrz71jy";
+      name = "svgpart-18.04.2.tar.xz";
     };
   };
   sweeper = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/sweeper-18.04.1.tar.xz";
-      sha256 = "0f8nyxdw2arpa85vwl834jqbydvsx7dswjl8cdy66frx5jyqirim";
-      name = "sweeper-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/sweeper-18.04.2.tar.xz";
+      sha256 = "1dz1a07kdynz405hn78ldn0gi3hn67qp1fl9amzb42r6akzlbzn3";
+      name = "sweeper-18.04.2.tar.xz";
     };
   };
   syndication = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/syndication-18.04.1.tar.xz";
-      sha256 = "1gcas0aqgzr6r571d66yn7hw86hdb4akd5vgk5jh3liww25y8qm5";
-      name = "syndication-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/syndication-18.04.2.tar.xz";
+      sha256 = "05cm4k1zd3jj6v1pbdmpfrky1fyrmwamsihncqn1bw8hx01dzmxp";
+      name = "syndication-18.04.2.tar.xz";
     };
   };
   umbrello = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/umbrello-18.04.1.tar.xz";
-      sha256 = "1vw8py5nm7mpv3qa0lxi72cvbvslxppag6aqhbp2zsnz6b152qhy";
-      name = "umbrello-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/umbrello-18.04.2.tar.xz";
+      sha256 = "0gi4ndvh15hvx10by8jk0viqh66ns1hpdd8zabwf9qg8n5gf7b5d";
+      name = "umbrello-18.04.2.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "18.04.1";
+    version = "18.04.2";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.04.1/src/zeroconf-ioslave-18.04.1.tar.xz";
-      sha256 = "09nvkcq924v3f8jl36618j0hx2b1dzkvbvspf98mnx9lsliyzsc3";
-      name = "zeroconf-ioslave-18.04.1.tar.xz";
+      url = "${mirror}/stable/applications/18.04.2/src/zeroconf-ioslave-18.04.2.tar.xz";
+      sha256 = "07pnsld72i6i8dx342llw53zjgb91lxh43fl2b7zc3vaxr7vzs62";
+      name = "zeroconf-ioslave-18.04.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New version.

@adisbladis @ttuegel @peterhoeg 

We should wait for tuesday, when plasma 5.13 is released and merge everything together:
https://github.com/NixOS/nixpkgs/pull/40893 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

