### PR TITLE
gshogi: init at 0.5.1

### DIFF
--- a/pkgs/games/gshogi/default.nix
+++ b/pkgs/games/gshogi/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub
+, gtk3, gobjectIntrospection
+, wrapGAppsHook, python3Packages }:
+
+buildPythonApplication rec {
+  pname = "gshogi";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "johncheetham";
+    repo = "gshogi";
+    rev = "v${version}";
+    sha256 = "06vgndfgwyfi50wg3cw92zspc9z0k7xn2pp6qsjih0l5yih8iwqh";
+  };
+
+  doCheck = false;  # no tests available
+
+  buildInputs = [
+    gtk3
+    gobjectIntrospection
+  ];
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    pycairo
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A graphical implementation of the Shogi board game, also known as Japanese Chess";
+    homepage = http://johncheetham.com/projects/gshogi/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ciil ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19308,6 +19308,8 @@ with pkgs;
 
   gogui = callPackage ../games/gogui {};
 
+  gshogi = python3Packages.callPackage ../games/gshogi {};
+
   gtetrinet = callPackage ../games/gtetrinet {
     inherit (gnome2) GConf libgnome libgnomeui;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

