### PR TITLE
moka-icon-theme: 5.3.6 -> 5.4.0, faba-icon-theme: 2016-09-13 -> 4.3

### DIFF
--- a/pkgs/data/icons/arc-icon-theme/default.nix
+++ b/pkgs/data/icons/arc-icon-theme/default.nix
@@ -20,7 +20,8 @@ stdenv.mkDerivation rec {
     description = "Arc icon theme";
     homepage = https://github.com/horst3180/arc-icon-theme;
     license = licenses.gpl3;
-    platforms = platforms.all;
+    # moka-icon-theme dependency is restricted to linux
+    platforms = platforms.linux;
     maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/data/icons/faba-icon-theme/default.nix
+++ b/pkgs/data/icons/faba-icon-theme/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, elementary-icon-theme, gtk3 }:
+{ stdenv, fetchFromGitHub, meson, ninja, gtk3, elementary-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${package-name}-${version}";
   package-name = "faba-icon-theme";
-  version = "2016-09-13";
+  version = "4.3";
 
   src = fetchFromGitHub {
     owner = "moka-project";
     repo = package-name;
-    rev = "00431894bce5fb1b8caccaee064788996be228a7";
-    sha256 = "0hif030pd4w3s851k0s65w0mf2pik10ha25ycpsv91gpbgarqcns";
+    rev = "v${version}";
+    sha256 = "0xh6ppr73p76z60ym49b4d0liwdc96w41cc5p07d48hxjsa6qd6n";
   };
 
-  nativeBuildInputs = [ autoreconfHook elementary-icon-theme gtk3 ];
+  nativeBuildInputs = [ meson ninja gtk3 elementary-icon-theme ];
 
   postPatch = ''
-    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
+    patchShebangs meson/post_install.py
   '';
-
-  postFixup = "gtk-update-icon-cache $out/share/icons/Faba";
 
   meta = with stdenv.lib; {
     description = "A sexy and modern icon theme with Tango influences";

--- a/pkgs/data/icons/faba-mono-icons/default.nix
+++ b/pkgs/data/icons/faba-mono-icons/default.nix
@@ -24,7 +24,8 @@ stdenv.mkDerivation rec {
     description = "The full set of Faba monochrome panel icons";
     homepage = https://snwh.org/moka;
     license = licenses.gpl3;
-    platforms = platforms.all;
+    # moka-icon-theme dependency is restricted to linux
+    platforms = platforms.linux;
     maintainers = with maintainers; [ romildo ];
   };
 }

--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, faba-icon-theme, gtk3 }:
+{ stdenv, fetchFromGitHub, meson, ninja, gtk3, faba-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "moka-icon-theme";
-  version = "5.3.6";
+  version = "5.4.0";
 
   src = fetchFromGitHub {
     owner = "snwh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "17f8k8z8xvib4hkxq0cw9j7bhdpqpv5frrkyc4sbyildcbavzzbr";
+    sha256 = "015l02im4mha5z91dbchxf6xkp66d346bg3xskwg0rh3lglhjsrd";
   };
 
-  nativeBuildInputs = [ autoreconfHook faba-icon-theme gtk3 ];
+  nativeBuildInputs = [ meson ninja gtk3 faba-icon-theme ];
 
   postPatch = ''
-    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
+    patchShebangs meson/post_install.py
   '';
-
-  postFixup = "gtk-update-icon-cache $out/share/icons/Moka";
 
   meta = with stdenv.lib; {
     description = "An icon theme designed with a minimal flat style using simple geometry and bright colours";

--- a/pkgs/data/icons/moka-icon-theme/default.nix
+++ b/pkgs/data/icons/moka-icon-theme/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
     description = "An icon theme designed with a minimal flat style using simple geometry and bright colours";
     homepage = https://snwh.org/moka;
     license = with licenses; [ cc-by-sa-40 gpl3 ];
-    platforms = platforms.all;
+    # darwin cannot deal with file names differing only in case
+    platforms = platforms.linux;
     maintainers = with maintainers; [ romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Update `moka-icon-theme` to version 5.4.0
- Update `faba-icon-theme` to version 4.3
- Build with meson
- Remove explicitly building of the icon cache, as it is built automatically now
- Restrict `moka-icon-theme` (and its dependents) to linux platforms, because the distributed archive contains file names that differ only in case, which is an issue for darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).