### PR TITLE
mpd: add NixOS tests

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -338,6 +338,7 @@ in rec {
   tests.mesos = callTest tests/mesos.nix {};
   tests.misc = callTest tests/misc.nix {};
   tests.mongodb = callTest tests/mongodb.nix {};
+  tests.mpd = callTest tests/mpd.nix {};
   tests.mumble = callTest tests/mumble.nix {};
   tests.munin = callTest tests/munin.nix {};
   tests.mutableUsers = callTest tests/mutable-users.nix {};

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -1,0 +1,119 @@
+import ./make-test.nix ({ pkgs, ... }:
+  let
+    track = pkgs.fetchurl {
+      # Sourced from http://freemusicarchive.org/music/Blue_Wave_Theory/Surf_Music_Month_Challenge/Skyhawk_Beach_fade_in
+      # License: http://creativecommons.org/licenses/by-sa/4.0/
+
+      name = "Blue_Wave_Theory-Skyhawk_Beach.mp3";
+      url = https://freemusicarchive.org/file/music/ccCommunity/Blue_Wave_Theory/Surf_Music_Month_Challenge/Blue_Wave_Theory_-_04_-_Skyhawk_Beach.mp3;
+      sha256 = "0xw417bxkx4gqqy139bb21yldi37xx8xjfxrwaqa0gyw19dl6mgp";
+    };
+
+    defaultCfg = rec {
+      user = "mpd";
+      group = "mpd";
+      dataDir = "/var/lib/mpd";
+      musicDirectory = "${dataDir}/music";
+    };
+
+    defaultMpdCfg = with defaultCfg; {
+      inherit dataDir musicDirectory user group;
+      enable = true;
+    };
+
+    musicService = { user, group, musicDirectory }: {
+      description = "Sets up the music file(s) for MPD to use.";
+      requires = [ "mpd.service" ];
+      after = [ "mpd.service" ];
+      wantedBy = [ "default.target" ];
+      script = ''
+        mkdir -p ${musicDirectory} && chown -R ${user}:${group} ${musicDirectory}
+        cp ${track} ${musicDirectory}
+        chown ${user}:${group} ${musicDirectory}/$(basename ${track})
+      '';
+    };
+
+    mkServer = { mpd, musicService, }:
+      { boot.kernelModules = [ "snd-dummy" ];
+        sound.enable = true;
+        services.mpd = mpd;
+        systemd.services.musicService = musicService;
+      };
+  in {
+    name = "mpd";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ emmanuelrosa ];
+    };
+
+  nodes =
+    { client = 
+      { config, pkgs, ... }: { };
+
+      serverALSA =
+        { config, pkgs, ... }: (mkServer {
+          mpd = defaultMpdCfg // {
+            network.listenAddress = "any";
+            extraConfig = ''
+              audio_output {
+                type "alsa"
+                name "ALSA"
+                mixer_type "null"
+              }
+            '';
+          };
+
+          musicService = with defaultMpdCfg; musicService { inherit user group musicDirectory; };
+        }) // { networking.firewall.allowedTCPPorts = [ 6600 ]; };
+
+      serverPulseAudio =
+        { config, pkgs, ... }: (mkServer {
+          mpd = defaultMpdCfg // {
+            extraConfig = ''
+              audio_output {
+                type "pulse"
+                name "The Pulse"
+              }
+            '';
+          };
+
+          musicService = with defaultCfg; musicService { inherit user group musicDirectory; };
+        }) // { hardware.pulseaudio.enable = true; };
+    };
+
+  testScript = ''
+    my $mpc = "${pkgs.mpc_cli}/bin/mpc --wait";
+
+    # Connects to the given server and attempts to play a tune.
+    sub play_some_music {
+        my $server = $_[0];
+
+        $server->waitForUnit("mpd.service");
+        $server->succeed("$mpc update");
+        my @tracks = $server->execute("$mpc ls");
+
+        for my $track (split(/\n/, $tracks[1])) {
+            $server->succeed("$mpc add $track");
+        };
+
+        my @added_tracks = $server->execute("$mpc listall");
+        (length $added_tracks[1]) > 0 or die "Failed to add audio tracks to the playlist.";
+
+        $server->succeed("$mpc play");
+
+        my @status = $server->execute("$mpc status");
+        my @output = split(/\n/, $status[1]);
+        $output[1] =~ /.*playing.*/ or die "Audio track is not playing, as expected.";
+
+        $server->succeed("$mpc stop");
+    };
+
+    play_some_music($serverALSA);
+    play_some_music($serverPulseAudio);
+
+    $client->succeed("$mpc -h serverALSA status");
+
+    # The PulseAudio-based server is configured not to accept external client connections
+    # to perform the following test:
+    $client->fail("$mpc -h serverPulseAudio status");
+  '';
+})


### PR DESCRIPTION
This change adds NixOS tests for the MPD (Music Player Daemon) module.
Tests include:

- Playing audio locally using ALSA directly.
- Playing audio locally using PulseAudio (backed by ALSA).
- Playing audio from an external client.
- Rejecting an external client when it's not explicitly allowed (default configuration).

~These tests revealed a bug in the MDP module: Unlike the playlist directory, the music
directly is not created prior to starting MPD, causing MPD client commands to fail.
This change includes a fix for the aforementioned bug.~

refs #41772

###### Motivation for this change

The intent of this change is to prepare the MDP module to be extended so it can optionally be configured to run as a systemd user service. These tests are meant to confirm the functionality of the MPD module as it stands today and mitigate the risk of making changes in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - ~[ ] macOS~
   - ~[ ] other Linux distributions~
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Note

~There's currently an issue with polkit. Because it doesn't build these tests will not run. However, they do run on nixos-unstable (4b649a99d84). In addition, something funky is going on with this markdown. I didn't intend this paragraph to be in-your-face like this. My troubleshooting muscles are done for today.~

It builds now and the tests run.
---

