### PR TITLE
xcode: add xcodeVer to system

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -100,6 +100,7 @@ rec {
     config = "aarch64-apple-ios";
     # config = "aarch64-apple-darwin14";
     sdkVer = "10.2";
+    xcodeVer = "8.2";
     useiOSPrebuilt = true;
     platform = {};
   };
@@ -108,6 +109,7 @@ rec {
     config = "armv7a-apple-ios";
     # config = "arm-apple-darwin10";
     sdkVer = "10.2";
+    xcodeVer = "8.2";
     useiOSPrebuilt = true;
     platform = {};
   };
@@ -116,6 +118,7 @@ rec {
     config = "x86_64-apple-ios";
     # config = "x86_64-apple-darwin14";
     sdkVer = "10.2";
+    xcodeVer = "8.2";
     useiOSPrebuilt = true;
     isiPhoneSimulator = true;
     platform = {};
@@ -125,6 +128,7 @@ rec {
     config = "i686-apple-ios";
     # config = "i386-apple-darwin11";
     sdkVer = "10.2";
+    xcodeVer = "8.2";
     useiOSPrebuilt = true;
     isiPhoneSimulator = true;
     platform = {};

--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile }:
+{ stdenv, requireFile, targetPlatform, lib }:
 
 let requireXcode = version: sha256:
   let
@@ -40,11 +40,11 @@ let requireXcode = version: sha256:
 
   in app.overrideAttrs ( oldAttrs: oldAttrs // { inherit meta; });
 
-in rec {
+in lib.makeExtensible (self: {
   xcode_8_1 = requireXcode "8.1" "18xjvfipwzia66gm3r9p770xdd4r375vak7chw5vgqnv9yyjiq2n";
   xcode_8_2 = requireXcode "8.2" "13nd1zsfqcp9hwp15hndr0rsbb8rgprrz7zr2ablj4697qca06m2";
   xcode_9_1 = requireXcode "9.1" "0ab1403wy84ys3yn26fj78cazhpnslmh3nzzp1wxib3mr1afjvic";
   xcode_9_2 = requireXcode "9.2" "1bgfgdp266cbbqf2axcflz92frzvhi0qw0jdkcw6r85kdpc8dj4c";
   xcode_9_4 = requireXcode "9.4" "6731381785075602a52489f7ea47ece8f6daf225007ba3ffae1fd59b1c0b5f01";
-  xcode = xcode_9_4;
-}
+  xcode = self."xcode_${lib.replaceStrings ["."] ["_"] (if targetPlatform.useiOSPrebuilt then targetPlatform.xcodeVer else "9.4")}";
+})

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -47,7 +47,7 @@ in
   iosSdkPkgs = darwin.callPackage ../os-specific/darwin/ios-sdk-pkgs {
     buildIosSdk = buildPackages.darwin.iosSdkPkgs.sdk;
     targetIosSdkPkgs = targetPackages.darwin.iosSdkPkgs;
-    xcode = darwin.xcode_8_2;
+    xcode = darwin.xcode;
     inherit (pkgs.llvmPackages) clang-unwrapped;
   };
 


### PR DESCRIPTION
This version number controls which xcode version to use when building
cross to iOS.

The default "darwin.xcode" attribute can be referred to to find the "right" xcode to use for your system. It will default to 9.4 (latest) on non-prebuilt targets.

/cc @alexfmpe 
