### PR TITLE
[wip] aliases: add old aliases for previous Nixpkgs version

### DIFF
--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -349,4 +349,16 @@ mapAliases (rec {
   ocaml_4_02   = ocamlPackages_4_02.ocaml;
   ocaml_4_03   = ocamlPackages_4_03.ocaml;
   ocaml        = ocamlPackages.ocaml;
-}))
+}) // # Old versions of Nixpkgs for convenience
+  self.lib.mapAttrs (n: v: import (builtins.fetchTarball
+      "https://nixos.org/channels/nixos-${v}/nixexprs.tar.xz") {}) {
+    aardvark    = "13.10";
+    baboon      = "14.04";
+    caterpillar = "14.12";
+    dingo       = "15.09";
+    emu         = "16.03";
+    flounder    = "16.09";
+    gorilla     = "17.03";
+    hummingbird = "17.09";
+    impala      = "18.03";
+})


### PR DESCRIPTION
This is adapted from my post:  https://matthewbauer.us/blog/channel-changing.html.

I am still undecided whether this is a good idea but I definitely
think it’s cool. This adds some top-level attributes for old releases
of NixOS/Nixpkgs. With them you can combine old versions of stuff in
one package, fairly easily:

```
{ pkgs }:
pkgs.impala.stdenv.mkDerivation {
  name = "hello";
  src = pkgs.impala.fetchurl { ... };
  buildInput = [ pkgs.gorilla.firefox
                 pkgs.emu.libedit ];
}
```
