### PR TITLE
fira fonts: Update url

### DIFF
--- a/pkgs/data/fonts/fira-mono/default.nix
+++ b/pkgs/data/fonts/fira-mono/default.nix
@@ -3,17 +3,17 @@
 fetchzip {
   name = "fira-mono-3.206";
 
-  url = http://www.carrois.com/downloads/fira_mono_3_2/FiraMonoFonts3206.zip;
+  url = https://github.com/mozilla/Fira/archive/4.106.zip;
 
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile Fira-4.106/otf/FiraMono\*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "0m4kdjh4xjyznybpgh21a0gibv4wsxq0rqyl3wv942zk6mclmgdf";
+  sha256 = "1ci3fxhdwabvfj4nl16pwcgqnh7s2slp8vblribk8zkpx8cbp1dj";
 
   meta = with stdenv.lib; {
-    homepage = http://www.carrois.com/fira-4-1/;
+    homepage = https://mozilla.github.io/Fira/;
     description = "Monospace font for Firefox OS";
     longDescription = ''
       Fira Mono is a monospace font designed by Erik Spiekermann,

--- a/pkgs/data/fonts/fira/default.nix
+++ b/pkgs/data/fonts/fira/default.nix
@@ -3,17 +3,17 @@
 fetchzip rec {
   name = "fira-4.106";
 
-  url = http://www.carrois.com/downloads/fira_4_1/FiraFonts4106.zip;
+  url = https://github.com/mozilla/Fira/archive/4.106.zip;
 
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile Fira-4.106/otf/FiraSans\*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "174nwmpvxqg1qjfj6h3yvrphs1s3n6zricdh27iaxilajm0ilbgs";
+  sha256 = "0c97nmihcq0ki7ywj8zn048a2bgrszc61lb9p0djfi65ar52jab4";
 
   meta = with stdenv.lib; {
-    homepage = http://www.carrois.com/fira-4-1/;
+    homepage = https://mozilla.github.io/Fira/;
     description = "Sans-serif font for Firefox OS";
     longDescription = ''
       Fira Sans is a sans-serif font designed by Erik Spiekermann,


### PR DESCRIPTION
###### Motivation for this change
The old homepage is gone: https://carrois.com/fira-4-1/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

