### PR TITLE
pythonPackages.salmon-mail: fix tests

### DIFF
--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -14,6 +14,12 @@ buildPythonPackage rec {
   checkInputs = [ nose jinja2 mock ];
   propagatedBuildInputs = [ chardet dnspython lmtpd pythondaemon six ];
 
+  # The tests use salmon executable installed by salmon itself so we need to add
+  # that to PATH
+  checkPhase = ''
+    PATH=$out/bin:$PATH nosetests .
+  '';
+
   meta = with stdenv.lib; {
     homepage = http://salmon-mail.readthedocs.org/;
     description = "Pythonic mail application server";


### PR DESCRIPTION
###### Motivation for this change

After the upgrade to 3.0.1, unit tests broke. Here's a fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

