### PR TITLE
feedgnuplot: init at 1.49

### DIFF
--- a/pkgs/tools/graphics/feedgnuplot/default.nix
+++ b/pkgs/tools/graphics/feedgnuplot/default.nix
@@ -31,7 +31,8 @@ buildPerlPackage rec {
     patchShebangs .
   '';
 
-  doCheck = true;
+  # Tests require gnuplot 4.6.4 and are completely skipped with gnuplot 5.
+  doCheck = false;
 
   postInstall = ''
     wrapProgram $out/bin/feedgnuplot \

--- a/pkgs/tools/graphics/feedgnuplot/default.nix
+++ b/pkgs/tools/graphics/feedgnuplot/default.nix
@@ -37,8 +37,11 @@ buildPerlPackage rec {
     wrapProgram $out/bin/feedgnuplot \
         --prefix "PATH" ":" "$PATH" \
         --prefix "PERL5LIB" ":" "$PERL5LIB"
+    install -D -m 444 -t $out/share/bash-completion/completions \
+        completions/bash/feedgnuplot
+    install -D -m 444 -t $out/share/zsh/site-functions \
+        completions/zsh/_feedgnuplot
   '';
-
 
   meta = with stdenv.lib; {
     description = "General purpose pipe-oriented plotting tool";

--- a/pkgs/tools/graphics/feedgnuplot/default.nix
+++ b/pkgs/tools/graphics/feedgnuplot/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, buildPerlPackage, makeWrapper, gawk
+, makeFontsConf, freefont_ttf, gnuplot, perl, perlPackages
+}:
+
+let
+
+  fontsConf = makeFontsConf { fontDirectories = [ freefont_ttf ]; };
+
+in
+
+buildPerlPackage rec {
+  name = "feedgnuplot-${version}";
+  version = "1.49";
+
+  src = fetchFromGitHub {
+    owner = "dkogan";
+    repo = "feedgnuplot";
+    rev = "v${version}";
+    sha256 = "1bjnx36rsxlj845w9apvdjpza8vd9rbs3dlmgvky6yznrwa6sm02";
+  };
+
+  nativeBuildInputs = [ makeWrapper gawk ];
+
+  buildInputs = [ gnuplot perl ]
+    ++ (with perlPackages; [ ListMoreUtils IPCRun StringShellQuote ]);
+
+  # Fontconfig error: Cannot load default config file
+  FONTCONFIG_FILE = fontsConf;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  doCheck = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/feedgnuplot \
+        --prefix "PATH" ":" "$PATH" \
+        --prefix "PERL5LIB" ":" "$PERL5LIB"
+  '';
+
+
+  meta = with stdenv.lib; {
+    description = "General purpose pipe-oriented plotting tool";
+    homepage = https://github.com/dkogan/feedgnuplot/;
+    license = with licenses; [ artistic1 gpl1Plus ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mnacamura ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2429,6 +2429,8 @@ with pkgs;
 
   fdk_aac = callPackage ../development/libraries/fdk-aac { };
 
+  feedgnuplot = callPackage ../tools/graphics/feedgnuplot { };
+
   fim = callPackage ../tools/graphics/fim { };
 
   flac123 = callPackage ../applications/audio/flac123 { };


### PR DESCRIPTION
###### Motivation for this change

It is a nice tool for doing data-science things in command line.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

