### PR TITLE
grafana: 5.1.4 -> 5.2.0, replace hard coded version

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchurl, fetchFromGitHub, phantomjs2 }:
 
 buildGoPackage rec {
-  version = "5.1.4";
+  version = "5.2.0";
   name = "grafana-${version}";
   goPackagePath = "github.com/grafana/grafana";
 
@@ -9,15 +9,21 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "09bpijjm7cm4p5ci04ihq55fy5zwpdcld791vdpk6m91ixpab2zc";
+    sha256 = "0ybnah8ziyawmmwrvm327xvr6cjbzgblf5f7qwmz6lk7irh8d9ra";
   };
 
   srcStatic = fetchurl {
-    url = "https://grafana-releases.s3.amazonaws.com/release/grafana-${version}.linux-x64.tar.gz";
-    sha256 = "0ygfq4my3bdqs942l31w0695a6rwyrwq7jr23g0vgaqadamgbgkg";
+    url = "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${version}.linux-amd64.tar.gz";
+    sha256 = "0ir9dhwm6h4673ic4pwhfwmg6jz8m8ia98cjkr9b4c68yrs1dv5j";
   };
 
+  postPatch = ''
+    substituteInPlace pkg/cmd/grafana-server/main.go \
+      --replace 'var version = "5.0.0"'  'var version = "${version}"'
+  '';
+
   preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";
+
   postInstall = ''
     tar -xvf $srcStatic
     mkdir -p $bin/share/grafana


### PR DESCRIPTION
###### Motivation for this change
[New release](https://github.com/grafana/grafana/releases/tag/v5.2.0) with bugfixes and new features.

###### Things done
Replaced the hard coded version with the packaged version
and updated the source URL which changed with the latest release.

Before this PR the displayed version for all minor and patch releases was hardcoded to 5.0.0:

before:
![before](https://user-images.githubusercontent.com/20464732/41977291-415bd924-7a1f-11e8-8c8d-f8cdb174e48a.png)

now:
![after](https://user-images.githubusercontent.com/20464732/41977299-44893b00-7a1f-11e8-9543-88b2999d345c.png)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -S /nix/store/qdq62vnk29h06sj1ljbi3ck635y62ssn-grafana-5.1.4-bin 
/nix/store/qdq62vnk29h06sj1ljbi3ck635y62ssn-grafana-5.1.4-bin	  601745400

$ nix path-info -S /nix/store/bymmr8wr96jkh71bl36cxhy08136aajd-grafana-5.2.0-bin
/nix/store/bymmr8wr96jkh71bl36cxhy08136aajd-grafana-5.2.0-bin	  607335720
```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---