### PR TITLE
atom, atom-beta: fixed #42730

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -21,6 +21,7 @@ let
       mv $out/usr/* $out/
       rm -r $out/share/lintian
       rm -r $out/usr/
+      sed -i "s/${pname})/.${pname}-wrapped)/" $out/bin/${pname}
       # sed -i "s/'${pname}'/'.${pname}-wrapped'/" $out/bin/${pname}
       wrapProgram $out/bin/${pname} \
         --prefix "PATH" : "${gvfs}/bin"

--- a/pkgs/applications/editors/atom/env.nix
+++ b/pkgs/applications/editors/atom/env.nix
@@ -1,11 +1,11 @@
-{ stdenv, lib, zlib, glib, alsaLib, dbus, gtk2, atk, pango, freetype, fontconfig
+{ stdenv, lib, zlib, glib, alsaLib, dbus, gtk3, atk, pango, freetype, fontconfig
 , libgnome-keyring3, gdk_pixbuf, gvfs, cairo, cups, expat, libgpgerror, nspr
 , gconf, nss, xorg, libcap, systemd, libnotify, libsecret
 }:
 
 let
   packages = [
-    stdenv.cc.cc zlib glib dbus gtk2 atk pango freetype libgnome-keyring3
+    stdenv.cc.cc zlib glib dbus gtk3 atk pango freetype libgnome-keyring3
     fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr gconf nss
     xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
     xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr


### PR DESCRIPTION
Swithed atom to use gtk3 instead of 2.
Fixed channel detection in the atom startup script.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

