### PR TITLE
nixos/kubernetes: improvements

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -288,9 +288,22 @@ inherit (pkgs.nixos {
    </listitem>
    <listitem>
     <para>
-     Recommented way to access the Kubernetes Dashboard is with HTTPS (TLS)
+     Recommended way to access the Kubernetes Dashboard is via HTTPS (TLS)
      Therefore; public service port for the dashboard has changed to 443
      (container port 8443) and scheme to https.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The option <varname>services.kubernetes.apiserver.address</varname>
+     was renamed to <varname>services.kubernetes.apiserver.bindAddress</varname>.
+     Note that the default value has changed from 127.0.0.1 to 0.0.0.0.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The option <varname>services.kubernetes.apiserver.publicAddress</varname>
+     was not used and thus has been removed.
     </para>
    </listitem>
   </itemizedlist>

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -32,6 +32,8 @@ with lib;
     (mkRenamedOptionModule [ "services" "i2pd" "extIp" ] [ "services" "i2pd" "address" ])
     (mkRenamedOptionModule [ "services" "kibana" "host" ] [ "services" "kibana" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "kubernetes" "apiserver" "admissionControl" ] [ "services" "kubernetes" "apiserver" "enableAdmissionPlugins" ])
+    (mkRenamedOptionModule [ "services" "kubernetes" "apiserver" "address" ] ["services" "kubernetes" "apiserver" "bindAddress"])
+    (mkRemovedOptionModule [ "services" "kubernetes" "apiserver" "publicAddress" ] "")
     (mkRenamedOptionModule [ "services" "logstash" "address" ] [ "services" "logstash" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])


### PR DESCRIPTION

###### Motivation for this change

Wanted to do some minor fixups and cleanups of the module. 

**APIServer Addresses**
Most notably I have changed the apiserver address options to conform better with the kube-apiserver cmdline args. kube-apiserver has "bindAddress" which selects which interfaces to listen on, and the "advertiseAddress" which is what other parties are expected to use to contact the apiserver. Ref: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/

Thus, I renamed "address" to "bindAddress" and put in default="0.0.0.0" - also default as per kubernetes docs.

As well I removed hardcoding of the implementation bind address, which was done already by https://github.com/NixOS/nixpkgs/pull/41018. Unfortunately this PR caused the kubernetes tests to break, since the "address" options was used for multiple purposes. 

**Configurable images for addons**
It is now possible to change the docker images seeded for KubeDNS and Kubernetes Dashboard. Unfortunately, it is not possible to spawn containers by reference to the imageDigest, due to image digests changing after `docker load`: https://github.com/moby/moby/issues/22011. Thanks especially to @srhb for help on this one.

**Custom directory for CNI config**
You can now specify `cni.configDir` and override the existing behavior of autogenerating CNI-config files at build time. Not only Kubernetes use CNI, and therefore this is useful if you have other ways of assembling your superset of CNI config files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

**/kubernetes/dns.nix** and **/kubernetes/rbac.nix**

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
