### PR TITLE
androidndk: Fix version selection

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -31,14 +31,14 @@ rec {
 
   armv5te-android-prebuilt = rec {
     config = "armv5tel-unknown-linux-androideabi";
-    sdkVer = "21";
+    sdkVer = "24";
     platform = platforms.armv5te-android;
     useAndroidPrebuilt = true;
   };
 
   armv7a-android-prebuilt = rec {
     config = "armv7a-unknown-linux-androideabi";
-    sdkVer = "21";
+    sdkVer = "24";
     platform = platforms.armv7a-android;
     useAndroidPrebuilt = true;
   };

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -31,7 +31,8 @@ rec {
 
   armv5te-android-prebuilt = rec {
     config = "armv5tel-unknown-linux-androideabi";
-    sdkVer = "24";
+    sdkVer = "21";
+    ndkVer = "10e";
     platform = platforms.armv5te-android;
     useAndroidPrebuilt = true;
   };
@@ -39,6 +40,7 @@ rec {
   armv7a-android-prebuilt = rec {
     config = "armv7a-unknown-linux-androideabi";
     sdkVer = "24";
+    ndkVer = "17";
     platform = platforms.armv7a-android;
     useAndroidPrebuilt = true;
   };
@@ -46,6 +48,7 @@ rec {
   aarch64-android-prebuilt = rec {
     config = "aarch64-unknown-linux-android";
     sdkVer = "24";
+    ndkVer = "17";
     platform = platforms.aarch64-multiplatform;
     useAndroidPrebuilt = true;
   };

--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -18,12 +18,12 @@ let
     "armv5tel-unknown-linux-androideabi" = {
       arch = "arm";
       triple = "arm-linux-androideabi";
-      gccVer = "4.8";
+      gccVer = "4.9";
     };
     "armv7a-unknown-linux-androideabi" = {
       arch = "arm";
       triple = "arm-linux-androideabi";
-      gccVer = "4.8";
+      gccVer = "4.9";
     };
     "aarch64-unknown-linux-android" = {
       arch = "arm64";

--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -18,7 +18,7 @@ let
     "armv5tel-unknown-linux-androideabi" = {
       arch = "arm";
       triple = "arm-linux-androideabi";
-      gccVer = "4.9";
+      gccVer = "4.8";
     };
     "armv7a-unknown-linux-androideabi" = {
       arch = "arm";

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -246,7 +246,7 @@ rec {
     sha256 = "00frcnvpcsngv00p6l2vxj4cwi2mwcm9lnjvm3zv4wrp6pss9pmw";
   };
 
-  androidndk = import ./androidndk.nix {
+  androidndk_17 = import ./androidndk.nix {
     inherit (buildPackages)
       p7zip makeWrapper;
     inherit (pkgs)
@@ -256,6 +256,7 @@ rec {
     version = "17";
     sha256 = "1jj3zy958zsidywqd5nwdyrnr72rf9zhippkl8rbqxfy8wxq2gds";
   };
+  androidndk = androidndk_17;
 
   androidndk_r8e = import ./androidndk_r8e.nix {
     inherit (buildPackages)
@@ -276,7 +277,7 @@ rec {
     inherit androidsdk;
   };
 
-  androidndkPkgs = import ./androidndk-pkgs.nix {
+  androidndkPkgs_17 = import ./androidndk-pkgs.nix {
     inherit (buildPackages)
       makeWrapper;
     inherit (pkgs)
@@ -286,10 +287,11 @@ rec {
     # but for splicing messing up on infinite recursion for the variants we
     # *dont't* use. Using this workaround, but also making a test to ensure
     # these two really are the same.
-    buildAndroidndk = buildPackages.buildPackages.androidenv.androidndk;
-    inherit androidndk;
-    targetAndroidndkPkgs = targetPackages.androidenv.androidndkPkgs;
+    buildAndroidndk = buildPackages.buildPackages.androidenv.androidndk_17;
+    androidndk = androidndk_17;
+    targetAndroidndkPkgs = targetPackages.androidenv.androidndkPkgs_17;
   };
+  androidndkPkgs = androidndkPkgs_17;
 
   androidndkPkgs_10e = import ./androidndk-pkgs.nix {
     inherit (buildPackages)

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -42,7 +42,7 @@ in lib.init bootStages ++ [
       cc = if crossSystem.useiOSPrebuilt or false
              then buildPackages.darwin.iosSdkPkgs.clang
            else if crossSystem.useAndroidPrebuilt
-             then buildPackages.androidenv.androidndkPkgs.gcc
+             then buildPackages.androidenv."androidndkPkgs_${crossSystem.ndkVer}".gcc
            else buildPackages.gcc;
     };
   })

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -41,9 +41,7 @@ in lib.init bootStages ++ [
       targetPlatform = crossSystem;
       cc = if crossSystem.useiOSPrebuilt or false
              then buildPackages.darwin.iosSdkPkgs.clang
-           else if (crossSystem.useAndroidPrebuilt && crossSystem.is32bit)
-             then buildPackages.androidenv.androidndkPkgs_10e.gcc
-           else if (crossSystem.useAndroidPrebuilt && crossSystem.is64bit)
+           else if crossSystem.useAndroidPrebuilt
              then buildPackages.androidenv.androidndkPkgs.gcc
            else buildPackages.gcc;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8695,7 +8695,7 @@ with pkgs;
 
   # TODO(@Ericson2314): Build bionic libc from source
   bionic = assert hostPlatform.useAndroidPrebuilt;
-    androidenv.androidndkPkgs.libraries;
+    androidenv."androidndkPkgs_${hostPlatform.ndkVer}".libraries;
 
   bobcat = callPackage ../development/libraries/bobcat { };
 


### PR DESCRIPTION
###### Motivation for this change

`bionic` was improperly ignoring the version. This fixes that, and also improves things so that such lapses are less likely in the future.

/cc @bkchr 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

