### PR TITLE
multimc: fix build with Qt 5.11, fix desktop icon

### DIFF
--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -24,6 +24,12 @@ in stdenv.mkDerivation rec {
     cp ../application/resources/multimc/scalable/multimc.svg $out/share/pixmaps
     cp ../application/package/linux/multimc.desktop $out/share/applications
     wrapProgram $out/bin/MultiMC --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH /run/opengl-driver/lib:${libpath} --prefix PATH : ${jdk}/bin/
+
+    # As of https://github.com/MultiMC/MultiMC5/blob/7ea1d68244fdae1e7672fb84199ee71e168b31ca/application/package/linux/multimc.desktop,
+    # the desktop icon refers to `multimc`, but the executable actually gets
+    # installed as `MultiMC`. Create compatibility symlink to fix the desktop
+    # icon.
+    ln -sf $out/bin/MultiMC $out/bin/multimc
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -4,12 +4,14 @@ let
   libpath = with xorg; stdenv.lib.makeLibraryPath [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio ];
 in stdenv.mkDerivation rec {
   name = "multimc-${version}";
-  version = "0.6.2";
+  # Current release as of 2018-06-23 (v0.6.2) breaks under Qt 5.11—see
+  # https://github.com/NixOS/nixpkgs/issues/42387
+  version = "unstable-2018-06-04";
   src = fetchFromGitHub {
     owner = "MultiMC";
     repo = "MultiMC5";
-    rev = version;
-    sha256 = "07jrr6si8nzfqwf073zhgw47y6snib23ad3imh1ik1nn5r7wqy3c";
+    rev = "19bb50b872da2702b8e0b65f3f7b6b54c1c5b071";
+    sha256 = "01frkk2klm1axr7ywnj23ikxn5pkgj8q6w8vqbslsvmh8bni8rk0";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ cmake file makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

MultiMC build has been broken since the upgrade to Qt 5.11 (see #42387). As mentioned in that issue, the desktop icon is also broken.

MultiMC had a [patch upstream](https://github.com/MultiMC/MultiMC5/commit/4d68c1b509cd289e9f02cbf258e69f2539349029) to fix build with Qt 5.11, but it hasn't hit a stable release yet, and applying the patch on top of 0.6.2 fails (see, again, discussion in #42387).

###### Things done

* Updated MultiMC temporarily to the latest commit from MultiMC's `develop` branch, where the Qt 5.11 fix has been applied.
* Created a compatibility symlink from `MultiMC` → `multimc` to fix the desktop icon.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

