### PR TITLE
ecs-agent: 1.14.0 -> 1.18.0-1

### DIFF
--- a/pkgs/applications/virtualization/ecs-agent/default.nix
+++ b/pkgs/applications/virtualization/ecs-agent/default.nix
@@ -3,7 +3,7 @@
 buildGoPackage rec {
   name    = "${pname}-${version}";
   pname   = "amazon-ecs-agent";
-  version = "1.14.0";
+  version = "1.18.0";
 
   goPackagePath = "github.com/aws/${pname}";
   subPackages   = [ "agent" ];
@@ -12,7 +12,7 @@ buildGoPackage rec {
     rev    = "v${version}";
     owner  = "aws";
     repo   = pname;
-    sha256 = "12c8l0x8pm883rlbdr1m07r0kjkzggkfz35cjqz8pzyr5ymjdrc3";
+    sha256 = "1l6c2if6wpjmq2hh6k818w38s1rsbwgd6igqy948dwcrb1g1mixr";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

version update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

