### PR TITLE
pythonPackages.python-hosts: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/python-hosts/default.nix
+++ b/pkgs/development/python-modules/python-hosts/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, pyyaml, pytest, pytestcov }:
+
+buildPythonPackage rec {
+  pname = "python-hosts";
+  version = "0.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4a169a4669bddb720c032ef0132203ff8a7b6646266f7e6ab349177bab02b3ba";
+  };
+
+  # win_inet_pton is required for windows support
+  prePatch = ''
+    substituteInPlace setup.py --replace "install_requires=['win_inet_pton']," ""
+    substituteInPlace python_hosts/utils.py --replace "import win_inet_pton" ""
+  '';
+
+  checkInputs = [ pyyaml pytest pytestcov ];
+
+  # Removing 1 test file (it requires internet connection) and keeping the other two
+  checkPhase = ''
+    pytest tests/test_hosts_entry.py
+    pytest tests/test_utils.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library for managing a hosts file. It enables adding and removing entries, or importing them from a file or URL";
+    homepage = https://github.com/jonhadfield/python-hosts;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -410,6 +410,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  python-hosts = callPackage ../development/python-modules/python-hosts { };
+
   python-openid = callPackage (if isPy3k
     then ../development/python-modules/python3-openid
     else ../development/python-modules/python-openid) { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

