### PR TITLE
nixos/autorandr: make default target in systemd service configurable

### DIFF
--- a/nixos/modules/services/misc/autorandr.nix
+++ b/nixos/modules/services/misc/autorandr.nix
@@ -12,6 +12,16 @@ in {
 
     services.autorandr = {
       enable = mkEnableOption "handling of hotplug and sleep events by autorandr";
+
+      defaultTarget = mkOption {
+        default = "default";
+        type = types.str;
+        description = ''
+          Fallback if no monitor layout can be detected. See the docs
+          (https://github.com/phillipberndt/autorandr/blob/v1.0/README.md#how-to-use)
+          for further reference.
+        '';
+      };
     };
 
   };
@@ -22,13 +32,21 @@ in {
 
     environment.systemPackages = [ pkgs.autorandr ];
 
-    systemd.packages = [ pkgs.autorandr ];
-
     systemd.services.autorandr = {
       wantedBy = [ "sleep.target" ];
+      description = "Autorandr execution hook";
+      after = [ "sleep.target" ];
+
+      serviceConfig = {
+        StartLimitInterval = 5;
+        StartLimitBurst = 1;
+        ExecStart = "${pkgs.autorandr}/bin/autorandr --batch --change --default ${cfg.defaultTarget}";
+        Type = "oneshot";
+        RemainAfterExit = false;
+      };
     };
 
   };
 
-  meta.maintainers = with maintainers; [ gnidorah ];
+  meta.maintainers = with maintainers; [ gnidorah ma27 ];
 }


### PR DESCRIPTION
###### Motivation for this change

The `.service` file defining the `systemd` unit for `autorandr.service`
which is bundled with the package itself uses `--default default` in the
`ExecStart` section. This can be an issue when having multiple layouts
(e.g. `default` as workstation layout I mostly work on and `mobile` when
I go somewhere else).

When the service gets restarted and `--default` can't be applied,
however the current layout can't be detected (e.g. when working with an
unknown beamer) the service silently fails with a message like this:

```
Jun 22 18:44:46 hauptshuhle autorandr[3168]: /nix/store/h83b72ffm68nm8fyjnppljchp456a94r-xrandr-1.5.0/bin/xrandr: ca>
Jun 22 18:44:46 hauptshuhle autorandr[3168]: Failed to apply profile 'default' (line 718):
Jun 22 18:44:46 hauptshuhle autorandr[3168]:   Command failed: /nix/store/h83b72ffm68nm8fyjnppljchp456a94r-xrandr-1.>
```

As discussed in the IRC (see https://botbot.me/freenode/nixos/2018-07-05/?msg=101791455&page=6)
it's a bad long-term solution in terms of maintenance to manually patch
the service file bundled with the derivation, instead the service shall
be configured declaratively. Additionally this makes possible overrides
from the user-space way easier.

The `udev` rule (in `$out/etc/udev/rules.d`) won't' be affected, it
simply runs `systemctl start autorandr.service` when e.g. a new display
is added, so now `udev` communicates with the NixOS systemd unit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

