### PR TITLE
idrisPackages.bi: 2018-01-17 -> 2018-06-25

### DIFF
--- a/pkgs/development/idris-modules/bi.nix
+++ b/pkgs/development/idris-modules/bi.nix
@@ -8,15 +8,15 @@
 }:
 build-idris-package  {
   name = "bi";
-  version = "2018-01-17";
+  version = "2018-06-25";
 
   idrisDeps = [ prelude contrib pruviloj ];
 
   src = fetchFromGitHub {
     owner = "sbp";
     repo = "idris-bi";
-    rev = "8ab40bc482ca948ac0f6ffb5b4c545a73688dd3a";
-    sha256 = "1lra945q2d6anwzjs94srprqj867lrz66rsns08p8828vg55fv97";
+    rev = "6bd90fb30b06ab02438efb5059e2fc699fdc7787";
+    sha256 = "1px550spigl8k1m1r64mjrw7qjvipa43xy95kz1pb5ibmy84d6r3";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Was broken since the 1.3 update, see https://github.com/sbp/idris-bi/issues/31

Ping @brainrape @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

