### PR TITLE
Platformio: 3.5.2 -> 3.5.3 and fix for click dependency

### DIFF
--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -13,6 +13,7 @@ let
               inherit version;
               sha256 = "678c98275431fad324275dec63791e4a17558b40e5a110e20a82866139a85a5a";
             };
+            patches = [];
           });
 
           platformio = self.callPackage ./core.nix { };

--- a/pkgs/development/arduino/platformio/core.nix
+++ b/pkgs/development/arduino/platformio/core.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage rec {
   pname = "platformio";
-  version = "3.5.2";
+  version = "3.5.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bb311ce5b8f12c95bc45c2071626a4887a3632fb2472b4d69a873b2acfc2e4ec";
+    sha256 = "1l4s2xh1p9h767amk9zapzivz4irl2y3kff3dna6icvsgq6rz011";
   };
 
   propagatedBuildInputs =  [


### PR DESCRIPTION
###### Motivation for this change

The normal click package now applies a patch that doesn't work with the
older version used for platformio.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

