### PR TITLE
dbeaver: 5.1.0 -> 5.1.1 (18.03)

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "5.1.0";
+  version = "5.1.1";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "041wqlipkwk4xp3qa4rrwyw6rgsn1ppv25qb4h2mkhrsjcjagqhj";
+    sha256 = "1ll1q585b7yca9jrgg7iw7i6xhyy1wc9q8hjqj1g3gzdagbrf396";
   };
 
   installPhase = ''


### PR DESCRIPTION
(cherry picked from commit 65f16a5818939a4fc971ab11b7736ac52b545fe8)

###### Motivation for this change

 * [Updates dbeaver 5.1.1](https://dbeaver.io/2018/06/17/dbeaver-5-1-1/).

This cherry-picks #42144

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> *As a side note, #34182 is still open and I will still gladly accept any help in figuring out how to build this using the source release.*