### PR TITLE
pythonPackages.monty: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
+    description = "Serves as a complement to the Python standard library by providing a suite of tools to solve many common problems";
     longDescription = "
       Monty implements supplementary useful functions for Python that are not part of the 
       standard library. Examples include useful utilities like transparent support for zipped files, useful design 

--- a/pkgs/development/python-modules/monty/default.nix
+++ b/pkgs/development/python-modules/monty/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, nose, numpy, six, ruamel_yaml, msgpack-python, coverage, coveralls, pymongo, lsof }:
+
+buildPythonPackage rec {
+  pname = "monty";
+  version = "1.0.2";
+
+  # No tests in Pypi
+  src = fetchFromGitHub {
+    owner = "materialsvirtuallab";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0ss70fanavqdpj56yymj06lacgnknb4ap39m2q28v9lz32cs6xdg";
+  };
+
+  propagatedBuildInputs = [ nose numpy six ruamel_yaml msgpack-python coverage coveralls pymongo lsof ];
+  
+  preCheck = ''
+    substituteInPlace tests/test_os.py \
+      --replace 'def test_which(self):' '#' \
+      --replace 'py = which("python")' '#' \
+      --replace 'self.assertEqual(os.path.basename(py), "python")' '#' \
+      --replace 'self.assertEqual("/usr/bin/find", which("/usr/bin/find"))' '#' \
+      --replace 'self.assertIs(which("non_existent_exe"), None)' '#' \
+  '';
+
+  meta = with stdenv.lib; {
+    longDescription = "
+      Monty implements supplementary useful functions for Python that are not part of the 
+      standard library. Examples include useful utilities like transparent support for zipped files, useful design 
+      patterns such as singleton and cached_class, and many more.
+    ";
+    homepage = https://github.com/materialsvirtuallab/monty;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -291,7 +291,9 @@ in {
 
   logster = callPackage ../development/python-modules/logster { };
 
-  mail-parser = callPackage ../development/python-modules/mail-parser {  };
+  mail-parser = callPackage ../development/python-modules/mail-parser { };
+
+  monty = callPackage ../development/python-modules/monty { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py {
     mpi = pkgs.openmpi;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

