### PR TITLE
 SDL2: do not propagate private dependencies

### DIFF
--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -1,14 +1,14 @@
-{ stdenv, lib, fetchurl, pkgconfig, audiofile
+{ stdenv, lib, fetchurl, pkgconfig, pruneLibtoolFiles
 , openglSupport ? false, libGL
 , alsaSupport ? true, alsaLib
-, x11Support ? true, libICE, libXi, libXScrnSaver, libXcursor, libXinerama, libXext, libXxf86vm, libXrandr
+, x11Support ? true, libX11, xproto, libICE, libXi, libXScrnSaver, libXcursor, libXinerama, libXext, libXxf86vm, libXrandr
 , waylandSupport ? true, wayland, wayland-protocols, libxkbcommon
 , dbusSupport ? false, dbus
 , udevSupport ? false, udev
 , ibusSupport ? false, ibus
 , pulseaudioSupport ? true, libpulseaudio
 , AudioUnit, Cocoa, CoreAudio, CoreServices, ForceFeedback, OpenGL
-, libiconv
+, audiofile, libiconv
 }:
 
 # NOTE: When editing this expression see if the same change applies to
@@ -33,18 +33,26 @@ stdenv.mkDerivation rec {
 
   patches = [ ./find-headers.patch ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig pruneLibtoolFiles ];
 
-  propagatedBuildInputs = [ libiconv ]
-    ++ optional  dbusSupport dbus
-    ++ optional  udevSupport udev
-    ++ optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ]
-    ++ optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
+  propagatedBuildInputs = dlopenPropagatedBuildInputs;
+
+  dlopenPropagatedBuildInputs = [ ]
+    # Propagated for #include <GLES/gl.h> in SDL_opengles.h.
+    ++ optional openglSupport libGL
+    # Propagated for #include <X11/Xlib.h> and <X11/Xatom.h> in SDL_syswm.h.
+    ++ optionals x11Support [ libX11 xproto ];
+
+  dlopenBuildInputs = [ ]
     ++ optional  alsaSupport alsaLib
-    ++ optional  pulseaudioSupport libpulseaudio;
+    ++ optional  dbusSupport dbus
+    ++ optional  pulseaudioSupport libpulseaudio
+    ++ optional  udevSupport udev
+    ++ optionals waylandSupport [ wayland wayland-protocols libxkbcommon ]
+    ++ optionals x11Support [ libICE libXi libXScrnSaver libXcursor libXinerama libXext libXrandr libXxf86vm ];
 
-  buildInputs = [ audiofile ]
-    ++ optional  openglSupport libGL
+  buildInputs = [ audiofile libiconv ]
+    ++ dlopenBuildInputs
     ++ optional  ibusSupport ibus
     ++ optionals stdenv.isDarwin [ AudioUnit Cocoa CoreAudio CoreServices ForceFeedback OpenGL ];
 
@@ -76,12 +84,13 @@ stdenv.mkDerivation rec {
   # SDL API that requires said libraries will fail to start.
   #
   # You can grep SDL sources with `grep -rE 'SDL_(NAME|.*_SYM)'` to
-  # confirm that they actually use most of the `propagatedBuildInputs`
-  # from above in this way. This is pretty weird.
-  postFixup = optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
+  # list the symbols used in this way.
+  postFixup = let
+    rpath = makeLibraryPath (dlopenPropagatedBuildInputs ++ dlopenBuildInputs);
+  in optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
     for lib in $out/lib/*.so* ; do
       if ! [[ -L "$lib" ]]; then
-        patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath propagatedBuildInputs}" "$lib"
+        patchelf --set-rpath "$(patchelf --print-rpath $lib):${rpath}" "$lib"
       fi
     done
   '';

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
   # from above in this way. This is pretty weird.
   postFixup = optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
     for lib in $out/lib/*.so* ; do
-      if [[ -L "$lib" ]]; then
+      if ! [[ -L "$lib" ]]; then
         patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath propagatedBuildInputs}" "$lib"
       fi
     done

--- a/pkgs/development/libraries/SDL2/default.nix
+++ b/pkgs/development/libraries/SDL2/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
   # You can grep SDL sources with `grep -rE 'SDL_(NAME|.*_SYM)'` to
   # confirm that they actually use most of the `propagatedBuildInputs`
   # from above in this way. This is pretty weird.
-  postFixup = ''
+  postFixup = optionalString (stdenv.hostPlatform.extensions.sharedLibrary == ".so") ''
     for lib in $out/lib/*.so* ; do
       if [[ -L "$lib" ]]; then
         patchelf --set-rpath "$(patchelf --print-rpath $lib):${lib.makeLibraryPath propagatedBuildInputs}" "$lib"


### PR DESCRIPTION
###### Motivation for this change

This uses `pruneLibtoolFiles` from #41819 to avoid the need to propagate private dependencies to dependent packages.

Fixes #41620 by adding libGL directory to libSDL2 runpath.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested compilation of some dependent packages on NixOS and macOS.

/cc @cpages as the maintainer, @oxij as the author of the previous refactoring.