### PR TITLE
fix rofi wrapper only passing along binary

### DIFF
--- a/pkgs/applications/misc/rofi/wrapper.nix
+++ b/pkgs/applications/misc/rofi/wrapper.nix
@@ -1,14 +1,19 @@
 { stdenv, rofi-unwrapped, makeWrapper, theme ? null, lib }:
 
+if theme == null then rofi-unwrapped else
 stdenv.mkDerivation {
   name = "rofi-${rofi-unwrapped.version}";
   buildInputs = [ makeWrapper ];
   preferLocalBuild = true;
-  passthru = { unwrapped = rofi-unwrapped; };
+  passthru.unwrapped = rofi-unwrapped;
   buildCommand = ''
-    mkdir -p $out/bin
-    ln -s ${rofi-unwrapped}/bin/rofi $out/bin/rofi
-    ${lib.optionalString (theme != null) ''wrapProgram $out/bin/rofi --add-flags "-theme ${theme}"''}
+    mkdir $out
+    ln -s ${rofi-unwrapped}/* $out
+    rm $out/bin
+    mkdir $out/bin
+    ln -s ${rofi-unwrapped}/bin/* $out/bin
+    rm $out/bin/rofi
+    makeWrapper ${rofi-unwrapped}/bin/rofi $out/bin/rofi --add-flags "-theme ${theme}"
   '';
 
   meta = rofi-unwrapped.meta // {


### PR DESCRIPTION
###### Motivation for this change
Was introduced in #36785

This change also makes it such that nothing is wrapped when no theme is set anyways.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

