### PR TITLE
haskell generic-builder: Always use separate pkg db for custom setup

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1068,3 +1068,14 @@ self: super: {
 in {
   inherit amazonka amazonka-core amazonka-test;
 })
+
+//
+
+# The actual Cabal library gets built while building its `Setup.hs`.
+(let
+  inherit (pkgs.lib) filterAttrs flip mapAttrs hasPrefix;
+  cabals = filterAttrs (n: v: hasPrefix "Cabal_" n) super;
+  fixCabal = n: v: addSetupDepends v [ self.mtl self.parsec ];
+in
+  mapAttrs fixCabal cabals
+)

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -166,14 +166,8 @@ let
     "--configure-option=--host=${hostPlatform.config}"
   ] ++ crossCabalFlags);
 
-  useSeparateSetupDb = setupHaskellDepends != [] || isCross || isGhcjs;
-
   setupCompileFlags = [
-    (optionalString (!coreSetup) "-${nativePackageDbFlag}=${
-      if useSeparateSetupDb
-      then "$setupPackageConfDir"
-      else "$packageConfDir"
-    }")
+    (optionalString (!coreSetup) "-${nativePackageDbFlag}=$setupPackageConfDir")
     (optionalString (isGhcjs || isHaLVM || versionOlder "7.8" ghc.version) "-j$NIX_BUILD_CORES")
     # https://github.com/haskell/cabal/issues/2398
     (optionalString (versionOlder "7.10" ghc.version && !isHaLVM) "-threaded")
@@ -270,10 +264,8 @@ stdenv.mkDerivation ({
     echo "Build with ${ghc}."
     ${optionalString (hasActiveLibrary && hyperlinkSource) "export PATH=${hscolour}/bin:$PATH"}
 
-  '' + (optionalString useSeparateSetupDb ''
     setupPackageConfDir="$TMPDIR/setup-package.conf.d"
     mkdir -p $setupPackageConfDir
-  '') + ''
     packageConfDir="$TMPDIR/package.conf.d"
     mkdir -p $packageConfDir
 
@@ -284,14 +276,13 @@ stdenv.mkDerivation ({
   # dependencies for the build machine.
   #
   # pkgs* arrays defined in stdenv/setup.hs
-  + (optionalString useSeparateSetupDb ''
+  + ''
     for p in "''${pkgsBuildBuild[@]}" "''${pkgsBuildHost[@]}" "''${pkgsBuildTarget[@]}"; do
       ${buildPkgDb nativeGhc.name "$setupPackageConfDir"}
     done
     ${nativeGhcCommand}-pkg --${nativePackageDbFlag}="$setupPackageConfDir" recache
-  '')
-
-    # For normal components
+  ''
+  # For normal components
   + ''
     for p in "''${pkgsHostHost[@]}" "''${pkgsHostTarget[@]}"; do
       ${buildPkgDb ghc.name "$packageConfDir"}


### PR DESCRIPTION
###### Motivation for this change

This decreases complexity and ensures setup dependencies are properly specified with `setup-depends` as they should be. Testing will say if this is a reasonable change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ElvishJerricco 