### PR TITLE
Manual fixes: users.extraUsers -> users.users (18.03)

### DIFF
--- a/nixos/doc/manual/administration/imperative-containers.xml
+++ b/nixos/doc/manual/administration/imperative-containers.xml
@@ -27,7 +27,7 @@
 <screen>
 # nixos-container create foo --config '
   services.openssh.enable = true;
-  users.extraUsers.root.openssh.authorizedKeys.keys = ["ssh-dss AAAAB3N…"];
+  users.users.root.openssh.authorizedKeys.keys = ["ssh-dss AAAAB3N…"];
 '
 </screen>
  </para>

--- a/nixos/doc/manual/configuration/network-manager.xml
+++ b/nixos/doc/manual/configuration/network-manager.xml
@@ -19,7 +19,7 @@ networking.networkmanager.enable = true;
   All users that should have permission to change network settings must belong
   to the <code>networkmanager</code> group:
 <programlisting>
-users.extraUsers.youruser.extraGroups = [ "networkmanager" ];
+users.users.youruser.extraGroups = [ "networkmanager" ];
 </programlisting>
  </para>
 

--- a/nixos/doc/manual/configuration/network-manager.xml
+++ b/nixos/doc/manual/configuration/network-manager.xml
@@ -19,7 +19,7 @@ networking.networkmanager.enable = true;
   All users that should have permission to change network settings must belong
   to the <code>networkmanager</code> group:
 <programlisting>
-users.users.youruser.extraGroups = [ "networkmanager" ];
+users.users.alice.extraGroups = [ "networkmanager" ];
 </programlisting>
  </para>
 

--- a/nixos/doc/manual/configuration/ssh.xml
+++ b/nixos/doc/manual/configuration/ssh.xml
@@ -20,7 +20,7 @@ services.openssh.enable = true;
   follows:
 <!-- FIXME: this might not work if the user is unmanaged. -->
 <programlisting>
-users.extraUsers.alice.openssh.authorizedKeys.keys =
+users.users.alice.openssh.authorizedKeys.keys =
   [ "ssh-dss AAAAB3NzaC1kc3MAAACBAPIkGWVEt4..." ];
 </programlisting>
  </para>

--- a/nixos/doc/manual/installation/changing-config.xml
+++ b/nixos/doc/manual/installation/changing-config.xml
@@ -66,7 +66,7 @@ $ ./result/bin/run-*-vm
   <literal>mutableUsers = false</literal>. Another way is to temporarily add
   the following to your configuration:
 <screen>
-users.extraUsers.your-user.initialPassword = "test"  
+users.users.your-user.initialPassword = "test"  
 </screen>
   <emphasis>Important:</emphasis> delete the $hostname.qcow2 file if you have
   started the virtual machine at least once without the right users, otherwise

--- a/nixos/doc/manual/installation/installing-from-other-distro.xml
+++ b/nixos/doc/manual/installation/installing-from-other-distro.xml
@@ -210,7 +210,7 @@ $ sudo groupdel nixbld</screen>
     or to lock the account with <literal>sudo passwd -l root</literal> if you
     use <literal>sudo</literal>)
    </para>
-<programlisting>users.extraUsers.root.initialHashedPassword = "";</programlisting>
+<programlisting>users.users.root.initialHashedPassword = "";</programlisting>
   </listitem>
   <listitem>
    <para>


### PR DESCRIPTION
###### Motivation for this change
Backport of #42746 to 18.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

