### PR TITLE
hplip: 3.18.3 -> 3.18.5

### DIFF
--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,26 +1,28 @@
 { stdenv, fetchurl, substituteAll
 , pkgconfig
 , makeWrapper
-, cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends, dbus, usbutils
-, net_snmp, openssl, polkit, nettools
+, cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends
+, dbus, file, ghostscript, usbutils
+, net_snmp, openssl, perl, polkit, nettools
 , bash, coreutils, utillinux
 , withQt5 ? true
 , withPlugin ? false
+, withStaticPPDInstall ? false
 }:
 
 let
 
   name = "hplip-${version}";
-  version = "3.18.3";
+  version = "3.18.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/hplip/${name}.tar.gz";
-    sha256 = "0x5xs86v18w46rxz5whc15bl4fb7p4km6xqjpwzclp83nl7rl01y";
+    sha256 = "0xb7ga2wgbwjxsss67mjn2y6fmqsfwzmv11ivvfzhnl36lh22hkb";
   };
 
   plugin = fetchurl {
     url = "https://www.openprinting.org/download/printdriver/auxfiles/HP/plugins/${name}-plugin.run";
-    sha256 = "11nc3cifhd2h2c7p0dr2jjzrg3fd5j43ih1wy0m186l6wcgdjssw";
+    sha256 = "1jf74jya071zqvwhy9n0c3007pzgcxydkw7qdh4sx70brly81i7p";
   };
 
   hplipState = substituteAll {
@@ -55,8 +57,11 @@ pythonPackages.buildPythonApplication {
     libusb1
     sane-backends
     dbus
+    file
+    ghostscript
     net_snmp
     openssl
+    perl
     zlib
   ];
 
@@ -86,6 +91,11 @@ pythonPackages.buildPythonApplication {
       -e s,/usr/share/hal/fdi/preprobe/10osvendor,$out/share/hal/fdi/preprobe/10osvendor,g \
       -e s,/usr/lib/systemd/system,$out/lib/systemd/system,g \
       -e s,/var/lib/hp,$out/var/lib/hp,g \
+      -e s,/usr/bin/perl,${perl}/bin/perl,g \
+      -e s,/usr/bin/file,${file}/bin/file,g \
+      -e s,/usr/bin/gs,${ghostscript}/bin/gs,g \
+      -e s,/usr/share/cups/fonts,${ghostscript}/share/ghostscript/fonts,g \
+      -e "s,ExecStart=/usr/bin/python /usr/bin/hp-config_usb_printer,ExecStart=$out/bin/hp-config_usb_printer,g" \
       {} +
   '';
 
@@ -98,6 +108,7 @@ pythonPackages.buildPythonApplication {
       --with-systraydir=$out/xdg/autostart
       --with-mimedir=$out/etc/cups
       --enable-policykit
+      ${stdenv.lib.optionalString withStaticPPDInstall "--enable-cups-ppd-install"}
       --disable-qt4
       ${stdenv.lib.optionalString withQt5 "--enable-qt5"}
     "
@@ -111,10 +122,20 @@ pythonPackages.buildPythonApplication {
       hplip_confdir=$out/etc/hp
       hplip_statedir=$out/var/lib/hp
     "
+
+    # Prevent 'ppdc: Unable to find include file "<font.defs>"' which prevent
+    # generation of '*.ppd' files.
+    # This seems to be a 'ppdc' issue when the tool is run in a hermetic sandbox.
+    # Could not find how to fix the problem in 'ppdc' so this is a workaround.
+    export CUPS_DATADIR="${cups}/share/cups"
   '';
 
   enableParallelBuilding = true;
 
+  #
+  # Running `hp-diagnose_plugin -g` can be used to diagnose
+  # issues with plugins.
+  #
   postInstall = stdenv.lib.optionalString withPlugin ''
     sh ${plugin} --noexec --keep
     cd plugin_tmp
@@ -130,15 +151,25 @@ pythonPackages.buildPythonApplication {
     mkdir -p $out/share/hplip/prnt/plugins
     for plugin in lj hbpl1; do
       cp $plugin-${hplipArch}.so $out/share/hplip/prnt/plugins
+      chmod 0755 $out/share/hplip/prnt/plugins/$plugin-${hplipArch}.so
       ln -s $out/share/hplip/prnt/plugins/$plugin-${hplipArch}.so \
         $out/share/hplip/prnt/plugins/$plugin.so
     done
 
     mkdir -p $out/share/hplip/scan/plugins
-    for plugin in bb_soap bb_marvell bb_soapht fax_marvell; do
+    for plugin in bb_soap bb_marvell bb_soapht bb_escl; do
       cp $plugin-${hplipArch}.so $out/share/hplip/scan/plugins
+      chmod 0755 $out/share/hplip/scan/plugins/$plugin-${hplipArch}.so
       ln -s $out/share/hplip/scan/plugins/$plugin-${hplipArch}.so \
         $out/share/hplip/scan/plugins/$plugin.so
+    done
+
+    mkdir -p $out/share/hplip/fax/plugins
+    for plugin in fax_marvell; do
+      cp $plugin-${hplipArch}.so $out/share/hplip/fax/plugins
+      chmod 0755 $out/share/hplip/fax/plugins/$plugin-${hplipArch}.so
+      ln -s $out/share/hplip/fax/plugins/$plugin-${hplipArch}.so \
+        $out/share/hplip/fax/plugins/$plugin.so
     done
 
     mkdir -p $out/var/lib/hp


### PR DESCRIPTION
Also fixes multiples issues:

 -  broken plugins:

     -  `fax_marvell.so file is not present or symbolic link is missing`
     -  `lj.so library file doesn't have user/group execute permission.`
     -  `bb_escl.so file is not present or symbolic link is missing`

 -  multiple error during configuration phase which prevented `*.ppd`
    generation:

     -  `ppdc: Unable to find include file "<font.defs>"`
     -  patched configure time `perl` script
     -  patched use of `file`

 -  some potentially problematic filter and services:

     -  patched reference to ghost script and fonts dir in filter.
     -  patched usb configuration service.

 -  patch scripts so that they refer to valid location.

Add some options:

 -  `withStaticPPDInstall`: Install `*.ppd` files along with `*.drv`.
    When true, configure outputs: `checking for cups ppd install... yes`.

###### Motivation for this change

Impossible to use my "HP LaserJet 400 colorMFP M475dw" from nixos. Worked fine on Ubuntu.

Improve hp printer support on nixos in general.

Latest version allows for qt5 `hp-diagnose_plugin -g`. Was only possible in previous version with qt4. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested succesfully multiple executables:

 -  `hp-diagnose_plugin -g`
 -  `hp-diagnose_queues -g`
 -  `hp-setup`
---

Might be a good thing to backport to stable.