### PR TITLE
nerdfonts: can be built on hydra?

### DIFF
--- a/pkgs/data/fonts/nerdfonts/default.nix
+++ b/pkgs/data/fonts/nerdfonts/default.nix
@@ -31,6 +31,5 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ garbas ];
     platforms = with platforms; unix;
-    hydraPlatforms = []; # 'Output limit exceeded' on Hydra
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This is more a question, but I thought I would ask with this PR

nerfonts build on hydra was disabled almost 2 years ago. I have no idea about the Hydra capacity, but I'm hopping that now it is better and it can build nerdfonts again.

The reason to ask for it is that I have an old computer that runs out of disk when I try to build the derivation, so I cannot install it. It would be nice to be able to install it from the cache.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

