### PR TITLE
jd-gui: 0.3.5 -> 1.4.0

### DIFF
--- a/pkgs/tools/security/jd-gui/default.nix
+++ b/pkgs/tools/security/jd-gui/default.nix
@@ -1,52 +1,102 @@
-{ stdenv, fetchurl, gtk2, atk, gdk_pixbuf, glib, pango, fontconfig, zlib, xorg, upx, patchelf }:
+{ stdenv, fetchurl, gradle_2_5, perl, makeWrapper, jre, makeDesktopItem, writeShellScriptBin, writeText }:
 
 let
-  dynlibPath = stdenv.lib.makeLibraryPath
-    ([ gtk2 atk gdk_pixbuf glib pango fontconfig zlib stdenv.cc.cc.lib ]
-    ++ (with xorg; [
-      libX11
-      libXext
-      libXrender
-      libXrandr
-      libSM
-      libXfixes
-      libXdamage
-      libXcursor
-      libXinerama
-      libXi
-      libXcomposite
-      libXxf86vm
-    ]));
-in
-stdenv.mkDerivation rec {
-  name    = "jd-gui-${version}";
-  version = "0.3.5";
+  version = "1.4.0";
+  name = "jd-gui-${version}";
 
   src = fetchurl {
-    url    = "http://jd.benow.ca/jd-gui/downloads/${name}.linux.i686.tar.gz";
-    sha256 = "0jrvzs2s836yvqi41c7fq0gfiwf187qg765b9r1il2bjc0mb3dqv";
+    url    = "https://github.com/java-decompiler/jd-gui/archive/v${version}.tar.gz";
+    sha256 = "0anz7szlr5kgmsmkyv34jdynsnk8v6kvibcyz98jsd96fh725lax";
   };
 
-  nativeBuildInputs = [ upx patchelf ];
+  deps = stdenv.mkDerivation {
+    name = "${name}-deps";
+    inherit src;
+    nativeBuildInputs = [ gradle_2_5 perl ];
 
-  unpackPhase = "tar xf ${src}";
-  installPhase = ''
-    mkdir -p $out/bin
-    upx -d jd-gui -o $out/bin/jd-gui
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon build
+    '';
 
-    patchelf \
-      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
-      --set-rpath ${dynlibPath} \
-      $out/bin/jd-gui
+    # Mavenize dependency paths
+    # e.g. org.codehaus.groovy/groovy/2.4.0/{hash}/groovy-2.4.0.jar -> org/codehaus/groovy/groovy/2.4.0/groovy-2.4.0.jar
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "1apmqiphnav79m4rdii58h7f4qslpfig4qybyyl2fr7zk92gv3l9";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    logger.lifecycle 'Replacing Maven repositories with ${deps}...'
+
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        buildscript {
+          repositories {
+            clear()
+            maven { url '${deps}' }
+          }
+        }
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+  '';
+
+  desktopItem = launcher: makeDesktopItem {
+    name = "jd-gui";
+    exec = "${launcher} %F";
+    icon = "jd-gui";
+    comment = "Java Decompiler JD-GUI";
+    desktopName = "JD-GUI";
+    genericName = "Java Decompiler";
+    mimeType = "application/x-java-archive;application/x-java";
+    categories = "Development;Debugger;";
+  };
+
+in stdenv.mkDerivation rec {
+  inherit name version src;
+
+  nativeBuildInputs = [ gradle_2_5 perl makeWrapper ];
+
+  buildPhase = ''
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --offline --no-daemon --info --init-script ${gradleInit} jar
+  '';
+
+  installPhase = let
+    jar = "$out/share/jd-gui/${name}.jar";
+  in ''
+    mkdir -p $out/bin $out/share/{jd-gui,icons/hicolor/128x128/apps}
+    cp build/libs/${name}.jar ${jar}
+    cp src/linux/resources/jd_icon_128.png $out/share/icons/hicolor/128x128/apps/jd-gui.png
+
+    cat > $out/bin/jd-gui <<EOF
+    #!${stdenv.shell}
+    export JAVA_HOME=${jre}
+    ${jre}/bin/java -jar ${jar} $@
+    EOF
+    chmod +x $out/bin/jd-gui
+
+    ${(desktopItem "$out/bin/jd-gui").buildCommand}
   '';
 
   dontStrip = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Fast Java Decompiler with powerful GUI";
     homepage    = "http://jd.benow.ca/";
-    license     = stdenv.lib.licenses.unfreeRedistributable;
-    platforms   = [ "i686-linux" ];
-    maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+    license     = licenses.gpl3;
+    platforms   = platforms.unix;
+    maintainers = [ maintainers.thoughtpolice ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3212,7 +3212,7 @@ with pkgs;
 
   jd = callPackage ../development/tools/jd { };
 
-  jd-gui = callPackage_i686 ../tools/security/jd-gui { };
+  jd-gui = callPackage ../tools/security/jd-gui { };
 
   jdiskreport = callPackage ../tools/misc/jdiskreport { };
 
@@ -16562,7 +16562,7 @@ with pkgs;
   });
 
   inherit (nodePackages) imapnotify;
-  
+
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 


### PR DESCRIPTION
##### Motivation for this change

Bump `jd-gui` to 1.4.0, which is now available on GitHub, is GPL3, and is buildable from source.

The project uses Gradle, so an incantation was lifted from the [mucommander](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/mucommander/default.nix) derivation to add all Maven dependencies to a fixed-output derivation.

Rather than rewrite the build script to apply the local dependency repo, I use Gradle's `--init-script` option for a more robust approach.

cc maintainer: @thoughtpolice 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

