### PR TITLE
keepassxc: fix build with qt 5.11

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -47,7 +47,11 @@ stdenv.mkDerivation rec {
       --replace "/usr/local/share/man" "../share/man"
   '';
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
-  patches = [ ./darwin.patch ];
+
+  patches = [
+    ./darwin.patch
+    ./qt511.patch
+  ];
 
   cmakeFlags = [
     "-DKEEPASSXC_BUILD_TYPE=Release"

--- a/pkgs/applications/misc/keepassx/qt511.patch
+++ b/pkgs/applications/misc/keepassx/qt511.patch
@@ -1,0 +1,15 @@
+diff --git a/src/gui/entry/EditEntryWidget.cpp b/src/gui/entry/EditEntryWidget.cpp
+index 6fd65c1a..e99275b0 100644
+--- a/src/gui/entry/EditEntryWidget.cpp
++++ b/src/gui/entry/EditEntryWidget.cpp
+@@ -29,6 +29,7 @@
+ #include <QMenu>
+ #include <QSortFilterProxyModel>
+ #include <QTemporaryFile>
++#include <QButtonGroup>
+ #include <QMimeData>
+ #include <QEvent>
+ #include <QColorDialog>
+-- 
+2.17.1
+


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

