### PR TITLE
deja-dup: fix nautilus extension breaking nautilus

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -19,7 +19,12 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       inherit coreutils;
     })
+    ./hardcode-gsettings.patch
   ];
+
+  postPatch = ''
+    substituteInPlace deja-dup/nautilus/NautilusExtension.c --subst-var-by DEJA_DUP_GSETTINGS_PATH $out/share/gsettings-schemas/${name}/glib-2.0/schemas
+  '';
 
   nativeBuildInputs = [
     meson ninja pkgconfig vala_0_40 gettext itstool

--- a/pkgs/applications/backup/deja-dup/hardcode-gsettings.patch
+++ b/pkgs/applications/backup/deja-dup/hardcode-gsettings.patch
@@ -1,0 +1,38 @@
+--- a/deja-dup/nautilus/NautilusExtension.c
++++ b/deja-dup/nautilus/NautilusExtension.c
+@@ -24,6 +24,8 @@
+ #include <glib/gi18n-lib.h>
+ 
+ GList *dirs = NULL;
++GSettingsSchemaSource *schema_source = NULL;
++GSettingsSchema *schema = NULL;
+ GSettings *settings = NULL;
+ 
+ // This will treat a < b iff a is 'lower' in the file tree than b
+@@ -313,7 +315,13 @@
+   bindtextdomain(GETTEXT_PACKAGE, LOCALE_DIR);
+   bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
+ 
+-  settings = g_settings_new("org.gnome.DejaDup");
++  schema_source = g_settings_schema_source_new_from_directory ("@DEJA_DUP_GSETTINGS_PATH@",
++    g_settings_schema_source_get_default (), TRUE, NULL);
++
++  schema = g_settings_schema_source_lookup (schema_source,
++                                            "org.gnome.DejaDup", FALSE);
++
++  settings = g_settings_new_full (schema, NULL, NULL);
+   g_signal_connect(settings, "changed::include-list",
+                    update_include_excludes, NULL);
+   g_signal_connect(settings, "changed::exclude-list",
+@@ -329,7 +337,11 @@
+ 
+ void nautilus_module_shutdown(void)
+ {
++  g_settings_schema_source_unref(schema_source);
++  g_settings_schema_unref(schema);
+   g_object_unref(settings);
++  schema_source = NULL;
++  schema = NULL;
+   settings = NULL;
+ 
+   update_include_excludes(); /* will clear it now that settings is NULL */


### PR DESCRIPTION
###### Motivation for this change
When deja-dup is installed, Nautilus segfaults on start due to the missing gsettings schemas.

This commit hard-codes path to the compiled schemas file to the extension.

Discuss the solutions in https://github.com/NixOS/nixpkgs/issues/42176

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

