### PR TITLE
osquery: 3.2.2 -> 3.2.8

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -12,15 +12,15 @@ let
   thirdparty = fetchFromGitHub {
     owner = "osquery";
     repo = "third-party";
-    rev = "4ef099c31a1165c5e7e3a699f9e4b3eb68c3c3d9";
-    sha256 = "1vm0prw4dix0m51vkw9z0vwfd8698gqjw499q8h604hs1rvn6132";
+    rev = "32e01462fbea75d3b1904693f937dfd62eaced15";
+    sha256 = "0va24gmgk43a1lyjs63q9qrhvpv8gmqjzpjr5595vhr16idv8wyf";
   };
 
 in
 
 stdenv.mkDerivation rec {
   name = "osquery-${version}";
-  version = "3.2.2";
+  version = "3.2.8";
 
   # this is what `osquery --help` will show as the version.
   OSQUERY_BUILD_VERSION = version;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "facebook";
     repo = "osquery";
     rev = version;
-    sha256 = "0qwj4cy6m25sqwb0irqfqinipx50l4imnz1gqxx147vzfwb52jlq";
+    sha256 = "1py5jizl7z1f9xzpg7pylbdnawvvifiyv9gpjwiim8ilgkmpaiv4";
   };
 
   patches = [ ./misc.patch ];

--- a/pkgs/tools/system/osquery/misc.patch
+++ b/pkgs/tools/system/osquery/misc.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b8eb5a16..319d81dc 100644
+index 71921740..156ea6dc 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -447,12 +447,6 @@ elseif(CLANG AND DEPS AND NOT FREEBSD)
+@@ -456,12 +456,6 @@ elseif(CLANG AND DEPS AND NOT FREEBSD)
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto=thin")
  endif()
  
@@ -15,7 +15,7 @@ index b8eb5a16..319d81dc 100644
  # Make sure deps were built before compiling (else show warning).
  execute_process(
    COMMAND "${CMAKE_SOURCE_DIR}/tools/provision.sh" check "${CMAKE_BINARY_DIR}"
-@@ -518,6 +512,8 @@ endif()
+@@ -528,6 +522,8 @@ endif()
  
  if(APPLE)
    LOG_PLATFORM("OS X")
@@ -24,7 +24,7 @@ index b8eb5a16..319d81dc 100644
  elseif(OSQUERY_BUILD_PLATFORM STREQUAL "debian")
    LOG_PLATFORM("Debian")
  elseif(OSQUERY_BUILD_PLATFORM STREQUAL "ubuntu")
-@@ -567,7 +563,6 @@ if(POSIX AND DEPS)
+@@ -577,7 +573,6 @@ if(POSIX AND DEPS)
    endif()
  endif()
  
@@ -32,7 +32,7 @@ index b8eb5a16..319d81dc 100644
  include_directories("${CMAKE_SOURCE_DIR}/include")
  include_directories("${CMAKE_SOURCE_DIR}")
  
-@@ -655,18 +650,6 @@ if(FREEBSD OR "${HAVE_TR1_TUPLE}" STREQUAL "")
+@@ -668,18 +663,6 @@ if(FREEBSD OR "${HAVE_TR1_TUPLE}" STREQUAL "")
    add_definitions(-DGTEST_USE_OWN_TR1_TUPLE=0)
  endif()
  
@@ -52,7 +52,7 @@ index b8eb5a16..319d81dc 100644
    add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/linenoise-ng")
  endif()
 diff --git a/osquery/CMakeLists.txt b/osquery/CMakeLists.txt
-index 1c8201ee..a89e6821 100644
+index c8cbac4e..a4382420 100644
 --- a/osquery/CMakeLists.txt
 +++ b/osquery/CMakeLists.txt
 @@ -35,8 +35,6 @@ if(CLANG AND POSIX)
@@ -64,7 +64,7 @@ index 1c8201ee..a89e6821 100644
      -Wno-unused-parameter
      -Wno-gnu-case-range
      -Weffc++
-@@ -61,14 +59,7 @@ endif()
+@@ -65,14 +63,7 @@ endif()
  
  # Construct a set of all object files, starting with third-party and all
  # of the osquery core objects (sources from ADD_CORE_LIBRARY macros).
@@ -80,7 +80,7 @@ index 1c8201ee..a89e6821 100644
  
  # Add subdirectories
  add_subdirectory(config)
-@@ -147,10 +138,11 @@ if(APPLE OR LINUX)
+@@ -153,10 +144,11 @@ if(APPLE OR LINUX)
    ADD_OSQUERY_LINK_ADDITIONAL("rocksdb_lite")
  elseif(FREEBSD)
    ADD_OSQUERY_LINK_CORE("icuuc")
@@ -93,15 +93,20 @@ index 1c8201ee..a89e6821 100644
  if(POSIX)
    ADD_OSQUERY_LINK_CORE("boost_system")
    ADD_OSQUERY_LINK_CORE("boost_filesystem")
-@@ -168,6 +160,8 @@ endif()
+@@ -174,10 +166,10 @@ endif()
  ADD_OSQUERY_LINK_CORE("glog${WO_KEY}")
  
  if(POSIX)
+-  # Hashing methods in core use libcrypto.
+-  ADD_OSQUERY_LINK_CORE("crypto")
+-
 +  ADD_OSQUERY_LINK_ADDITIONAL("benchmark")
 +  ADD_OSQUERY_LINK_ADDITIONAL("snappy")
    ADD_OSQUERY_LINK_ADDITIONAL("ssl")
-   ADD_OSQUERY_LINK_ADDITIONAL("crypto")
++  ADD_OSQUERY_LINK_ADDITIONAL("crypto")
    ADD_OSQUERY_LINK_ADDITIONAL("libpthread")
+   ADD_OSQUERY_LINK_ADDITIONAL("magic")
+ endif()
 diff --git a/osquery/extensions/CMakeLists.txt b/osquery/extensions/CMakeLists.txt
 index 52f3bf80..066ed1c0 100644
 --- a/osquery/extensions/CMakeLists.txt


### PR DESCRIPTION
###### Motivation for this change

The 3.2.2 build fails ATM on Hydra: https://hydra.nixos.org/build/75998362

Bumping to 3.2.8 and rebasing `osquery/CMakeLists.txt` with `misc.patch`
fixes the issue. Additionally the NixOS test remains functional.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

