### PR TITLE
nixos/virtualbox: Adds more options to virtualbox-image.nix

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -25,21 +25,21 @@ in {
         '';
       };
       vmDerivationName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "nixos-ova-${config.system.nixos.label}-${pkgs.stdenv.system}";
         description = ''
           The name of the derivation for the VirtualBox appliance.
         '';
       };
       vmName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "NixOS ${config.system.nixos.label} (${pkgs.stdenv.system})";
         description = ''
           The name of the VirtualBox appliance.
         '';
       };
       vmFileName = mkOption {
-        type = types.string;
+        type = types.str;
         default = "nixos-${config.system.nixos.label}-${pkgs.stdenv.system}.ova";
         description = ''
           The file name of the VirtualBox appliance.

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -17,12 +17,40 @@ in {
           The size of the VirtualBox base image in MiB.
         '';
       };
+      memorySize = mkOption {
+        type = types.int;
+        default = 1536;
+        description = ''
+          The amount of RAM the VirtualBox appliance can use in MiB.
+        '';
+      };
+      vmDerivationName = mkOption {
+        type = types.string;
+        default = "nixos-ova-${config.system.nixos.label}-${pkgs.stdenv.system}";
+        description = ''
+          The name of the derivation for the VirtualBox appliance.
+        '';
+      };
+      vmName = mkOption {
+        type = types.string;
+        default = "NixOS ${config.system.nixos.label} (${pkgs.stdenv.system})";
+        description = ''
+          The name of the VirtualBox appliance.
+        '';
+      };
+      vmFileName = mkOption {
+        type = types.string;
+        default = "nixos-${config.system.nixos.label}-${pkgs.stdenv.system}.ova";
+        description = ''
+          The file name of the VirtualBox appliance.
+        '';
+      };
     };
   };
 
   config = {
     system.build.virtualBoxOVA = import ../../lib/make-disk-image.nix {
-      name = "nixos-ova-${config.system.nixos.label}-${pkgs.stdenv.system}";
+      name = cfg.vmDerivationName;
 
       inherit pkgs lib config;
       partitionTableType = "legacy";
@@ -37,11 +65,11 @@ in {
           VBoxManage internalcommands createrawvmdk -filename disk.vmdk -rawdisk $diskImage
 
           echo "creating VirtualBox VM..."
-          vmName="NixOS ${config.system.nixos.label} (${pkgs.stdenv.system})"
+          vmName="${cfg.vmName}";
           VBoxManage createvm --name "$vmName" --register \
             --ostype ${if pkgs.stdenv.system == "x86_64-linux" then "Linux26_64" else "Linux26"}
           VBoxManage modifyvm "$vmName" \
-            --memory 1536 --acpi on --vram 32 \
+            --memory ${toString cfg.memorySize} --acpi on --vram 32 \
             ${optionalString (pkgs.stdenv.system == "i686-linux") "--pae on"} \
             --nictype1 virtio --nic1 nat \
             --audiocontroller ac97 --audio alsa \
@@ -53,7 +81,7 @@ in {
 
           echo "exporting VirtualBox VM..."
           mkdir -p $out
-          fn="$out/nixos-${config.system.nixos.label}-${pkgs.stdenv.system}.ova"
+          fn="$out/${cfg.vmFileName}"
           VBoxManage export "$vmName" --output "$fn"
 
           rm -v $diskImage


### PR DESCRIPTION
Previously you could only set the size of the disk.

This change adds the ability to change the amount of memory
that the image gets, along with the name / derivation name /
file name for the VM.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

