### PR TITLE
opera: 50.0.2762.45 -> 53.0.2907.99

### DIFF
--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -11,7 +11,7 @@
 , freetype
 , gdk_pixbuf
 , glib
-, gnome2
+, gnome3
 , gtk3
 , libX11
 , libxcb
@@ -32,12 +32,13 @@
 , pango
 , stdenv
 , systemd
+, at-spi2-atk
 }:
 
 let
 
   mirror = https://get.geo.opera.com/pub/opera/desktop;
-  version = "50.0.2762.45";
+  version = "53.0.2907.99";
 
   rpath = stdenv.lib.makeLibraryPath [
 
@@ -54,7 +55,7 @@ let
     freetype.out
     gdk_pixbuf.out
     glib.out
-    gnome2.GConf.out
+    gnome3.gconf
     gtk3.out
     libX11.out
     libXScrnSaver.out
@@ -81,6 +82,8 @@ let
 
     # Works fine without this except there is no sound.
     libpulseaudio.out
+
+    at-spi2-atk
   ];
 
 in stdenv.mkDerivation {
@@ -89,7 +92,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "${mirror}/${version}/linux/opera-stable_${version}_amd64.deb";
-    sha256 = "1ajdr6yzqc9xkvdcgkps6j5996n60ibjhj518gmminx90da6x5dy";
+    sha256 = "0fih5047xv275rmbcr2drji81wxi6p0kyp172mmn328g3pzddmwx";
   };
 
   unpackCmd = "${dpkg}/bin/dpkg-deb -x $curSrc .";


### PR DESCRIPTION
###### Motivation for this change

* Updates opera to the latest version available (fixes #40780)
* Use gnome3 package set for gconf (see #39976)
* Needs `at-spi2-atk` now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

