### PR TITLE
pythonPackages.cmd2: 0.8.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/cmd2/default.nix
+++ b/pkgs/development/python-modules/cmd2/default.nix
@@ -1,17 +1,15 @@
-{ stdenv, fetchPypi, buildPythonPackage, pythonOlder
-, pyperclip, six, pyparsing, vim
+{ stdenv, fetchPypi, buildPythonPackage, pythonOlder, isPy3k
+, pyperclip, six, pyparsing, vim, wcwidth, colorama
 , contextlib2 ? null, subprocess32 ? null
 , pytest, mock, which, fetchFromGitHub, glibcLocales
 }:
 buildPythonPackage rec {
   pname = "cmd2";
-  version = "0.8.0";
+  version = "0.9.1";
 
-  src = fetchFromGitHub {
-    owner = "python-cmd2";
-    repo = "cmd2";
-    rev = version;
-    sha256 = "0nw2b7n7zg51bc3glxw0l9fn91mwjnjshklhmxhyvjbsg7khf64z";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wpw4f9zix30hfncm0hwxjjdx78zq26x3r8s9nvsq9vnxf41xb49";
   };
 
   LC_ALL="en_US.UTF-8";
@@ -31,14 +29,16 @@ buildPythonPackage rec {
     py.test -k 'not test_path_completion_user_expansion'
   '';
   doCheck = !stdenv.isDarwin;
+  disabled = !isPy3k;
 
   propagatedBuildInputs = [
+    colorama
     pyperclip
     six
     pyparsing
+    wcwidth
   ]
   ++ stdenv.lib.optional (pythonOlder "3.5") contextlib2
-  ++ stdenv.lib.optional (pythonOlder "3.0") subprocess32
   ;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/cmd2/old.nix
+++ b/pkgs/development/python-modules/cmd2/old.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchPypi, buildPythonPackage, pythonOlder
+, pyperclip, six, pyparsing, vim
+, contextlib2 ? null, subprocess32 ? null
+, pytest, mock, which, fetchFromGitHub, glibcLocales
+}:
+buildPythonPackage rec {
+  pname = "cmd2";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "python-cmd2";
+    repo = "cmd2";
+    rev = version;
+    sha256 = "0nw2b7n7zg51bc3glxw0l9fn91mwjnjshklhmxhyvjbsg7khf64z";
+  };
+
+  LC_ALL="en_US.UTF-8";
+
+  postPatch = stdenv.lib.optional stdenv.isDarwin ''
+    # Fake the impure dependencies pbpaste and pbcopy
+    mkdir bin
+    echo '#/bin/sh' > bin/pbpaste
+    echo '#/bin/sh' > bin/pbcopy
+    chmod +x bin/{pbcopy,pbpaste}
+    export PATH=$(realpath bin):$PATH
+  '';
+
+  checkInputs= [ pytest mock which vim glibcLocales ];
+  checkPhase = ''
+    # test_path_completion_user_expansion might be fixed in the next release
+    py.test -k 'not test_path_completion_user_expansion'
+  '';
+  doCheck = !stdenv.isDarwin;
+
+  propagatedBuildInputs = [
+    pyperclip
+    six
+    pyparsing
+  ]
+  ++ stdenv.lib.optional (pythonOlder "3.5") contextlib2
+  ++ stdenv.lib.optional (pythonOlder "3.0") subprocess32
+  ;
+
+  meta = with stdenv.lib; {
+    description = "Enhancements for standard library's cmd module";
+    homepage = https://github.com/python-cmd2/cmd2;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/development/python-modules/wcwidth/default.nix
+++ b/pkgs/development/python-modules/wcwidth/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, buildPythonPackage }:
+
+buildPythonPackage rec {
+    name = "wcwidth-${version}";
+    version = "0.1.7";
+
+    src = fetchurl {
+      url = "mirror://pypi/w/wcwidth/${name}.tar.gz";
+      sha256 = "0pn6dflzm609m4r3i8ik5ni9ijjbb5fa3vg1n7hn6vkd49r77wrx";
+    };
+
+    # Checks fail due to missing tox.ini file:
+    doCheck = false;
+
+    meta = with stdenv.lib; {
+      description = "Measures number of Terminal column cells of wide-character codes";
+      longDescription = ''
+        This API is mainly for Terminal Emulator implementors -- any Python
+        program that attempts to determine the printable width of a string on
+        a Terminal. It is implemented in python (no C library calls) and has
+        no 3rd-party dependencies.
+      '';
+      homepage = https://github.com/jquast/wcwidth;
+      license = licenses.mit;
+    };
+  }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14845,30 +14845,7 @@ EOF
     imagemagick = pkgs.imagemagickBig;
   };
 
-  wcwidth = buildPythonPackage rec {
-    name = "wcwidth-${version}";
-    version = "0.1.6";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/w/wcwidth/${name}.tar.gz";
-      sha256 = "02wjrpf001gjdjsaxxbzcwfg19crlk2dbddayrfc2v06f53yrcyw";
-    };
-
-    # Checks fail due to missing tox.ini file:
-    doCheck = false;
-
-    meta = {
-      description = "Measures number of Terminal column cells of wide-character codes";
-      longDescription = ''
-        This API is mainly for Terminal Emulator implementors -- any Python
-        program that attempts to determine the printable width of a string on
-        a Terminal. It is implemented in python (no C library calls) and has
-        no 3rd-party dependencies.
-      '';
-      homepage = https://github.com/jquast/wcwidth;
-      license = licenses.mit;
-    };
-  };
+  wcwidth = callPackage ../development/python-modules/wcwidth { };
 
   web = buildPythonPackage rec {
     version = "0.37";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9142,7 +9142,9 @@ in {
    cachetools_1 = callPackage ../development/python-modules/cachetools/1.nix {};
    cachetools = callPackage ../development/python-modules/cachetools {};
 
-  cmd2 = callPackage ../development/python-modules/cmd2 {};
+  cmd2_8 = callPackage ../development/python-modules/cmd2/old.nix {};
+  cmd2_9 = callPackage ../development/python-modules/cmd2 {};
+  cmd2 = if isPy27 then self.cmd2_8 else self.cmd2_9;
 
  warlock = buildPythonPackage rec {
    name = "warlock-${version}";


### PR DESCRIPTION
###### Motivation for this change
Many new features in cmd2 (subcommands/argparse support...)

The problem is that cmd2 dropped python support so I think we should keep both python2 compatible version (0.8.X) and the newest one. Is there any example of this ? 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

