### PR TITLE
Disable fortify and stackprotector hardening for spl/zfs.

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -25,7 +25,7 @@ let
 
       nativeBuildInputs = [ autoreconfHook ] ++ kernel.moduleBuildDependencies;
 
-      hardeningDisable = [ "pic" ];
+      hardeningDisable = [ "fortify" "stackprotector" "pic" ];
 
       preConfigure = ''
         substituteInPlace ./module/spl/spl-generic.c --replace /usr/bin/hostid hostid

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -55,7 +55,7 @@ let
       # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
       NIX_CFLAGS_LINK = "-lgcc_s";
 
-      hardeningDisable = [ "pic" ];
+      hardeningDisable = [ "fortify" "stackprotector" "pic" ];
 
       preConfigure = ''
         substituteInPlace ./module/zfs/zfs_ctldir.c   --replace "umount -t zfs"           "${utillinux}/bin/umount -t zfs"
@@ -148,7 +148,7 @@ in {
   # to be adapted
   zfsStable = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    incompatibleKernelVersion = null;
 
     # this package should point to the latest release.
     version = "0.7.9";
@@ -167,7 +167,7 @@ in {
 
   zfsUnstable = common rec {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-05-22";
@@ -190,7 +190,7 @@ in {
   # also remove boot.zfs.enableLegacyCrypto
   zfsLegacyCrypto = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.16";
+    incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
     version = "2018-02-01";


### PR DESCRIPTION
Linux 4.16 introduces a stackprotector detection script that returns
different results for the kernel compilation run and the spl/zfs
compilation run, as the setting for hardening are different. This
results in a broken ABI between spl/zfs and the compiled kernel,
breaking ZFS. Also disabling the fortify and stackprotector hardening,
as we do for the kernel, fixes that.

(cherry picked from commit 43a737b81cd3f41f1df0f4f0bef25e048ac9155a)

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/39225

###### Things done
Running this on my 4.16 machine for two days.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

