### PR TITLE
radare2-cutter: 1.3 -> 1.4

### DIFF
--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -1,23 +1,28 @@
-{ stdenv, fetchFromGitHub, fetchpatch, qmake, pkgconfig, qtbase, qtsvg, radare2 }:
+{ stdenv, fetchFromGitHub
+# nativeBuildInputs
+, qmake, pkgconfig
+# Qt
+, qtbase, qtsvg, qtwebengine
+# buildInputs
+, radare2
+, python3 }:
 
 
 stdenv.mkDerivation rec {
   name = "radare2-cutter-${version}";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "radareorg";
     repo = "cutter";
     rev = "v${version}";
-    sha256 = "1z76yz2i9k8mxjk85k2agdj941szdbl2gi66p3dh50878zqavfrr";
+    sha256 = "0wsxb6jfpsmgsigmbnh08j99779bsjz02v6aasqcwl6hwjx0mjfk";
   };
 
   postUnpack = "export sourceRoot=$sourceRoot/src";
 
-  patchFlags = [ "-p2" ];
-
   nativeBuildInputs = [ qmake pkgconfig ];
-  buildInputs = [ qtbase qtsvg radare2 ];
+  buildInputs = [ qtbase qtsvg qtwebengine radare2 python3 ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Added new required deps, minor org touchup.



WIP because it seems to crash on startup, I haven't determined why.
It may need to use its internally pinned r2 version
instead of the "system" (currently 2.6.0) version we build against.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---