### PR TITLE
albert: 0.14.15 -> 0.14.21

### DIFF
--- a/pkgs/applications/misc/albert/default.nix
+++ b/pkgs/applications/misc/albert/default.nix
@@ -1,15 +1,18 @@
 { mkDerivation, lib, fetchFromGitHub, makeWrapper, qtbase,
   qtdeclarative, qtsvg, qtx11extras, muparser, cmake, python3 }:
 
+let
+  pname = "albert";
+  version = "0.14.21";
+in
 mkDerivation rec {
-  name    = "albert-${version}";
-  version = "0.14.15";
+  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner  = "albertlauncher";
     repo   = "albert";
     rev    = "v${version}";
-    sha256 = "1rjp0bmzs8b9blbxz3sfcanyhgmds882pf1g3jx5qp85y64j8507";
+    sha256 = "16nk9krn1mwr0bh57viig9hizqyp3slna0qg7s5a736nsfxy226w";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Albert has a new release including several extensions and bug fixes.
Additionally, this upgrade solves current QT build issues. See
https://albertlauncher.github.io/news/ for the full changelog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

