### PR TITLE
soapui: init at 5.4.0

### DIFF
--- a/pkgs/applications/networking/soapui/default.nix
+++ b/pkgs/applications/networking/soapui/default.nix
@@ -1,0 +1,51 @@
+{ fetchurl, stdenv, writeText, jdk, maven, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "soapui-${version}";
+  version = "5.4.0";
+
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/downloads.eviware/soapuios/${version}/SoapUI-${version}-linux-bin.tar.gz";
+    sha256 = "1yqx1fsh8mr5zf36df7pi25dysb28gfscr1667jzd5s0k9jl42xd";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jdk maven ];
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    cp -R bin lib $out/share/java
+
+    makeWrapper $out/share/java/bin/soapui.sh $out/bin/soapui --set SOAPUI_HOME $out/share/java
+  '';
+
+  patches = [
+    (writeText "soapui-${version}.patch" ''
+      --- a/bin/soapui.sh
+      +++ b/bin/soapui.sh
+      @@ -34,7 +34,7 @@ SOAPUI_CLASSPATH=$SOAPUI_HOME/bin/soapui-${version}.jar:$SOAPUI_HOME/lib/*
+       export SOAPUI_CLASSPATH
+
+       JAVA_OPTS="-Xms128m -Xmx1024m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -Dsoapui.properties=soapui.properties -Dsoapui.home=$SOAPUI_HOME/bin -splash:SoapUI-Spashscreen.png"
+      -JFXRTPATH=`java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
+      +JFXRTPATH=`${jdk}/bin/java -cp $SOAPUI_CLASSPATH com.eviware.soapui.tools.JfxrtLocator`
+       SOAPUI_CLASSPATH=$JFXRTPATH:$SOAPUI_CLASSPATH
+
+       if $darwin
+      @@ -69,4 +69,4 @@ echo = SOAPUI_HOME = $SOAPUI_HOME
+       echo =
+       echo ================================
+
+      -java $JAVA_OPTS -cp $SOAPUI_CLASSPATH com.eviware.soapui.SoapUI "$@"
+      +${jdk}/bin/java $JAVA_OPTS -cp $SOAPUI_CLASSPATH com.eviware.soapui.SoapUI "$@"
+    '')
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The Most Advanced REST & SOAP Testing Tool in the World";
+    homepage = https://www.soapui.org/;
+    license = "SoapUI End User License Agreement";
+    maintainers = with maintainers; [ gerschtli ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5044,6 +5044,8 @@ with pkgs;
 
   snort = callPackage ../applications/networking/ids/snort { };
 
+  soapui = callPackage ../applications/networking/soapui { };
+
   sshguard = callPackage ../tools/security/sshguard {};
 
   softhsm = callPackage ../tools/security/softhsm {


### PR DESCRIPTION
###### Motivation for this change

Adds SoapUI package at 5.4.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

