### PR TITLE
ntp: fix a missed syscall in seccomp

### DIFF
--- a/pkgs/tools/networking/ntp/seccomp.patch
+++ b/pkgs/tools/networking/ntp/seccomp.patch
@@ -34,11 +34,12 @@ diff -urN ntp-4.2.8p10.orig/ntpd/ntpd.c ntp-4.2.8p10/ntpd/ntpd.c
  	SCMP_SYS(madvise),
  	SCMP_SYS(mmap),
  	SCMP_SYS(mmap2),
-@@ -1211,6 +1216,7 @@
+@@ -1211,6 +1216,8 @@
  	SCMP_SYS(select),
  	SCMP_SYS(setitimer),
  	SCMP_SYS(setsid),
 +        SCMP_SYS(setsockopt),
++        SCMP_SYS(openat),
  	SCMP_SYS(sigprocmask),
  	SCMP_SYS(sigreturn),
  	SCMP_SYS(socketcall),


### PR DESCRIPTION
ntpd uses `openat` to adjust the drift file, which it only does after a few hours of uptime
that syscall was missed in the previous PR that was fixing ntp

###### Motivation for this change

without these changes, ntpd will crash after a few hours of uptime

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

