### PR TITLE
i3status-rust: 0.9.0.2018-03-31 -> 0.9.0.2018-06-22

### DIFF
--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   name = "i3status-rust-${version}";
-  version = "0.9.0.2018-03-31";
+  version = "0.9.0.2018-06-22";
 
   src = fetchFromGitHub {
     owner = "greshake";
     repo = "i3status-rust";
-    rev = "18f99299bcd5b63da4e315c8d78622c4bbf59c45";
-    sha256 = "1pfcq3f724ri6jzchkgf96zd7lb5mc882r64ffx634gqf3n8ch41";
+    rev = "fdca01e88a7ce9bf4de0f58a922de5131e33dd00";
+    sha256 = "12dfvamf9a13b3fa7mqrwhjk3rl53463h03arqd8pvbch006hhqd";
   };
 
-  cargoSha256 = "1197hp6d4z14j0r22bvw9ly294li0ivg6yfql4lgi27hbvzag71h";
+  cargoSha256 = "01pwknfzkv49cip6asqd4pzkh9l42v06abyd9lb09ip5pkcs60lq";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change

Update as there have been a few fixes and it is not clear when the next stable version will come out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

