### PR TITLE
palp: fix runtime error introduced by #28029

### DIFF
--- a/pkgs/applications/science/math/palp/default.nix
+++ b/pkgs/applications/science/math/palp/default.nix
@@ -14,11 +14,26 @@ stdenv.mkDerivation rec {
     sha256 = "1s7s2lc5f0ig1yy7ygsh3sddm3sbq4mxwybqsj8lp9wjdxs7qfrs";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [
+    "format"
+    "strictoverflow" # causes runtime failure (tested in checkPhase)
+  ];
 
   preBuild = ''
       echo Building PALP optimized for ${dim} dimensions
       sed -i "s/^#define[^a-zA-Z]*POLY_Dmax.*/#define POLY_Dmax ${dim}/" Global.h
+  '';
+
+  # palp has no tests of its own. This test is an adapted sage test that failed
+  # when #28029 was merged.
+  doCheck = true;
+  checkPhase = ''
+    ./nef.x -f -N << EOF | grep -q 'np='
+      3 6
+      1  0  0 -1  0  0
+      0  1  0  0 -1  0
+      0  0  1  0  0 -1
+    EOF
   '';
 
   installPhase = ''


### PR DESCRIPTION
After #28029 it is necessary to add "strictoverflow" to the disabled
hardening flags. That probably has something to do with the `-O3` option
in palps makefile.

This commit also adds a test to check for this regression (as it only
occured at runtime).

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

