### PR TITLE
krop: init -> 0.5.0

### DIFF
--- a/pkgs/applications/graphics/krop/default.nix
+++ b/pkgs/applications/graphics/krop/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, python3Packages, libsForQt5, ghostscript }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "krop";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "arminstraub";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0y8z9xr10wbzmi1dg1zpcsf3ihnxrnvlaf72821x3390s3qsnydf";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyqt5
+    pypdf2
+    poppler-qt5
+    libsForQt5.poppler
+    ghostscript
+  ];
+
+  # Disable checks because of interference with older Qt versions // xcb
+  doCheck = false;
+
+  meta = {
+    homepage = http://arminstraub.com/software/krop;
+    description = "Graphical tool to crop the pages of PDF files";
+    longDescription = ''
+    Krop is a tool that allows you to optimise your PDF files, and remove
+    sections of the page you do not want.  A unique feature of krop, at least to my
+    knowledge, is its ability to automatically split pages into subpages to fit the
+    limited screensize of devices such as eReaders. This is particularly useful, if
+    your eReader does not support convenient scrolling. Krop also has a command line
+    interface.
+    '';
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ leenaars ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3327,6 +3327,8 @@ with pkgs;
 
   kronometer = libsForQt5.callPackage ../tools/misc/kronometer { };
 
+  krop = callPackage ../applications/graphics/krop { };
+
   elisa = libsForQt5.callPackage ../applications/audio/elisa { };
 
   kdiff3 = libsForQt5.callPackage ../tools/text/kdiff3 { };


### PR DESCRIPTION
###### Motivation for this change

A useful graphical and command line tool that solves a real need: cropping PDF's. Useful to clean up scans etc.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

