### PR TITLE
cmrt, vaapi-intel-hybrid, vaapiIntel: init at 1.0.6, init at 1.0.2, add enableHybridCodec option

### DIFF
--- a/pkgs/development/libraries/cmrt/default.nix
+++ b/pkgs/development/libraries/cmrt/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, libdrm, libva }:
+
+stdenv.mkDerivation rec {
+  name = "cmrt-${version}";
+  version = "1.0.6";
+
+  src = fetchurl {
+    url = "https://github.com/intel/cmrt/archive/${version}.tar.gz";
+    sha256 = "1q7651nvvcqhph5rgfhklm71zqd0c405mrh3wx0cfzvil82yj8na";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ libdrm libva ];
+
+  meta = with stdenv.lib; {
+    homepage = https://01.org/linuxmedia;
+    description = "Intel C for Media Runtime";
+    longDescription = "Media GPU kernel manager for Intel G45 & HD Graphics family";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tadfisher ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/vaapi-intel-hybrid/default.nix
+++ b/pkgs/development/libraries/vaapi-intel-hybrid/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, cmrt, libdrm, libva, libX11, libGL, wayland }:
+
+stdenv.mkDerivation rec {
+  name = "intel-hybrid-driver-${version}";
+  version = "1.0.2";
+
+  src = fetchurl {
+    url = "https://github.com/01org/intel-hybrid-driver/archive/${version}.tar.gz";
+    sha256 = "0ywdhbvzwzzrq4qhylnw1wc8l3j67h26l0cs1rncwhw05s3ndk8n";
+  };
+
+  patches = [
+    # driver_init: load libva-x11.so for any ABI version
+    (fetchurl {
+      url = https://github.com/01org/intel-hybrid-driver/pull/26.diff;
+      sha256 = "1ql4mbi5x1d2a5c8mkjvciaq60zj8nhx912992winbhfkyvpb3gx";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ cmrt libdrm libva libX11 libGL wayland ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-drm"
+    "--enable-x11"
+    "--enable-wayland"
+  ];
+
+  postPatch = ''
+    patchShebangs ./src/shaders/gpp.py
+  '';
+
+  preConfigure = ''
+    sed -i -e "s,LIBVA_DRIVERS_PATH=.*,LIBVA_DRIVERS_PATH=$out/lib/dri," configure
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://01.org/linuxmedia;
+    description = "Intel driver for the VAAPI library with partial HW acceleration";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tadfisher ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/vaapi-intel/default.nix
+++ b/pkgs/development/libraries/vaapi-intel/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, autoreconfHook, gnum4, pkgconfig, python2
 , intel-gpu-tools, libdrm, libva, libX11, libGL, wayland, libXext
+, enableHybridCodec ? false, vaapi-intel-hybrid
 }:
 
 stdenv.mkDerivation rec {
@@ -7,8 +8,8 @@ stdenv.mkDerivation rec {
   inherit (libva) version;
 
   src = fetchFromGitHub {
-    owner  = "01org";
-    repo   = "libva-intel-driver";
+    owner  = "intel";
+    repo   = "intel-vaapi-driver";
     rev    = version;
     sha256 = "15ag4al9h6b8f8sw1zpighyhsmr5qfqp1882q7r3gsh5g4cnj763";
   };
@@ -21,20 +22,25 @@ stdenv.mkDerivation rec {
     sed -i -e "s,LIBVA_DRIVERS_PATH=.*,LIBVA_DRIVERS_PATH=$out/lib/dri," configure
   '';
 
+  postInstall = stdenv.lib.optionalString enableHybridCodec ''
+    ln -s ${vaapi-intel-hybrid}/lib/dri/* $out/lib/dri/
+  '';
+
   configureFlags = [
     "--enable-drm"
     "--enable-x11"
     "--enable-wayland"
-  ];
+  ] ++ stdenv.lib.optional enableHybridCodec "--enable-hybrid-codec";
 
   nativeBuildInputs = [ autoreconfHook gnum4 pkgconfig python2 ];
 
-  buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext libGL wayland ];
+  buildInputs = [ intel-gpu-tools libdrm libva libX11 libXext libGL wayland ]
+    ++ stdenv.lib.optional enableHybridCodec vaapi-intel-hybrid;
 
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = https://cgit.freedesktop.org/vaapi/intel-driver/;
+    homepage = https://01.org/linuxmedia;
     license = licenses.mit;
     description = "Intel driver for the VAAPI library";
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12010,6 +12010,8 @@ with pkgs;
 
   vaapiIntel = callPackage ../development/libraries/vaapi-intel { };
 
+  vaapi-intel-hybrid = callPackage ../development/libraries/vaapi-intel-hybrid { };
+
   vaapiVdpau = callPackage ../development/libraries/vaapi-vdpau { };
 
   vale = callPackage ../tools/text/vale { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8837,6 +8837,8 @@ with pkgs;
 
   cmocka = callPackage ../development/libraries/cmocka { };
 
+  cmrt = callPackage ../development/libraries/cmrt { };
+
   cogl = callPackage ../development/libraries/cogl { };
 
   coin3d = callPackage ../development/libraries/coin3d { };


### PR DESCRIPTION
###### Motivation for this change

Adds the Intel hybrid VAAPI driver to enable partially-accelerated VP9 decoding on Westmere through Skylake architectures.

Adds a flag to enable the hybrid driver to `vaapiIntel`, as the benefits are hardware-dependent.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

