### PR TITLE
ocaml-top: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -2,11 +2,12 @@
 , ocamlPackages
 , jbuilder }:
 
-stdenv.mkDerivation {
-  name = "ocaml-top-1.1.4";
+stdenv.mkDerivation rec {
+  version = "1.1.5";
+  name = "ocaml-top-${version}";
   src = fetchzip {
-    url = https://github.com/OCamlPro/ocaml-top/archive/1.1.4.tar.gz;
-    sha256 = "1lmzjmnzsg8xdz0q5nm95zclihi9z80kzsalapg0s9wq0id8qm4j";
+    url = "https://github.com/OCamlPro/ocaml-top/archive/${version}.tar.gz";
+    sha256 = "1d4i6aanrafgrgk4mh154k6lkwk0b6mh66rykz33awlf5pfqd8yv";
   };
 
   buildInputs = [ ncurses jbuilder ]


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

