### PR TITLE
Cherry-pick pgmanage-10.3.0 on release-18.03

### DIFF
--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -24,9 +24,10 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A fast replacement for PGAdmin";
     longDescription = ''
-      At the heart of Postage is a modern, fast, event-based C-binary, built in
-      the style of NGINX and Node.js. This heart makes Postage as fast as any
-      PostgreSQL interface can hope to be.
+      At the heart of pgManage is a modern, fast, event-based C-binary, built in
+      the style of NGINX and Node.js. This heart makes pgManage as fast as any
+      PostgreSQL interface can hope to be. (Note: pgManage replaces Postage,
+      which is no longer maintained.)
     '';
     homepage = https://github.com/pgManage/pgManage;
     license = licenses.postgresql;

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "pgmanage-${version}";
-  version = "10.1.1";
+  version = "10.3.0";
 
   src = fetchFromGitHub {
     owner  = "pgManage";
     repo   = "pgManage";
     rev    = "v${version}";
-    sha256 = "1gv96an1ff9amh16lf71wknshmxl3l4hsl3ga7wb106c10i14zzc";
+    sha256 = "105gmwkifq04qmp5kpgybwjyx01528r6m3x1pxbvnfyni8sf74qj";
   };
 
   patchPhase = ''

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0kzdq3xl6wyclngq307544yk57vpm10wyklkbgzx649z3pls3kyw";
   };
 
+  patchPhase = ''
+    patchShebangs src/configure
+  '';
+
   buildInputs = [ postgresql openssl ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/pgmanage/default.nix
+++ b/pkgs/applications/misc/pgmanage/default.nix
@@ -2,17 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "pgmanage-${version}";
-  version = "10.1.0";
+  version = "10.1.1";
 
   src = fetchFromGitHub {
     owner  = "pgManage";
     repo   = "pgManage";
     rev    = "v${version}";
-    sha256 = "0kzdq3xl6wyclngq307544yk57vpm10wyklkbgzx649z3pls3kyw";
+    sha256 = "1gv96an1ff9amh16lf71wknshmxl3l4hsl3ga7wb106c10i14zzc";
   };
 
   patchPhase = ''
     patchShebangs src/configure
+  '';
+
+  configurePhase = ''
+    ./configure --prefix $out
   '';
 
   buildInputs = [ postgresql openssl ];


### PR DESCRIPTION
###### Motivation for this change

`release-18.03` contains `pgmanage-10.1.0`. Since then there have been two releases containing useful bugfixes:

* https://github.com/pgManage/pgManage/releases/tag/v10.1.1
* https://github.com/pgManage/pgManage/releases/tag/v10.3.0

This just cherry-picks the relevant commits on `release-18.03`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

