### PR TITLE
structure-synth: init at v1.5

### DIFF
--- a/pkgs/tools/graphics/structure-synth/default.nix
+++ b/pkgs/tools/graphics/structure-synth/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, qt4, qmake4Hook, unzip, mesa_glu, makeWrapper }:
+
+stdenv.mkDerivation rec {
+
+  name = "structure-synth-${version}";
+  version = "v1.5";
+
+  src = fetchurl {
+    url = mirror://sourceforge/structuresynth/StructureSynth-Source-v1.5.0.zip;
+    sha256 = "1kiammx46719az6jzrav8yrwz82nk4m72ybj0kpbnvp9wfl3swbb";
+  };
+
+  buildInputs = [ qt4 unzip mesa_glu makeWrapper ];
+  nativeBuildInputs = [ qmake4Hook ];
+
+  # Thanks to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672000#15:
+  patches = [ ./gcc47.patch ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    ${qt4}/bin/qmake -project -after "CONFIG+=opengl" -after "QT+=xml opengl script" -after "unix:LIBS+=-lGLU"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin;
+    mkdir -p $out/share/Examples $out/share/Misc;
+    cp "Structure Synth Source Code" $out/bin/structure-synth;
+    cp -r Examples/* $out/share/Examples;
+    cp -r Misc/* $out/share/Misc;
+  '';
+
+  # Structure Synth expects to see 'Examples' and 'Misc' directory in
+  # either $HOME or $PWD - so help it along by moving $PWD to 'share',
+  # where we just copied those two directories:
+  preFixup = ''
+    wrapProgram "$out/bin/structure-synth" --run "cd $out/share"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Application for generating 3D structures by specifying a design grammar";
+    homepage = http://structuresynth.sourceforge.net;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/graphics/structure-synth/gcc47.patch
+++ b/pkgs/tools/graphics/structure-synth/gcc47.patch
@@ -1,0 +1,50 @@
+diff -rc "Structure Synth Source Code/SyntopiaCore/GLEngine/Raytracer/RayTracer.cpp" "Structure Synth Source Code2/SyntopiaCore/GLEngine/Raytracer/RayTracer.cpp"
+*** "Structure Synth Source Code/SyntopiaCore/GLEngine/Raytracer/RayTracer.cpp"	2010-11-13 22:32:44.000000000 -0500
+--- "Structure Synth Source Code2/SyntopiaCore/GLEngine/Raytracer/RayTracer.cpp"	2018-06-24 14:23:30.794296776 -0400
+***************
+*** 1,5 ****
+  #include <QThread>
+! 
+  
+  #include "RayTracer.h"
+  
+--- 1,5 ----
+  #include <QThread>
+! #include <GL/glu.h>
+  
+  #include "RayTracer.h"
+  
+diff -rc "Structure Synth Source Code/SyntopiaCore/GLEngine/Raytracer/VoxelStepper.cpp" "Structure Synth Source Code2/SyntopiaCore/GLEngine/Raytracer/VoxelStepper.cpp"
+*** "Structure Synth Source Code/SyntopiaCore/GLEngine/Raytracer/VoxelStepper.cpp"	2010-09-08 21:25:30.000000000 -0400
+--- "Structure Synth Source Code2/SyntopiaCore/GLEngine/Raytracer/VoxelStepper.cpp"	2018-06-24 14:23:12.542868194 -0400
+***************
+*** 122,128 ****
+  						currentT = p;
+  
+  						// We do not intersect grid.
+! 						if (!found) return false;
+  				}
+  
+  				stepX = (dir.x() > 0) ? 1 : -1;
+--- 122,128 ----
+  						currentT = p;
+  
+  						// We do not intersect grid.
+! 						if (!found) return NULL;
+  				}
+  
+  				stepX = (dir.x() > 0) ? 1 : -1;
+Only in Structure Synth Source Code2/SyntopiaCore/GLEngine/Raytracer: VoxelStepper.cpp.orig
+diff -rc "Structure Synth Source Code/SyntopiaCore/GLEngine/Sphere.h" "Structure Synth Source Code2/SyntopiaCore/GLEngine/Sphere.h"
+*** "Structure Synth Source Code/SyntopiaCore/GLEngine/Sphere.h"	2010-08-11 15:12:22.000000000 -0400
+--- "Structure Synth Source Code2/SyntopiaCore/GLEngine/Sphere.h"	2018-06-24 14:23:30.793296807 -0400
+***************
+*** 2,7 ****
+--- 2,8 ----
+  
+  #include "SyntopiaCore/Math/Vector3.h"
+  #include "Object3D.h"
++ #include <GL/glu.h>
+  
+  namespace SyntopiaCore {
+  	namespace GLEngine {	

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5129,6 +5129,8 @@ with pkgs;
 
   sstp = callPackage ../tools/networking/sstp {};
 
+  structure-synth = callPackage ../tools/graphics/structure-synth { };
+
   su-exec = callPackage ../tools/security/su-exec {};
 
   subsurface = libsForQt5.callPackage ../applications/misc/subsurface { };


### PR DESCRIPTION
###### Motivation for this change

I needed this package, and it's fairly old at this point and has received no updates since 2010, so hopefully no updates are needed until GCC/Qt upgrades break things further.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

