### PR TITLE
pythonPackages.GitPython: set path to git executable

### DIFF
--- a/pkgs/development/python-modules/GitPython/default.nix
+++ b/pkgs/development/python-modules/GitPython/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, gitdb2, mock, nose, ddt }:
+{ lib, buildPythonPackage, fetchPypi, git, gitdb2, mock, nose, ddt }:
 
 buildPythonPackage rec {
   version = "2.1.9";
@@ -11,6 +11,10 @@ buildPythonPackage rec {
 
   checkInputs = [ mock nose ddt ];
   propagatedBuildInputs = [ gitdb2 ];
+
+  postPatch = ''
+    sed -i "s|^refresh()$|refresh(path='${git}/bin/git')|" git/__init__.py
+  '';
 
   # Tests require a git repo
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
GitPython wants the git binary to be in `$PATH`, or some other environment variables being set to that executable. Patch path to git during initialization call to `${git}/bin/git`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

