### PR TITLE
pythonPackages.plaid-python: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/plaid-python/default.nix
+++ b/pkgs/development/python-modules/plaid-python/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, requests }:
+{ lib, buildPythonPackage, fetchPypi, requests, pytest }:
 
 buildPythonPackage rec {
   version = "2.3.0";
@@ -9,8 +9,9 @@ buildPythonPackage rec {
     sha256 = "0kp0crzjginmga6qvwwppar5b2pbdvwryf6vdpxgx7kkwzv33w97";
   };
 
-  # Upstream has tests in a makefile, but they're not configured to run in setup.py
-  doCheck = false;
+  checkInputs = [ pytest ];
+  # Integration tests require API keys and internet access
+  checkPhase = "py.test -rxs ./tests/unit";
 
   propagatedBuildInputs = [ requests ];
 

--- a/pkgs/development/python-modules/plaid-python/default.nix
+++ b/pkgs/development/python-modules/plaid-python/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, requests }:
+
+buildPythonPackage rec {
+  version = "2.3.0";
+  pname = "plaid-python";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kp0crzjginmga6qvwwppar5b2pbdvwryf6vdpxgx7kkwzv33w97";
+  };
+
+  # Upstream has tests in a makefile, but they're not configured to run in setup.py
+  doCheck = false;
+
+  propagatedBuildInputs = [ requests ];
+
+  meta = {
+    description = "Python client library for the Plaid API and Link";
+    homepage = https://github.com/plaid/plaid-python;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3867,6 +3867,8 @@ in {
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 
+  plaid-python = callPackage ../development/python-modules/plaid-python { };
+
   plaster = callPackage ../development/python-modules/plaster {};
 
   plaster-pastedeploy = callPackage ../development/python-modules/plaster-pastedeploy {};


### PR DESCRIPTION
###### Motivation for this change
Using this as a library for other applications that access financial data through Plaid.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

