### PR TITLE
puddletag: install desktop entry and man page

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -27,17 +27,6 @@ python2Packages.buildPythonApplication rec {
   doCheck = false;   # there are no tests
   dontStrip = true;  # we are not generating any binaries
 
-  installPhase = ''
-    runHook preInstall
-
-    siteDir=$(toPythonPath $out)
-    mkdir -p $siteDir
-    PYTHONPATH=$PYTHONPATH:$siteDir
-    ${python2Packages.python.interpreter} setup.py install --prefix $out
-
-    runHook postInstall
-  '';
-
   meta = with stdenv.lib; {
     homepage    = https://puddletag.net;
     description = "An audio tag editor similar to the Windows program, Mp3tag";


### PR DESCRIPTION
###### Motivation for this change

While provided by upstream due to the deleted lines the desktop entry and man page were copied to the wrong location. I have no idea what the purpose of those lines is in the first place. Hope someone can take a look at this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @peterhoeg
