### PR TITLE
monetdb: 11.29.3 -> 11.29.7

### DIFF
--- a/pkgs/servers/sql/monetdb/default.nix
+++ b/pkgs/servers/sql/monetdb/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, bison, openssl }:
+
+let
+  version = "11.29.7";
+in stdenv.mkDerivation rec {
+
+  name = "monetdb-${version}";
+
+  src = fetchurl {
+    url = "https://dev.monetdb.org/downloads/sources/archive/MonetDB-${version}.tar.bz2";
+    sha256 = "19f9zfg94k8hr9qc7jp1iwl8av08mibzgmid0gbqplyhf6x1j0r7";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ bison openssl ];
+
+  meta = with stdenv.lib; {
+    description = "An open source database system";
+    homepage = https://www.monetdb.org/;
+    license = licenses.mpl20;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.StillerHarpo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

