### PR TITLE
webkitgtk: 2.20.2 -> 2.20.3

### DIFF
--- a/pkgs/development/libraries/webkitgtk/2.20.nix
+++ b/pkgs/development/libraries/webkitgtk/2.20.nix
@@ -15,7 +15,7 @@ assert stdenv.isDarwin -> !enableGtk2Plugins;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "webkitgtk-${version}";
-  version = "2.20.2";
+  version = "2.20.3";
 
   meta = {
     description = "Web content rendering engine, GTK+ port";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "http://webkitgtk.org/releases/${name}.tar.xz";
-    sha256 = "1qi6nnj4qidzija1am9xscwjxwfqwhiy7x39ndriqgzh86i97znz";
+    sha256 = "1n0dy94bm7wvxln4jis1gp8plv8n4a01g41724zsf5psg1yk16sp";
   };
 
   patches = optionals stdenv.isDarwin [


### PR DESCRIPTION
This addresses several issues with webkitgtk 2.20.2:

- CVE-2018-4190, information leak (credentials)
- CVE-2018-4199, arbitrary code execution
- CVE-2018-4218, arbitrary code execution
- CVE-2018-4222, arbitrary code execution
- CVE-2018-4232, cookies might be overriden
- CVE-2018-4233, arbitrary code execution
- CVE-2018-11646, application crash
- CVE-2018-12293, heap buffer overflow

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

