### PR TITLE
kde-frameworks: 5.46 -> 5.47

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.46/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.47/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,627 +3,627 @@
 
 {
   attica = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/attica-5.46.0.tar.xz";
-      sha256 = "0xj4wn7nd28hfvbcpx4gfgf00vdg3kyfvqy0vk4js49xq14q9j09";
-      name = "attica-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/attica-5.47.0.tar.xz";
+      sha256 = "17i580hhi9rpd6d4nf408snlnf8xivwskkzbjja0snajx0nrd8bj";
+      name = "attica-5.47.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/baloo-5.46.0.tar.xz";
-      sha256 = "01ww9yqw9zi2r71i8gh87vs20k3kmvc1mq9a3di21zk5glb8hdy3";
-      name = "baloo-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/baloo-5.47.0.tar.xz";
+      sha256 = "15jpbl47pr86h5ji2x3079b6x38fchc2pf03rjqlf5mgkabdpafq";
+      name = "baloo-5.47.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/bluez-qt-5.46.0.tar.xz";
-      sha256 = "0hgqxpxx1b2vpr5fxhgk8s4m1njc9i080zqb62bh4vvsdayzib6l";
-      name = "bluez-qt-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/bluez-qt-5.47.0.tar.xz";
+      sha256 = "1pqgvpgr9xmgv8cxgvqx08jnabgmgzh2skkhwc9d9rdc2i4g7b1k";
+      name = "bluez-qt-5.47.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/breeze-icons-5.46.0.tar.xz";
-      sha256 = "1sq7j0clqc1zm330p49ny76jasn0dvvf1lszclfldg540n376343";
-      name = "breeze-icons-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/breeze-icons-5.47.0.tar.xz";
+      sha256 = "0fyzk196r8r0mzvijs9ws8ldh5vrw4yrgnvd1szb57vyy1agnnd7";
+      name = "breeze-icons-5.47.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/extra-cmake-modules-5.46.0.tar.xz";
-      sha256 = "0xf232d9znln6a7i8mcff4nr0kd5x6qpp1hxbf5pp7g1cwdkxnp5";
-      name = "extra-cmake-modules-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/extra-cmake-modules-5.47.0.tar.xz";
+      sha256 = "1591d27r6a2b7jn6zi2ik0i195pvl014dwxfpxv974hbbb8qnvcp";
+      name = "extra-cmake-modules-5.47.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/frameworkintegration-5.46.0.tar.xz";
-      sha256 = "1nb5b81b5g1y8crn6mwkjhkf8dzamyfpcl49c3ml34i1d68jbil3";
-      name = "frameworkintegration-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/frameworkintegration-5.47.0.tar.xz";
+      sha256 = "0iwdfa7q8ryszsl2w3bgix8bxkn3jj2lfdlcicfz9qh6av76p4yf";
+      name = "frameworkintegration-5.47.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kactivities-5.46.0.tar.xz";
-      sha256 = "1a1339i0zag6zsp7mq2w86v7h2fz3bc5jd6w7kb5yphagnwdp9kk";
-      name = "kactivities-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kactivities-5.47.0.tar.xz";
+      sha256 = "01h5a4m0wkgz1gafhbqdidxdr2x6g5siwcx4csv9293pc5xf0qcd";
+      name = "kactivities-5.47.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kactivities-stats-5.46.0.tar.xz";
-      sha256 = "18mdx8fxrq71rwz7zgx7j30k5ch0yjiyh86nwx9a4yrf6d2ykxwj";
-      name = "kactivities-stats-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kactivities-stats-5.47.0.tar.xz";
+      sha256 = "0linsga4d7lincnpj747wnbgidp2x7xk3jzh31lpfq8izkmqz1q5";
+      name = "kactivities-stats-5.47.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kapidox-5.46.0.tar.xz";
-      sha256 = "16kn5mka2mzvqpdfa7w82zgj7vi0ig611qa16flgazzrcbl2m827";
-      name = "kapidox-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kapidox-5.47.0.tar.xz";
+      sha256 = "1z2ka5fnwqsmjhxdbahk7gkjmhgzndg3lq6196dmpws1zjqf14vq";
+      name = "kapidox-5.47.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/karchive-5.46.0.tar.xz";
-      sha256 = "1xphgm8lxicws4bss5svq7r81n1j1zssgfq35vmlms22cpr7pr28";
-      name = "karchive-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/karchive-5.47.0.tar.xz";
+      sha256 = "0r8xxfg1wsnpzyfggpzhxap853gqfsnmbci1al6xyd0pslgcsb5r";
+      name = "karchive-5.47.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kauth-5.46.0.tar.xz";
-      sha256 = "0w0zvaxzv6bl76hr8wxhg6w0cfp3sdcqdpimspyc7dvddvq3vbr3";
-      name = "kauth-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kauth-5.47.0.tar.xz";
+      sha256 = "1s80grzkxvbkw39z5xida50ijb0k3aqy80k5h0025m9rqpbc7ir9";
+      name = "kauth-5.47.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kbookmarks-5.46.0.tar.xz";
-      sha256 = "1i7dsw5rskf7fb8bylwnnysppgmrzizw35wl8n5rw2lkk814a7xl";
-      name = "kbookmarks-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kbookmarks-5.47.0.tar.xz";
+      sha256 = "0b4b2yp3pvlisf0g1gwnisn2rc94wn874aad3dlg0607kd11xmwk";
+      name = "kbookmarks-5.47.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kcmutils-5.46.0.tar.xz";
-      sha256 = "0bwvsn3fm53d3wqsapakkg0v791vx9kxla973576mlaqpk1zgn1v";
-      name = "kcmutils-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kcmutils-5.47.0.tar.xz";
+      sha256 = "0qpsjijd51cxmp3y8knr6k6bx8bg5hhngsh63nr8yskpms38kj5d";
+      name = "kcmutils-5.47.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kcodecs-5.46.0.tar.xz";
-      sha256 = "0ywj61zmfr09nwd9v8x11jnlymkv2r3bvvkbar1p4wc8291n7cfd";
-      name = "kcodecs-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kcodecs-5.47.0.tar.xz";
+      sha256 = "1qhdj54cx98dqdy8bqkxm8jgq8mm2i7l3h9vyd2bvvzc8nzhd1hv";
+      name = "kcodecs-5.47.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kcompletion-5.46.0.tar.xz";
-      sha256 = "01rj0z26ppv2m3a7h4gh5kz96q877afk79354bvmwqi5w99iqv5a";
-      name = "kcompletion-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kcompletion-5.47.0.tar.xz";
+      sha256 = "1wdw434bi90ldmdxw8wpkgszligqapy19klpnn528vh3gv5is00p";
+      name = "kcompletion-5.47.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kconfig-5.46.0.tar.xz";
-      sha256 = "1yx2f81mik3c3hdr424j92drqs3zmsqcjryfyzczxsbllsmf6zma";
-      name = "kconfig-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kconfig-5.47.0.tar.xz";
+      sha256 = "0ifv7i6w7jz221rw07vb40sljx95kdjhxd7l9nfx95dbd5bjb0nq";
+      name = "kconfig-5.47.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kconfigwidgets-5.46.0.tar.xz";
-      sha256 = "0d4x323j6yrjjf191vf25g4fl9iad652y0kgqdqv4r2sszb7w3bp";
-      name = "kconfigwidgets-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kconfigwidgets-5.47.0.tar.xz";
+      sha256 = "05pxa7519f0730wrbh2bsqzfvc9dwvrh8l9vjh24rkaiaxnzhd6k";
+      name = "kconfigwidgets-5.47.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kcoreaddons-5.46.0.tar.xz";
-      sha256 = "13chb3xh9xyacf72kzvw6rkc9i54p1gifcnk7wx5g223bdym7h3z";
-      name = "kcoreaddons-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kcoreaddons-5.47.0.tar.xz";
+      sha256 = "0ihbggv5ziazhv66cnc6d4h4m2bci0cgwh498k49phaagrsh9zs0";
+      name = "kcoreaddons-5.47.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kcrash-5.46.0.tar.xz";
-      sha256 = "0d9k9i7lk5cj9j91av87x5gjahzs2lhkk6m1q27675sadp9hb6ih";
-      name = "kcrash-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kcrash-5.47.0.tar.xz";
+      sha256 = "15wn4g7c26f3cpk7q2imci7p8pmcksw47h6csihyvlpi3b6ykqg9";
+      name = "kcrash-5.47.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdbusaddons-5.46.0.tar.xz";
-      sha256 = "07h3n06ld1p3gspky3xsx89vpl46hq5apjqr4f2ccahscmyk1fn3";
-      name = "kdbusaddons-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdbusaddons-5.47.0.tar.xz";
+      sha256 = "04270rnfmasb9cq7kj40wny7vgkb7hksjnhr4sgyg4v2p8v5dmib";
+      name = "kdbusaddons-5.47.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdeclarative-5.46.0.tar.xz";
-      sha256 = "10r20wx36q4kzr973kgwr7j2wq140xiarjawnqpmszcp1gm9qv8c";
-      name = "kdeclarative-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdeclarative-5.47.0.tar.xz";
+      sha256 = "183l926yyhdw270rcwqh2lf1rjd4a9vbkcjlqyss2k7d79mj6m9s";
+      name = "kdeclarative-5.47.0.tar.xz";
     };
   };
   kded = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kded-5.46.0.tar.xz";
