### PR TITLE
nginx: Flag to build with debugging and parallel builds

### DIFF
--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation {
 
   hardeningEnable = optional (!stdenv.isDarwin) "pie";
 
+  enableParallelBuilding = true;
+
   postInstall = ''
     mv $out/sbin $out/bin
   '';

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, openssl, zlib, pcre, libxml2, libxslt, expat
 , gd, geoip
+, withDebug ? false
 , withStream ? true
 , withMail ? false
 , modules ? []
@@ -44,6 +45,8 @@ stdenv.mkDerivation {
     "--with-pcre-jit"
     # Install destination problems
     # "--with-http_perl_module"
+  ] ++ optional withDebug [
+    "--with-debug"
   ] ++ optional withStream [
     "--with-stream"
     "--with-stream_geoip_module"


### PR DESCRIPTION
In order to use nginx's `debug log level, such as

    https://docs.nginx.com/nginx/admin-guide/monitoring/debugging/

as described on

		https://docs.nginx.com/nginx/admin-guide/monitoring/debugging/

nginx needs to be compiled with `--with-debug`.

As mentioned there, upstream "nginx PLUS" packages bring two different nginx
binaries (`nginx` and `nginx-debug`); for nixpkgs we at least want to at least
add a convenient flag to enable it.

---

A second commit enables parallel building.