### PR TITLE
 Enable parallel building for rtaudio and rtmidi

### DIFF
--- a/pkgs/development/libraries/audio/rtaudio/default.nix
+++ b/pkgs/development/libraries/audio/rtaudio/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0jkqnhc2pq31nmq4daxhmqdjgv2qi4ib27hwms2r5zhnmvvzlr67";
   };
 
+  enableParallelBuilding = true;
+
   buildInputs = [ autoconf automake libtool libjack2 alsaLib rtmidi ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/audio/rtmidi/default.nix
+++ b/pkgs/development/libraries/audio/rtmidi/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "11pl45lp8sq5xkpipwk622w508nw0qcxr03ibicqn1lsws0hva96";
   };
 
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ autoconf automake libtool libjack2 alsaLib ];
 


### PR DESCRIPTION
###### Motivation for this change

Enable parallel building for rtaudio and rtmidi.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

