### PR TITLE
clementine: add gst_plugins to buildInputs so setup hooks work

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -72,7 +72,8 @@ let
     name = "clementine-free-${version}";
     inherit src patches nativeBuildInputs postPatch;
 
-    buildInputs = buildInputs ++ [ makeWrapper ];
+    # gst_plugins needed for setup-hooks
+    buildInputs = buildInputs ++ [ makeWrapper gst_plugins ];
 
     cmakeFlags = [ "-DUSE_SYSTEM_PROJECTM=ON" ];
 
@@ -104,7 +105,7 @@ let
       ./clementine-spotify-blob.patch
     ];
 
-    buildInputs = buildInputs ++ [ libspotify makeWrapper gst_plugins ];
+    buildInputs = buildInputs ++ [ libspotify makeWrapper ];
     # Only build and install the Spotify blob
     preBuild = ''
       cd ext/clementine-spotifyblob


### PR DESCRIPTION
when the build was refactored in ef5e212d, this was lost.  a4ba8c65
got most of it back, but missed the addition of gst_plugins to
buildInputs.

fixes #39960

cc @Ma27 @peterhoeg 

I don't claim to really understand what's going on in the setup-hooks that makes this necessary, I'm just glad the comment was there in the parent of ef5e212d :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).