### PR TITLE
multi-ghc-travis: db63eb7f2ea -> 05926968f17

### DIFF
--- a/pkgs/development/tools/haskell/multi-ghc-travis/default.nix
+++ b/pkgs/development/tools/haskell/multi-ghc-travis/default.nix
@@ -18,8 +18,8 @@ mkDerivation {
   src = fetchFromGitHub {
     owner = "haskell-CI";
     repo = "haskell-ci";
-    rev = "db63eb7f2eaa64b7b0e4759e98258fea2a27a424";
-    sha256 = "0ff55zafx7561s1yps7aw83ws4vcpc5cq9r6bbckaagvwwla0dcq";
+    rev = "05926968f17256cae2308756835a3a24d9de437b";
+    sha256 = "0s1g1yq6j6vl2bspc90bwbwp7532pcrmh8fhnz8j6yv9py927mmm";
   };
   patches = [ newShellCheck ];
   isLibrary = true;


### PR DESCRIPTION
###### Motivation for this change

Just a routine bump; adds support for GHC 8.4.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

