### PR TITLE
pythonPackages.block-io: init at 1.1.8

### DIFF
--- a/pkgs/development/python-modules/base58/default.nix
+++ b/pkgs/development/python-modules/base58/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, pytest, pyhamcrest }:
+
+buildPythonPackage rec {
+  pname = "base58";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "keis";
+    repo = "base58";
+    rev = "v${version}";
+    sha256 = "0f8isdpvbgw0sqn9bj7hk47y8akpvdl8sn6rkszla0xb92ywj0f6";
+  };
+
+  buildInputs = [ pytest pyhamcrest ];
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Base58 and Base58Check implementation";
+    homepage = https://github.com/keis/base58;
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/development/python-modules/block-io/default.nix
+++ b/pkgs/development/python-modules/block-io/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchPypi, fetchpatch, buildPythonPackage, base58, ecdsa, pycryptodome, requests, six }:
+
+buildPythonPackage rec {
+  pname = "block-io";
+  version = "1.1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15468pvpcp41ly7kjpmikpyi4av57d9zhf5j1v01j78r1xqqk56g";
+  };
+
+  propagatedBuildInputs = [
+    base58
+    ecdsa
+    pycryptodome
+    requests
+    six
+  ];
+
+  # Tests needs a BlockIO API key to run properly
+  # https://github.com/BlockIo/block_io-python/blob/79006bc8974544b70a2d8e9f19c759941d32648e/test.py#L18
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Integrate Bitcoin, Dogecoin and Litecoin in your Python applications using block.io";
+    homepage = https://github.com/BlockIo/block_io-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1095,6 +1095,8 @@ in {
   };
 
   blessed = callPackage ../development/python-modules/blessed {};
+  
+  block-io = callPackage ../development/python-modules/block-io {};
 
   # Build boost for this specific Python version
   # TODO: use separate output for libboost_python.so

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -980,6 +980,8 @@ in {
     inherit (pkgs) gcc wirelesstools;
   };
 
+  base58 = callPackage ../development/python-modules/base58 {};
+
   batinfo = callPackage ../development/python-modules/batinfo {};
 
   bcdoc = callPackage ../development/python-modules/bcdoc {};


### PR DESCRIPTION
###### Motivation for this change
Block.io official python bindings and a missing dependancy (base58)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

