### PR TITLE
Fix packages broken by python-dateutil bump

### DIFF
--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -1,8 +1,22 @@
-{ stdenv, pkgs, python3Packages }:
+{ stdenv, pkgs, python3 }:
 
-with python3Packages;
+let
+  python = python3.override {
+    packageOverrides = self: super: {
 
-buildPythonApplication rec {
+      # https://github.com/pimutils/khal/issues/780
+      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
+        version = "2.6.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca";
+        };
+      });
+
+    };
+  };
+
+in with python.pkgs; buildPythonApplication rec {
   pname = "khal";
   version = "0.9.9";
 
@@ -29,10 +43,11 @@ buildPythonApplication rec {
     pkginfo
     freezegun
   ];
-  buildInputs = [ setuptools_scm pytest pkgs.glibcLocales ];
+  nativeBuildInputs = [ setuptools_scm pkgs.glibcLocales ];
+  checkInputs = [ pytest ];
 
   checkPhase = ''
-    # py.test
+    py.test
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchPypi, buildPythonPackage, dateutil, pytzdata, tzlocal }:
+{ lib, fetchPypi, buildPythonPackage, pythonOlder
+, dateutil, pytzdata, typing }:
 
 buildPythonPackage rec {
   pname = "pendulum";
@@ -9,12 +10,12 @@ buildPythonPackage rec {
     sha256 = "544e44d8a92954e5ef4db4fa8b662d3282f2ac7b7c2cbf4227dc193ba78b9e1e";
   };
 
-  propagatedBuildInputs = [ dateutil pytzdata tzlocal ];
+  propagatedBuildInputs = [ dateutil pytzdata ] ++ lib.optional (pythonOlder "3.5") typing;
 
   # No tests
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Python datetimes made easy";
     homepage = https://github.com/sdispater/pendulum;
     license = licenses.mit;

--- a/pkgs/development/python-modules/pytest-httpbin/default.nix
+++ b/pkgs/development/python-modules/pytest-httpbin/default.nix
@@ -28,6 +28,9 @@ buildPythonPackage rec {
     py.test
   '';
 
+  # https://github.com/kevin1024/pytest-httpbin/pull/51
+  doCheck = false;
+
   meta = {
     description = "Easily test your HTTP library against a local copy of httpbin.org";
     homepage = https://github.com/kevin1024/pytest-httpbin;

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -1,11 +1,26 @@
-{ stdenv, fetchFromGitHub, python3Packages }:
+{ stdenv, fetchFromGitHub, python3 }:
 
 let
   version = "2.1.9";
   sha256 = "1sywxn7j9bq39qwq74h327crc44j9049cykai1alv44agx8s1nhz";
+
+  python = python3.override {
+    packageOverrides = self: super: {
+
+      # https://github.com/eventable/vobject/issues/112
+      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
+        version = "2.6.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca";
+        };
+      });
+
+    };
+  };
 in
 
-python3Packages.buildPythonApplication {
+python.pkgs.buildPythonApplication {
   name = "radicale-${version}";
   inherit version;
 
@@ -18,7 +33,7 @@ python3Packages.buildPythonApplication {
 
   doCheck = false;
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python.pkgs; [
     vobject
     passlib
     pytz

--- a/pkgs/tools/misc/papis/default.nix
+++ b/pkgs/tools/misc/papis/default.nix
@@ -1,12 +1,24 @@
 { buildPythonApplication, lib, fetchFromGitHub, bashInteractive
-, argcomplete, arxiv2bib, beautifulsoup4, bibtexparser
-, configparser, dmenu-python, habanero, papis-python-rofi
-, pylibgen, prompt_toolkit, pyparser, pytest, python_magic
-, pyyaml, requests, unidecode, urwid, vobject, tkinter
-, vim
+, python3, vim
 }:
 
-buildPythonApplication rec {
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+
+      # https://github.com/eventable/vobject/issues/112
+      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
+        version = "2.6.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca";
+        };
+      });
+
+    };
+  };
+
+in python.pkgs.buildPythonApplication rec {
   pname = "papis";
   version = "0.5.3";
 
@@ -23,7 +35,7 @@ buildPythonApplication rec {
     patchShebangs tests
   '';
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python.pkgs; [
     argcomplete arxiv2bib beautifulsoup4 bibtexparser
     configparser dmenu-python habanero papis-python-rofi
     pylibgen prompt_toolkit pyparser python_magic pyyaml
@@ -31,7 +43,7 @@ buildPythonApplication rec {
     vim
   ];
 
-  checkInputs = [ pytest ];
+  checkInputs = with python.pkgs; [ pytest ];
 
   # Papis tries to create the config folder under $HOME during the tests
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change
All these applications are broken due to https://github.com/eventable/vobject/issues/112.
For khal, there is also https://github.com/pimutils/khal/issues/780.

An alternative would be to apply https://github.com/eventable/vobject/pull/115 to the vobject package.

~Note that papis doesn't build because pytest-httpbin is broken.~
Also, I did not fix all applications that depend on vobject.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

