### PR TITLE
esh: init at 0.1.1

### DIFF
--- a/pkgs/tools/text/esh/default.nix
+++ b/pkgs/tools/text/esh/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, asciidoctor, gawk, gnused }:
+
+stdenv.mkDerivation rec {
+  name = "esh-${version}";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jirutka";
+    repo = "esh";
+    rev = "v${version}";
+    sha256 = "1ddaji5nplf1dyvgkrhqjy8m5djaycqcfhjv30yprj1avjymlj6w";
+  };
+
+  nativeBuildInputs = [ asciidoctor ];
+
+  buildInputs = [ gawk gnused ];
+
+  makeFlags = [ "prefix=$(out)" "DESTDIR=" ];
+
+  postPatch = ''
+    patchShebangs .
+    substituteInPlace esh \
+        --replace '"/bin/sh"' '"${stdenv.shell}"' \
+        --replace '"awk"' '"${gawk}/bin/awk"' \
+        --replace 'sed' '${gnused}/bin/sed'
+    substituteInPlace tests/test-dump.exp \
+        --replace '#!/bin/sh' '#!${stdenv.shell}'
+  '';
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    description = "Simple templating engine based on shell";
+    homepage = https://github.com/jirutka/esh;
+    license = licenses.mit;
+    maintainers = with maintainers; [ mnacamura ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -645,6 +645,8 @@ with pkgs;
 
   enpass = callPackage ../tools/security/enpass { };
 
+  esh = callPackage ../tools/text/esh { };
+
   ezstream = callPackage ../tools/audio/ezstream { };
 
   genymotion = callPackage ../development/mobile/genymotion { };


### PR DESCRIPTION
###### Motivation for this change

It is a very useful tool with which one can embed shell scripts in templates, similar to embedded ruby.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

