### PR TITLE
elfutils: 0.171 -> 0.172

### DIFF
--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -3,11 +3,11 @@
 # TODO: Look at the hardcoded paths to kernel, modules etc.
 stdenv.mkDerivation rec {
   name = "elfutils-${version}";
-  version = "0.171";
+  version = "0.172";
 
   src = fetchurl {
     url = "https://sourceware.org/elfutils/ftp/${version}/${name}.tar.bz2";
-    sha256 = "0rph73czyhg7rv1vxrkyf9k12vscyxd688yw36xs7l75zzn87s6c";
+    sha256 = "090fmbnvd9jblkwhb2bm3hanim63rrvd5f30mfxq4jac6kk9k73p";
   };
 
   patches = ./debug-info-from-env.patch;


### PR DESCRIPTION
https://sourceware.org/git/?p=elfutils.git;a=blob;f=NEWS;h=2b7f442e91d77315fa619c72bdf5c59d99f7b998;hb=7a1fd63a74e456f0ad9ab954bc381050e702eeb6



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---