### PR TITLE
brightnessctl: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -78,6 +78,11 @@
     github = "DmitryTsygankov";
     name = "Dmitry Tsygankov";
   };
+  Dje4321 = {
+    email = "dje4321@gmail.com";
+    github = "dje4321";
+    name = "Dje4321";
+  };
   Esteth = {
     email = "adam.copp@gmail.com";
     name = "Adam Copp";

--- a/nixos/modules/hardware/brightnessctl.nix
+++ b/nixos/modules/hardware/brightnessctl.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.brightnessctl;
+in
+{
+
+  options = {
+
+    hardware.brightnessctl = {
+
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable brightnessctl in userspace.
+          This will allow brightness control from users in the video group.
+        '';
+
+      };
+    };
+  };
+
+
+  config = mkIf cfg.enable {
+    services.udev.packages = with pkgs; [ brightnessctl ];
+  };
+
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -29,6 +29,7 @@
   ./config/vpnc.nix
   ./config/zram.nix
   ./hardware/all-firmware.nix
+  ./hardware/brightnessctl.nix
   ./hardware/ckb.nix
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix

--- a/pkgs/misc/brightnessctl/default.nix
+++ b/pkgs/misc/brightnessctl/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, coreutils }:
+
+stdenv.mkDerivation rec {
+  name = "brightnessctl-${version}";
+  version = "0.3.2";
+
+  src = fetchurl {
+    url = "https://github.com/Hummer12007/brightnessctl/archive/0.3.2.tar.gz";
+    sha256 = "92687d8739b8395cf942287bdb8905a78b428102ab6029680829ab917363e0ab";
+  };
+
+  patchPhase = ''
+    substituteInPlace 90-brightnessctl.rules --replace /bin/ ${coreutils}/bin/
+    substituteInPlace 90-brightnessctl.rules --replace %k '*'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/man/man1,etc/udev/rules.d}
+    install -D brightnessctl $out/bin
+    install -D brightnessctl.1 $out/share/man/man1
+    install -D 90-brightnessctl.rules $out/etc/udev/rules.d
+  '';
+
+  meta = {
+    homepage = "https://github.com/Hummer12007/brightnessctl";
+    license = stdenv.lib.licenses.mit;
+    description = "This program allows you read and control device brightness";
+    platforms = stdenv.lib.platforms.linux;
+  };
+
+}

--- a/pkgs/misc/brightnessctl/default.nix
+++ b/pkgs/misc/brightnessctl/default.nix
@@ -1,28 +1,26 @@
-{ stdenv, fetchurl, coreutils }:
+{ stdenv, fetchFromGitHub, coreutils }:
 
 stdenv.mkDerivation rec {
   name = "brightnessctl-${version}";
   version = "0.3.2";
 
-  src = fetchurl {
-    url = "https://github.com/Hummer12007/brightnessctl/archive/0.3.2.tar.gz";
-    sha256 = "92687d8739b8395cf942287bdb8905a78b428102ab6029680829ab917363e0ab";
+  src = fetchFromGitHub {
+    owner = "Hummer12007";
+    repo = "brightnessctl";
+    rev = "${version}";
+    sha256 = "0amxhcikcgj04z81272kz35m5h5q4jx9x7v71h8yl1rv4b2lzh7z";
   };
+
+  makeFlags = "MODE=0 PREFIX=/ DESTDIR=$(out)";
 
   patchPhase = ''
     substituteInPlace 90-brightnessctl.rules --replace /bin/ ${coreutils}/bin/
     substituteInPlace 90-brightnessctl.rules --replace %k '*'
   '';
 
-  installPhase = ''
-    mkdir -p $out/{bin,share/man/man1,etc/udev/rules.d}
-    install -D brightnessctl $out/bin
-    install -D brightnessctl.1 $out/share/man/man1
-    install -D 90-brightnessctl.rules $out/etc/udev/rules.d
-  '';
-
   meta = {
     homepage = "https://github.com/Hummer12007/brightnessctl";
+    maintainers = [ stdenv.lib.maintainers.Dje4321 ];
     license = stdenv.lib.licenses.mit;
     description = "This program allows you read and control device brightness";
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20732,6 +20732,8 @@ with pkgs;
 
   brgenml1cupswrapper = callPackage ../misc/cups/drivers/brgenml1cupswrapper {};
 
+  brightnessctl = callPackage ../misc/brightnessctl { };
+
   calaos_installer = libsForQt5.callPackage ../misc/calaos/installer {};
 
   click = callPackage ../applications/networking/cluster/click { };


### PR DESCRIPTION
###### Motivation for this change
Adding brightnessctl for better backlight support. brightnessctl package is what provides the binary and the brightnessctl module enables the udev rule for access from userspace for anyone in the video group. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

