### PR TITLE
dlib: 19.9 -> 19.13

### DIFF
--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, openblas, libpng, libjpeg
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, libpng, libjpeg
 , guiSupport ? false, libX11
 }:
 
 stdenv.mkDerivation rec {
-  version = "19.9";
+  version = "19.13";
   name = "dlib-${version}";
 
   src = fetchFromGitHub {
     owner = "davisking";
     repo = "dlib";
     rev ="v${version}";
-    sha256 = "0lc54r928j9dg7f2wn25m887z24d31wrc14v2hn6aknp1z084lrc";
+    sha256 = "11ia4pd2lm2s9hzwrdvimj3r2qcnvjdp3g4fry2j1a6z9f99zvz3";
   };
 
   postPatch = ''
@@ -19,14 +19,13 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ openblas libpng libjpeg ] ++ lib.optional guiSupport libX11;
+  buildInputs = [ libpng libjpeg ] ++ lib.optional guiSupport libX11;
 
   meta = with stdenv.lib; {
     description = "A general purpose cross-platform C++ machine learning library";
     homepage = http://www.dlib.net;
     license = licenses.boost;
-    maintainers = with maintainers; [ christopherpoole ];
+    maintainers = with maintainers; [ christopherpoole ma27 ];
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/development/python-modules/dlib/build-cores.patch
+++ b/pkgs/development/python-modules/dlib/build-cores.patch
@@ -1,0 +1,27 @@
+diff --git a/setup.py b/setup.py
+index 0c8d8f16..565ef8ef 100644
+--- a/setup.py
++++ b/setup.py
+@@ -172,21 +172,7 @@ class CMakeBuild(build_ext):
+         subprocess.check_call(cmake_build, cwd=build_folder)
+ 
+ def num_available_cpu_cores(ram_per_build_process_in_gb):
+-    if 'TRAVIS' in os.environ and os.environ['TRAVIS']=='true':
+-        # When building on travis-ci, just use 2 cores since travis-ci limits
+-        # you to that regardless of what the hardware might suggest.
+-        return 2 
+-    try:
+-        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')  
+-        mem_gib = mem_bytes/(1024.**3)
+-        num_cores = multiprocessing.cpu_count() 
+-        # make sure we have enough ram for each build process.
+-        mem_cores = int(floor(mem_gib/float(ram_per_build_process_in_gb)+0.5));
+-        # We are limited either by RAM or CPU cores.  So pick the limiting amount
+-        # and return that.
+-        return max(min(num_cores, mem_cores), 1)
+-    except ValueError:
+-        return 2 # just assume 2 if we can't get the os to tell us the right answer.
++    return os.getenv("NIX_BUILD_CORES", 1)
+ 
+ 
+ from setuptools.command.test import test as TestCommand

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1229,9 +1229,9 @@ in {
   cypari2 = callPackage ../development/python-modules/cypari2 { };
 
   dlib = buildPythonPackage rec {
-    inherit (pkgs.dlib) name src nativeBuildInputs meta;
+    inherit (pkgs.dlib) name src nativeBuildInputs meta buildInputs;
 
-    buildInputs = pkgs.dlib.buildInputs ++ [ self.boost ];
+    patches = [ ../development/python-modules/dlib/build-cores.patch ];
 
     checkInputs = with self; [ pytest ];
   };


### PR DESCRIPTION
###### Motivation for this change

This fixes the latest `dlib` build for `nixpkgs` compliancy:

* Patched `setup.py` to use number of jobs defined in `$NIX_BUILD_CORES`
  rather than using all available cores.

* Bumped `dlib` to latest version (v19.13 ATM).

* Dropped `openblas` build input, `cblas` which actually works lives in
  `dlib/external`. Otherwise the test suite runs into segfaults (see
  https://github.com/NixOS/nixpkgs/pull/39255#issuecomment-384535129 for
  further reference).

* Added myself as maintainer in case of any further breakage in the
  future.

Closes #39255

/cc @dotlambda @ryantm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

