### PR TITLE
jetbrains.editors: Fix update script and update versions

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -263,12 +263,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2018.1.3"; /* updated by script */
+    version = "2018.1.4"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "02nl6dssf2r4lk0fy40cvgm1m0nnfvaz2k6yygwzr35qmbsw2xjq"; /* updated by script */
+      sha256 = "1ipib91443sb27snnqik8rm3bm9w6gb5niildbd538lhc9agc9xb"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -341,12 +341,12 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "2018.1"; /* updated by script */
+    version = "2018.1.2"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-${version}.tar.gz";
-      sha256 = "0jhzfi9r18hy6mig8rrrr2n55lrfn5ysa7h347w5yv2dm7kx09ib"; /* updated by script */
+      sha256 = "1jsj0g4mv7fci3jgwx9skaz2m40g3ray2n17djaln08731rls5cc"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
     update-channel = "Rider 2018.1.2";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -367,12 +367,12 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2018.1.3"; /* updated by script */
+    version = "2018.1.5"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "03nhs4vmqbm5s4ykjz475nvcbwvp2hb0bq5ijfjxwayj3jgv0zbm"; /* updated by script */
+      sha256 = "1mqms8gzmsaqvwzfk821vj1z1cxdgjw5nnwq63mag6rly04h60n6"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
     update-channel = "WebStorm Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -276,12 +276,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.1.5"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "1qb425wg4690474g348yizhkcqcgigz2synp4blcfv4p0pg79ri6"; /* updated by script */
+      sha256 = "0bhajghwh5r5mdv3lbnq0xlr6669hid5kyzlsxnsfzc2z737zwc5"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -289,12 +289,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.1.5"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jdk.tar.gz";
-      sha256 = "0jn771z09bscnk283kwrki0zyzhh4v4n6mr2swbd0ccs9v12dx71"; /* updated by script */
+      sha256 = "046wyvk2f7vbh4zam1bbri4yxzb34q43rjpk6i6npxrb25jv6clx"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -245,7 +245,7 @@ in
       sha256 = "0daj1ha7d9kxgb60mx2yzyj01m6ahw5d6wzs0vvwp5fh5qf4mpw5";
     };
     wmClass = "jetbrains-clion";
