### PR TITLE
libtorrentRasterbar: use boost166 (fix build)

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, automake, autoconf, boost, openssl, lib, libtool, pkgconfig, zlib, python, libiconv, geoip, ... }:
+{ stdenv, fetchurl, automake, autoconf, boost166, openssl, lib, libtool, pkgconfig, zlib, python, libiconv, geoip, ... }:
 
 stdenv.mkDerivation rec {
   name = "libtorrent-rasterbar-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     };
 
   nativeBuildInputs = [ automake autoconf libtool pkgconfig ];
-  buildInputs = [ boost openssl zlib python libiconv geoip ];
+  buildInputs = [ boost166 openssl zlib python libiconv geoip ];
 
   preConfigure = "./autotool.sh";
 
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     "--enable-python-binding"
     "--with-libgeoip=system"
     "--with-libiconv=yes"
-    "--with-boost=${boost.dev}"
-    "--with-boost-libdir=${boost.out}/lib"
+    "--with-boost=${boost166.dev}"
+    "--with-boost-libdir=${boost166.out}/lib"
     "--with-libiconv=yes"
   ];
 


### PR DESCRIPTION
###### Motivation for this change
libtorrentRasterbar-1.1.7 won't build with boost167.
Fixes #42396 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

