### PR TITLE
qiskit: fix build

### DIFF
--- a/pkgs/development/python-modules/qiskit/setup.py.patch
+++ b/pkgs/development/python-modules/qiskit/setup.py.patch
@@ -1,19 +1,21 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -28,11 +28,11 @@ from setuptools.dist import Distribution
+@@ -18,13 +18,13 @@ from setuptools.dist import Distribution
  
  requirements = [
-     "IBMQuantumExperience>=1.8.29",
+     "IBMQuantumExperience>=1.9.2",
 -    "matplotlib>=2.1,<2.2",
 -    "networkx>=2.0,<2.1",
 -    "numpy>=1.13,<1.15",
 -    "ply==3.10",
--    "scipy>=0.19,<1.1",
+-    "scipy>=0.19,<1.2",
+-    "sympy>=1.0,<1.2",
+-    "pillow>=4.2.1,<5.2"
 +    "matplotlib>=2.1",
 +    "networkx>=2.0",
 +    "numpy>=1.13",
 +    "ply>=3.10",
 +    "scipy>=0.19",
-     "sympy>=1.0",
-     "pillow>=4.2.1"
++    "sympy>=1.0",
++    "pillow>=4.2.1"
  ]


### PR DESCRIPTION
###### Motivation for this change
Fixed build error of QISKit

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

