### PR TITLE
sqldeveloper: add desktop item

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,7 +1,21 @@
-{ stdenv, makeWrapper, requireFile, unzip, openjdk }:
+{ stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, openjdk }:
 
-stdenv.mkDerivation rec {
+let
   version = "17.4.1.054.0712";
+
+  desktopItem = makeDesktopItem {
+    name = "sqldeveloper";
+    exec = "sqldeveloper";
+    icon = "sqldeveloper";
+    desktopName = "Oracle SQL Developer";
+    genericName = "Oracle SQL Developer";
+    comment = "Oracle's Oracle DB GUI client";
+    categories = "Application;Development;";
+  };
+in
+  stdenv.mkDerivation rec {
+
+  inherit version;
   name = "sqldeveloper-${version}";
 
   src = requireFile rec {
@@ -51,6 +65,10 @@ stdenv.mkDerivation rec {
     cd $out
     unzip ${src}
     mv sqldeveloper $out/lib/${name}
+
+    install -D -m 444 $out/lib/$name/icon.png $out/share/pixmaps/sqldeveloper.png
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Backport of #39368 to 18.03
###### Motivation for this change
This adds the missing desktop item for sqldeveloper to 18.03.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

