### PR TITLE
nixos/kubernetes: dashboard lockdown

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -306,6 +306,22 @@ inherit (pkgs.nixos {
      was not used and thus has been removed.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The option <varname>services.kubernetes.addons.dashboard.enableRBAC</varname>
+     was renamed to <varname>services.kubernetes.addons.dashboard.rbac.enable</varname>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The Kubernetes Dashboard now has only minimal RBAC permissions by default.
+     If dashboard cluster-admin rights are desired,
+     set <varname>services.kubernetes.addons.dashboard.rbac.clusterAdmin</varname> to true.
+     On existing clusters, in order for the revocation of privileges to take effect,
+     the current ClusterRoleBinding for kubernetes-dashboard must be manually removed:
+     <literal>kubectl delete clusterrolebinding kubernetes-dashboard</literal>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -34,6 +34,7 @@ with lib;
     (mkRenamedOptionModule [ "services" "kubernetes" "apiserver" "admissionControl" ] [ "services" "kubernetes" "apiserver" "enableAdmissionPlugins" ])
     (mkRenamedOptionModule [ "services" "kubernetes" "apiserver" "address" ] ["services" "kubernetes" "apiserver" "bindAddress"])
     (mkRemovedOptionModule [ "services" "kubernetes" "apiserver" "publicAddress" ] "")
+    (mkRenamedOptionModule [ "services" "kubernetes" "addons" "dashboard" "enableRBAC" ] [ "services" "kubernetes" "addons" "dashboard" "rbac" "enable" ])
     (mkRenamedOptionModule [ "services" "logstash" "address" ] [ "services" "logstash" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "mpd" "network" "host" ] [ "services" "mpd" "network" "listenAddress" ])
     (mkRenamedOptionModule [ "services" "neo4j" "host" ] [ "services" "neo4j" "listenAddress" ])


### PR DESCRIPTION
Kubernetes dashboard currently has cluster admin permissions, which is not recommended. See: https://github.com/kubernetes/dashboard/wiki/Access-control.

I've added _minimal granted privileges_ for the Dashboard as per: https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml

A new option is available for re-enabling cluster admin permissions, for those who find that desirable.

To assign other custom privileges to the dashboard, one can add verbatim roles and rolebindings to the addon-manager, using: `services.kubernetes.addonManager.addons`.

What's changed:

- Renamed option "services.kubernetes.addons.dashboard.enableRBAC" to "services.kubernetes.addons.dashboard.rbac.enable"

- Added option "services.kubernetes.addons.dashboard.rbac.clusterAdmin", default = false.

- Setting recommended minimal permissions for the dashboard in accordance with https://github.com/kubernetes/dashboard/wiki/Installation

- Updated release note for 18.09.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

----

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
**/nixos/tests/kubernetes/dns.nix**
**/nixos/tests/kubernetes/rbac.nix**

- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

