### PR TITLE
haskell: make generic builder follow compiler’s shared config

### DIFF
--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -153,7 +153,10 @@ stdenv.mkDerivation rec {
     [ $(./main) == "yes" ]
   '';
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+    enableShared = true;
+  };
 
   meta.license = stdenv.lib.licenses.bsd3;
   meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin" "armv7l-linux"];

--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -177,6 +177,7 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+    inherit enableShared;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-7.10.3";

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -183,6 +183,7 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+    inherit enableShared;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.0.2";

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -155,7 +155,10 @@ stdenv.mkDerivation rec {
     [ $(./main) == "yes" ]
   '';
 
-  passthru = { targetPrefix = ""; };
+  passthru = {
+    targetPrefix = "";
+    enableShared = true;
+  };
 
   meta.license = stdenv.lib.licenses.bsd3;
   # AArch64 should work in theory but eventually some builds start segfaulting

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -199,6 +199,7 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+    inherit enableShared;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.2.2";

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -193,6 +193,7 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+    inherit enableShared;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.4.3";

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -191,6 +191,7 @@ stdenv.mkDerivation rec {
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
+    inherit enableShared;
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.5";

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -42,6 +42,8 @@ let
     inherit (bootGhcjs) version;
     isGhcjs = true;
 
+    enableShared = true;
+
     socket-io = nodePackages."socket.io";
 
     # Relics of the old GHCJS build system
@@ -96,4 +98,3 @@ in stdenv.mkDerivation {
 
     meta.platforms = passthru.bootPkgs.ghc.meta.platforms;
   }
-

--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -179,6 +179,8 @@ in mkDerivation (rec {
     # let us assume ghcjs is never actually cross compiled
     targetPrefix = "";
 
+    enableShared = true;
+
     inherit stage1Packages;
     mkStage2 = stage2 {
       inherit ghcjsBoot;

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -30,7 +30,7 @@ in
 , profilingDetail ? "all-functions"
 # TODO enable shared libs for cross-compiling
 , enableSharedExecutables ? false
-, enableSharedLibraries ? ((ghc.isGhcjs or false) || stdenv.lib.versionOlder "7.7" ghc.version)
+, enableSharedLibraries ? (ghc.enableShared or false)
 , enableDeadCodeElimination ? (!stdenv.isDarwin)  # TODO: use -dead_strip for darwin
 , enableStaticLibraries ? !hostPlatform.isWindows
 , enableHsc2hsViaAsm ? hostPlatform.isWindows && stdenv.lib.versionAtLeast ghc.version "8.4"


### PR DESCRIPTION
enableShared in generic-builder.nix should default to what the GHC
compiler was compiled with. Add a passthru to all of the GHC compilers
to hold the value of enableShared. If enableShared is not set in the
GHC we just use false as the default value for enableSharedLibraries.

Note: I may have missed some compilers. Only GHC & GHCJS are covered
by this commit but this shouldn’t break evaluation of anything else.
