### PR TITLE
linux: Switch to schedutil governor

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -75,6 +75,11 @@ with stdenv.lib;
   ''}
   INTEL_IDLE y
   CPU_FREQ_DEFAULT_GOV_PERFORMANCE y
+  ${optionalString (versionAtLeast version "4.9") ''
+    CPU_FREQ_GOV_SCHEDUTIL y
+    CPU_FREQ_DEFAULT_GOV_SCHEDUTIL y
+    CPU_FREQ_DEFAULT_GOV_PERFORMANCE n
+  ''}
   ${optionalString (versionOlder version "3.10") ''
     USB_SUSPEND y
   ''}


### PR DESCRIPTION
###### Motivation for this change

Since 4.9, the Linux kernel has included the "schedutil" CPU governor (in its current implementation):  https://cateee.net/lkddb/web-lkddb/CPU_FREQ_GOV_SCHEDUTIL.html 

This governor adjusts the CPU frequency based on utilization data provided by the scheduler.

Switching to this governor should allow for energy-savings while still making "high-performance" possible.

Closes #41003

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Add these to my config:
```nix
boot.kernelParams = [ "intel_pstate=passive" ];
powerManagement.cpuFreqGovernor = "schedutil";
```

```shell
λ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
schedutil
λ cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors
performance schedutil
λ systemctl status cpufreq.service
● cpufreq.service - CPU Frequency Governor Setup
   Loaded: loaded (/nix/store/lzk05z7a3l0gslpsbrmh8qcacmvzw65x-unit-cpufreq.service/cpufreq.service; enabled; vendor preset: enabled)
   Active: active (exited) since Thu 2018-06-21 10:30:01 EDT; 35min ago
  Process: 838 ExecStart=/nix/store/c1zaswjv476fyxdkl78yr6816wnp9qrb-cpupower-4.16.16/bin/cpupower frequency-set -g schedutil (code=exited, status=0/SUCCESS)
 Main PID: 838 (code=exited, status=0/SUCCESS)

Jun 21 10:30:01 nixus-desktop systemd[1]: Starting CPU Frequency Governor Setup...
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 0
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 1
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 2
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 3
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 4
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 5
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 6
Jun 21 10:30:01 nixus-desktop cpupower[838]: Setting cpu: 7
Jun 21 10:30:01 nixus-desktop systemd[1]: Started CPU Frequency Governor Setup.
```