### PR TITLE
mariadb galera: fix build

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -2,7 +2,7 @@
 , libiconv, openssl, pcre, boost, judy, bison, libxml2
 , libaio, libevent, groff, jemalloc, cracklib, systemd, numactl, perl
 , fixDarwinDylibNames, cctools, CoreServices
-, asio, buildEnv, check, qt4, scons
+, asio, buildEnv, check, scons
 }:
 
 with stdenv.lib;
@@ -224,7 +224,7 @@ galera = stdenv.mkDerivation rec {
     sha256 = "11pfc85z29jk0h6g6bmi3hdv4in4yb00xsr2r0qm1b0y7m2wq3ra";
   };
 
-  buildInputs = [ asio boost check openssl qt4 scons ];
+  buildInputs = [ asio boost check openssl scons ];
 
   patchPhase = ''
     substituteInPlace SConstruct \
@@ -232,7 +232,7 @@ galera = stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    export CPPFLAGS="-I${asio}/include  -I${boost.dev}/include -I${check}/include -I${openssl.dev}/include"
+    export CPPFLAGS="-I${asio}/include -I${boost.dev}/include -I${check}/include -I${openssl.dev}/include"
     export LIBPATH="${galeraLibs}/lib"
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12783,6 +12783,7 @@ with pkgs;
   rpcbind = callPackage ../servers/rpcbind { };
 
   mariadb = callPackage ../servers/sql/mariadb {
+    asio = asio_1_10;
     inherit (darwin) cctools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change
Plugins mariadb galero error build with asio 1.12.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

