### PR TITLE
fetchFromGitHub: make owner and repo accessible

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -19,6 +19,7 @@ in
 , # Shell code executed after the file has been fetched
   # successfully. This can do things like check or transform the file.
   postFetch ? ""
+, passthru ? {}
 }:
 
 /* NOTE:
@@ -67,4 +68,6 @@ stdenvNoCC.mkDerivation {
   ];
 
   preferLocalBuild = true;
+
+  inherit passthru;
 }

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -12,6 +12,7 @@
 , url
 , extraPostFetch ? ""
 , name ? "source"
+, passthru ? {}
 , ... } @ args:
 
 lib.overrideDerivation (fetchurl ({
@@ -48,6 +49,8 @@ lib.overrideDerivation (fetchurl ({
       mv "$unpackDir" "$out"
     '') #*/
     + extraPostFetch;
+
+    inherit passthru;
 } // removeAttrs args [ "stripRoot" "extraPostFetch" ]))
 # Hackety-hack: we actually need unzip hooks, too
 (x: {nativeBuildInputs = x.nativeBuildInputs++ [unzip];})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -235,7 +235,7 @@ with pkgs;
   }@args: assert private -> !fetchSubmodules;
   let
     baseUrl = "https://${githubBase}/${owner}/${repo}";
-    passthruAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "private" "githubBase" "varPrefix" ];
+    fetcherAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "private" "githubBase" "varPrefix" ];
     varBase = "NIX${if varPrefix == null then "" else "_${varPrefix}"}_GITHUB_PRIVATE_";
     # We prefer fetchzip in cases we don't need submodules as the hash
     # is more stable in that case.
@@ -257,8 +257,8 @@ with pkgs;
     fetcherArgs = (if fetchSubmodules
         then { inherit rev fetchSubmodules; url = "${baseUrl}.git"; }
         else ({ url = "${baseUrl}/archive/${rev}.tar.gz"; } // privateAttrs)
-      ) // passthruAttrs // { inherit name; };
-  in fetcher fetcherArgs // { meta.homepage = baseUrl; inherit rev; };
+      ) // fetcherAttrs // { inherit name; passthru = { inherit owner repo rev; }; };
+  in fetcher fetcherArgs // { meta.homepage = baseUrl; };
 
   fetchFromBitbucket = {
     owner, repo, rev, name ? "source",


### PR DESCRIPTION
I would like to be able to get the `repo` and `owner` attrs of a `fetchFromGitHub` derivation so that I can add changelog information to nixpkgs-update's pull requests.

I renamed `passthruArgs` because I thought this is a confusing name given we have a `passthru` concept already, and added `owner`, `repo`, and `rev` to the passthru attrs for the `fetchzip` and `fetchgit` derivations. I also removed "inherit rev" from the attrset, since it seems to be covered by the passthru attrs.

I'm not that familiar with this kind of nix editing and this is an important derivation, so please check my work!