### PR TITLE
kubernetes-helm: 2.9.0 -> 2.9.1

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -5,10 +5,10 @@ let
          then "linux-amd64"
          else "darwin-amd64";
   checksum = if isLinux
-             then "0bnjpiivhsxhl45ab32vzf6crv4z8nbq5kcjkvlbcbswdbgp0pq6"
-             else "0smwhj4pmd4k7csz82akbkrkb0j2jxnmb33ifhkqw7n33jhl3aqp";
+             then "1fk6w6sajdi6iphxrzi9r7xfyaf923nxcqnl01s6x3f611fjvbjn"
+             else "1jzgy641hm3khj0bakfbr5wd5zl3s7w5jb622fjv2jxwmnv7dxiv";
   pname = "helm";
-  version = "2.9.0";
+  version = "2.9.1";
 in
 stdenv.mkDerivation {
   name = "${pname}-${version}";
@@ -45,6 +45,6 @@ stdenv.mkDerivation {
     description = "A package manager for kubernetes";
     license = licenses.asl20;
     maintainers = [ maintainers.rlupton20 ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = [ "x86_64-linux" ] ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
Semi-automatic update generated by https://github.com/ryantm/nixpkgs-update tools.

This update was made based on information from https://repology.org/metapackage/helm/versions.

These checks were done:

- built on NixOS
- /nix/store/clpdnyjaysh2i2h1xjilxryzzb5ywp7y-helm-2.9.1/bin/helm passed the binary check.
- 1 of 1 passed binary check by having a zero exit code.
- 0 of 1 passed binary check by having the new version present in output.
- found 2.9.1 with grep in /nix/store/clpdnyjaysh2i2h1xjilxryzzb5ywp7y-helm-2.9.1
- directory tree listing: https://gist.github.com/ed779ecaf62619059b08a121472e6a96
- du listing: https://gist.github.com/2621c9acfcbf3fa34c093d8bbd9d0292

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

