### PR TITLE
libvmi: init at 0.12

### DIFF
--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -1,20 +1,33 @@
-{ stdenv, xen, which, autoreconfHook, fetchFromGitHub, yacc, bison, flex, glib, libtool, autoconf, automake, pkgconfig, libvirt }:
+{ stdenv,
+  fetchFromGitHub,
+  which,
+  autoreconfHook,
+  autoconf,
+  automake,
+  libtool,
+  yacc,
+  bison,
+  flex,
+  glib,
+  pkgconfig,
+  json_c,
+  xen,
+  libvirt }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libvmi-${version}";
-  version = "${stdenv.lib.strings.substring 0 7 rev}-2017-05-27";
-  rev = "3e4114a64f012f1d3e2eb660bc65dcd130295d49";
+  version = "0.12";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "libvmi";
     repo = "libvmi";
-    sha256 = "0vbmrj0ij19i55afkqj64q7sgh0scpwk3c99qx6p6gn1qcy2wdss";
+    rev = "6934e8a4758018983ec53ec791dd14a7d6ac31a9";
+    sha256 = "0wbi2nasb1gbci6cq23g6kq7i10rwi1y7r44rl03icr5prqjpdyv";
   };
 
-  buildInputs = [ glib xen which libvirt ];
+  buildInputs = [ glib which libvirt json_c xen ];
   nativeBuildInputs = [ autoreconfHook yacc bison flex libtool autoconf automake pkgconfig ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, xen, which, autoreconfHook, fetchFromGitHub, yacc, bison, flex, glib, libtool, autoconf, automake, pkgconfig, libvirt }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "libvmi-${version}";
+  version = "${stdenv.lib.strings.substring 0 7 rev}-2017-05-27";
+  rev = "3e4114a64f012f1d3e2eb660bc65dcd130295d49";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "libvmi";
+    repo = "libvmi";
+    sha256 = "0vbmrj0ij19i55afkqj64q7sgh0scpwk3c99qx6p6gn1qcy2wdss";
+  };
+
+  buildInputs = [ glib xen which libvirt ];
+  nativeBuildInputs = [ autoreconfHook yacc bison flex libtool autoconf automake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://libvmi.com/";
+    description = "A C library for virtual machine introspection";
+    longDescription = ''
+      LibVMI is a C library with Python bindings that makes it easy to monitor the low-level
+      details of a running virtual machine by viewing its memory, trapping on hardware events,
+      and accessing the vCPU registers.
+    '';
+    license = [ licenses.gpl3 licenses.lgpg ];
+    maintainers = with maintainers; [ eleanor ];
+  };
+}

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       details of a running virtual machine by viewing its memory, trapping on hardware events,
       and accessing the vCPU registers.
     '';
-    license = [ licenses.lgpl3 ];
+    license = with licenses; [ gpl3 lgpl3 ];
     maintainers = with maintainers; [ lschuermann ];
   };
 }

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -12,7 +12,8 @@
   pkgconfig,
   json_c,
   xen,
-  libvirt }:
+  libvirt,
+  xenSupport ? true }:
 
 with stdenv.lib;
 
@@ -27,8 +28,10 @@ stdenv.mkDerivation rec {
     sha256 = "0wbi2nasb1gbci6cq23g6kq7i10rwi1y7r44rl03icr5prqjpdyv";
   };
 
-  buildInputs = [ glib which libvirt json_c xen ];
+  buildInputs = [ glib which libvirt json_c ] ++ (optional xenSupport xen);
   nativeBuildInputs = [ autoreconfHook yacc bison flex libtool autoconf automake pkgconfig ];
+
+  configureFlags = optional (!xenSupport) "--disable-xen";
 
   meta = with stdenv.lib; {
     homepage = "http://libvmi.com/";

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
       and accessing the vCPU registers.
     '';
     license = with licenses; [ gpl3 lgpl3 ];
+    platforms = platforms.linux;
     maintainers = with maintainers; [ lschuermann ];
   };
 }

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -1,11 +1,6 @@
 { stdenv,
   fetchFromGitHub,
-  which,
   autoreconfHook,
-  autoconf,
-  automake,
-  libtool,
-  yacc,
   bison,
   flex,
   glib,
@@ -28,8 +23,8 @@ stdenv.mkDerivation rec {
     sha256 = "0wbi2nasb1gbci6cq23g6kq7i10rwi1y7r44rl03icr5prqjpdyv";
   };
 
-  buildInputs = [ glib which libvirt json_c ] ++ (optional xenSupport xen);
-  nativeBuildInputs = [ autoreconfHook yacc bison flex libtool autoconf automake pkgconfig ];
+  buildInputs = [ glib libvirt json_c ] ++ (optional xenSupport xen);
+  nativeBuildInputs = [ autoreconfHook bison flex pkgconfig ];
 
   configureFlags = optional (!xenSupport) "--disable-xen";
 

--- a/pkgs/development/libraries/libvmi/default.nix
+++ b/pkgs/development/libraries/libvmi/default.nix
@@ -19,12 +19,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libvmi-${version}";
-  version = "0.12";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "libvmi";
     repo = "libvmi";
-    rev = "6934e8a4758018983ec53ec791dd14a7d6ac31a9";
+    rev = "v${version}";
     sha256 = "0wbi2nasb1gbci6cq23g6kq7i10rwi1y7r44rl03icr5prqjpdyv";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9103,6 +9103,8 @@ with pkgs;
 
   libvisual = callPackage ../development/libraries/libvisual { };
 
+  libvmi = callPackage ../development/libraries/libvmi { };
+
   libvncserver = callPackage ../development/libraries/libvncserver {};
 
   libviper = callPackage ../development/libraries/libviper { };
@@ -13355,7 +13357,7 @@ with pkgs;
   clipit = callPackage ../applications/misc/clipit { };
 
   cloud-print-connector = callPackage ../servers/cloud-print-connector { };
-  
+
   cmatrix = callPackage ../applications/misc/cmatrix { };
 
   cmus = callPackage ../applications/audio/cmus {
@@ -17791,7 +17793,7 @@ with pkgs;
   coqPackages_8_5 = mkCoqPackages_8_5 coqPackages_8_5;
   coqPackages_8_6 = mkCoqPackages_8_6 coqPackages_8_6;
   coqPackages = coqPackages_8_6;
-  
+
   coq_8_4 = coqPackages_8_4.coq;
   coq_8_5 = coqPackages_8_5.coq;
   coq_8_6 = coqPackages_8_6.coq;


### PR DESCRIPTION
###### Motivation for this change
With #26162 there already is an attempt to create a nix derivation for libvmi, which seems to have stagnated. This work is based off of this original pull request but resolves merge conflicts and updates the library to its current release, v0.12.

It also adds an option to disable Xen support entirely.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
I'm currently investigating whether it is also possible and makes sense to provide an option for disabling KVM support.
Additionally, for libvmi to work fast on KVM, they provide a patch for QEMU which integrates further debug interfaces. I'll test this patch and try to create another QEMU derivation with the libvmi integrations.