### PR TITLE
epkowa: added Perfection V500 support

### DIFF
--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -6,7 +6,7 @@ libxslt,
 libusb,
 sane-backends,
 rpm, cpio,
-eject,
+getopt,
 patchelf, gcc
 }:
 
@@ -55,6 +55,7 @@ let plugins = {
         '';
       hw = "Perfection V500 Photo";
       };
+    meta = common_meta // { description = "iscan esci x770 plugin for "+passthru.hw; };
     };
   f720 = stdenv.mkDerivation rec {
     name = "iscan-gt-f720-bundle";
@@ -155,7 +156,7 @@ stdenv.mkDerivation rec {
     '';
   postFixup = ''
     # iscan-registry is a shell script requiring getopt
-    wrapProgram $out/bin/iscan-registry --prefix PATH : ${eject}/bin
+    wrapProgram $out/bin/iscan-registry --prefix PATH : ${getopt}/bin
     registry=$out/bin/iscan-registry;
     '' +
     stdenv.lib.concatStrings (stdenv.lib.mapAttrsToList (name: value: ''

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -25,6 +25,37 @@ in
 # adding a plugin for another printer shouldn't be too difficult, but you need the firmware to test...
 
 let plugins = {
+  x770 =   stdenv.mkDerivation rec {
+    name = "iscan-gt-x770-bundle";
+    version = "1.0.1";
+    pluginVersion = "2.1.2-1";
+
+    buildInputs = [ patchelf rpm ];
+    src = fetchurl {
+      url = "https://download2.ebz.epson.net/iscan/plugin/gt-x770/rpm/x64/iscan-gt-x770-bundle-${version}.x64.rpm.tar.gz";
+      sha256 = "0m9c60rszzdvq1pqfzygzzrjycm1giy465lj29108j7hsnfcv56r";
+    };
+    installPhase = ''
+      cd plugins
+      ${rpm}/bin/rpm2cpio iscan-plugin-gt-x770-${pluginVersion}.x86_64.rpm | ${cpio}/bin/cpio -idmv
+      mkdir $out
+      cp -r usr/share $out
+      cp -r usr/lib64 $out/lib
+      mv $out/share/iscan $out/share/esci
+      mv $out/lib/iscan $out/lib/esci
+      '';
+    preFixup = ''
+      lib=$out/lib/esci/libesint7C.so
+      rpath=${gcc.cc.lib}/lib/
+      patchelf --set-rpath $rpath $lib
+      '';
+    passthru = {
+      registrationCommand = ''
+        $registry --add interpreter usb 0x04b8 0x0130 "$plugin/lib/esci/libesint7C $plugin/share/esci/esfw7C.bin"
+        '';
+      hw = "Perfection V500 Photo";
+      };
+    };
   f720 = stdenv.mkDerivation rec {
     name = "iscan-gt-f720-bundle";
     version = "1.0.1";

--- a/pkgs/misc/drivers/epkowa/firmware_location.patch
+++ b/pkgs/misc/drivers/epkowa/firmware_location.patch
@@ -8,11 +8,12 @@ set this environment variable. Instead, we patch iscan to set this variable
 before loading libesci-interpreter-gt-f720.so.
 --- backend/channel-usb.c.orig	2017-08-14 11:24:27.669582456 +0200
 +++ backend/channel-usb.c	2017-08-14 11:31:40.509010897 +0200
-@@ -169,6 +169,8 @@
+@@ -169,6 +169,9 @@
  {
    SANE_Status s;
  
 +  setenv("ESCI_FIRMWARE_DIR", NIX_ESCI_PREFIX, 1);
++  setenv("ISCAN_FW_DIR", NIX_ESCI_PREFIX, 1);
 +
    s = sanei_usb_open (self->name, &self->fd);
  


### PR DESCRIPTION
###### Motivation for this change
Add support for Epson Perfection V500 Photo

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

