### PR TITLE
[18.03] pass: 1.7.1 -> 1.7.2

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -33,12 +33,12 @@ let
   );
 
 in stdenv.mkDerivation rec {
-  version = "1.7.1";
+  version = "1.7.2";
   name    = "password-store-${version}";
 
   src = fetchurl {
     url    = "http://git.zx2c4.com/password-store/snapshot/${name}.tar.xz";
-    sha256 = "0scqkpll2q8jhzcgcsh9kqz0gwdpvynivqjmmbzax2irjfaiklpn";
+    sha256 = "1sl0d7nc85c6c2bmmmyb8rpmn47vhkj831l153mjlkawjvhwas27";
   };
 
   patches = [ ./set-correct-program-name-for-sleep.patch


### PR DESCRIPTION
###### Motivation for this change

This addresses some issues regarding CVE-2018-12356. There is a
annoucement for that version on the password-store ML [1] which goes
into details.

This is more or less a backport of #42049 which couldn't be
cherry-picked due to larger changes in the pass expression.

[1] https://lists.zx2c4.com/pipermail/password-store/2018-June/003308.html


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

