### PR TITLE
lastpass-cli: 1.2.2 -> 1.3.1 (18.03)

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "lastpass-cli-${version}";
 
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "lastpass";
     repo = "lastpass-cli";
     rev = "v${version}";
-    sha256 = "0041z2awpmwq2fk8lbgp4fcia0r6wss2csvq5bxps0cx7fq69wc1";
+    sha256 = "0k3vnlibv05wnn6qn3qjlcyj2s07di7zkmdnijd6cp1hfk76z2r5";
   };
 
   nativeBuildInputs = [ asciidoc cmake docbook_xsl pkgconfig ];

--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -4,13 +4,13 @@
 stdenv.mkDerivation rec {
   name = "lastpass-cli-${version}";
 
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "lastpass";
     repo = "lastpass-cli";
     rev = "v${version}";
-    sha256 = "0k3vnlibv05wnn6qn3qjlcyj2s07di7zkmdnijd6cp1hfk76z2r5";
+    sha256 = "11drzmfdvb8ydw1dxaz9zz8rk0jjqmfv076vydz05qqvgx59s38h";
   };
 
   nativeBuildInputs = [ asciidoc cmake docbook_xsl pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

See: https://github.com/NixOS/nixpkgs/pull/40734

Otherwise `lastpass-cli` errors with:

```
Error: Peer certificate cannot be authenticated with given CA certificates.
```

Both commits were `cherry-pick -x`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ❌ macOS
   - ❌ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

