### PR TITLE
lyx: Fixes building with Qt5.11

### DIFF
--- a/pkgs/applications/misc/lyx/default.nix
+++ b/pkgs/applications/misc/lyx/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, python, file, bc
+{ fetchurl, stdenv, pkgconfig, python, file, bc, fetchpatch
 , qtbase, qtsvg, hunspell, makeWrapper #, mythes, boost
 }:
 
@@ -34,6 +34,13 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/lyx" \
       --prefix PATH : '${python}/bin'
   '';
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-office/lyx/files/lyx-2.3.0-qt-5.11.patch?id=07e82fd1fc07bf055c78b81eaa128f8f837da80d";
+      sha256 = "1bnx0il2iv36lnrnyb370wyvww0rd8bphcy6z8d7zmvd3pwhyfql";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "WYSIWYM frontend for LaTeX, DocBook";


### PR DESCRIPTION
###### Motivation for this change
Fixes: https://github.com/NixOS/nixpkgs/issues/42124

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

