### PR TITLE
pythonPackages.sklearn-deap: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/sklearn-deap/default.nix
+++ b/pkgs/development/python-modules/sklearn-deap/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, deap, scikitlearn, python }:
+
+buildPythonPackage rec {
+  pname = "sklearn-deap";
+  version = "0.2.2";
+
+  # No tests in Pypi
+  src = fetchFromGitHub {
+    owner = "rsteca";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "01ynmzxg181xhv2d7bs53zjvk9x2qpxix32sspq54mpigxh13ava";
+  };
+
+  propagatedBuildInputs = [ numpy scipy deap scikitlearn ];
+
+  #doCheck = false;
+  checkPhase = ''
+    ${python.interpreter} test.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Use evolutionary algorithms instead of gridsearch in scikit-learn";
+    homepage = https://github.com/rsteca/sklearn-deap;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/development/python-modules/sklearn-deap/default.nix
+++ b/pkgs/development/python-modules/sklearn-deap/default.nix
@@ -14,7 +14,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ numpy scipy deap scikitlearn ];
 
-  #doCheck = false;
   checkPhase = ''
     ${python.interpreter} test.py
   '';

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -464,6 +464,8 @@ in {
 
   sip = callPackage ../development/python-modules/sip { };
 
+  sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
+
   spglib = callPackage ../development/python-modules/spglib { };
 
   supervise_api = callPackage ../development/python-modules/supervise_api { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

