### PR TITLE
Update configuration-common.nix

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -919,6 +919,7 @@ self: super: {
   # With ghc-8.2.x haddock would time out for unknown reason
   # See https://github.com/haskell/haddock/issues/679
   language-puppet = dontHaddock super.language-puppet;
+  filecache = dontCheck super.filecache;
 
   # Missing FlexibleContexts in testsuite
   # https://github.com/EduardSergeev/monad-memo/pull/4

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -919,7 +919,7 @@ self: super: {
   # With ghc-8.2.x haddock would time out for unknown reason
   # See https://github.com/haskell/haddock/issues/679
   language-puppet = dontHaddock super.language-puppet;
-  filecache = dontCheck super.filecache;
+  filecache = overrideCabal super.filecache(drv: { doCheck = !pkgs.stdenv.isDarwin; });
 
   # Missing FlexibleContexts in testsuite
   # https://github.com/EduardSergeev/monad-memo/pull/4


### PR DESCRIPTION
`filecache` test suite won't pass in `osx` :
see https://hydra.nixos.org/job/nixpkgs/trunk/haskellPackages.filecache.x86_64-darwin
see https://github.com/bartavelle/filecache/issues/4

###### Motivation for this change

This is required for https://github.com/NixOS/nixpkgs/pull/42612

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

