### PR TITLE
libxml2: add enableStatic argument

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -3,6 +3,7 @@
 , buildPlatform, hostPlatform
 , pythonSupport ? buildPlatform == hostPlatform
 , icuSupport ? false, icu ? null
+, enableStatic ? false
 }:
 
 let
@@ -18,7 +19,8 @@ in stdenv.mkDerivation rec {
   };
 
   outputs = [ "bin" "dev" "out" "man" "doc" ]
-    ++ lib.optional pythonSupport "py";
+    ++ lib.optional pythonSupport "py"
+    ++ lib.optional enableStatic "static";
   propagatedBuildOutputs = "out bin" + lib.optionalString pythonSupport " py";
 
   buildInputs = lib.optional pythonSupport python
@@ -32,7 +34,8 @@ in stdenv.mkDerivation rec {
   configureFlags =
        lib.optional pythonSupport "--with-python=${python}"
     ++ lib.optional icuSupport    "--with-icu"
-    ++ [ "--exec_prefix=$dev" ];
+    ++ [ "--exec_prefix=$dev" ]
+    ++ lib.optional enableStatic "--enable-static";
 
   enableParallelBuilding = true;
 
@@ -57,6 +60,8 @@ in stdenv.mkDerivation rec {
     moveToOutput bin/xml2-config "$dev"
     moveToOutput lib/xml2Conf.sh "$dev"
     moveToOutput share/man/man1 "$bin"
+  '' + lib.optionalString enableStatic ''
+    moveToOutput lib/libxml2.a "$static"
   '';
 
   passthru = { inherit version; pythonSupport = pythonSupport; };


### PR DESCRIPTION
libxml2Static is built by overriding the enableStatic attribute of
libxml2.

###### Motivation for this change
Bring static version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

