### PR TITLE
looking-glass-client: a10 -> a11

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -1,24 +1,24 @@
 { stdenv, fetchFromGitHub
 , pkgconfig, SDL2, SDL, SDL2_ttf, openssl, spice-protocol, fontconfig
-, libX11, freefont_ttf
+, libX11, freefont_ttf, nettle, libconfig
 }:
 
 stdenv.mkDerivation rec {
   name = "looking-glass-client-${version}";
-  version = "a10";
+  version = "a11";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "10jxnkrvskjzkg86iz3hnb5v91ykzx6pvcnpy1v4436g5f2d62wn";
+    sha256 = "0q4isn86pl5wddf6h8qd62fw3577ns2sd2myzw969sbl796bwcil";
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
   buildInputs = [
     SDL SDL2 SDL2_ttf openssl spice-protocol fontconfig
-    libX11 freefont_ttf
+    libX11 freefont_ttf nettle libconfig
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Requires new dependencies libconfig and nettle.

###### Motivation for this change

https://github.com/gnif/LookingGlass/releases/tag/a11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

