### PR TITLE
Cryptsetup: 2.0.2 -> 2.0.3. Also, add upstream libressl-2.7 patch.

### DIFF
--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -1,15 +1,23 @@
-{ stdenv, fetchurl, devicemapper, json_c, openssl, libuuid, pkgconfig, popt
+{ stdenv, fetchurl, fetchpatch, devicemapper, json_c, openssl, libuuid, pkgconfig, popt
 , enablePython ? false, python2 ? null }:
 
 assert enablePython -> python2 != null;
 
 stdenv.mkDerivation rec {
-  name = "cryptsetup-2.0.2";
+  name = "cryptsetup-2.0.3";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/cryptsetup/v2.0/${name}.tar.xz";
-    sha256 = "15wyjfgcqjf0wy5gxnmjj8aah33csv5v6n1hv9c8sxdzygbhb0ag";
+    sha256 = "1m01wl8njjraz69fsk97l3nqfc32nbpr1la5s1l4mzzmq42clv2d";
   };
+
+  patches = [
+    # NOTE: Patch to support LibreSSL-2.7. It is from upstream, and can be removed when cryptsetup is next updated.
+    (fetchpatch {
+      url = "https://gitlab.com/cryptsetup/cryptsetup/commit/5fcf430c8105fbeeb07a8cacbae84f941d2a3d55.patch";
+      sha256 = "1d3ycsqszq0frlv9r7kmfdfmnk4qa4b4mv25iivmayvpgc8yja7m";
+    })
+  ];
 
   NIX_LDFLAGS = "-lgcc_s";
 


### PR DESCRIPTION
###### Motivation for this change
[Let's try this again, now that #38382 is merged!]

Update Cryptsetup from 2.0.2 to 2.0.3.

Also, apply [an upstream patch](https://gitlab.com/cryptsetup/cryptsetup/commit/5fcf430c8105fbeeb07a8cacbae84f941d2a3d55) to support building against LibreSSL-2.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

