### PR TITLE
Force positive stackprotector detection on x64 for Linux >=4.16

### DIFF
--- a/pkgs/os-specific/linux/kernel/force-stack-protector-x64.diff
+++ b/pkgs/os-specific/linux/kernel/force-stack-protector-x64.diff
@@ -1,0 +1,13 @@
+--- linux/scripts/gcc-x86_64-has-stack-protector.sh.orig	2018-06-22 09:18:45.601691761 +0200
++++ linux/scripts/gcc-x86_64-has-stack-protector.sh	2018-06-22 09:18:53.084892998 +0200
+@@ -1,9 +1,4 @@
+ #!/bin/sh
+ # SPDX-License-Identifier: GPL-2.0
++echo y
+ 
+-echo "int foo(void) { char X[200]; return 3; }" | $* -S -x c -c -O0 -mcmodel=kernel -fno-PIE -fstack-protector - -o - 2> /dev/null | grep -q "%gs"
+-if [ "$?" -eq "0" ] ; then
+-	echo y
+-else
+-	echo n
+-fi

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -38,6 +38,11 @@ rec {
     patch = ./copperhead-4-16.patch;
   };
 
+  force_stack_protector_x64 = rec {
+    name = "force-stack-protector";
+    patch = ./force-stack-protector-x64.diff;
+  };
+
   # https://bugzilla.kernel.org/show_bug.cgi?id=197591#c6
   iwlwifi_mvm_support_version_7_scan_req_umac_fw_command = rec {
     name = "iwlwifi_mvm_support_version_7_scan_req_umac_fw_command";

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -157,7 +157,7 @@ in {
   # to be adapted
   zfsStable = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    # incompatibleKernelVersion = "4.xx";
 
     # this package should point to the latest release.
     version = "0.7.9";
@@ -176,7 +176,7 @@ in {
 
   zfsUnstable = common rec {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    # incompatibleKernelVersion = "4.xx";
 
     # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-05-22";
@@ -199,7 +199,7 @@ in {
   # also remove boot.zfs.enableLegacyCrypto
   zfsLegacyCrypto = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    # incompatibleKernelVersion = "4.xx";
 
     # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-02-01";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13616,6 +13616,7 @@ with pkgs;
         # kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
         kernelPatches.bcm2835_mmal_v4l2_camera_driver # Only needed for 4.16!
+        kernelPatches.force_stack_protector_x64
       ];
   };
 
@@ -13627,6 +13628,7 @@ with pkgs;
         # kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
         kernelPatches.bcm2835_mmal_v4l2_camera_driver # Only needed for 4.16!
+        kernelPatches.force_stack_protector_x64
       ];
   };
 


### PR DESCRIPTION
The stackprotector is not detected correctly when during out-of-kernel compilations, breaking ZFS under >=4.16.

###### Motivation for this change
Fixes #39225

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - `nix-build -A stable zfs.nix` for kernelPackage forced to pkgs.linuxPackages_4_16 and pkgs.linuxPackages_4_17.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

