### PR TITLE
Mutable users vs authorizedKeysFiles

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -287,7 +287,7 @@ let
           ${optionalString cfg.logFailures
               "auth required pam_tally.so"}
           ${optionalString (config.security.pam.enableSSHAgentAuth && cfg.sshAgentAuth)
-              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=~/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u"}
+              "auth sufficient ${pkgs.pam_ssh_agent_auth}/libexec/pam_ssh_agent_auth.so file=${concatStringsSep ":" config.services.openssh.authorizedKeysFiles}"}
           ${optionalString cfg.fprintAuth
               "auth sufficient ${pkgs.fprintd}/lib/security/pam_fprintd.so"}
           ${optionalString cfg.u2fAuth

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -405,7 +405,9 @@ in
       };
 
     services.openssh.authorizedKeysFiles =
-      [ ".ssh/authorized_keys" ".ssh/authorized_keys2" "/etc/ssh/authorized_keys.d/%u" ];
+      [ "/etc/ssh/authorized_keys.d/%u" ]
+      ++ lib.optionals config.users.mutableUsers
+      [ "%h/.ssh/authorized_keys" "%h/.ssh/authorized_keys2" ];
 
     services.openssh.extraConfig = mkOrder 0
       ''


### PR DESCRIPTION
No mutable SSH keys by default for immutable users
    
There are security concerns: someone could upload a new SSH key,
and we will never know. This still can be extended or overridden.
    
The %h placeholder is added to fit both sshd_config and pam_ssh_agent_auth.
Also synchronize keys with openssh.
