### PR TITLE
pythonPackages.seekpath: init at 1.8.1

### DIFF
--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, future, spglib, glibcLocales }:
+
+buildPythonPackage rec {
+  pname = "seekpath";
+  version = "1.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bdc0400c96952525b1165894807e4bec90aaedb11cfeb27a57414e6091eb026";
+  };  
+
+  LC_ALL = "en_US.utf-8";
+
+  propagatedBuildInputs = [ numpy spglib future ];
+
+  nativeBuildInputs = [ glibcLocales ];
+
+  meta = with stdenv.lib; {
+    description = "A module to obtain and visualize band paths in the Brillouin zone of crystal structures.";
+    homepage = https://github.com/giovannipizzi/seekpath;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -458,6 +458,8 @@ in {
 
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
+  seekpath = callPackage ../development/python-modules/seekpath { };
+
   serversyncstorage = callPackage ../development/python-modules/serversyncstorage {};
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