-      sha256 = "0is8x8r2dpam2m83pylyb3wfjdnn6nnrdaqkpglmbrq3r71n002r";
-      name = "kded-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kded-5.47.0.tar.xz";
+      sha256 = "0z5xsxalxasnyhhkvy247a08l37012fiaahwyy0477p7p5x3c845";
+      name = "kded-5.47.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/portingAids/kdelibs4support-5.46.0.tar.xz";
-      sha256 = "19jjn5dxgayi9m3kglalg473zslbxc0818fqckichxxn4a0wmylz";
-      name = "kdelibs4support-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/portingAids/kdelibs4support-5.47.0.tar.xz";
+      sha256 = "1rij23ns9axlwi2fvbiz2wv3y3vh1p9cm3nxkkrj3axc0hs39n20";
+      name = "kdelibs4support-5.47.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdesignerplugin-5.46.0.tar.xz";
-      sha256 = "11xvl7vjmwv5s9bhkywcapc4h4g8sdrnkwgwzgjf528mfhysi76a";
-      name = "kdesignerplugin-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdesignerplugin-5.47.0.tar.xz";
+      sha256 = "0ijdjjfqj2wpl0jrr2n90i74d378986lkqwdicig2rwkylsivr1g";
+      name = "kdesignerplugin-5.47.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdesu-5.46.0.tar.xz";
-      sha256 = "0jm4cyy85afq69qaxxzvgfv59y80i76skvwrpa59w8sl173xh8di";
-      name = "kdesu-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdesu-5.47.0.tar.xz";
+      sha256 = "1rc2v13d4i0wwzmgrbwf6i6khcd4wfa79flq764cvx62flingfvr";
+      name = "kdesu-5.47.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdewebkit-5.46.0.tar.xz";
-      sha256 = "0vr4smvj34yycxrwzhaqd8kmh6jfjxf4a0y2c1j5k41m1w0wdppl";
-      name = "kdewebkit-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdewebkit-5.47.0.tar.xz";
+      sha256 = "1yg4lydz03y6cc1f44larfd4xnvnbnzpkfa97qxjzvvrk06hdxx3";
+      name = "kdewebkit-5.47.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdnssd-5.46.0.tar.xz";
-      sha256 = "1rpf9hjqcv3k8dcwdzdlbyx5shwmjkvck59cgfmzzh6jl81w9z6d";
-      name = "kdnssd-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdnssd-5.47.0.tar.xz";
+      sha256 = "0xgv4fvhyr3gk99vaicq45zqf5mnbc4xpyz66jfhsk1w655bqijp";
+      name = "kdnssd-5.47.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kdoctools-5.46.0.tar.xz";
-      sha256 = "1zkxnib2b08nb1mxc7sjij07nk0bbylfrrd7p1h8jrx0m4gip7ik";
-      name = "kdoctools-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kdoctools-5.47.0.tar.xz";
+      sha256 = "06zlk04ldi9cq3ricni74s3737gmvs73g2k9mgfkdjq5grcsw177";
+      name = "kdoctools-5.47.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kemoticons-5.46.0.tar.xz";
-      sha256 = "0yxi72x1acjpmkpnkpy8m4y7il095bmmrgnkc9yrax4lmr9hksil";
-      name = "kemoticons-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kemoticons-5.47.0.tar.xz";
+      sha256 = "1hg72mf629g67wll5b80rw9k85qia1jdfhabg64vy7n7i9fm912y";
+      name = "kemoticons-5.47.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kfilemetadata-5.46.0.tar.xz";
-      sha256 = "15panysvxn7di38dplslpii9xskich09j9x7s79p43pxyczmq0l3";
-      name = "kfilemetadata-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kfilemetadata-5.47.0.tar.xz";
+      sha256 = "0ywp45akvn0cky757azkf6p4ql2l02xy7fplbhv7j6qz39s0p2vm";
+      name = "kfilemetadata-5.47.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kglobalaccel-5.46.0.tar.xz";
-      sha256 = "0xnljxkp9rcl3y22mzlz7zlq923ngyvihg6s7mqpfh97ayfh3pvv";
-      name = "kglobalaccel-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kglobalaccel-5.47.0.tar.xz";
+      sha256 = "1lcac55kanddpn6nphmyixp33mk8zmhfih7p9vzhnxvrc5k9r6hb";
+      name = "kglobalaccel-5.47.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kguiaddons-5.46.0.tar.xz";
-      sha256 = "02x9aqdvy3gl1y25g03cpk340xzhrmdi84v5xw8y7i2xbmgax244";
-      name = "kguiaddons-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kguiaddons-5.47.0.tar.xz";
+      sha256 = "14pivzmpsmmqrhvmvlc10fc7mc6gdq214qy27r4dsxmjdvgljhhj";
+      name = "kguiaddons-5.47.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kholidays-5.46.0.tar.xz";
-      sha256 = "10xb35zinriah3q214qhdwx3riqfj7w0dvn2ds5kcfa070q694yq";
-      name = "kholidays-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kholidays-5.47.0.tar.xz";
+      sha256 = "001misp4bdd4q05ns4bch7gx1j8h2wpa2is7zdazqy0bp1blsfwb";
+      name = "kholidays-5.47.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/portingAids/khtml-5.46.0.tar.xz";
-      sha256 = "0cdq8y09qbciwaxvkln03n9jy91li0yp2g440sd580hd3n4zvs09";
-      name = "khtml-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/portingAids/khtml-5.47.0.tar.xz";
+      sha256 = "1c9fja1mb2jrlrial2mz2bvw004s14kn7jnakawqg0d19fhlqg1h";
+      name = "khtml-5.47.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/ki18n-5.46.0.tar.xz";
-      sha256 = "0lwjmxkfqhxwjm0m86f0saa3irzv70psl5y8pv1qib82q3fv73ns";
-      name = "ki18n-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/ki18n-5.47.0.tar.xz";
+      sha256 = "1a190wf2ms09cwzpk1ylx7kjfz8yvzv2p14fjwyld6vf32hgl9r6";
+      name = "ki18n-5.47.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kiconthemes-5.46.0.tar.xz";
-      sha256 = "1y8f2piy258n0k8jrlyhgflafxcqax18fi46719av29ls48cgcap";
-      name = "kiconthemes-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kiconthemes-5.47.0.tar.xz";
+      sha256 = "14j8d1glrcd6a9xn86jxa7wx80bpf5wax5vkv09swcbbshp7vqdp";
+      name = "kiconthemes-5.47.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kidletime-5.46.0.tar.xz";
-      sha256 = "0hvgvmgfrnfmfgi19mjc1cg31yli7pzr9fq2ny9pk63is6zgq3vm";
-      name = "kidletime-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kidletime-5.47.0.tar.xz";
+      sha256 = "0dirflwwnq83nxml66kk4bf70nl04dhrg8pvh9md3hip5cn6mq2f";
+      name = "kidletime-5.47.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kimageformats-5.46.0.tar.xz";
-      sha256 = "0gkmd5ma0dh06vdr8kzw5v9hqw6xqiizzvq7aya2y9lk42p4hay3";
-      name = "kimageformats-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kimageformats-5.47.0.tar.xz";
+      sha256 = "19j6wdfv9yncdgcm5ij0rz5rv0a3jlgdnwmyrw1gjyz5isv2qp4f";
+      name = "kimageformats-5.47.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kinit-5.46.0.tar.xz";
-      sha256 = "0szpvni3ff50i5w4c2jdi8wsb2i4dfhdna7wcmrzc5qd2l62yi6m";
-      name = "kinit-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kinit-5.47.0.tar.xz";
+      sha256 = "1rc0ig4gw7lkvkpwcik6krn5w1zqj6y710c58i9kr9vxxpffj170";
+      name = "kinit-5.47.0.tar.xz";
     };
   };
   kio = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kio-5.46.0.tar.xz";
