### PR TITLE
elisa: 0.1 -> 0.1.80

### DIFF
--- a/pkgs/applications/audio/elisa/default.nix
+++ b/pkgs/applications/audio/elisa/default.nix
@@ -7,13 +7,13 @@
 
 mkDerivation rec {
   name = "elisa-${version}";
-  version = "0.1";
+  version = "0.1.80";
 
   src = fetchFromGitHub {
     owner  = "KDE";
     repo   = "elisa";
     rev    = version;
-    sha256 = "13i0fkpwrskric3gfalh7mcpp4l2knwnq7jpq391lgh6krq04r4w";
+    sha256 = "1kyvdxbsfi692zazw8vjy6mwyy0sa4r1cim8gsiv9pphfh5bpxb1";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];

--- a/pkgs/applications/audio/elisa/default.nix
+++ b/pkgs/applications/audio/elisa/default.nix
@@ -12,7 +12,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "KDE";
     repo   = "elisa";
-    rev    = version;
+    rev    = "v${version}";
     sha256 = "1kyvdxbsfi692zazw8vjy6mwyy0sa4r1cim8gsiv9pphfh5bpxb1";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @peterhoeg
