### PR TITLE
ocaml: 4.07.0+beta2 -> 4.07.0+rc1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.07.nix
+++ b/pkgs/development/compilers/ocaml/4.07.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "07";
-  patch_version = "0+beta2";
-  sha256 = "0rrvl47kq982z2ns7cnasmlbj60mpmza2zyhl1kh45c5a3n7692n";
+  patch_version = "0+rc1";
+  sha256 = "0ggzh078k68na2mahj3nrqkl57i1iv9aymlz8mmlcd8hbvp1fcn8";
 
   # If the executable is stripped it does not work
   dontStrip = true;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

