### PR TITLE
python2Packages.rpy2: fix python2 compatibility

### DIFF
--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , isPyPy
+, isPy27
 , readline
 , R
 , pcre
@@ -16,12 +17,18 @@
 }:
 
 buildPythonPackage rec {
-    version = "2.9.3";
+    version = if isPy27 then
+      "2.8.6" # python2 support dropped in 2.9.x
+    else
+      "2.9.3";
     pname = "rpy2";
     disabled = isPyPy;
     src = fetchPypi {
       inherit version pname;
-      sha256 = "1b72958e683339ea0c3bd9f73738e9ece2da8da8008a10e2e0c68fc7864e9361";
+      sha256 = if isPy27 then
+        "162zki5c1apgv6qbafi7n66y4hgpgp43xag7q75qb6kv99ri6k80" # 2.8.x
+      else
+        "1b72958e683339ea0c3bd9f73738e9ece2da8da8008a10e2e0c68fc7864e9361"; # 2.9.x
     };
     buildInputs = [
       readline


### PR DESCRIPTION
###### Motivation for this change

As mentioned [here](https://trac.sagemath.org/ticket/24824), rpy2 dropped python2 support in their latest version. Here I fix the rpy2 version to the latest python2 compatible one (as upstream suggests) if python is python2. I'm not sure if the way I'm doing it is correct though.

Requesting review @FRidh.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

