### PR TITLE
ngspice: Fix regression due to missing X libs

### DIFF
--- a/pkgs/applications/science/electronics/ngspice/default.nix
+++ b/pkgs/applications/science/electronics/ngspice/default.nix
@@ -1,4 +1,5 @@
-{stdenv, fetchurl, readline, bison, flex, libX11, libICE, libXaw, libXext, fftw}:
+{stdenv, fetchurl, bison, flex
+, readline, libX11, libICE, libXaw, libXmu, libXext, libXt, fftw }:
 
 stdenv.mkDerivation {
   name = "ngspice-28";
@@ -9,7 +10,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ flex bison ];
-  buildInputs = [ readline libX11 libICE libXaw libXext fftw ];
+  buildInputs = [ readline libX11 libICE libXaw libXmu libXext libXt fftw ];
 
   configureFlags = [ "--enable-x" "--with-x" "--with-readline" "--enable-xspice" "--enable-cider" ];
 


### PR DESCRIPTION
###### Motivation for this change
Most of ngspice, esp. the ngspice binary, was not built due to missing X libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

