### PR TITLE
qt5: 5.11.0 -> 5.11.1

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.11/fetch.sh
@@ -1,2 +1,2 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.11/5.11.0/submodules/ \
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.11/5.11.1/submodules/ \
             -A '*.tar.xz' )

--- a/pkgs/development/libraries/qt-5/5.11/qtbase-darwin.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtbase-darwin.patch
@@ -20,9 +20,8 @@ index 341d3bccf2..3368234c26 100644
      for (NSString *ifName in wifiInterfaces) {
              scanThread->interfaceName = QString::fromNSString(ifName);
              scanThread->start();
-diff --git a/src/plugins/platforms/cocoa/qcocoascreen.mm b/src/plugins/platforms/cocoa/qcoco
-ascreen.mm
-index a17a02b6..d76c42fa 100644
+diff --git a/src/plugins/platforms/cocoa/qcocoascreen.mm b/src/plugins/platforms/cocoa/qcocoascreen.mm
+index a17a02b629..d76c42fa03 100644
 --- a/src/plugins/platforms/cocoa/qcocoascreen.mm
 +++ b/src/plugins/platforms/cocoa/qcocoascreen.mm
 @@ -114,7 +114,7 @@ void QCocoaScreen::updateGeometry()
@@ -35,10 +34,10 @@ index a17a02b6..d76c42fa 100644
      m_availableGeometry = qt_mac_flip(QRectF::fromCGRect(nsScreen.visibleFrame), primaryScreenGeometry).toRect();
 
 diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
-index 54254455e4..e10f62909a 100644
+index 72f3bc0075..a9c058a850 100644
 --- a/src/plugins/platforms/cocoa/qcocoawindow.mm
 +++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
-@@ -1674,7 +1674,7 @@ void QCocoaWindow::applyContentBorderThickness(NSWindow *window)
+@@ -1676,7 +1676,7 @@ void QCocoaWindow::applyContentBorderThickness(NSWindow *window)
  
      if (!m_drawContentBorderGradient) {
          window.styleMask = window.styleMask & ~NSTexturedBackgroundWindowMask;

--- a/pkgs/development/libraries/qt-5/5.11/qtbase-revert-no-macos10.10.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtbase-revert-no-macos10.10.patch
@@ -21,7 +21,7 @@ Reviewed-by: Konstantin Ritt <ritt.ks@gmail.com>
  3 files changed, 4 insertions(+), 34 deletions(-)
 
 diff --git a/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm b/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
-index 98b753ef..489d9cd0 100644
+index 98b753eff9..489d9cd031 100644
 --- a/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
 +++ b/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
 @@ -47,18 +47,28 @@
@@ -57,7 +57,7 @@ index 98b753ef..489d9cd0 100644
  #define kCTFontWeightThin NSFontWeightThin
  #define kCTFontWeightLight NSFontWeightLight
 diff --git a/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm b/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm
-index 94f2125b..272cd9f3 100644
+index 94f2125bad..272cd9f3dc 100644
 --- a/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm
 +++ b/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm
 @@ -162,7 +162,11 @@ QT_NAMESPACE_ALIAS_OBJC_CLASS(QNSOpenSavePanelDelegate);
@@ -74,11 +74,11 @@ index 94f2125b..272cd9f3 100644
      if (mOptions->isLabelExplicitlySet(QFileDialogOptions::Accept))
          [mSavePanel setPrompt:[self strip:options->labelText(QFileDialogOptions::Accept)]];
 diff --git a/src/plugins/platforms/cocoa/qnswindowdelegate.mm b/src/plugins/platforms/cocoa/qnswindowdelegate.mm
-index 6e5623d6..cdecd86d 100644
+index 057a4c2943..eb55e50622 100644
 --- a/src/plugins/platforms/cocoa/qnswindowdelegate.mm
 +++ b/src/plugins/platforms/cocoa/qnswindowdelegate.mm
-@@ -80,6 +80,22 @@ static QRegExp whitespaceRegex = QRegExp(QStringLiteral("\\s*"));
-     return NSRectFromCGRect(m_cocoaWindow->screen()->availableGeometry().toCGRect());
+@@ -103,6 +103,22 @@ static QRegExp whitespaceRegex = QRegExp(QStringLiteral("\\s*"));
+     return QCocoaScreen::mapToNative(maximizedFrame);
  }
  
 +#if QT_MACOS_DEPLOYMENT_TARGET_BELOW(__MAC_10_11)

--- a/pkgs/development/libraries/qt-5/5.11/qtbase.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtbase.patch
@@ -12,7 +12,7 @@ index 5208379f9a..92fe29a0ac 100644
  
  QMAKE_LFLAGS_REL_RPATH  =
 diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
-index 66acedef55..fe01bf8de4 100644
+index 2ed708e085..05e60ff45f 100644
 --- a/mkspecs/features/create_cmake.prf
 +++ b/mkspecs/features/create_cmake.prf
 @@ -21,7 +21,7 @@ load(cmake_functions)
@@ -24,7 +24,7 @@ index 66acedef55..fe01bf8de4 100644
  contains(CMAKE_INSTALL_LIBS_DIR, ^(/usr)?/lib(64)?.*): CMAKE_USR_MOVE_WORKAROUND = $$CMAKE_INSTALL_LIBS_DIR
  
  CMAKE_OUT_DIR = $$MODULE_BASE_OUTDIR/lib/cmake
-@@ -47,49 +47,20 @@ split_incpath {
+@@ -51,45 +51,20 @@ split_incpath {
          $$cmake_extra_source_includes.output
  }
  
@@ -33,11 +33,9 @@ index 66acedef55..fe01bf8de4 100644
 -    CMAKE_INCLUDE_DIR = $$[QT_INSTALL_HEADERS]/
 -    CMAKE_INCLUDE_DIR_IS_ABSOLUTE = True
 -}
--
--isEmpty(QT.$${MODULE}_private.includes)| \
--        !exists($$first(QT.$${MODULE}_private.includes)): \
--    CMAKE_NO_PRIVATE_INCLUDES = true
--
++CMAKE_INCLUDE_DIR = $$NIX_OUTPUT_DEV/include/
++CMAKE_INCLUDE_DIR_IS_ABSOLUTE = True
+ 
 -CMAKE_LIB_DIR = $$cmakeRelativePath($$[QT_INSTALL_LIBS], $$[QT_INSTALL_PREFIX])
 -contains(CMAKE_LIB_DIR,"^\\.\\./.*") {
 -    CMAKE_LIB_DIR = $$[QT_INSTALL_LIBS]/
@@ -48,25 +46,23 @@ index 66acedef55..fe01bf8de4 100644
 -    # installed in $${CMAKE_LIB_DIR}/cmake/Qt5$${CMAKE_MODULE_NAME}
 -    CMAKE_RELATIVE_INSTALL_DIR = "$${CMAKE_RELATIVE_INSTALL_LIBS_DIR}../../"
 -}
-+CMAKE_INCLUDE_DIR = $$NIX_OUTPUT_DEV/include/
-+CMAKE_INCLUDE_DIR_IS_ABSOLUTE = True
++CMAKE_BIN_DIR = $$NIX_OUTPUT_BIN/bin/
++CMAKE_BIN_DIR_IS_ABSOLUTE = True
  
 -CMAKE_BIN_DIR = $$cmakeRelativePath($$[QT_HOST_BINS], $$[QT_INSTALL_PREFIX])
 -contains(CMAKE_BIN_DIR, "^\\.\\./.*") {
 -    CMAKE_BIN_DIR = $$[QT_HOST_BINS]/
 -    CMAKE_BIN_DIR_IS_ABSOLUTE = True
 -}
-+CMAKE_BIN_DIR = $$NIX_OUTPUT_BIN/bin/
-+CMAKE_BIN_DIR_IS_ABSOLUTE = True
++CMAKE_LIB_DIR = $$NIX_OUTPUT_OUT/lib/
++CMAKE_LIB_DIR_IS_ABSOLUTE = True
  
 -CMAKE_PLUGIN_DIR = $$cmakeRelativePath($$[QT_INSTALL_PLUGINS], $$[QT_INSTALL_PREFIX])
 -contains(CMAKE_PLUGIN_DIR, "^\\.\\./.*") {
 -    CMAKE_PLUGIN_DIR = $$[QT_INSTALL_PLUGINS]/
 -    CMAKE_PLUGIN_DIR_IS_ABSOLUTE = True
 -}
-+CMAKE_LIB_DIR = $$NIX_OUTPUT_OUT/lib/
-+CMAKE_LIB_DIR_IS_ABSOLUTE = True
- 
+-
 -win32:!static:!staticlib {
 -    CMAKE_DLL_DIR = $$cmakeRelativePath($$[QT_INSTALL_BINS], $$[QT_INSTALL_PREFIX])
 -    contains(CMAKE_DLL_DIR, "^\\.\\./.*") {
@@ -85,7 +81,7 @@ index 66acedef55..fe01bf8de4 100644
  
  static|staticlib:CMAKE_STATIC_TYPE = true
  
-@@ -169,7 +140,7 @@ contains(CONFIG, plugin) {
+@@ -169,7 +144,7 @@ contains(CONFIG, plugin) {
        cmake_target_file
  
      cmake_qt5_plugin_file.files = $$cmake_target_file.output
@@ -94,7 +90,7 @@ index 66acedef55..fe01bf8de4 100644
      INSTALLS += cmake_qt5_plugin_file
  
      return()
-@@ -316,7 +287,7 @@ exists($$cmake_macros_file.input) {
+@@ -316,7 +291,7 @@ exists($$cmake_macros_file.input) {
      cmake_qt5_module_files.files += $$cmake_macros_file.output
  }
  
@@ -264,13 +260,14 @@ index 27f4c277d6..18b4813e25 100644
          set_target_properties(Qt5::${Plugin} PROPERTIES
              \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
 diff --git a/mkspecs/features/mac/default_post.prf b/mkspecs/features/mac/default_post.prf
-index 50a1ec6764..d6368b769e 100644
+index 21d487f1f9..a0e5c68b7e 100644
 --- a/mkspecs/features/mac/default_post.prf
 +++ b/mkspecs/features/mac/default_post.prf
-@@ -25,188 +25,3 @@ qt {
+@@ -24,196 +24,3 @@ qt {
+         }
      }
  }
- 
+-
 -# Add the same default rpaths as Xcode does for new projects.
 -# This is especially important for iOS/tvOS/watchOS where no other option is possible.
 -!no_default_rpath {
@@ -456,14 +453,21 @@ index 50a1ec6764..d6368b769e 100644
 -    cache(QMAKE_XCODE_VERSION, stash)
 -
 -QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
+-
+-xcode_product_bundle_identifier_setting.name = PRODUCT_BUNDLE_IDENTIFIER
+-xcode_product_bundle_identifier_setting.value = $$QMAKE_TARGET_BUNDLE_PREFIX
+-isEmpty(xcode_product_bundle_identifier_setting.value): \
+-    xcode_product_bundle_identifier_setting.value = "com.yourcompany"
+-xcode_product_bundle_identifier_setting.value = "$${xcode_product_bundle_identifier_setting.value}.${PRODUCT_NAME:rfc1034identifier}"
+-QMAKE_MAC_XCODE_SETTINGS += xcode_product_bundle_identifier_setting
 diff --git a/mkspecs/features/mac/default_pre.prf b/mkspecs/features/mac/default_pre.prf
-index f1a4ca77b2..61ed486a76 100644
+index e3534561a5..3b01424e67 100644
 --- a/mkspecs/features/mac/default_pre.prf
 +++ b/mkspecs/features/mac/default_pre.prf
-@@ -1,67 +1,3 @@
+@@ -1,60 +1,2 @@
  CONFIG = asset_catalogs rez $$CONFIG
  load(default_pre)
- 
+-
 -isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
 -    # Get path of Xcode's Developer directory
 -    QMAKE_XCODE_DEVELOPER_PATH = $$system("/usr/bin/xcode-select --print-path 2>/dev/null")
@@ -521,13 +525,6 @@ index f1a4ca77b2..61ed486a76 100644
 -xcode_copy_phase_strip_setting.name = COPY_PHASE_STRIP
 -xcode_copy_phase_strip_setting.value = NO
 -QMAKE_MAC_XCODE_SETTINGS += xcode_copy_phase_strip_setting
--
--xcode_product_bundle_identifier_setting.name = PRODUCT_BUNDLE_IDENTIFIER
--xcode_product_bundle_identifier_setting.value = $$QMAKE_TARGET_BUNDLE_PREFIX
--isEmpty(xcode_product_bundle_identifier_setting.value): \
--    xcode_product_bundle_identifier_setting.value = "com.yourcompany"
--xcode_product_bundle_identifier_setting.value = "$${xcode_product_bundle_identifier_setting.value}.${PRODUCT_NAME:rfc1034identifier}"
--QMAKE_MAC_XCODE_SETTINGS += xcode_product_bundle_identifier_setting
 diff --git a/mkspecs/features/mac/sdk.prf b/mkspecs/features/mac/sdk.prf
 index 8360dd8b38..8b13789179 100644
 --- a/mkspecs/features/mac/sdk.prf
@@ -658,7 +655,7 @@ index 1848f00e90..2af93675c5 100644
 +    MODULE_QMAKE_OUTDIR = $$NIX_OUTPUT_OUT
  }
 diff --git a/mkspecs/features/qt_common.prf b/mkspecs/features/qt_common.prf
-index f4ae5bde80..6d4c6d223f 100644
+index 415044bb64..7163ef56cd 100644
 --- a/mkspecs/features/qt_common.prf
 +++ b/mkspecs/features/qt_common.prf
 @@ -32,8 +32,8 @@ contains(TEMPLATE, .*lib) {
@@ -1044,10 +1041,10 @@ index cc982b3379..0c5005d3d7 100644
  #endif
              }
 diff --git a/src/plugins/platforms/xcb/qxcbcursor.cpp b/src/plugins/platforms/xcb/qxcbcursor.cpp
-index 8d151b760b..a8b39d282a 100644
+index b401100dd4..b45a290065 100644
 --- a/src/plugins/platforms/xcb/qxcbcursor.cpp
 +++ b/src/plugins/platforms/xcb/qxcbcursor.cpp
-@@ -314,10 +314,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
+@@ -316,10 +316,10 @@ QXcbCursor::QXcbCursor(QXcbConnection *conn, QXcbScreen *screen)
  #if QT_CONFIG(xcb_xlib) && QT_CONFIG(library)
      static bool function_ptrs_not_initialized = true;
      if (function_ptrs_not_initialized) {

--- a/pkgs/development/libraries/qt-5/5.11/qtdeclarative.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtdeclarative.patch
@@ -1,8 +1,8 @@
 diff --git a/src/qml/qml/qqmlimport.cpp b/src/qml/qml/qqmlimport.cpp
-index a7cafa1a9..e17ffd35b 100644
+index 005db4248..685c5b1b2 100644
 --- a/src/qml/qml/qqmlimport.cpp
 +++ b/src/qml/qml/qqmlimport.cpp
-@@ -1737,6 +1737,15 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
+@@ -1760,6 +1760,15 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
      QString installImportsPath =  QLibraryInfo::location(QLibraryInfo::Qml2ImportsPath);
      addImportPath(installImportsPath);
  
@@ -19,10 +19,10 @@ index a7cafa1a9..e17ffd35b 100644
      if (Q_UNLIKELY(!qEnvironmentVariableIsEmpty("QML2_IMPORT_PATH"))) {
          const QString envImportPath = qEnvironmentVariable("QML2_IMPORT_PATH");
 diff --git a/tools/qmlcachegen/qmlcache.prf b/tools/qmlcachegen/qmlcache.prf
-index 330da358b..cdf570205 100644
+index 537eaf62e..e21de58f6 100644
 --- a/tools/qmlcachegen/qmlcache.prf
 +++ b/tools/qmlcachegen/qmlcache.prf
-@@ -44,7 +44,7 @@ defineReplace(qmlCacheOutputFileName) {
+@@ -26,7 +26,7 @@ defineReplace(qmlCacheOutputFileName) {
  }
  
  qmlcacheinst.base = $$QMLCACHE_DESTDIR

--- a/pkgs/development/libraries/qt-5/5.11/srcs.nix
+++ b/pkgs/development/libraries/qt-5/5.11/srcs.nix
@@ -3,323 +3,323 @@
 
 {
   qt3d = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qt3d-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1h3hb395vpbblwin5bx3zazwcz5gwf2fjawdcqd866mkmcb1am2d";
-      name = "qt3d-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qt3d-everywhere-src-5.11.1.tar.xz";
+      sha256 = "03fkbrghj40rp8pf5r5979pcvq7qjsj7db446r6fl6slwphmk1nb";
+      name = "qt3d-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtactiveqt = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtactiveqt-everywhere-src-5.11.0.tar.xz";
-      sha256 = "019ppkqi8kzd3sjxilig9sqqfw331d3nbq8c3d4xanwqsl6vxak9";
-      name = "qtactiveqt-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtactiveqt-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1f9w3dc2wvhz7pqhrsb2p908kc2c6xrqsp82ny8akil4xx6nrvn6";
+      name = "qtactiveqt-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtandroidextras = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtandroidextras-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1yw1fsjbs4ibxi01nxk1431v7ky22ll9npxc5x7fpd4w3h6y73gw";
-      name = "qtandroidextras-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtandroidextras-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1qiggrz2hdb7vrkvsh71hqdipj3klak0jpn2nq8qpilqxgb9dx76";
+      name = "qtandroidextras-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtbase = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtbase-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0rny87ypnkkvyp9p76nim77v6np0cdf1dbjfmcilklzphkdlcvpd";
-      name = "qtbase-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtbase-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0ipv18ypbgpxhh49rfplqmflskmnhhwj1bjr5hrwi0jpvar4gl50";
+      name = "qtbase-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtcanvas3d = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtcanvas3d-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1kqcaks6lkz8cp9s3pwrvgrr8381rjzf5fbf2bzshdw7psphxiiz";
-      name = "qtcanvas3d-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtcanvas3d-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1pif3m1f44jrly2nh0hzid6dmdxqiy5qgx645hz6g5fmpl113d8g";
+      name = "qtcanvas3d-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtcharts = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtcharts-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0lg39vd6i0l76spjz6bhb1kkpbk2mgc0hxccj7733xxbxaz14vn4";
-      name = "qtcharts-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtcharts-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0avscsni84zrzydilkkp456sbaypyzhkn42qygjdq7wcn045zxk2";
+      name = "qtcharts-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtconnectivity = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtconnectivity-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0wqq5q5saf007aphvpn5pvj6l0qp0z7wxvfba6v9iq5ylyqm6bnd";
-      name = "qtconnectivity-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtconnectivity-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0mz6mbf069yqdvi6mcvp6izskcn9wzig4s3dzmygwd430pmx93kk";
+      name = "qtconnectivity-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtdatavis3d = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtdatavis3d-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1s7gmgh6g3aia74yiqahffrc6n8f4491vb7g3i4i10ilandipg34";
-      name = "qtdatavis3d-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtdatavis3d-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0gay0dsz05xfrlx190y95hp9wipzb988h02fqbqvyn00ds3s178w";
+      name = "qtdatavis3d-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtdeclarative = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtdeclarative-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1h2pbyr7dnak4q96373xpa6gk6rl528rnqima8xnvhdi2y5kgagf";
-      name = "qtdeclarative-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtdeclarative-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0fjg9ii64mhx2ww70rj44cy65rwwkwyjxcm435kwp3v1pzv5xkwy";
+      name = "qtdeclarative-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtdoc = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtdoc-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1y4cr3a9pi83mbabd8g6gz072dqgj26bla2qw2dgcv1v7ifhcpky";
-      name = "qtdoc-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtdoc-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1z0sqmn0pw5g4ycdi8igsi89151cw6p3kv9g97pxl2qx3my1ppmc";
+      name = "qtdoc-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtgamepad = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtgamepad-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0g52c03gdgz57h7szdxvc5hdy45l7q7m29yfzhwqc57hwdfl98bi";
-      name = "qtgamepad-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtgamepad-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1n97w9rcbg8mzkvjgn3i8jbfmplp7w0p80ykdchpml47gxk1kwma";
+      name = "qtgamepad-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtgraphicaleffects = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtgraphicaleffects-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0xzr4421w7idlgndxnd68wwc2asabycjiskkyl1f8nwqv34lcy3j";
-      name = "qtgraphicaleffects-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtgraphicaleffects-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1ws8aj7bq3rxpzjs370dcyqk8a5v1y6fwvrdhf70j8b2d4v75lnr";
+      name = "qtgraphicaleffects-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtimageformats = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtimageformats-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0w0yy7zzln3v7dm7ksjxkzhq8r0a9nwk823wv4f1x7vsa3pnyh2q";
-      name = "qtimageformats-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtimageformats-everywhere-src-5.11.1.tar.xz";
+      sha256 = "05jnyrq7klr3mdiz0r9c151vl829yc8y9cxfbw5dwbp1rkndwl7b";
+      name = "qtimageformats-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtlocation = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtlocation-everywhere-src-5.11.0.tar.xz";
-      sha256 = "074cjqhr14mqlsqj9rzagzdcqnayyichp31lq02k05q07wg93xi8";
-      name = "qtlocation-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtlocation-everywhere-src-5.11.1.tar.xz";
+      sha256 = "03vrbymwbn4nqsypcmr4ccqv20nvwdfs9gb01pi3jxr6x0wrlb0p";
+      name = "qtlocation-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtmacextras = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtmacextras-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1dwlfngp0bs8v1c64p677dbdprv5fpcwva2xq7ir6zca5pma88yz";
-      name = "qtmacextras-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtmacextras-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1wf3n5n4gg8gmjnjq88lmymkssg8q5s3qkrpsxd1hb6pd3n32gpn";
+      name = "qtmacextras-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtmultimedia = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtmultimedia-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0g4x1w251imq58zp1px6yschwj6icsxzwl3fy7pjfbgd27qjhlzg";
-      name = "qtmultimedia-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtmultimedia-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0369b0mh7sr718l119b07grb1v8xqlq6l4damyd6lrmlj1wbb2zj";
+      name = "qtmultimedia-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtnetworkauth = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtnetworkauth-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1kr8hwjsb8a5cypvqj48vrnkcvm2rcni102dh6i909i70a7hcsym";
-      name = "qtnetworkauth-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtnetworkauth-everywhere-src-5.11.1.tar.xz";
+      sha256 = "05p4pvfp3k5612d54anvpj39bgc7v572x6kgk3fy69xgn7lhbd02";
+      name = "qtnetworkauth-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtpurchasing = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtpurchasing-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1c92yv2yi38sic06nyr9r6zpq3y4sxnasmj14d3jmg50gc1ncqfs";
-      name = "qtpurchasing-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtpurchasing-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0crm39fy9aqns10mjlbxvkkna9xklic49zfp3f7v7cwl66wap6dc";
+      name = "qtpurchasing-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtquickcontrols = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtquickcontrols-everywhere-src-5.11.0.tar.xz";
-      sha256 = "01ziibf4afdhb5b3gfci8maprmviqwhdvma2z1jlq2ck45cpsqi6";
-      name = "qtquickcontrols-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtquickcontrols-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0mn662j0gkpama7zlrsn4h27sjrk49kpbha1h0zxxyiza5cpzsms";
+      name = "qtquickcontrols-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtquickcontrols2 = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtquickcontrols2-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1hsa8n4dlqpyz9xq2kq1hsxrxsjc7ywzzfhqijylgzzclvlqgb7y";
-      name = "qtquickcontrols2-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtquickcontrols2-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0hn4kvrkz5ivwrp9p6yzwlw7cn4j72kcpm2nqyi3dbai1px6dc5x";
+      name = "qtquickcontrols2-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtremoteobjects = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtremoteobjects-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1chn1xxhapfwvhrlv4chwfgf2dw8x8kn1lssdmpmg5s420z3pbq9";
-      name = "qtremoteobjects-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtremoteobjects-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1yv9f2329nv4viiyqmq7ciz51574wd11grj8s88qm0ndcb36jbgb";
+      name = "qtremoteobjects-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtscript = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtscript-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1ib8a5gsxarbm2j94j5d097ly3ap4snqkx2imz3sl6xk6gknm4i5";
-      name = "qtscript-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtscript-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0z6sb4b9ds5lwkr0sxrnx6nim3aq2qx4a8illjy5vclfdv80yhqw";
+      name = "qtscript-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtscxml = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtscxml-everywhere-src-5.11.0.tar.xz";
-      sha256 = "00wb89ris8fyivhz9qpqn72mzpkh6mqdjss82j3q10g3c142072k";
-      name = "qtscxml-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtscxml-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0f1k4fnk2aydagxqvkb636pcsi17sbq2zj2fn0ad50dvq013yiph";
+      name = "qtscxml-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtsensors = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtsensors-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1az22rdkpc1m44qb3dyh7cpiprplkvynzjr629ai05i8ngbfdi0g";
-      name = "qtsensors-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtsensors-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1yn065l6kzs3fn74950pkxxglqi55lzk7alf15klsd1wnxc0zsfb";
+      name = "qtsensors-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtserialbus = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtserialbus-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0r3crk7gw0xs6wk1gvw2k8r9s9vam3sfwrji1njhswavii9fbp85";
-      name = "qtserialbus-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtserialbus-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0jjmdd6vkvs5izqazp1rsrad0b1fzk6knrbdjl37lvcsawyfxfyk";
+      name = "qtserialbus-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtserialport = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtserialport-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1cbf1jsginp5p3y17cyb6dfhsafxal0bn9pya6aybz0q799zgvl5";
-      name = "qtserialport-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtserialport-everywhere-src-5.11.1.tar.xz";
+      sha256 = "18v4pbq7bnmrl81m8s11ksbjlvzbb4kw5py6ji2dhmnm44w9k9sn";
+      name = "qtserialport-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtspeech = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtspeech-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1bgfg0akqf1nfzm28n8dhvhj0p1niwxrfs763gj7m0g6vpwjbhd1";
-      name = "qtspeech-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtspeech-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1nwvbaijg35i98yaiqgnyn5vv0cn4v3wrxhwi1s0hfv9sv3q5iyw";
+      name = "qtspeech-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtsvg = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtsvg-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0m0zglp0m5gv75ivma6l3hm8brb0cf44dhbc6lqwfdwacxhgx3jb";
-      name = "qtsvg-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtsvg-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0drhig0jcss3cf01aqfmafajf8gzf6bh468g1ikyrkh46czgyshx";
+      name = "qtsvg-everywhere-src-5.11.1.tar.xz";
     };
   };
   qttools = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qttools-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1nb77bfs63nyy0wkhsci9qbqmahncy3sdcrwj4qr1prc4y2cm4wx";
-      name = "qttools-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qttools-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1zhl8p29mbabf07rhaks13qcm45zdckzymvz9qn95nxfj9piiyxp";
+      name = "qttools-everywhere-src-5.11.1.tar.xz";
     };
   };
   qttranslations = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qttranslations-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0778y8vxa26wr4vgqi79si1dpflfyxdn926hpzjc1k1mx7y94gpi";
-      name = "qttranslations-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qttranslations-everywhere-src-5.11.1.tar.xz";
+      sha256 = "01kid5dc20jnzjmd4ycjmacrsmrw4hsh2s4y5k9y9p34z8m9pn0j";
+      name = "qttranslations-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtvirtualkeyboard = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtvirtualkeyboard-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1g9wj4j29lysqp6wxnck6s7h36qj87g3lbapvkfsqchvm00yckci";
-      name = "qtvirtualkeyboard-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtvirtualkeyboard-everywhere-src-5.11.1.tar.xz";
+      sha256 = "16xzpdqn07z8j6f8iywy3967djap5bbi2myqp37s4xh9fz60scsv";
+      name = "qtvirtualkeyboard-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwayland = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwayland-everywhere-src-5.11.0.tar.xz";
-      sha256 = "09s1ckqj0cgjmmi7jylsf039vgzlq7i9rr4swb590fkz427lx0b8";
-      name = "qtwayland-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwayland-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1sj4lsza48xji1qhmi1wqpx07jgm1mpa95gmd2w1kxw240hbr6p0";
+      name = "qtwayland-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwebchannel = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwebchannel-everywhere-src-5.11.0.tar.xz";
-      sha256 = "05fa5pwvk24cjp8m6pbw3ma95vnls762crpjdgvygfk0h8xilxmh";
-      name = "qtwebchannel-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebchannel-everywhere-src-5.11.1.tar.xz";
+      sha256 = "11rfjkb4h8dzxfmk889x7kkc73cbk26smc7h62lnh35f2nppd95r";
+      name = "qtwebchannel-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwebengine = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwebengine-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0iabqkan99msp0jab0hndap6jqkf9b1ggd4n7glkcvf60gb59msx";
-      name = "qtwebengine-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebengine-everywhere-src-5.11.1.tar.xz";
+      sha256 = "136lc2kw4af4bilgn7vn9hdckpk62xvyjb4kr0gc2firr919z79q";
+      name = "qtwebengine-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwebglplugin = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwebglplugin-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1al7dv7i9rg4z4p8vnipbjbbgc6113lbfjggxxap3sn6hqs986fm";
-      name = "qtwebglplugin-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebglplugin-everywhere-src-5.11.1.tar.xz";
+      sha256 = "108yhi3sj6d1ysmlpka69ivb20mx9h6jpra6yq099i3jw4gc753x";
+      name = "qtwebglplugin-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwebsockets = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwebsockets-everywhere-src-5.11.0.tar.xz";
-      sha256 = "1drr6nxxbkwpmz39bhyfmmsqjhy11bj3w1nc3q9dwhpcbf04an3x";
-      name = "qtwebsockets-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebsockets-everywhere-src-5.11.1.tar.xz";
+      sha256 = "1bj82y3f1nd2adnj3ljfr4vlx4bkgdlm3zvhlsas2lz837vi5aks";
+      name = "qtwebsockets-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwebview = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwebview-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0a89v8mj5pb7a7whyhasf4ms0n34ghfmv2qp0pyxnq56f2bsjbl4";
-      name = "qtwebview-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwebview-everywhere-src-5.11.1.tar.xz";
+      sha256 = "18da6a13wpb23vb6mbg9v75gphdf5mjmch7q3v1qjrv2sdwbpjbp";
+      name = "qtwebview-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtwinextras = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtwinextras-everywhere-src-5.11.0.tar.xz";
-      sha256 = "0qrf6vf9i1cvfcyg22d4f611bl3xi5qb3vcbb2idk24jg9q48cqw";
-      name = "qtwinextras-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtwinextras-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0qxwfhg962a456lb9b6y7xhi6fvvvb42z0li6v7695vfbckifbzz";
+      name = "qtwinextras-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtx11extras = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtx11extras-everywhere-src-5.11.0.tar.xz";
-      sha256 = "13vbx61wcd8pnpgk3j5r665pm03s7jp2s98apvc6fhp1njlr0rhi";
-      name = "qtx11extras-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtx11extras-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0rccpmhz48kq4xs441lj9mnwpbi6kxwl8y7dj7w7g5zvpv41kwmw";
+      name = "qtx11extras-everywhere-src-5.11.1.tar.xz";
     };
   };
   qtxmlpatterns = {
-    version = "5.11.0";
+    version = "5.11.1";
     src = fetchurl {
-      url = "${mirror}/official_releases/qt/5.11/5.11.0/submodules/qtxmlpatterns-everywhere-src-5.11.0.tar.xz";
-      sha256 = "13nj2pa706sy874bqbv7y94ypicr4k09x6n2jyxkw93flb5pi8qr";
-      name = "qtxmlpatterns-everywhere-src-5.11.0.tar.xz";
+      url = "${mirror}/official_releases/qt/5.11/5.11.1/submodules/qtxmlpatterns-everywhere-src-5.11.1.tar.xz";
+      sha256 = "0n5gacpni019i2872m4b1p5qaqibhszsdl3xhw3xsckvr0hf25v1";
+      name = "qtxmlpatterns-everywhere-src-5.11.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This may be needed to unbreak a couple of builds such as nextcloud clients or rstudio (alternatively they would have to downgrade to 5.9 individually if that is even possible): https://codereview.qt-project.org/#/c/232367/

###### Things done

I only ran the update script and rebased the patches for the sub modules, but maybe there are more steps involved I'm not aware of.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

