### PR TITLE
elasticsearch5: Set classpath for elasticsearch-plugin

### DIFF
--- a/pkgs/servers/search/elasticsearch/5.x.nix
+++ b/pkgs/servers/search/elasticsearch/5.x.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
       --set JAVA_HOME "${jre_headless}" \
       --set ES_JVM_OPTIONS "$out/config/jvm.options"
 
-    wrapProgram $out/bin/elasticsearch-plugin --set JAVA_HOME "${jre_headless}"
+    wrapProgram $out/bin/elasticsearch-plugin \
+      --prefix ES_CLASSPATH : "$out/lib/*" \
+      --set JAVA_HOME "${jre_headless}"
   '';
 
   meta = {

--- a/pkgs/servers/search/elasticsearch/es-classpath-5.x.patch
+++ b/pkgs/servers/search/elasticsearch/es-classpath-5.x.patch
@@ -32,3 +32,12 @@ diff -rupN a/bin/elasticsearch.in.sh b/bin/elasticsearch.in.sh
 -fi
 -
 -ES_CLASSPATH="$ES_HOME/lib/*"
+diff -rupN a/bin/elasticsearch-plugin b/bin/elasticsearch-plugin
+--- a/bin/elasticsearch-plugin	2018-04-13 01:21:55.000000000 +0900
++++ b/bin/elasticsearch-plugin	2018-06-28 19:08:54.700969245 +0900
+@@ -88,4 +88,4 @@ if [ -e "$CONF_DIR" ]; then
+   path_props=("${path_props[@]}" -Des.path.conf="$CONF_DIR")
+ fi
+ 
+-exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch "${path_props[@]}" -cp "$ES_HOME/lib/*" org.elasticsearch.plugins.PluginCli "${args[@]}"
++exec "$JAVA" $ES_JAVA_OPTS -Delasticsearch "${path_props[@]}" -cp "$ES_CLASSPATH" org.elasticsearch.plugins.PluginCli "${args[@]}"


### PR DESCRIPTION
###### Motivation for this change

In `elasticsearch5`, `elasticsearch-plugin` fails with the error message:

```
Error: Could not find or load main class org.elasticsearch.plugins.PluginCli
```

Since it forces the class path to `ES_HOME/lib/*`, and makes it difficult to override. This change makes the class path be specified by `ES_CLASSPATH`, like the main `elasticsearch` script, so the wrapper can set it to the correct path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

