### PR TITLE
nixos/tests/morty: fix non-deterministic failure

### DIFF
--- a/nixos/tests/morty.nix
+++ b/nixos/tests/morty.nix
@@ -22,9 +22,9 @@ import ./make-test.nix ({ pkgs, ... }:
   testScript =
     { nodes , ... }:
     ''
-      startAll;
+      $mortyProxyWithKey->waitForUnit("default.target");
 
-      $mortyProxyWithKey->waitForUnit("morty");
+      $mortyProxyWithKey->waitForOpenPort(3001);
       $mortyProxyWithKey->succeed("curl -L 127.0.0.1:3001 | grep MortyProxy");
 
     '';


### PR DESCRIPTION
###### Motivation for this change

Test failed non-deterministically [on hydra](https://hydra.nixos.org/build/75467376) because of timing issues: the service was started but not yet listening on its port when the request was sent.

Fix: Wait for machine to be fully booted and the port to open.

/cc @leenaars 


###### Things done

- [x] Tested locally

