### PR TITLE
python3Packages.git-annex-adapter: fix build

### DIFF
--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, fetchurl
-, utillinux, pygit2, gitMinimal, git-annex }:
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, fetchpatch
+, utillinux, pygit2, gitMinimal, git-annex
+}:
 
 buildPythonPackage rec {
   pname = "git-annex-adapter";
@@ -22,10 +23,13 @@ buildPythonPackage rec {
   '';
 
   # TODO: Remove for next version
-  patches = fetchurl {
-    url = "https://github.com/alpernebbi/git-annex-adapter/commit/9f64c4b99cae7b681820c6c7382e1e40489f4d1e.patch";
-    sha256 = "1hbw8651amjskakvs1wv2msd1wryrq0vpryvbispg5267rs8q7hp";
-  };
+  patches = [
+    ./not-a-git-repo-testcase.patch
+    (fetchpatch {
+      url = "https://github.com/alpernebbi/git-annex-adapter/commit/9f64c4b99cae7b681820c6c7382e1e40489f4d1e.patch";
+      sha256 = "0yh66gial6bx7kbl7s7lkzljnkpgvgr8yahqqcq9z76d0w752dir";
+    })
+  ];
 
   checkInputs = [
     utillinux # `rev` is needed in tests/test_process.py
@@ -43,6 +47,6 @@ buildPythonPackage rec {
     homepage = https://github.com/alpernebbi/git-annex-adapter;
     description = "Call git-annex commands from Python";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ dotlambda ];
+    maintainers = with maintainers; [ dotlambda ma27 ];
   };
 }

--- a/pkgs/development/python-modules/git-annex-adapter/not-a-git-repo-testcase.patch
+++ b/pkgs/development/python-modules/git-annex-adapter/not-a-git-repo-testcase.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_process.py b/tests/test_process.py
+index 493fc8f..feb1833 100644
+--- a/tests/test_process.py
++++ b/tests/test_process.py
+@@ -126,7 +126,7 @@ class TestProcessOnEmptyDir(TempDirTestCase):
+         with self.assertRaises(subprocess.CalledProcessError) as cm:
+             runner('status', '-sb')
+         self.assertIn(
+-            "fatal: Not a git repository",
++            "fatal: not a git repository",
+             cm.exception.stderr,
+         )
+ 


### PR DESCRIPTION
###### Motivation for this change

The exception message is broken becuase of some uppercase vs. lowercase
issues that have been patched accordingly.

Additionally use `fetchpatch` rather than `fetchurl` to apply patches
into the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

