### PR TITLE
libtorrentRasterbar: fix build with boost167

### DIFF
--- a/pkgs/development/libraries/libtorrent-rasterbar/default.nix
+++ b/pkgs/development/libraries/libtorrent-rasterbar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, automake, autoconf, boost, openssl, lib, libtool, pkgconfig, zlib, python, libiconv, geoip, ... }:
+{ stdenv, fetchurl, fetchpatch, automake, autoconf, boost, openssl, lib, libtool, pkgconfig, zlib, python, libiconv, geoip, ... }:
 
 stdenv.mkDerivation rec {
   name = "libtorrent-rasterbar-${version}";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/arvidn/libtorrent/archive/libtorrent-${formattedVersion}.tar.gz";
       sha256 = "0vbw7wcw8x9787rq5fwaibpvvspm3237l8ahbf20gjpzxhn4yfwc";
     };
+
+patches = [
+  (fetchpatch {
+    url = "https://github.com/arvidn/libtorrent/commit/64d6b4900448097b0157abb328621dd211e2947d.patch";
+    sha256 = "0d4h0g129rsgm8xikybxypgv6nnya7ap7kskl7q78p4h6y2a0fhc";
+  })
+];
 
   nativeBuildInputs = [ automake autoconf libtool pkgconfig ];
   buildInputs = [ boost openssl zlib python libiconv geoip ];


### PR DESCRIPTION
###### Motivation for this change
libtorrentRasterbar fails to build with boost167.
This patch from upstream makes it build with boost167.

Fixes https://github.com/NixOS/nixpkgs/issues/42396

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

