### PR TITLE
Libprefixed to multioutput/heimdal

### DIFF
--- a/nixos/modules/services/system/kerberos.nix
+++ b/nixos/modules/services/system/kerberos.nix
@@ -42,7 +42,7 @@ in
         protocol = "tcp";
         user = "root";
         server = "${pkgs.tcp_wrappers}/bin/tcpd";
-        serverArgs = "${pkgs.heimdalFull}/bin/kadmind";
+        serverArgs = "${pkgs.heimdalFull}/libexec/heimdal/kadmind";
       };
 
     systemd.services.kdc = {
@@ -51,13 +51,13 @@ in
       preStart = ''
         mkdir -m 0755 -p ${stateDir}
       '';
-      script = "${heimdalFull}/bin/kdc";
+      script = "${heimdalFull}/libexec/heimdal/kdc";
     };
 
     systemd.services.kpasswdd = {
       description = "Kerberos Password Changing daemon";
       wantedBy = [ "multi-user.target" ];
-      script = "${heimdalFull}/bin/kpasswdd";
+      script = "${heimdalFull}/libexec/heimdal/kpasswdd";
     };
   };
 

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1j38wjj4k0q8vx168k3d3k0fwa8j1q5q8f2688nnx1b9qgjd6w1d";
   };
 
-  outputs = [ "out" "bin" "dev" "man" ];
+  outputs = [ "out" "bin" "dev" "man" "info" ];
 
   patches = [ ./heimdal-make-missing-headers.patch ];
 
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
+    "--infodir=$info/share/info"
     "--enable-hdb-openldap-module"
     "--with-sqlite3=${sqlite.dev}"
 
@@ -66,7 +67,6 @@ stdenv.mkDerivation rec {
     (cd lib/hcrypto; make -j $NIX_BUILD_CORES)
   '';
 
-  # FIXME: share/info hits $bin, IDK why, but I decide is to minor to block
   postInstall = ''
     # Install hcrypto
     (cd include/hcrypto; make -j $NIX_BUILD_CORES install)

--- a/pkgs/development/libraries/kerberos/heimdal.nix
+++ b/pkgs/development/libraries/kerberos/heimdal.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1j38wjj4k0q8vx168k3d3k0fwa8j1q5q8f2688nnx1b9qgjd6w1d";
   };
 
-  outputs = [ "out" "bin" "dev" "man" "info" ];
+  outputs = [ "out" "dev" "man" "info" ];
 
   patches = [ ./heimdal-make-missing-headers.patch ];
 
@@ -53,9 +53,9 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     configureFlagsArray+=(
-      "--bindir=$out/bin" # Put binaries to $out, then move them to $bin,
-                          # otherwise we go a cyclic dependecny
+      "--bindir=$out/bin"
       "--sbindir=$out/sbin"
+      "--libexecdir=$out/libexec/heimdal"
       "--mandir=$man/share/man"
       "--infodir=$man/share/info"
       "--includedir=$dev/include")
@@ -75,18 +75,12 @@ stdenv.mkDerivation rec {
     # Do we need it?
     rm $out/bin/su
 
-    # Doesn't succeed with --libexec=$out/sbin, so
     mkdir -p $dev/bin
-    mkdir -p $bin/{,s}bin
-    mv "$out/libexec/heimdal/"* $dev/bin/
-    rmdir $out/libexec/heimdal
-    mv "$out/libexec/"* $bin/sbin/
-    rmdir $out/libexec
+    mv $out/bin/krb5-config $dev/bin/
 
-    mkdir -p $dev/bin && mv $out/bin/krb5-config $dev/bin/
-
-    # Move remaining binaries to $bin
-    mv $out/bin/* $bin/bin/
+    # asn1 compilers, move them to $dev
+    mv $out/libexec/heimdal/heimdal/* $dev/bin
+    rmdir $out/libexec/heimdal/heimdal
   '';
 
   # Issues with hydra

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9700,10 +9700,6 @@ with pkgs;
 
   hamlib = callPackage ../development/libraries/hamlib { };
 
-  # TODO : Let admin choose.
-  # We are using mit-krb5 because it is better maintained
-  kerberos = libkrb5;
-
   heimdal = callPackage ../development/libraries/kerberos/heimdal.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9700,10 +9700,14 @@ with pkgs;
 
   hamlib = callPackage ../development/libraries/hamlib { };
 
+  # TODO : Let admin choose.
+  # We are using mit-krb5 because it is better maintained
+  kerberos = libkrb5;
+
   heimdal = callPackage ../development/libraries/kerberos/heimdal.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
   };
-  libheimdal = heimdal.override { type = "lib"; };
+  libheimdal = heimdal;
 
   harfbuzz = callPackage ../development/libraries/harfbuzz { };
   harfbuzz-icu = harfbuzz.override {


### PR DESCRIPTION
###### Motivation for this change


Say "farewell" to long-lived ad-hoc hack, when we had two derivations for one package -- one for library-only version, second one with programs and daemons built.

This PR contain finalized heimdal rework, factored out of #38494
(because it hard to maintain so long live branch, which cause significant local rebuild)

See #14693 for problem history and details.

Actually I haven't test `nixos` service module, because IDK how to run heimdal kerberos server.
So some feedback for users welcomed.  Applications which build against heimdal kerberos buildds and run (at least some of them, which I tried)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

