### PR TITLE
lwp-protocol-https: honour NIX_SSL_CERT_FILE

### DIFF
--- a/pkgs/development/perl-modules/lwp-protocol-https-cert-file.patch
+++ b/pkgs/development/perl-modules/lwp-protocol-https-cert-file.patch
@@ -1,15 +1,31 @@
-diff -ru -x '*~' LWP-Protocol-https-6.04-orig/lib/LWP/Protocol/https.pm LWP-Protocol-https-6.04/lib/LWP/Protocol/https.pm
---- LWP-Protocol-https-6.04-orig/lib/LWP/Protocol/https.pm	2013-04-29 23:16:18.000000000 +0200
-+++ LWP-Protocol-https-6.04/lib/LWP/Protocol/https.pm	2016-03-02 14:59:01.639844511 +0100
-@@ -24,6 +24,11 @@
+From 321401098f2c86a6f68e186cfc06e030b09484b6 Mon Sep 17 00:00:00 2001
+From: Tyson Whitehead <twhitehead@gmail.com>
+Date: Fri, 29 Jun 2018 15:47:00 -0400
+Subject: [PATCH] Respect NIX_SSL_CERT_FILE and SSL_CERT_FILE (in that order)
+
+---
+ lib/LWP/Protocol/https.pm | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lib/LWP/Protocol/https.pm b/lib/LWP/Protocol/https.pm
+index f7230e2..c78b9ce 100644
+--- a/lib/LWP/Protocol/https.pm
++++ b/lib/LWP/Protocol/https.pm
+@@ -23,6 +23,14 @@ sub _extra_sock_opts
+ 	$ssl_opts{SSL_verify_mode} = 0;
      }
      if ($ssl_opts{SSL_verify_mode}) {
- 	unless (exists $ssl_opts{SSL_ca_file} || exists $ssl_opts{SSL_ca_path}) {
-+	    $ssl_opts{SSL_ca_file} = $ENV{'SSL_CERT_FILE'};
++	unless (exists $ssl_opts{SSL_ca_file} || exists $ssl_opts{SSL_ca_path}) {
++	    $ssl_opts{SSL_ca_file} = $ENV{'NIX_SSL_CERT_FILE'}
++                if !defined $ssl_opts{SSL_ca_file};
++	    $ssl_opts{SSL_ca_file} = $ENV{'SSL_CERT_FILE'}
++                if !defined $ssl_opts{SSL_ca_file};
 +	    $ssl_opts{SSL_ca_file} = "/etc/ssl/certs/ca-certificates.crt"
 +		if !defined $ssl_opts{SSL_ca_file} && -e "/etc/ssl/certs/ca-certificates.crt";
 +	}
-+	unless (exists $ssl_opts{SSL_ca_file} || exists $ssl_opts{SSL_ca_path}) {
+ 	unless (exists $ssl_opts{SSL_ca_file} || exists $ssl_opts{SSL_ca_path}) {
  	    eval {
  		require Mozilla::CA;
- 	    };
+-- 
+2.14.0
+


### PR DESCRIPTION
###### Motivation for this change

Extending the `SSL_CERT_FILE` patch to also honour, with precendence, `NIX_SSL_CERT_FILE`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

