### PR TITLE
nixos/xrdp: add fonts.enableDefaultFonts

### DIFF
--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -97,6 +97,7 @@ in
     # xrdp can run X11 program even if "services.xserver.enable = false"
     environment.pathsToLink =
       [ "/etc/xdg" "/share/xdg" "/share/applications" "/share/icons" "/share/pixmaps" ];
+    fonts.enableDefaultFonts = mkDefault true;
 
     systemd = {
       services.xrdp = {


### PR DESCRIPTION
###### Motivation for this change

```services.xserver.enable = true``` enables it, but ```xrdp``` might be used with ```services.xserver.enable = false``` too
