### PR TITLE
Haskell bash completion

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -663,7 +663,7 @@ self: super: {
   }));
 
   # Need newer versions of their dependencies than the ones we have in LTS-11.x.
-  cabal2nix = super.cabal2nix.overrideScope (self: super: { hpack = self.hpack_0_28_2; hackage-db = self.hackage-db_2_0_1; });
+  cabal2nix = generateOptparseApplicativeCompletions ["cabal2nix"] (super.cabal2nix.overrideScope (self: super: { hpack = self.hpack_0_28_2; hackage-db = self.hackage-db_2_0_1; }));
   dbus-hslogger = super.dbus-hslogger.overrideScope (self: super: { dbus = self.dbus_1_0_1; });
   graphviz = (addBuildTool super.graphviz pkgs.graphviz).overrideScope (self: super: { wl-pprint-text = self.wl-pprint-text_1_2_0_0; base-compat = self.base-compat_0_10_4; });
   status-notifier-item = super.status-notifier-item.overrideScope (self: super: { dbus = self.dbus_1_0_1; });

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -717,7 +717,7 @@ self: super: {
   });
 
   # The standard libraries are compiled separately
-  idris = doJailbreak (dontCheck super.idris);
+  idris = generateOptparseApplicativeCompletions ["idris"] (doJailbreak (dontCheck super.idris));
 
   # https://github.com/bos/math-functions/issues/25
   math-functions = dontCheck super.math-functions;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -885,7 +885,8 @@ self: super: {
   });
 
   # Needs newer versions than what we have in LTS-11.x at the moment.
-  stack = super.stack.overrideScope (self: super: { hpack = self.hpack_0_28_2; });
+  stack = generateOptparseApplicativeCompletions ["stack"] (
+    super.stack.overrideScope (self: super: { hpack = self.hpack_0_28_2; }));
 
   # These packages depend on each other, forming an infinite loop.
   scalendar = markBroken (super.scalendar.override { SCalendar = null; });

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1072,6 +1072,8 @@ self: super: {
   dhall-nix = generateOptparseApplicativeCompletions ["dhall-to-nix"] (
     super.dhall-nix.override { dhall = self.dhall_1_15_0; });
 
+  purescript = generateOptparseApplicativeCompletions ["purs"] super.purescript;
+
   # https://github.com/fpco/streaming-commons/issues/49
   streaming-commons = dontCheck super.streaming-commons;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -254,7 +254,7 @@ self: super: {
   digit = doJailbreak super.digit;
 
   # https://github.com/jwiegley/hnix/issues/98 - tied to an older deriving-compat
-  hnix = (overrideCabal super.hnix (old: {
+  hnix = generateOptparseApplicativeCompletions ["hnix"] (overrideCabal super.hnix (old: {
     patches = old.patches or [] ++ [
       # should land in hnix-5.2
       (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1062,11 +1062,15 @@ self: super: {
     strictDeps = true;
   });
 
+  dhall = generateOptparseApplicativeCompletions ["dhall" "dhall-format" "dhall-hash"] super.dhall;
+
   # dhall-json requires a very particular dhall version
-  dhall-json_1_2_1 = super.dhall-json_1_2_1.override { dhall = self.dhall_1_15_0; };
+  dhall-json_1_2_1 = generateOptparseApplicativeCompletions ["dhall-to-json" "dhall-to-yaml"] (
+    super.dhall-json_1_2_1.override { dhall = self.dhall_1_15_0; });
 
   # dhall-nix requires a very particular dhall version
-  dhall-nix = super.dhall-nix.override { dhall = self.dhall_1_15_0; };
+  dhall-nix = generateOptparseApplicativeCompletions ["dhall-to-nix"] (
+    super.dhall-nix.override { dhall = self.dhall_1_15_0; });
 
   # https://github.com/fpco/streaming-commons/issues/49
   streaming-commons = dontCheck super.streaming-commons;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -199,10 +199,16 @@ rec {
   generateOptparseApplicativeCompletion = command: pkg:
     overrideCabal pkg (old: {
       postInstall = old.postInstall or "" + ''
-        echo "installing bash completion script for ${command}"
-        mkdir -p $out/share/bash-completion/completions
-        $out/bin/${command} --bash-completion-script $out/bin/${command} \
+        echo "installing shell completion scripts for ${command}"
+        mkdir -p $out/share/{bash-completion/completions,zsh/vendor-completions,fish/completions}
+        exe="$out/bin/${command}"
+        $exe --bash-completion-script $exe \
           >$out/share/bash-completion/completions/${command}
+        $exe --zsh-completion-script $exe \
+          >$out/share/zsh/vendor-completions/_${command}
+        $exe --fish-completion-script $exe \
+          >$out/share/fish/completions/${command}.fish
+
         # Sanity check
         grep -F ${command} <$out/share/bash-completion/completions/${command} >/dev/null || {
           echo 'Could not find ${command} in completion script.'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -946,17 +946,13 @@ with pkgs;
     isLibrary = false;
     enableSharedExecutables = false;
     executableToolDepends = [ makeWrapper ];
-    postInstall = ''
+    postInstall = drv.postInstall or "" + ''
       exe=$out/libexec/${drv.pname}-${drv.version}/${drv.pname}
       install -D $out/bin/${drv.pname} $exe
-      rm -rf $out/{bin,lib,share}
+      rm -rf $out/{bin,lib}
       makeWrapper $exe $out/bin/${drv.pname} \
         --prefix PATH ":" "${nix}/bin" \
         --prefix PATH ":" "${nix-prefetch-scripts}/bin"
-      mkdir -p $out/share/{bash-completion/completions,zsh/vendor-completions,fish/completions}
-      $exe --bash-completion-script $exe >$out/share/bash-completion/completions/${drv.pname}
-      $exe --zsh-completion-script $exe >$out/share/zsh/vendor-completions/_${drv.pname}
-      $exe --fish-completion-script $exe >$out/share/fish/completions/${drv.pname}.fish
     '';
   });
 


### PR DESCRIPTION
###### Motivation for this change

The `optparse-applicative` library provides a uniform method of adding completions to haskell programs. This introduces two helper functions in `haskell.lib` that capture that.

This PR also adds completion to a small number of Haskell commands that are built with this library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

