### PR TITLE
pythonPackages.python-prctl: init at 1.7

### DIFF
--- a/pkgs/development/python-modules/python-prctl/default.nix
+++ b/pkgs/development/python-modules/python-prctl/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, libcap
+}:
+
+buildPythonPackage rec {
+  pname = "python-prctl";
+  version = "1.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1njgixnavmwq45r3gpkhn1y760sax204clagg4gzwvvdc5bdbssp";
+  };
+
+  patches = [ ./skip_bad_tests.patch ];
+  buildInputs = [ libcap ];
+
+  meta = {
+    description = "Python(ic) interface to the linux prctl syscall";
+    homepage = https://github.com/seveas/python-prctl;
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ catern ];
+  };
+}

--- a/pkgs/development/python-modules/python-prctl/skip_bad_tests.patch
+++ b/pkgs/development/python-modules/python-prctl/skip_bad_tests.patch
@@ -1,0 +1,34 @@
+--- ./test_prctl.py	2018-01-26 16:02:52.000000000 -0500
++++ ./test_prctl.py	2018-06-21 18:26:43.370065009 -0400
+@@ -154,6 +154,7 @@
+         prctl.set_keepcaps(False)
+         self.assertEqual(prctl.get_keepcaps(), False)
+ 
++    @unittest.skip("No access to /proc in the Nix build sandbox")
+     @require('set_mce_kill')
+     def test_mce_kill(self):
+         """Test the MCE_KILL setting"""
+@@ -173,6 +174,7 @@
+         prctl.set_name(name)
+         self.assertEqual(prctl.get_name(), name[:15])
+ 
++    @unittest.skip("The Nix build sandbox has no_new_privs already enabled")
+     @require('get_no_new_privs')
+     def test_no_new_privs(self):
+         """Test the no_new_privs function"""
+@@ -189,6 +191,7 @@
+                 self.assertNotEqual(sp.returncode, 0)
+             os._exit(0)
+ 
++    @unittest.skip("No access to /proc in the Nix build sandbox")
+     def test_proctitle(self):
+         """Test setting the process title, including too long titles"""
+         title = "This is a test!"
+@@ -225,6 +228,7 @@
+             os._exit(0)
+         self.assertRaises(OSError, prctl.set_ptracer, new_pid)
+ 
++    @unittest.skip("The Nix build sandbox has seccomp already enabled")
+     @require('get_seccomp')
+     def test_seccomp(self):
+         """Test manipulation of the seccomp setting"""

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -440,6 +440,8 @@ in {
 
   python-periphery = callPackage ../development/python-modules/python-periphery { };
 
+  python-prctl = callPackage ../development/python-modules/python-prctl { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };


### PR DESCRIPTION
###### Motivation for this change

I want to use this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

