### PR TITLE
[18.03] geary: 0.12.1 -> 0.12.2

### DIFF
--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_38, enchant
-, wrapGAppsHook, gdk_pixbuf, cmake, desktop-file-utils
-, libnotify, libcanberra-gtk3, libsecret, gmime
-, libpthreadstubs, sqlite
+{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_40, enchant
+, wrapGAppsHook, gdk_pixbuf, cmake, ninja, desktop-file-utils
+, libnotify, libcanberra-gtk3, libsecret, gmime, isocodes
+, gobjectIntrospection, libpthreadstubs, sqlite
 , gnome3, librsvg, gnome-doc-utils, webkitgtk }:
 
 let
@@ -17,10 +17,16 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome-themes-standard ];
 
-  nativeBuildInputs = [ vala_0_38 intltool pkgconfig wrapGAppsHook cmake desktop-file-utils gnome-doc-utils ];
-  buildInputs = [ gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
-                  libpthreadstubs gnome3.gsettings-desktop-schemas gnome3.gcr
-                  gdk_pixbuf librsvg gnome3.defaultIconTheme ];
+  nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobjectIntrospection ];
+  buildInputs = [
+    gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
+    libpthreadstubs gnome3.gsettings-desktop-schemas gnome3.gcr isocodes
+    gdk_pixbuf librsvg gnome3.defaultIconTheme
+  ];
+
+  cmakeFlags = [
+    "-DISOCODES_DIRECTORY=${isocodes}/share/xml/iso-codes"
+  ];
 
   preConfigure = ''
     substituteInPlace src/CMakeLists.txt --replace '`''${PKG_CONFIG_EXECUTABLE} --variable=girdir gobject-introspection-1.0`' '${webkitgtk.dev}/share/gir-1.0'
@@ -30,8 +36,6 @@ stdenv.mkDerivation rec {
     # Add geary to path for geary-attach
     gappsWrapperArgs+=(--prefix PATH : "$out/bin")
   '';
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Geary;

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -5,17 +5,16 @@
 , gnome3, librsvg, gnome-doc-utils, webkitgtk }:
 
 let
-  majorVersion = "0.12";
+  pname = "geary";
+  version = "0.12.1";
 in
 stdenv.mkDerivation rec {
-  name = "geary-${majorVersion}.1";
+  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/geary/${majorVersion}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "12hbpd5j3rb122nrsqmgsg31x82xl0ksm0nmsl614v1dd7crqnh6";
   };
-
-  propagatedUserEnvPkgs = [ gnome3.gnome-themes-standard ];
 
   nativeBuildInputs = [ vala_0_38 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobjectIntrospection ];
   buildInputs = [
@@ -28,14 +27,20 @@ stdenv.mkDerivation rec {
     "-DISOCODES_DIRECTORY=${isocodes}/share/xml/iso-codes"
   ];
 
-  preConfigure = ''
-    substituteInPlace src/CMakeLists.txt --replace '`''${PKG_CONFIG_EXECUTABLE} --variable=girdir gobject-introspection-1.0`' '${webkitgtk.dev}/share/gir-1.0'
-  '';
+  # TODO: This is bad, upstream should fix their code.
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${webkitgtk.dev}/share/gir-1.0";
 
   preFixup = ''
     # Add geary to path for geary-attach
     gappsWrapperArgs+=(--prefix PATH : "$out/bin")
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Geary;

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -6,14 +6,14 @@
 
 let
   pname = "geary";
-  version = "0.12.1";
+  version = "0.12.2";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "12hbpd5j3rb122nrsqmgsg31x82xl0ksm0nmsl614v1dd7crqnh6";
+    sha256 = "09j5gh4zm49fcg2ycvy00dkkw69rfppqwc3lqdi4994hry4jivx9";
   };
 
   nativeBuildInputs = [ vala_0_38 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobjectIntrospection ];

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_40, enchant
+{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_38, enchant
 , wrapGAppsHook, gdk_pixbuf, cmake, ninja, desktop-file-utils
 , libnotify, libcanberra-gtk3, libsecret, gmime, isocodes
 , gobjectIntrospection, libpthreadstubs, sqlite
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gnome3.gnome-themes-standard ];
 
-  nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobjectIntrospection ];
+  nativeBuildInputs = [ vala_0_38 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobjectIntrospection ];
   buildInputs = [
     gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
     libpthreadstubs gnome3.gsettings-desktop-schemas gnome3.gcr isocodes


### PR DESCRIPTION
###### Motivation for this change

Geary 0.12.2 fixes an [annoying bug](https://bugzilla.gnome.org/show_bug.cgi?id=788637).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

