### PR TITLE
Opensmtpd backport fix

### DIFF
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -5,27 +5,27 @@
 # see also https://github.com/OpenSMTPD/OpenSMTPD/issues/678
 , unpriviledged_smtpctl_encrypt ? true
 
-# Deprecated: use the subaddressing-delimiter in the config file going forward
+# This enables you to override the '+' character which typically separates the user from the tag in user+tag@domain.tld
 , tag_char ? null
 }:
 
 stdenv.mkDerivation rec {
   name = "opensmtpd-${version}";
-  version = "6.0.3p1";
+  version = "6.0.2p1";
 
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ libasr libevent zlib openssl db pam ];
 
   src = fetchurl {
     url = "https://www.opensmtpd.org/archives/${name}.tar.gz";
-    sha256 = "291881862888655565e8bbe3cfb743310f5dc0edb6fd28a889a9a547ad767a81";
+    sha256 = "1b4h64w45hpmfq5721smhg4s0shs64gbcjqjpx3fbiw4hz8bdy9a";
   };
 
   patches = [
     ./proc_path.diff
     (fetchpatch {
-      url = "https://github.com/OpenSMTPD/OpenSMTPD/commit/725ba4fa2ddf23bbcd1ff9ec92e86bbfaa6825c8.diff";
-      sha256 = "19rla0b2r53jpdiz25fcza29c2msz6j6paivxhp9jcy1xl457dqa";
+      url = "https://github.com/Ekleog/OpenSMTPD/commit/80172fb0cd3c90c112bdd9c04fe05d84e6f562c6.diff";
+      sha256 = "1xgfm0mydhv70ndn212fsvlwaf3axl3wdg2v1nqnrbyl919y5a10";
     })
   ];
 

--- a/pkgs/servers/mail/opensmtpd/proc_path.diff
+++ b/pkgs/servers/mail/opensmtpd/proc_path.diff
@@ -1,8 +1,33 @@
+diff --git a/smtpd/parse.y b/smtpd/parse.y
+index ab02719..c1c77d9 100644
+--- a/smtpd/parse.y
++++ b/smtpd/parse.y
+@@ -2534,13 +2534,19 @@ create_filter_proc(char *name, char *prog)
+ {
+ 	struct filter_conf	*f;
+ 	char			*path;
++	const char		*proc_path;
+ 
+ 	if (dict_get(&conf->sc_filters, name)) {
+ 		yyerror("filter \"%s\" already defined", name);
+ 		return (NULL);
+ 	}
+ 
+-	if (asprintf(&path, "%s/filter-%s", PATH_LIBEXEC, prog) == -1) {
++	proc_path = getenv("OPENSMTPD_PROC_PATH");
++	if (proc_path == NULL) {
++		proc_path = PATH_LIBEXEC;
++	}
++
++	if (asprintf(&path, "%s/filter-%s", proc_path, prog) == -1) {
+ 		yyerror("filter \"%s\" asprintf failed", name);
+ 		return (0);
+ 	}
 diff --git a/smtpd/smtpd.c b/smtpd/smtpd.c
-index e049f07c..a1bd03a0 100644
+index afc8891..9b0a80f 100644
 --- a/smtpd/smtpd.c
 +++ b/smtpd/smtpd.c
-@@ -1157,6 +1157,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
+@@ -795,6 +795,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
  	char		path[PATH_MAX];
  	char		name[PATH_MAX];
  	char		*arg;
@@ -10,7 +35,7 @@ index e049f07c..a1bd03a0 100644
  
  	if (strlcpy(name, conf, sizeof(name)) >= sizeof(name)) {
  		log_warnx("warn: %s-proc: conf too long", key);
-@@ -1167,7 +1168,12 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
+@@ -805,7 +806,12 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
  	if (arg)
  		*arg++ = '\0';
  
@@ -25,10 +50,10 @@ index e049f07c..a1bd03a0 100644
  		log_warn("warn: %s-proc: exec path too long", key);
  		return (-1);
 diff --git a/smtpd/table.c b/smtpd/table.c
-index 9cfdfb99..24dfcca4 100644
+index 21ee237..95b5164 100644
 --- a/smtpd/table.c
 +++ b/smtpd/table.c
-@@ -201,6 +201,7 @@ table_create(const char *backend, const char *name, const char *tag,
+@@ -193,6 +193,7 @@ table_create(const char *backend, const char *name, const char *tag,
  	struct table_backend	*tb;
  	char			 buf[LINE_MAX];
  	char			 path[LINE_MAX];
@@ -36,7 +61,7 @@ index 9cfdfb99..24dfcca4 100644
  	size_t			 n;
  	struct stat		 sb;
  
-@@ -215,11 +216,16 @@ table_create(const char *backend, const char *name, const char *tag,
+@@ -207,11 +208,16 @@ table_create(const char *backend, const char *name, const char *tag,
  	if (name && table_find(name, NULL))
  		fatalx("table_create: table \"%s\" already defined", name);
  


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/42168#issuecomment-398932594

The total diff of #42168 and this is the following:
```diff
diff --git a/pkgs/servers/mail/opensmtpd/default.nix b/pkgs/servers/mail/opensmtpd/default.nix
index d2667597c62..80217ee3d6b 100644
--- a/pkgs/servers/mail/opensmtpd/default.nix
+++ b/pkgs/servers/mail/opensmtpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoconf, automake, libtool, bison
+{ stdenv, lib, fetchurl, fetchpatch, autoconf, automake, libtool, bison
 , libasr, libevent, zlib, openssl, db, pam
 
 # opensmtpd requires root for no reason to encrypt passwords, this patch fixes it
@@ -21,7 +21,13 @@ stdenv.mkDerivation rec {
     sha256 = "1b4h64w45hpmfq5721smhg4s0shs64gbcjqjpx3fbiw4hz8bdy9a";
   };
 
-  patches = [ ./proc_path.diff ];
+  patches = [
+    ./proc_path.diff
+    (fetchpatch {
+      url = "https://github.com/Ekleog/OpenSMTPD/commit/80172fb0cd3c90c112bdd9c04fe05d84e6f562c6.diff";
+      sha256 = "1xgfm0mydhv70ndn212fsvlwaf3axl3wdg2v1nqnrbyl919y5a10";
+    })
+  ];
 
   postPatch = with builtins; with lib;
     optionalString (isString tag_char) ''
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

