### PR TITLE
mattermost: 4.10.0 -> 5.0.0

### DIFF
--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -25,7 +25,7 @@ in
 {
   options = {
     services.mattermost = {
-      enable = mkEnableOption "Mattermost chat platform";
+      enable = mkEnableOption "Mattermost chat server";
 
       statePath = mkOption {
         type = types.str;
@@ -167,7 +167,7 @@ in
       '';
 
       systemd.services.mattermost = {
-        description = "Mattermost chat platform service";
+        description = "Mattermost chat service";
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" "postgresql.service" ];
 
@@ -201,7 +201,7 @@ in
           PermissionsStartOnly = true;
           User = cfg.user;
           Group = cfg.group;
-          ExecStart = "${pkgs.mattermost}/bin/mattermost-platform";
+          ExecStart = "${pkgs.mattermost}/bin/mattermost";
           WorkingDirectory = "${cfg.statePath}";
           JoinsNamespaceOf = mkIf cfg.localDatabaseCreate "postgresql.service";
           Restart = "always";

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, buildGoPackage, buildEnv }:
 
 let
-  version = "4.10.0";
+  version = "5.0.0";
 
   mattermost-server = buildGoPackage rec {
     name = "mattermost-server-${version}";
@@ -10,7 +10,7 @@ let
       owner = "mattermost";
       repo = "mattermost-server";
       rev = "v${version}";
-      sha256 = "02isw8qapp35pgriy4w1ar1ppvgc5a10j550hjbc1mylnhzkg1jf";
+      sha256 = "12wiw8k5is78ppazrf26y2xq73kwbafa9w75wjnb1839v2k9sark";
     };
 
     goPackagePath = "github.com/mattermost/mattermost-server";
@@ -20,11 +20,6 @@ let
         -X ${goPackagePath}/model.BuildNumber=nixpkgs-${version}
     '';
 
-    postInstall = ''
-      ln -s $bin/bin/mattermost-server $bin/bin/platform
-      ln -s $bin/bin/mattermost-server $bin/bin/mattermost-platform
-    '';
-
   };
 
   mattermost-webapp = stdenv.mkDerivation {
@@ -32,7 +27,7 @@ let
 
     src = fetchurl {
       url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-      sha256 = "0pfj2dxl4qrv4w6yj0385nw0fa4flcg95kkahs0arwhan5bgifl5";
+      sha256 = "1pal65di6w9idf3rwxh77la1v816h8kama1ilkbs40cpp2vazw3b";
     };
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

There is a new version of Mattermost.

###### Things done

The new version of `mattermost-server` changes the binary name again. Instead of using symlinks to continuously patch over their binary name changes, let's hope they have finally settled on `mattermost` and use that. 

I've built and tested this on NixOS with a 70ish person deployment.

Warning: this version makes some breaking changes, like disabling the v3 API and requires you to put all the schemes you want turned into links on a whitelist. The full list of important changes is at https://docs.mattermost.com/administration/important-upgrade-notes.html.