### PR TITLE
idrisPackages: Progress reporting

### DIFF
--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -1,5 +1,5 @@
 # Build an idris package
-{ stdenv, idrisPackages, gmp }:
+{ stdenv, idrisPackages, gmp, expect }:
   { idrisDeps ? []
   , name
   , version
@@ -27,7 +27,7 @@ stdenv.mkDerivation ({
   '';
 
   buildPhase = ''
-    ${idris-with-packages}/bin/idris --build *.ipkg
+    unbuffer ${idris-with-packages}/bin/idris --build *.ipkg
   '';
 
   checkPhase = ''
@@ -40,7 +40,7 @@ stdenv.mkDerivation ({
     ${idris-with-packages}/bin/idris --install *.ipkg --ibcsubdir $out/libs
   '';
 
-  buildInputs = [ gmp ] ++ extraBuildInputs;
+  buildInputs = [ gmp expect ] ++ extraBuildInputs;
 
   propagatedBuildInputs = idrisDeps;
 })


### PR DESCRIPTION
###### Motivation for this change
Before this change, Idris would silently build all files of a package without indicating any progress until everything is done, because it doesn't seem to flush on newlines when the output isn't a tty. This is especially frustrating because Idris can take a very long time to compile things.

Ping @brainrape @mpickering @shlevy 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

