### PR TITLE
ghcjs: add version to haskellCompilerName

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -48,7 +48,7 @@ let
     stage1Packages = [];
     mkStage2 = _: {};
 
-    haskellCompilerName = "ghcjs";
+    haskellCompilerName = "ghcjs-${bootGhcjs.version}";
   };
 
   bootGhcjs = haskellLib.justStaticExecutables passthru.bootPkgs.ghcjs;

--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -174,7 +174,7 @@ in mkDerivation (rec {
     isGhcjs = true;
     inherit nodejs ghcjsBoot;
     socket-io = pkgs.nodePackages."socket.io";
-    haskellCompilerName = "ghcjs";
+    haskellCompilerName = "ghcjs-${version}";
 
     # let us assume ghcjs is never actually cross compiled
     targetPrefix = "";


### PR DESCRIPTION
This is needed for some cabal2nix stuff in getting the version.
Previously we had left out the version but apparently this can cause
problems in some scenarios. Hopefully this is the correct use of
haskellCompilerName.

/cc @elvishjerricco @peti @ericson2314