-      sha256 = "19fkijl7h1p92sngsqypsd2ni9qld9cxwh8c7diq0ybp8qzpjspb";
-      name = "kio-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kio-5.47.0.tar.xz";
+      sha256 = "0847dxrhdywrx2v6knf6l70slm8dfz4n4j1c1si13jrj1fp2w4ji";
+      name = "kio-5.47.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kirigami2-5.46.0.tar.xz";
-      sha256 = "1d6w4kc6kf0jlgji83r8zn0r5rdggygi28938wyb3wz4pgaz8m8d";
-      name = "kirigami2-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kirigami2-5.47.0.tar.xz";
+      sha256 = "1mdahdb5z0i9bf63480b2j6xm7cgsh1anx0cljn2hivglpixjbgd";
+      name = "kirigami2-5.47.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kitemmodels-5.46.0.tar.xz";
-      sha256 = "0xy8bqbaqnkxk34p7hfslm42dm98ka86fwi77pz04gw9r6048wq2";
-      name = "kitemmodels-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kitemmodels-5.47.0.tar.xz";
+      sha256 = "0151arf7s5ns2qadn86z385i9v9z8rga0jcj8pnw329k4pjpc2ks";
+      name = "kitemmodels-5.47.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kitemviews-5.46.0.tar.xz";
-      sha256 = "1ni3c2ivqr5vczl7z5707nv469xbwys1vz625ypwfh8py2b9nnwz";
-      name = "kitemviews-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kitemviews-5.47.0.tar.xz";
+      sha256 = "0dnk7y50d5wxpl4fppb0hdzy5w6xa04a178y49zggpjm5x048mp5";
+      name = "kitemviews-5.47.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kjobwidgets-5.46.0.tar.xz";
-      sha256 = "129mxv7c0fmqdmzg1j8r0cb8sr9masrmkjl4dp8i6yark49k61hf";
-      name = "kjobwidgets-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kjobwidgets-5.47.0.tar.xz";
+      sha256 = "05vgqm3nfpbwbnv46ajb8hc5wzs1444513ahay1qn8vpah4kqbpp";
+      name = "kjobwidgets-5.47.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/portingAids/kjs-5.46.0.tar.xz";
-      sha256 = "002k1jbcwxyv8dcmz3x4m7zv1ry2gdzg5gl466vf5hlc5cwgjac5";
-      name = "kjs-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/portingAids/kjs-5.47.0.tar.xz";
+      sha256 = "1rhvmdwmsr48ih0qrpwphiwcl25af8shwj8nrkq619krc549gf8q";
+      name = "kjs-5.47.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/portingAids/kjsembed-5.46.0.tar.xz";
-      sha256 = "13l2i0i8qlzs993nfbcgaijkhy7w9npn5358d5hfkxjlay7imcq2";
-      name = "kjsembed-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/portingAids/kjsembed-5.47.0.tar.xz";
+      sha256 = "104nv33zpqh78zxqj1z9sj6cyliv0l9gzgmsc4n9nq9fcr1f2hdd";
+      name = "kjsembed-5.47.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/portingAids/kmediaplayer-5.46.0.tar.xz";
-      sha256 = "0y4cn63fa5g35vrdx2hfhrw1fzwg5k3lxgx84r3c33cybxswcigi";
-      name = "kmediaplayer-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/portingAids/kmediaplayer-5.47.0.tar.xz";
+      sha256 = "0cz0m2sa48893p6vq4pm92xmvq2aqqgfmijlskzdpd3gp3x9l1qw";
+      name = "kmediaplayer-5.47.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/knewstuff-5.46.0.tar.xz";
-      sha256 = "12r38m7p86b2dfhp8nybm335cvizma4p26gxrwn7jg1kcvbg3hf5";
-      name = "knewstuff-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/knewstuff-5.47.0.tar.xz";
+      sha256 = "04zn4iy0gy00d835qjfmb0prm802ggphj4aw328v29474nqs14nf";
+      name = "knewstuff-5.47.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/knotifications-5.46.0.tar.xz";
-      sha256 = "0hyf3wv3iy3v7l134pmb623bfa9j578rdymhz4sm5fix4mv23g5z";
-      name = "knotifications-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/knotifications-5.47.0.tar.xz";
+      sha256 = "08cm2aks35lzspchyb6p25bfk4mrljb6wf7yi29674k4kg7gr6sv";
+      name = "knotifications-5.47.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/knotifyconfig-5.46.0.tar.xz";
-      sha256 = "0wr0kliagkbpv89h9qviib6b16s2cw5j9jq4gpk3j5ij9zli4lkj";
-      name = "knotifyconfig-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/knotifyconfig-5.47.0.tar.xz";
+      sha256 = "0zava15sabmxc38ngmw9yylwnm27h8ah8df0jadxbqjpaaf0jssl";
+      name = "knotifyconfig-5.47.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kpackage-5.46.0.tar.xz";
-      sha256 = "1q45zjh0a741f1w1g0vggbcygzzvkzpwj0iy13fwhgf4g7qrdp8c";
-      name = "kpackage-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kpackage-5.47.0.tar.xz";
+      sha256 = "1pwlvcmn9crjgqf1ccwb86zq962jnwavx6h6dcx7vb982z772j98";
+      name = "kpackage-5.47.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kparts-5.46.0.tar.xz";
-      sha256 = "1hr0hy1jsi00rfnjy1wf59skricib6cc0c4bw0h0gw0rdy1vv80j";
-      name = "kparts-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kparts-5.47.0.tar.xz";
+      sha256 = "1b21kmn8bjq69qhldacqpby9pa56c4y8j84kkwailylk3nngilsf";
+      name = "kparts-5.47.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kpeople-5.46.0.tar.xz";
-      sha256 = "1gkm9ylwm4ajpw6lv78qy4zkmqirm4xnrf0nld3x7jrbpiadfrni";
-      name = "kpeople-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kpeople-5.47.0.tar.xz";
+      sha256 = "13x1f5jwxhmdq5qq43qzfmxm20j95dwa0fck1ns1rg8k7gazmdqb";
+      name = "kpeople-5.47.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kplotting-5.46.0.tar.xz";
-      sha256 = "1vkwv2khww1v13r2ys06nfb6c0fwyn152wrfc9vqzcdcv6znq48n";
-      name = "kplotting-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kplotting-5.47.0.tar.xz";
+      sha256 = "0sw448g5wa2gz6krzp7d8q1ryh6qs51hgxv432fjpblijnwzb6xx";
+      name = "kplotting-5.47.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kpty-5.46.0.tar.xz";
-      sha256 = "1m1spwgrgjiazkxwddh5xcii482bvxf015x70wnkyyygilbn6871";
-      name = "kpty-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kpty-5.47.0.tar.xz";
+      sha256 = "1q4hkm701ridf07a4m93zvifi1sk6vn8z1h0b1rz5srxasaxnxlh";
+      name = "kpty-5.47.0.tar.xz";
     };
   };
   kross = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/portingAids/kross-5.46.0.tar.xz";
