### PR TITLE
Skribilo: New Package(s)

### DIFF
--- a/pkgs/development/guile-modules/guile-reader/default.nix
+++ b/pkgs/development/guile-modules/guile-reader/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchurl, fetchpatch, pkgconfig
+, gperf, guile, guile-lib, libffi }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "guile-reader-${version}";
+  version = "0.6.2";
+
+  src = fetchurl {
+    url = "http://download.savannah.nongnu.org/releases/guile-reader/${name}.tar.gz";
+    sha256 = "0592s2s8ampqmqwilc4fvcild6rb9gy79di6vxv5kcdmv23abkgx";
+  };
+
+  patches = [
+    (fetchpatch {
+       name = "0001-fix-prototypes.patch";
+       url = https://aur.archlinux.org/cgit/aur.git/plain/reader_flag.patch?h=guile-reader&id=63ac0413a1aa65eb6a0db57bc16ef4481b70dc31;
+       sha256 = "01ar34xgpxyli8v2bk4kj6876kyrxhxhfpv9v07lx36d254bzrjb";
+     }) ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ gperf guile guile-lib libffi ];
+
+  GUILE_SITE="${guile-lib}/share/guile/site";
+
+  configureFlags = [ "--with-guilemoduledir=$(out)/share/guile/site" ];
+
+  meta = with stdenv.lib; {
+    description = "A simple framework for building readers for GNU Guile";
+    longDescription = ''
+       Guile-Reader is a simple framework for building readers for GNU
+       Guile.
+
+       The idea is to make it easy to build procedures that extend
+       Guile's read procedure. Readers supporting various syntax
+       variants can easily be written, possibly by re-using existing
+       "token readers" of a standard Scheme readers. For example, it
+       is used to implement Skribilo's R5RS-derived document syntax.
+    '';
+    homepage = https://www.gnu.org/software/guile-reader;
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.gnu;
+  };
+}

--- a/pkgs/tools/typesetting/skribilo/default.nix
+++ b/pkgs/tools/typesetting/skribilo/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchurl, pkgconfig, gettext
+, guile, guile-reader, guile-lib
+, ploticus, imagemagick
+, ghostscript, transfig
+, enableEmacs ? false, emacs ? null
+, enableLout ? true, lout ? null
+, enableTex ? true, tex ? null
+, makeWrapper }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+
+  name = "skribilo-${version}";
+  version = "0.9.4";
+
+  src = fetchurl {
+    url = "http://download.savannah.nongnu.org/releases/skribilo/${name}.tar.gz";
+    sha256 = "06ywnfjfa9sxrzdszb5sryzg266380g519cm64kq62sskzl7zmnf";
+  };
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+
+  buildInputs = [ gettext guile ploticus imagemagick ghostscript transfig ]
+  ++ optional enableEmacs emacs
+  ++ optional enableLout lout
+  ++ optional enableTex tex;
+
+  propagatedBuildInputs = [ guile-reader guile-lib ];
+
+  postInstall = ''
+    wrapProgram $out/bin/skribilo \
+      --prefix GUILE_LOAD_PATH : "$out/share/guile/site:${guile-lib}/share/guile/site:${guile-reader}/share/guile/site" \
+      --prefix GUILE_LOAD_COMPILED_PATH : "$out/share/guile/site:${guile-lib}/share/guile/site:${guile-reader}/share/guile/site"
+  '';
+
+  meta = {
+    description = "The Ultimate Document Programming Framework";
+    longDescription = ''
+      Skribilo is a free document production tool that takes a
+      structured document representation as its input and renders that
+      document in a variety of output formats: HTML and Info for
+      on-line browsing, and Lout and LaTeX for high-quality hard
+      copies.
+
+      The input document can use Skribilo's markup language to provide
+      information about the document's structure, which is similar to
+      HTML or LaTeX and does not require expertise. Alternatively, it
+      can use a simpler, "markup-less" format that borrows from Emacs'
+      outline mode and from other conventions used in emails, Usenet
+      and text.
+    '';
+    homepage = https://www.nongnu.org/skribilo/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+  };
+}
+# TODO: Better Emacs and TeX integration

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7645,6 +7645,8 @@ with pkgs;
 
   guile-opengl = callPackage ../development/guile-modules/guile-opengl { };
 
+  guile-reader = callPackage ../development/guile-modules/guile-reader { };
+
   guile-sdl = callPackage ../development/guile-modules/guile-sdl { };
 
   guile-sdl2 = callPackage ../development/guile-modules/guile-sdl2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5034,6 +5034,10 @@ with pkgs;
 
   sipcalc = callPackage ../tools/networking/sipcalc { };
 
+  skribilo = callPackage ../tools/typesetting/skribilo {
+    tex = texlive.combined.scheme-small;
+  };
+
   sleuthkit = callPackage ../tools/system/sleuthkit {};
 
   sleepyhead = callPackage ../applications/misc/sleepyhead {};


### PR DESCRIPTION
###### Motivation for this change

Two additions:
- Guile-reader: init at 0.6.2
- Skribilo: init at 0.9.4 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

