### PR TITLE
ghc8.4: build statically on prebuilt iOS

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.2.nix
+++ b/pkgs/development/compilers/ghc/8.4.2.nix
@@ -22,7 +22,7 @@
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.
-  enableShared ? !targetPlatform.isWindows && !targetPlatform.useAndroidPrebuilt
+  enableShared ? !targetPlatform.isWindows && !targetPlatform.useAndroidPrebuilt && !targetPlatform.useiOSPrebuilt
 
 , # Whetherto build terminfo.
   enableTerminfo ? !targetPlatform.isWindows

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -22,7 +22,7 @@
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.
-  enableShared ? !targetPlatform.isWindows && !targetPlatform.useAndroidPrebuilt
+  enableShared ? !targetPlatform.isWindows && !targetPlatform.useAndroidPrebuilt && !targetPlatform.useiOSPrebuilt
 
 , # Whetherto build terminfo.
   enableTerminfo ? !targetPlatform.isWindows


### PR DESCRIPTION
Otherwise we run into issues in stage 1 with libffi.dylib unable to be
built. It is probably a similar case to the prebuilt Android.

/cc @ericson2314
