### PR TITLE
python3Packages.click: fix 'locale' path

### DIFF
--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+{ stdenv, buildPythonPackage, fetchPypi, substituteAll, glibc, pytest }:
 
 buildPythonPackage rec {
   pname = "click";
@@ -8,6 +8,12 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "02qkfpykbq35id8glfgwc38yc430427yd05z1wc5cnld8zgicmgi";
   };
+
+  patches = stdenv.lib.optionals (stdenv.isLinux && !stdenv.hostPlatform.isMusl)
+    (substituteAll {
+      src = ./fix-paths.patch;
+      locale = "${glibc.bin}/bin/locale";
+    });
 
   buildInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/click/fix-paths.patch
+++ b/pkgs/development/python-modules/click/fix-paths.patch
@@ -1,0 +1,11 @@
+--- a/click/_unicodefun.py	2018-06-11 15:08:59.369358278 +0200
++++ b/click/_unicodefun.py	2018-06-11 15:09:09.342325998 +0200
+@@ -60,7 +60,7 @@
+     extra = ''
+     if os.name == 'posix':
+         import subprocess
+-        rv = subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE,
++        rv = subprocess.Popen(['@locale@', '-a'], stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE).communicate()[0]
+         good_locales = set()
+         has_c_utf8 = False


### PR DESCRIPTION
importing click shells out to 'locale', which currently needs to be in
PATH. Fix by setting patching locale command at runtime.

###### Motivation for this change
Tried dockerizing a flask application, which uses click, which failed to import due to above error

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

