### PR TITLE
Revert "Merge pull request #42376 from dtzWill/update/git-2.18.0"

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -18,7 +18,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.18.0";
+  version = "2.17.1";
   svn = subversionClient.override { perlBindings = perlSupport; };
 in
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "14hfwfkrci829a9316hnvkglnqqw1p03cw9k56p4fcb078wbwh4b";
+    sha256 = "0pm6bdnrrm165k3krnazxcxadifk2gqi30awlbcf9fism1x6w4vr";
   };
 
   outputs = [ "out" ] ++ stdenv.lib.optional perlSupport "gitweb";
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
 
   patches = [
     ./docbook2texi.patch
+    ./symlinks-in-bin.patch
     ./git-sh-i18n.patch
     ./ssh-path.patch
     ./git-send-email-honor-PATH.patch
@@ -276,21 +277,10 @@ EOF
 
     # XXX: I failed to understand why this one fails.
     # Could someone try to re-enable it on the next release ?
-    # Tested to fail: 2.18.0
     disable_test t1700-split-index "null sha1"
-
-    # Tested to fail: 2.18.0
-    disable_test t7005-editor "editor with a space"
-    disable_test t7005-editor "core.editor with a space"
-
-    # Tested to fail: 2.18.0
-    disable_test t9902-completion "sourcing the completion script clears cached --options"
   '' + stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
     # Test fails (as of 2.17.0, musl 1.1.19)
     disable_test t3900-i18n-commit
-    # Fails largely due to assumptions about BOM
-    # Tested to fail: 2.18.0
-    disable_test t0028-working-tree-encoding
   '';
 
 

--- a/pkgs/applications/version-management/git-and-tools/git/symlinks-in-bin.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/symlinks-in-bin.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+--- a/Makefile
++++ b/Makefile
+@@ -2609,8 +2609,7 @@
+ 	{ test "$$bindir/" = "$$execdir/" || \
+ 	  for p in git$X $(filter $(install_bindir_programs),$(ALL_PROGRAMS)); do \
+ 		$(RM) "$$execdir/$$p" && \
+-		test -z "$(NO_INSTALL_HARDLINKS)$(NO_CROSS_DIRECTORY_HARDLINKS)" && \
+-		ln "$$bindir/$$p" "$$execdir/$$p" 2>/dev/null || \
++		ln -s "$$bindir/$$p" "$$execdir/$$p" 2>/dev/null || \
+ 		cp "$$bindir/$$p" "$$execdir/$$p" || exit; \
+ 	  done; \
+ 	} && \


### PR DESCRIPTION
This reverts commit 2624f9079617df6b1fffda8c10f6a7a35068ecdc, reversing
changes made to 37aab4cbb5552bf021b20cf05d64e8ded6f3538a.

See:
https://github.com/NixOS/nixpkgs/pull/42376#issuecomment-399789096

Basically this breaks at least some users of fetchgit,
so let's revert this until this is sorted out.



Breakage.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---