### PR TITLE
Adding mill build tool

### DIFF
--- a/pkgs/development/tools/build-managers/mill/default.nix
+++ b/pkgs/development/tools/build-managers/mill/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, fetchurl, makeWrapper, jre, gnused }:
+
+stdenv.mkDerivation rec {
+  name = "mill-${version}";
+  version = "0.2.2";
+
+   src = fetchurl {
+     url = "https://github.com/lihaoyi/mill/releases/download/${version}/${version}";
+     sha256 = "15fssc1d8vdwm6hnd74zdf98mg3f8yfba19ji83vwpgv7vynwkqi";
+  };
+
+  propagatedBuildInputs = [ jre ] ;
+  buildInputs = [ makeWrapper gnused ] ;
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/mill
+    chmod +x $out/bin/mill
+    ${gnused}/bin/sed -i '0,/java/{s|java|${jre}/bin/java|}' $out/bin/mill
+    ${gnused}/bin/sed -i '0,/mill.MillMain/{s|mill.MillMain|mill.MillMain --no-remote-logging|}' $out/bin/mill
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.lihaoyi.com/mill;
+    license = licenses.mit;
+    description = "A build tool for Scala, Java and more";
+    maintainers = with maintainers; [ ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/development/tools/build-managers/mill/default.nix
+++ b/pkgs/development/tools/build-managers/mill/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mill-${version}";
-  version = "0.2.2";
+  version = "0.2.3";
 
    src = fetchurl {
      url = "https://github.com/lihaoyi/mill/releases/download/${version}/${version}";
-     sha256 = "15fssc1d8vdwm6hnd74zdf98mg3f8yfba19ji83vwpgv7vynwkqi";
+     sha256 = "15rrfnsrabq2gk5f33dviq1g2ydg1f61x9w5s5wgahvphwpxaik9";
   };
 
   propagatedBuildInputs = [ jre ] ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8325,6 +8325,8 @@ with pkgs;
 
   sbt-extras = callPackage ../development/tools/build-managers/sbt-extras { };
 
+  mill = callPackage ../development/tools/build-managers/mill { };
+
   shallot = callPackage ../tools/misc/shallot { };
 
   shards = callPackage ../development/tools/build-managers/shards { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8399,6 +8399,8 @@ with pkgs;
 
   sbt-extras = callPackage ../development/tools/build-managers/sbt-extras { };
 
+  mill = callPackage ../development/tools/build-managers/mill { };
+
   shallot = callPackage ../tools/misc/shallot { };
 
   shards = callPackage ../development/tools/build-managers/shards { };


### PR DESCRIPTION
###### Motivation for this change

Mill is a very nice tool for building java and scala projects. It is easier to learn than sbt, maven and gradle for beginners in Scala.

I lack a maintainer. I guess it needs to be one of the main contributors to the nixpkgs or can I put myself in there ? I could be a maintainer on bioinformatic tools and scala tools if you need one, depending a bit on how much work such an effort would require, in addition to skillset. I am more into development than operations.

I have used mill locally for a while on my Nixos 18.03 distribution. It seems to work very well!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

