### PR TITLE
ktorrent: fix build with CMake 3.11

### DIFF
--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake
+{ stdenv, fetchurl, fetchpatch, cmake
 , extra-cmake-modules, qtbase, qtscript
 , karchive, kcrash, kdnssd, ki18n, kio, knotifications, knotifyconfig
 , kdoctools, kross, kcmutils, kwindowsystem
@@ -20,6 +20,14 @@ stdenv.mkDerivation rec {
     qtbase qtscript
     karchive kcrash kdnssd ki18n kio knotifications knotifyconfig kross kcmutils kwindowsystem
     libktorrent taglib libgcrypt kplotting
+  ];
+
+  patches = [
+    # Fix build with CMake 3.11
+    (fetchpatch {
+      url = "https://cgit.kde.org/ktorrent.git/patch/?id=672c5076de7e3a526d9bdbb484a69e9386bc49f8";
+      sha256 = "1cn4rnbhadrsxqx50fawpd747azskavbjraygr6s11rh1wbfrxid";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

KTorrent 5.1.0 fails to build with CMake 3.11. This PR backports a fix from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

