### PR TITLE
yubikey-manager: 0.4.0 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/fido2/default.nix
+++ b/pkgs/development/python-modules/fido2/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, six, cryptography }:
+
+buildPythonPackage rec {
+  pname = "fido2";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ddbhg4nsabi9w66l8vkr0i5r80jqihlic5yrdl3v1aqahvxph1j";
+  };
+
+  # The pypi package does not include tests
+  # Check https://github.com/Yubico/python-fido2/pull/8
+  doCheck = false;
+
+  propagatedBuildInputs = [ six cryptography ];
+
+  meta = with lib; {
+    description = "Provides library functionality for FIDO 2.0, including communication with a device over USB.";
+    homepage = https://github.com/Yubico/python-fido2;
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/tools/misc/yubikey-manager/default.nix
+++ b/pkgs/tools/misc/yubikey-manager/default.nix
@@ -2,11 +2,11 @@
   yubikey-personalization, libu2f-host, libusb1 }:
 
 pythonPackages.buildPythonPackage rec {
-  name = "yubikey-manager-0.4.0";
+  name = "yubikey-manager-0.7.0";
 
   srcs = fetchurl {
     url = "https://developers.yubico.com/yubikey-manager/Releases/${name}.tar.gz";
-    sha256 = "0dc0mqg8r6kjh0s2rmrggfxbx9imslajjrj80rffcvg64a2vgsgb";
+    sha256 = "13vvl3jc5wg6d4h5cpaf969apsbf72dxad560d02ly061ss856zr";
   };
 
   propagatedBuildInputs =
@@ -18,6 +18,7 @@ pythonPackages.buildPythonPackage rec {
       pyusb
       pyopenssl
       six
+      fido2
     ] ++ [
       libu2f-host
       libusb1

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -266,6 +266,8 @@ in {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  fido2 = callPackage ../development/python-modules/fido2 {  };
+
   globus-sdk = callPackage ../development/python-modules/globus-sdk { };
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };


### PR DESCRIPTION
###### Motivation for this change
0.4.0 is over a year old and doesn't work correctly.

###### Things done
Depends on the fido2 library, packaged in a separate commit for convenient cherry picking.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

