### PR TITLE
chrony: disable the whole timesyncd module when chronyd is enabled (cherry-pick on release-18.03)

### DIFF
--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -109,7 +109,7 @@ in
         home = stateDir;
       };
 
-    systemd.services.timesyncd.enable = mkForce false;
+    services.timesyncd.enable = mkForce false;
 
     systemd.services.chronyd =
       { description = "chrony NTP daemon";


### PR DESCRIPTION
cherry picked from commit 56ef1068488c64af7c1e5b811caa24255a818bf4 on `release-18.03`. See PR: https://github.com/NixOS/nixpkgs/pull/42365 for the motivation.
