### PR TITLE
nixos/seahorse: require gnome3.dconf

### DIFF
--- a/nixos/modules/services/desktops/gnome3/seahorse.nix
+++ b/nixos/modules/services/desktops/gnome3/seahorse.nix
@@ -29,7 +29,7 @@ with lib;
 
   config = mkIf config.services.gnome3.seahorse.enable {
 
-    environment.systemPackages = [ pkgs.gnome3.seahorse ];
+    environment.systemPackages = [ pkgs.gnome3.seahorse pkgs.gnome3.dconf ];
 
     services.dbus.packages = [ pkgs.gnome3.seahorse ];
 


### PR DESCRIPTION
Fix #41886.

###### Motivation for this change

Seahorse previously would not function (at least, not without GNOME installed).

###### Things done

Adds `pkgs.gnome3.dconf` to `environment.systemPackages`. Tested with the `gnome3.nix` test.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

