### PR TITLE
sqlint: init at 0.1.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -33,6 +33,11 @@
     github = "Anton-Latukha";
     name = "Anton Latukha";
   };
+  ariutta = {
+    email = "anders.riutta@gmail.com";
+    github = "ariutta";
+    name = "Anders Riutta";
+  };
   Baughn = {
     email = "sveina@gmail.com";
     github = "Baughn";

--- a/pkgs/development/tools/sqlint/Gemfile
+++ b/pkgs/development/tools/sqlint/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sqlint'

--- a/pkgs/development/tools/sqlint/Gemfile.lock
+++ b/pkgs/development/tools/sqlint/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.1.0)
+    pg_query (1.0.0)
+      json (>= 1.8, < 3)
+    sqlint (0.1.7)
+      pg_query (~> 0.13.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sqlint
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/development/tools/sqlint/default.nix
+++ b/pkgs/development/tools/sqlint/default.nix
@@ -1,0 +1,34 @@
+{ lib, bundlerApp, fetchurl, ruby }:
+
+let
+  LIB_PG_QUERY_TAG = "10-1.0.1";
+  libpgQuerySrc = fetchurl {
+    name = "libpg_query.tar.gz";
+    url = "https://codeload.github.com/lfittl/libpg_query/tar.gz/${LIB_PG_QUERY_TAG}";
+    sha256 = "0m5jv134hgw2vcfkqlnw80fr3wmrdvgrvk1ndcx9s44bzi5nsp47";
+  };
+in bundlerApp {
+  pname = "sqlint";
+  gemdir = ./.;
+  inherit ruby;
+
+  exes = [ "sqlint" ];
+
+  gemConfig = {
+    pg_query = attrs: {
+      dontBuild = false;
+      postPatch = ''
+        substituteInPlace ext/pg_query/extconf.rb \
+          --replace "#{workdir}/libpg_query.tar.gz" "${libpgQuerySrc}"
+      '';
+    };
+  };
+
+  meta = with lib; {
+    description = "Simple SQL linter";
+    homepage    = https://github.com/purcell/sqlint;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ ariutta ];
+    platforms   = with platforms; [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/development/tools/sqlint/gemset.nix
+++ b/pkgs/development/tools/sqlint/gemset.nix
@@ -1,0 +1,28 @@
+{
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  pg_query = {
+    dependencies = ["json"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zgwnrf5mkpkxfh49r2pvh2djivrbqd19350g8hxapmkya9w3qpi";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  sqlint = {
+    dependencies = ["pg_query"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wm81dgdmgc16b97bz73vm0wjd2m1ra1b40h0kwfd9wgrh9ig2al";
+      type = "gem";
+    };
+    version = "0.1.7";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1489,6 +1489,8 @@ with pkgs;
     utillinux = utillinuxMinimal;
   };
 
+  sqlint = callPackage ../development/tools/sqlint { };
+
   antibody = callPackage ../shells/zsh/antibody { };
 
   antigen = callPackage ../shells/zsh/antigen { };


### PR DESCRIPTION
###### Motivation for this change

Add an SQL linter: https://github.com/purcell/sqlint

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

