### PR TITLE
pencil : fix udev dependency

### DIFF
--- a/pkgs/applications/graphics/pencil/default.nix
+++ b/pkgs/applications/graphics/pencil/default.nix
@@ -2,7 +2,7 @@
   # build dependencies
   alsaLib, atk, cairo, cups, dbus, expat, fontconfig,
   freetype, gdk_pixbuf, glib, gnome2, nspr, nss, xorg,
-  glibc, udev
+  glibc, systemd
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     ar p "$src" data.tar.xz | tar xJ
   '';
 
-  buildPhase = ":";
+  dontBuild = true;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -89,7 +89,7 @@ stdenv.mkDerivation rec {
     chmod a+x $out/opt/Pencil/libffmpeg.so
 
     # fix missing libudev
-    ln -s ${udev}/lib/systemd/libsystemd-shared.so $out/opt/Pencil/libudev.so.1
+    ln -s ${systemd.lib}/lib/libudev.so.1 $out/opt/Pencil/libudev.so.1
     wrapProgram $out/opt/Pencil/pencil \
       --prefix LD_LIBRARY_PATH : $out/opt/Pencil
   '';


### PR DESCRIPTION
###### Motivation for this change

because of changes in the udev package the package was not working anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

