### PR TITLE
pcsclite: use canonical src url

### DIFF
--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -1,17 +1,14 @@
-{ stdenv, fetchFromGitLab, pkgconfig, udev, dbus_libs, perl, python2
+{ stdenv, fetchurl, pkgconfig, udev, dbus_libs, perl, python2
 , IOKit ? null }:
 
 stdenv.mkDerivation rec {
   name = "pcsclite-${version}";
   version = "1.8.23";
 
-  src = fetchFromGitLab {
-    domain = "salsa.debian.org";
-    owner = "debian";
-    repo = "pcsc-lite";
-    rev = "upstream%2F${version}";
-    sha256 = "09b7a79hjkgiyvhyvwf8gpxaf8b7wd0342hx6zrpd269hhfbjvwy";
-  };
+  src = fetchurl {
+     url = "https://pcsclite.apdu.fr/files/pcsc-lite-${version}.tar.bz2";
+     sha256 = "1jc9ws5ra6v3plwraqixin0w0wfxj64drahrbkyrrwzghqjjc9ss";
+   };
 
   patches = [ ./no-dropdir-literals.patch ];
 


### PR DESCRIPTION
As pointed out by @ookhoi in https://github.com/NixOS/nixpkgs/pull/41790,
there's a standard upstream URL that we should be using instead of the debian
mirror.

This is a better fix than the initial one merged in c256347ceea6c0434fd755e8c8fb5f6a7df620d6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

