### PR TITLE
perlPackages.JSON: fix cross-compilation

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8171,6 +8171,10 @@ let self = _self // overrides; _self = with self; {
       url = mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-2.97001.tar.gz;
       sha256 = "0nlgdzy40q26z8qhwngsd461glyai8dpwaccyhiljmrkaqwdjxz2";
     };
+    # Do not abort cross-compilation on failure to load native JSON module into host perl
+    preConfigure = ''
+      substituteInPlace Makefile.PL --replace "exit 0;" ""
+    '';
     meta = {
       description = "JSON (JavaScript Object Notation) encoder/decoder";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];


### PR DESCRIPTION
###### Motivation for this change

Fixes cross-compilation https://github.com/NixOS/nixpkgs/pull/41712#issuecomment-396128046

it is a reimplementation of https://github.com/NixOS/nixpkgs/commit/b0d6c67505e1 from https://github.com/NixOS/nixpkgs/pull/36187 compatible with newer version of ```perlPackages.JSON```

@ElvishJerricco