### PR TITLE
opensmtpd: fix interaction with dovecot-2.3.1

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoconf, automake, libtool, bison
+{ stdenv, lib, fetchurl, fetchpatch, autoconf, automake, libtool, bison
 , libasr, libevent, zlib, openssl, db, pam
 
 # opensmtpd requires root for no reason to encrypt passwords, this patch fixes it
@@ -23,7 +23,13 @@ else stdenv.mkDerivation rec {
     sha256 = "291881862888655565e8bbe3cfb743310f5dc0edb6fd28a889a9a547ad767a81";
   };
 
-  patches = [ ./proc_path.diff ];
+  patches = [
+    ./proc_path.diff
+    (fetchpatch {
+      url = "https://github.com/OpenSMTPD/OpenSMTPD/commit/725ba4fa2ddf23bbcd1ff9ec92e86bbfaa6825c8.diff";
+      sha256 = "19rla0b2r53jpdiz25fcza29c2msz6j6paivxhp9jcy1xl457dqa";
+    })
+  ];
 
   postPatch = with builtins; with lib;
     optionalString unpriviledged_smtpctl_encrypt ''


### PR DESCRIPTION
This has been merged upstream at
    https://github.com/OpenSMTPD/OpenSMTPD/pull/847

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

