### PR TITLE
slurm: 17.11.5 -> 17.11.7, pyslurm: 20180427 -> 20180604

### DIFF
--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pyslurm";
-  version = "20180427";
+  version = "20180604";
 
   src = fetchFromGitHub {
     repo = "pyslurm";
     owner = "PySlurm";
-    rev = "3900e1afac9ffd13c80c57d8c39933d42eb7bad7";
-    sha256 = "1a183ig4sdbc70rx2yyaslyq61wkbsf8cbim1jj0kzrp65nf0vls";
+    rev = "9dd4817e785fee138a9e29c3d71d2ea44898eedc";
+    sha256 = "14ivwc27sjnk0z0jpfgyy9bd91m2bhcz11lzp1kk9xn4495i7wvj";
   };
 
   buildInputs = [ cython slurm ];

--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonPackage, cython, slurm }:
+{ lib, fetchFromGitHub, buildPythonPackage, cython, slurm, nose }:
 
 buildPythonPackage rec {
   pname = "pyslurm";
@@ -13,6 +13,14 @@ buildPythonPackage rec {
 
   buildInputs = [ cython slurm ];
   setupPyBuildFlags = [ "--slurm-lib=${slurm}/lib" "--slurm-inc=${slurm.dev}/include" ];
+
+  # Test cases need /etc/slurm/slurm.conf and require a working slurm installation
+  doCheck = false;
+
+  checkInputs = [ nose ];
+  checkPhase = ''
+    nosetests -v
+  '';
 
   meta = with lib; {
     homepage = https://github.com/PySlurm/pyslurm;

--- a/pkgs/development/python-modules/pyslurm/default.nix
+++ b/pkgs/development/python-modules/pyslurm/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonPackage, cython, slurm, nose }:
+{ lib, fetchFromGitHub, buildPythonPackage, cython, slurm }:
 
 buildPythonPackage rec {
   pname = "pyslurm";
@@ -16,11 +16,6 @@ buildPythonPackage rec {
 
   # Test cases need /etc/slurm/slurm.conf and require a working slurm installation
   doCheck = false;
-
-  checkInputs = [ nose ];
-  checkPhase = ''
-    nosetests -v
-  '';
 
   meta = with lib; {
     homepage = https://github.com/PySlurm/pyslurm;

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libtool, curl
+{ stdenv, fetchFromGitHub, pkgconfig, libtool, curl
 , python, munge, perl, pam, openssl
 , ncurses, mysql, gtk2, lua, hwloc, numactl
 , readline, freeipmi, libssh2, xorg
@@ -8,11 +8,16 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.11.5";
+  version = "17.11.7";
 
-  src = fetchurl {
-    url = "https://download.schedmd.com/slurm/${name}.tar.bz2";
-    sha256 = "07ghyyz12k4rksm06xf7dshwp1ndm13zphdbqja99401q4xwbx9r";
+  # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
+  # because the latter does not keep older releases.
+  src = fetchFromGitHub {
+    owner = "SchedMD";
+    repo = "slurm";
+    # The release tags use - instead of ., and have an extra -1 suffix.
+    rev = "${builtins.replaceStrings ["."] ["-"] name}-1";
+    sha256 = "00dgirjd75i1x6pj80avp18hx5gr3dsnh13vbkqbf0iwpd72qyhp";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
This commit also swaps to use the official repository's github release tags
instead of their download site, which only keeps the most recent version with no
historical archives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

