### PR TITLE
openjdk: fix build for !enableGnome2

### DIFF
--- a/pkgs/development/compilers/openjdk/10.nix
+++ b/pkgs/development/compilers/openjdk/10.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, bash, cpio, pkgconfig, file, which, unzip, zip, cups, freetype
 , alsaLib, bootjdk, cacert, perl, liberation_ttf, fontconfig, zlib, lndir
-, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor
+, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
 , libjpeg, giflib
 , setJavaClassPath
 , minimal ? false
@@ -36,7 +36,7 @@ let
     buildInputs = [
       cpio file which unzip zip perl bootjdk zlib cups freetype alsaLib
       libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
-      libXi libXinerama libXcursor lndir fontconfig
+      libXi libXinerama libXcursor libXrandr lndir fontconfig
     ] ++ lib.optionals (!minimal && enableGnome2) [
       gtk3 gnome_vfs GConf glib
     ];

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, bash, cpio, pkgconfig, file, which, unzip, zip, cups, freetype
 , alsaLib, bootjdk, cacert, perl, liberation_ttf, fontconfig, zlib, lndir
-, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor
+, libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
 , libjpeg, giflib
 , setJavaClassPath
 , minimal ? false
@@ -70,7 +70,7 @@ let
     buildInputs = [
       cpio file which unzip zip perl bootjdk zlib cups freetype alsaLib
       libjpeg giflib libX11 libICE libXext libXrender libXtst libXt libXtst
-      libXi libXinerama libXcursor lndir fontconfig
+      libXi libXinerama libXcursor libXrandr lndir fontconfig
     ] ++ lib.optionals (!minimal && enableGnome2) [
       gtk2 gnome_vfs GConf glib
     ];


### PR DESCRIPTION
###### Motivation for this change

This OpenJDK packaging has a headless build configuration controlled by the `minimal` flag, which is regularly build-tested by Hydra, and a non-headless configuration based on pure Xlib libraries without Gnome features, which is not normally tested.

Sometime before OpenJDK 8, the !enableGnome2 case broke, because it needs to link against libXrandr but that wasn't included in the buildInputs.

It might be nice to add packages with this flag set to `all-packages.nix` so Hydra tests this configuration regularly. This would be analogous to `jre_headless` and similar, but I couldn't decide what the best package name would be (`jre_gnomeless`?) so I haven't written such a patch. I also wasn't sure if it would be desirable since obviously most people aren't using this package with the Gnome support turned off, so it's kind of a waste of CI compute time...

If this patch is backported to NixOS 18.03 or earlier, the same fix needs to be applied to OpenJDK 9.

I tested `openjdk9.override { enableGnome2 = false; }` with an application I care about on NixOS 18.03 using `.overrideAttrs` to patch the buildInputs. I tested `openjdk10` the same way against Nixpkgs commit 44f3a1dd41bc6ec78d827bb2aa5997a4cb67be70.

Before submitting this pull request, I ran:

```sh
nix-build --expr \
  '(import ./. {}).openjdk10.override { enableGnome2 = false; }' \
  '(import ./. {}).openjdk8.override { enableGnome2 = false; }'
```

and tested `result/bin/java -version` and `result-2/bin/java -version`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

