### PR TITLE
ocamlPackages.utop: 1.19.3 -> 2.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, buildOcaml, fetchurl, libev, ocaml, findlib, jbuilder, zed, lwt_react }:
+{ stdenv, fetchurl, libev, ocaml, findlib, jbuilder, zed, lwt_react }:
 
 assert stdenv.lib.versionAtLeast ocaml.version "4.02";
 
-buildOcaml rec {
+stdenv.mkDerivation rec {
   version = "1.12.0";
-  name = "lambda-term";
+  name = "ocaml${ocaml.version}-lambda-term-${version}";
 
   src = fetchurl {
     url = "https://github.com/diml/lambda-term/archive/${version}.tar.gz";

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, bash, ocaml, findlib, ocamlbuild, camlp4
-, lambdaTerm, ocaml_lwt, camomile, zed, cppo, ppx_tools, makeWrapper
+{ stdenv, fetchurl, bash, ocaml, findlib, ocamlbuild, jbuilder
+, lambdaTerm, cppo, makeWrapper
 }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.02"
@@ -7,30 +7,20 @@ then throw "utop is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "1.19.3";
+  version = "2.1.0";
   name = "utop-${version}";
 
   src = fetchurl {
     url = "https://github.com/diml/utop/archive/${version}.tar.gz";
-    sha256 = "16z02vp9n97iax4fqpbi7v86r75vbabxvnd1rirh8w2miixs1g4x";
+    sha256 = "0lpfyhnm4v3xmcpac76g1px3x7na4p29w6xj2q8chqxhcw131n2y";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ ocaml findlib ocamlbuild cppo camlp4 ppx_tools ];
+  buildInputs = [ ocaml findlib ocamlbuild cppo jbuilder ];
 
-  propagatedBuildInputs = [ lambdaTerm ocaml_lwt ];
+  propagatedBuildInputs = [ lambdaTerm ];
 
-  createFindlibDestdir = true;
-
-  configureFlags = [ "--enable-camlp4" ]
-  ++ stdenv.lib.optional (ppx_tools != null && !stdenv.lib.versionAtLeast ocaml.version "4.04") "--enable-interact";
-
-  buildPhase = ''
-    make
-    make doc
-    '';
-
-  dontStrip = true;
+  inherit (jbuilder) installPhase;
 
   postFixup =
    let


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

