### PR TITLE
fcitx-qt5: fix build with Qt 5.11

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-qt5.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules }:
+{ stdenv, lib, fetchurl, cmake, fcitx, pkgconfig, qtbase, extra-cmake-modules
+, fetchpatch
+}:
 
 stdenv.mkDerivation rec {
   name = "fcitx-qt5-${version}";
@@ -8,6 +10,15 @@ stdenv.mkDerivation rec {
     url = "http://download.fcitx-im.org/fcitx-qt5/${name}.tar.xz";
     sha256 = "0z8ax0dxk88byic41mfaiahjdv1k8ciwn97xfjkkgr4ijgscdr8c";
   };
+
+  patches = [
+    # Fix build with Qt 5.11
+    # https://github.com/fcitx/fcitx-qt5/issues/34
+    (fetchpatch {
+      url = https://github.com/fcitx/fcitx-qt5/commit/af033e3d5305108eecc568adff7f8b2da5831ed6.diff;
+      sha256 = "14vfz1fw2k362wnqpglw766fg3d3mc8cmfgic2p96yyipjh9xx3b";
+    })
+  ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/fcitx/fcitx-qt5/issues/34

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

