### PR TITLE
pythonPackages.cheroot: fixed tests

### DIFF
--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchPypi, buildPythonPackage
 , more-itertools, six
 , pytest, pytestcov, portend
-, backports_unittest-mock, setuptools_scm }:
+, backports_unittest-mock
+, backports_functools_lru_cache }:
 
 buildPythonPackage rec {
   pname = "cheroot";
@@ -14,9 +15,16 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ more-itertools six ];
 
-  buildInputs = [ setuptools_scm ];
+  checkInputs = [ pytest pytestcov portend backports_unittest-mock backports_functools_lru_cache ];
 
-  checkInputs = [ pytest pytestcov portend backports_unittest-mock ];
+# Disable testmon, it needs pytest-testmon, which we do not currently have in nikpkgs,
+# and is only used to skip some tests that are already known to work.
+  postPatch = ''
+    substituteInPlace "./pytest.ini" --replace "--testmon" ""
+    substituteInPlace setup.py --replace "use_scm_version=True" "version=\"${version}\"" \
+  --replace "'setuptools_scm>=1.15.0'," "" \
+  --replace "'setuptools_scm_git_archive>=1.0'," "" \
+  '';
 
   checkPhase = ''
     py.test cheroot

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -2,6 +2,7 @@
 , cheroot, portend, routes, six
 , setuptools_scm
 , backports_unittest-mock, objgraph, pathpy, pytest, pytestcov
+, backports_functools_lru_cache, requests_toolbelt
 }:
 
 buildPythonPackage rec {
@@ -17,7 +18,7 @@ buildPythonPackage rec {
 
   buildInputs = [ setuptools_scm ];
 
-  checkInputs = [ backports_unittest-mock objgraph pathpy pytest pytestcov ];
+  checkInputs = [ backports_unittest-mock objgraph pathpy pytest pytestcov backports_functools_lru_cache requests_toolbelt ];
 
   checkPhase = ''
     LANG=en_US.UTF-8 pytest


### PR DESCRIPTION
###### Motivation for this change
Fix #42715

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

