### PR TITLE
trivial-builders: disallow sub in requireFile

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -181,6 +181,7 @@ rec {
       outputHashAlgo = hashAlgo;
       outputHash = hash;
       preferLocalBuild = true;
+      allowSubstitutes = false;
       builder = writeScript "restrict-message" ''
         source ${stdenvNoCC}/setup
         cat <<_EOF_


### PR DESCRIPTION
The requireFile call was being substituted from the binary cache. We
do not want this to happen as the user needs to download the file
themselves.

*Note* that there is stil an issue where nix-serve can provide these files if you request them.