### PR TITLE
zerotier module: interface names changed; fix no dhcp

### DIFF
--- a/nixos/modules/services/networking/zerotierone.nix
+++ b/nixos/modules/services/networking/zerotierone.nix
@@ -47,7 +47,7 @@ in
     };
 
     # ZeroTier does not issue DHCP leases, but some strangers might...
-    networking.dhcpcd.denyInterfaces = [ "zt0" ];
+    networking.dhcpcd.denyInterfaces = [ "zt*" ];
 
     # ZeroTier receives UDP transmissions on port 9993 by default
     networking.firewall.allowedUDPPorts = [ 9993 ];


### PR DESCRIPTION
The NixOS ZT module disables the DHCP client on the interface named zt0.

Since ZT v1.2.8 interface names are no longer "zt\<sequence number>", instead they are by default named "zt\<network hash>". See https://www.zerotier.com/blog/2018-05-04-128.shtml.

This PR restores the previous intended behavior.

Pinging @obadz.


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).