### PR TITLE
luxcorerender: init at 2.0, embree: init at 2.17.4

### DIFF
--- a/pkgs/development/libraries/embree/2.x.nix
+++ b/pkgs/development/libraries/embree/2.x.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, ispc, tbb, glfw,
+openimageio, libjpeg, libpng, libpthreadstubs, libX11
+}:
+
+stdenv.mkDerivation rec {
+  name = "embree-${version}";
+  version = "2.17.4";
+
+  src = fetchFromGitHub {
+    owner = "embree";
+    repo = "embree";
+    rev = "v2.17.4";
+    sha256 = "0q3r724r58j4b6cbyy657fsb78z7a2c7d5mwdp7552skynsn2mn9";
+  };
+
+  cmakeFlags = [ "-DEMBREE_TUTORIALS=OFF" ];
+  enableParallelBuilding = true;
+  
+  buildInputs = [ pkgconfig cmake ispc tbb glfw openimageio libjpeg libpng libX11 libpthreadstubs ];
+  meta = with stdenv.lib; {
+    description = "High performance ray tracing kernels from Intel"; 
+    homepage = https://embree.github.io/;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -1,0 +1,87 @@
+{ stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, python35
+, tbb, openimageio, libjpeg, libpng, zlib, libtiff, ilmbase
+, freetype, openexr, libXdmcp, libxkbcommon, epoxy, at-spi2-core
+, dbus, doxygen, qt5, c-blosc, mesa_glu, gnome3, pcre
+, bison, flex, libpthreadstubs, libX11
+, embree2, makeWrapper, gsettings_desktop_schemas, glib
+, withOpenCL ? true , opencl-headers, ocl-icd, opencl-clhpp
+}:
+
+let boost_static = boost165.override {
+      python = python35;
+      enableStatic = true;
+    };
+
+in stdenv.mkDerivation rec {
+  name = "luxcorerender-${version}";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "LuxCoreRender";
+    repo = "LuxCore";
+    rev = "luxcorerender_v2.0";
+    sha256 = "15nn39ybsfjf3cw3xgkbarvxn4a9ymfd579ankm7yjxkw5gcif38";
+  };
+
+  buildInputs =
+   [ embree2 pkgconfig cmake zlib boost_static libjpeg
+     libtiff libpng ilmbase freetype openexr openimageio
+     tbb qt5.full c-blosc mesa_glu pcre bison
+     flex libX11 libpthreadstubs python35 libXdmcp libxkbcommon
+     epoxy at-spi2-core dbus doxygen
+     # needed for GSETTINGS_SCHEMAS_PATH
+     gsettings_desktop_schemas glib gnome3.gtk
+     # needed for XDG_ICON_DIRS
+     gnome3.defaultIconTheme
+     makeWrapper
+     (stdenv.lib.getLib gnome3.dconf)
+   ] ++ stdenv.lib.optionals withOpenCL [opencl-headers ocl-icd opencl-clhpp];
+
+  cmakeFlags = [
+    "-DOpenEXR_Iex_INCLUDE_DIR=${openexr.dev}/include/OpenEXR"
+    "-DOpenEXR_IlmThread_INCLUDE_DIR=${ilmbase.dev}/include/OpenEXR"
+    "-DOpenEXR_Imath_INCLUDE_DIR=${openexr.dev}/include/OpenEXR"
+    "-DOpenEXR_half_INCLUDE_DIR=${ilmbase.dev}/include"
+    "-DPYTHON_LIBRARY=${python35}/lib/libpython3.so"
+    "-DPYTHON_INCLUDE_DIR=${python35}/include/python3.5"
+    "-DEMBREE_INCLUDE_PATH=${embree2}/include"
+    "-DEMBREE_LIBRARY=${embree2}/lib/libembree.so"
+    "-DBoost_PYTHON_LIBRARY_RELEASE=${boost_static}/lib/libboost_python3-mt.so"
+  ] ++ stdenv.lib.optional withOpenCL
+       "-DOPENCL_INCLUDE_DIR=${opencl-headers}/include";
+  preConfigure = ''
+    NIX_CFLAGS_COMPILE+=" -isystem ${python35}/include/python3.5"
+    NIX_LDFLAGS+=" -lpython3"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/lib
+    cp -va bin/* $out/bin
+    cp -va lib/* $out/lib
+  '';
+
+  preFixup = ''
+    wrapProgram "$out/bin/luxcoreui" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+      --suffix XDG_DATA_DIRS : '${gnome3.defaultIconTheme}/share' \
+      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open source, physically based, unbiased rendering engine";
+    homepage = https://luxcorerender.org/;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}
+
+
+# TODO (might not be necessary):
+#
+# luxcoreui still gives warnings like: "failed to commit changes to
+# dconf: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The
+# name ca.desrt.dconf was not provided by any .service files"
+
+# CMake complains of the FindOpenGL/GLVND preference

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2227,6 +2227,8 @@ with pkgs;
     callPackage ../servers/search/elasticsearch/plugins.nix { }
   );
 
+  embree2 = callPackage ../development/libraries/embree/2.x.nix { };
+
   emem = callPackage ../applications/misc/emem { };
 
   emv = callPackage ../tools/misc/emv { };
@@ -3690,6 +3692,8 @@ with pkgs;
 
   lzip = callPackage ../tools/compression/lzip { };
 
+  luxcorerender = callPackage ../tools/graphics/luxcorerender { };
+  
   xz = callPackage ../tools/compression/xz { };
 
   lz4 = callPackage ../tools/compression/lz4 { };


### PR DESCRIPTION
###### Motivation for this change

LuxCoreRender is one of the larger open-source renderers still updated, and I was building it on NixOS anyway. Embree 2.x is a dependency that also needed packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

