### PR TITLE
pasystray: add libappindicator-gtk3 for appindicator support

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -1,5 +1,7 @@
-{stdenv, fetchFromGitHub, autoconf, automake, makeWrapper, pkgconfig
-, gnome3, avahi, gtk3, libnotify, libpulseaudio, xlibsWrapper}:
+{ stdenv, fetchFromGitHub, autoconf, automake, makeWrapper, pkgconfig
+, gnome3, avahi, gtk3, libappindicator-gtk3, libnotify, libpulseaudio
+, xlibsWrapper
+}:
 
 stdenv.mkDerivation rec {
   name = "pasystray-${version}";
@@ -13,9 +15,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake makeWrapper 
-                  gnome3.defaultIconTheme
-                  avahi gtk3 libnotify libpulseaudio xlibsWrapper ];
+  buildInputs = [
+    autoconf automake makeWrapper
+    gnome3.defaultIconTheme
+    avahi gtk3 libappindicator-gtk3 libnotify libpulseaudio xlibsWrapper
+  ];
 
   preConfigure = ''
     aclocal


### PR DESCRIPTION
###### Motivation for this change

Add appindicator support to pasystray

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

