### PR TITLE
nixos-18.03/pgbackup: Fix bug in postgresql-backup module that causes to fail

### DIFF
--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -9,7 +9,7 @@ let
 
   postgresqlBackupCron = db:
     ''
-      ${config.services.postgresqlBackup.period} root ${config.services.postgresql.package}/bin/pg_dump ${db} | ${gzip}/bin/gzip -c > ${location}/${db}.gz
+      ${config.services.postgresqlBackup.period} root ${config.services.postgresql.package}/bin/pg_dump ${db} -U postgres | ${gzip}/bin/gzip -c > ${location}/${db}.gz
     '';
 
 in


### PR DESCRIPTION
###### Motivation for this change
The `postgresqlBackup` module fails to backup the database.
User `root` is ignored and pg_dump does not create a backup (at least in newer postgres version?).
See https://github.com/NixOS/nixpkgs/issues/41388

This is a hotfix for 18.03. See https://github.com/NixOS/nixpkgs/pull/42133 for a more thorough
refactoring of the `postgresqlBackup` module.

###### Things done
Run pg_dump as postgres super user instead of root. Otherwise


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

