### PR TITLE
Initial home contents

### DIFF
--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -213,7 +213,15 @@ foreach my $u (@{$spec->{users}}) {
 
     # Create a home directory.
     if ($u->{createHome}) {
-        make_path($u->{home}, { mode => 0700 }) if ! -e $u->{home};
+        my $new_home = 0;
+        if ( !-e $u->{home} ) {
+            make_path($u->{home}, { mode => 0700 });
+            $new_home = 1;
+        }
+        if (defined $new_home && $u->{initialHomeContents}) {
+            system("cp --recursive --preserve=mode --no-preserve=owner $u->{initialHomeContents}/. $u->{home}");
+            system("chown -R $u->{uid}, $u->{gid}, $u->{home}");
+        }
         chown $u->{uid}, $u->{gid}, $u->{home};
     }
 

--- a/nixos/modules/config/update-users-groups.pl
+++ b/nixos/modules/config/update-users-groups.pl
@@ -220,7 +220,7 @@ foreach my $u (@{$spec->{users}}) {
         }
         if (defined $new_home && $u->{initialHomeContents}) {
             system("cp --recursive --preserve=mode --no-preserve=owner $u->{initialHomeContents}/. $u->{home}");
-            system("chown -R $u->{uid}, $u->{gid}, $u->{home}");
+            system("chown -R $u->{uid}:$u->{gid} $u->{home}");
         }
         chown $u->{uid}, $u->{gid}, $u->{home};
     }

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -171,6 +171,20 @@ let
         '';
       };
 
+      initialHomeContents = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Specifies the directory that represents the contents of a newly
+          created home directory. The contents of this directory is copied
+          to the home directory when the home directory is being created.
+          This represents the behavior of
+          <filename>/etc/skel</filename>.
+          This option only applies when <option>createHome</option>
+          is enabled.
+        '';
+      };
+
       useDefaultShell = mkOption {
         type = types.bool;
         default = false;
@@ -383,7 +397,8 @@ let
     inherit (cfg) mutableUsers;
     users = mapAttrsToList (_: u:
       { inherit (u)
-          name uid group description home createHome isSystemUser
+          name uid group description isSystemUser
+          home createHome initialHomeContents
           password passwordFile hashedPassword
           initialPassword initialHashedPassword;
         shell = utils.toShellPath u.shell;

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -337,6 +337,7 @@ in rec {
   tests.mumble = callTest tests/mumble.nix {};
   tests.munin = callTest tests/munin.nix {};
   tests.mutableUsers = callTest tests/mutable-users.nix {};
+  tests.initialHomeContents = callTest tests/initial-home-contents.nix {};
   tests.mysql = callTest tests/mysql.nix {};
   tests.mysqlBackup = callTest tests/mysql-backup.nix {};
   tests.mysqlReplication = callTest tests/mysql-replication.nix {};

--- a/nixos/tests/initial-home-contents.nix
+++ b/nixos/tests/initial-home-contents.nix
@@ -1,0 +1,27 @@
+import ./make-test.nix ({ pkgs, ...} : {
+  name = "initial-home-contents";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ bobvanderlinden ];
+  };
+
+  nodes = {
+    machine = { config, lib, pkgs, ... }: {
+      users.users.testuser = {
+        isNormalUser = true;
+        home = "/home/testuser";
+        initialHomeContents = pkgs.runCommand "homecontent" {} ''
+          mkdir -p $out/new-directory
+          touch $out/new-file
+        '';
+      };
+    };
+  };
+
+  testScript = {nodes, ...}: ''
+    $machine->start();
+    $machine->waitForUnit("default.target");
+
+    $machine->succeed("test -d /home/testuser/new-directory");
+    $machine->succeed("test -f /home/testuser/new-file");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

See #33586. This change will allow setting the files that should reside inside newly created home directories. This is similar to `/etc/skel` in other distros.

This is especially useful for cases where users need predefined `.config` that should not affect other users.

The following NixOS configuration is now possible:

```
      users.users.testuser = {
        isNormalUser = true;
        initialHomeContents = pkgs.runCommand "homecontent" {} ''
          mkdir -p $out/.config/openbox
          cp ${openboxConfig} $out/.config/openbox/rc.xml
        '';
      };
```

Let me know whether this is the right approach. An alternative I've been thinking of was using a similar scheme as `etc` uses, where each content (and its target in home) can be defined as a structure, instead of defining a directory where the contents is copied from.

Let me know what you think!

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

