### PR TITLE
patchwork-classic : add 2.12.0

### DIFF
--- a/pkgs/applications/networking/ssb/patchwork-classic/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork-classic/default.nix
@@ -1,0 +1,106 @@
+{ stdenv, fetchurl, lib, makeWrapper,
+  # build dependencies
+  alsaLib, atk, cairo, cups, dbus, expat, fontconfig,
+  freetype, gdk_pixbuf, glib, gnome2, nspr, nss, xorg,
+  glibc, systemd
+}:
+
+stdenv.mkDerivation rec {
+
+  version = "2.12.0";
+
+  name = "patchwork-clasic-${version}";
+
+  src = fetchurl {
+    url    = "https://github.com/ssbc/patchwork-classic-electron/releases/download/v2.12.0/ssb-patchwork-electron_2.12.0_linux-amd64.deb";
+    sha256 = "1rvp07cgqwv7ac319p0qwpfxd7l8f53m1rlvvig7qf7q23fnmbsj";
+  };
+
+  sourceRoot = ".";
+
+  unpackCmd = ''
+    ar p "$src" data.tar.xz | tar xJ
+  '';
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R usr/share opt $out/
+
+    # fix the path in the desktop file
+    substituteInPlace \
+      $out/share/applications/ssb-patchwork-electron.desktop \
+      --replace /opt/ $out/opt/
+
+    # symlink the binary to bin/
+    ln -s $out/opt/ssb-patchwork-electron/ssb-patchwork-electron $out/bin/patchwork-classic
+  '';
+
+
+  preFixup = let
+    packages = [
+      alsaLib
+      atk
+      cairo
+      cups
+      dbus
+      expat
+      fontconfig
+      freetype
+      gdk_pixbuf
+      glib
+      gnome2.GConf
+      gnome2.gtk
+      gnome2.pango
+      nspr
+      nss
+      xorg.libX11
+      xorg.libXScrnSaver
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      stdenv.cc.cc.lib
+      stdenv.cc.cc
+      glibc
+    ];
+    libPathNative = lib.makeLibraryPath packages;
+    libPath64 = lib.makeSearchPathOutput "lib" "lib64" packages;
+    libPath = "${libPathNative}:${libPath64}";
+  in ''
+    # patch executable
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}:$out/opt/ssb-patchwork-electron" \
+      $out/opt/ssb-patchwork-electron/ssb-patchwork-electron
+
+    # patch libnode
+    patchelf \
+      --set-rpath "${libPath}" \
+      $out/opt/ssb-patchwork-electron/libnode.so
+
+    # libffmpeg is for some reason  not executable
+    chmod a+x $out/opt/ssb-patchwork-electron/libffmpeg.so
+
+    # fix missing libudev
+    ln -s ${systemd.lib}/lib/libudev.so.1 $out/opt/ssb-patchwork-electron/libudev.so.1
+    wrapProgram $out/opt/ssb-patchwork-electron/ssb-patchwork-electron \
+      --prefix LD_LIBRARY_PATH : $out/opt/ssb-patchwork-electron
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Electron wrapper for Patchwork Classic: run as a desktop app outside the browser";
+    homepage    = "https://github.com/ssbc/patchwork-classic-electron";
+    license     = licenses.gpl3; 
+    maintainers = with maintainers; [ mrVanDalo ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4365,6 +4365,8 @@ with pkgs;
 
   patchage = callPackage ../applications/audio/patchage { };
 
+  patchwork-classic = callPackage ../applications/networking/ssb/patchwork-classic { };
+
   pcapfix = callPackage ../tools/networking/pcapfix { };
 
   pbzip2 = callPackage ../tools/compression/pbzip2 { };


### PR DESCRIPTION
###### Motivation for this change

Add a working patchwork package. Because #35334 and #31052 are far from being useful.
I had to package the classic version because i offers the package as a `deb` package.
I wanted to make version `3.8.0` to work, but it is delivered as an `AppImage` and I was not able to make it run, at all. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

