### PR TITLE
kmod-blacklist-ubuntu: Fix typo from commit "do not blacklist i2c_i801"

### DIFF
--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
       echo "''\n''\n## file: "`basename "$f"`"''\n''\n" >> "$out"/modprobe.conf
       cat "$f" >> "$out"/modprobe.conf
       # https://bugs.launchpad.net/ubuntu/+source/kmod/+bug/1475945
-      sed -i '/^blacklist i2c_801/d' $out/modprobe.conf
+      sed -i '/^blacklist i2c_i801/d' $out/modprobe.conf
     done
 
     substituteInPlace "$out"/modprobe.conf \


### PR DESCRIPTION
That commit did not actually accomplish its intent because it misspelled the module name.

I did not verify that this fixes any real issue but I am sending this fix after noticing the mistake incidentally. I have verified that after this fix `/etc/modprobe.d/ubuntu.conf` does not have that blacklist line while it did before.

Should probably be backported to 18.03.

###### Motivation for this change

Typo in module name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

