### PR TITLE
treewide: make added libs optional

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     ../../../build-support/setup-hooks/role.bash
     ./gettext-setup-hook.sh
   ];
-  gettextNeedsLdflags = hostPlatform.libc != "glibc" && !hostPlatform.isMusl;
+  dontAddLibintl = hostPlatform.libc == "glibc" || hostPlatform.isMusl;
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gettext/gettext-setup-hook.sh
+++ b/pkgs/development/libraries/gettext/gettext-setup-hook.sh
@@ -10,7 +10,7 @@ addEnvHooks "$hostOffset" gettextDataDirsHook
 
 # libintl must be listed in load flags on non-Glibc
 # it doesn't hurt to have it in Glibc either though
-if [ ! -z "@gettextNeedsLdflags@" ]; then
+if [ -z "$dontAddLibintl" ] && [ -z "$dontAddLibs" ]; then
     # See pkgs/build-support/setup-hooks/role.bash
     getHostRole
     export NIX_${role_pre}LDFLAGS+=" -lintl"

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     ./setup-hook.sh
   ];
 
+  dontAddLibintl = hostPlatform.libc == "glibc" || hostPlatform.libc == "musl";
+
   postPatch =
     lib.optionalString ((hostPlatform != buildPlatform && hostPlatform.libc == "msvcrt") || stdenv.cc.nativeLibc)
       ''

--- a/pkgs/development/libraries/libiconv/setup-hook.sh
+++ b/pkgs/development/libraries/libiconv/setup-hook.sh
@@ -2,5 +2,7 @@
 # it doesn't hurt to have it in Glibc either though
 
 # See pkgs/build-support/setup-hooks/role.bash
-getHostRole
-export NIX_${role_pre}LDFLAGS+=" -liconv"
+if [ -z "$dontAddLibiconv" ] && [ -z "$dontAddLibs" ]; then
+    getHostRole
+    export NIX_${role_pre}LDFLAGS+=" -liconv"
+fi

--- a/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/compat-setup-hook.sh
@@ -1,6 +1,9 @@
 # See pkgs/build-support/setup-hooks/role.bash
-getHostRole
 
-export NIX_${role_pre}LDFLAGS+=" -lnbcompat"
-export NIX_${role_pre}CFLAGS_COMPILE+=" -DHAVE_NBTOOL_CONFIG_H"
-export NIX_${role_pre}CFLAGS_COMPILE+=" -include nbtool_config.h"
+if ! [ -z "$dontAddLibs" ]; then
+    getHostRole
+
+    export NIX_${role_pre}LDFLAGS+=" -lnbcompat"
+    export NIX_${role_pre}CFLAGS_COMPILE+=" -DHAVE_NBTOOL_CONFIG_H"
+    export NIX_${role_pre}CFLAGS_COMPILE+=" -include nbtool_config.h"
+fi

--- a/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
+++ b/pkgs/os-specific/bsd/netbsd/fts-setup-hook.sh
@@ -1,4 +1,7 @@
 # See pkgs/build-support/setup-hooks/role.bash
-getHostRole
 
-export NIX_${role_pre}LDFLAGS+=" -lfts"
+if ! [ -z "$dontAddLibs" ]; then
+    getHostRole
+
+    export NIX_${role_pre}LDFLAGS+=" -lfts"
+fi


### PR DESCRIPTION
Some linker configurtions have issues when you give it a library that
it’s not expecting. This seems to happen most often in cross
compilation for some reason. We now add a global option to disable
this behavior:

>  $dontAddLibs

When set to non-empty, this will prevent Nix setup hooks from adding
"compatibility" libraries. Because certain libc’s will not need these
compatiblity libraries, we have two other variables that control
adding libintl & libiconv.

>  $dontAddLibiconv
>  $dontAddLibintl

These will be set when compiling with Glibc & Musl which already have
their own version bundled. You can also set them manually in your
derivation to disable the behavior.

###### Motivation for this change

This was created in response to issues I had with libiconv & the Android NDK in #42333.