### PR TITLE
Update simgrid 3.19.1 -> 3.20 + parallel tests + enable darwin

### DIFF
--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -18,13 +18,13 @@ in
 
 stdenv.mkDerivation rec {
   name = "simgrid-${version}";
-  version = "3.19.1";
+  version = "3.20";
 
   src = fetchFromGitHub {
     owner = "simgrid";
     repo = "simgrid";
     rev = "v${version}";
-    sha256 = "0vpgcp40xv20hcpslx5wz2mf2phaq41f7x8yr0bm7mknqd3zwxih";
+    sha256 = "0xb20qhvsah2dz2hvn850i3w9a5ghsbcx8vka2ap6xsdkxf593gy";
   };
 
   nativeBuildInputs = [ cmake perl elfutils python3 boost valgrind ]

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -87,14 +87,8 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     runHook preCheck
 
-    if [ "$enableParallelBuilding" = 1 ]; then
-      if [ ''${NIX_BUILD_CORES:-0} = 0 ]; then
-        NB_CORES="$(nproc)"
-      else
-        NB_CORES="$NIX_BUILD_CORES"
-      fi
-    fi
-    ctest -j $NB_CORES --output-on-failure -E smpi-replay-multiple
+    ctest -j $NIX_BUILD_CORES --output-on-failure -E smpi-replay-multiple
+
     runHook postCheck
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Enable the build on Darwin.
Speed up testing

###### Things done

I use this update to remove ``elfutils`` from the ``nativeBuildInputs`` because it was only needed for Model Checking. This should enables the build on Darwin without this option which is activated by default.

Also I add a falg to Ctest command to enable parallel run of the tests  
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

