### PR TITLE
haskellPackages.callCabal2nix: accept extraCabal2nixOptions argument

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -37,7 +37,7 @@ self:
 let
   inherit (stdenv) buildPlatform hostPlatform;
 
-  inherit (stdenv.lib) fix' extends makeOverridable;
+  inherit (stdenv.lib) fix' extends makeOverridable filterAttrs;
   inherit (haskellLib) overrideCabal getHaskellBuildInputs;
 
   mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
@@ -161,13 +161,15 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
       filter = path: type:
                  pkgs.lib.hasSuffix "${name}.cabal" path ||
                  baseNameOf path == "package.yaml";
-      expr = self.haskellSrc2nix {
+      expr = self.haskellSrc2nix ({
         inherit name;
         src = if pkgs.lib.canCleanSource src
                 then pkgs.lib.cleanSourceWith { inherit src filter; }
               else src;
-      };
-    in overrideCabal (callPackageKeepDeriver expr args) (orig: {
+      } // haskellSrc2nixArgs);
+      callPackageArgs = filterAttrs (name: v: name != "extraCabal2nixOptions") args;
+      haskellSrc2nixArgs = filterAttrs (name: v: name == "extraCabal2nixOptions") args;
+    in overrideCabal (callPackageKeepDeriver expr callPackageArgs) (orig: {
          inherit src;
        });
 


### PR DESCRIPTION
###### Motivation for this change

This should resolve https://github.com/NixOS/nixpkgs/issues/42051 and https://github.com/NixOS/nixpkgs/issues/42550

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

