### PR TITLE
bison2: Fix Darwin runtime crash

### DIFF
--- a/pkgs/development/tools/parsing/bison/2.x.nix
+++ b/pkgs/development/tools/parsing/bison/2.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, m4, perl }:
+{ stdenv, lib, fetchurl, m4, perl }:
 
 stdenv.mkDerivation rec {
   name = "bison-2.7";
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ m4 ] ++ stdenv.lib.optional doCheck perl;
   propagatedBuildInputs = [ m4 ];
+
+  patches = lib.optional stdenv.isDarwin ./darwin-vasnprintf.patch;
 
   doCheck = true;
   # M4 = "${m4}/bin/m4";

--- a/pkgs/development/tools/parsing/bison/darwin-vasnprintf.patch
+++ b/pkgs/development/tools/parsing/bison/darwin-vasnprintf.patch
@@ -1,0 +1,12 @@
+diff -ur bison-2.7-pristine/lib/vasnprintf.c bison-2.7/lib/vasnprintf.c
+--- bison-2.7-pristine/lib/vasnprintf.c	2012-11-30 20:48:23.000000000 +0900
++++ bison-2.7/lib/vasnprintf.c	2018-06-28 16:55:31.000000000 +0900
+@@ -4870,7 +4870,7 @@
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__) || (defined __APPLE__ && defined __MACH__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';


### PR DESCRIPTION
###### Motivation for this change

Noticed bison2 crashes on startup on Darwin. Don't know if bison2 is significant any more.

Before:

```
$ nix-shell -I nixpkgs=channel:nixpkgs-unstable -p bison2 --run 'bison --version | head -1'
.../nix-shell-21482-0/rc: line 1: 22036 Abort trap: 6           bison --version
```

After:

```
$ nix-shell -I nixpkgs=. -p bison2 --run 'bison --version | head -1'
bison (GNU Bison) 2.7
```

Similar change to the same underlying code that caused a similar problem with cvs: https://github.com/NixOS/nixpkgs/commit/e49f601b7f84e2bfe1b5c1487e132fcbb4284f91

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
