### PR TITLE
mpage: fix urls from mesa → glu transition

### DIFF
--- a/pkgs/tools/text/mpage/default.nix
+++ b/pkgs/tools/text/mpage/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "mpage-2.5.6";
   src = fetchurl {
-    url = "http://www.libGLU_combined.nl/pub/mpage/${name}.tgz";
+    url = "http://www.mesa.nl/pub/mpage/${name}.tgz";
     sha256 = "016w9sm06sn1d2lim4p8fzl6wbmad3wigxhflsybzi7p4zy6vrjg";
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     '';
 
     license = "liberal";  # a non-copyleft license, see `Copyright' file
-    homepage = http://www.libGLU_combined.nl/pub/mpage/;
+    homepage = http://www.mesa.nl/pub/mpage/;
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Find/replace error in 0acec7e984ff38b7a296a459ba4b539a3b719c1b.

###### Motivation for this change

Mentioned in a comment of 0acec7e984ff38b7a296a459ba4b539a3b719c1b.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

