### PR TITLE
nix-prefetch-git: fix output `fetchSubmodules` property

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -356,7 +356,7 @@ print_results() {
   "rev": "$(json_escape "$fullRev")",
   "date": "$(json_escape "$commitDateStrict8601")",
   "$(json_escape "$hashType")": "$(json_escape "$hash")",
-  "fetchSubmodules": $([[ -n "fetchSubmodules" ]] && echo true || echo false)
+  "fetchSubmodules": $([[ -n "$fetchSubmodules" ]] && echo true || echo false)
 }
 EOF
     fi


### PR DESCRIPTION
###### Motivation for this change

nix-prefetch-git currently always outputs `fetchSubmodules: true`, because it's testing the length of the literal `"fetchSubmodules"`, not the variable `$fetchSubmodules` (yay for bash).