### PR TITLE
dmraid: patch to fix users of dmraid when using musl

### DIFF
--- a/pkgs/os-specific/linux/dmraid/default.nix
+++ b/pkgs/os-specific/linux/dmraid/default.nix
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
         stripLen = 2;
         extraPrefix = "1.0.0.rc16/";
       })
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/void-linux/void-packages/fceed4b8e96b3c1da07babf6f67b6ed1588a28b2/srcpkgs/dmraid/patches/007-fix-loff_t-musl.patch";
+        sha256 = "0msnq39qnzg3b1pdksnz1dgqwa3ak03g41pqh0lw3h7w5rjc016k";
+        stripLen = 2;
+        extraPrefix = "1.0.0.rc16/";
+      })
     ];
 
   postPatch = ''


### PR DESCRIPTION
I hoped that setting -D_GNU_SOURCE in the build would avoid
the need for this patch -- but that only fixes the build itself,
this patch adds the define so headers work elsewhere.

Particularly, this fixes libblockdev w/musl -- before this change
it fails to "detect" headers for dmraid.h since it doesn't compile.



Follow-on to more completely fix what was started in #42198.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---