### PR TITLE
fac: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/development/tools/fac/default.nix
+++ b/pkgs/development/tools/fac/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "fac-${version}";
-  version = "1.1.0";
+  version = "2.0.0";
 
   goPackagePath = "github.com/mkchoi212/fac";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "mkchoi212";
     repo = "fac";
     rev = "v${version}";
-    sha256 = "054j8yrblf1frcfn3dwrjbgf000i3ngbaz2c172nwbx75g309ihx";
+    sha256 = "054bbiw0slz9szy3ap2sh5dy97w3g7ms27rd3ww3i1zdhvnggwpc";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/development/tools/fac/deps.nix
+++ b/pkgs/development/tools/fac/deps.nix
@@ -5,8 +5,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/chroma";
-      rev =  "1b755a90bd109f170385cb3964f0abdfd3451145";
-      sha256 = "1ilmavg291qhb0xq881f5h172zw40aaynqfb0y4yjyq13jnrf8p8";
+      rev =  "0c0b382eca61a71c1eb4cb4dea2bc78aa4939d96";
+      sha256 = "0chpzs542s366vv01bfhrajdrbhmrvc3gi8jhpw3xgz6wfkivcp4";
     };
   }
   {
@@ -46,21 +46,21 @@
     };
   }
   {
-    goPackagePath  = "github.com/mkchoi212/fac";
-    fetch = {
-      type = "git";
-      url = "https://github.com/mkchoi212/fac";
-      rev =  "642a3ad8d8b4b76c7eb201e6f69b3bddb210c502";
-      sha256 = "10rsmnixs3lybnj4xv09b2ya6x0hjjd03y148f78qfppyz2hsvaz";
-    };
-  }
-  {
     goPackagePath  = "github.com/nsf/termbox-go";
     fetch = {
       type = "git";
       url = "https://github.com/nsf/termbox-go";
-      rev =  "21a4d435a86280a2927985fd6296de56cbce453e";
-      sha256 = "0afbb0nr9rqzlpg5n7dg070w5scdvckyzyy525mhndp8phhzwpg7";
+      rev =  "5c94acc5e6eb520f1bcd183974e01171cc4c23b3";
+      sha256 = "1fi8imdgwvlsgifw2qfl3ww0lsrgkfsimkzz7bnrq41nar78s0fw";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
     };
   }
 ]


### PR DESCRIPTION
* update deps (dep2nix)
* seems to need $HOME/.fac.yml or emits warning
  (looks like even `touch ~/.fac.yml` appeases this)



Version bump.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---