### PR TITLE
prometheus-node-exporter: 0.15.2 -> 0.16.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "node_exporter-${version}";
-  version = "0.15.2";
+  version = "0.16.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/node_exporter";
@@ -11,10 +11,10 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "node_exporter";
-    sha256 = "1vxbkps80ba8c0ndawijg07am5gyc8y49h8fd0ky5h05zmkp25qv";
+    sha256 = "0rm6ahccgr1djpwvsa3p1kfal3mpy4a6g5w974pra84gk3krli5a";
   };
 
-  # FIXME: megacli test fails
+  # FIXME: tests fail due to read-only nix store
   doCheck = false;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md#0160--2018-05-15

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Note: This release contains a bunch of user-facing breaking changes as many metrics have been renamed.