### PR TITLE
vcv-rack: Init at 0.6.2b

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -143,6 +143,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     free = false;
   };
 
+  cc-by-nc-40 = spdx {
+    spdxId = "CC-BY-NC-4.0";
+    fullName = "Creative Commons Attribution Non Commercial 4.0 International";
+    free = false;
+  };
+
   cc-by-nd-30 = spdx {
     spdxId = "CC-BY-ND-3.0";
     fullName = "Creative Commons Attribution-No Derivative Works v3.00";

--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, makeWrapper, fetchFromBitbucket, fetchFromGitHub, pkgconfig
+, alsaLib, curl, glew, glfw, gtk2-x11, jansson, libjack2, libXext, libXi
+, libzip, rtaudio, rtmidi, speex }:
+
+let
+  glfw-git = glfw.overrideAttrs (oldAttrs: {
+    name = "glfw-git-20180529";
+    src = fetchFromGitHub {
+      owner = "glfw";
+      repo = "glfw";
+      rev = "0be4f3f75aebd9d24583ee86590a38e741db0904";
+      sha256 = "0zbcjgc7ks25yi949k0wjknfl00a4dqmz45mhp00k62vlq2sj0i5";
+    };
+    buildInputs = oldAttrs.buildInputs ++ [ libXext libXi ];
+  });
+  pfft-source = fetchFromBitbucket {
+    owner = "jpommier";
+    repo = "pffft";
+    rev = "29e4f76ac53bef048938754f32231d7836401f79";
+    sha256 = "084csgqa6f1a270bhybjayrh3mpyi2jimc87qkdgsqcp8ycsx1l1";
+  };
+in
+with stdenv.lib; stdenv.mkDerivation rec {
+  name = "VCV-Rack-${version}";
+  version = "0.6.2b";
+
+  src = fetchFromGitHub {
+    owner = "VCVRack";
+    repo = "Rack";
+    rev = "v${version}";
+    sha256 = "17ynhxcci6dyn1yi871fd8yli4924fh12pmk510djwkcj5crhas6";
+    fetchSubmodules = true;
+  };
+
+  prePatch = ''
+    ln -s ${pfft-source} dep/jpommier-pffft-source
+
+    mkdir -p dep/include
+
+    cp dep/jpommier-pffft-source/*.h dep/include
+    cp dep/nanosvg/src/*.h dep/include
+    cp dep/nanovg/src/*.h dep/include
+    cp dep/osdialog/*.h dep/include
+    cp dep/oui-blendish/*.h dep/include
+
+    substituteInPlace include/audio.hpp --replace "<RtAudio.h>" "<rtaudio/RtAudio.h>"
+    substituteInPlace compile.mk --replace "-march=nocona" ""
+    substituteInPlace Makefile \
+       --replace "-Wl,-Bstatic" "" \
+       --replace "-lglfw3" "-lglfw"
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
+  buildInputs = [ glfw-git alsaLib curl glew gtk2-x11 jansson libjack2 libzip rtaudio rtmidi speex ];
+
+  buildFlags = "Rack";
+
+  installPhase = ''
+    install -D -m755 -t $out/bin Rack
+    cp -r res $out/
+
+    mkdir -p $out/share/rack
+    cp LICENSE.txt LICENSE-dist.txt $out/share/rack
+
+    # Override the default global resource file directory
+    wrapProgram $out/bin/Rack --add-flags "-g $out"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open-source virtual modular synthesizer";
+    homepage = http://vcvrack.com/;
+    # The source is BSD-3 licensed, some of the art is CC-BY-NC 4.0 or unfree
+    license = [ licenses.bsd3 licenses.cc-by-nc-40 licenses.unfree ];
+    maintainers = with maintainers; [ moredread ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18664,6 +18664,8 @@ with pkgs;
 
   vcprompt = callPackage ../applications/version-management/vcprompt { };
 
+  vcv-rack = callPackage ../applications/audio/vcv-rack { };
+
   vdirsyncer = callPackage ../tools/misc/vdirsyncer { };
 
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };


### PR DESCRIPTION
###### Motivation for this change

[VCV Rack](https://vcvrack.com/) is an interesting and relatively new [Eurorack](https://en.wikipedia.org/wiki/Eurorack) emulator.

There are a few problems I have with packing it, so your help would be appreciated.

Currently the following points need to be addressed:

- [x] Get installation working (there is no `make install` target, but it builds in a nix-shell)
- [x] Check whether all derivation dependencies are really needed
- [x] Better names for the overridden dependencies, i.e. with commit date
- [x] Check if we have permission to use the VCV name. **Edit:** I asked via mail and got an OK. Any ideas how to document that permanently?


It would be nice to fix these points:

- [x] Fetch all dependencies via Nix facilities, i.e. don't use `fetchSubmodules`. This would also allow to specify a tag instead of a revision for `fetchFromGitHub`
- [x] Cleanup/sort derivation arguments
- [x] Check if we can update the overridden dependencies in general
- [x] Maybe override optimization, as `-march=nocona`  doesn't match the Nix default
- [x] Address `glfw` error when building against `master` on `nixos-18.03 systems` (See https://github.com/NixOS/nixpkgs/pull/42679#issuecomment-400852126)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

