### PR TITLE
make-bootstrap-tools-cross: remove broken i686-musl variant

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -14,7 +14,6 @@ in with (import ../../../lib).systems.examples; {
   armv7l     = make armv7l-hf-multiplatform;
   aarch64    = make aarch64-multiplatform;
   x86_64-musl  = make musl64;
-  i686-musl    = make musl32;
   armv6l-musl  = make muslpi;
   aarch64-musl = make aarch64-multiplatform-musl;
   riscv64 = make riscv64;


### PR DESCRIPTION
Not terribly difficult to get this working, but until it does
remove it so the cross jobset doesn't have the failures this introduces.

Easy enough to restore in the future when this is fixed :).


cc #42407


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---