### PR TITLE
[18.03] libgcrypt: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -6,11 +6,11 @@ assert enableCapabilities -> stdenv.isLinux;
 
 stdenv.mkDerivation rec {
   name = "libgcrypt-${version}";
-  version = "1.8.2";
+  version = "1.8.3";
 
   src = fetchurl {
     url = "mirror://gnupg/libgcrypt/${name}.tar.bz2";
-    sha256 = "01sca9m8hm6b5v8hmqsfdjhyz013869p1f0fxw9ln52qfnp4q1n8";
+    sha256 = "0z5gs1khzyknyfjr19k8gk4q148s6q987ya85cpn0iv70fz91v36";
   };
 
   outputs = [ "out" "dev" "info" ];


### PR DESCRIPTION
###### Motivation for this change

From the changelog:

   - Use blinding for ECDSA signing to mitigate a novel side-channel
     attack.  [CVE-2018-0495]

   - Fix incorrect counter overflow handling for GCM when using an IV
     size other than 96 bit.

   - Fix incorrect output of AES-keywrap mode for in-place encryption
     on some platforms.

   - Fix the gcry_mpi_ec_curve_point point validation function.

   - Fix rare assertion failure in gcry_prime_check.

   Release info at <https://dev.gnupg.org/T4016>.

(cherry picked from commit 2f24d327a6a90c440e345aeb21ac7481dd4797a9)




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

