### PR TITLE
mupdf: apply CVE-2018-10289 patch

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -23,12 +23,15 @@ in stdenv.mkDerivation rec {
   };
 
   patches = [
+    (fetchpatch {
+      # CVE-2018-10289
+      url = "https://bugs.ghostscript.com/attachment.cgi?id=15230";
+      sha256 = "0jmpacxd9930g6k57kda9jrcrbk75whdlv8xwmqg5jwn848qvy4q";
+    })
   ]
-
-  # Use shared libraries to decrease size
-  ++ stdenv.lib.optional (!stdenv.isDarwin) ./mupdf-1.13-shared_libs-1.patch
-
-  ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch
+    # Use shared libraries to decrease size
+    ++ stdenv.lib.optional (!stdenv.isDarwin) ./mupdf-1.13-shared_libs-1.patch
+    ++ stdenv.lib.optional stdenv.isDarwin ./darwin.patch
   ;
 
   postPatch = ''


### PR DESCRIPTION
Fixes mupdf issue in https://github.com/NixOS/nixpkgs/issues/41748 by applying
patch from https://bugs.ghostscript.com/show_bug.cgi?id=699271

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

