### PR TITLE
darwin stdenv: Put back "man" attribute on clang and llvm

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -323,8 +323,16 @@ in rec {
         coreutils findutils diffutils patchutils;
 
       llvmPackages_5 = super.llvmPackages_5 // (let
-        tools = super.llvmPackages_5.tools.extend (_: _: {
-          inherit (llvmPackages_5) llvm clang-unwrapped;
+        tools = super.llvmPackages_5.tools.extend (_: super: {
+          # Build man pages with final stdenv not before
+          llvm = lib.extendDerivation
+            true
+            { inherit (super.llvm) man; }
+            llvmPackages_5.llvm;
+          clang-unwrapped = lib.extendDerivation
+            true
+            { inherit (super.clang-unwrapped) man; }
+            llvmPackages_5.clang-unwrapped;
         });
         libraries = super.llvmPackages_5.libraries.extend (_: _: {
           inherit (llvmPackages_5) libcxx libcxxabi;
@@ -370,7 +378,8 @@ in rec {
         inherit (prevStage) stdenv;
       };
       inherit (pkgs) coreutils gnugrep;
-      cc       = pkgs.llvmPackages.clang-unwrapped;
+      # Hack to avoid man pages in stdenv to avoid mass rebuild
+      cc       = builtins.removeAttrs pkgs.llvmPackages.clang-unwrapped [ "man" ];
       bintools = pkgs.darwin.binutils;
       libc     = pkgs.darwin.Libsystem;
       extraPackages = [ pkgs.libcxx ];


### PR DESCRIPTION
###### Motivation for this change

We take care to make it use the final stdenv to avoid mass rebuilds and bootstrap python.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

