### PR TITLE
nixos/stage-1, nixos/f2fs: added F2FS resizing

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -336,7 +336,7 @@ mountFS() {
                 echo "resizing $device..."
                 e2fsck -fp "$device"
                 resize2fs "$device"
-            else [ "$fsType" = f2fs ]; then
+            elif [ "$fsType" = f2fs ]; then
                 echo "resizing $device..."
                 fsck.f2fs -fp "$device"
                 resize.f2fs "$device" 

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -336,6 +336,10 @@ mountFS() {
                 echo "resizing $device..."
                 e2fsck -fp "$device"
                 resize2fs "$device"
+            else [ "$fsType" = f2fs ]; then
+                echo "resizing $device..."
+                fsck.f2fs -fp "$device"
+                resize.f2fs "$device" 
             fi
             ;;
     esac

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -122,14 +122,14 @@ let
       copy_bin_and_libs ${pkgs.kmod}/bin/kmod
       ln -sf kmod $out/bin/modprobe
 
-      # Copy resize2fs if needed.
-      ${optionalString (any (fs: fs.autoResize) fileSystems) ''
+      # Copy resize2fs if any ext* filesystems are to be resized
+      ${optionalString (any (fs: fs.autoResize && (lib.hasPrefix "ext" fs.fsType)) fileSystems) ''
         # We need mke2fs in the initrd.
         copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
       ''}
 
       # Copy f2fs-tools' fsck and resize if needed
-      ${optionalString (any (fs: fs.autoResize) (filter (x: x.fsType == "f2fs") fileSystems)) ''
+      ${optionalString (any (fs: fs.autoResize && fs.fsType = "f2fs") fileSystems) ''
         # We need f2fs-tools' tools to resize filesystems
         copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs
         copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/resize.f2fs

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -126,8 +126,11 @@ let
       ${optionalString (any (fs: fs.autoResize) fileSystems) ''
         # We need mke2fs in the initrd.
         copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
-        # Copy also f2fs-tools' fsck and resize
-        # TODO: separate these in case no f2fs fs are present
+      ''}
+
+      # Copy f2fs-tools' fsck and resize if needed
+      ${optionalString (any (fs: fs.autoResize) (filter (x: x.fsType == "f2fs") fileSystems)) ''
+        # We need f2fs-tools' tools to resize filesystems
         copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs
         copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/resize.f2fs
       ''}

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -126,6 +126,10 @@ let
       ${optionalString (any (fs: fs.autoResize) fileSystems) ''
         # We need mke2fs in the initrd.
         copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
+        # Copy also f2fs-tools' fsck and resize
+        # TODO: separate these in case no f2fs fs are present
+        copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs
+        copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/resize.f2fs
       ''}
 
       # Copy secrets if needed.

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -128,13 +128,6 @@ let
         copy_bin_and_libs ${pkgs.e2fsprogs}/sbin/resize2fs
       ''}
 
-      # Copy f2fs-tools' fsck and resize if needed
-      ${optionalString (any (fs: fs.autoResize && fs.fsType = "f2fs") fileSystems) ''
-        # We need f2fs-tools' tools to resize filesystems
-        copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs
-        copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/resize.f2fs
-      ''}
-
       # Copy secrets if needed.
       ${optionalString (!config.boot.loader.supportsInitrdSecrets)
           (concatStringsSep "\n" (mapAttrsToList (dest: source:

--- a/nixos/modules/tasks/filesystems/f2fs.nix
+++ b/nixos/modules/tasks/filesystems/f2fs.nix
@@ -14,6 +14,11 @@ in
 
     boot.initrd.extraUtilsCommands = mkIf inInitrd ''
       copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs
+      ${optionalString (any (fs: fs.autoResize && fs.fsType = "f2fs") fileSystems) ''
+        # We need f2fs-tools' tools to resize filesystems
+        copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/resize.f2fs
+      ''}
+
     '';
   };
 }

--- a/nixos/modules/tasks/filesystems/f2fs.nix
+++ b/nixos/modules/tasks/filesystems/f2fs.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   inInitrd = any (fs: fs == "f2fs") config.boot.initrd.supportedFilesystems;
+  fileSystems = filter (x: x.fsType == "f2fs") config.system.build.fileSystems;
 in
 {
   config = mkIf (any (fs: fs == "f2fs") config.boot.supportedFilesystems) {
@@ -14,7 +15,7 @@ in
 
     boot.initrd.extraUtilsCommands = mkIf inInitrd ''
       copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/fsck.f2fs
-      ${optionalString (any (fs: fs.autoResize && fs.fsType = "f2fs") fileSystems) ''
+      ${optionalString (any (fs: fs.autoResize) fileSystems) ''
         # We need f2fs-tools' tools to resize filesystems
         copy_bin_and_libs ${pkgs.f2fs-tools}/sbin/resize.f2fs
       ''}


### PR DESCRIPTION
Adding F2FS resize support like with ext* filesystems in stage1.

###### Motivation for this change
F2FS is used on Raspberry Pi-like devices to enhance SD card performance. Allowing F2FS resizing would help in automatic deploying of SD card images without a Linux box to resize the file system offline.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

