### PR TITLE
nixos/xsession: check for env vars

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -62,6 +62,11 @@ let
       . /etc/profile
       cd "$HOME"
 
+      # Allow the user to execute commands at the beginning of the X session.
+      if test -f ~/.xprofile; then
+          source ~/.xprofile
+      fi
+
       # The first argument of this script is the session type.
       sessionType="$1"
       if [ "$sessionType" = default ]; then sessionType=""; fi
@@ -122,11 +127,6 @@ let
       unset _DID_SYSTEMD_CAT
 
       ${cfg.displayManager.sessionCommands}
-
-      # Allow the user to execute commands at the beginning of the X session.
-      if test -f ~/.xprofile; then
-          source ~/.xprofile
-      fi
 
       # Start systemd user services for graphical sessions
       ${config.systemd.package}/bin/systemctl --user start graphical-session.target

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -110,12 +110,14 @@ let
 
       # Speed up application start by 50-150ms according to
       # http://kdemonkey.blogspot.nl/2008/04/magic-trick.html
-      rm -rf "$HOME/.compose-cache"
-      mkdir "$HOME/.compose-cache"
+      compose_cache="''${$XCOMPOSECACHE:-$HOME/.compose-cache}"
+      rm -rf "$compose_cache"
+      mkdir -p "$compose_cache"
 
       # Work around KDE errors when a user first logs in and
       # .local/share doesn't exist yet.
-      mkdir -p "$HOME/.local/share"
+      xdg_data_home="''${XDG_DATA_HOME:-$HOME/.local/share}"
+      mkdir -p "$xdg_data_home"
 
       unset _DID_SYSTEMD_CAT
 


### PR DESCRIPTION
Read $XCOMPOSECACHE and $XDG_DATA_HOME environment variables when writing ~/.compose-cache and ~/.local/share, otherwise use default values.

###### Motivation for this change
Old script did not check for $XCOMPOSECACHE and $XDG_DATA_HOME
environment variables.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

