### PR TITLE
dwm-status: 0.5.1 -> 1.0.0

### DIFF
--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -1,23 +1,23 @@
-{ stdenv, lib, rustPlatform, fetchFromGitHub, dbus, gdk_pixbuf, libnotify, makeWrapper, pkgconfig, xorg, alsaUtils }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, dbus, gdk_pixbuf, libnotify, makeWrapper, pkgconfig, xorg
+, enableAlsaUtils ? true, alsaUtils }:
 
 rustPlatform.buildRustPackage rec {
   name = "dwm-status-${version}";
-  version = "0.5.1";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "Gerschtli";
     repo = "dwm-status";
     rev = version;
-    sha256 = "1mppj57h5yr0azypf5d2cgz2wv3k52mg3k4npyfhbmfy1393qbjs";
+    sha256 = "0r0irzm5y9xvqxrr8gvvn4x9c56qwgynljnzba4mh5s5dpbmz0iq";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [ dbus gdk_pixbuf libnotify xorg.libX11 ];
 
-  cargoSha256 = "0qr999hwrqn7a4n4kvbrpli7shxp9jchj8csxzsw951qmzq32qwv";
+  cargoSha256 = "13ibcbk8shfajk200d8v2p6y3zfrz5dlvxqfw1zsm630s5dmy6qx";
 
-  # needed because alsaUtils is an optional runtime dependency
-  postInstall = lib.optionalString (alsaUtils != null) ''
+  postInstall = lib.optionalString enableAlsaUtils ''
     wrapProgram $out/bin/dwm-status \
       --prefix "PATH" : "${alsaUtils}/bin"
   '';


### PR DESCRIPTION
###### Motivation for this change

Updates `dwm-status` to 1.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

