### PR TITLE
pythonPackages.thumbor: 6.4.2 -> 6.5.1

### DIFF
--- a/pkgs/development/python-modules/thumbor/default.nix
+++ b/pkgs/development/python-modules/thumbor/default.nix
@@ -1,25 +1,18 @@
 { buildPythonPackage, stdenv, tornado, pycrypto, pycurl, pytz
 , pillow, derpconf, python_magic, pexif, libthumbor, opencv, webcolors
-, piexif, futures, statsd, thumborPexif, fetchPypi, fetchpatch, isPy3k, lib
+, piexif, futures, statsd, thumborPexif, fetchPypi, isPy3k, lib
 }:
 
 buildPythonPackage rec {
   pname = "thumbor";
-  version = "6.4.2";
+  version = "6.5.1";
 
   disabled = isPy3k; # see https://github.com/thumbor/thumbor/issues/1004
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0y9mf78j80vjh4y0xvgnybc1wqfcwm5s19xhsfgkn12hh8pmh14d";
+    sha256 = "0yalqwpxb6m0dz2qfnyv1pqqd5dd020wl7hc0n0bvsvxg1ib9if0";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/thumbor/thumbor/commit/4f2bc99451409e404f7fa0f3e4a3bdaea7b49869.patch";
-      sha256 = "0qqw1n1pfd8f8cn168718gzwf4b35j2j9ajyw643xpf92s0iq2cc";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace "setup.py" \


### PR DESCRIPTION
###### Motivation for this change

The current `thumbor` build on master: https://hydra.nixos.org/build/76000076

This is mainly caused by several dependency bumps (e.g.
`pythonPackages.tornado` to v5 in dd936ccdb9bb04436f4e045998f305de12a67eb2)
that broke the `setup.py` from version 6.4.

Bumping to the latest stable version (6.5.1) fixes these issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