-      sha256 = "0wnj01ml3j3ij4f6plw8d1by8k9fkbslq0finiyxrn64zqfkr1sd";
-      name = "kross-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/portingAids/kross-5.47.0.tar.xz";
+      sha256 = "13nav8fihj1pammiwz8na482qpsmcxmyxd47rqhwldvxz1z0kbq1";
+      name = "kross-5.47.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/krunner-5.46.0.tar.xz";
-      sha256 = "1nvcprp1b5npzvcdbwzi1yn6953f8kjyfnavhjjp9vfafp4jgdca";
-      name = "krunner-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/krunner-5.47.0.tar.xz";
+      sha256 = "0j3j6831y5j96cl19jdwcnd9h4rl95ymj3gy5sxilazgafzfihbd";
+      name = "krunner-5.47.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kservice-5.46.0.tar.xz";
-      sha256 = "0q502wqvqb61gwy07byg35nk9ac12d02hhqa0qhil6qkv9f7dx57";
-      name = "kservice-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kservice-5.47.0.tar.xz";
+      sha256 = "0ryipmvydh924zjpfzmwivwagaad9dicnfcfa4drrygbwnm60bd9";
+      name = "kservice-5.47.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/ktexteditor-5.46.0.tar.xz";
-      sha256 = "1yjyni3f123i2yx20gj13yw0v6cqwwdvk6x8f3maqqdzrfnqmm8b";
-      name = "ktexteditor-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/ktexteditor-5.47.0.tar.xz";
+      sha256 = "1k089k9ssk06734wnjyfmvlgxy2hqxh7fgy5qiyjvp807kmf4jkb";
+      name = "ktexteditor-5.47.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/ktextwidgets-5.46.0.tar.xz";
-      sha256 = "1bniracp5q6p4k1ji0gn1a51sylbgxh0bqdlrfkd953mp35rh1wf";
-      name = "ktextwidgets-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/ktextwidgets-5.47.0.tar.xz";
+      sha256 = "19w84d6v8yrci4fb6c7m91q2ykc9p24cf85cnm6lsb8ggis4dsyr";
+      name = "ktextwidgets-5.47.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kunitconversion-5.46.0.tar.xz";
-      sha256 = "14db0835zd375sn3d4v6d2pa5yp67gn9p8dxfs8111minmraqk43";
-      name = "kunitconversion-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kunitconversion-5.47.0.tar.xz";
+      sha256 = "0avm3g78zfzrh4h6ampf54n9j715ii5cra8praq0waiy94idn7cq";
+      name = "kunitconversion-5.47.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kwallet-5.46.0.tar.xz";
-      sha256 = "15fvbyfdbmdq7zvsbj1c7xzyyhfd5mhv9zvgiss00ranhghsbbzh";
-      name = "kwallet-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kwallet-5.47.0.tar.xz";
+      sha256 = "0hy3kzkcqbzkjkvnaaanfdcnwcidnbw6j14ifvhlh2padql7kyix";
+      name = "kwallet-5.47.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kwayland-5.46.0.tar.xz";
-      sha256 = "1dwvxhpa93k9l2iqbpyf6s7hkmi91kc56hm0v5q6k2mgb43g32nj";
-      name = "kwayland-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kwayland-5.47.0.tar.xz";
+      sha256 = "0j15xzlzxqi0g8lj5k9w0lbnvx26h6bblgz8rhqlkl80ml2wzgfv";
+      name = "kwayland-5.47.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kwidgetsaddons-5.46.0.tar.xz";
-      sha256 = "0h8n4hiyzynpg59bfrk3wgdc1w0b3pdbvimykgjvrrmn4wi6h8f9";
-      name = "kwidgetsaddons-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kwidgetsaddons-5.47.0.tar.xz";
+      sha256 = "0d2sxh6g7igjdsgj9agknx8zvymyvq9rb0xkfbr044vg5q0g99js";
+      name = "kwidgetsaddons-5.47.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kwindowsystem-5.46.0.tar.xz";
-      sha256 = "0rxhi8wjjxkqsspx0mqn5049f75s3jihkp73hdgxwwdp1qc66kx3";
-      name = "kwindowsystem-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kwindowsystem-5.47.0.tar.xz";
+      sha256 = "1hfbjy17b6iw6443a3zw304syi4j0vid7nmm5hqdv8685lnp4wx6";
+      name = "kwindowsystem-5.47.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kxmlgui-5.46.0.tar.xz";
-      sha256 = "0wwxry3kf2xsw40dhjpa8gh1qbh4wdnd1hp1g9mmh8l0wpfv289l";
-      name = "kxmlgui-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kxmlgui-5.47.0.tar.xz";
+      sha256 = "194linh0px5mk404hbgrzcfx9zblk4q835nvj4lrbl62nffzwnlp";
+      name = "kxmlgui-5.47.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/kxmlrpcclient-5.46.0.tar.xz";
-      sha256 = "05wf844ipikikhxcri0xpdwfxs8h3m677frsqkimf778g8vf7crh";
-      name = "kxmlrpcclient-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/kxmlrpcclient-5.47.0.tar.xz";
+      sha256 = "1wmsycpg5yljdpa0slv47baqpag6jzg75g0l2jddl3knznp7br8i";
+      name = "kxmlrpcclient-5.47.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/modemmanager-qt-5.46.0.tar.xz";
-      sha256 = "1h9hj1v4js02gyxbh1cizz69vh8pdwb93k9pi334a2s0lxbn5205";
-      name = "modemmanager-qt-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/modemmanager-qt-5.47.0.tar.xz";
+      sha256 = "00wxsc4wz5fflld4h1w77726w1c06g1ql5qld2r30yibx1fb2slb";
+      name = "modemmanager-qt-5.47.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/networkmanager-qt-5.46.0.tar.xz";
-      sha256 = "1pp5sgp76fjd62iqki3cc7b2drmfgq2fjhab9ai44r852ydgkzpn";
-      name = "networkmanager-qt-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/networkmanager-qt-5.47.0.tar.xz";
+      sha256 = "02c2d1jm3azzbwd52awq6ikjsgfg9f2dc12dkw14zkz41r87gcyh";
+      name = "networkmanager-qt-5.47.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/oxygen-icons5-5.46.0.tar.xz";
-      sha256 = "141qhbk6rakvh2clxyfhinzka3ap99ac8y90qplgss31ww0wxbb5";
-      name = "oxygen-icons5-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/oxygen-icons5-5.47.0.tar.xz";
+      sha256 = "19w7ab5b7qdhj3j0pg8378k918kwjd1m5lm13jdg2kkn1f4j0j4m";
+      name = "oxygen-icons5-5.47.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/plasma-framework-5.46.0.tar.xz";
-      sha256 = "0zpv6b128ll9yf23ys8hv35a95igmlbk3zid5k4385b6h0j4h367";
-      name = "plasma-framework-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/plasma-framework-5.47.0.tar.xz";
+      sha256 = "1d3f2k5y966jnwrjps1x5lx9scpakq3ri3111m5h0vidkrlvnhsa";
+      name = "plasma-framework-5.47.0.tar.xz";
     };
   };
   prison = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/prison-5.46.0.tar.xz";
