### PR TITLE
chrony: disable the whole timesyncd module when chronyd is enabled

### DIFF
--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -109,7 +109,7 @@ in
         home = stateDir;
       };
 
-    systemd.services.timesyncd.enable = mkForce false;
+    services.timesyncd.enable = mkForce false;
 
     systemd.services.chronyd =
       { description = "chrony NTP daemon";


### PR DESCRIPTION
Peviously only the timesyncd systemd unit was disabled when you enable chrony. This meant that when you activate a system that has chronyd enabled the following strange startup behaviour takes place:

```
  systemd[1]: Starting chrony NTP daemon...
  systemd[1]: Stopping Network Time Synchronization...
  systemd[1]: Stopped chrony NTP daemon.
  systemd[1]: Starting Network Time Synchronization...
```

###### Motivation for this change


###### Things done

Tested this on my laptop by setting `services.chrony.enable = true`, switching the configuration and observing that timesyncd is stopped and chronyd is started.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

