### PR TITLE
udisks slimming

### DIFF
--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk-doc, libxslt, docbook_xsl
 , docbook_xml_dtd_43, python3, gobjectIntrospection, glib, libudev, kmod, parted, libyaml
-, cryptsetup, devicemapper, dmraid, utillinux, libbytesize, libndctl, nss, volume_key
+, cryptsetup, devicemapper, dmraid, utillinuxMinimal, libbytesize, libndctl, nss, volume_key
+, minimal ? false
 }:
 
 let
@@ -25,9 +26,21 @@ in stdenv.mkDerivation rec {
     autoreconfHook pkgconfig gtk-doc libxslt docbook_xsl docbook_xml_dtd_43 python3 gobjectIntrospection
   ];
 
-  buildInputs = [
-    glib libudev kmod parted cryptsetup devicemapper dmraid utillinux libbytesize libndctl nss volume_key libyaml
+  configureFlags = stdenv.lib.optionals minimal [
+    "--without-btrfs"
+    "--without-dm"
+    "--without-dmraid"
+    "--without-escrow"
+    "--without-kbd"
+    "--without-lvm"
+    "--without-lvm_dbus"
+    "--without-mpath"
+    "--without-vdo"
   ];
+
+  buildInputs = [
+    glib libudev devicemapper kmod parted cryptsetup utillinuxMinimal libbytesize libndctl nss
+  ] ++ stdenv.lib.optionals (!minimal) [ dmraid volume_key libyaml ];
 
   meta = with stdenv.lib; {
     description = "A library for manipulating block devices";

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, systemd, libudev, utillinux, coreutils, libuuid
+{ stdenv, fetchurl, fetchpatch, pkgconfig, eudev, libudev, utillinux, coreutils, libuuid
 , thin-provisioning-tools, enable_dmeventd ? false }:
 
 let
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   preConfigure =
     ''
       substituteInPlace scripts/lvm2_activation_generator_systemd_red_hat.c \
-        --replace /usr/bin/udevadm ${systemd}/bin/udevadm
+        --replace /usr/bin/udevadm ${eudev}/bin/udevadm
 
       sed -i /DEFAULT_SYS_DIR/d Makefile.in
       sed -i /DEFAULT_PROFILE_DIR/d conf/Makefile.in

--- a/pkgs/tools/filesystems/ntfs-3g/default.nix
+++ b/pkgs/tools/filesystems/ntfs-3g/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, fetchpatch, utillinux, libuuid
+{stdenv, fetchurl, fetchpatch, utillinuxMinimal, libuuid
 , crypto ? false, libgcrypt, gnutls, pkgconfig}:
 
 stdenv.mkDerivation rec {
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Makefile.in --replace /sbin '@sbindir@'
     substituteInPlace ntfsprogs/Makefile.in --replace /sbin '@sbindir@'
     substituteInPlace libfuse-lite/mount_util.c \
-      --replace /bin/mount ${utillinux}/bin/mount \
-      --replace /bin/umount ${utillinux}/bin/umount
+      --replace /bin/mount ${utillinuxMinimal}/bin/mount \
+      --replace /bin/umount ${utillinuxMinimal}/bin/umount
   '';
 
   configureFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14390,6 +14390,7 @@ with pkgs;
   udisks1 = callPackage ../os-specific/linux/udisks/1-default.nix { };
   udisks2 = callPackage ../os-specific/linux/udisks/2-default.nix { };
   udisks = udisks2;
+  udisksMinimal = udisks2.override { minimal = true; };
 
   udisks_glue = callPackage ../os-specific/linux/udisks-glue { };
 


### PR DESCRIPTION
###### Motivation for this change
Removed `python2` from the closure, reducing its size from 353M to 297M.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

