### PR TITLE
WIP: Log stage-{1,2} output to secondary consoles

### DIFF
--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -17,6 +17,7 @@ let
     inherit (config.system.build) earlyMountScript;
     path = lib.makeBinPath [
       pkgs.coreutils
+      pkgs.gnused
       pkgs.utillinux
       pkgs.openresolv
     ];


### PR DESCRIPTION
Currently, if you pass multiple consoles to the kernel (e.g.`console=ttyS0 console=tty0`) you only get stage-1 and stage-2 output on the primary console (the last one specified on the command line). This change redirects them to the secondary consoles as well.

systemd's output is still only on the primary console. Need to look into that next.