### PR TITLE
tinc_pre: 1.1pre15 -> 1.1pre16

### DIFF
--- a/pkgs/tools/networking/tinc/pre.nix
+++ b/pkgs/tools/networking/tinc/pre.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "tinc-${version}";
-  version = "1.1pre15";
+  version = "1.1pre16";
 
   src = fetchgit {
     rev = "refs/tags/release-${version}";
     url = "git://tinc-vpn.org/tinc";
-    sha256 = "1msym63jpipvzb5dn8yn8yycrii43ncfq6xddxh2ifrakr48l6y5";
+    sha256 = "03dsm1kxagq8srskzg649xyhbdqbbqxc84pdwrz7yakpa9m6225c";
   };
 
   outputs = [ "out" "man" "info" ];
@@ -21,10 +21,6 @@ stdenv.mkDerivation rec {
     echo "${version}" > configure-version
     echo "https://tinc-vpn.org/git/browse?p=tinc;a=log;h=refs/tags/release-${version}" > ChangeLog
     sed -i '/AC_INIT/s/m4_esyscmd_s.*/${version})/' configure.ac
-  '';
-
-  postInstall = ''
-    rm $out/bin/tinc-gui
   '';
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

update tinc_pre to recent version
remove obsolete postInstall (since tinc-gui doesn't exist anymore)