-      sha256 = "1508pcqvyjfqg0yxk2jx32cqlvvz658z001n6iaf4c7hwclkyspg";
-      name = "prison-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/prison-5.47.0.tar.xz";
+      sha256 = "17j12mg11fnjnlj04fzxd5x95cs2f34xc2lk09hjlm7ihkw932xh";
+      name = "prison-5.47.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/purpose-5.46.0.tar.xz";
-      sha256 = "1mrssw484hb3nk9hafys0ns1ixd8h3l6m8qnyry9ky964xqmbkg1";
-      name = "purpose-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/purpose-5.47.0.tar.xz";
+      sha256 = "1symzvzk50d3szz2rh7c9jd60hzpvlv6d8n7r6j9rzrplvshk879";
+      name = "purpose-5.47.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/qqc2-desktop-style-5.46.0.tar.xz";
-      sha256 = "0hfl0qk4nadz2jykn0xaphppiqva0h83br4ym6zf2wc3c5sd6w91";
-      name = "qqc2-desktop-style-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/qqc2-desktop-style-5.47.0.tar.xz";
+      sha256 = "1w897ixs0bfhzrzq8v4yg3rsrd8zmb08j5xh52ysb4mp7zs8jcyk";
+      name = "qqc2-desktop-style-5.47.0.tar.xz";
     };
   };
   solid = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/solid-5.46.0.tar.xz";
