### PR TITLE
vimPlugins.dhall-vim: init at 2018-06-04

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -716,6 +716,17 @@ rec {
 
   };
 
+  dhall-vim = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "dhall-vim-2018-06-04";
+    src = fetchgit {
+      url = "https://github.com/vmchale/dhall-vim";
+      rev = "290c2ec86b5c3d35dd3913cbb6ab9d2139074e38";
+      sha256 = "03jhcaz6r2lbd4drc8acc9kv2k0287nzvw7lyl36jjkk3qy4c499";
+    };
+    dependencies = [];
+
+  };
+
   clighter8 = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "clighter8-2018-04-15";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -260,6 +260,7 @@
 "github:vim-scripts/wombat256.vim"
 "github:vim-scripts/YankRing.vim"
 "github:vimwiki/vimwiki"
+"github:vmchale/dhall-vim"
 "github:w0rp/ale"
 "github:wakatime/vim-wakatime"
 "github:wellle/targets.vim"


### PR DESCRIPTION
###### Motivation for this change
dhall syntax highlighting for Vim.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

