### PR TITLE
x2goclient: fix build with qt 5.11

### DIFF
--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -3,11 +3,11 @@ makeWrapper, qtbase, qtsvg, qtx11extras, qttools, phonon }:
 
 stdenv.mkDerivation rec {
   name = "x2goclient-${version}";
-  version = "4.1.1.1";
+  version = "4.1.2.0";
 
   src = fetchurl {
     url = "http://code.x2go.org/releases/source/x2goclient/${name}.tar.gz";
-    sha256 = "0jzlwn0v8b123h5l7hrhs35x2z6mb98zg1s0shqb4yfp2g641yp3";
+    sha256 = "1x1iiyszz6mbrnsqacxzclyx172djq865bw3y83ya7lc9j8a71zn";
   };
 
   buildInputs = [ cups libssh libXpm nxproxy openldap openssh

--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
                   qtbase qtsvg qtx11extras qttools phonon ];
   nativeBuildInputs = [ makeWrapper ];
 
-  patchPhase = ''
+  patches = [ ./qt511.patch ];
+
+  postPatch = ''
      substituteInPlace Makefile \
        --replace "SHELL=/bin/bash" "SHELL=$SHELL" \
        --replace "lrelease-qt4" "${qttools.dev}/bin/lrelease" \

--- a/pkgs/applications/networking/remote/x2goclient/qt511.patch
+++ b/pkgs/applications/networking/remote/x2goclient/qt511.patch
@@ -1,0 +1,15 @@
+diff --git a/src/printwidget.cpp b/src/printwidget.cpp
+index 58a8af7..131d340 100644
+--- a/src/printwidget.cpp
++++ b/src/printwidget.cpp
+@@ -23,6 +23,7 @@
+ #include "x2gosettings.h"
+ #include "x2gologdebug.h"
+ #include <QDir>
++#include <QButtonGroup>
+ #ifdef Q_OS_WIN
+ #include "wapi.h"
+ #endif
+-- 
+2.17.1
+


### PR DESCRIPTION
###### Motivation for this change
Fixes #42298. Also upgrade to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

