### PR TITLE
tests.plasma5: Fixes OCR in sddm by providing a custom theme

### DIFF
--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -6,13 +6,28 @@ import ./make-test.nix ({ pkgs, ...} :
     maintainers = [ ttuegel ];
   };
 
-  machine = { lib, ... }: {
+  machine = { lib, ... }:
+  let
+    sddm_theme = pkgs.stdenv.mkDerivation {
+      name = "breeze-ocr-theme";
+      phases = "buildPhase";
+      buildCommand = ''
+        mkdir -p $out/share/sddm/themes/
+        cp -r ${pkgs.plasma-workspace}/share/sddm/themes/breeze $out/share/sddm/themes/breeze-ocr-theme
+        chmod -R +w $out/share/sddm/themes/breeze-ocr-theme
+        printf "[General]\ntype=color\ncolor=#1d99f3\nbackground=\n" > $out/share/sddm/themes/breeze-ocr-theme/theme.conf
+      '';
+    };
+  in
+  {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.displayManager.sddm.enable = true;
+    services.xserver.displayManager.sddm.theme = "breeze-ocr-theme";
     services.xserver.desktopManager.plasma5.enable = true;
     services.xserver.desktopManager.default = "plasma5";
     virtualisation.memorySize = 1024;
+    environment.systemPackages = [ sddm_theme ];
 
     # fontconfig-penultimate-0.3.3 -> 0.3.4 broke OCR apparently, but no idea why.
     nixpkgs.config.packageOverrides = superPkgs: {
@@ -30,7 +45,6 @@ import ./make-test.nix ({ pkgs, ...} :
     xdo = "${pkgs.xdotool}/bin/xdotool";
   in ''
     startAll;
-
     # Wait for display manager to start
     $machine->waitForText(qr/${user.description}/);
     $machine->screenshot("sddm");


### PR DESCRIPTION
The custom theme just sets the old background colour that OCR works
again.

###### Motivation for this change
Fixes: https://github.com/NixOS/nixpkgs/issues/42315

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

