### PR TITLE
Use a NixOS module for generating the gdk-pixbuf loaders cache.

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -703,6 +703,7 @@
   ./services/x11/hardware/multitouch.nix
   ./services/x11/hardware/synaptics.nix
   ./services/x11/hardware/wacom.nix
+  ./services/x11/gdk-pixbuf.nix
   ./services/x11/redshift.nix
   ./services/x11/urxvtd.nix
   ./services/x11/window-managers/awesome.nix

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -181,10 +181,8 @@ in
         target = "X11/xkb";
       };
 
-      environment.variables = {
-        # Enable GTK applications to load SVG icons
-        GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
-      };
+      # Enable GTK applications to load SVG icons
+      services.xserver.gdk-pixbuf.modulePackages = [ pkgs.librsvg ];
 
       fonts.fonts = with pkgs; [ noto-fonts hack-font ];
       fonts.fontconfig.defaultFonts = {

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -112,9 +112,10 @@ in
     ];
 
     environment.variables = {
-      GDK_PIXBUF_MODULE_FILE = "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache";
       GIO_EXTRA_MODULES = [ "${pkgs.xfce.gvfs}/lib/gio/modules" ];
     };
+
+    services.xserver.gdk-pixbuf.modulePackages = [ pkgs.librsvg ];
 
     services.xserver.desktopManager.session = [{
       name = "xfce";

--- a/nixos/modules/services/x11/gdk-pixbuf.nix
+++ b/nixos/modules/services/x11/gdk-pixbuf.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.gdk-pixbuf;
+
+  # Get packages to generate the cache for. We always include gdk_pixbuf.
+  effectivePackages = unique ([pkgs.gdk_pixbuf] ++ cfg.modulePackages);
+
+  # Generate the cache file by running gdk-pixbuf-query-loaders for each
+  # package and concatenating the results.
+  loadersCache = pkgs.runCommand "gdk-pixbuf-loaders.cache" {} ''
+    (
+      for package in ${concatStringsSep " " effectivePackages}; do
+        module_dir="$package/${pkgs.gdk_pixbuf.moduleDir}"
+        if [[ ! -d $module_dir ]]; then
+          echo "Warning (services.xserver.gdk-pixbuf): missing module directory $module_dir" 1>&2
+          continue
+        fi
+        GDK_PIXBUF_MODULEDIR="$module_dir" \
+          ${pkgs.gdk_pixbuf.dev}/bin/gdk-pixbuf-query-loaders
+      done
+    ) > "$out"
+  '';
+in
+
+{
+  options = {
+    services.xserver.gdk-pixbuf.modulePackages = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = "Packages providing GDK-Pixbuf modules, for cache generation.";
+    };
+  };
+
+  # If there is any package configured in modulePackages, we generate the
+  # loaders.cache based on that and set the environment variable
+  # GDK_PIXBUF_MODULE_FILE to point to it.
+  config = mkIf (cfg.modulePackages != []) {
+    environment.variables = {
+      GDK_PIXBUF_MODULE_FILE = "${loadersCache}";
+    };
+  };
+}


### PR DESCRIPTION
Fixes issue #33231 and makes it possible to enable Plasma and KDE at the same time.

Previously, this worked like this:
- The gdk-pixbuf package comes with a cache file covering the modules bundled
  with gdk-pixbuf.
- The librsvg package comes with a cache covering modules from gdk-pixbuf as
  well as librsvg.
- plasma5 and xfce modules set the environment variable GDK_PIXBUF_MODULE_FILE
  to the one from librsvg, so that SVG was supported in addition to the
  formats supported by gdk-pixbuf. However if both were enabled a configuration
  conflict would result (despite setting to the same value).

While this sort of worked (ignoring the conflict which perhaps could be hacked
around), it is unscalable and a hack, as there would be a real problem when one
wanted to add a third package that supports additional image formats.

A new NixOS module (gdk-pixbuf) is added with a configuration option
(modulePackages) that other modules use to request specific packages to be
included in the loaders cache. When any package is present in the list, the
module generates a system-wide loaders cache which includes the requested
packages (and always gdk-pixbuf itself), and sets the environment variable
GDK_PIXBUF_MODULE_FILE to point to the generated cache file.

The plasma5 and xfce modules are updated to add librsvg to modulePackages
instead of setting GDK_PIXBUF_MODULE_FILE.

Note that many packages create wrappers that set GDK_PIXBUF_MODULE_FILE,
some directly to the one from librsvg. Therefore this change does not
change the existing hack in the librsvg package which ensures that
file is generated. This change aims only to solve the conflict in the
global environent variable configuration.

###### Motivation for this change

Could not enable XFCE and Plasma at the same time. I confirm that with this change, I can enable both and then use Thunar from a Plasma session. I also confirm that the GDK_PIXBUF_MODULE_FILE enavironment variable is set correctly to the generated cache file and that the latter appears to be correct, listing image formats from both xdg-pixbuf modules and SVG from librsvg.

I suggest that this also be backported to 18.03 because the inability to use XFCE apps in KDE is pretty annoying and a regression from 17.09. Note that XFCE apps do not work in KDE correctly when the XFCE desktop is not enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

