### PR TITLE
Fix aliases.nix using the wrong self refs.

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1,4 +1,4 @@
-self:
+lib: self: super:
 
 with self;
 
@@ -19,7 +19,7 @@ let
 
   # Make sure that we are not shadowing something from
   # all-packages.nix.
-  checkInPkgs = n: alias: if builtins.hasAttr n self
+  checkInPkgs = n: alias: if builtins.hasAttr n super
                           then throw "Alias ${n} is still in all-packages.nix"
                           else alias;
 
@@ -32,7 +32,7 @@ in
 
   ### Deprecated aliases - for backward compatibility
 
-mapAliases (rec {
+mapAliases ({
   PPSSPP = ppsspp; # added 2017-10-01
   QmidiNet = qmidinet;  # added 2016-05-22
   accounts-qt = libsForQt5.accounts-qt; # added 2015-12-19

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -98,7 +98,7 @@ let
     in res;
 
   aliases = self: super: if config.skipAliases or false then {}
-                         else import ./aliases.nix super;
+                         else import ./aliases.nix lib self super;
 
   # stdenvOverrides is used to avoid having multiple of versions
   # of certain dependencies that were used in bootstrapping the


### PR DESCRIPTION
###### Motivation for this change

Addresses [this comment](https://github.com/NixOS/nixpkgs/commit/218d81bc9db409a72a572336a4dadc40a9088cde#commitcomment-29311864). For example, `dbus_libs` is frequently depended on instead of `dbus`, so the use of `noXlibs` (which overrides `dbus` to prevent X deps) did not properly change those dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

