### PR TITLE
pygtkglext: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2839,6 +2839,11 @@
     github = "nthorne";
     name = "Niklas Thörne";
   };
+  numinit = {
+    email = "me@numin.it";
+    github = "numinit";
+    name = "Morgan Jones";
+  };
   nyanloutre = {
     email = "paul@nyanlout.re";
     github = "nyanloutre";

--- a/pkgs/development/python-modules/pygtkglext/default.nix
+++ b/pkgs/development/python-modules/pygtkglext/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, buildPythonPackage, pkgconfig, gtk2, pygtk, gtkglext, pygobject2
+, libglade ? null, libGLU, xorg, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "pygtkglext";
+  version = "1.1.0";
+  format = "other";
+
+  disabled = isPy3k;
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/1.1/${pname}-${version}.tar.gz";
+    sha256 = "18vq07f65rgxdnplc59sh3mc55800ir6cshcbv8ffvmzc16c04lp";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  propagatedBuildInputs = [
+    pygtk pygobject2 gtk2 gtkglext
+    libGLU xorg.libXmu
+  ];
+  configureFlags = "--disable-gtkglext-test";
+
+  meta = {
+    description = "Python GTK GL extension bindings";
+    homepage = https://projects-old.gnome.org/gtkglext/index.html ;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.numinit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -384,6 +384,10 @@ in {
   pygtail = callPackage ../development/python-modules/pygtail { };
 
   pygtk = callPackage ../development/python-modules/pygtk { libglade = null; };
+  pygtkglext = callPackage ../development/python-modules/pygtkglext {
+    libglade = pkgs.gnome2.libglade;
+    gtkglext = pkgs.gnome2.gtkglext;
+  };
 
   pygtksourceview = callPackage ../development/python-modules/pygtksourceview { };
 


### PR DESCRIPTION
This is a rather old library that is a dependency of the xpra client.
If it's not provided, the xpra client warns you.

###### Motivation for this change

This library was missing and xpra was warning me.

This is my first new derivation, let me know if anything looks unnecessary. This package's setup.py doesn't even work, so I had to use the standard build process. Is there a way that the site-packages folder can automatically be added to Python's module search directories? I'm not sure it's totally functional at this point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

