### PR TITLE
openmvg: 1.1 -> 1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3871,6 +3871,11 @@
     github = "timor";
     name = "timor";
   };
+  timput = {
+    email = "tim@timput.com";
+    github = "TimPut";
+    name = "Tim Put";
+  };
   tiramiseb = {
     email = "sebastien@maccagnoni.eu";
     github = "tiramiseb";

--- a/pkgs/applications/science/misc/openmvg/default.nix
+++ b/pkgs/applications/science/misc/openmvg/default.nix
@@ -8,7 +8,7 @@
 , enableDocs ? false }:
 
 stdenv.mkDerivation rec {
-  version = "1.1";
+  version = "1.3";
   name = "openmvg-${version}";
 
   src = fetchgit {
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
     # Tag v1.1
     rev = "refs/tags/v${version}";
-    sha256 = "1di9i7yxnkdvl8lhflynmqw62gaxwv00r1sd7nzzs9qn63g0af0f";
+    sha256 = "1cf1gbcl8zvxp4rr6f6vaxwcg0yzc4xban2b5p9zy1m4k1f81zyb";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Upstream library changes broke the building of openmvg on nixos. However, these are fixed in openmvg 1.3, so this simple version bump fixes building.

###### Things done
openmvg: 1.1 -> 1.3 version bump
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

