### PR TITLE
font-awesome-5: update to version 5.1.0

### DIFF
--- a/pkgs/data/fonts/font-awesome-5/default.nix
+++ b/pkgs/data/fonts/font-awesome-5/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "5.0.6";
+  version = "5.1.0";
 in fetchzip rec {
   name = "font-awesome-${version}";
 
@@ -14,7 +14,7 @@ in fetchzip rec {
     unzip -j $downloadedFile "Font-Awesome-${version}/use-on-desktop/Font Awesome 5 Free-Solid-900.otf" -d $out/share/fonts/opentype
   '';
 
-  sha256 = "1p7xb8s371r62rx0akcnlkk4mspjid6y0s9h04gakx83ymgjlfg4";
+  sha256 = "12m35bk61d8pddhybg2jpl5xv16dclz1qacdmk05m11nzshd3nz1";
 
   meta = with stdenv.lib; {
     description = "Font Awesome - OTF font";


### PR DESCRIPTION
###### Motivation for this change
Update to latest font awesome version

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

