### PR TITLE
clipit-gtk3: init at 20180725

### DIFF
--- a/pkgs/applications/misc/clipit-gtk3/default.nix
+++ b/pkgs/applications/misc/clipit-gtk3/default.nix
@@ -1,0 +1,41 @@
+{ fetchFromGitHub
+, autoconf
+, automake
+, stdenv
+, intltool
+, pkgconfig
+, gtk3
+, xdotool
+, hicolor-icon-theme
+, libappindicator-gtk3
+}:
+
+stdenv.mkDerivation rec {
+  name = "clipit-${version}";
+  version = "50d983514386029a1f133187902084b753458f32";
+
+  src = fetchFromGitHub {
+    owner = "IvanMalison";
+    repo = "ClipIt";
+    rev = version;
+    sha256 = "1d52zjnxmcp2kr4wvq2yn9fhr61v9scp91fxfvasvz5m7k1zagdn";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+      autoconf automake intltool gtk3 xdotool hicolor-icon-theme
+      libappindicator-gtk3
+    ];
+
+  preConfigure = "./autogen.sh";
+  configureFlags = ["--with-gtk3" "--enable-appindicator"];
+  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+
+  meta = with stdenv.lib; {
+    description = "Lightweight GTK+ Clipboard Manager";
+    homepage    = "http://clipit.rspwn.com";
+    maintainers = with stdenv.lib.maintainers; [ imalison ];
+    license     = licenses.gpl3;
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15324,6 +15324,8 @@ with pkgs;
 
   clipit = callPackage ../applications/misc/clipit { };
 
+  clipit-gtk3 = callPackage ../applications/misc/clipit-gtk3 { };
+
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
 
   clp = callPackage ../applications/science/math/clp { };


### PR DESCRIPTION
###### Motivation for this change

The current version of clipit, hosted from

https://github.com/CristianHenzel/ClipIt

doesn't work with current versions of gtk3, which is why this is pointed to my fork.

This seems to build without the maintainer statement from:

https://github.com/NixOS/nixpkgs/pull/41876

although it shoudl really depend on it.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS N/A
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

