### PR TITLE
neovim: 0.2.2 -> 0.3.0

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -11,13 +11,13 @@ let
 
   neovim = stdenv.mkDerivation rec {
     name = "neovim-unwrapped-${version}";
-    version = "0.2.2";
+    version = "0.3.0";
 
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "neovim";
       rev = "v${version}";
-      sha256 = "1dxr29d0hyag7snbww5s40as90412qb61rgj7gd9rps1iccl9gv4";
+      sha256 = "10c8y309fdwvr3d9n6vm1f2c0k6pzicnhc64l2dvbw1lnabp04vv";
     };
 
     enableParallelBuilding = true;

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -61,8 +61,8 @@ let
 
         makeWrapper "$(readlink -v --canonicalize-existing "${bin}")" \
           "$out/bin/nvim" --add-flags " \
-        --cmd \"${if withPython then "let g:python_host_prog='$out/bin/nvim-python'" else "let g:loaded_python_provider = 1"}\" \
-        --cmd \"${if withPython3 then "let g:python3_host_prog='$out/bin/nvim-python3'" else "let g:loaded_python3_provider = 1"}\" \
+        --cmd \"${if withPython then "let g:python_host_prog='${pythonEnv.interpreter}'" else "let g:loaded_python_provider = 1"}\" \
+        --cmd \"${if withPython3 then "let g:python3_host_prog='${python3Env.interpreter}'" else "let g:loaded_python3_provider = 1"}\" \
         --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
         --unset PYTHONPATH \
          ${optionalString withRuby '' --suffix PATH : ${rubyEnv}/bin --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
@@ -71,15 +71,12 @@ let
       + optionalString (!stdenv.isDarwin) ''
         # copy and patch the original neovim.desktop file
         mkdir -p $out/share/applications
+        cp -R ${neovim}/share/man $out/share/
         substitute ${neovim}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
           --replace 'TryExec=nvim' "TryExec=$out/bin/nvim" \
           --replace 'Name=Neovim' 'Name=WrappedNeovim'
       ''
-      + optionalString withPython ''
-      ln -s ${pythonEnv}/bin/python $out/bin/nvim-python
-    '' + optionalString withPython3 ''
-      ln -s ${python3Env}/bin/python3 $out/bin/nvim-python3
-    '' + optionalString withRuby ''
+      + optionalString withRuby ''
       ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
     ''
       + optionalString withPyGUI ''


### PR DESCRIPTION
Changelog at https://github.com/neovim/neovim/commit/44c6deb91ac917703c157d564eb3accbff4d37af

Fixed missing manpage.
Remove the indirection for the python interpreters (why was it there in the first place ? I am afraid there is a good reason but I don't know it).

Sadly we still can't run the tests but if anyone is interested, this used to be possible with
https://github.com/NixOS/nixpkgs/pull/33903#pullrequestreview-97792751

###### Motivation for this change

Neovim is freaking cool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

