### PR TITLE
yabar: fix build

### DIFF
--- a/pkgs/applications/window-managers/yabar/build.nix
+++ b/pkgs/applications/window-managers/yabar/build.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cairo, gdk_pixbuf, libconfig, pango, pkgconfig
 , xcbutilwm, alsaLib, wirelesstools, asciidoc, libxslt, makeWrapper, docbook_xsl
 , configFile ? null, lib
-, rev, sha256, version
+, rev, sha256, version, patches ? []
 }:
 
 stdenv.mkDerivation {
@@ -13,6 +13,8 @@ stdenv.mkDerivation {
     owner = "geommer";
     repo  = "yabar";
   };
+
+  inherit patches;
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/window-managers/yabar/default.nix
+++ b/pkgs/applications/window-managers/yabar/default.nix
@@ -1,10 +1,18 @@
-{ callPackage, attrs ? {} }:
+{ callPackage, attrs ? {}, fetchpatch }:
 
 let
-  overrides = {
+  overrides = rec {
     version = "0.4.0";
 
-    rev = "746387f0112f9b7aa2e2e27b3d69cb2892d8c63b";
+    rev = version;
     sha256 = "1nw9dar1caqln5fr0dqk7dg6naazbpfwwzxwlkxz42shsc3w30a6";
+
+    patches = [
+      (fetchpatch {
+        url = "https://github.com/geommer/yabar/commit/9779a5e04bd6e8cdc1c9fcf5d7ac31416af85a53.patch";
+        sha256 = "1szhr3k1kq6ixgnp74wnzgfvgxm6r4zpc3ny2x2wzy6lh2czc07s";
+      })
+    ];
+
   } // attrs;
 in callPackage ./build.nix overrides


### PR DESCRIPTION
###### Motivation for this change

The stable build for `yabar` is currently broken: https://hydra.nixos.org/build/75989172

Main reason is that the inline function `ya_setup_prefix_suffix` is
supposed to be an inline function, but was insufficiently declared as
such which broke the compiler recently with the following message:

```
gcc -std=c99 -Iinclude -pedantic -Wall -Os `pkg-config --cflags pango pangocairo libconfig` -DVERSION=\"0.4.0\" -D_POSIX_C_SOURCE=199309L -DYA_INTERNAL -DYA_DYN_COL -DYA_ENV_VARS -DYA_INTERNAL_EWMH  -c -o src/intern_blks/ya_intern.o src/intern_blks/ya_intern.c
gcc -o yabar src/ya_main.o src/ya_draw.o src/ya_exec.o src/ya_parse.o src/intern_blks/ya_intern.o -lxcb -lpthread -lxcb-randr -lxcb-ewmh `pkg-config --libs pango pangocairo libconfig`
src/intern_blks/ya_intern.o: In function `ya_int_date':
ya_intern.c:(.text+0x49): undefined reference to `ya_setup_prefix_suffix'
src/intern_blks/ya_intern.o: In function `ya_int_uptime':
ya_intern.c:(.text+0xf4): undefined reference to `ya_setup_prefix_suffix'
src/intern_blks/ya_intern.o: In function `ya_int_brightness':
ya_intern.c:(.text+0x1d8): undefined reference to `ya_setup_prefix_suffix'
src/intern_blks/ya_intern.o: In function `ya_int_bandwidth':
ya_intern.c:(.text+0x377): undefined reference to `ya_setup_prefix_suffix'
src/intern_blks/ya_intern.o: In function `ya_int_cpu':
ya_intern.c:(.text+0x6de): undefined reference to `ya_setup_prefix_suffix'
src/intern_blks/ya_intern.o:ya_intern.c:(.text+0x924): more undefined references to `ya_setup_prefix_suffix' follow
collect2: error: ld returned 1 exit status
make: *** [Makefile:18: yabar] Error 1
```

This issue has been fixed on master (see
https://github.com/geommer/yabar/commit/9779a5e04bd6e8cdc1c9fcf5d7ac31416af85a53)
which is why `nixos.yabar-unstable` remained functional.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

