### PR TITLE
haskell generic-builder: Yet more cross fixes

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -211,18 +211,6 @@ let
       cp -f "$p/lib/${ghcName}/package.conf.d/"*.conf ${packageConfDir}/
       continue
     fi
-    if [ -d "$p/include" ]; then
-      configureFlags+=" --extra-include-dirs=$p/include"
-    fi
-    if [ -d "$p/lib" ]; then
-      configureFlags+=" --extra-lib-dirs=$p/lib"
-    fi
-  ''
-  # It is not clear why --extra-framework-dirs does work fine on Linux
-  + optionalString (!buildPlatform.isDarwin || versionAtLeast nativeGhc.version "8.0") ''
-    if [[ -d "$p/Library/Frameworks" ]]; then
-      configureFlags+=" --extra-framework-dirs=$p/Library/Frameworks"
-    fi
   '';
 
 in
@@ -287,6 +275,19 @@ stdenv.mkDerivation ({
   + ''
     for p in "''${pkgsHostHost[@]}" "''${pkgsHostTarget[@]}"; do
       ${buildPkgDb ghc.name "$packageConfDir"}
+      if [ -d "$p/include" ]; then
+        configureFlags+=" --extra-include-dirs=$p/include"
+      fi
+      if [ -d "$p/lib" ]; then
+        configureFlags+=" --extra-lib-dirs=$p/lib"
+      fi
+    ''
+    # It is not clear why --extra-framework-dirs does work fine on Linux
+    + optionalString (!buildPlatform.isDarwin || versionAtLeast nativeGhc.version "8.0") ''
+      if [[ -d "$p/Library/Frameworks" ]]; then
+        configureFlags+=" --extra-framework-dirs=$p/Library/Frameworks"
+      fi
+  '' + ''
     done
   ''
   # only use the links hack if we're actually building dylibs. otherwise, the

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -179,7 +179,8 @@ let
   allPkgconfigDepends = pkgconfigDepends ++ libraryPkgconfigDepends ++ executablePkgconfigDepends ++
                         optionals doCheck testPkgconfigDepends ++ optionals doBenchmark benchmarkPkgconfigDepends;
 
-  nativeBuildInputs = [ ghc nativeGhc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
+  depsBuildBuild = [ nativeGhc ];
+  nativeBuildInputs = [ ghc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
                       setupHaskellDepends ++
                       buildTools ++ libraryToolDepends ++ executableToolDepends;
   propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends ++ libraryFrameworkDepends;
@@ -242,7 +243,7 @@ stdenv.mkDerivation ({
 
   inherit src;
 
-  inherit nativeBuildInputs;
+  inherit depsBuildBuild nativeBuildInputs;
   buildInputs = otherBuildInputs ++ optionals (!hasActiveLibrary) propagatedBuildInputs;
   propagatedBuildInputs = optionals hasActiveLibrary propagatedBuildInputs;
 


### PR DESCRIPTION
###### Motivation for this change

1. `nativeGhc` targets the build platform so it should be a `depsBuildBuild`. This is more important because GHC propagates some dependencies, and we want those to be propagated properly.

2. The `--extra-*` flags are only for host dependencies. They *ought* to be harmless when given others as the linker can just skip, but we ran into some issue indicating otherwise. Best to preemptively fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @kirelagin @angerman  
