### PR TITLE
thunderbolt: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/os-specific/linux/thunderbolt/default.nix
+++ b/pkgs/os-specific/linux/thunderbolt/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   # These can't go in the normal nix cmakeFlags because $out needs to be
   # expanded by the shell, not by cmake or nix.  $ENV{out} doesn't work right
   # either; it results in /build/source/build//nix/store/blahblahblahblah/bin/
+  # TODO: use ${placeholder "out"} when possible.
+  #       See https://github.com/NixOS/nixpkgs/pull/37693
   preConfigure = ''
     cmakeFlags+=" -DUDEV_BIN_DIR=$out/bin"
     cmakeFlags+=" -DUDEV_RULES_DIR=$out/etc/udev/rules.d"

--- a/pkgs/os-specific/linux/thunderbolt/default.nix
+++ b/pkgs/os-specific/linux/thunderbolt/default.nix
@@ -4,16 +4,17 @@
 , fetchFromGitHub
 , pkgconfig
 , txt2tags
+, udev
 }:
 
 stdenv.mkDerivation rec {
   name = "thunderbolt-${version}";
-  version = "0.9.2";
+  version = "0.9.3";
   src = fetchFromGitHub {
     owner = "01org";
     repo = "thunderbolt-software-user-space";
-    rev = "1ae06410180320a5d0e7408a8d1a6ae2aa443c23";
-    sha256 = "03yk419gj0767lpk6zvla4jx3nx56zsg4x4adl4nd50xhn409rcc";
+    rev = "v${version}";
+    sha256 = "02w1bfm7xvq0dzkhwqiq0camkzz9kvciyhnsis61c8vzp39cwx0x";
   };
 
   buildInputs = [
@@ -23,11 +24,13 @@ stdenv.mkDerivation rec {
     txt2tags
   ];
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE='Release'"
-    "-DUDEV_BIN_DIR=$out/bin"
-    "-DUDEV_RULES_DIR=$out/udev"
-  ];
+  # These can't go in the normal nix cmakeFlags because $out needs to be
+  # expanded by the shell, not by cmake or nix.  $ENV{out} doesn't work right
+  # either; it results in /build/source/build//nix/store/blahblahblahblah/bin/
+  preConfigure = ''
+    cmakeFlags+=" -DUDEV_BIN_DIR=$out/bin"
+    cmakeFlags+=" -DUDEV_RULES_DIR=$out/etc/udev/rules.d"
+  '';
 
   meta = {
     description = "Thunderbolt(TM) user-space components";


### PR DESCRIPTION
Fixed up `cmakeFlags` so `tbtacl`, `tbtacl-write`, `tbtxdomain`, and the udev rules now show up in the derivation output. Previously there was only `tbtadm`.

###### Motivation for this change

New version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

