### PR TITLE
dunst: Also install dunstify

### DIFF
--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, makeWrapper
 , pkgconfig, which, perl, libXrandr
 , cairo, dbus, systemd, gdk_pixbuf, glib, libX11, libXScrnSaver
-, libXinerama, libnotify, libxdg_basedir, pango, xproto, librsvg
+, libXinerama, libnotify, libxdg_basedir, pango, xproto, librsvg, dunstify ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -31,7 +31,11 @@ stdenv.mkDerivation rec {
     "SERVICEDIR_SYSTEMD=$(out)/lib/systemd/user"
   ];
 
+  buildFlags = if dunstify then [ "dunstify" ] else [];
+
   postInstall = ''
+    ${if dunstify then "install -Dm755 dunstify $out/bin" else ""}
+    install -Dm755 dunstify $out/bin
     wrapProgram $out/bin/dunst \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
   '';


### PR DESCRIPTION
###### Motivation for this change

Dunst was lacking dunstify which is really useful to use non-standard features of the notification daemon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

