### PR TITLE
editline: init at 1.15.3

### DIFF
--- a/pkgs/development/libraries/editline/default.nix
+++ b/pkgs/development/libraries/editline/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "editline-${version}";
+  version = "1.15.3";
+  src = fetchFromGitHub {
+    owner = "troglobit";
+    repo = "editline";
+    rev = version;
+    sha256 = "0dm5fgq0acpprr938idwml64nclg9l6c6avirsd8r6f40qicbgma";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  dontDisableStatic = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://troglobit.com/editline.html;
+    description = "A readline() replacement for UNIX without termcap (ncurses)";
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8926,6 +8926,8 @@ with pkgs;
 
   eclib = callPackage ../development/libraries/eclib {};
 
+  editline = callPackage ../development/libraries/editline { };
+
   eigen = callPackage ../development/libraries/eigen {};
   eigen3_3 = callPackage ../development/libraries/eigen/3.3.nix {};
 


### PR DESCRIPTION
Not sure why I didn't submit this earlier!

Anyway, generally useful library and may be used in Nix one day.

https://github.com/NixOS/nix/pull/2228

Distinct from the libedit package, apparently :).



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---