-    update-channel = "CLion_Release"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
+    update-channel = "CLion Release"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
   };
 
   datagrip = buildDataGrip rec {
@@ -258,7 +258,7 @@ in
       sha256 = "0y959p9jsfqlf6cnj2k5m4bxc85yn5lv549rbacwicx4f0g6zp6r"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
-    update-channel = "datagrip_2018_1";
+    update-channel = "DataGrip 2018.1";
   };
 
   goland = buildGoland rec {
@@ -271,7 +271,7 @@ in
       sha256 = "02nl6dssf2r4lk0fy40cvgm1m0nnfvaz2k6yygwzr35qmbsw2xjq"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
-    update-channel = "goland_release";
+    update-channel = "GoLand Release";
   };
 
   idea-community = buildIdea rec {
@@ -284,7 +284,7 @@ in
       sha256 = "1qb425wg4690474g348yizhkcqcgigz2synp4blcfv4p0pg79ri6"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
-    update-channel = "IDEA_Release";
+    update-channel = "IntelliJ IDEA Release";
   };
 
   idea-ultimate = buildIdea rec {
@@ -297,7 +297,7 @@ in
       sha256 = "0jn771z09bscnk283kwrki0zyzhh4v4n6mr2swbd0ccs9v12dx71"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
-    update-channel = "IDEA_Release";
+    update-channel = "IntelliJ IDEA Release";
   };
 
   phpstorm = buildPhpStorm rec {
@@ -310,7 +310,7 @@ in
       sha256 = "0rrcsn44va942nrznldjkxymir45q8gq1lf3f8vg1w3k87cfk1zp"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
-    update-channel = "PS2018.1";
+    update-channel = "PhpStorm 2018.1";
   };
 
   pycharm-community = buildPycharm rec {
@@ -323,7 +323,7 @@ in
       sha256 = "1cwrqdcp6hwr8wd234g120bblc4bjmhwxwsgj9mmxblj31c7c6an"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
-    update-channel = "PyCharm_Release";
+    update-channel = "PyCharm Release";
   };
 
   pycharm-professional = buildPycharm rec {
@@ -336,7 +336,7 @@ in
       sha256 = "1chri4cknfvvqhxy973dyf7dl5linqdxc97zshrzdqhmwq6y7580"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
-    update-channel = "PyCharm_Release";
+    update-channel = "PyCharm Release";
   };
 
   rider = buildRider rec {
@@ -349,7 +349,7 @@ in
       sha256 = "0jhzfi9r18hy6mig8rrrr2n55lrfn5ysa7h347w5yv2dm7kx09ib"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
-    update-channel = "rider_2018_1";
+    update-channel = "Rider 2018.1.2";
   };
 
   ruby-mine = buildRubyMine rec {
@@ -362,7 +362,7 @@ in
       sha256 = "033rjsx6zjrfbl89i513ms14iw53ip56h4bkilrij32hshb7c2c5"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
-    update-channel = "rm2018.1";
+    update-channel = "RubyMine 2018.1";
   };
 
   webstorm = buildWebStorm rec {
@@ -375,7 +375,7 @@ in
       sha256 = "03nhs4vmqbm5s4ykjz475nvcbwvp2hb0bq5ijfjxwayj3jgv0zbm"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
-    update-channel = "WS_Release";
+    update-channel = "WebStorm Release";
   };
 
 }

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -315,12 +315,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2018.1.3"; /* updated by script */
+    version = "2018.1.4"; /* updated by script */
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1cwrqdcp6hwr8wd234g120bblc4bjmhwxwsgj9mmxblj31c7c6an"; /* updated by script */
+      sha256 = "0frzasqh3jx7wcip4dnwdl9ap2g1nkx7anapwd416cxv4jj3r5ch"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -302,12 +302,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.1.6"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "0rrcsn44va942nrznldjkxymir45q8gq1lf3f8vg1w3k87cfk1zp"; /* updated by script */
+      sha256 = "0v07sfg7ywawk6wb52zhr3753hscpxw3m53ppgw4n50dcdwx0kdn"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PhpStorm 2018.1";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -250,12 +250,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2018.1.3"; /* updated by script */
+    version = "2018.1.4"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "0y959p9jsfqlf6cnj2k5m4bxc85yn5lv549rbacwicx4f0g6zp6r"; /* updated by script */
+      sha256 = "1m0qckq645jw7cj40m5vfgr212b8hji539skavch2j5s5fbqy3ln"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip 2018.1";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -328,12 +328,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2018.1.3"; /* updated by script */
+    version = "2018.1.4"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1chri4cknfvvqhxy973dyf7dl5linqdxc97zshrzdqhmwq6y7580"; /* updated by script */
+      sha256 = "1kv1d5y2ph36aq91sq08lbz8hvfp765xi7m0hdwkhqdi2wkrpnkc"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -237,12 +237,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2018.1.3";
+    version = "2018.1.5"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "0daj1ha7d9kxgb60mx2yzyj01m6ahw5d6wzs0vvwp5fh5qf4mpw5";
+      sha256 = "0hd58i531schyjlm99vff9bi5gjskdbsljd367k9zafjfh53z91l"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion Release"; # channel's id as in http://www.jetbrains.com/updates/updates.xml

--- a/pkgs/applications/editors/jetbrains/update.pl
+++ b/pkgs/applications/editors/jetbrains/update.pl
@@ -17,7 +17,7 @@ sub get_latest_versions {
   my @channels = get("http://www.jetbrains.com/updates/updates.xml") =~ /(<channel .+?<\/channel>)/gs;
   my %h = {};
   for my $ch (@channels) {
-    my ($id) = $ch =~ /^<channel id="([^"]+)"/;
+    my ($id) = $ch =~ /^<channel id="[^"]+" name="([^"]+)"/;
     my @builds = $ch =~ /(<build .+?<\/build>)/gs;
     my $latest_build = reduce {
       my ($aversion) = $a =~ /^<build [^>]*version="([^"]+)"/; die "no version in $a" unless $aversion;


### PR DESCRIPTION
###### Motivation for this change

Jetbrains released a new product called "IntelliJ IDEA with EDU" and decided to use the same channel ID ("IDEA_Release") with IDEA community and ultimate editions, which broke the update script for the latter.

The first commit makes the update script use the channel **name** instead of ID for all the Jetbrains editors and the following ones update the versions.

I have tested just jetbrains.idea-ultimate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

