### PR TITLE
keepassxc: fix build

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -47,7 +47,10 @@ stdenv.mkDerivation rec {
       --replace "/usr/local/share/man" "../share/man"
   '';
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-rpath ${libargon2}/lib";
-  patches = [ ./darwin.patch ];
+  patches = [ 
+    ./darwin.patch
+    ./keepassxc-qt-5.11.patch
+  ];
 
   cmakeFlags = [
     "-DKEEPASSXC_BUILD_TYPE=Release"

--- a/pkgs/applications/misc/keepassx/keepassxc-qt-5.11.patch
+++ b/pkgs/applications/misc/keepassx/keepassxc-qt-5.11.patch
@@ -1,0 +1,11 @@
+fixes build with qt 5.11
+--- a/src/gui/entry/EditEntryWidget.cpp
++++ b/src/gui/entry/EditEntryWidget.cpp
+@@ -31,6 +31,7 @@
+ #include <QTemporaryFile>
+ #include <QMimeData>
+ #include <QEvent>
+ #include <QColorDialog>
++#include <QButtonGroup>
+
+ #include "autotype/AutoType.h"


### PR DESCRIPTION
see https://github.com/keepassxreboot/keepassxc/commit/3bbc6ac0e6298d27bfe0c41999460cafda8edf18#diff-c6ef17e5536e3e1f6bfb1545fa1fb2dc

###### Motivation for this change
fix keepasxc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

