### PR TITLE
bazel: Don't hardcode build tools

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -114,11 +114,10 @@ stdenv.mkDerivation rec {
         examples/java-native/src/test/java/com/example/myproject:hello
   '';
 
-  # Bazel expects gcc and java to be in the path.
   installPhase = ''
     mkdir -p $out/bin
     mv output/bazel $out/bin
-    wrapProgram "$out/bin/bazel" --prefix PATH : "${lib.makeBinPath [ stdenv.cc jdk ]}"
+    wrapProgram "$out/bin/bazel" --set JAVA_HOME "${jdk}"
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
     mv output/bazel-complete.bash $out/share/bash-completion/completions/
     cp scripts/zsh_completion/_bazel $out/share/zsh/site-functions/


### PR DESCRIPTION
Bazel is a build tool, much like Make and many others. Like Make, it
should be agnostic to the compiler toolchains the user brings into
scope. Bazel has special rules that encode domain specific knowledge
for how to compile a C++ program, or indeed a Java program and a few
others. But that's not to say that at runtime Bazel should assume
a specific C++ compiler or Java compiler anymore than Make does.

The main impact of this change is that packages that build with Bazel
will have to list the compilers they want in their `buildInputs` or
similar, rather than relying on the `bazel` package pulling them in
transitively.