### PR TITLE
agedu: init at 20180522.5b12791

### DIFF
--- a/pkgs/tools/misc/agedu/default.nix
+++ b/pkgs/tools/misc/agedu/default.nix
@@ -1,0 +1,35 @@
+{stdenv, fetchgit, autoreconfHook, halibut}:
+let
+  date = "20180522";
+  rev = "5b12791";
+in
+stdenv.mkDerivation {
+  name = "agedu-${date}.${rev}";
+  # upstream provides tarballs but it seems they disappear after the next version is released
+  src = fetchgit {
+    url = https://git.tartarus.org/simon/agedu.git;
+    inherit rev;
+    sha256 = "1zyxif0i3yil4xm8y9aqk6wsdwi7b3jg682lv6ds6a6bl047fz1q";
+  };
+
+  nativeBuildInputs = [autoreconfHook halibut];
+
+  meta = with stdenv.lib; {
+    description = "A Unix utility for tracking down wasted disk space";
+    longDescription = ''
+       Most Unix file systems, in their default mode, helpfully record when a
+       file was last accessed. So if you generated a large amount of data years
+       ago, forgot to clean it up, and have never used it since, then it ought
+       in principle to be possible to use those last-access time stamps to tell
+       the difference between that and a large amount of data you're still
+       using regularly.
+
+       agedu uses this information to tell you which files waste disk space when
+       you haven't used them since a long time.
+    '';
+    homepage = https://www.chiark.greenend.org.uk/~sgtatham/agedu/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ symphorien ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14883,6 +14883,8 @@ with pkgs;
     stdenv = overrideCC stdenv gcc49;
   };
 
+  agedu = callPackage ../tools/misc/agedu { };
+
   ahoviewer = callPackage ../applications/graphics/ahoviewer {
     useUnrar = config.ahoviewer.useUnrar or false;
   };


### PR DESCRIPTION
###### Motivation for this change

packaging https://www.chiark.greenend.org.uk/~sgtatham/agedu/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

