### PR TITLE
rainloop: Init at 1.12.1

### DIFF
--- a/pkgs/servers/rainloop/default.nix
+++ b/pkgs/servers/rainloop/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, unzip, dataPath ? "/etc/rainloop" }: let
+  common = { edition, sha256 }:
+    stdenv.mkDerivation (rec {
+      name = "rainloop-${edition}-${version}";
+      version = "1.12.1";
+
+      buildInputs = [ unzip ];
+
+      unpackPhase = ''
+        mkdir rainloop
+        unzip -q -d rainloop $src
+      '';
+
+      src = fetchurl {
+        url = "https://github.com/RainLoop/rainloop-webmail/releases/download/v${version}/rainloop-${edition}${stdenv.lib.optionalString (edition != "") "-"}${version}.zip";
+        sha256 = sha256;
+      };
+
+      installPhase = ''
+        mkdir $out
+        cp -r rainloop/* $out
+        rm -rf $out/data
+        ln -s ${dataPath} $out/data
+      '';
+
+      meta = with stdenv.lib; {
+        description = "Simple, modern & fast web-based email client";
+        homepage = "https://www.rainloop.net";
+        downloadPage = https://github.com/RainLoop/rainloop-webmail/releases;
+        license = licenses.agpl3;
+        platforms = platforms.all;
+        maintainers = with maintainers; [ das_j ];
+      };
+    });
+  in {
+    rainloop-community = common {
+      edition = "community";
+      sha256 = "06w1vxqpcj2j8dzzjqh6azala8l46hzy85wcvqbjdlj5w789jzsx";
+    };
+    rainloop-standard = common {
+      edition = "";
+      sha256 = "1fbnpk7l2fbmzn31vx36caqg9xm40g4hh4mv3s8d70slxwhlscw0";
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1480,6 +1480,10 @@ with pkgs;
 
   syslogng_incubator = callPackage ../tools/system/syslog-ng-incubator { };
 
+  inherit (callPackages ../servers/rainloop { })
+    rainloop-community
+    rainloop-standard;
+
   ring-daemon = callPackage ../applications/networking/instant-messengers/ring-daemon { };
 
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {


### PR DESCRIPTION
###### Motivation for this change

I'm using rainloop webmail on my legacy (non-NixOS) servers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

