### PR TITLE
pythonPackages.python-periphery: init at 1.1.1

### DIFF
--- a/pkgs/development/python-modules/python-periphery/default.nix
+++ b/pkgs/development/python-modules/python-periphery/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "python-periphery";
+  version = "1.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fe8f351934edce72cd919b4eb070878ebff551db5e21aea61e0f446101f0a79f";
+  };
+
+  # Some tests require physical probing and additional physical setup
+  doCheck = false;
+
+  meta = {
+    homepage = https://github.com/vsergeev/python-periphery;
+    description = "Linux Peripheral I/O (GPIO, LED, PWM, SPI, I2C, MMIO, Serial) with Python 2 & 3";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bandresen ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -434,6 +434,8 @@ in {
     then ../development/python-modules/python3-openid
     else ../development/python-modules/python-openid) { };
 
+  python-periphery = callPackage ../development/python-modules/python-periphery { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };


### PR DESCRIPTION
###### Motivation for this change
Library needed for a undervolting service I use

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

