### PR TITLE
Add saml2aws package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3092,6 +3092,11 @@
     github = "pmiddend";
     name = "Philipp Middendorf";
   };
+  pmyjavec = {
+    email = "pauly@myjavec.com";
+    github = "pmyjavec";
+    name = "Pauly Myjavec";
+  };
   pneumaticat = {
     email = "kevin@potatofrom.space";
     github = "pneumaticat";

--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "saml2aws-${version}";
+  version = "2.6.1";
+
+  goPackagePath = "github.com/versent/saml2aws";
+  goDeps = ./deps.nix;
+
+  buildFlagsArray = ''
+    -ldflags=-X main.Version=${version}
+  '';
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "Versent";
+    repo = "saml2aws";
+    sha256 = "0sg5qm1gyrisna247lmxfgpa22y6rnz9vd6yg92kxlcwr4ji8l1j";
+  };
+
+  meta = with stdenv.lib; {
+    description = "CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP";
+    homepage    = https://github.com/Versent/saml2aws;
+    license     = licenses.mit;
+    platforms   = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.pmyjavec ];
+  };
+}

--- a/pkgs/tools/security/saml2aws/deps.nix
+++ b/pkgs/tools/security/saml2aws/deps.nix
@@ -1,0 +1,291 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/AlecAivazis/survey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/AlecAivazis/survey";
+      rev =  "e752db451e07e09c7d7dc8cada807a44bdb0fd47";
+      sha256 = "00fhmsaymrf86pg246cqxvfrivgfkyg3i0aixsp3sn15hg3i0vlq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/go-ntlmssp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-ntlmssp";
+      rev =  "4b934ac9dad38d389d34f0b98d98b2467c422012";
+      sha256 = "0pwrax8mih2jgsdifag0346vh0vivgyz45jc4kjy6dhp3qhsy34z";
+    };
+  }
+  {
+    goPackagePath  = "github.com/PuerkitoBio/goquery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/PuerkitoBio/goquery";
+      rev =  "dc2ec5c7ca4d9aae063b79b9f581dd3ea6afd2b2";
+      sha256 = "11010z9ask21r0dskvm2pbh3z8951bnpcqg8aqa213if4h34gaa2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/kingpin";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kingpin";
+      rev =  "947dcec5ba9c011838740e680966fd7087a71d0d";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev =  "a0175ee3bccc567396460bf5acd36800cb10c49c";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev =  "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/andybalholm/cascadia";
+    fetch = {
+      type = "git";
+      url = "https://github.com/andybalholm/cascadia";
+      rev =  "901648c87902174f774fac311d7f176f8647bdaa";
+      sha256 = "09j8cavbhqqdxjqrkwbc40g8p0i49zf3184rpjm5p2rjbprcghcc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev =  "bfc1a07cf158c30c41a3eefba8aae043d0bb5bff";
+      sha256 = "0vfpygjhdikmsqn9dgmp965ji5q790gcz9mg49mcpipc9n2lzx0d";
+    };
+  }
+  {
+    goPackagePath  = "github.com/beevik/etree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beevik/etree";
+      rev =  "9d7e8feddccb4ed1b8afb54e368bd323d2ff652c";
+      sha256 = "0f3lj7azxd5qq29hqd32211ds7n56i3rgmfll6c1f4css1f3srxg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/briandowns/spinner";
+    fetch = {
+      type = "git";
+      url = "https://github.com/briandowns/spinner";
+      rev =  "48dbb65d7bd5c74ab50d53d04c949f20e3d14944";
+      sha256 = "1178kn72agihs13ffgm2sz5ad61pqwdmkrh8rhggzbaagch9mc75";
+    };
+  }
+  {
+    goPackagePath  = "github.com/danieljoos/wincred";
+    fetch = {
+      type = "git";
+      url = "https://github.com/danieljoos/wincred";
+      rev =  "412b574fb496839b312a75fba146bd32a89001cf";
+      sha256 = "1bb1928nnikx5036aw4152p55g8xgwx42rv0n2i5zydh1031f50m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev =  "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
+      sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev =  "0b12d6b5";
+      sha256 = "1vv6hph8j6xgv7gwl9vvhlsaaqsm22sxxqmgmldi4v11783pc1ld";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "0360b2af4f38e8d38c7fce2a9f4e702702d73a39";
+      sha256 = "06w45aqz2a6yrk25axbly2k5wmsccv8cspb94bfmz4izvw8h927n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mgutz/ansi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mgutz/ansi";
+      rev =  "9520e82c474b0a04dd04f8a40959027271bab992";
+      sha256 = "00bz22314j26736w1f0q4jy9d9dfaml17vn890n5zqy3cmvmww1j";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev =  "3864e76763d94a6df2f9960b16a20a33da9f9a66";
+      sha256 = "1n8vya16l60i5jms43yb8fzdgwvqa2q926p5wkg3lbrk8pxy1nv0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "c155da19408a8799da419ed3eeb0cb5db0ad5dbc";
+      sha256 = "0g5z7al7kky11ai2dhac6gkp3b5pxsvx72yj3xg4wg3265gbn7yz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev =  "477a77ecc69700c7cdeb1fa9e129548e1c1c393c";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "f35b8ab0b5a2cef36673838d662e249dd9c94686";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tidwall/gjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tidwall/gjson";
+      rev =  "afaeb9562041a8018c74e006551143666aed08bf";
+      sha256 = "1hysk947mrlpaqjq7mab0nnm190fwvfdifaa2cq3sbwfrzx6h1c8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tidwall/match";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tidwall/match";
+      rev =  "1731857f09b1f38450e2c12409748407822dc6be";
+      sha256 = "14nv96h0mjki5q685qx8y331h4yga6hlfh3z9nz6acvnv284q578";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "a8fb68e7206f8c78be19b432c58eb52a6aa34462";
+      sha256 = "1svphap40hy5srcqnb0l207r6wfm9hf0f3fcaq124qp4m91s6vlf";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "db08ff08e8622530d9ed3a0e8ac279f6d4c02196";
+      sha256 = "1f6q8kbijnrfy6wjqxrzgjf38ippckc5w34lhqsjs7kq045aar9a";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "8014b7b116a67fea23fbb82cd834c9ad656ea44b";
+      sha256 = "1ld5nr0zqjgkny7d5biix9hbnxnlzxxa5nspnal2q2c7wnai8apa";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/AlecAivazis/survey.v1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/AlecAivazis/survey";
+      rev =  "e752db451e07e09c7d7dc8cada807a44bdb0fd47";
+      sha256 = "00fhmsaymrf86pg246cqxvfrivgfkyg3i0aixsp3sn15hg3i0vlq";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/ini.v1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev =  "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5";
+      sha256 = "0fx123601aiqqn0yr9vj6qp1bh8gp240w4qdm76irs73q8dxlk7a";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4909,6 +4909,8 @@ with pkgs;
 
   salut_a_toi = callPackage ../applications/networking/instant-messengers/salut-a-toi {};
 
+  saml2aws = callPackage ../tools/security/saml2aws {};
+
   samplicator = callPackage ../tools/networking/samplicator { };
 
   sasview = callPackage ../applications/science/misc/sasview {};


### PR DESCRIPTION
###### Motivation for this change

Adds a new package, saml2aws, a CLI tool for managaing AWS logins via
SAML. For more information see https://github.com/Versent/saml2aws.

###### Things done

* Add nix expression to build the package.
* Add myself as a maintainer.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

