### PR TITLE
 kicad-unstable: 2018-03-10 -> 2018-06-12

### DIFF
--- a/pkgs/applications/science/electronics/kicad/unstable.nix
+++ b/pkgs/applications/science/electronics/kicad/unstable.nix
@@ -12,13 +12,13 @@ assert ngspiceSupport -> libngspice != null;
 with lib;
 stdenv.mkDerivation rec {
   name = "kicad-unstable-${version}";
-  version = "2018-03-10";
+  version = "2018-06-12";
 
   src = fetchFromGitHub {
     owner = "KICad";
     repo = "kicad-source-mirror";
-    rev = "17c0917dac12ea0be50ff95cee374a0cd8b7f862";
-    sha256 = "1yn5hj5hjnpb5fkzzlyawg62a96fbfvha49395s22dcp95riqvf0";
+    rev = "bc7bd107d980da147ad515aeae0469ddd55c2368";
+    sha256 = "11nsx52pd3jr2wbzr11glmcs1a9r7z1mqkqx6yvlm0awbgd8qlv8";
   };
 
   postPatch = ''
@@ -38,7 +38,8 @@ stdenv.mkDerivation rec {
       "-DCMAKE_CXX_FLAGS=-I${wxPython}/include/wx-3.0"
     ];
 
-  nativeBuildInputs = [ cmake doxygen  pkgconfig ];
+  # https://www.mail-archive.com/kicad-developers@lists.launchpad.net/msg29840.html
+  nativeBuildInputs = [ (cmake.override {majorVersion = "3.10";}) doxygen  pkgconfig ];
   buildInputs = [
     libGLU_combined zlib libX11 wxGTK pcre libXdmcp gettext glew glm libpthreadstubs
     cairo curl openssl boost

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   # Don't search in non-Nix locations such as /usr, but do search in our libc.
   patches = [ ./search-path-3.9.patch ]
     # Don't depend on frameworks.
-    ++ optional useSharedLibraries ./application-services.patch  # TODO: remove conditional
+    ++ optional (useSharedLibraries && majorVersion == "3.11") ./application-services.patch  # TODO: remove conditional
     ++ optional stdenv.isCygwin ./3.2.2-cygwin.patch;
 
   outputs = [ "out" ];


### PR DESCRIPTION
###### Motivation for this change

Just an update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

