### PR TITLE
[staging] always expose perl.version

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -23,6 +23,8 @@ let
   libcLib = lib.getLib libc;
   crossCompiling = stdenv.buildPlatform != stdenv.hostPlatform;
   common = { version, sha256 }: stdenv.mkDerivation (rec {
+    inherit version;
+
     name = "perl-${version}";
 
     src = fetchurlBoot {
@@ -179,8 +181,6 @@ let
 
     configurePlatforms = [ "build" "host" "target" ];
 
-    inherit version;
-
     # TODO merge setup hooks
     setupHook = ./setup-hook-cross.sh;
   });
@@ -194,7 +194,7 @@ in rec {
 
   perl524 = common {
     version = "5.24.4";
-    sha256 = "0w0r6v5k5hw5q1k3p4c7krcxidkj2qzsj5dlrlrxhm01n7fksbxz"; 
+    sha256 = "0w0r6v5k5hw5q1k3p4c7krcxidkj2qzsj5dlrlrxhm01n7fksbxz";
   };
 
   perl526 = common {


### PR DESCRIPTION
###### Motivation for this change

Always expose ```perl.version``` 

Currently it is only visible ```if (stdenv.buildPlatform != stdenv.hostPlatform)```

As ```perl-5.26``` introduces some breaking changes it would allow to write conditions like
```optional (versionAtLeast perl.version "5.26")```