### PR TITLE
Emacs cask version update and wrapper

### DIFF
--- a/pkgs/applications/editors/emacs-modes/cask/default.nix
+++ b/pkgs/applications/editors/emacs-modes/cask/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, emacs, python }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.1";
+  version = "0.8.4";
   name = "cask-${version}";
 
   src = fetchFromGitHub {
     owner = "cask";
     repo = "cask";
     rev = "v${version}";
-    sha256 = "1sl094adnchjvf189c3l1njawrj5ww1sv5vvjr9hb1ng2rw20z7b";
+    sha256 = "1p37lq8xpyq0rc7phxgsw3b73h8vf9rkpa5959rb5k46w6ps9686";
   };
 
   buildInputs = [ emacs python ];

--- a/pkgs/development/tools/build-managers/cask/default.nix
+++ b/pkgs/development/tools/build-managers/cask/default.nix
@@ -1,11 +1,10 @@
-{ emacsPackagesNg, writeScriptBin }:
+{ emacsPackages, writeScriptBin }:
 let
 
-  emacs = emacsPackagesNg.emacsWithPackages (epkgs: [ epkgs.cask-package-toolset ]);
-  cpt = emacsPackagesNg.cask-package-toolset;
+  cask = emacsPackages.cask;
 
 in writeScriptBin "cask" ''
 #!/bin/sh
 
-exec ${emacs}/bin/emacs --script ${cpt}/share/emacs/site-lisp/elpa/cask-package-toolset-${cpt.version}/cask-package-toolset.el -- "$@"
+exec ${cask}/bin/cask $@
 ''


### PR DESCRIPTION
###### Motivation for this change
emacsPackages.cask was updated to 0.8.4
cask was not properly executing the cask script, but rather https://github.com/AdrieanKhisbe/cask-package-toolset.el which is an "add-on"

We should review if a top-level cask even has a reason for existing.

emacsPackage.cask can be installed and works fine (has bin/)
emacsPackageNg.cask can be installed but lacks bin/

I've now adapted the top-level cask wrapper to reference emacsPackages.cask but I'm quite sure this reference won't update when emacsPackages.cask is updated. Only a reinstall/install will properly fix it, AFAICS.

Maintainers of the packages notificaiton:
@bendlas @jgeerds 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

