### PR TITLE
firebird-emu: init at 1.4

### DIFF
--- a/pkgs/misc/emulators/firebird-emu/default.nix
+++ b/pkgs/misc/emulators/firebird-emu/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, qmake, qtbase, qtdeclarative }:
+
+stdenv.mkDerivation rec {
+  name = "firebird-emu-${version}";
+  version = "1.4";
+
+  src = fetchFromGitHub {
+    owner = "nspire-emus";
+    repo = "firebird";
+    rev = "v${version}";
+    sha256 = "0pdca6bgnmzfgf5kp83as99y348gn4plzbxnqxjs61vp489baahq";
+    fetchSubmodules = true;
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [ qtbase qtdeclarative ];
+
+  makeFlags = [ "INSTALL_ROOT=$(out)" ];
+
+  # Attempts to install to /usr/bin and /usr/share/applications, which Nix does
+  # not use.
+  prePatch = ''
+    substituteInPlace firebird.pro \
+      --replace '/usr/' '/'
+  '';
+
+  meta = {
+    homepage = https://github.com/nspire-emus/firebird;
+    description = "Third-party multi-platform emulator of the ARM-based TI-Nspire™ calculators";
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ pneumaticat ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/misc/emulators/firebird-emu/default.nix
+++ b/pkgs/misc/emulators/firebird-emu/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     description = "Third-party multi-platform emulator of the ARM-based TI-Nspire™ calculators";
     license = stdenv.lib.licenses.gpl3;
     maintainers = with stdenv.lib.maintainers; [ pneumaticat ];
-    platforms = stdenv.lib.platforms.unix;
+    # Only tested on Linux, but likely possible to build on, e.g. macOS
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2399,6 +2399,8 @@ with pkgs;
 
   fio = callPackage ../tools/system/fio { };
 
+  firebird-emu = libsForQt5.callPackage ../misc/emulators/firebird-emu { };
+
   flamerobin = callPackage ../applications/misc/flamerobin { };
 
   flashtool = callPackage_i686 ../development/mobile/flashtool {


### PR DESCRIPTION
###### Motivation for this change

[Firebird](https://github.com/nspire-emus/firebird) is an emulator for the TI-Nspire series calculators.

###### Things done

Successfully builds and runs on NixOS unstable. The executable is added to the path, and the desktop icon is installed correctly.

I haven't tested it on macOS, but Firebird _does_ have macOS releases, so it should be possible to make it work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

