### PR TITLE
xcircuit: init at 3.9.73

### DIFF
--- a/pkgs/applications/science/electronics/xcircuit/default.nix
+++ b/pkgs/applications/science/electronics/xcircuit/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, autoreconfHook, automake, pkgconfig
+, cairo, ghostscript, ngspice, tcl, tk, xorg, zlib }:
+
+let
+  version = "3.9.73";
+  name = "xcircuit-${version}";
+  inherit (stdenv.lib) getBin;
+
+in stdenv.mkDerivation {
+  inherit name version;
+
+  src = fetchurl {
+    url = "http://opencircuitdesign.com/xcircuit/archive/${name}.tgz";
+    sha256 = "1kj9hayipplzm4960kx48vxddqj154qnxkccaqj9cnkp62b7q3jg";
+  };
+
+  nativeBuildInputs = [ autoreconfHook automake pkgconfig ];
+  hardeningDisable = [ "format" ];
+
+  configureFlags = "--with-tcl=${tcl}/lib --with-tk=${tk}/lib --with-ngspice=${getBin ngspice}/bin/ngspice";
+
+  buildInputs = with xorg; [ cairo ghostscript libSM libXt libICE libX11 libXpm tcl tk zlib ];
+
+  meta = with stdenv.lib; {
+    description = "Generic drawing program tailored to circuit diagrams";
+    homepage = http://opencircuitdesign.com/xcircuit;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.spacefrogg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20486,6 +20486,7 @@ with pkgs;
 
   qucs = callPackage ../applications/science/electronics/qucs { };
 
+  xcircuit = callPackage ../applications/science/electronics/xcircuit { };
 
   xoscope = callPackage ../applications/science/electronics/xoscope { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

