### PR TITLE
oh-my-fish: init at 6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -571,7 +571,7 @@
     email = "brandon.barker@gmail.com";
     github = "bbarker";
     name = "Brandon Elam Barker";
-  };  
+  };
   bcarrell = {
     email = "brandoncarrell@gmail.com";
     github = "bcarrell";
@@ -3959,6 +3959,11 @@
     email = "twey@twey.co.uk";
     github = "twey";
     name = "James ‘Twey’ Kay";
+  };
+  tycho01 = {
+    email = "tychogrouwstra@gmail.com";
+    github = "tycho01";
+    name = "Tycho Grouwstra";
   };
   typetetris = {
     email = "ericwolf42@mail.com";

--- a/pkgs/shells/fish/oh-my-fish/default.nix
+++ b/pkgs/shells/fish/oh-my-fish/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, fish }:
+
+stdenv.mkDerivation rec {
+  version = "6";
+  name = "oh-my-fish-${version}";
+
+  src = fetchFromGitHub {
+    owner = "oh-my-fish";
+    repo = "oh-my-fish";
+    rev = "v${version}";
+    sha256 = "1fb8827hm1fngydnh3qkww7dy2p0sdzcvn0hzpg8czhazrl72kls";
+  };
+
+  buildInputs = [ fish ];
+
+  installPhase = ''
+  outdir=$out/share/oh-my-fish
+  mkdir -p $outdir
+  cp -r $src/* $outdir
+  '';
+
+  meta = with stdenv.lib; {
+  description     = "The Fishshell Framework";
+  longDescription = ''
+  Oh My Fish provides core infrastructure to allow you to install
+  packages which extend or modify the look of your shell.
+  It's fast, extensible and easy to use.
+
+  To copy the Oh My Fish configuration to your home directory, run:
+
+    # make directories
+    $ mkdir -p ~/.config/omf
+    $ mkdir -p ~/.config/fish/conf.d
+
+    $ cd ~/.config/omf && echo "stable" > channel && echo "default" > theme && echo "theme default" > bundle
+
+    # set fish file
+    $ cat > ~/.config/fish/conf.d/omf.fish <<EOF
+    # Path to Oh My Fish install.
+    set -gx OMF_PATH "$(nix-env -q --out-path oh-my-fish | cut -d' ' -f3)/share/oh-my-fish"
+    # Load Oh My Fish configuration.
+    source \$OMF_PATH/init.fish
+    >EOF
+
+    $ fish -c "omf install"
+  '';
+  homepage        = "https://github.com/oh-my-fish/oh-my-fish";
+  license         = licenses.mit;
+  platforms       = platforms.all;
+  maintainers     = with maintainers; [ tycho01 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4163,6 +4163,8 @@ with pkgs;
 
   offlineimap = callPackage ../tools/networking/offlineimap { };
 
+  oh-my-fish = callPackage ../shells/fish/oh-my-fish { };
+
   oh-my-zsh = callPackage ../shells/zsh/oh-my-zsh { };
 
   ola = callPackage ../applications/misc/ola { };


### PR DESCRIPTION
###### Motivation for this change

more packages!

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] ~~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~~
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first package, and I looked at `oh-my-zsh` for inspiration.

However, I'm not quite content at similarly handling the `~/.config` dotfiles the way I did now.
I'd appreciate pointers on a more idiomatic approach there.

Right now, I'm not sure when `longDescription` prints, because for me it didn't on install.

I'm unhappy about the `fish` line as well, as it looks like it should be run afterwards as well, though I'd prefer to minimize manual involvement...
