### PR TITLE
gitAndTools.hub: remove go compiler from runtime closure

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/hub/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hub/default.nix
@@ -1,38 +1,35 @@
-{ stdenv, fetchgit, go, ronn, groff, utillinux, Security }:
+{ stdenv, buildGoPackage, fetchFromGitHub, go, ronn, ruby, groff, Security, utillinux }:
 
-stdenv.mkDerivation rec {
+buildGoPackage rec {
   name = "hub-${version}";
   version = "2.4.0";
 
-  src = fetchgit {
-    url = https://github.com/github/hub.git;
-    rev = "refs/tags/v${version}";
+  goPackagePath = "github.com/github/hub";
+
+  src = fetchFromGitHub {
+    owner = "github";
+    repo = "hub";
+    rev = "v${version}";
     sha256 = "1lr6vg0zhg2air9bnzcl811g97jraxq05l3cs46wqqflwy57xpz2";
   };
 
+  buildInputs = [ groff ronn ruby utillinux ] ++
+    stdenv.lib.optional stdenv.isDarwin Security;
 
-  buildInputs = [ go ronn groff utillinux ]
-    ++ stdenv.lib.optional stdenv.isDarwin Security;
-
-  buildPhase = ''
+  postPatch = ''
     mkdir bin
     ln -s ${ronn}/bin/ronn bin/ronn
-
     patchShebangs .
-    make all man-pages
   '';
 
-  installPhase = ''
-    prefix=$out sh -x < script/install.sh
+  postInstall = ''
+    cd go/src/${goPackagePath}
+    install -D etc/hub.zsh_completion "$bin/share/zsh/site-functions/_hub"
+    install -D etc/hub.bash_completion.sh "$bin/etc/bash_completion.d/hub.bash_completion.sh"
+    install -D etc/hub.fish_completion  "$bin/share/fish/vendor_completions.d/hub.fish"
 
-    mkdir -p "$out/share/zsh/site-functions"
-    cp "etc/hub.zsh_completion" "$out/share/zsh/site-functions/_hub"
-
-    mkdir -p "$out/etc/bash_completion.d"
-    cp "etc/hub.bash_completion.sh" "$out/etc/bash_completion.d/"
-
-    # Should we also install provided git-hooks?
-    # And fish completion?
+    make man-pages
+    cp -r share/man $bin/share/man
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

