### PR TITLE
MusE: add new package at version 3.0.2

### DIFF
--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libjack2
-    qt5.qtbase
-    qt5.qtx11extras
     qt5.qtsvg
     qt5.qttools
     cmake

--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, fetchFromGitHub
 , libjack2
 , qt5
 , cmake
@@ -34,9 +35,11 @@ stdenv.mkDerivation rec {
   };
 
   src =
-    fetchGit {
-      url = "https://github.com/muse-sequencer/muse.git";
+    fetchFromGitHub {
+      owner = "muse-sequencer";
+      repo = "muse";
       rev = "02d9dc6abd757c3c1783fdd46dacd3c4ef2c0a6d";
+      sha256 = "0pn0mcg79z3bhjwxbss3ylypdz3gg70q5d1ij3x8yw65ryxbqf51";
     };
 
 

--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, libjack2
+, qt5
+, cmake
+, libsndfile
+, libsamplerate
+, ladspaH
+, fluidsynth
+, alsaLib
+, rtaudio
+, lash
+, dssi
+, liblo
+, pkgconfig
+, gitAndTools
+}:
+
+stdenv.mkDerivation rec {
+  name = "muse-sequencer-${version}";
+  version = "3.0.2";
+
+  meta = with stdenv.lib; {
+    homepage = http://www.muse-sequencer.org;
+    description = "MIDI/Audio sequencer with recording and editing capabilities";
+    longDescription = ''
+      MusE is a MIDI/Audio sequencer with recording and editing capabilities
+      written originally by Werner Schweer now developed and maintained
+      by the MusE development team.
+
+      MusE aims to be a complete multitrack virtual studio for Linux,
+      it is published under the GNU General Public License.
+    '';
+    license = stdenv.lib.licenses.gpl2;
+  };
+
+  src =
+    fetchGit {
+      url = "https://github.com/muse-sequencer/muse.git";
+      rev = "02d9dc6abd757c3c1783fdd46dacd3c4ef2c0a6d";
+    };
+
+
+  buildInputs = [
+    libjack2
+    qt5.qtbase
+    qt5.qtx11extras
+    qt5.qtsvg
+    qt5.qttools
+    cmake
+    libsndfile
+    libsamplerate
+    ladspaH
+    fluidsynth
+    alsaLib
+    rtaudio
+    lash
+    dssi
+    liblo
+    pkgconfig
+    gitAndTools.gitFull
+  ];
+
+  sourceRoot = "source/muse3";
+
+  buildPhase = ''
+    cd ..
+    bash compile_muse.sh
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cd build
+    make install
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21012,6 +21012,8 @@ with pkgs;
 
   mupen64plus = callPackage ../misc/emulators/mupen64plus { };
 
+  muse = callPackage ../applications/audio/muse { };
+
   mynewt-newt = callPackage ../tools/package-management/mynewt-newt { };
 
   inherit (callPackages ../tools/package-management/nix {


### PR DESCRIPTION
Added MusE; an application for working with midi. Allowing recording
from midi instruments, playback and editing of midi files.

###### Motivation for this change
This program was not yet in nixpkgs

###### Things done
- Built on platform(s)
   - [ Y] NixOS
   - [ N] macOS
   - [ N] other Linux distributions
- [Y] Tested execution of all binary files (usually in `./result/bin/`)

executing `./result/bin/muse3` does not work because the program cannot find the qt plugins directory.
See [ttuegel's comment this issue](https://github.com/NixOS/nixpkgs/issues/24256#issuecomment-328349797)

What I did was run `nix-env -f ~/nixpkgs/ -e muse-sequencer-3.0.2` and then execute muse3 and test it.

- [ N] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ?] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
