### PR TITLE
powershell: fix the build

### DIFF
--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  buildInputs = [ autoPatchelfHook makeWrapper less ] ++ libraries;
+  buildInputs = [ less ] ++ libraries;
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
   # TODO: remove PAGER after upgrading to v6.1.0-preview.1 or later as it has been addressed in
   # https://github.com/PowerShell/PowerShell/pull/6144


### PR DESCRIPTION
For some reason, building powershell derivation started failing with
these errors:

```
  liblttng-ust.so.0 -> not found!
  ...
  libpam.so.0 -> not found!
```

This patch adds these dependencies

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

