### PR TITLE
libxml2: add static output

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
     sha256 = "0ci7is75bwqqw2p32vxvrk6ds51ik7qgx73m920rakv5jlayax0b";
   };
 
-  outputs = [ "bin" "dev" "out" "man" "doc" ]
+  outputs = [ "bin" "dev" "out" "man" "doc" "static" ]
     ++ lib.optional pythonSupport "py";
   propagatedBuildOutputs = "out bin" + lib.optionalString pythonSupport " py";
 
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
   configureFlags =
        lib.optional pythonSupport "--with-python=${python}"
     ++ lib.optional icuSupport    "--with-icu"
-    ++ [ "--exec_prefix=$dev" ];
+    ++ [ "--exec_prefix=$dev" "--enable-static" ];
 
   enableParallelBuilding = true;
 
@@ -57,6 +57,11 @@ in stdenv.mkDerivation rec {
     moveToOutput bin/xml2-config "$dev"
     moveToOutput lib/xml2Conf.sh "$dev"
     moveToOutput share/man/man1 "$bin"
+  '';
+
+  postInstall = ''
+    mkdir -p $static/lib
+    cp .libs/libxml2.a $static/lib/
   '';
 
   passthru = { inherit version; pythonSupport = pythonSupport; };


### PR DESCRIPTION
I don't know if this has to be conditional (such as `pkgs.zlib` that have a boolean `static` argument) or not (such as `pkgs.glibc`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

