### PR TITLE
libgcrypt: disable tests w/musl, seems to hang

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   '';
 
   # TODO: reenable with next update?
-  doCheck = !stdenv.isDarwin;
+  doCheck = !stdenv.isDarwin && !stdenv.hostPlatform.isMusl;
 
   meta = with stdenv.lib; {
     homepage = https://www.gnu.org/software/libgcrypt/;


### PR DESCRIPTION
Maybe same problem as on Darwin, unsure.

From gdb:

> Thread 1 (process 23820):
> #0  0x00007ffff7dab684 in __syscall_cp_c () from target:/nix/store/66m5z7marjbs7pa3gv8sf5j1qrqjacfj-musl-1.1.19/lib/ld-musl-x86_64.so.1
> #1  0x00007ffff7daac69 in __timedwait_cp () from target:/nix/store/66m5z7marjbs7pa3gv8sf5j1qrqjacfj-musl-1.1.19/lib/ld-musl-x86_64.so.1
> #2  0x00007ffff7daad17 in __timedwait () from target:/nix/store/66m5z7marjbs7pa3gv8sf5j1qrqjacfj-musl-1.1.19/lib/ld-musl-x86_64.so.1
> #3  0x00007ffff7dacaf4 in pthread_mutex_timedlock () from target:/nix/store/66m5z7marjbs7pa3gv8sf5j1qrqjacfj-musl-1.1.19/lib/ld-musl-x86_64.so.1
> #4  0x00007ffff781e409 in _gpgrt_lock_lock () from target:/nix/store/f7qid95jabfr665qc1kbcl6adf48gq7w-libgpg-error-1.28/lib/libgpg-error.so.0
> #5  0x00007ffff7b035d5 in lock_rng () at ./rndjent.c:212
> #6  0x00007ffff7b036ab in _gcry_rndjent_poll (add=0x0, origin=RANDOM_ORIGIN_INIT, length=0) at ./rndjent.c:268
> #7  0x00007ffff7b038cf in _gcry_rndjent_get_version (r_active=0x7fffffffc800) at ./rndjent.c:339
> #8  0x00007ffff7a44f7f in print_config (fp=0x6026e0, what=0x0) at global.c:391
> #9  _gcry_get_config (mode=mode@entry=0, what=<optimized out>, what@entry=0x0) at global.c:420
> #10 0x00007ffff7a456a3 in _gcry_vcontrol (cmd=<optimized out>, arg_ptr=<optimized out>) at global.c:652
> #11 0x00007ffff7a41689 in gcry_control (cmd=cmd@entry=GCRYCTL_PRINT_CONFIG) at visibility.c:79
> #12 0x0000000000400ec3 in main (argc=<optimized out>, argv=<optimized out>) at version.c:160



Planning to cherry-pick this onto 18.03 as well
(like was done for the Darwin fix).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---