### PR TITLE
yafaray-core: init at v3.3.0

### DIFF
--- a/pkgs/tools/graphics/yafaray-core/default.nix
+++ b/pkgs/tools/graphics/yafaray-core/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, opencv, zlib
+, libxml2, freetype, libjpeg, libtiff, swig, openexr
+, ilmbase, boost165
+, withPython ? true, python35
+}:
+
+stdenv.mkDerivation rec {
+
+    name = "yafaray-core-${version}";
+    version = "v3.3.0";
+
+    src = fetchFromGitHub {
+      owner  = "YafaRay";
+      repo   = "Core";
+      rev    = "${version}";
+      sha256 = "04p3nlg1rv617qf8v1nzjl6f0w43rvi8w9j6l6ck4bvl77v6cjp6";
+    };
+
+    preConfigure = ''
+      NIX_CFLAGS_COMPILE+=" -isystem ${ilmbase.dev}/include/OpenEXR"
+    '';
+
+    buildInputs = [
+      cmake pkgconfig boost165 opencv zlib libxml2 freetype libjpeg libtiff
+      swig openexr ilmbase
+    ] ++ stdenv.lib.optional withPython python35;
+
+    meta = with stdenv.lib; {
+      description = "A free, open source raytracer";
+      homepage = http://www.yafaray.org;
+      maintainers = with maintainers; [ hodapp ];
+      license = licenses.lgpl21;
+      platforms = platforms.linux;
+    };
+  }
+
+# TODO: Add optional Ruby support
+# TODO: Add Qt support? (CMake looks for it, but what for?)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5932,6 +5932,8 @@ with pkgs;
 
   xwinwrap = callPackage ../tools/X11/xwinwrap {};
 
+  yafaray-core = callPackage ../tools/graphics/yafaray-core { };
+
   yaft = callPackage ../applications/misc/yaft { };
 
   yarn = callPackage ../development/tools/yarn  { };


### PR DESCRIPTION
###### Motivation for this change

I needed Yafaray for some work I was doing, and it's a fairly stable rendering package at this point.

This should build on OS X but I don't have a machine to test it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

