### PR TITLE
lice: init at 0.4

### DIFF
--- a/pkgs/tools/misc/lice/default.nix
+++ b/pkgs/tools/misc/lice/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+
+  package = "lice";
+  version = "0.4";
+  name = "${package}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "licenses";
+    repo = "lice";
+    rev = "71635c2544d5edf9e93af4141467763916a86624";
+    sha256 = "059f9mnq7a5pxz2iiaih0nczq1v11m9zxr221agzv85qbwr7ii9f";
+    fetchSubmodules = true;
+  };
+
+  meta = with stdenv.lib; {
+    description = "";
+    longDescription = ''
+
+  '';
+    homepage = https://github.com/licenses/lice;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ swflint ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/tools/misc/lice/default.nix
+++ b/pkgs/tools/misc/lice/default.nix
@@ -2,23 +2,19 @@
 
 python3Packages.buildPythonPackage rec {
 
-  package = "lice";
   version = "0.4";
-  name = "${package}-${version}";
+  name = "lice-${version}";
 
   src = fetchFromGitHub {
     owner = "licenses";
     repo = "lice";
-    rev = "71635c2544d5edf9e93af4141467763916a86624";
-    sha256 = "059f9mnq7a5pxz2iiaih0nczq1v11m9zxr221agzv85qbwr7ii9f";
+    rev = version;
+    sha256 = "0yxf70fi8ds3hmwjply2815k466r99k8n22r0ppfhwjvp3rn60qx";
     fetchSubmodules = true;
   };
 
   meta = with stdenv.lib; {
-    description = "";
-    longDescription = ''
-
-  '';
+    description = "Print license based on selection and user options.";
     homepage = https://github.com/licenses/lice;
     license = licenses.bsd3;
     maintainers = with maintainers; [ swflint ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21095,6 +21095,8 @@ with pkgs;
 
   lkproof = callPackage ../tools/typesetting/tex/lkproof { };
 
+  lice = callPackage ../tools/misc/lice {};
+
   m33-linux = callPackage ../misc/drivers/m33-linux { };
 
   mnemonicode = callPackage ../misc/mnemonicode { };


### PR DESCRIPTION
###### Motivation for this change

The `lice` utility is useful in development to automatically generate `LICENSE` files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

