### PR TITLE
tests.cc-wrapper: Fix sanitizer condition

### DIFF
--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,9 @@ with stdenv.lib;
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersBroken = stdenv.cc.isClang && versionOlder (getVersion stdenv.cc.name) "6.0.0";
+  sanitizersWorking =
+       (stdenv.cc.isClang && versionAtLeast (getVersion stdenv.cc.name) "6.0.0")
+    || (stdenv.cc.isGNU && stdenv.isLinux);
 in stdenv.mkDerivation {
   name = "cc-wrapper-test";
 
@@ -43,7 +45,7 @@ in stdenv.mkDerivation {
     NIX_LDFLAGS="-L$NIX_BUILD_TOP/foo/lib -rpath $NIX_BUILD_TOP/foo/lib" $CC -lfoo -o ldflags-check ${./ldflags-main.c}
     ./ldflags-check
 
-    ${optionalString (!sanitizersBroken) ''
+    ${optionalString sanitizersWorking ''
       printf "checking whether sanitizers are fully functional... ">&2
       $CC -o sanitizers -fsanitize=address,undefined ${./sanitizers.c}
       ./sanitizers


### PR DESCRIPTION
###### Motivation for this change

fc9644d4c9c9d29958e9bcf1676d48d4b3026bb4 accidentally enabled the sanitizer tests for GCC on Darwin, when fixing that case was never attempted. Also inverted the condition from broken to working for clarity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

