### PR TITLE
tasknc: fix

### DIFF
--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeWrapper, perl, ncurses, taskwarrior }:
+{ stdenv, fetchFromGitHub, makeWrapper, perl, ncurses5, taskwarrior }:
 
 stdenv.mkDerivation rec {
   version = "2017-05-15";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     perl # For generating the man pages with pod2man
   ];
 
-  buildInputs = [ ncurses ];
+  buildInputs = [ ncurses5 ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change
Was broken on master since https://github.com/NixOS/nixpkgs/pull/34477 which updated ncurses to 6.1. Switching to version 5 makes it work again.

Ping @dtzWill

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

