### PR TITLE
libreoffice-fresh: 6.0.3.2 -> 6.0.4.2 and don't use system xmlsec

### DIFF
--- a/pkgs/applications/office/libreoffice/default-primary-src.nix
+++ b/pkgs/applications/office/libreoffice/default-primary-src.nix
@@ -3,7 +3,7 @@
 rec {
   major = "6";
   minor = "0";
-  patch = "3";
+  patch = "4";
   tweak = "2";
 
   subdir = "${major}.${minor}.${patch}";
@@ -12,6 +12,6 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "16w5f8jbicby9jgsrpaj7g9c0wzymcmk1qk1fqdxaykrgpss5f0j";
+    sha256 = "1xqh4l1nrvgara4ni9zk8pqywz3gbq4a8sw9v0ggxsch409zp0ch";
   };
 }

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -42,14 +42,14 @@ let
 
     translations = fetchSrc {
       name = "translations";
-      sha256 = "1cx537akvil4ci4lc9gnz83xmhxyjjrpv9xcibkif6vhdck539la";
+      sha256 = "0bjl3hdckd5bcgskh46xqna1hpxjjx0ycgpnilyk7j8l6407hpw6";
     };
 
     # TODO: dictionaries
 
     help = fetchSrc {
       name = "help";
-      sha256 = "00a7iqknww28z0ifcjrx529p2nxqsa4gjavk75rwykvcfyn9x686";
+      sha256 = "1z21bk5lwd5gxsyjdwh0fmgkys4lhnx7flbjd6dbn9d99paz1w6f";
     };
 
   };

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -12,7 +12,7 @@
 , libatomic_ops, graphite2, harfbuzz, libodfgen, libzmf
 , librevenge, libe-book, libmwaw, glm, glew, gst_all_1
 , gdb, commonsLogging, librdf_rasqal, wrapGAppsHook
-, defaultIconTheme, glib, ncurses, xmlsec, epoxy, gpgme
+, defaultIconTheme, glib, ncurses, epoxy, gpgme
 , langs ? [ "ca" "de" "en-GB" "en-US" "eo" "es" "fr" "hu" "it" "nl" "pl" "ru" "sl" ]
 , withHelp ? true
 , kdeIntegration ? false
@@ -241,6 +241,7 @@ in stdenv.mkDerivation rec {
     "--without-system-mdds"
     # https://github.com/NixOS/nixpkgs/commit/5c5362427a3fa9aefccfca9e531492a8735d4e6f
     "--without-system-orcus"
+    "--without-system-xmlsec"
   ];
 
   checkPhase = ''
@@ -261,7 +262,7 @@ in stdenv.mkDerivation rec {
       python3 sablotron sane-backends unzip vigra which zip zlib
       mdds bluez5 glibc libcmis libwps libabw libzmf libtool
       libxshmfence libatomic_ops graphite2 harfbuzz gpgme utillinux
-      librevenge libe-book libmwaw glm glew ncurses xmlsec epoxy
+      librevenge libe-book libmwaw glm glew ncurses epoxy
       libodfgen CoinMP librdf_rasqal defaultIconTheme gettext
       gdb
     ]


### PR DESCRIPTION
###### Motivation for this change

I have upgraded libreoffice-fresh to its latest upstream version and noticed that some tests have started to break. NixOS uses apparently a new version of xmlsec and LibreOffice is incompatible with it. As such, the second commit disables it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

