### PR TITLE
tvbrowser-bin: init at 4.0.1

### DIFF
--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, makeWrapper, jre, makeDesktopItem }:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "tvbrowser";
+    exec = "tvbrowser";
+    icon = "tvbrowser";
+    comment = "Themeable and easy to use TV Guide";
+    desktopName = "TV-Browser";
+    genericName = "Electronic TV Program Guide";
+    categories = "AudioVideo;TV;Java;";
+    startupNotify = "true";
+    extraEntries = ''
+      StartupWMClass=tvbrowser-TVBrowser
+    '';
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "tvbrowser";
+  version = "4.0.1";
+  name = "${pname}-bin-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/TV-Browser%20Releases%20%28Java%208%20and%20higher%29/${version}/${pname}_${version}_bin.tar.gz";
+    sha256 = "0ahsirf6cazs5wykgbwsc6n35w6jprxyphzqmm7d370n37sb07pm";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/share/java/${pname}
+    cp -R * $out/share/java/${pname}
+    rm $out/share/java/${pname}/${pname}.{sh,desktop}
+
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+
+    for i in 16 32 48 128; do
+      mkdir -p $out/share/icons/hicolor/''${i}x''${i}/apps
+      ln -s $out/share/java/${pname}/imgs/${pname}$i.png $out/share/icons/hicolor/''${i}x''${i}/apps/${pname}.png
+    done
+
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $out/share/java/${pname}/${pname}.jar" \
+      --run "cd $out/share/java/${pname}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Electronic TV Program Guide";
+    homepage = https://www.tvbrowser.org/;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21384,6 +21384,8 @@ with pkgs;
 
   trufflehog = callPackage ../tools/security/trufflehog { };
 
+  tvbrowser-bin = callPackage ../applications/misc/tvbrowser/bin.nix { };
+
   tvheadend = callPackage ../servers/tvheadend { };
 
   ums = callPackage ../servers/ums { };


### PR DESCRIPTION
###### Motivation for this change

Missing package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

