### PR TITLE
darwin bootstrapping: Avoid overriding aliases for LLVM

### DIFF
--- a/pkgs/development/compilers/llvm/3.7/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/default.nix
@@ -16,7 +16,7 @@ let
   compiler-rt_src = fetch "compiler-rt" "10c1mz2q4bdq9bqfgr3dirc6hz1h3sq8573srd5q5lr7m7j6jiwx";
   clang-tools-extra_src = fetch "clang-tools-extra" "0sxw2l3q5msbrwxv1ck72arggdw6n5ysi929gi69ikniranfv4aa";
 
-  tools = let
+  tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv isl version fetch; });
   in {
     llvm = callPackage ./llvm.nix {
@@ -41,9 +41,9 @@ let
     };
 
     lldb = callPackage ./lldb.nix {};
-  };
+  });
 
-  libraries = let
+  libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv isl version fetch; });
   in {
 
@@ -54,6 +54,6 @@ let
     libcxx = callPackage ./libc++ {};
 
     libcxxabi = callPackage ./libc++abi.nix {};
-  };
+  });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -15,7 +15,7 @@ let
   compiler-rt_src = fetch "compiler-rt" "0p0y85c7izndbpg2l816z7z7558axq11d5pwkm4h11sdw7d13w0d";
   clang-tools-extra_src = fetch "clang-tools-extra" "15n39r4ssphpaq4a0wzyjm7ilwxb0bch6nrapy8c5s8d49h5qjk6";
 
-  tools = let
+  tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv isl version fetch; });
  in {
     llvm = callPackage ./llvm.nix {
@@ -41,9 +41,9 @@ let
     };
 
     lldb = callPackage ./lldb.nix {};
-  };
+  });
 
-  libraries = let
+  libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv isl version fetch; });
   in {
 
@@ -54,6 +54,6 @@ let
     libcxx = callPackage ./libc++ {};
 
     libcxxabi = callPackage ./libc++abi.nix {};
-  };
+  });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -15,7 +15,7 @@ let
   compiler-rt_src = fetch "compiler-rt" "16gc2gdmp5c800qvydrdhsp0bzb97s8wrakl6i8a4lgslnqnf2fk";
   clang-tools-extra_src = fetch "clang-tools-extra" "0d9nh7j7brbh9avigcn69dlaihsl9p3cf9s45mw6fxzzvrdvd999";
 
-  tools = let
+  tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv isl version fetch; });
   in {
     llvm = callPackage ./llvm.nix {
@@ -41,9 +41,9 @@ let
     };
 
     lldb = callPackage ./lldb.nix {};
-  };
+  });
 
-  libraries = let
+  libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv isl version fetch; });
   in {
 
@@ -54,6 +54,6 @@ let
     libcxx = callPackage ./libc++ {};
 
     libcxxabi = callPackage ./libc++abi.nix {};
-  };
+  });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -22,7 +22,7 @@ let
     let drv-manpages = drv.override { enableManpages = true; }; in
     drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
-  tools = let
+  tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
@@ -52,9 +52,9 @@ let
     lld = callPackage ./lld.nix {};
 
     lldb = callPackage ./lldb.nix {};
-  };
+  });
 
-  libraries = let
+  libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
@@ -67,6 +67,6 @@ let
     libcxxabi = callPackage ./libc++abi.nix {};
 
     openmp = callPackage ./openmp.nix {};
-  };
+  });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -22,7 +22,7 @@ let
     let drv-manpages = drv.override { enableManpages = true; }; in
     drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
-  tools = let
+  tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
@@ -53,9 +53,9 @@ let
     lld = callPackage ./lld.nix {};
 
     lldb = callPackage ./lldb.nix {};
-  };
+  });
 
-  libraries = let
+  libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
@@ -68,6 +68,6 @@ let
     libcxxabi = callPackage ./libc++abi.nix {};
 
     openmp = callPackage ./openmp.nix {};
-  };
+  });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -21,7 +21,7 @@ let
     let drv-manpages = drv.override { enableManpages = true; }; in
     drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
 
-  tools = let
+  tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
@@ -71,9 +71,9 @@ let
     lld = callPackage ./lld.nix {};
 
     lldb = callPackage ./lldb.nix {};
-  };
+  });
 
-  libraries = let
+  libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
   in {
 
@@ -88,6 +88,6 @@ let
     libcxxabi = callPackage ./libc++abi.nix {};
 
     openmp = callPackage ./openmp.nix {};
-  };
+  });
 
 in { inherit tools libraries; } // libraries // tools

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -159,26 +159,27 @@ in rec {
         dyld = bootstrapTools;
       };
 
