### PR TITLE
dwm-status: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -1,29 +1,25 @@
 { stdenv, lib, rustPlatform, fetchFromGitHub, dbus, gdk_pixbuf, libnotify, makeWrapper, pkgconfig, xorg, alsaUtils }:
 
-let
-  runtimeDeps = [ xorg.xsetroot ]
-    ++ lib.optional (alsaUtils != null) alsaUtils;
-in
-
 rustPlatform.buildRustPackage rec {
   name = "dwm-status-${version}";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "Gerschtli";
     repo = "dwm-status";
     rev = version;
-    sha256 = "0nw0iz78mnrmgpc471yjv7yzsaf7346mwjp6hm5kbsdclvrdq9d7";
+    sha256 = "1mppj57h5yr0azypf5d2cgz2wv3k52mg3k4npyfhbmfy1393qbjs";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
-  buildInputs = [ dbus gdk_pixbuf libnotify ];
+  buildInputs = [ dbus gdk_pixbuf libnotify xorg.libX11 ];
 
-  cargoSha256 = "0169k91pb7ipvi0m71cmkppp1klgp5ghampa7x0fxkyrvrf0dvqg";
+  cargoSha256 = "0qr999hwrqn7a4n4kvbrpli7shxp9jchj8csxzsw951qmzq32qwv";
 
-  postInstall = ''
+  # needed because alsaUtils is an optional runtime dependency
+  postInstall = lib.optionalString (alsaUtils != null) ''
     wrapProgram $out/bin/dwm-status \
-      --prefix "PATH" : "${stdenv.lib.makeBinPath runtimeDeps}"
+      --prefix "PATH" : "${alsaUtils}/bin"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Updates `dwm-status` to version `0.5.1`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

