### PR TITLE
haskellPackages.llvm-hs_6_2_0: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -269,6 +269,10 @@ self: super: builtins.intersectAttrs super {
     );
 
   llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm; };
+  llvm-hs_6_2_0 = super.llvm-hs_6_2_0.override {
+    llvm-config = pkgs.llvm_6;
+    llvm-hs-pure = super.llvm-hs-pure_6_2_0;
+  };
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool super.spaceprobe self.llvmPackages.llvm;


### PR DESCRIPTION
Where does the package even come from? It does not seem to be listed in `configuration-hackage2nix.yaml`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

