### PR TITLE
slic3r-prusa3d: 1.39.2 -> 1.40.0

### DIFF
--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, makeWrapper, which, cmake, perl, perlPackages,
   boost, tbb, wxGTK30, pkgconfig, gtk3, fetchurl, gtk2, bash, libGLU,
-  glew, eigen }:
+  glew, eigen, curl }:
 let
   AlienWxWidgets = perlPackages.buildPerlPackage rec {
     name = "Alien-wxWidgets-0.69";
@@ -33,12 +33,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "slic3r-prusa-edition-${version}";
-  version = "1.39.2";
+  version = "1.40.0";
 
   enableParallelBuilding = true;
 
   buildInputs = [
     cmake
+    curl
     perl
     makeWrapper
     eigen
@@ -73,6 +74,8 @@ stdenv.mkDerivation rec {
 
   prePatch = ''
     sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' xs/src/libslic3r/GCodeSender.cpp
+    sed -i "s|\''${PERL_VENDORARCH}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
+    sed -i "s|\''${PERL_VENDORLIB}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
   '';
 
   postInstall = ''
@@ -82,14 +85,14 @@ stdenv.mkDerivation rec {
 
     # it seems we need to copy the icons...
     mkdir -p $out/bin/var
-    cp ../resources/icons/* $out/bin/var/
+    cp -r ../resources/icons/* $out/bin/var/
     cp -r ../resources $out/bin/
   '';
 
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "Slic3r";
-    sha256 = "0vbqkmd2yqi469ijqm4wyzjmq9w1kwiy8av1kchm4429z5hpmxcd";
+    sha256 = "1cisplrfv6y9ijgl5bs46bxxmid5hl71hjzl73bay2i2bl8hid2f";
     rev = "version_${version}";
   };
 


### PR DESCRIPTION
Don't understand why PERL_VENDORARCH and PERL_VENDORLIB need replacing now.

###### Motivation for this change

update

###### Things done

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

