### PR TITLE
gopass: override GOPASS_CONFIG to fix completion generation

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -26,6 +26,9 @@ buildGoPackage rec {
       $bin/share/bash-completion/completions \
       $bin/share/zsh/site-functions \
       $bin/share/fish/vendor_completions.d
+    # by default, gopass tries to write configuration to /homeless-shelter
+    # during startup, which lands in stdout
+    export GOPASS_CONFIG=/dev/null
     $bin/bin/gopass completion bash > $bin/share/bash-completion/completions/_gopass
     $bin/bin/gopass completion zsh  > $bin/share/zsh/site-functions/_gopass
     $bin/bin/gopass completion fish > $bin/share/fish/vendor_completions.d/gopass.fish


### PR DESCRIPTION
gopass tries to write a version number to it's configuaration, even when
just generating the shell completion scripts. This fails, as
/homeless-shelter is read-only inside the sandbox.
As error messages are printed to stdout instead of stderr
(see https://github.com/gopasspw/gopass/issues/877), the error message
lands inside the completion script, thus breaking it.

Workaround that by setting GOPASS_CONFIG to `/dev/null`

###### Motivation for this change
`gopass`' shell completion was broken. Turns out, first line of each completion script is
>  Failed to save config: failed to create dir '/homeless-shelter/.config/gopass': mkdir /homeless-shelter: permission denied


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

