### PR TITLE
lollypop: init at 0.9.514

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchgit, meson, ninja, pkgconfig, wrapGAppsHook
+, appstream-glib, desktop-file-utils, gobjectIntrospection
+, python36Packages, gnome3, glib, gst_all_1 }:
+
+stdenv.mkDerivation rec  {  
+  version = "0.9.514";
+  name = "lollypop-${version}";
+
+  src = fetchgit {
+    url = "https://gitlab.gnome.org/World/lollypop";
+    rev = "refs/tags/${version}";
+    fetchSubmodules = true;
+    sha256 = "0ny8c5apldhhrcjl3wz01pbyjvf60b7xy39mpvbshvdpnqlnqsca";
+  };
+
+  nativeBuildInputs = with python36Packages; [
+    desktop-file-utils
+    meson
+    ninja
+    pkgconfig
+    wrapGAppsHook
+    wrapPython
+  ];
+
+  buildInputs = [
+    appstream-glib glib gobjectIntrospection
+  ] ++ (with gnome3; [
+    easytag gsettings_desktop_schemas gtk3 libsecret libsoup totem-pl-parser
+  ]) ++ (with gst_all_1; [
+    gst-libav gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly
+    gstreamer
+  ]);
+
+  pythonPath = with python36Packages; [
+    beautifulsoup4
+    gst-python
+    pillow
+    pycairo
+    pydbus
+    pygobject3
+    pylast
+  ];
+
+  postFixup = "wrapPythonPrograms";
+
+  postPatch = ''
+    chmod +x ./meson_post_install.py
+    patchShebangs ./meson_post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A modern music player for GNOME";
+    homepage    = https://wiki.gnome.org/Apps/Lollypop;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16195,6 +16195,8 @@ with pkgs;
 
   linssid = libsForQt5.callPackage ../applications/networking/linssid { };
 
+  lollypop = callPackage ../applications/audio/lollypop { };
+
   m32edit = callPackage ../applications/audio/midas/m32edit.nix {};
 
   manuskript = callPackage ../applications/editors/manuskript { };


### PR DESCRIPTION
###### Motivation for this change
Lollypop is cool. Should be in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

