### PR TITLE
fontin, fontinsans: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2651,6 +2651,11 @@
     github = "fstamour";
     name = "Francis St-Amour";
   };
+  mredaelli = {
+    email = "m.redaelli@gmail.com";
+    github = "mredaelli";
+    name = "Massimo Redaelli";
+  };
   mrkkrp = {
     email = "markkarpov92@gmail.com";
     github = "mrkkrp";

--- a/pkgs/data/fonts/fontin-sans/default.nix
+++ b/pkgs/data/fonts/fontin-sans/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip }:
+fetchzip rec {
+  name = "fontin-sans";
+
+  url = http://www.exljbris.com/dl/FontinSans_49.zip;
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "04q01kqx9jq7snjfgd4x4dbr3ff756x5zwwn5ls69d8gsfzfmb6n";
+
+  meta = with stdenv.lib; {
+    homepage = https://www.exljbris.com/fontinsans.html;
+    description = "The Fontin Sans free font";
+    longDescription = ''
+      This font is a suitable sans companion of Fontin. With a nice classical appearance it will be a perfect match.
+    '';
+    license = https://www.exljbris.com/eula.html;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/data/fonts/fontin/default.nix
+++ b/pkgs/data/fonts/fontin/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip }:
+fetchzip rec {
+  name = "fontin";
+
+  url = http://www.exljbris.com/dl/fontin_pc.zip;
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "1aizmyl62j0cncwp783ka1jlmk9g8jkwaxsg1564rx1i6zybbp4p";
+
+  meta = with stdenv.lib; {
+    homepage = https://www.exljbris.com/fontin.html;
+    description = "The Fontin free font";
+    longDescription = ''
+      This is designed to be used at small sizes. It's available in Roman, italic, bold & small caps. The color is darkish, the spacing loose and the x-height tall.
+    '';
+    license = https://www.exljbris.com/eula.html;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14568,6 +14568,10 @@ with pkgs;
 
   freefont_ttf = callPackage ../data/fonts/freefont-ttf { };
 
+  fontin = callPackage ../data/fonts/fontin { };
+
+  fontin-sans = callPackage ../data/fonts/fontin-sans { };
+
   font-droid = callPackage ../data/fonts/droid { };
 
   freepats = callPackage ../data/misc/freepats { };


### PR DESCRIPTION
###### Motivation for this change
Adding two free fonts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

