### PR TITLE
glib: patch to fix w/musl, static ctor order assumptions (quark/gobject)

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -54,8 +54,10 @@ stdenv.mkDerivation rec {
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch
     ++ optional doCheck ./skip-timer-test.patch
-    ++ optional stdenv.hostPlatform.isMusl ./quark_init_on_demand.patch
-    ++ [ ./schema-override-variable.patch ];
+    ++ optionals stdenv.hostPlatform.isMusl [
+      ./quark_init_on_demand.patch
+      ./gobject_init_on_demand.patch
+    ] ++ [ ./schema-override-variable.patch ];
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch
     ++ optional doCheck ./skip-timer-test.patch
+    ++ optional stdenv.hostPlatform.isMusl ./quark_init_on_demand.patch
     ++ [ ./schema-override-variable.patch ];
 
   outputs = [ "out" "dev" "devdoc" ];

--- a/pkgs/development/libraries/glib/gobject_init_on_demand.patch
+++ b/pkgs/development/libraries/glib/gobject_init_on_demand.patch
@@ -1,0 +1,87 @@
+--- glib-source/gobject/gtype.c	2016-08-17 17:20:47.000000000 +0200
++++ glib-source/gobject/gtype.c	2016-09-01 21:56:31.777406646 +0200
+@@ -209,6 +209,9 @@
+ static gboolean				type_node_is_a_L		(TypeNode		*node,
+ 									 TypeNode		*iface_node);
+ 
++#if !defined(__GLIBC__)
++static void gobject_init (void);
++#endif
+ 
+ /* --- enumeration --- */
+ 
+@@ -2631,7 +2634,10 @@
+ 			     GTypeFlags			 flags)
+ {
+   TypeNode *node;
+-  
++ 
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (type_id > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -2749,6 +2755,9 @@
+   TypeNode *pnode, *node;
+   GType type = 0;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (parent_type > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -2804,6 +2813,9 @@
+   TypeNode *pnode, *node;
+   GType type;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (parent_type > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -3319,6 +3331,9 @@
+ {
+   TypeNode *node;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   
+   node = lookup_type_node_I (type);
+@@ -4343,6 +4358,9 @@
+ void
+ g_type_init_with_debug_flags (GTypeDebugFlags debug_flags)
+ {
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+ 
+   if (debug_flags)
+@@ -4361,6 +4379,9 @@
+ void
+ g_type_init (void)
+ {
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+ }
+ 
+@@ -4372,6 +4393,12 @@
+   TypeNode *node;
+   GType type;
+ 
++#if !defined(__GLIBC__)
++  static int gobject_initialized = 0;
++  if (gobject_initialized)
++    return;
++  gobject_initialized = 1;
++#endif
+   /* Ensure GLib is initialized first, see
+    * https://bugzilla.gnome.org/show_bug.cgi?id=756139
+    */

--- a/pkgs/development/libraries/glib/quark_init_on_demand.patch
+++ b/pkgs/development/libraries/glib/quark_init_on_demand.patch
@@ -1,0 +1,33 @@
+--- glib-source/glib/gquark.c	2016-08-17 17:20:47.000000000 +0200
++++ glib-source/glib/gquark.c	2016-08-30 07:49:13.298234757 +0200
+@@ -57,6 +57,9 @@
+ void
+ g_quark_init (void)
+ {
++  if (quark_ht)
++    return;
++
+   g_assert (quark_seq_id == 0);
+   quark_ht = g_hash_table_new (g_str_hash, g_str_equal);
+   quarks = g_new (gchar*, QUARK_BLOCK_SIZE);
+@@ -138,9 +141,12 @@
+     return 0;
+ 
+   G_LOCK (quark_global);
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
+   G_UNLOCK (quark_global);
+
+   return quark;
+ }
+ 
+@@ -280,6 +286,7 @@
+   GQuark quark;
+   gchar **quarks_new;
+ 
++  g_quark_init ();
+   if (quark_seq_id % QUARK_BLOCK_SIZE == 0)
+     {
+       quarks_new = g_new (gchar*, quark_seq_id + QUARK_BLOCK_SIZE);


### PR DESCRIPTION
From [1] with prefix added, using local copy to avoid dep on fetchpatch.

[1] https://raw.githubusercontent.com/void-linux/void-packages/master/srcpkgs/glib/patches/quark_init_on_demand.patch





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---