### PR TITLE
avidemux: 2.7.0 -> 2.7.1

### DIFF
--- a/pkgs/applications/video/avidemux/default.nix
+++ b/pkgs/applications/video/avidemux/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, cmake, pkgconfig, lndir
+{ stdenv, lib, fetchurl, cmake, pkgconfig, lndir
 , zlib, gettext, libvdpau, libva, libXv, sqlite
 , yasm, freetype, fontconfig, fribidi
 , makeWrapper, libXext, libGLU, qttools, qtbase
@@ -25,21 +25,16 @@ assert !withQT -> default != "qt5";
 
 stdenv.mkDerivation rec {
   name = "avidemux-${version}";
-  version = "2.7.0";
+  version = "2.7.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/avidemux/avidemux/${version}/avidemux_${version}.tar.gz";
-    sha256 = "1bf4l9qwxq3smc1mx5pybydc742a4qqsk17z50j9550d9iwnn7gy";
+    sha256 = "15g9h791qbnmycabbbl7s2b3n3xpvygm88qrfk35g2cw6957ik9w";
   };
 
   patches = [
     ./dynamic_install_dir.patch
     ./bootstrap_logging.patch
-    # glibc 2.27 compat
-    (fetchpatch {
-      url = https://github.com/mean00/avidemux2/commit/afdd9c4b876d77a4974d3fa7d9f25caeffbdf13d.patch;
-      sha256 = "0mf8vpfdqybziqsfyvxwcdm3zsmnp64293icinhvfpq9xp5b6vn6";
-    })
   ];
 
   nativeBuildInputs = [ yasm cmake pkgconfig ];
@@ -58,7 +53,10 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withQT [ qttools qtbase ]
     ++ lib.optional withVPX libvpx;
 
-  buildCommand = ''
+  buildCommand = let
+    qtVersion = "5.${stdenv.lib.versions.minor qtbase.version}";
+    wrapProgram = f: "wrapProgram ${f} --set ADM_ROOT_DIR $out --prefix LD_LIBRARY_PATH : ${libXext}/lib";
+  in ''
     unpackPhase
     cd "$sourceRoot"
     patchPhase
@@ -73,11 +71,13 @@ stdenv.mkDerivation rec {
     mkdir $out
     cp -R install/usr/* $out
 
-    for i in $out/bin/*; do
-      wrapProgram $i \
-        --set ADM_ROOT_DIR $out \
-        --prefix LD_LIBRARY_PATH ":" "${libXext}/lib"
-    done
+    ${wrapProgram "$out/bin/avidemux3_cli"}
+
+    ${stdenv.lib.optionalString withQT ''
+      ${wrapProgram "$out/bin/avidemux3_qt5"} --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-${qtVersion}/plugins
+      ${wrapProgram "$out/bin/avidemux3_jobs_qt5"} --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-${qtVersion}/plugins
+    ''}
+
     ln -s "$out/bin/avidemux3_${default}" "$out/bin/avidemux"
 
     fixupPhase


### PR DESCRIPTION
###### Motivation for this change

The current version of `avidemux` (v2.7.0) breaks on master (see
https://hydra.nixos.org/build/75993794), the 18.03 build remains fine
(https://hydra.nixos.org/build/75935027).

The following changes have been applied:

* `glibc` compat patch is obsolete as it landed in upstream.

* Fixed QT_PLUGIN_PATH for QT binaries to avoid errors because of
  missing plugins like this:

  ```
  qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
  This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

  [1]    20081 abort      /nix/store/rjwxc6ih15zwvvy71ss8bvnh56ibfbmj-avidemux-2.7.1/bin/avidemux3_qt5
  ```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

