### PR TITLE
add erlang-21.0

### DIFF
--- a/pkgs/development/interpreters/erlang/R21.nix
+++ b/pkgs/development/interpreters/erlang/R21.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, fetchurl }:
+
+mkDerivation rec {
+  version = "21.0";
+  sha256 = "0khprgawmbdpn9b8jw2kksmvs6b45mibpjralsc0ggxym1397vm8";
+
+  prePatch = ''
+    substituteInPlace configure.in --replace '`sw_vers -productVersion`' '10.10'
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7175,7 +7175,7 @@ with pkgs;
   beam = callPackage ./beam-packages.nix { };
 
   inherit (beam.interpreters)
-    erlang erlangR18 erlangR19 erlangR20
+    erlang erlangR18 erlangR19 erlangR20 erlangR21
     erlang_odbc erlang_javac erlang_odbc_javac erlang_nox erlang_basho_R16B02
     elixir elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3
     lfe lfe_1_2;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -41,6 +41,15 @@ rec {
       javacSupport = true; odbcSupport = true;
     };
     erlangR20_nox = erlangR20.override { wxSupport = false; };
+    erlangR21 = lib.callErlang ../development/interpreters/erlang/R21.nix {
+      wxGTK = wxGTK30;
+    };
+    erlangR21_odbc = erlangR21.override { odbcSupport = true; };
+    erlangR21_javac = erlangR21.override { javacSupport = true; };
+    erlangR21_odbc_javac = erlangR21.override {
+      javacSupport = true; odbcSupport = true;
+    };
+    erlangR21_nox = erlangR21.override { wxSupport = false; };
 
     # Basho fork, using custom builder.
     erlang_basho_R16B02 = lib.callErlang ../development/interpreters/erlang/R16B02-basho.nix {
@@ -69,6 +78,7 @@ rec {
     erlangR18 = packagesWith interpreters.erlangR18;
     erlangR19 = packagesWith interpreters.erlangR19;
     erlangR20 = packagesWith interpreters.erlangR20;
+    erlangR21 = packagesWith interpreters.erlangR21;
 
   };
 }


### PR DESCRIPTION
###### Motivation for this change
A new major revision of Erlang OTP was recently released (21).

The PR adds package `erlangR21`.  The default `erlang` remains as `erlangR19`.  There are no packages that depend on `erlangR21` at this moment.

I used this build for some development on [erlang_nif-sys](https://github.com/goertzenator/erlang_nif-sys).  I had no issues.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

