### PR TITLE
dockerTools.buildImage: add option to use nix output hash as tag

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -521,7 +521,7 @@ merge:"diff3"
     <callout arearefs='ex-dockerTools-buildImage-2'>
      <para>
       <varname>tag</varname> specifies the tag of the resulting image. By
-      default it's <literal>latest</literal>.
+      default it's <literal>null</literal>, which indicates that the nix output hash will be used as tag.
      </para>
     </callout>
     <callout arearefs='ex-dockerTools-buildImage-3'>

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -127,6 +127,12 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
      Make sure the key file is accessible to the daemon.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      <varname>dockerTools.buildImage</varname> now uses <literal>null</literal> as default value for <varname>tag</varname>,
+      which indicates that the nix output hash will be used as tag.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
###### Motivation for this change

I want the tag of my docker image to only change when its content gets changed. Nix already tracks all the dependencies of the image and represents that in the nix-store path. I would like to re-use that value for the docker image tag.

When setting `useOutputHashAsTag` to `true` the given `tag` will be ignored and the extracted hash of `$out` will be used instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

