### PR TITLE
llvm 5: split out compiler-rt and remove libcxxabi dep

### DIFF
--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -30,10 +30,7 @@ let
       "-DSPHINX_OUTPUT_MAN=ON"
       "-DSPHINX_OUTPUT_HTML=OFF"
       "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-    ]
-    # Maybe with compiler-rt this won't be needed?
-    ++ stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}"
-    ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include";
+    ];
 
     patches = [ ./purity.patch ];
 
@@ -50,13 +47,12 @@ let
 
     outputs = [ "out" "lib" "python" ];
 
+    # Clang expects to find LLVMgold in its own prefix
     postInstall = ''
-      # Clang expects to find LLVMgold in its own prefix
       if [ -e ${llvm}/lib/LLVMgold.so ]; then
         ln -sv ${llvm}/lib/LLVMgold.so $out/lib
       fi
-      # Clang expects to find sanitizer libraries in its own prefix
-      ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
+
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/5/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/5/compiler-rt.nix
@@ -1,0 +1,37 @@
+{ stdenv, version, fetch, cmake, python, llvm, libcxxabi }:
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "compiler-rt-${version}";
+  inherit version;
+  src =  fetch "compiler-rt" "0ipd4jdxpczgr2w6lzrabymz6dhzj69ywmyybjjc1q397zgrvziy";
+
+  nativeBuildInputs = [ cmake python llvm ];
+  buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
+
+  configureFlags = [
+    "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  patches = [
+    ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
+  ] ++ optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build.
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cmake/config-ix.cmake \
+      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+  '';
+
+  # Hack around weird upsream RPATH bug
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '';
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -11,7 +11,6 @@
 , version
 , release_version
 , zlib
-, compiler-rt_src
 , libcxxabi
 , debugVersion ? false
 , enableManpages ? false
@@ -32,8 +31,6 @@ in stdenv.mkDerivation (rec {
     unpackFile ${src}
     mv llvm-${version}* llvm
     sourceRoot=$PWD/llvm
-    unpackFile ${compiler-rt_src}
-    mv compiler-rt-* $sourceRoot/projects/compiler-rt
   '';
 
   outputs = [ "out" "python" ]
@@ -48,15 +45,7 @@ in stdenv.mkDerivation (rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
-  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
-  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
-  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
-  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
-  # a flag and turn the flag off during the stdenv build.
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
-      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
-
     substituteInPlace cmake/modules/AddLLVM.cmake \
       --replace 'set(_install_name_dir INSTALL_NAME_DIR "@rpath")' "set(_install_name_dir INSTALL_NAME_DIR "$lib/lib")" \
       --replace 'set(_install_rpath "@loader_path/../lib" ''${extra_libdir})' ""
@@ -70,9 +59,6 @@ in stdenv.mkDerivation (rec {
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "Path.cpp" ""
     rm unittests/Support/Path.cpp
-
-    # Revert compiler-rt commit that makes codesign mandatory
-    patch -p1 -i ${./compiler-rt-codesign.patch} -d projects/compiler-rt
   '' + stdenv.lib.optionalString stdenv.isAarch64 ''
     patch -p0 < ${../aarch64.patch}
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
@@ -80,7 +66,6 @@ in stdenv.mkDerivation (rec {
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "add_subdirectory(DynamicLibrary)" ""
     rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
-    patch -p1 -i ${./sanitizers-nongnu.patch} -d projects/compiler-rt
   '';
 
   # hacky fix: created binaries need to be run before installation
@@ -95,7 +80,6 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_BUILD_TESTS=ON"
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"
-    "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
   ]
   ++ stdenv.lib.optional enableSharedLibraries
     "-DLLVM_LINK_LLVM_DYLIB=ON"

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,7 @@ with stdenv.lib;
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersBroken = stdenv.isDarwin || stdenv.cc.isClang && builtins.compareVersions (getVersion stdenv.cc.name) "6.0.0" < 0;
+  sanitizersBroken = stdenv.cc.isClang && versionOlder (getVersion stdenv.cc.name) "6.0.0";
 in stdenv.mkDerivation {
   name = "cc-wrapper-test";
 

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,7 @@ with stdenv.lib;
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersBroken = stdenv.cc.isClang && versionOlder (getVersion stdenv.cc.name) "6.0.0";
+  sanitizersBroken = stdenv.cc.isClang && versionOlder (getVersion stdenv.cc.name) "5.0.0";
 in stdenv.mkDerivation {
   name = "cc-wrapper-test";
 


### PR DESCRIPTION
###### Motivation for this change

We already did them on non-mass-rebuild llvm 6. Also, this allows simplifying the stdenv booting.

We were missing the libcxxabi dep in compile-rt in llvm 6, so fixed that too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @Ralith 

