### PR TITLE
phonon-backend-vlc: use qt5 by default

### DIFF
--- a/pkgs/applications/audio/tomahawk/default.nix
+++ b/pkgs/applications/audio/tomahawk/default.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation rec {
     homepage = http://tomahawk-player.org/;
     license = licenses.gpl3Plus;
     platforms = platforms.all;
+    broken = true; # 2018-06-25
   };
 }

--- a/pkgs/development/libraries/phonon/backends/vlc.nix
+++ b/pkgs/development/libraries/phonon/backends/vlc.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, cmake, phonon, pkgconfig, vlc
 , extra-cmake-modules, qtbase ? null, qtx11extras ? null, qt4 ? null
-, withQt5 ? false
+, withQt4 ? false
 , debug ? false
 }:
 
@@ -11,11 +11,12 @@ let
   pname = "phonon-backend-vlc";
 in
 
-assert withQt5 -> qtbase != null;
-assert withQt5 -> qtx11extras != null;
+assert withQt4 -> qt4 != null;
+assert !withQt4 -> qtbase != null;
+assert !withQt4 -> qtx11extras != null;
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${if withQt5 then "qt5" else "qt4"}-${v}";
+  name = "${pname}-${if withQt4 then "qt4" else "qt5"}-${v}";
 
   meta = with stdenv.lib; {
     homepage = https://phonon.kde.org/;
@@ -30,11 +31,11 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ phonon vlc ]
-    ++ (if withQt5 then [ qtbase qtx11extras ] else [ qt4 ]);
+    ++ (if withQt4 then [ qt4 ] else [ qtbase qtx11extras ]);
 
-  nativeBuildInputs = [ cmake pkgconfig ] ++ optional withQt5 extra-cmake-modules;
+  nativeBuildInputs = [ cmake pkgconfig ] ++ optional (!withQt4) extra-cmake-modules;
 
   cmakeFlags =
     [ "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}" ]
-    ++ optional withQt5 "-DPHONON_BUILD_PHONON4QT5=ON";
+    ++ optional (!withQt4) "-DPHONON_BUILD_PHONON4QT5=ON";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11192,7 +11192,10 @@ with pkgs;
 
   phonon-backend-gstreamer = callPackage ../development/libraries/phonon/backends/gstreamer.nix {};
 
-  phonon-backend-vlc = callPackage ../development/libraries/phonon/backends/vlc.nix {};
+  # TODO(@Ma27) get rid of that as soon as QT4 can be dropped
+  phonon-backend-vlc = callPackage ../development/libraries/phonon/backends/vlc.nix {
+    withQt4 = true;
+  };
 
   inherit (callPackage ../development/libraries/physfs { })
     physfs_2


### PR DESCRIPTION
###### Motivation for this change

`minitube` is currently broken transitively due to the broken
`phonon-backend-qt4`: https://hydra.nixos.org/build/76523277

Although QT4 is fairly old, this package is still built with `qt4` ATM,
however QT5 is available as well. After this change, QT5 will be built
by default and in case anybody requires legacy QT4 it has to be enabled
explicitly like this:

```
with import <nixpkgs> { };
phonon-backend-vlc.override { withQt4 = true; }
```

Now the QT5-only build can be used (which fixes `minitube`) and there
are no confusions anymore with the build dependencies. Previously
`phonon-backend-vlc` and `libsForQt5.phonon-backend-vlc` used `qt4` by
default which was likely responsible for broken `minitube`.

The only package which uses `phonon-backend-vlc` as well is `tomahawk`
which is currently unmaintained in `nixpkgs` (see c76ad476b0245c474c057b451ba6fec18e7f81f1)
and broken since March (https://hydra.nixos.org/build/71873808).
FOr now I've marked it as broken as the last *stable* release is from
2015 (see https://github.com/tomahawk-player/tomahawk/releases/tag/0.8.4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

