### PR TITLE
gnirehtet: init at 2.2.1

### DIFF
--- a/pkgs/tools/networking/gnirehtet/default.nix
+++ b/pkgs/tools/networking/gnirehtet/default.nix
@@ -1,0 +1,50 @@
+{stdenv, rustPlatform, fetchFromGitHub, fetchzip, androidenv, substituteAll}:
+let
+version = "2.2.1";
+apk = stdenv.mkDerivation {
+  name = "gnirehtet.apk-${version}";
+  src = fetchzip {
+    url = "https://github.com/Genymobile/gnirehtet/releases/download/v${version}/gnirehtet-rust-linux64-v${version}.zip";
+    sha256 = "1rz2wdjc1y7n8fhskmki1nj0ak80ylxspcsrcdnjkk9r7jbq0kan";
+  };
+  installPhase = ''
+    mkdir $out
+    mv gnirehtet.apk $out
+  '';
+};
+in
+rustPlatform.buildRustPackage rec {
+  name = "gnirehtet-${version}";
+
+  src = fetchFromGitHub {
+      owner = "Genymobile";
+      repo = "gnirehtet";
+      rev = "v${version}";
+      sha256 = "1mv8nq4422k2d766qjqqnqp47qzzbbvlwhdni0k6w4nmd3m5cnd9";
+  };
+  sourceRoot = "source/relay-rust";
+  cargoSha256 = "11qf9n6h6akvb0rbmsgdlfmypkbnas8ss1cs7i8w19mh7524n0v5";
+
+  patchFlags = [ "-p2" ];
+  patches = [
+    (substituteAll {
+      src = ./paths.patch;
+      adb = "${androidenv.platformTools}/bin/adb";
+      inherit apk;
+    })
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Reverse tethering over adb for Android";
+    longDescription = ''
+      This project provides reverse tethering over adb for Android: it allows devices to use the internet connection of the computer they are plugged on. It does not require any root access (neither on the device nor on the computer).
+
+      This relies on adb, make sure you have the required permissions/udev rules.
+    '';
+    homepage = https://github.com/Genymobile/gnirehtet;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ symphorien ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/tools/networking/gnirehtet/paths.patch
+++ b/pkgs/tools/networking/gnirehtet/paths.patch
@@ -1,0 +1,35 @@
+diff --git a/relay-rust/src/main.rs b/relay-rust/src/main.rs
+index 4f1be53..96d2e78 100644
+--- a/relay-rust/src/main.rs
++++ b/relay-rust/src/main.rs
+@@ -299,7 +299,7 @@ impl Command for RelayCommand {
+ 
+ fn cmd_install(serial: Option<&String>) -> Result<(), CommandExecutionError> {
+     info!(target: TAG, "Installing gnirehtet client...");
+-    exec_adb(serial, vec!["install", "-r", "gnirehtet.apk"])
++    exec_adb(serial, vec!["install", "-r", "@apk@/gnirehtet.apk"])
+ }
+ 
+ fn cmd_uninstall(serial: Option<&String>) -> Result<(), CommandExecutionError> {
+@@ -467,8 +467,8 @@ fn exec_adb<S: Into<String>>(
+     args: Vec<S>,
+ ) -> Result<(), CommandExecutionError> {
+     let adb_args = create_adb_args(serial, args);
+-    debug!(target: TAG, "Execute: adb {:?}", adb_args);
+-    match process::Command::new("adb").args(&adb_args[..]).status() {
++    debug!(target: TAG, "Execute: @adb@ {:?}", adb_args);
++    match process::Command::new("@adb@").args(&adb_args[..]).status() {
+         Ok(exit_status) => {
+             if exit_status.success() {
+                 Ok(())
+@@ -490,8 +490,8 @@ fn must_install_client(serial: Option<&String>) -> Result<bool, CommandExecution
+         serial,
+         vec!["shell", "dumpsys", "package", "com.genymobile.gnirehtet"],
+     );
+-    debug!(target: TAG, "Execute: adb {:?}", args);
+-    match process::Command::new("adb").args(&args[..]).output() {
++    debug!(target: TAG, "Execute: @adb@ {:?}", args);
++    match process::Command::new("@adb@").args(&args[..]).output() {
+         Ok(output) => {
+             if output.status.success() {
+                 // the "regex" crate makes the binary far bigger, so just parse the versionCode

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2656,6 +2656,8 @@ with pkgs;
     stdenv = overrideCC stdenv gcc49;
   };
 
+  gnirehtet = callPackage ../tools/networking/gnirehtet { };
+
   gnome15 = callPackage ../applications/misc/gnome15 {
     inherit (gnome2) gnome_python gnome_python_desktop;
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/35515

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

