### PR TITLE
libgcrypt: fix bad locking behavior introduced in update

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   # The build enables -O2 by default for everything else.
   hardeningDisable = stdenv.lib.optional stdenv.cc.isClang "fortify";
 
+  patches = [ ./fix-jent-locking.patch ];
+
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   buildInputs = [ libgpgerror ]

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   # The build enables -O2 by default for everything else.
   hardeningDisable = stdenv.lib.optional stdenv.cc.isClang "fortify";
 
+  # Accepted upstream, should be in next update: #42150, https://dev.gnupg.org/T4034
   patches = [ ./fix-jent-locking.patch ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -52,8 +52,7 @@ stdenv.mkDerivation rec {
     cp src/.libs/libgcrypt.20.dylib $out/lib
   '';
 
-  # TODO: reenable with next update?
-  doCheck = !stdenv.isDarwin;
+  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = https://www.gnu.org/software/libgcrypt/;

--- a/pkgs/development/libraries/libgcrypt/fix-jent-locking.patch
+++ b/pkgs/development/libraries/libgcrypt/fix-jent-locking.patch
@@ -1,0 +1,29 @@
+From bbe989be6ca5e093d5244413590bd80e12c2ec9b Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Sun, 17 Jun 2018 18:53:58 -0500
+Subject: [PATCH] rndjent: move locking to fix trying to obtain held lock,
+ hanging
+
+---
+ random/rndjent.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/random/rndjent.c b/random/rndjent.c
+index 0c5a820b..3740ddd4 100644
+--- a/random/rndjent.c
++++ b/random/rndjent.c
+@@ -334,9 +334,10 @@ _gcry_rndjent_get_version (int *r_active)
+     {
+       if (r_active)
+         {
+-          lock_rng ();
+           /* Make sure the RNG is initialized.  */
+           _gcry_rndjent_poll (NULL, 0, 0);
++
++          lock_rng ();
+           /* To ease debugging we store 2 for a clock_gettime based
+            * implementation and 1 for a rdtsc based code.  */
+           *r_active = jent_rng_collector? is_rng_available () : 0;
+-- 
+2.18.0-rc2
+


### PR DESCRIPTION
As-is this hangs on musl (and possibly cause of Darwin hangs)
due to trying to obtain non-recursive lock already held.

Especially if this seems to fix hanging problems on Darwin,
will be reporting upstream.

Probably should wait until that happens or this is
otherwise investigated further.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---