### PR TITLE
lief: init at 0.9.0

### DIFF
--- a/pkgs/development/libraries/lief/default.nix
+++ b/pkgs/development/libraries/lief/default.nix
@@ -1,0 +1,14 @@
+{ stdenv, fetchzip }:
+
+fetchzip {
+  url = https://github.com/lief-project/LIEF/releases/download/0.9.0/LIEF-0.9.0-Linux.tar.gz;
+  sha256 = "1c47hwd00bp4mqd4p5b6xjfl89c3wwk9ccyc3a2gk658250g2la6";
+
+  meta = with stdenv.lib; {
+    description = "Library to Instrument Executable Formats";
+    homepage = https://lief.quarkslab.com/;
+    license = [ licenses.asl20 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.lassulus ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1353,6 +1353,8 @@ with pkgs;
 
   languagetool = callPackage ../tools/text/languagetool {  };
 
+  lief = callPackage ../development/libraries/lief {};
+
   loadwatch = callPackage ../tools/system/loadwatch { };
 
   loccount = callPackage ../development/tools/misc/loccount { };


### PR DESCRIPTION
https://lief.quarkslab.com/

For now I just use the released version because I couldn't get the cmake build to work, as it wants to do something with git I couldn't figure out.

