### PR TITLE
python.pkgs.pythonix: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/development/python-modules/pythonix/default.nix
+++ b/pkgs/development/python-modules/pythonix/default.nix
@@ -1,21 +1,26 @@
-{ stdenv, fetchFromGitHub, ninja, meson, pkgconfig, nixUnstable, isPy3k }:
+{ stdenv, fetchFromGitHub, ninja, boost, meson, pkgconfig, nix, isPy3k }:
 
-assert isPy3k;
 
 stdenv.mkDerivation rec {
   name = "pythonix-${version}";
-  version = "0.1.0";
+  version = "0.1.4";
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "pythonix";
     rev = "v${version}";
-    sha256 = "1piblysypyr442a6najk4mdh87xc377i2fdbfw6fr569z60mnnnj";
+    sha256 = "1q1fagfwzvmcm1n3a0liay7m5krazmhw9l001m90rrz2x7vrsqwk";
   };
 
-  nativeBuildInputs = [ meson pkgconfig ninja ];
+  disabled = !isPy3k;
 
-  buildInputs = [ nixUnstable ];
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+
+  buildInputs = [ nix boost ];
+
+  checkPhase = ''
+    ninja test
+  '';
 
   meta = with stdenv.lib; {
     description = ''
@@ -23,6 +28,5 @@ stdenv.mkDerivation rec {
     '';
     maintainers = [ maintainers.mic92 ];
     license = licenses.mit;
-    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
also fix the build

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

