### PR TITLE
not-detected: use lib.mkDefault

### DIFF
--- a/nixos/modules/installer/scan/not-detected.nix
+++ b/nixos/modules/installer/scan/not-detected.nix
@@ -1,9 +1,6 @@
-# List all devices which are _not_ detected by nixos-generate-config.
-# Common devices are enabled by default.
-{ config, lib, pkgs, ... }:
-
-with lib;
+# Enables non-free firmware on devices not recognized by `nixos-generate-config`.
+{ lib, ... }:
 
 {
-  hardware.enableRedistributableFirmware = true;
+  hardware.enableRedistributableFirmware = lib.mkDefault true;
 }


### PR DESCRIPTION
The way currently `nixos-generate-config` works requires user that doesn't want to run non-free firmware to set `hardware.enableRedistributableFirmware = lib.mkForce false;`. It would be nicer if `lib.mkForce` was not required.