### PR TITLE
nixos/ibus: detail workaround for issue #11558

### DIFF
--- a/nixos/modules/i18n/input-method/default.xml
+++ b/nixos/modules/i18n/input-method/default.xml
@@ -68,6 +68,18 @@ ibus.engines = with pkgs.ibus-engines; [ table table-others ];
 <para>To use any input method, the package must be added in the configuration,
   as shown above, and also (after running <literal>nixos-rebuild</literal>) the
   input method must be added from IBus' preference dialog.</para>
+
+<simplesect>
+  <title>Troubleshooting</title>
+  <para>If IBus works in some applications but not others, a likely cause of
+  this is that IBus is depending on a different version of
+  <literal>glib</literal> to what the applications are depending on. This can
+  be checked by running <literal>nix-store -q --requisites &lt;path&gt; | grep
+  glib</literal>, where <literal>&lt;path&gt;</literal> is the path of either
+  IBus or an application in the Nix store. The <literal>glib</literal>
+  packages must match exactly. If they do not, uninstalling and reinstalling
+  the application is a likely fix.</para>
+</simplesect>
 </section>
 
 <section><title>Fcitx</title>


### PR DESCRIPTION
###### Motivation for this change
Translation of https://github.com/NixOS/nixpkgs/issues/11558#issuecomment-170702789 into the manual.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Profpatsch 
