### PR TITLE
Gnome-latex: init at 3.28.1

### DIFF
--- a/pkgs/applications/editors/gnome-latex/default.nix
+++ b/pkgs/applications/editors/gnome-latex/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, wrapGAppsHook
+, tepl, amtk, gnome3, glib, pkgconfig, intltool, itstool, libxml2 }:
+let
+  version = "3.28.1";
+  pname = "gnome-latex";
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1z481izrx057wraphnr82kxnpmmi8nvl7jswyylzm22kfs0mw402";
+  };
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+  configureFlags = ["--disable-dconf-migration"];
+
+  nativeBuildInputs = [
+    pkgconfig
+    wrapGAppsHook
+    itstool
+    intltool
+  ];
+
+  buildInputs = with gnome3; [
+    amtk
+    defaultIconTheme
+    glib
+    gsettings-desktop-schemas
+    gspell
+    gtksourceview4
+    libgee
+    libxml2
+    tepl
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = gnome3.updateScript { packageName = pname; };
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/GNOME-LaTeX;
+    description = "A LaTeX editor for the GNOME desktop";
+    maintainers = [ maintainers.manveru ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/amtk/default.nix
+++ b/pkgs/development/libraries/amtk/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl
+, pkgconfig, gnome3, dbus, xvfb_run }:
+let
+  version = "4.99.1";
+  pname = "amtk";
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "00fhvw5y638z584s8cfdslh47ngfzcgx4f0b0456sw8p754j3f8d";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    dbus
+  ];
+
+  buildInputs = [
+    gnome3.gtk
+  ];
+
+  doCheck = stdenv.isLinux;
+  checkPhase = ''
+    export NO_AT_BRIDGE=1
+    ${xvfb_run}/bin/xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+      --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      make check
+  '';
+
+  passthru.updateScript = gnome3.updateScript { packageName = pname; };
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Projects/Amtk;
+    description = "Actions, Menus and Toolbars Kit for GTK+ applications";
+    maintainers = [ maintainers.manveru ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/tepl/default.nix
+++ b/pkgs/development/libraries/tepl/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl
+, amtk, gnome3, gtksourceview4, libuchardet, libxml2, pkgconfig }:
+let
+  version = "4.1.1";
+  pname = "tepl";
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "13kflywpc6iyfpc9baaa54in5vzn4p7i3dh9pr2ival2nkxfnkp2";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    amtk
+    libxml2
+    gtksourceview4
+    libuchardet
+    gnome3.gtk
+  ];
+
+  doCheck = false;
+  # TODO: one test fails because of
+  # (./test-file-metadata:20931): Tepl-WARNING **: 14:41:36.942: GVfs metadata
+  # is not supported. Fallback to TeplMetadataManager. Either GVfs is not
+  # correctly installed or GVfs metadata are not supported on this platform. In
+  # the latter case, you should configure Tepl with --disable-gvfs-metadata.
+
+  passthru.updateScript = gnome3.updateScript { packageName = pname; };
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Projects/Tepl;
+    description = "Text editor product line";
+    maintainers = [ maintainers.manveru ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7574,6 +7574,8 @@ with pkgs;
     samples = true;
   };
 
+  amtk = callPackage ../development/libraries/amtk { };
+
   avrgcclibc = throw "avrgcclibs are now separate packages, install avrbinutils, avrgcc and avrlibc";
 
   avrbinutils = callPackage ../development/misc/avr/binutils {};
@@ -8054,6 +8056,8 @@ with pkgs;
   gnome-desktop-testing = callPackage ../development/tools/gnome-desktop-testing {};
 
   gnome-usage = callPackage ../applications/misc/gnome-usage {};
+
+  gnome-latex = callPackage ../applications/editors/gnome-latex/default.nix { };
 
   gnum4 = callPackage ../development/tools/misc/gnum4 { };
   m4 = gnum4;
@@ -11840,6 +11844,8 @@ with pkgs;
   tecla = callPackage ../development/libraries/tecla { };
 
   tectonic = callPackage ../tools/typesetting/tectonic { };
+
+  tepl = callPackage ../development/libraries/tepl { };
 
   telepathy-glib = callPackage ../development/libraries/telepathy/glib { };
 


### PR DESCRIPTION
###### Motivation for this change

Package request in https://github.com/NixOS/nixpkgs/issues/42261

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

