### PR TITLE
nixos/tinc: minor fixes

### DIFF
--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -163,12 +163,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         path = [ data.package ];
-        restartTriggers =
-          let
-            drvlist = [ config.environment.etc."tinc/${network}/tinc.conf".source ]
-                        ++ mapAttrsToList (host: _: config.environment.etc."tinc/${network}/hosts/${host}".source) data.hosts;
-          in # drvlist might be too long to be used directly
-            [ (builtins.hashString "sha256" (concatMapStrings (d: d.outPath) drvlist)) ];
+        restartTriggers = [ config.environment.etc."tinc/${network}/tinc.conf".source ];
         serviceConfig = {
           Type = "simple";
           Restart = "always";
@@ -207,7 +202,8 @@ in
           ${concatStringsSep "\n" (mapAttrsToList (network: data:
             optionalString (versionAtLeast data.package.version "1.1pre") ''
               makeWrapper ${data.package}/bin/tinc "$out/bin/tinc.${network}" \
-                --add-flags "--pidfile=/run/tinc.${network}.pid"
+                --add-flags "--pidfile=/run/tinc.${network}.pid" \
+                --add-flags "--config=/etc/tinc/${network}"
             '') cfg.networks)}
         '';
       };


### PR DESCRIPTION
###### Motivation for this change

 - [x] exclude hosts files from ```restartTriggers``` 
I did it once (https://github.com/NixOS/nixpkgs/pull/27660) and then put back (https://github.com/NixOS/nixpkgs/pull/29881) with the only reason to force restart ```tinc``` if some of the peers has been removed from the configuration in order ```tinc``` to forget its public key as soon as possible (as the peer removal might occur because of its key has been compromised, a laptop has been stolen, a server hacked, etc; so quicker key removal would prevent connecting to VPN using that key).
But since ```tinc``` distribute public keys in a gossip way, restarting ```tinc``` does not help to forget deprecated keys, so now it is just a needless restart condition and redundant code.

- [x] add path to .conf-file to command line of cli-wrappers
It fixes
```# tinc.lan export```
```Could not open /etc/tinc/tinc.conf: No such file or directory```
