### PR TITLE
18.03-google-authenticator-failed-to-use-libqrencode - use libqrencod…

### DIFF
--- a/pkgs/os-specific/linux/google-authenticator/default.nix
+++ b/pkgs/os-specific/linux/google-authenticator/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "google-authenticator-libpam-${version}";
-  version = "1.03";
+  version = "1.05";
 
   src = fetchurl {
     url = "https://github.com/google/google-authenticator-libpam/archive/${version}.tar.gz";
-    sha256 = "0wb95z5v1w4sk0p7y9pbn4v95w9hrbf80vw9k2z2sgs0156ljkb7";
+    sha256 = "026vljmddi0zqcb3c0vdpabmi4r17kahc00mh6fs3qbyjbb14946";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ pam ];
 
   preConfigure = ''
-    sed -i "s|libqrencode.so.3|${qrencode}/lib/libqrencode.so.3|" src/google-authenticator.c
+    sed -i "s|libqrencode.so.4|${qrencode}/lib/libqrencode.so.4|" src/google-authenticator.c
   '';
 
   installPhase = ''

--- a/pkgs/tools/graphics/qrencode/default.nix
+++ b/pkgs/tools/graphics/qrencode/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, libpng, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "qrencode-4.0.0";
+  name = "qrencode-4.0.2";
 
   src = fetchurl {
     url = "${meta.homepage}/${name}.tar.bz2";
-    sha256 = "02vx69fl52jbcrmnydsaxcmy6nxqm9jyxzd7hr07s491d7hka069";
+    sha256 = "1d2q5d3v8g3hsi3h5jq4n177bjhf3kawms09immw7p187f6jgjy9";
   };
 
   buildInputs = [ libpng ];


### PR DESCRIPTION
…e 4 and update both qrencode and google-authenticator

###### Motivation for this change
 #42337 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

