### PR TITLE
riemann-tools: 0.2.6 -> 0.2.13 (package name only)

### DIFF
--- a/pkgs/tools/misc/riemann-tools/default.nix
+++ b/pkgs/tools/misc/riemann-tools/default.nix
@@ -1,7 +1,7 @@
 { bundlerEnv }:
 
 bundlerEnv {
-  name = "riemann-tools-0.2.6";
+  name = "riemann-tools-0.2.13";
   gemfile = ./Gemfile;
   lockfile = ./Gemfile.lock;
   gemset = ./gemset.nix;


### PR DESCRIPTION
fix the package name that a previous PR missed

###### Motivation for this change

an update to a package missed to change the package name

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

