### PR TITLE
pythonPackages.flask-restful: disable broken test

### DIFF
--- a/pkgs/development/python-modules/flask-restful/default.nix
+++ b/pkgs/development/python-modules/flask-restful/default.nix
@@ -17,6 +17,10 @@ buildPythonPackage rec {
   patchPhase = if isPy3k then ''
     rm tests/test_crypto.py tests/test_paging.py
     '' else null;
+# Disable test broken with aniso > 3.0.0, can be removed when updating to a flask-restful version with commit 54979f0
+  preCheck = ''
+  substituteInPlace "./tests/test_inputs.py" --replace "test_bad_isointervals" "disabled_bad_isointervals"
+  '';
   buildInputs = [ nose mock blinker ];
   propagatedBuildInputs = [ flask six pytz aniso8601 pycrypto ];
   PYTHON_EGG_CACHE = "`pwd`/.egg-cache";


### PR DESCRIPTION
###### Motivation for this change
Fix #42641

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
nox-review fails due to #42640, already fixed in #42409
