### PR TITLE
f2fs-tools: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/tools/filesystems/f2fs-tools/default.nix
+++ b/pkgs/tools/filesystems/f2fs-tools/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "f2fs-tools-${version}";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git";
     rev = "refs/tags/v${version}";
-    sha256 = "0aj9dbhv7vv19pyb2rhcg99v5v0s66sb9yzrdmi46bmvzz124pal";
+    sha256 = "1254pd254l1hxkzkkzqmzc0j9vywj2wddg9apqaixjninj21jrbc";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

