### PR TITLE
deluge: add patch for libtorrent >=0.16 compat

### DIFF
--- a/pkgs/applications/networking/p2p/deluge/default.nix
+++ b/pkgs/applications/networking/p2p/deluge/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, intltool, libtorrentRasterbar, pythonPackages }:
+{ stdenv, fetchurl, fetchpatch, intltool, libtorrentRasterbar, pythonPackages }:
+
 pythonPackages.buildPythonPackage rec {
   name = "deluge-${version}";
   version = "1.3.15";
@@ -7,6 +8,14 @@ pythonPackages.buildPythonPackage rec {
     url = "http://download.deluge-torrent.org/source/${name}.tar.bz2";
     sha256 = "1467b9hmgw59gf398mhbf40ggaka948yz3afh6022v753c9j7y6w";
   };
+
+  patches = [
+    # Fix preferences when built against libtorrent >=0.16
+    (fetchpatch {
+      url = "https://git.deluge-torrent.org/deluge/patch/?id=38d7b7cdfde3c50d6263602ffb03af92fcbfa52e";
+      sha256 = "0la3i0lkj6yv4725h4kbd07mhfwcb34w7prjl9gxg12q7px6c31d";
+    })
+  ];
 
   propagatedBuildInputs = with pythonPackages; [
     pyGtkGlade libtorrentRasterbar twisted Mako chardet pyxdg pyopenssl service-identity


### PR DESCRIPTION
###### Motivation for this change

cc @mkaito 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

