### PR TITLE
Even more android fixes

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -22,7 +22,7 @@
 
 , # Whether to build dynamic libs for the standard library (on the target
   # platform). Static libs are always built.
-  enableShared ? !targetPlatform.isWindows && !targetPlatform.useAndroidPrebuilt && !targetPlatform.useiOSPrebuilt
+  enableShared ? !targetPlatform.isWindows && !targetPlatform.useiOSPrebuilt
 
 , # Whetherto build terminfo.
   enableTerminfo ? !targetPlatform.isWindows

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -75,7 +75,7 @@ let
   targetCC = builtins.head toolsForTarget;
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (rec {
   version = "8.4.3";
   name = "${targetPrefix}ghc-${version}";
 
@@ -209,4 +209,8 @@ stdenv.mkDerivation rec {
     inherit (ghc.meta) license platforms;
   };
 
-}
+} // stdenv.lib.optionalAttrs targetPlatform.useAndroidPrebuilt {
+  dontStrip = true;
+  dontPatchELF = true;
+  noAuditTmpdir = true;
+})

--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -58,6 +58,9 @@ rec {
   binutils = wrapBintoolsWith {
     bintools = binaries;
     libc = targetAndroidndkPkgs.libraries;
+    extraBuildCommands = ''
+      echo "--build-id" >> $out/nix-support/libc-ldflags
+    '';
   };
 
   gcc = wrapCCWith {

--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -67,7 +67,10 @@ rec {
     cc = binaries;
     bintools = binutils;
     libc = targetAndroidndkPkgs.libraries;
-    extraBuildCommands = lib.optionalString targetPlatform.isAarch32 (let
+    extraBuildCommands = ''
+      echo "-D__ANDROID_API__=${targetPlatform.sdkVer}" >> $out/nix-support/cc-cflags
+    ''
+    + lib.optionalString targetPlatform.isAarch32 (let
         p =  targetPlatform.platform.gcc or {}
           // targetPlatform.parsed.abi;
         flags = lib.concatLists [

--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -1,6 +1,9 @@
 { stdenv, fetchurl, zlib, ncurses5, unzip, lib, makeWrapper
 , coreutils, file, findutils, gawk, gnugrep, gnused, jdk, which
 , platformTools, python3, libcxx, version, sha256
+, fullNDK ? false # set to true if you want other parts of the NDK
+                  # that is not used by Nixpkgs like sources,
+                  # examples, docs, or LLVM toolchains
 }:
 
 stdenv.mkDerivation rec {
@@ -55,11 +58,14 @@ stdenv.mkDerivation rec {
     }
     cd ${pkg_path}
 
+  '' + lib.optionalString (!fullNDK) ''
     # Steps to reduce output size
     rm -rf docs sources tests
     # We only support cross compiling with gcc for now
     rm -rf toolchains/*-clang* toolchains/llvm*
+  '' +
 
+  ''
     find ${pkg_path}/toolchains \( \
         \( -type f -a -name "*.so*" \) -o \
         \( -type f -a -perm -0100 \) \

--- a/pkgs/development/mobile/androidenv/androidndk_r8e.nix
+++ b/pkgs/development/mobile/androidenv/androidndk_r8e.nix
@@ -1,6 +1,9 @@
 { stdenv, fetchurl, zlib, ncurses, lib, makeWrapper
 , coreutils, file, findutils, gawk, gnugrep, gnused, jdk, which
 , platformTools
+, fullNDK ? false # set to true if you want other parts of the NDK
+                  # that is not used by Nixpkgs like sources,
+                  # examples, docs, or LLVM toolchains
 }:
 
 stdenv.mkDerivation rec {
@@ -49,11 +52,13 @@ stdenv.mkDerivation rec {
         -d $out/libexec/${name} < ${ ./make-standalone-toolchain_r8e.patch }
     cd ${pkg_path}
 
+  '' + lib.optionalString (!fullNDK) ''
     # Steps to reduce output size
     rm -rf docs sources tests
     # We only support cross compiling with gcc for now
     rm -rf toolchains/*-clang* toolchains/llvm-*
 
+  '' + ''
     find ${pkg_path}/toolchains \( \
         \( -type f -a -name "*.so*" \) -o \
         \( -type f -a -perm -0100 \) \

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -83,5 +83,6 @@ import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
   inherit config overlays crossSystem;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
-  localSystem = { system = builtins.currentSystem; } // localSystem;
+  localSystem = (if args ? localSystem then {}
+                 else { system = builtins.currentSystem; }) // localSystem;
 })


### PR DESCRIPTION
###### Motivation for this change

This is a collection of tweaks for handling android. dc261f6896106deab2efd6329479d536d3e9c255 is the commit that solves my original problem & definitely should be merged if possible as it isn't a mass rebuild.

On the other hand, 62024d280eb7ecd1f49d80406193a65901317bcb, may not be that useful but it seems like a safe thing to just disable stripping & patchelf in cross drvs. Interested in feedback on whether this is a good idea.

It doesn't seem like 25e54c53a25f673f2ada852ae143f17dd1280842 should be needed but it fixed a non-fatal warning I was getting & might give us trouble if we don't properly set up the rpath.