### PR TITLE
configuration-hackage2nix: language-puppet

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -6543,7 +6543,7 @@ dont-distribute-packages:
   language-oberon:                              [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-objc:                                [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-pig:                                 [ i686-linux, x86_64-linux, x86_64-darwin ]
-  language-puppet:                              [ i686-linux, x86_64-darwin ]
+  language-puppet:                              [ i686-linux]
   language-python-colour:                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python-test:                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   language-python:                              [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
Enable darwin build for language-puppet.

###### Motivation for this change

I would like to enable `darwin`build for `language-puppet`. `filecache` now works for `OSX` so this build should succeed.
I do have os x user so this build will be quite useful.
I have recently had an issue with nixpkgs commit 95eb2fa40e6f0edd625abdafe7d7b76e0c722263 that fails with 
 ```
In file included from ./security_utilities/utilities.h:32:

./security_utilities/errors.h:33:10: fatal error: '/nix/store/kmfa1i8rim3big8br77jcn3lfzf8b18w-MacOS_SDK-10.10/include/MacTypes.h' file not found

#include "/nix/store/kmfa1i8rim3big8br77jcn3lfzf8b18w-MacOS_SDK-10.10/include/MacTypes.h"
```
This error is not related to `language-puppet` per se.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (succeeds with a two weeks nixpkgs commit but fails with a more recent one)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

