### PR TITLE
dozenal: init at version v12010904

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -673,6 +673,11 @@
     github = "changlinli";
     name = "Changlin Li";
   };
+  CharlesHD = {
+    email = "charleshdespointes@gmail.com";
+    github = "CharlesHD";
+    name = "Charles Huyghues-Despointes";
+  };
   chaoflow = {
     email = "flo@chaoflow.net";
     github = "chaoflow";

--- a/pkgs/applications/misc/dozenal/default.nix
+++ b/pkgs/applications/misc/dozenal/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchFromGitHub, ncurses, hdate, lua5_2 }:
+
+stdenv.mkDerivation rec {
+  version = "12010904";
+  name = "dozenal-${version}";
+  src = fetchFromGitHub {
+    owner = "dgoodmaniii";
+    repo = "dozenal";
+    rev = "v${version}";
+    sha256 = "1ic63gpdda762x6ks3al71dwgmsy2isicqyr2935bd245jx8s209";
+  };
+  makeFlags = [
+              # author do not use configure and prefix directly using $prefix
+              "prefix=$(out)"
+              # graphical version of dozdc requires xforms, which is not i nixpkgs so I turned it down
+              "XFORMS_FLAGS=-UXFORMS"
+              "LUALIB=-llua"
+              "bindir=$(prefix)/bin/"
+            ];
+  # some include hardcodes the lua libraries path. This is a patch for that
+  patches = [ ./lua-header.patch ];
+  preBuild = "cd dozenal";
+  buildInputs = [ ncurses hdate lua5_2 ];
+  # I remove gdozdc, as I didn't figure all it's dependency yet.
+  postInstall = "rm $out/bin/gdozdc";
+
+  meta = {
+    description = "A complete suite of dozenal (base twelve) programs";
+    longDescription = ''
+      Programs
+
+      doz --- a converter; converts decimal numbers into dozenal. Accepts
+         input in standard or exponential notation (i.e., "1492.2" or "1.4922e3").
+      dec --- a converter; converts dozenal numbers into decimal. Accepts input
+         in standard or exponential notation (i.e., "X44;4" or "X;444e2").
+      dozword --- converts a dozenal number (integers only) into words,
+         according to the Pendlebury system.
+      dozdc --- a full-featured scientific calculator which works in the
+         dozenal base. RPN command line.
+      tgmconv --- a converter for all standard measurements; converts to and
+         from TGM, Imperial, customary, and SI metric.
+      dozpret --- a pretty-printer for dozenal numbers; inserts spacing (or
+         other characters) as desired, and can also transform transdecimal digits
+         from 'X' to 'E' into any character or sequence of characters desired.
+      dozdate --- a more-or-less drop-in replacement for GNU and BSD date, it
+         outputs the date and time in dozenal, as well as containing some TGM
+         extensions.
+      dozstring --- a simple byte converter; absorbs a string either from
+         standard input or a command line argument, leaving it identical but
+         for the numbers, which it converts into dozenal. Options for padding
+         and for not converting specific numbers.
+      doman --- a converter which takes a dozenal integer and
+         emits its equivalent in a non-place-value system, such as
+         Roman numerals.  Arbitrary ranks and symbols may be used.
+         Defaults to dozenal Roman numerals.
+    '';
+    homepage = https://github.com/dgoodmaniii/dozenal/;
+    maintainers = with stdenv.lib.maintainers; [ CharlesHD ];
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/applications/misc/dozenal/lua-header.patch
+++ b/pkgs/applications/misc/dozenal/lua-header.patch
@@ -1,0 +1,16 @@
+diff -ruN dozenal-12010904/dozenal/dozcal/call_lua.c dozenal-patched/dozenal/dozcal/call_lua.c
+--- dozenal-12010904/dozenal/dozcal/call_lua.c	2017-09-04 19:25:01.000000000 +0200
++++ dozenal-patched/dozenal/dozcal/call_lua.c	2018-06-13 10:19:57.821950327 +0200
+@@ -38,9 +38,9 @@
+ #include"utility.h"
+ #include"conv.h"
+ #include"proc_date.h"
+-#include<lua5.2/lua.h>
+-#include<lua5.2/lauxlib.h>
+-#include<lua5.2/lualib.h>
++#include<lua.h>
++#include<lauxlib.h>
++#include<lualib.h>
+ 
+ void bail(lua_State *L, int err_code, char *filename);
+ int file_prefix(char **s, char *t);

--- a/pkgs/applications/misc/hdate/default.nix
+++ b/pkgs/applications/misc/hdate/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "1.6.02";
+  name = "hdate-${version}";
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/libhdate/files/libhdate/libhdate-${version}/libhdate-${version}.tar.bz2";
+    sha256 = "3c930a8deb57c01896dc37f0d7804e5a330ee8e88c4ff610b71f9d2b02c17762";
+  };
+  meta = {
+    description = "Hebrew calendar and solar astronomical times library and utilities";
+    homepage = https://sourceforge.net/projects/libhdate/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ CharlesHD ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1216,6 +1216,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  dozenal = callPackage ../applications/misc/dozenal { };
+
   dpic = callPackage ../tools/graphics/dpic { };
 
   dragon-drop = callPackage ../tools/X11/dragon-drop {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1362,6 +1362,8 @@ with pkgs;
 
   gti = callPackage ../tools/misc/gti { };
 
+  hdate = callPackage ../applications/misc/hdate { };
+
   heatseeker = callPackage ../tools/misc/heatseeker { };
 
   hebcal = callPackage ../tools/misc/hebcal {};


### PR DESCRIPTION
###### Motivation for this change
dozenal is a toolsuite for working with base twelve instead of base ten that I use on a daily basis. 

hdate is a library for working with hebraic date, I do not use it but dozenal depends on hdate, so I added an hdate derivation too. The hdate utilities works too, maybe it can be useful to others.

###### Things done
- Added a hdate derivation, which is a dozenal depency
- Added the dozenal derivation
- Added myself in the list of maintainers
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

