### PR TITLE
appleseed: init at 1.9.0-beta, osl: init at 1.9.9, seexpr: init at 2.11

### DIFF
--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -1,0 +1,39 @@
+{ clangStdenv, stdenv, fetchFromGitHub, cmake, zlib, openexr,
+openimageio, llvm, boost165, flex, bison, partio, pugixml,
+utillinux, python
+}:
+
+let boost_static = boost165.override { enableStatic = true; };
+in clangStdenv.mkDerivation rec {
+  # In theory this could use GCC + Clang rather than just Clang,
+  # but https://github.com/NixOS/nixpkgs/issues/29877 stops this
+  name = "openshadinglanguage-${version}";
+  version = "1.9.9";
+
+  src = fetchFromGitHub {
+    owner = "imageworks";
+    repo = "OpenShadingLanguage";
+    rev = "Release-1.9.9";
+    sha256 = "1w6wbz013nirzsiw11c9dpdkcwlfncs5va8q583pdw0q2pfkj5dn";
+  };
+
+  cmakeFlags = [ "-DUSE_BOOST_WAVE=ON" "-DENABLERTTI=ON" ];
+  enableParallelBuilding = true;
+
+  preConfigure = '' patchShebangs src/liboslexec/serialize-bc.bash '';
+  
+  buildInputs = [
+     cmake zlib openexr openimageio llvm
+     boost_static flex bison partio pugixml
+     utillinux # needed just for hexdump
+     python # CMake doesn't check this?
+  ];
+  # TODO: How important is partio? CMake doesn't seem to find it
+  meta = with stdenv.lib; {
+    description = "Advanced shading language for production GI renderers";
+    homepage = http://opensource.imageworks.com/?p=osl;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/compilers/seexpr/default.nix
+++ b/pkgs/development/compilers/seexpr/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, libpng, zlib, qt4,
+bison, flex, mesa_glu, pythonPackages
+}:
+
+stdenv.mkDerivation rec {
+  name = "seexpr-${version}";
+  version = "2.11";
+  src = fetchFromGitHub {
+    owner  = "wdas";
+    repo   = "SeExpr";
+    rev    = "v2.11";
+    sha256 = "0a44k56jf6dl36fwgg4zpc252wq5lf9cblg74mp73k82hxw439l4";
+  };
+
+  buildInputs = [ cmake mesa_glu libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
+  meta = with stdenv.lib; {
+    description = "Embeddable expression evaluation engine from Disney Animation";
+    homepage = https://www.disneyanimation.com/technology/seexpr.html;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, guile,
+eigen3_3, libpng, python, mesa_glu, qt4, openexr, openimageio,
+opencolorio, xercesc, ilmbase, osl, seexpr
+}:
+
+let boost_static = boost165.override { enableStatic = true; };
+in stdenv.mkDerivation rec {
+
+  name = "appleseed-${version}";
+  version = "1.9.0-beta";
+
+  src = fetchFromGitHub {
+    owner  = "appleseedhq";
+    repo   = "appleseed";
+    rev    = "1.9.0-beta";
+    sha256 = "0m7zvfkdjfn48zzaxh2wa1bsaj4l876a05bzgmjlfq5dz3202anr";
+  };
+  buildInputs = [
+    cmake pkgconfig boost_static guile eigen3_3 libpng python
+    mesa_glu qt4 openexr openimageio opencolorio xercesc
+    osl seexpr
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${openexr.dev}/include/OpenEXR -I${ilmbase.dev}/include/OpenEXR -I${openimageio.dev}/include/OpenImageIO";
+
+  cmakeFlags = [
+      "-DUSE_EXTERNAL_XERCES=ON" "-DUSE_EXTERNAL_OCIO=ON" "-DUSE_EXTERNAL_OIIO=ON"
+      "-DUSE_EXTERNAL_OSL=ON" "-DWITH_CLI=ON" "-DWITH_STUDIO=ON" "-DWITH_TOOLS=ON"
+      "-DUSE_EXTERNAL_PNG=ON" "-DUSE_EXTERNAL_ZLIB=ON"
+      "-DUSE_EXTERNAL_EXR=ON" "-DUSE_EXTERNAL_SEEXPR=ON"
+      "-DWITH_PYTHON2_BINDINGS=ON"
+      # TODO: Look further into this if someone needs Python 3.x:
+      # "-DWITH_PYTHON3_BINDINGS=ON"
+      "-DWITH_DISNEY_MATERIAL=ON"
+      "-DUSE_SSE=ON"
+      "-DUSE_SSE42=ON"
+  ];
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Open source, physically-based global illumination rendering engine";
+    homepage = https://appleseedhq.net/;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}
+
+# TODO: Is the below problematic?
+
+# CMake Warning (dev) at /nix/store/dsyw2zla2h3ld2p0jj4cv0j3wal1bp3h-cmake-3.11.2/share/cmake-3.11/Modules/FindOpenGL.cmake:270 (message):
+#  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
+#  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
+#  cmake_policy command to set the policy and suppress this warning.
+#
+#  FindOpenGL found both a legacy GL library:
+#
+#    OPENGL_gl_LIBRARY: /nix/store/yxrgmcz2xlgn113wz978a91qbsy4rc8g-libGL-1.0.0/lib/libGL.so
+#
+#  and GLVND libraries for OpenGL and GLX:
+#
+#    OPENGL_opengl_LIBRARY: /nix/store/yxrgmcz2xlgn113wz978a91qbsy4rc8g-libGL-1.0.0/lib/libOpenGL.so
+#    OPENGL_glx_LIBRARY: /nix/store/yxrgmcz2xlgn113wz978a91qbsy4rc8g-libGL-1.0.0/lib/libGLX.so
+#
+#  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
+#  compatibility with CMake 3.10 and below the legacy GL library will be used.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1501,6 +1501,8 @@ with pkgs;
 
   appdata-tools = callPackage ../tools/misc/appdata-tools { };
 
+  appleseed = callPackage ../tools/graphics/appleseed { };
+
   arping = callPackage ../tools/networking/arping { };
 
   arpoison = callPackage ../tools/networking/arpoison { };
@@ -4263,6 +4265,8 @@ with pkgs;
 
   os-prober = callPackage ../tools/misc/os-prober {};
 
+  osl = callPackage ../development/compilers/osl { };
+
   ossec = callPackage ../tools/security/ossec {};
 
   ostree = callPackage ../tools/misc/ostree { };
@@ -4945,6 +4949,8 @@ with pkgs;
 
   securefs = callPackage ../tools/filesystems/securefs { };
 
+  seexpr = callPackage ../development/compilers/seexpr { };
+ 
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };


### PR DESCRIPTION
###### Motivation for this change

This sort of goes alongside https://github.com/NixOS/nixpkgs/pull/42334 but the commits don't relate at all - it was just when I was in the process of packaging some 3D renderers. Open Shading Language and SeExpr are both dependencies that I had to add in the process.

Blender can be built with Open Shading Language support, but I will worry about adding this later.

This may build elsewhere than NixOS but I don't have a machine to test this on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

