### PR TITLE
installer: Don't run graphical installer ISOs as root

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -78,6 +78,12 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
   <itemizedlist>
    <listitem>
     <para>
+     The installer is no longer running the graphical session as root.
+     To gain root privileges in the graphical session use <literal>sudo</literal> without a password.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      <literal>lib.strict</literal> is removed. Use
      <literal>builtins.seq</literal> instead.
     </para>

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -1,0 +1,73 @@
+# This module contains the basic configuration for building a graphical NixOS
+# installation CD.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ./installation-cd-base.nix ];
+
+  users.extraUsers.live = {
+    isNormalUser = true;
+    uid = 1000;
+    extraGroups = [ "wheel" "networkmanager" "video" ];
+    # Allow the graphical user to login without password
+    initialHashedPassword = "";
+  };
+
+  # Allow passwordless sudo from live user
+  security.sudo = {
+    enable = lib.mkForce true;
+    wheelNeedsPassword = lib.mkForce false;
+  };
+
+  # Whitelist wheel users to do anything
+  # This is useful for things like pkexec
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (subject.isInGroup("wheel")) {
+        return polkit.Result.YES;
+      }
+    });
+  '';
+
+  services.xserver = {
+    enable = true;
+
+    # Don't start the X server by default.
+    autorun = mkForce false;
+
+    # Automatically login as live user.
+    displayManager.slim = {
+      enable = true;
+      defaultUser = "live";
+      autoLogin = true;
+    };
+
+  };
+
+  # Provide networkmanager for easy wireless configuration.
+  networking.networkmanager.enable = true;
+  networking.wireless.enable = mkForce false;
+
+  # KDE complains if power management is disabled (to be precise, if
+  # there is no power management backend such as upower).
+  powerManagement.enable = true;
+
+  environment.systemPackages = [
+    # Include gparted for partitioning disks.
+    pkgs.gparted
+
+    # Include some editors.
+    pkgs.vim
+    pkgs.bvi # binary editor
+    pkgs.joe
+
+    # Firefox for reading the manual.
+    pkgs.firefox
+
+    pkgs.glxinfo
+  ];
+
+}

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -6,16 +6,9 @@
 with lib;
 
 {
-  imports = [ ./installation-cd-base.nix ];
+  imports = [ ./installation-cd-graphical-base.nix ];
 
   services.xserver = {
-    enable = true;
-    # GDM doesn't start in virtual machines with ISO
-    displayManager.slim = {
-      enable = true;
-      defaultUser = "root";
-      autoLogin = true;
-    };
     desktopManager.gnome3 = {
       enable = true;
       extraGSettingsOverrides = ''
@@ -33,46 +26,10 @@ with lib;
     };
   };
 
-  environment.systemPackages =
-    [ # Include gparted for partitioning disks.
-      pkgs.gparted
-
-      # Include some editors.
-      pkgs.vim
-      pkgs.bvi # binary editor
-      pkgs.joe
-
-      pkgs.glxinfo
-    ];
-
-  # Don't start the X server by default.
-  services.xserver.autorun = mkForce false;
-
-  # Auto-login as root.
+  # Auto-login as live.
   services.xserver.displayManager.gdm.autoLogin = {
     enable = true;
-    user = "root";
+    user = "live";
   };
-
-  system.activationScripts.installerDesktop = let
-    # Must be executable
-    desktopFile = pkgs.writeScript "nixos-manual.desktop" ''
-      [Desktop Entry]
-      Version=1.0
-      Type=Link
-      Name=NixOS Manual
-      URL=${config.system.build.manual.manual}/share/doc/nixos/index.html
-      Icon=system-help
-    '';
-
-  # use cp and chmod +x, we must be sure the apps are in the nix store though
-  in ''
-    mkdir -p /root/Desktop
-    ln -sfT ${desktopFile} /root/Desktop/nixos-manual.desktop
-    cp ${pkgs.gnome3.gnome-terminal}/share/applications/gnome-terminal.desktop /root/Desktop/gnome-terminal.desktop
-    chmod a+rx /root/Desktop/gnome-terminal.desktop
-    cp ${pkgs.gparted}/share/applications/gparted.desktop /root/Desktop/gparted.desktop
-    chmod a+rx /root/Desktop/gparted.desktop
-  '';
 
 }


### PR DESCRIPTION
###### Motivation for this change
This is currently causing issues with some tools like Dolphin (the KDE
file manager) that refuses to run as root.
It's also very rare for graphical install media to be running as root nowadays, all other distros I know of run their installation processes as unprivileged users.
We can instead allow passwordless sudo with similar effect.

On the TTY you are still root, it's just the graphical session user that has changed.

I also took the opportunity to deduplicate some configuration that was the same across KDE/GNOME live ISOs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

