### PR TITLE
Helmfile updates (0.16.0 -> 0.19.0, use wrapProgram)

### DIFF
--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoPackage, fetchFromGitHub, ... }:
+{ lib, buildGoPackage, fetchFromGitHub, makeWrapper, kubernetes-helm, ... }:
 
 let version = "0.19.0"; in
 
@@ -13,6 +13,14 @@ buildGoPackage {
   };
 
   goPackagePath = "github.com/roboll/helmfile";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $bin/bin/helmfile \
+      --prefix PATH : ${lib.makeBinPath [ kubernetes-helm ]}
+  '';
+
 
   meta = {
     description = "Deploy Kubernetes Helm charts";

--- a/pkgs/applications/networking/cluster/helmfile/default.nix
+++ b/pkgs/applications/networking/cluster/helmfile/default.nix
@@ -1,6 +1,6 @@
 { lib, buildGoPackage, fetchFromGitHub, ... }:
 
-let version = "0.16.0"; in
+let version = "0.19.0"; in
 
 buildGoPackage {
   name = "helmfile-${version}";
@@ -9,7 +9,7 @@ buildGoPackage {
     owner = "roboll";
     repo = "helmfile";
     rev = "v${version}";
-    sha256 = "12gxlan89h0r83aaacshh58nd1pi26gx5gkna0ksll9wsfvraj4d";
+    sha256 = "0wjzzaygdnnvyi5a78bhmz2sxc4gykdl00h78dkgvj7aaw05s9yd";
   };
 
   goPackagePath = "github.com/roboll/helmfile";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/roboll/helmfile/releases/tag/v0.19.0 and helmfile only worked if Kubernetes Helm was explicitly installed alongside.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

