### PR TITLE
asc-key-to-qr-code-gif: init at 20180613

### DIFF
--- a/pkgs/tools/security/asc-key-to-qr-code-gif/default.nix
+++ b/pkgs/tools/security/asc-key-to-qr-code-gif/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, imagemagick, libqrencode
+, testQR ? false, zbar ? null
+}:
+
+assert testQR -> zbar != false;
+
+stdenv.mkDerivation rec {
+  name = "asc-key-to-qr-code-gif-${version}";
+  version = "20180613";
+
+  src = fetchFromGitHub {
+    owner = "yishilin14";
+    repo = "asc-key-to-qr-code-gif";
+    rev = "5b7b239a0089a5269444cbe8a651c99dd43dce3f";
+    sha256 = "0yrc302a2fhbzryb10718ky4fymfcps3lk67ivis1qab5kbp6z8r";
+  };
+
+  buildInputs = [ imagemagick libqrencode ] ++ stdenv.lib.optional testQR zbar;
+  dontBuild = true;
+  dontStrip = true;
+  dontPatchELF = true;
+
+  preInstall = ''
+    substituteInPlace asc-to-gif.sh \
+      --replace "convert" "${imagemagick}/bin/convert" \
+      --replace "qrencode" "${libqrencode}/bin/qrencode"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp * $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/yishilin14/asc-key-to-qr-code-gif;
+    description = "Convert ASCII-armored PGP keys to animated QR code";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ asymmetric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -680,6 +680,8 @@ with pkgs;
 
   passExtensions = recurseIntoAttrs pass.extensions;
 
+  asc-key-to-qr-code-gif = callPackage ../tools/security/asc-key-to-qr-code-gif { };
+
   gopass = callPackage ../tools/security/gopass { };
 
   browserpass = callPackage ../tools/security/browserpass { };


### PR DESCRIPTION
###### Motivation for this change

**NOTE** No idea why I only had to run `substituteInPlace` on `convert` and not on e.g. `qrencode`. 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

