### PR TITLE
php: add imagick + mailparse support

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -230,6 +230,14 @@ let
           configureFlags = ["--with-sodium=${libsodium.dev}"];
           buildInputs = [libsodium];
         };
+
+        imagick = {
+          configureFlags = ["--enable-imagick"];
+        };
+
+        mailparse = {
+          configureFlags = ["--enable-mailparse"];
+        };
       };
 
       cfg = {
@@ -270,6 +278,8 @@ let
         ztsSupport = config.php.zts or false;
         calendarSupport = config.php.calendar or true;
         sodiumSupport = (lib.versionAtLeast version "7.2") && config.php.sodium or true;
+        imagickSupport = config.php.imagick or true;
+        mailparseSupport = config.php.mailparse or true;
       };
 
       hardeningDisable = [ "bindnow" ];


### PR DESCRIPTION
###### Motivation for this change

I have project in which I use the php PECL extensions [imagick](https://php.net/manual/en/book.imagick.php) and [mailparse](https://secure.php.net/manual/en/book.mailparse.php).

Even though these are already available as packages `phpPackages.imagick` and `phpPackages.mailparse`, they cannot be used yet, because they require php to be compiled with the `--enable-imagick` and `--enable-mailparse` flags.

This PR adds those flags.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

