### PR TITLE
drawpile: init at 2.0.10

### DIFF
--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchurl
+, cmake
+, qtbase
+, qtsvg
+, qtmultimedia
+, qttools
+, kdnssd
+, karchive
+, libsodium
+, libmicrohttpd
+, giflib
+, miniupnpc
+}:
+
+stdenv.mkDerivation rec {
+  name = "drawpile-${version}";
+  version = "2.0.11";
+  src = fetchurl {
+    url = "https://drawpile.net/files/src/drawpile-${version}.tar.gz";
+    sha256 = "0h018rxhc0lwpqwmlihalz634nd0xaafk4p2b782djjd87irnjpk";
+  };
+  buildInputs = [
+    cmake
+    qtbase qtsvg qtmultimedia qttools
+    karchive
+    # optional deps:
+    libsodium # ext-auth support
+    libmicrohttpd # HTTP admin api
+    giflib # gif animation export support
+    miniupnpc # automatic port forwarding
+    kdnssd # local server discovery with Zeroconf
+  ];
+  configurePhase = "cmake -DCMAKE_INSTALL_PREFIX=$out .";
+
+  meta = with stdenv.lib; {
+    description = "A collaborative drawing program that allows multiple users to sketch on the same canvas simultaneously";
+    homepage = https://drawpile.net/;
+    downloadPage = https://drawpile.net/download/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15860,6 +15860,8 @@ with pkgs;
 
   dragonfly-reverb = callPackage ../applications/audio/dragonfly-reverb { };
 
+  drawpile = libsForQt5.callPackage ../applications/graphics/drawpile { };
+
   droopy = callPackage ../applications/networking/droopy {
     inherit (python3Packages) wrapPython;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

There's only one issue that I found: I can't get the icons to show up when I run ./result/bin/drawpile . Maybe it's because i use a window manager instead of a full de?

Edit: wait... once the package is installed with nix-env -i the icons show up. Is this normal?