### PR TITLE
Riemann-tools: 0.2.6 -> 0.2.13

### DIFF
--- a/pkgs/tools/misc/riemann-tools/Gemfile
+++ b/pkgs/tools/misc/riemann-tools/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "riemann-tools", "0.2.6"
+gem "riemann-tools", "0.2.13"

--- a/pkgs/tools/misc/riemann-tools/Gemfile.lock
+++ b/pkgs/tools/misc/riemann-tools/Gemfile.lock
@@ -1,142 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.1)
-    beefcake (1.1.0)
-    builder (3.2.2)
-    excon (0.45.3)
-    faraday (0.9.1)
-      multipart-post (>= 1.2, < 3)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.31.0)
-      fog-atmos
-      fog-aws (~> 0.0)
-      fog-brightbox (~> 0.4)
-      fog-core (~> 1.30)
-      fog-ecloud
-      fog-google (>= 0.0.2)
-      fog-json
-      fog-local
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (0.6.0)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.7.2)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-core (1.31.1)
-      builder
-      excon (~> 0.45)
-      formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.0.6)
-      fog-core
-      fog-json
-      fog-xml
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
-      multi_json (~> 1.10)
-    fog-local (0.2.1)
-      fog-core (~> 1.27)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (0.0.3)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-radosgw (0.0.4)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.0.1)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (0.4.7)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-xml (0.1.2)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
-    formatador (0.2.5)
-    inflecto (0.0.2)
-    ipaddress (0.8.0)
-    mime-types (2.6.1)
-    mini_portile (0.6.2)
+    beefcake (1.0.0)
+    json (1.8.6)
     mtrc (0.0.4)
-    multi_json (1.11.1)
-    multipart-post (2.0.0)
-    munin-ruby (0.2.5)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    riemann-client (0.2.5)
-      beefcake (>= 0.3.5)
+    riemann-client (0.2.6)
+      beefcake (>= 0.3.5, <= 1.0.0)
       mtrc (>= 0.0.4)
       trollop (>= 1.16.2)
-    riemann-tools (0.2.6)
-      faraday (>= 0.8.5)
-      fog (>= 1.4.0)
-      munin-ruby (>= 0.2.1)
-      nokogiri (>= 1.5.6)
-      riemann-client (>= 0.2.2)
+    riemann-tools (0.2.13)
+      json (~> 1.8)
+      riemann-client (>= 0.2.6)
       trollop (>= 1.16.2)
-      yajl-ruby (>= 1.1.0)
     trollop (2.1.2)
-    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  riemann-tools (= 0.2.6)
+  riemann-tools (= 0.2.13)
 
 BUNDLED WITH
-   1.10.2
+   1.14.6

