### PR TITLE
darwin stdenv: fix llvmPackages overrides

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -275,10 +275,9 @@ in rec {
         libcxxabi libcxx ncurses libffi zlib gmp pcre gnugrep
         coreutils findutils diffutils patchutils;
 
-       llvmPackages = let llvmOverride = llvmPackages.llvm.override { inherit libcxxabi; };
-       in super.llvmPackages // {
-         llvm = llvmOverride;
-         clang-unwrapped = llvmPackages.clang-unwrapped.override { llvm = llvmOverride; };
+       llvmPackages_5 = super.llvmPackages_5 // {
+         llvm = llvmPackages_5.llvm.override { inherit libcxxabi; };
+         clang-unwrapped = llvmPackages_5.clang-unwrapped.override { llvm = self.llvmPackages_5.llvm; };
        };
 
       darwin = super.darwin // {
@@ -314,8 +313,8 @@ in rec {
         libcxxabi libcxx ncurses libffi zlib llvm gmp pcre gnugrep
         coreutils findutils diffutils patchutils;
 
-      llvmPackages = super.llvmPackages // {
-        inherit (llvmPackages) llvm clang-unwrapped;
+      llvmPackages_5 = super.llvmPackages_5 // {
+        inherit (llvmPackages_5) llvm clang-unwrapped;
       };
 
       darwin = super.darwin // {


### PR DESCRIPTION
###### Motivation for this change

It may seem nice and abstract to just override the default version, but that breaks the alias relationship where the original llvmPackages_* is no longer in sync. Put another away, modifying the referee rather instead of breaking the reference "copy-on-write" is impossible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

