### PR TITLE
llvm 6: Fix libcxxabi impurity and darwin sanitizers

### DIFF
--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,7 @@ with stdenv.lib;
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersBroken = stdenv.isDarwin || stdenv.cc.isClang && builtins.compareVersions (getVersion stdenv.cc.name) "6.0.0" < 0;
+  sanitizersBroken = stdenv.cc.isClang && versionOlder (getVersion stdenv.cc.name) "6.0.0";
 in stdenv.mkDerivation {
   name = "cc-wrapper-test";
 


### PR DESCRIPTION
###### Motivation for this change

Pulled out of https://github.com/NixOS/nixpkgs/pull/42048

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

