### PR TITLE
autokey: init at 0.94.1

### DIFF
--- a/pkgs/applications/office/autokey/default.nix
+++ b/pkgs/applications/office/autokey/default.nix
@@ -1,0 +1,38 @@
+{ lib, python3Packages, fetchFromGitHub, wrapGAppsHook, gobjectIntrospection
+, gtksourceview, gnome3, libappindicator-gtk3, libnotify }:
+
+python3Packages.buildPythonApplication rec {
+  name = "autokey-${version}";
+  version = "0.94.1";
+
+  src = fetchFromGitHub {
+    owner = "autokey";
+    repo = "autokey";
+    rev = "v${version}";
+    sha256 = "1syxyciyxzs0khbfs9wjgj03q967p948kipw27j1031q0b5z3jxr";
+  };
+
+  # Arch requires a similar work around—see
+  # https://aur.archlinux.org/packages/autokey-py3/?comments=all
+  patches = [ ./remove-requires-dbus-python.patch ];
+
+  # Tests appear to be broken with import errors within the project structure
+  doCheck = false;
+
+  # Note: no dependencies included for Qt GUI because Qt ui is poorly
+  # maintained—see https://github.com/autokey/autokey/issues/51
+
+  buildInputs = [ wrapGAppsHook gobjectIntrospection gnome3.gtksourceview
+    libappindicator-gtk3 libnotify ];
+
+  propagatedBuildInputs = with python3Packages; [
+    dbus-python pyinotify xlib pygobject3 ];
+
+  meta = {
+    homepage = https://github.com/autokey/autokey;
+    description = "Desktop automation utility for Linux and X11";
+    license = with lib.licenses; [ gpl3 ];
+    maintainers = with lib.maintainers; [ pneumaticat ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/office/autokey/remove-requires-dbus-python.patch
+++ b/pkgs/applications/office/autokey/remove-requires-dbus-python.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -71,7 +71,7 @@
+         'console_scripts': ['autokey-gtk=autokey.gtkui.__main__:main']
+     },
+     scripts=['autokey-qt', 'autokey-run', 'autokey-shell'],
+-    install_requires=['dbus-python', 'pyinotify', 'python3-xlib'],
++    install_requires=['pyinotify', 'python-xlib'],
+     classifiers=[
+         'Development Status :: 4 - Beta',
+         'Intended Audience :: Developers',

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15003,6 +15003,8 @@ with pkgs;
 
   audio-recorder = callPackage ../applications/audio/audio-recorder { };
 
+  autokey = callPackage ../applications/office/autokey { };
+
   autotrace = callPackage ../applications/graphics/autotrace {};
 
   avocode = callPackage ../applications/graphics/avocode {};


### PR DESCRIPTION
###### Motivation for this change

[AutoKey](https://github.com/autokey/autokey/) is a text expander program written in Python 3, for Linux and X11.

###### Things done

Enough to run the GTK3 UI. The Qt UI is broken upstream due to being outdated and using PyQt4 (I tried, and I couldn't get it to run with NixOS's PyQt4 either). See autokey/autokey#51.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

