### PR TITLE
nixos/initrd-network: support hetzner

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -12,6 +12,7 @@ let
       if [ "$1" = bound ]; then
         ip address add "$ip/$mask" dev "$interface"
         if [ -n "$router" ]; then
+          ip route add "$router" dev "$interface" # just in case if "$router" is not within "$ip/$mask" (e.g. Hetzner Cloud)
           ip route add default via "$router" dev "$interface"
         fi
         if [ -n "$dns" ]; then


### PR DESCRIPTION
###### Motivation for this change

Default router on Hetzner Cloud is ```172.31.1.1``` 
So ```ip route add default via "172.31.1.1" dev "eth0"``` fails because the router address is not reachable.
