### PR TITLE
singularity: add checkPhase

### DIFF
--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -51,7 +51,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook makeWrapper ];
-  buildInputs = [ coreutils gnugrep python e2fsprogs which gnutar squashfsTools gzip gnused curl utillinux libarchive file ];
+  buildInputs = [ coreutils gnugrep python e2fsprogs which gnutar squashfsTools gzip gnused curl utillinux libarchive file];
+
+  installCheckTarget = "test";
 
   meta = with stdenv.lib; {
     homepage = http://singularity.lbl.gov/;


### PR DESCRIPTION
added correct checkPhase, but fails to run correctly in nixpkgs

###### Motivation for this change

Currently singularity checks aren't run when `doCheck=true` is specified since we need to run `make test`, and because some aspects of singularity require many system tools, SUID, etc, it will be good to test.

###### Things done

Currently, there is an issue; when `checkPhase` is run, it appears to be trying to look into a directory in the `/nix/store` that may not exist yet. Can I have confirmation on if this is the likely problem, and suggestions for possible workarounds? It may require fixes on the Singularity code base, but i'll try to get them in.

```
nix-build -I nixpkgs=/home/brandon/workspace/nixpkgs -E '(import <nixpkgs>{}).singularity.overrideAttrs (oldAttrs: { doCheck=true; })' --pure
```
eventually resulted in:

```
 -Wl,-rpath -Wl,/nix/store/fjwqxfxqjnva7880vwisd3780vnaaz5n-singularity-2.5.1/lib -Wl,-z -Wl,relro -Wl,-z -Wl,now -o .libs/start-suid 
start_suid-start.o util/start_suid-util.o util/start_suid-file.o util/start_suid-registry.o util/start_suid-privilege.o util/start_sui
d-sessiondir.o util/start_suid-suid.o util/start_suid-cleanupd.o util/start_suid-fork.o util/start_suid-daemon.o util/start_suid-signa
l.o util/start_suid-mount.o  lib/image/.libs/libsingularity-image.so lib/runtime/.libs/libsingularity-runtime.so action-lib/.libs/libi
nternal.a -Wl,-rpath -Wl,/nix/store/fjwqxfxqjnva7880vwisd3780vnaaz5n-singularity-2.5.1/lib/singularity                               
libtool: link: gcc -Wall -fpie -fPIC -g -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -fstack-protector --param ssp-buffer-size=4
 -Wl,-rpath -Wl,/nix/store/fjwqxfxqjnva7880vwisd3780vnaaz5n-singularity-2.5.1/lib -Wl,-z -Wl,relro -Wl,-z -Wl,now -o .libs/mount-suid 
mount_suid-mount.o util/mount_suid-util.o util/mount_suid-file.o util/mount_suid-registry.o util/mount_suid-suid.o util/mount_suid-pri
vilege.o util/mount_suid-mount.o  lib/image/.libs/libsingularity-image.so lib/runtime/.libs/libsingularity-runtime.so -Wl,-rpath -Wl,/
nix/store/fjwqxfxqjnva7880vwisd3780vnaaz5n-singularity-2.5.1/lib/singularity                                                         
make[3]: Leaving directory '/tmp/nix-build-singularity-2.5.1.drv-0/source/src'
make[2]: Leaving directory '/tmp/nix-build-singularity-2.5.1.drv-0/source/src'
make[1]: Leaving directory '/tmp/nix-build-singularity-2.5.1.drv-0/source/src'
make[1]: Entering directory '/tmp/nix-build-singularity-2.5.1.drv-0/source'
make[1]: Nothing to be done for 'all-am'.
make[1]: Leaving directory '/tmp/nix-build-singularity-2.5.1.drv-0/source'
running tests
sh ./test.sh
Building/Installing Singularity to temporary directory
Reinvoking in a clean shell
ERROR: Could not locate singularity program at: /nix/store/fjwqxfxqjnva7880vwisd3780vnaaz5n-singularity-2.5.1/bin/singularity
make: *** [Makefile:832: test] Error 1
builder for '/nix/store/wy87hm0vrfzh20gv0ai5pz24n5alxqxv-singularity-2.5.1.drv' failed with exit code 2
error: build of '/nix/store/wy87hm0vrfzh20gv0ai5pz24n5alxqxv-singularity-2.5.1.drv' failed
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

