### PR TITLE
nixos/screen: add `pkgs.screen` to the system closure

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -322,6 +322,14 @@ inherit (pkgs.nixos {
      <literal>kubectl delete clusterrolebinding kubernetes-dashboard</literal>
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <varname>programs.screen</varname> module provides allows to configure
+     <literal>/etc/screenrc</literal>, however the module behaved fairly counterintuitive as
+     the config exists, but the package wasn't available. Since 18.09 <literal>pkgs.screen</literal>
+     will be added to <literal>environment.systemPackages</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/programs/screen.nix
+++ b/nixos/modules/programs/screen.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   inherit (lib) mkOption mkIf types;
@@ -25,6 +25,8 @@ in
 
   config = mkIf (cfg.screenrc != "") {
     environment.etc."screenrc".text = cfg.screenrc;
+
+    environment.systemPackages = [ pkgs.screen ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

When enabling any software in `programs.*` the package should be available globally. Just adding config files seems fairly counterintuitive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

