### PR TITLE
lollypop: 0.9.514 -> 0.9.516

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec  {
   };
 
   nativeBuildInputs = with python36Packages; [
+    appstream-glib
     desktop-file-utils
+    gobjectIntrospection
     meson
     ninja
     pkgconfig
@@ -22,9 +24,7 @@ stdenv.mkDerivation rec  {
     wrapPython
   ];
 
-  buildInputs = [
-    appstream-glib glib gobjectIntrospection
-  ] ++ (with gnome3; [
+  buildInputs = [ glib ] ++ (with gnome3; [
     easytag gsettings_desktop_schemas gtk3 libsecret libsoup totem-pl-parser
   ]) ++ (with gst_all_1; [
     gst-libav gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -3,14 +3,14 @@
 , python36Packages, gnome3, glib, gst_all_1 }:
 
 stdenv.mkDerivation rec  {  
-  version = "0.9.514";
+  version = "0.9.516";
   name = "lollypop-${version}";
 
   src = fetchgit {
     url = "https://gitlab.gnome.org/World/lollypop";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    sha256 = "0ny8c5apldhhrcjl3wz01pbyjvf60b7xy39mpvbshvdpnqlnqsca";
+    sha256 = "0ln77cmcl5wi4xis9kmzg0knbykzwsd1n78rr7ff5y35m9p2zgrf";
   };
 
   nativeBuildInputs = with python36Packages; [


### PR DESCRIPTION
###### Motivation for this change
package bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

