### PR TITLE
pythonPackages.python-forecastio: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/python-forecastio/default.nix
+++ b/pkgs/development/python-modules/python-forecastio/default.nix
@@ -1,0 +1,31 @@
+{ buildPythonPackage, stdenv, fetchPypi
+, requests
+, nose
+, responses
+}:
+
+buildPythonPackage rec {
+  pname = "python-forecastio";
+  version = "1.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0m6lf4a46pnwm5xg9dnmwslwzrpnj6d9agw570grciivbvb1ji0l";
+
+  };
+
+  checkInputs = [ nose ];
+
+  propagatedBuildInputs = [ requests responses ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://zeevgilovitz.com/python-forecast.io/;
+    description = "A thin Python Wrapper for the Dark Sky (formerly forecast.io) weather API";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ makefu ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -794,7 +794,7 @@
     "sensor.cups" = ps: with ps; [ pycups ];
     "sensor.currencylayer" = ps: with ps; [  ];
     "sensor.daikin" = ps: with ps; [  ];
-    "sensor.darksky" = ps: with ps; [  ];
+    "sensor.darksky" = ps: with ps; [ python-forecastio ];
     "sensor.deconz" = ps: with ps; [  ];
     "sensor.deluge" = ps: with ps; [ deluge-client ];
     "sensor.demo" = ps: with ps; [  ];
@@ -1183,7 +1183,7 @@
     "weather" = ps: with ps; [  ];
     "weather.bom" = ps: with ps; [  ];
     "weather.buienradar" = ps: with ps; [  ];
-    "weather.darksky" = ps: with ps; [  ];
+    "weather.darksky" = ps: with ps; [ python-forecastio ];
     "weather.demo" = ps: with ps; [  ];
     "weather.ecobee" = ps: with ps; [  ];
     "weather.ipma" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2615,6 +2615,8 @@ in {
     };
   };
 
+  python-forecastio = callPackage ../development/python-modules/python-forecastio { };
+
   fpdf = callPackage ../development/python-modules/fpdf { };
 
   fpylll = callPackage ../development/python-modules/fpylll { };


### PR DESCRIPTION
###### Motivation for this change

add the python package to get the darksky home-assistant module to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) - works with home-assistant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

