### PR TITLE
casync: init at 2-152-ge4a3c5e

### DIFF
--- a/pkgs/applications/networking/sync/casync/default.nix
+++ b/pkgs/applications/networking/sync/casync/default.nix
@@ -1,6 +1,9 @@
 { stdenv, fetchFromGitHub, fetchpatch
 , meson, ninja, pkgconfig, sphinx
 , acl, curl, fuse, libselinux, udev, xz, zstd
+, fuseSupport ? true
+, selinuxSupport ? true
+, udevSupport ? true
 , glibcLocales, rsync
 }:
 
@@ -15,7 +18,10 @@ stdenv.mkDerivation rec {
     sha256 = "0zx6zvj5a6rr3w9s207rvpfw7gwssiqmp1p3c75bsirmz4nmsdf0";
   };
 
-  buildInputs = [ acl curl fuse libselinux udev xz zstd ];
+  buildInputs = [ acl curl xz zstd ]
+                ++ stdenv.lib.optionals (fuseSupport) [ fuse ]
+                ++ stdenv.lib.optionals (selinuxSupport) [ libselinux ]
+                ++ stdenv.lib.optionals (udevSupport) [ udev ];
   nativeBuildInputs = [ meson ninja pkgconfig sphinx ];
   checkInputs = [ glibcLocales rsync ];
 
@@ -27,6 +33,9 @@ stdenv.mkDerivation rec {
   '';
 
   PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
+  mesonFlags = stdenv.lib.optionals (!fuseSupport) [ "-Dfuse=false" ]
+               ++ stdenv.lib.optionals (!udevSupport) [ "-Dudev=false" ]
+               ++ stdenv.lib.optionals (!selinuxSupport) [ "-Dselinux=false" ];
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/applications/networking/sync/casync/default.nix
+++ b/pkgs/applications/networking/sync/casync/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     description = "Content-Addressable Data Synchronizer";
     homepage    = https://github.com/systemd/casync;
     license     = licenses.lgpl21;
-    platforms   = platforms.all;
+    platforms   = platforms.linux;
     maintainers = with maintainers; [ flokli ];
   };
 }

--- a/pkgs/applications/networking/sync/casync/default.nix
+++ b/pkgs/applications/networking/sync/casync/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, fetchpatch, meson, ninja, pkgconfig, sphinx, acl, curl, fuse, libselinux, udev, xz, zstd }:
+
+stdenv.mkDerivation rec {
+  name = "casync-${version}";
+  version = "2-152-ge4a3c5e";
+
+  src = fetchFromGitHub {
+    owner  = "systemd";
+    repo   = "casync";
+    rev    = "e4a3c5efc8f11e0e99f8cc97bd417665d92b40a9";
+    sha256 = "0zx6zvj5a6rr3w9s207rvpfw7gwssiqmp1p3c75bsirmz4nmsdf0";
+  };
+
+  buildInputs = [ acl curl fuse libselinux udev xz zstd ];
+  nativeBuildInputs = [ meson ninja pkgconfig sphinx ];
+
+  PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
+
+  meta = with stdenv.lib; {
+    description = "Content-Addressable Data Synchronizer";
+    homepage    = https://github.com/systemd/casync;
+    license     = licenses.lgpl21;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/applications/networking/sync/casync/default.nix
+++ b/pkgs/applications/networking/sync/casync/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchFromGitHub, fetchpatch, meson, ninja, pkgconfig, sphinx, acl, curl, fuse, libselinux, udev, xz, zstd }:
+{ stdenv, fetchFromGitHub, fetchpatch
+, meson, ninja, pkgconfig, sphinx
+, acl, curl, fuse, libselinux, udev, xz, zstd
+, glibcLocales, rsync
+}:
 
 stdenv.mkDerivation rec {
   name = "casync-${version}";
@@ -13,8 +17,21 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ acl curl fuse libselinux udev xz zstd ];
   nativeBuildInputs = [ meson ninja pkgconfig sphinx ];
+  checkInputs = [ glibcLocales rsync ];
+
+  postPatch = ''
+    for f in test/test-*.sh.in; do
+      patchShebangs $f
+    done
+    patchShebangs test/http-server.py
+  '';
 
   PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
+
+  doCheck = true;
+  preCheck = ''
+    export LC_ALL="en_US.utf-8"
+  '';
 
   meta = with stdenv.lib; {
     description = "Content-Addressable Data Synchronizer";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -991,6 +991,10 @@ with pkgs;
   capstone = callPackage ../development/libraries/capstone { };
   unicorn-emu = callPackage ../development/libraries/unicorn-emu { };
 
+  casync = callPackage ../applications/networking/sync/casync {
+    sphinx = python3Packages.sphinx;
+  };
+
   cataract          = callPackage ../applications/misc/cataract { };
   cataract-unstable = callPackage ../applications/misc/cataract/unstable.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
This adds casync to nixpkgs, with their tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

