### PR TITLE
curl: disable default CA bundle

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -63,6 +63,10 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [
+      # Disable default CA bundle, use NIX_SSL_CERT_FILE or fallback
+      # to nss-cacert from the default profile.
+      "--without-ca-bundle"
+      "--without-ca-path"
       "--with-ca-fallback"
       "--disable-manual"
       ( if sslSupport then "--with-ssl=${openssl.dev}" else "--without-ssl" )


### PR DESCRIPTION
###### Motivation for this change

Without this curl might detect /etc/ssl/cert.pem at build time on macOS,
causing curl to ignore NIX_SSL_CERT_FILE.

Tested curl with both `NIX_SSL_CERT_FILE` and the fallback to `/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt` when it's not defined.

Fixes #42317

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
