### PR TITLE
[staging] automake111x: fix for perl5.26 ("Unescaped left brace in regex is illegal here")

### DIFF
--- a/pkgs/development/tools/misc/automake/automake-1.11.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.11.x.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ffbc6cc41f0ea6c864fbe9485b981679dc5e350f6c4bc6c3512f5a4226936b5";
   };
 
-  patches = [ ./fix-test-autoconf-2.69.patch ];
+  patches = [ ./fix-test-autoconf-2.69.patch ./fix-perl-5.26.patch ];
 
   buildInputs = [perl autoconf makeWrapper];
 

--- a/pkgs/development/tools/misc/automake/fix-perl-5.26.patch
+++ b/pkgs/development/tools/misc/automake/fix-perl-5.26.patch
@@ -1,0 +1,10 @@
+--- automake-1.11.2/automake.in
++++ automake-1.11.2/automake.in
+@@ -4156,7 +4156,7 @@ sub substitute_ac_subst_variables_worker($)
+ sub substitute_ac_subst_variables ($)
+ {
+   my ($text) = @_;
+-  $text =~ s/\${([^ \t=:+{}]+)}/&substitute_ac_subst_variables_worker ($1)/ge;
++  $text =~ s/\$\{([^ \t=:+{}]+)}/&substitute_ac_subst_variables_worker ($1)/ge;
+   return $text;
+ }


### PR DESCRIPTION
###### Motivation for this change

Fix legacy ```automake``` to work with moderner ```perl```