### PR TITLE
fix dockertools.pullImage on darwin 

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -649,6 +649,8 @@ merge:"diff3"
     imageDigest = "sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b"; <co xml:id='ex-dockerTools-pullImage-2' />
     finalImageTag = "1.11";  <co xml:id='ex-dockerTools-pullImage-3' />
     sha256 = "0mqjy3zq2v6rrhizgb9nvhczl87lcfphq9601wcprdika2jz7qh8"; <co xml:id='ex-dockerTools-pullImage-4' />
+    os = "linux"; <co xml:id='ex-dockerTools-pullImage-5' />
+    arch = "x86_64"; <co xml:id='ex-dockerTools-pullImage-6' />
   }
   </programlisting>
    </example>
@@ -664,9 +666,15 @@ merge:"diff3"
     <callout arearefs='ex-dockerTools-pullImage-2'>
      <para>
       <varname>imageDigest</varname> specifies the digest of the image to be
-      downloaded. Skopeo can be used to get the digest of an image
+      downloaded. Skopeo can be used to get the digest of an image, with its
+      <varname>inspect</varname> subcommand.  Since a given <varname>imageName</varname>
+      may transparently refer to a manifest list of images which support
+      multiple architectures and/or operating systems, supply the `--override-os`
+      and `--override-arch` arguments to specify exactly which image you
+      want.  By default it will match the OS and architecture of the host the
+      command is run on.
 <programlisting>
-  $ skopeo inspect docker://docker.io/nixos/nix:1.11 | jq -r '.Digest'
+  $ nix-shell --packages skopeo jq --command "skopeo --override-os linux --override-arch x86_64 inspect docker://docker.io/nixos/nix:1.11 | jq -r '.Digest'"
   sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b
   </programlisting>
       This argument is required.
@@ -685,6 +693,18 @@ merge:"diff3"
       <varname>sha256</varname> is the checksum of the whole fetched image.
       This argument is required.
      </para>
+    </callout>
+    <callout arearefs='ex-dockerTools-pullImage-5'>
+      <para>
+        <varname>os</varname>, if specified, is the operating system of the fetched image.
+        By default it's <literal>linux</literal>.
+      </para>
+    </callout>
+    <callout arearefs='ex-dockerTools-pullImage-6'>
+      <para>
+        <varname>arch</varname>, if specified, is the cpu architecture of the fetched image.
+        By default it's <literal>x86_64</literal>.
+      </para>
     </callout>
    </calloutlist>
   </section>

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -36,10 +36,11 @@ rec {
   in
     { imageName
       # To find the digest of an image, you can use skopeo:
-      # skopeo inspect docker://docker.io/nixos/nix:1.11 | jq -r '.Digest'
-      # sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b
+      # see doc/functions.xml
     , imageDigest
     , sha256
+    , os ? "linux"
+    , arch ? "x86_64"
       # This used to set a tag to the pulled image
     , finalImageTag ? "latest"
     , name ? fixName "docker-image-${imageName}-${finalImageTag}.tar"
@@ -59,7 +60,7 @@ rec {
       sourceURL = "docker://${imageName}@${imageDigest}";
       destNameTag = "${imageName}:${finalImageTag}";
     } ''
-      skopeo copy "$sourceURL" "docker-archive://$out:$destNameTag"
+      skopeo --override-os ${os} --override-arch ${arch} copy "$sourceURL" "docker-archive://$out:$destNameTag"
     '';
 
   # We need to sum layer.tar, not a directory, hence tarsum instead of nix-hash.

--- a/pkgs/development/tools/skopeo/default.nix
+++ b/pkgs/development/tools/skopeo/default.nix
@@ -28,7 +28,7 @@ buildGoPackage rec {
   excludedPackages = "integration";
 
   nativeBuildInputs = [ pkgconfig (lib.getBin go-md2man) ];
-  buildInputs = [ gpgme libgpgerror lvm2 btrfs-progs ostree libselinux ];
+  buildInputs = [ gpgme ] ++ lib.optionals stdenv.isLinux [ libgpgerror lvm2 btrfs-progs ostree libselinux ];
 
   buildFlagsArray = ''
     -ldflags=
@@ -37,8 +37,8 @@ buildGoPackage rec {
   '';
 
   preBuild = ''
-    export CGO_CFLAGS="-I${getDev gpgme}/include -I${getDev libgpgerror}/include -I${getDev lvm2}/include -I${getDev btrfs-progs}/include"
-    export CGO_LDFLAGS="-L${getLib gpgme}/lib -L${getLib libgpgerror}/lib -L${getLib lvm2}/lib"
+    export CGO_CFLAGS="$CFLAGS"
+    export CGO_LDFLAGS="$LDFLAGS"
   '';
 
   postBuild = ''


### PR DESCRIPTION
###### Motivation for this change

`buildImage` works, so I wanted to start using it.

The `--override-{os,architecture}` arguments are necessary for me, since skopeo's default behavior is to choose the manifest which matches the host system's os and architecture.  For people on macs, this frequently doesn't exist, and is rarely what we want.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

