### PR TITLE
Fix Android-prebuilt ghc build

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -58,6 +58,8 @@ let
   '' + stdenv.lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC
+  '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    EXTRA_CC_OPTS += -std=gnu99
   '';
 
   # Splicer will pull out correct variations

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -121,6 +121,8 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS+=" -no_dtrace_dof"
+  '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
+    sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
   '';
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, m4, cxx ? true
-, buildPackages
+{ stdenv, fetchurl, m4, cxx ? !hostPlatform.useAndroidPrebuilt
+, buildPackages, hostPlatform
 , withStatic ? false }:
 
 let inherit (stdenv.lib) optional optionalString; in


### PR DESCRIPTION
###### Motivation for this change
This should address some of the issues with GHC on prebuilt Android.

Note: even with the GMP fix, GHC will still not use it for cross compilation because the default for all cross GHC will be integer-simple (https://github.com/ghc/ghc/blob/master/mk/flavours/perf-cross.mk#L13) & it is never overriden in the GHC derivtion.