### PR TITLE
bintools-wrapper: add support for frameworks

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -22,6 +22,10 @@ bintoolsWrapper_addLDVars () {
     if [[ -d "$1/lib" ]]; then
         export NIX_${role_pre}LDFLAGS+=" -L$1/lib"
     fi
+
+    if [[ -d "$1/Library/Frameworks" ]]; then
+        export NIX_${role_pre}LDFLAGS+=" -F$1/Library/Frameworks"
+    fi
 }
 
 # See ../setup-hooks/role.bash


### PR DESCRIPTION
###### Motivation for this change

Equivalent to what was done in 7bea6aafae10731b53e2f8b9a66d6488a3a9f54a for cc-wrapper.

This adds the right `-F` flags to `NIX_LDFLAGS` when adding frameworks to build inputs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

