### PR TITLE
pythonPackages.deap: init at 1.2.2

### DIFF
--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, python, numpy, matplotlib }:
+
+buildPythonPackage rec {
+  pname = "deap";
+  version = "1.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "95c63e66d755ec206c80fdb2908851c0bef420ee8651ad7be4f0578e9e909bcf";
+  };
+
+  propagatedBuildInputs = [ numpy matplotlib ];
+
+  checkPhase = ''
+    ${python.interpreter} setup.py nosetests --verbosity=3
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DEAP is a novel evolutionary computation framework for rapid prototyping and testing of ideas.";
+    homepage = https://github.com/DEAP/deap;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -237,6 +237,8 @@ in {
 
   dbfread = callPackage ../development/python-modules/dbfread { };
 
+  deap = callPackage ../development/python-modules/deap { };
+
   dkimpy = callPackage ../development/python-modules/dkimpy { };
 
   diff_cover = callPackage ../development/python-modules/diff_cover { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

