### PR TITLE
nixos/networkmanager: add extraConfig

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -124,7 +124,7 @@ in {
       
       extraConfig = mkOption {
         type = types.lines;
-        default = '''';
+        default = "";
         description = ''
           Configuration appended to the generated NetworkManager.conf. 
         '';

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -38,6 +38,8 @@ let
 
     [device]
     wifi.scan-rand-mac-address=${if cfg.wifi.scanRandMacAddress then "yes" else "no"}
+    
+    ${cfg.extraConfig}
   '';
 
   /*
@@ -117,6 +119,14 @@ in {
           configured. If enabled, a group <literal>networkmanager</literal>
           will be created. Add all users that should have permission
           to change network settings to this group.
+        '';
+      };
+      
+      extraConfig = mkOption {
+        type = types.lines;
+        default = '''';
+        description = ''
+          Configuration appended to the generated NetworkManager.conf. 
         '';
       };
 


### PR DESCRIPTION
Would like to set MAC randomization on Wi-Fi connection, and current NetworkManager module doesn't provide an option for that.

