### PR TITLE
typora: don't set XDG_RUNTIME_DIR

### DIFF
--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/typora \
       "''${gappsWrapperArgs[@]}" \
       --suffix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
-      --set XDG_RUNTIME_DIR "XDG-RUNTIME-DIR" \
       --prefix XDG_DATA_DIRS : "${gnome3.defaultIconTheme}/share"
 
     # Fix the desktop link

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -3,18 +3,18 @@
 
 stdenv.mkDerivation rec {
   name = "typora-${version}";
-  version = "0.9.48";
+  version = "0.9.53";
 
   src =
     if stdenv.system == "x86_64-linux" then
       fetchurl {
         url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
-        sha256 = "36a7c5f855306bcbe3364d12aca94c2f6d013a013e59b46f89df81496ec11800";
+        sha256 = "02k6x30l4mbjragqbq5rn663xbw3h4bxzgppfxqf5lwydswldklb";
       }
     else
       fetchurl {
         url = "https://www.typora.io/linux/typora_${version}_i386.deb";
-        sha256 = "7197c526918a791b15b701846f9f2f1747a5b8ceac77c4cba691ee6d74d07d1d";
+        sha256 = "1wyq1ri0wwdy7slbd9dwyrdynsaa644x44c815jl787sg4nhas6y";
       }
     ;
 


### PR DESCRIPTION
###### Motivation for this change
I introduced 
https://github.com/NixOS/nixpkgs/blob/daf3220213163c1e45f56abb14f245f9e5e213b4/pkgs/applications/editors/typora/default.nix#L84
in #41125 to fix the infamous gsettings error.

I discovered that this is not needed, and will make a `XDG_RUNTIME_DIR` in the current directory that it was executed in. I don't think this needs to be wrapped either.

Other than that this pr includes a version bump to 0.9.53.
[Release Notes](https://typora.io/windows/dev_release.html)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

