### PR TITLE
ocamlPackages.psmt2-frontend: init at 0.1

### DIFF
--- a/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
+++ b/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, ocaml, findlib, menhir }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "psmt2-frontend is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.1";
+  name = "ocaml${ocaml.version}-psmt2-frontend-${version}";
+
+  src = fetchFromGitHub {
+    owner = "Coquera";
+    repo = "psmt2-frontend";
+    rev = version;
+    sha256 = "0k7jlsbkdyg7hafmvynp0ik8xk7mfr00wz27vxn4ncnmp20yz4vn";
+  };
+
+  prefixKey = "-prefix ";
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ ocaml findlib menhir ];
+
+  createFindlibDestdir = true;
+
+  installFlags = "LIBDIR=$(OCAMLFIND_DESTDIR)";
+
+  meta = {
+    description = "A simple parser and type-checker for polomorphic extension of the SMT-LIB 2 language";
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -534,6 +534,8 @@ let
     piqi = callPackage ../development/ocaml-modules/piqi { };
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    psmt2-frontend = callPackage ../development/ocaml-modules/psmt2-frontend { };
+
     psq = callPackage ../development/ocaml-modules/psq { };
 
     ptime = callPackage ../development/ocaml-modules/ptime { };


### PR DESCRIPTION
###### Motivation for this change

Dependency of alt-ergo-2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

