### PR TITLE
clisp-tip: allow build on Darwin

### DIFF
--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -93,6 +93,6 @@ stdenv.mkDerivation rec {
     homepage = http://clisp.cons.org;
     maintainers = with stdenv.lib.maintainers; [raskin tohl];
     # problems on Darwin: https://github.com/NixOS/nixpkgs/issues/20062
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

People say it might build on Darwin

###### Things done

Nothing — it is pure ofborg abuse.