### PR TITLE
perlPackages.MHonArc: fix build

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9522,7 +9522,7 @@ let self = _self // overrides; _self = with self; {
       url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/${name}.tar.gz";
       sha256 = "1xmf26dfwr8achprc3n1pxgl0mkiyr6pf25wq3dqgzqkghrrsxa2";
     };
-    propagatedBuildInputs = [ ];
+    outputs = [ "out" "dev" ]; # no "devdoc"
 
     installTargets = "install";
 


### PR DESCRIPTION
###### Motivation for this change

fix build problem

```
builder for '/nix/store/dkj8rc5zrh2x8scl1q9ra44x7b0k6z0v-perl-MHonArc-2.6.18.drv' failed to produce output path '/nix/store/kjyzhqxlnsv6vmfrygr7c472zhrlbdnr-perl-MHonArc-2.6.18-devdoc' 
```