### PR TITLE
init targetcli and dependencies for lio iscsi target management

### DIFF
--- a/pkgs/development/python-modules/configshell/default.nix
+++ b/pkgs/development/python-modules/configshell/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, pyparsing, six }:
+
+buildPythonPackage rec {
+  pname = "configshell";
+  version = "1.1.fb25";
+
+  src = fetchFromGitHub {
+    owner = "open-iscsi";
+    repo ="${pname}-fb";
+    rev = "v${version}";
+    sha256 = "0zpr2n4105qqsklyfyr9lzl1rhxjcv0mnsl57hgk0m763w6na90h";
+  };
+
+  propagatedBuildInputs = [ pyparsing six ];
+
+  meta = with stdenv.lib; {
+    description = "A Python library for building configuration shells";
+    homepage = https://github.com/open-iscsi/configshell-fb;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/rtslib/default.nix
+++ b/pkgs/development/python-modules/rtslib/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, six, pyudev, pygobject3 }:
+
+buildPythonPackage rec {
+  pname = "rtslib";
+  version = "2.1.fb69";
+
+  src = fetchFromGitHub {
+    owner = "open-iscsi";
+    repo ="${pname}-fb";
+    rev = "v${version}";
+    sha256 = "17rlcrd9757nq91pa8xjr7147k7mxxp8zdka7arhlgsp3kcnbsfd";
+  };
+
+  propagatedBuildInputs = [ six pyudev pygobject3 ];
+
+  meta = with stdenv.lib; {
+    description = "A Python object API for managing the Linux LIO kernel target";
+    homepage = https://github.com/open-iscsi/rtslib-fb;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/os-specific/linux/targetcli/default.nix
+++ b/pkgs/os-specific/linux/targetcli/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, python, fetchFromGitHub }:
+
+python.pkgs.buildPythonApplication rec {
+  pname = "targetcli";
+  version = "2.1.fb49";
+
+  src = fetchFromGitHub {
+    owner = "open-iscsi";
+    repo = "${pname}-fb";
+    rev = "v${version}";
+    sha256 = "093dmwc5g6yz4cdgpbfszmc97i7nd286w4x447dvg22hvwvjwqhh";
+  };
+
+  propagatedBuildInputs = with python.pkgs; [ configshell rtslib ];
+
+  meta = with stdenv.lib; {
+    description = "A command shell for managing the Linux LIO kernel target";
+    homepage = https://github.com/open-iscsi/targetcli-fb;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5634,6 +5634,8 @@ with pkgs;
 
   znapzend = callPackage ../tools/backup/znapzend { };
 
+  targetcli = callPackage ../os-specific/linux/targetcli { };
+
   tarsnap = callPackage ../tools/backup/tarsnap { };
 
   tarsnapper = callPackage ../tools/backup/tarsnapper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -995,6 +995,8 @@ in {
 
   colour = callPackage ../development/python-modules/colour {};
 
+  configshell = callPackage ../development/python-modules/configshell { };
+
   constantly = callPackage ../development/python-modules/constantly { };
 
   cornice = callPackage ../development/python-modules/cornice { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3783,6 +3783,8 @@ in {
 
   rpy2 = callPackage ../development/python-modules/rpy2 {};
 
+  rtslib = callPackage ../development/python-modules/rtslib {};
+
   Rtree = callPackage ../development/python-modules/Rtree { inherit (pkgs) libspatialindex; };
 
   typing = callPackage ../development/python-modules/typing { };


### PR DESCRIPTION
###### Motivation for this change
The LIO iscsi target is (relatively) widely used and packaged in a lot of distributions. That and I happen to use it, myself.

It might be noteworthy, that these packages all use the "-fb" branch, meaning the open-iscsi version and not the old, seemingly unmaintained versions. Some distributions still append this suffix, for some reason.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

