### PR TITLE
ical2org: init at v.1.1.5

### DIFF
--- a/pkgs/tools/misc/ical2org/default.nix
+++ b/pkgs/tools/misc/ical2org/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, buildGoPackage}:
+
+buildGoPackage rec {
+  name = "ical2org-${version}";
+  version="v.1.1.5";
+
+  goPackagePath = "github.com/rjhorniii/ical2org";
+
+  src = fetchFromGitHub {
+    owner = "rjhorniii";
+    repo = "ical2org";
+    rev = "${version}";
+    sha256 = "0hdx2j2innjh0z4kxcfzwdl2d54nv0g9ai9fyacfiagjhnzgf7cm";
+    fetchSubmodules = true;
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Convert an iCal file to org agenda format, optionally deduplicating entries.";
+    homepage = https://github.com/rjhorniii/ical2org;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ swflint ];
+    platforms = platforms.unix;
+  }
+  
+}

--- a/pkgs/tools/misc/ical2org/default.nix
+++ b/pkgs/tools/misc/ical2org/default.nix
@@ -22,6 +22,6 @@ buildGoPackage rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ swflint ];
     platforms = platforms.unix;
-  }
+  };
   
 }

--- a/pkgs/tools/misc/ical2org/deps.nix
+++ b/pkgs/tools/misc/ical2org/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/rjhorniii/ics-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rjhorniii/ics-golang";
+      rev = "da66d6f502fac65073773ea3779cae2959545cb2";
+      sha256 = "1mm5rssvyjk29n1gq4l5xw26gm8bhvbzrs5c059i41zh9af121px";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -396,6 +396,8 @@ with pkgs;
 
   useOldCXXAbi = makeSetupHook { } ../build-support/setup-hooks/use-old-cxx-abi.sh;
 
+  ical2org = callPackage ../tools/misc/ical2org {};
+
   iconConvTools = callPackage ../build-support/icon-conv-tools {};
 
 


### PR DESCRIPTION
###### Motivation for this change

`ical2org` is a package that allows users to pull ical files and convert them to org-mode format for use with the org-mode agenda.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

