### PR TITLE
Revert "python: jupyterlab_launcher: 0.10.5 -> 0.11.0"

### DIFF
--- a/pkgs/development/python-modules/jupyterlab_launcher/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_launcher/default.nix
@@ -1,11 +1,11 @@
 { lib, buildPythonPackage, fetchPypi, jsonschema, notebook }:
 buildPythonPackage rec {
   pname = "jupyterlab_launcher";
-  version = "0.11.0";
+  version = "0.10.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "2eea0cc95b312e136e6e5abc64e2e62baaeca493cd32f553c2205f79e01c0423";
+    sha256 = "1v1ir182zm2dl14lqvqjhx2x40wnp0i32n6rldxnm1allfpld1n7";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
This reverts commit a4404adbcb15403b480070118809cad486398577.

###### Motivation for this change

Upgrade was part of the mass-upgrade in #41894 but this launcher version is not compatible with the latest released jupyterlab.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

