### PR TITLE
ksonnet: init at v0.11.0

### DIFF
--- a/pkgs/applications/networking/cluster/ksonnet/default.nix
+++ b/pkgs/applications/networking/cluster/ksonnet/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub, ... }:
+
+let version = "0.11.0"; in
+
+buildGoPackage {
+  name = "ksonnet-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ksonnet";
+    repo = "ksonnet";
+    rev = "v${version}";
+    sha256 = "0z7gkgcsiclm72bznmzv5jcgx5rblndcsiqc0r2mwhxhmv19bs04";
+  };
+
+  goPackagePath = "github.com/ksonnet/ksonnet";
+
+  meta = {
+    description = "A CLI-supported framework that streamlines writing and deployment of Kubernetes configurations to multiple clusters. ";
+    homepage = https://github.com/ksonnet/ksonnet;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ colemickens ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16774,6 +16774,8 @@ with pkgs;
 
   kubecfg = callPackage ../applications/networking/cluster/kubecfg { };
 
+  ksonnet = callPackage ../applications/networking/cluster/ksonnet { };
+
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {  };
 
   kubectl = (kubernetes.override { components = [ "cmd/kubectl" ]; }).overrideAttrs(oldAttrs: {


### PR DESCRIPTION
###### Motivation for this change

We already have kubecfg from @bentley, this adds `ksonnet` as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

