### PR TITLE
Manual fixes: users.extraUsers -> users.users

### DIFF
--- a/nixos/doc/manual/administration/imperative-containers.xml
+++ b/nixos/doc/manual/administration/imperative-containers.xml
@@ -27,7 +27,7 @@
 <screen>
 # nixos-container create foo --config '
   <xref linkend="opt-services.openssh.enable"/> = true;
-  <link linkend="opt-users.users._name__.openssh.authorizedKeys.keys">users.extraUsers.root.openssh.authorizedKeys.keys</link> = ["ssh-dss AAAAB3N…"];
+  <link linkend="opt-users.users._name__.openssh.authorizedKeys.keys">users.users.root.openssh.authorizedKeys.keys</link> = ["ssh-dss AAAAB3N…"];
 '
 </screen>
  </para>

--- a/nixos/doc/manual/configuration/network-manager.xml
+++ b/nixos/doc/manual/configuration/network-manager.xml
@@ -19,7 +19,7 @@
   All users that should have permission to change network settings must belong
   to the <code>networkmanager</code> group:
 <programlisting>
-<link linkend="opt-users.users._name__.extraGroups">users.extraUsers.youruser.extraGroups</link> = [ "networkmanager" ];
+<link linkend="opt-users.users._name__.extraGroups">users.users.youruser.extraGroups</link> = [ "networkmanager" ];
 </programlisting>
  </para>
 

--- a/nixos/doc/manual/configuration/network-manager.xml
+++ b/nixos/doc/manual/configuration/network-manager.xml
@@ -19,7 +19,7 @@
   All users that should have permission to change network settings must belong
   to the <code>networkmanager</code> group:
 <programlisting>
-<link linkend="opt-users.users._name__.extraGroups">users.users.youruser.extraGroups</link> = [ "networkmanager" ];
+<link linkend="opt-users.users._name__.extraGroups">users.users.alice.extraGroups</link> = [ "networkmanager" ];
 </programlisting>
  </para>
 

--- a/nixos/doc/manual/configuration/ssh.xml
+++ b/nixos/doc/manual/configuration/ssh.xml
@@ -20,7 +20,7 @@
   follows:
 <!-- FIXME: this might not work if the user is unmanaged. -->
 <programlisting>
-<link linkend="opt-users.users._name__.openssh.authorizedKeys.keys">users.extraUsers.alice.openssh.authorizedKeys.keys</link> =
+<link linkend="opt-users.users._name__.openssh.authorizedKeys.keys">users.users.alice.openssh.authorizedKeys.keys</link> =
   [ "ssh-dss AAAAB3NzaC1kc3MAAACBAPIkGWVEt4..." ];
 </programlisting>
  </para>

--- a/nixos/doc/manual/installation/changing-config.xml
+++ b/nixos/doc/manual/installation/changing-config.xml
@@ -66,7 +66,7 @@ $ ./result/bin/run-*-vm
   <literal>mutableUsers = false</literal>. Another way is to temporarily add
   the following to your configuration:
 <screen>
-<link linkend="opt-users.users._name__.initialHashedPassword">users.extraUsers.your-user.initialHashedPassword</link> = "test";
+<link linkend="opt-users.users._name__.initialHashedPassword">users.users.your-user.initialHashedPassword</link> = "test";
 </screen>
   <emphasis>Important:</emphasis> delete the $hostname.qcow2 file if you have
   started the virtual machine at least once without the right users, otherwise

--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -211,7 +211,7 @@ $ sudo groupdel nixbld</screen>
     use <literal>sudo</literal>)
    </para>
 <programlisting>
-<link linkend="opt-users.users._name__.initialHashedPassword">users.extraUsers.root.initialHashedPassword</link> = "";
+<link linkend="opt-users.users._name__.initialHashedPassword">users.users.root.initialHashedPassword</link> = "";
               </programlisting>
   </listitem>
   <listitem>


### PR DESCRIPTION
###### Motivation for this change
This fixes some oddities while reading through the NixOS manual.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

