### PR TITLE
ktorrent: fix build with Qt 5.11

### DIFF
--- a/pkgs/applications/networking/p2p/ktorrent/default.nix
+++ b/pkgs/applications/networking/p2p/ktorrent/default.nix
@@ -28,6 +28,16 @@ stdenv.mkDerivation rec {
       url = "https://cgit.kde.org/ktorrent.git/patch/?id=672c5076de7e3a526d9bdbb484a69e9386bc49f8";
       sha256 = "1cn4rnbhadrsxqx50fawpd747azskavbjraygr6s11rh1wbfrxid";
     })
+
+    # Fix build against Qt 5.11
+    (fetchpatch {
+      url = "https://cgit.kde.org/ktorrent.git/patch/?id=7876857d204188016a135a25938d9f8530fba4e8";
+      sha256 = "1wnmfzkhf6y7fd0z2djwphs6i9lsg7fcrj8fqmbyi0j57dvl9gxl";
+    })
+    (fetchpatch {
+      url = "https://cgit.kde.org/ktorrent.git/patch/?id=36d112e56e56541d439326a267eb906da8b3ee60";
+      sha256 = "1d41pqniljhwqs6awa644s6ks0zwm9sr0hpfygc63wyxnpcrsw2y";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

KTorrent fails to build with Qt 5.11 because of missing includes:

```
[ 90%] Building CXX object ktorrent/CMakeFiles/ktorrent_app.dir/dialogs/pastedialog.cpp.o
/build/ktorrent-5.1.0/ktorrent/groups/groupviewmodel.cpp: In member function 'void kt::GroupViewModel::groupRemoved(kt::Group*)':
/build/ktorrent-5.1.0/ktorrent/groups/groupviewmodel.cpp:186:21: warning: variable 'idx' set but not used [-Wunused-but-set-variable]
         QModelIndex idx = findGroup(g).parent();
                     ^~~
/build/ktorrent-5.1.0/ktorrent/groups/groupview.cpp: In constructor 'kt::GroupView::GroupView(kt::GroupManager*, kt::View*, kt::Core*, kt::GUI*, QWidget*)':
/build/ktorrent-5.1.0/ktorrent/groups/groupview.cpp:63:17: error: invalid use of incomplete type 'class QHeaderView'
         header()->hide();
                 ^~
In file included from /nix/store/ni5sy11fvw9yj5i8bihbvxprm2cy6d3q-qtbase-5.11.0-dev/include/QtWidgets/qtreewidget.h:44:0,
                 from /nix/store/ni5sy11fvw9yj5i8bihbvxprm2cy6d3q-qtbase-5.11.0-dev/include/QtWidgets/QTreeWidget:1,
                 from /build/ktorrent-5.1.0/ktorrent/groups/groupview.h:24,
                 from /build/ktorrent-5.1.0/ktorrent/groups/groupview.cpp:21:
/nix/store/ni5sy11fvw9yj5i8bihbvxprm2cy6d3q-qtbase-5.11.0-dev/include/QtWidgets/qtreeview.h:53:7: note: forward declaration of 'class QHeaderView'
 class QHeaderView;
       ^~~~~~~~~~~
/build/ktorrent-5.1.0/ktorrent/groups/groupview.cpp:63:19: error: invalid use of incomplete type 'class QHeaderView'
         header()->hide();
                   ^~~~
In file included from /nix/store/ni5sy11fvw9yj5i8bihbvxprm2cy6d3q-qtbase-5.11.0-dev/include/QtWidgets/qtreewidget.h:44:0,
                 from /nix/store/ni5sy11fvw9yj5i8bihbvxprm2cy6d3q-qtbase-5.11.0-dev/include/QtWidgets/QTreeWidget:1,
                 from /build/ktorrent-5.1.0/ktorrent/groups/groupview.h:24,
                 from /build/ktorrent-5.1.0/ktorrent/groups/groupview.cpp:21:
/nix/store/ni5sy11fvw9yj5i8bihbvxprm2cy6d3q-qtbase-5.11.0-dev/include/QtWidgets/qtreeview.h:53:7: note: forward declaration of 'class QHeaderView'
 class QHeaderView;
       ^~~~~~~~~~~
make[2]: *** [ktorrent/CMakeFiles/ktorrent_app.dir/build.make:328: ktorrent/CMakeFiles/ktorrent_app.dir/groups/groupview.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:2011: ktorrent/CMakeFiles/ktorrent_app.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
builder for '/nix/store/v1n3hzqmcaxbljmrg6d8c6ilqf4lzxfh-ktorrent-5.1.0.drv' failed with exit code 2
error: build of '/nix/store/v1n3hzqmcaxbljmrg6d8c6ilqf4lzxfh-ktorrent-5.1.0.drv' failed
```

This PR backports a fix from upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

