### PR TITLE
pHash: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1722,6 +1722,11 @@
     github = "IvanMalison";
     name = "Ivan Malison";
   };
+  imalsogreg = {
+    email = "imalsogreg@gmail.com";
+    github = "imalsogreg";
+    name = "Greg Hale";
+  };
   infinisil = {
     email = "infinisil@icloud.com";
     github = "infinisil";

--- a/pkgs/development/libraries/phash/default.nix
+++ b/pkgs/development/libraries/phash/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cimg, imagemagick }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "pHash";
+  version = "0.9.4";
+
+  buildInputs = [ cimg ];
+
+  # CImg.h calls to external binary `convert` from the `imagemagick` package
+  # at runtime
+  propagatedBuildInputs = [ imagemagick ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  configureFlags = ["--enable-video-hash=no" "--enable-audio-hash=no"];
+  postInstall = ''
+    cp ${cimg}/include/CImg.h $out/include/
+  '';
+
+  src = fetchFromGitHub {
+    owner = "clearscene";
+    repo = "pHash";
+    rev = version;
+    sha256 = "0y4gknfkns5sssfaj0snyx29752my20xmxajg6xggijx0myabbv0";
+  };
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = "Compute the perceptual hash of an image";
+    license = licenses.gpl3;
+    maintainers = [maintainers.imalsogreg];
+    platforms = platforms.all;
+    homepage = http://www.phash.org;
+    downloadPage = "https://github.com/clearscene/pHash";
+    updateWalker = true;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4078,6 +4078,8 @@ with pkgs;
 
   pasystray = callPackage ../tools/audio/pasystray { };
 
+  phash = callPackage ../development/libraries/phash { };
+
   pnmixer = callPackage ../tools/audio/pnmixer { };
 
   pulsemixer = callPackage ../tools/audio/pulsemixer { };


### PR DESCRIPTION
###### Motivation for this change

`pHash` is a useful c library with several small quirks in its build process and increasing numbers of workarounds for building on other systems.

We also have `phash` Haskell bindings in `nixpkgs` which is broken due to lack of packaging of the c library.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on 14.3.4. Tested compilation of all pkgs that depend on this change using nox-review
NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (N/A)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Additional testing

**C**
Wrote a small c program depending on `pHash` which passes a CLI argument to the library and prints the hash. This works on NixOS and Darwin. 

**Haskell**
The `phash` Haskell library with modifications to the cabal file, to use `pkgconfig-depends` field. This doesn't quite work out of the box, for reasons I am still trying to understand (and which may be due to problems with `pHash`, my nix packaging, `cabal`, or `pkg-config`, or any combination of the above). I can get the library to compile only if I add a second fake `pkg-config` dependency (I chose `libzmq` randomly). With two entries in `pkgconfig-depends` field, the `phash` bindings can successfully hash an image from a filepath. However when using only the true dependency, `configure` phase fails:

```
Setup: Missing dependency on a foreign library:
* Missing C library: pHash
This problem can usually be solved by installing the system package that
provides this library (you may need the "-dev" version). If the library is
already installed but in a non-standard location then you can use the flags
--extra-include-dirs= and --extra-lib-dirs= to specify where it is.
builder for '/nix/store/larbzl42wciih3ac4ffd1cd02blpw2gc-phash-0.0.6.drv' failed with exit code 1
error: build of '/nix/store/larbzl42wciih3ac4ffd1cd02blpw2gc-phash-0.0.6.drv' failed
```