### PR TITLE
Fix a typo in doc/languages-frameworks/python.section.md.

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -973,7 +973,7 @@ stdenv.mkDerivation {
     # the following packages are related to the dependencies of your python
     # project.
     # In this particular example the python modules listed in the
-    # requirements.tx require the following packages to be installed locally
+    # requirements.txt require the following packages to be installed locally
     # in order to compile any binary extensions they may require.
     #
     taglib


### PR DESCRIPTION
###### Motivation for this change

I read the docs and found a typo. I did not test anything at all after changing the correponding md file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