-      libcxx = stdenv.mkDerivation {
-        name = "bootstrap-stage0-libcxx";
-        phases = [ "installPhase" "fixupPhase" ];
-        installPhase = ''
-          mkdir -p $out/lib $out/include
-          ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib/libc++.dylib
-          ln -s ${bootstrapTools}/include/c++      $out/include/c++
-        '';
-        linkCxxAbi = false;
-        setupHook = ../../development/compilers/llvm/3.9/libc++/setup-hook.sh;
-      };
+      llvmPackages_5 = {
+        libcxx = stdenv.mkDerivation {
+          name = "bootstrap-stage0-libcxx";
+          phases = [ "installPhase" "fixupPhase" ];
+          installPhase = ''
+            mkdir -p $out/lib $out/include
+            ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib/libc++.dylib
+            ln -s ${bootstrapTools}/include/c++      $out/include/c++
+          '';
+          linkCxxAbi = false;
+          setupHook = ../../development/compilers/llvm/3.9/libc++/setup-hook.sh;
+        };
 
-      libcxxabi = stdenv.mkDerivation {
-        name = "bootstrap-stage0-libcxxabi";
-        buildCommand = ''
-          mkdir -p $out/lib
-          ln -s ${bootstrapTools}/lib/libc++abi.dylib $out/lib/libc++abi.dylib
-        '';
+        libcxxabi = stdenv.mkDerivation {
+          name = "bootstrap-stage0-libcxxabi";
+          buildCommand = ''
+            mkdir -p $out/lib
+            ln -s ${bootstrapTools}/lib/libc++abi.dylib $out/lib/libc++abi.dylib
+          '';
+        };
       };
-
     };
 
     extraNativeBuildInputs = [];
@@ -236,8 +237,11 @@ in rec {
         patchutils m4 scons flex perl bison unifdef unzip openssl python
         gettext sharutils libarchive pkg-config groff bash subversion
         openssh sqlite sed serf openldap db cyrus-sasl expat apr-util
-        findfreetype libssh curl cmake autoconf automake libtool cpio
-        libcxx libcxxabi;
+        findfreetype libssh curl cmake autoconf automake libtool cpio;
+
+      llvmPackages_5 = super.llvmPackages_5 // {
+        inherit (llvmPackages_5) libcxx libcxxabi;
+      };
 
       darwin = super.darwin // {
         inherit (darwin)
@@ -272,13 +276,18 @@ in rec {
     persistent = self: super: with prevStage; {
       inherit
         gnumake gzip gnused bzip2 gawk ed xz patch bash
-        libcxxabi libcxx ncurses libffi zlib gmp pcre gnugrep
+        ncurses libffi zlib gmp pcre gnugrep
         coreutils findutils diffutils patchutils;
 
-       llvmPackages_5 = super.llvmPackages_5 // {
-         llvm = llvmPackages_5.llvm.override { inherit libcxxabi; };
-         clang-unwrapped = llvmPackages_5.clang-unwrapped.override { llvm = self.llvmPackages_5.llvm; };
-       };
+      llvmPackages_5 = super.llvmPackages_5 // (let
+        tools = super.llvmPackages_5.tools.extend (_: _: {
+          llvm = llvmPackages_5.llvm.override { inherit libcxxabi; };
+          clang-unwrapped = llvmPackages_5.clang-unwrapped.override { llvm = self.llvmPackages_5.llvm; };
+        });
+        libraries = super.llvmPackages_5.libraries.extend (_: _: {
+          inherit (llvmPackages_5) libcxx libcxxabi;
+        });
+      in { inherit tools libraries; } // tools // libraries);
 
       darwin = super.darwin // {
         inherit (darwin) dyld Libsystem libiconv locale;
@@ -310,12 +319,17 @@ in rec {
     persistent = self: super: with prevStage; {
       inherit
         gnumake gzip gnused bzip2 gawk ed xz patch bash
-        libcxxabi libcxx ncurses libffi zlib llvm gmp pcre gnugrep
+        ncurses libffi zlib llvm gmp pcre gnugrep
         coreutils findutils diffutils patchutils;
 
-      llvmPackages_5 = super.llvmPackages_5 // {
-        inherit (llvmPackages_5) llvm clang-unwrapped;
-      };
+      llvmPackages_5 = super.llvmPackages_5 // (let
+        tools = super.llvmPackages_5.tools.extend (_: _: {
+          inherit (llvmPackages_5) llvm clang-unwrapped;
+        });
+        libraries = super.llvmPackages_5.libraries.extend (_: _: {
+          inherit (llvmPackages_5) libcxx libcxxabi;
+        });
+      in { inherit tools libraries; } // tools // libraries);
 
       darwin = super.darwin // {
         inherit (darwin) dyld ICU Libsystem libiconv;


### PR DESCRIPTION
###### Motivation for this change

Respect the fix points and aliases by overriding originals.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

