### PR TITLE
vscode-extensions.WakaTime.vscode-wakatime: init at 1.2.3

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -26,4 +26,6 @@ rec {
   ms-vscode.cpptools = callPackage ./cpptools {};
 
   ms-python.python = callPackage ./python {};
+
+  WakaTime.vscode-wakatime = callPackage ./wakatime {};
 }

--- a/pkgs/misc/vscode-extensions/vscode-utils.nix
+++ b/pkgs/misc/vscode-extensions/vscode-utils.nix
@@ -65,10 +65,10 @@ let
     "sha256"
   ];
 
-  mktplcExtRefToExtDrv = ext: 
-    buildVscodeMarketplaceExtension ((removeAttrs ext mktplcRefAttrList) // { 
-      mktplcRef = ext; 
-    }); 
+  mktplcExtRefToExtDrv = ext:
+    buildVscodeMarketplaceExtension ((removeAttrs ext mktplcRefAttrList) // {
+      mktplcRef = ext;
+    });
 
   extensionFromVscodeMarketplace = mktplcExtRefToExtDrv;
   extensionsFromVscodeMarketplace = mktplcExtRefList:
@@ -77,7 +77,7 @@ let
 in
 
 {
-  inherit fetchVsixFromVscodeMarketplace buildVscodeExtension 
+  inherit fetchVsixFromVscodeMarketplace buildVscodeExtension
           buildVscodeMarketplaceExtension extensionFromVscodeMarketplace
           extensionsFromVscodeMarketplace;
 }

--- a/pkgs/misc/vscode-extensions/wakatime/default.nix
+++ b/pkgs/misc/vscode-extensions/wakatime/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, wakatime, vscode-utils }:
+
+let
+  inherit (vscode-utils) buildVscodeMarketplaceExtension;
+in
+  buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-wakatime";
+      publisher = "WakaTime";
+      version = "1.2.3";
+      sha256 = "1n7bxkwgpip11k6d7zc3ifp9zb6p7f27f4x4g584wisrnfnqj1bp";
+    };
+
+    postPatch = ''
+      mkdir -p out/wakatime-master
+
+      cp -rt out/wakatime-master --no-preserve=all ${wakatime}/lib/python*/site-packages/wakatime
+    '';
+
+    meta = with stdenv.lib; {
+      description = ''
+        Visual Studio Code plugin for automatic time tracking and metrics generated
+        from your programming activity
+      '';
+      license = licenses.bsd3;
+      maintainers = with maintainers; [
+        eadwu
+      ];
+    };
+  }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

