### PR TITLE
clightning: init at 0.6

### DIFF
--- a/pkgs/applications/altcoins/clightning.nix
+++ b/pkgs/applications/altcoins/clightning.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchpatch, python3, pkgconfig, which, libtool, autoconf, automake,
+  autogen, git, sqlite, gmp, zlib, fetchFromGitHub }:
+
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "clightning-${version}";
+  version = "0.6";
+
+  src = fetchFromGitHub {
+    fetchSubmodules = true;
+    owner = "ElementsProject";
+    repo = "lightning";
+    rev = "v${version}";
+    sha256 = "1xbi8c7kn21wj255fxnb9s0sqnzbn3wsz4p96z084k8mw1nc71vn";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ which sqlite gmp zlib autoconf libtool automake autogen python3 pkgconfig ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  configurePhase = ''
+    ./configure --prefix=$out --disable-developer --disable-valgrind
+  '';
+
+  postPatch = ''
+    echo "" > tools/refresh-submodules.sh
+    patchShebangs tools/generate-wire.py
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "A Bitcoin Lightning Network implementation in C";
+    longDescription= ''
+      c-lightning is a standard compliant implementation of the Lightning
+      Network protocol. The Lightning Network is a scalability solution for
+      Bitcoin, enabling secure and instant transfer of funds between any two
+      parties for any amount.
+    '';
+    homepage = https://github.com/ElementsProject/lightning;
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -6,6 +6,7 @@ rec {
 
   bitcoin  = libsForQt5.callPackage ./bitcoin.nix { miniupnpc = miniupnpc_2; withGui = true; };
   bitcoind = callPackage ./bitcoin.nix { miniupnpc = miniupnpc_2; withGui = false; };
+  clightning = callPackage ./clightning.nix { };
 
   bitcoin-abc  = libsForQt5.callPackage ./bitcoin-abc.nix { boost = boost165; withGui = true; };
   bitcoind-abc = callPackage ./bitcoin-abc.nix { boost = boost165; withGui = false; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15012,7 +15012,10 @@ with pkgs;
   schismtracker = callPackage ../applications/audio/schismtracker { };
 
   altcoins = recurseIntoAttrs ( callPackage ../applications/altcoins { } );
+
   bitcoin = altcoins.bitcoin;
+  clightning = altcoins.clightning;
+
   bitcoin-xt = altcoins.bitcoin-xt;
   cryptop = altcoins.cryptop;
 


### PR DESCRIPTION
c-lightning is a standard compliant implementation of the Lightning
Network protocol. The Lightning Network is a scalability solution for
Bitcoin, enabling secure and instant transfer of funds between any two
parties for any amount.

###### Motivation for this change

c-lightning first beta release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

