### PR TITLE
Fix the problem of kiwisolver not compling in macOS

### DIFF
--- a/pkgs/development/python-modules/kiwisolver/default.nix
+++ b/pkgs/development/python-modules/kiwisolver/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, stdenv
+, libcxx
 }:
 
 buildPythonPackage rec {
@@ -11,7 +13,9 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278";
   };
-
+  
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
+  
   # Does not include tests
   doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change
The package kiwisolver, which is a dependency of matplotlib, cannot compile in macOS now. The reason is similar to https://github.com/NixOS/nixpkgs/issues/26531.

###### Things done

Similar solution as https://github.com/NixOS/nixpkgs/pull/26709
The package installs successfully after the change.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

