### PR TITLE
openmvs: build with CGAL 4.12

### DIFF
--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -24,10 +24,28 @@ stdenv.mkDerivation rec {
       "-DBUILD_STATIC_RUNTIME=ON"
       "-DINSTALL_BIN_DIR=$out/bin"
       "-DVCG_DIR=${vcg}"
+      "-DCGAL_ROOT=${cgal}/lib/cmake/CGAL"
       "-DCERES_DIR=${ceres-solver}/lib/cmake/Ceres/"
     )
   '';
+  
+  postFixup = ''
+    rp=$(patchelf --print-rpath $out/bin/DensifyPointCloud)
+    patchelf --set-rpath $rp:$out/lib/OpenMVS $out/bin/DensifyPointCloud
 
+    rp=$(patchelf --print-rpath $out/bin/InterfaceVisualSFM)
+    patchelf --set-rpath $rp:$out/lib/OpenMVS $out/bin/InterfaceVisualSFM
+
+    rp=$(patchelf --print-rpath $out/bin/ReconstructMesh)
+    patchelf --set-rpath $rp:$out/lib/OpenMVS $out/bin/ReconstructMesh
+
+    rp=$(patchelf --print-rpath $out/bin/RefineMesh)
+    patchelf --set-rpath $rp:$out/lib/OpenMVS $out/bin/RefineMesh
+
+    rp=$(patchelf --print-rpath $out/bin/TextureMesh)
+    patchelf --set-rpath $rp:$out/lib/OpenMVS $out/bin/TextureMesh
+  '';
+  
   cmakeDir = "./";
 
   dontUseCmakeBuildDir = true;


### PR DESCRIPTION
###### Motivation for this change
Changes to the folder structure of new versions of CGAL broke building of this package.

###### Things done
added explicit CMAKE declaration of CGAL library location.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

~~NOTE: This fixes the building of the package, but in order to run the binaries I needed to manually append the location of the openMVS .so files in the nix/store/ to my LD_LIBRARY_PATH environment variable. This is clearly not a complete solution. I'd appreciate it if anyone can direct me towards the correct way to fix the binaries.~~