### PR TITLE
I3-easyfocus

### DIFF
--- a/pkgs/applications/window-managers/i3/easyfocus.nix
+++ b/pkgs/applications/window-managers/i3/easyfocus.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, pkgconfig, xproto, libxcb, xcbutilkeysyms
+, xlibs , i3ipc-glib , glib
+}:
+
+stdenv.mkDerivation rec {
+  name = "i3easyfocus-${version}";
+  version = "20180622";
+
+  src = fetchFromGitHub {
+    owner = "cornerman";
+    repo = "i3-easyfocus";
+    rev = "3631d5af612d58c3d027f59c86b185590bd78ae1";
+    sha256 = "1wgknmmm7iz0wxsdh29gmx4arizva9101pzhnmac30bmixf3nzhr";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libxcb xcbutilkeysyms xproto xlibs.libX11.dev i3ipc-glib glib.dev ];
+
+  # Makefile has no rule for 'install'
+  installPhase = ''
+    mkdir -p $out/bin
+    cp i3-easyfocus $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Focus and select windows in i3";
+    homepage = https://github.com/cornerman/i3-easyfocus;
+    maintainers = with maintainers; [teto];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/window-managers/i3/i3ipc-glib.nix
+++ b/pkgs/applications/window-managers/i3/i3ipc-glib.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, pkgconfig, xproto, libxcb
+, autoreconfHook, json-glib, gtk-doc, which
+, gobjectIntrospection
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "i3ipc-glib-${version}";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "acrisci";
+    repo = "i3ipc-glib";
+    rev = "v${version}";
+    sha256 = "1gmk1zjafrn6jh4j7r0wkwrpwvf9drl1lcw8vya23i1f4zbk0wh4";
+  };
+
+  nativeBuildInputs = [ autoreconfHook which pkgconfig ];
+
+  buildInputs = [ libxcb json-glib gtk-doc xproto gobjectIntrospection ];
+
+
+  preAutoreconf = ''
+    gtkdocize
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A C interface library to i3wm";
+    homepage = https://github.com/acrisci/i3ipc-glib;
+    maintainers = with maintainers; [teto];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16454,6 +16454,8 @@ with pkgs;
 
   i3-gaps = callPackage ../applications/window-managers/i3/gaps.nix { };
 
+  i3-easyfocus = callPackage ../applications/window-managers/i3/easyfocus.nix { };
+
   i3blocks = callPackage ../applications/window-managers/i3/blocks.nix { };
 
   i3blocks-gaps = callPackage ../applications/window-managers/i3/blocks-gaps.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16460,6 +16460,8 @@ with pkgs;
 
   i3cat = callPackage ../tools/misc/i3cat { };
 
+  i3ipc-glib = callPackage ../applications/window-managers/i3/i3ipc-glib.nix { };
+
   i3lock = callPackage ../applications/window-managers/i3/lock.nix {
     cairo = cairo.override { xcbSupport = true; };
   };


### PR DESCRIPTION
###### Motivation for this change
This is a very practical tool to quickly focus windows, similar to what vimium, vim-sneak, qutebrowser do to give focus on specific elements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