--- a/pkgs/tools/misc/riemann-tools/gemset.nix
+++ b/pkgs/tools/misc/riemann-tools/gemset.nix
@@ -1,444 +1,52 @@
 {
-  "CFPropertyList" = {
-    version = "2.3.1";
+  beefcake = {
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10gid0a7pdllh3qmjiqkqxgfqvd7m1f2dmcm4gcd19s63pv620gv";
       type = "gem";
-      sha256 = "1wnk3gxnhfafbhgp0ic7qhzlx3lhv04v8nws2s31ii5s8135hs6k";
     };
+    version = "1.0.0";
   };
-  "beefcake" = {
-    version = "1.1.0";
+  json = {
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qmj7fypgb9vag723w1a49qihxrcf5shzars106ynw2zk352gbv5";
       type = "gem";
-      sha256 = "009gzy9jp81lsnxnwisinhc58cd0qljdiipj2701lzzrha5d826z";
     };
+    version = "1.8.6";
   };
-  "builder" = {
-    version = "3.2.2";
+  mtrc = {
     source = {
-      type = "gem";
-      sha256 = "14fii7ab8qszrvsvhz6z2z3i4dw0h41a62fjr2h1j8m41vbrmyv2";
-    };
-  };
-  "excon" = {
-    version = "0.45.3";
-    source = {
-      type = "gem";
-      sha256 = "183kfxfjjlc97w4rxkrxjw3kis4lxm65vppmvl4bkblvlw4nq94j";
-    };
-  };
-  "faraday" = {
-    version = "0.9.1";
-    source = {
-      type = "gem";
-      sha256 = "1h33znnfzxpscgpq28i9fcqijd61h61zgs3gabpdgqfa1043axsn";
-    };
-    dependencies = [
-      "multipart-post"
-    ];
-  };
-  "fission" = {
-    version = "0.5.0";
-    source = {
-      type = "gem";
-      sha256 = "09pmp1j1rr8r3pcmbn2na2ls7s1j9ijbxj99xi3a8r6v5xhjdjzh";
-    };
-    dependencies = [
-      "CFPropertyList"
-    ];
-  };
-  "fog" = {
-    version = "1.31.0";
-    source = {
-      type = "gem";
-      sha256 = "0xr8xyrrkljm2hxi420x4qr5v6wqcj8d63v0qy1g6rkb3b1yhl9i";
-    };
-    dependencies = [
-      "fog-atmos"
-      "fog-aws"
-      "fog-brightbox"
-      "fog-core"
-      "fog-ecloud"
-      "fog-google"
-      "fog-json"
-      "fog-local"
-      "fog-powerdns"
-      "fog-profitbricks"
-      "fog-radosgw"
-      "fog-riakcs"
-      "fog-sakuracloud"
-      "fog-serverlove"
-      "fog-softlayer"
-      "fog-storm_on_demand"
-      "fog-terremark"
-      "fog-vmfusion"
-      "fog-voxel"
-      "fog-xml"
-      "ipaddress"
-      "nokogiri"
-    ];
-  };
-  "fog-atmos" = {
-    version = "0.1.0";
-    source = {
-      type = "gem";
-      sha256 = "1aaxgnw9zy96gsh4h73kszypc32sx497s6bslvhfqh32q9d1y8c9";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-xml"
-    ];
-  };
-  "fog-aws" = {
-    version = "0.6.0";
-    source = {
-      type = "gem";
-      sha256 = "1m79s5ha6qq60pxqqxr9qs9fg8fwaz79sfxckidyhxdydcsjwx6z";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-      "fog-xml"
-      "ipaddress"
-    ];
-  };
-  "fog-brightbox" = {
-    version = "0.7.2";
-    source = {
-      type = "gem";
-      sha256 = "0636sqaf2w1rh4i2hxfgs24374l4ai8dgch8a7nycqhvjk2dm0aq";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-      "inflecto"
-    ];
-  };
-  "fog-core" = {
-    version = "1.31.1";
-    source = {
-      type = "gem";
-      sha256 = "1bcsy4cq7vyjmdf3h2v7q6hfj64v6phn0rfvwgj5wfza7yaxnhk7";
-    };
-    dependencies = [
-      "builder"
-      "excon"
-      "formatador"
-      "mime-types"
-      "net-scp"
-      "net-ssh"
-    ];
-  };
-  "fog-ecloud" = {
-    version = "0.3.0";
-    source = {
-      type = "gem";
-      sha256 = "18rb4qjad9xwwqvvpj8r2h0hi9svy71pm4d3fc28cdcnfarmdi06";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-xml"
-    ];
-  };
-  "fog-google" = {
-    version = "0.0.6";
-    source = {
-      type = "gem";
-      sha256 = "1g3ykk239nxpdsr5anhprkp8vzk106gi4q6aqjh4z8q4bii0dflm";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-      "fog-xml"
-    ];
-  };
-  "fog-json" = {
-    version = "1.0.2";
-    source = {
-      type = "gem";
-      sha256 = "0advkkdjajkym77r3c0bg2rlahl2akj0vl4p5r273k2qmi16n00r";
-    };
-    dependencies = [
-      "fog-core"
-      "multi_json"
-    ];
-  };
-  "fog-local" = {
-    version = "0.2.1";
-    source = {
-      type = "gem";
-      sha256 = "0i5hxwzmc2ag3z9nlligsaf679kp2pz39cd8n2s9cmxaamnlh2s3";
-    };
-    dependencies = [
-      "fog-core"
-    ];
-  };
-  "fog-powerdns" = {
-    version = "0.1.1";
-    source = {
-      type = "gem";
-      sha256 = "08zavzwfkk344gz83phz4sy9nsjznsdjsmn1ifp6ja17bvydlhh7";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-      "fog-xml"
-    ];
-  };
-  "fog-profitbricks" = {
-    version = "0.0.3";
-    source = {
-      type = "gem";
-      sha256 = "01a3ylfkjkyagf4b4xg9x2v20pzapr3ivn9ydd92v402bjsm1nmr";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-xml"
-      "nokogiri"
-    ];
-  };
-  "fog-radosgw" = {
-    version = "0.0.4";
-    source = {
-      type = "gem";
-      sha256 = "1pxbvmr4dsqx4x2klwnciyhki4r5ryr9y0hi6xmm3n6fdv4ii7k3";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-      "fog-xml"
-    ];
-  };
-  "fog-riakcs" = {
-    version = "0.1.0";
-    source = {
-      type = "gem";
-      sha256 = "1nbxc4dky3agfwrmgm1aqmi59p6vnvfnfbhhg7xpg4c2cf41whxm";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-      "fog-xml"
-    ];
-  };
-  "fog-sakuracloud" = {
-    version = "1.0.1";
-    source = {
-      type = "gem";
-      sha256 = "1s16b48kh7y03hjv74ccmlfwhqqq7j7m4k6cywrgbyip8n3258n8";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-    ];
-  };
-  "fog-serverlove" = {
-    version = "0.1.2";
-    source = {
-      type = "gem";
-      sha256 = "0hxgmwzygrw25rbsy05i6nzsyr0xl7xj5j2sjpkb9n9wli5sagci";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-    ];
-  };
-  "fog-softlayer" = {
-    version = "0.4.7";
-    source = {
-      type = "gem";
-      sha256 = "0fgfbhqnyp8ywymvflflhvbns54d1432x57pgpnfy8k1cxvhv9b8";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-    ];
-  };
-  "fog-storm_on_demand" = {
-    version = "0.1.1";
-    source = {
-      type = "gem";
-      sha256 = "0fif1x8ci095b2yyilf65n7x6iyvn448azrsnmwsdkriy8vxxv3y";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-json"
-    ];
-  };
-  "fog-terremark" = {
-    version = "0.1.0";
-    source = {
-      type = "gem";
-      sha256 = "01lfkh9jppj0iknlklmwyb7ym3bfhkq58m3absb6rf5a5mcwi3lf";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-xml"
-    ];
-  };
-  "fog-vmfusion" = {
-    version = "0.1.0";
-    source = {
-      type = "gem";
-      sha256 = "0g0l0k9ylxk1h9pzqr6h2ba98fl47lpp3j19lqv4jxw0iw1rqxn4";
-    };
-    dependencies = [
-      "fission"
-      "fog-core"
-    ];
-  };
-  "fog-voxel" = {
-    version = "0.1.0";
-    source = {
-      type = "gem";
-      sha256 = "10skdnj59yf4jpvq769njjrvh2l0wzaa7liva8n78qq003mvmfgx";
-    };
-    dependencies = [
-      "fog-core"
-      "fog-xml"
-    ];
-  };
-  "fog-xml" = {
-    version = "0.1.2";
-    source = {
-      type = "gem";
-      sha256 = "1576sbzza47z48p0k9h1wg3rhgcvcvdd1dfz3xx1cgahwr564fqa";
-    };
-    dependencies = [
-      "fog-core"
-      "nokogiri"
-    ];
-  };
-  "formatador" = {
-    version = "0.2.5";
-    source = {
-      type = "gem";
-      sha256 = "1gc26phrwlmlqrmz4bagq1wd5b7g64avpx0ghxr9xdxcvmlii0l0";
-    };
-  };
-  "inflecto" = {
-    version = "0.0.2";
-    source = {
-      type = "gem";
-      sha256 = "085l5axmvqw59mw5jg454a3m3gr67ckq9405a075isdsn7bm3sp4";
-    };
-  };
-  "ipaddress" = {
-    version = "0.8.0";
-    source = {
-      type = "gem";
-      sha256 = "0cwy4pyd9nl2y2apazp3hvi12gccj5a3ify8mi8k3knvxi5wk2ir";
-    };
-  };
-  "mime-types" = {
-    version = "2.6.1";
-    source = {
-      type = "gem";
-      sha256 = "1vnrvf245ijfyxzjbj9dr6i1hkjbyrh4yj88865wv9bs75axc5jv";
-    };
-  };
-  "mini_portile" = {
-    version = "0.6.2";
-    source = {
-      type = "gem";
-      sha256 = "0h3xinmacscrnkczq44s6pnhrp4nqma7k056x5wv5xixvf2wsq2w";
-    };
-  };
-  "mtrc" = {
-    version = "0.0.4";
-    source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "0xj2pv4cpn0ad1xw38sinsxfzwhgqs6ff18hw0cwz5xmsf3zqmiz";
-    };
-  };
-  "multi_json" = {
-    version = "1.11.1";
-    source = {
       type = "gem";
-      sha256 = "0lrmadw2scqwz7nw3j5pfdnmzqimlbaxlxi37xsydrpbbr78qf6g";
     };
+    version = "0.0.4";
   };
-  "multipart-post" = {
-    version = "2.0.0";
+  riemann-client = {
+    dependencies = ["beefcake" "mtrc" "trollop"];
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02rp8x2y8h61x8mx9c8kwgm2yyvgg63g8km93zmwmkpp5fyi3fi8";
       type = "gem";
-      sha256 = "09k0b3cybqilk1gwrwwain95rdypixb2q9w65gd44gfzsd84xi1x";
     };
-  };
-  "munin-ruby" = {
-    version = "0.2.5";
-    source = {
-      type = "gem";
-      sha256 = "0378jyf0hdbfs2vvk7v8k7hqilzi1rfkpn271dyrqqal7g2lnjl2";
-    };
-  };
-  "net-scp" = {
-    version = "1.2.1";
-    source = {
-      type = "gem";
-      sha256 = "0b0jqrcsp4bbi4n4mzyf70cp2ysyp6x07j8k8cqgxnvb4i3a134j";
-    };
-    dependencies = [
-      "net-ssh"
-    ];
-  };
-  "net-ssh" = {
-    version = "2.9.2";
-    source = {
-      type = "gem";
-      sha256 = "1p0bj41zrmw5lhnxlm1pqb55zfz9y4p9fkrr9a79nrdmzrk1ph8r";
-    };
-  };
-  "nokogiri" = {
-    version = "1.6.6.2";
-    source = {
-      type = "gem";
-      sha256 = "1j4qv32qjh67dcrc1yy1h8sqjnny8siyy4s44awla8d6jk361h30";
-    };
-    dependencies = [
-      "mini_portile"
-    ];
-  };
-  "riemann-client" = {
-    version = "0.2.5";
-    source = {
-      type = "gem";
-      sha256 = "1myhyh31f290jm1wlhhjvf331n5l8qdm7axkxyacdgjsfg4szsjc";
-    };
-    dependencies = [
-      "beefcake"
-      "mtrc"
-      "trollop"
-    ];
-  };
-  "riemann-tools" = {
     version = "0.2.6";
-    source = {
-      type = "gem";
-      sha256 = "0qjm7p55h70l5bs876hhvz3isr204663f97py9g0ajxz2z8jkzpi";
-    };
-    dependencies = [
-      "faraday"
-      "fog"
-      "munin-ruby"
-      "nokogiri"
-      "riemann-client"
-      "trollop"
-      "yajl-ruby"
-    ];
   };
-  "trollop" = {
-    version = "2.1.2";
+  riemann-tools = {
+    dependencies = ["json" "riemann-client" "trollop"];
     source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0brf44cq4xz0nqhs189zlg76527bfv3jr453yc00410qdzz8fpxa";
       type = "gem";
+    };
+    version = "0.2.13";
+  };
+  trollop = {
+    source = {
+      remotes = ["https://rubygems.org"];
       sha256 = "0415y63df86sqj43c0l82and65ia5h64if7n0znkbrmi6y0jwhl8";
-    };
-  };
-  "yajl-ruby" = {
-    version = "1.2.1";
-    source = {
       type = "gem";
-      sha256 = "0zvvb7i1bl98k3zkdrnx9vasq0rp2cyy5n7p9804dqs4fz9xh9vf";
     };
+    version = "2.1.2";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

riemann-tools is broken

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