-      sha256 = "0ywx5nbms6nk7dmcbbgjfm8w3lchhf90wlhv077yhmxlnqciv3im";
-      name = "solid-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/solid-5.47.0.tar.xz";
+      sha256 = "041fvxxlazbpdl5ncdpxzj8jq48rk31kd1nqsm8p5wqglzrz6dsl";
+      name = "solid-5.47.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/sonnet-5.46.0.tar.xz";
-      sha256 = "13jmyiqfwcc7r5y2mb2hwwnn28bq1l0pjlfv8g963r0agzyap424";
-      name = "sonnet-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/sonnet-5.47.0.tar.xz";
+      sha256 = "14nfrv1z1lpjhxsxhjx8bi88yp1qx4dzwf6v22w0mk71qc6z2rgr";
+      name = "sonnet-5.47.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/syntax-highlighting-5.46.0.tar.xz";
-      sha256 = "18b7v6l3ckqkhp5mxpfvyzl89yl3w9hcqbvfvbzzr9pd0lg09xxx";
-      name = "syntax-highlighting-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/syntax-highlighting-5.47.0.tar.xz";
+      sha256 = "0bv25cv3xvhl9v23dn3yxhdcv5ag2i1zhvna6gnng6k30n316v0c";
+      name = "syntax-highlighting-5.47.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.46.0";
+    version = "5.47.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.46/threadweaver-5.46.0.tar.xz";
-      sha256 = "0zndyxj3kkxs4mlznykf3lm5bq3mmwanxd80pb7y0rymnzsd2n7q";
-      name = "threadweaver-5.46.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.47/threadweaver-5.47.0.tar.xz";
+      sha256 = "0h48b6mvgq3igbs6jzngj1iad7m5kgkird17shk86ma79k6igriz";
+      name = "threadweaver-5.47.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New version.

@adisbladis @ttuegel @peterhoeg 

We should wait for tuesday, when plasma 5.13 is released and merge everything together:
https://github.com/NixOS/nixpkgs/pull/40893 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

