### PR TITLE
ispell: fix compilation on Darwin

### DIFF
--- a/pkgs/tools/text/ispell/default.nix
+++ b/pkgs/tools/text/ispell/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
     ./patches/0030-Display-whole-multibyte-character.patch
   ];
   postPatch = ''
+    if [ ! stdenv.isDarwin ]; then echo "#define USG" >> local.h; fi
     cat >> local.h <<EOF
-    #define USG
     #define TERMLIB "-lncurses"
     #define LANGUAGES "{american,MASTERDICTS=american.med,HASHFILES=americanmed.hash}"
     #define MASTERHASH "americanmed.hash"

--- a/pkgs/tools/text/ispell/default.nix
+++ b/pkgs/tools/text/ispell/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
     ./patches/0030-Display-whole-multibyte-character.patch
   ];
   postPatch = ''
-    if [ ! stdenv.isDarwin ]; then echo "#define USG" >> local.h; fi
     cat >> local.h <<EOF
+    ${stdenv.lib.optionalString (!stdenv.isDarwin) "#define USG"}
     #define TERMLIB "-lncurses"
     #define LANGUAGES "{american,MASTERDICTS=american.med,HASHFILES=americanmed.hash}"
     #define MASTERHASH "americanmed.hash"


### PR DESCRIPTION
###### Motivation for this change

Fixes #41948.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

