### PR TITLE
doc: add installCheckTarget and installCheckFlags to manual

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1731,11 +1731,34 @@ set debug-file-directory ~/.nix-profile/lib/debug
        Controls whether the installCheck phase is executed. By default it is
        skipped, but if <varname>doInstallCheck</varname> is set to true, the
        installCheck phase is usually executed. Thus you should set
-<programlisting>doInstallCheck = true;</programlisting>
+       <programlisting>doInstallCheck = true;</programlisting>
        in the derivation to enable install checks. The exception is cross
        compilation. Cross compiled builds never run tests, no matter how
        <varname>doInstallCheck</varname> is set, as the newly-built program
        won't run on the platform used to build it.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <varname>installCheckTarget</varname>
+     </term>
+     <listitem>
+      <para>
+       The make target that runs the install tests. Defaults to
+       <literal>installcheck</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <varname>installCheckFlags</varname> / <varname>installCheckFlagsArray</varname>
+     </term>
+     <listitem>
+      <para>
+       A list of strings passed as additional flags to <command>make</command>.
+       Like <varname>makeFlags</varname> and <varname>makeFlagsArray</varname>,
+       but only used by the installCheck phase.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Fixes #42393

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

