### PR TITLE
salt: be Python version agnostic

### DIFF
--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,5 +1,5 @@
 {
-  stdenv, python2Packages, openssl,
+  stdenv, pythonPackages, openssl,
 
   # Many Salt modules require various Python modules to be installed,
   # passing them in this array enables Salt to find them.
@@ -8,7 +8,7 @@
 
 let
   # Use tornado-4.x until https://github.com/saltstack/salt/issues/45790 is resolved
-  tornado = python2Packages.tornado.overridePythonAttrs (oldAttrs: rec {
+  tornado = pythonPackages.tornado.overridePythonAttrs (oldAttrs: rec {
     version = "4.5.3";
     name = "${oldAttrs.pname}-${version}";
     src = oldAttrs.src.override {
@@ -17,17 +17,16 @@ let
     };
   });
 in
-python2Packages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   pname = "salt";
   version = "2018.3.0";
 
-  src = python2Packages.fetchPypi {
+  src = pythonPackages.fetchPypi {
     inherit pname version;
     sha256 = "0cbbnmaynnpfknmppzlz04mqw4d3d2ay1dqrli11b5pnzli5v950";
   };
 
-  propagatedBuildInputs = with python2Packages; [
-    futures
+  propagatedBuildInputs = with pythonPackages; [
     jinja2
     markupsafe
     msgpack-python
@@ -36,6 +35,8 @@ python2Packages.buildPythonApplication rec {
     pyzmq
     requests
     tornado
+  ] ++ stdenv.lib.optional (!pythonPackages.isPy3k) [
+    futures
   ] ++ extraInputs;
 
   patches = [ ./fix-libcrypto-loading.patch ];


### PR DESCRIPTION
###### Motivation for this change

As of Salt 2017.7 (Salt Nitrogen), Salt supports Python 3.
Release notes: https://docs.saltstack.com/en/develop/topics/releases/2017.7.0.html#python-3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).