### PR TITLE
darktable: add opencl support

### DIFF
--- a/pkgs/applications/graphics/darktable/default.nix
+++ b/pkgs/applications/graphics/darktable/default.nix
@@ -3,6 +3,7 @@
 , ilmbase, gtk3, intltool, lcms2, lensfun, libX11, libexif, libgphoto2, libjpeg
 , libpng, librsvg, libtiff, openexr, osm-gps-map, pkgconfig, sqlite, libxslt
 , openjpeg, lua, pugixml, colord, colord-gtk, libwebp, libsecret, gnome3
+, ocl-icd
 }:
 
 stdenv.mkDerivation rec {
@@ -21,9 +22,9 @@ stdenv.mkDerivation rec {
     libgphoto2 libjpeg libpng librsvg libtiff openexr sqlite libxslt
     libsoup graphicsmagick json-glib openjpeg lua pugixml
     colord colord-gtk libwebp libsecret gnome3.adwaita-icon-theme
-    osm-gps-map
+    osm-gps-map ocl-icd
   ];
-
+    
   cmakeFlags = [
     "-DBUILD_USERMANUAL=False"
   ];
@@ -34,7 +35,7 @@ stdenv.mkDerivation rec {
   # the wrappers:
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix LD_LIBRARY_PATH ":" "$out/lib/darktable"
+      --prefix LD_LIBRARY_PATH ":" "$out/lib/darktable:${ocl-icd}/lib"
     )
   '';
 


### PR DESCRIPTION
###### Motivation for this change
fixes open opencl support in darktable
this commit fixes #42429
###### Things done
add ocl-icd as build input, and point darktables build scripts to that library.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

