### PR TITLE
gnome-session: add wrapGAppsHook

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, meson, ninja, pkgconfig, gnome3, glib, gtk, gsettings-desktop-schemas
 , gnome-desktop, dbus, json-glib, libICE, xmlto, docbook_xsl, docbook_xml_dtd_412
-, libxslt, gettext, makeWrapper, systemd, xorg, epoxy }:
+, libxslt, gettext, makeWrapper, systemd, xorg, epoxy, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "gnome-session-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja pkgconfig gettext makeWrapper
     xmlto libxslt docbook_xsl docbook_xml_dtd_412
-    dbus # for DTD
+    wrapGAppsHook dbus # for DTD
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, meson, ninja, pkgconfig, gnome3, glib, gtk, gsettings-desktop-schemas
 , gnome-desktop, dbus, json-glib, libICE, xmlto, docbook_xsl, docbook_xml_dtd_412
-, libxslt, gettext, makeWrapper, systemd, xorg, epoxy, wrapGAppsHook }:
+, libxslt, gettext, systemd, xorg, epoxy, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "gnome-session-${version}";
@@ -29,19 +29,11 @@ stdenv.mkDerivation rec {
     patchShebangs meson_post_install.py
   '';
 
-  # FIXME: glib binaries shouldn't be in .dev!
   preFixup = ''
-    for desktopFile in $(grep -rl "Exec=gnome-session" $out/share)
-    do
+    for desktopFile in $(grep -rl "Exec=gnome-session" $out/share); do
       echo "Patching gnome-session path in: $desktopFile"
       sed -i "s,^Exec=gnome-session,Exec=$out/bin/gnome-session," $desktopFile
     done
-    wrapProgram "$out/bin/gnome-session" \
-      --prefix PATH : "${glib.dev}/bin" \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --suffix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
-      --suffix XDG_DATA_DIRS : "${gnome3.gnome-shell}/share"\
-      --suffix XDG_CONFIG_DIRS : "${gnome3.gnome-settings-daemon}/etc/xdg"
   '';
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -14,14 +14,30 @@ stdenv.mkDerivation rec {
   mesonFlags = [ "-Dsystemd=true" ];
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext makeWrapper
-    xmlto libxslt docbook_xsl docbook_xml_dtd_412
-    wrapGAppsHook dbus # for DTD
+    dbus # for DTD
+    docbook_xml_dtd_412
+    docbook_xsl
+    gettext
+    libxslt
+    meson
+    ninja
+    pkgconfig
+    wrapGAppsHook
+    xmlto
   ];
 
   buildInputs = [
-    glib gtk libICE gnome-desktop json-glib xorg.xtrans gnome3.defaultIconTheme
-    gnome3.gnome-settings-daemon gsettings-desktop-schemas systemd epoxy
+    epoxy
+    glib
+    gnome-desktop
+    gnome3.defaultIconTheme
+    gnome3.gnome-settings-daemon
+    gsettings-desktop-schemas
+    gtk
+    json-glib
+    libICE
+    systemd
+    xorg.xtrans
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

This is required to start Wayland session without `nix-shell`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

