### PR TITLE
trash-cli: enable darwin build

### DIFF
--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -1,8 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, coreutils
 , python3, python3Packages, substituteAll }:
 
-assert stdenv.isLinux;
-
 python3Packages.buildPythonApplication rec {
   name = "trash-cli-${version}";
   version = "0.17.1.14";
@@ -19,7 +17,8 @@ python3Packages.buildPythonApplication rec {
     (substituteAll {
       src = ./nix-paths.patch;
       df = "${coreutils}/bin/df";
-      libc = "${stdenv.cc.libc.out}/lib/libc.so.6";
+      libc = let ext = if stdenv.isDarwin then ".dylib" else ".so.6";
+             in "${stdenv.cc.libc}/lib/libc${ext}";
     })
 
     # Fix build on Python 3.6.
@@ -37,7 +36,7 @@ python3Packages.buildPythonApplication rec {
     homepage = https://github.com/andreafrancia/trash-cli;
     description = "Command line tool for the desktop trash can";
     maintainers = [ maintainers.rycee ];
-    platforms = platforms.all;
+    platforms = platforms.unix;
     license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

