### PR TITLE
ceres-solver: clean up cmake configuration

### DIFF
--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -20,18 +20,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ glog ]
+  buildInputs = [ eigen glog ]
     ++ stdenv.lib.optional (google-gflags != null) google-gflags;
-
-  inherit eigen;
 
   doCheck = runTests;
 
   checkTarget = "test";
-
-  cmakeFlags = "
-    -DEIGEN_INCLUDE_DIR=${eigen}/include/eigen3
-  ";
 
   meta = with stdenv.lib; {
     description = "C++ library for modeling and solving large, complicated optimization problems";


### PR DESCRIPTION
No need to explicitely set cmakeFlags, specifying the eigen library in the
build inputs should be enough.

Also, packages that build against ceres-solver and also use the eigen library
seem to be problematic.  For this reason, it should be propagated.

###### Motivation for this change

While writing a derivation for colmap, when pulling in eigen3_3 there, it complains about ceres-solver being built with a different version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

