### PR TITLE
nixos/grub: light grub by default, 150MB closure size reduction

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -9,12 +9,12 @@ let
   efi = config.boot.loader.efi;
 
   realGrub = if cfg.version == 1 then pkgs.grub
-    else if cfg.zfsSupport then pkgs.grub2.override { zfsSupport = true; }
+    else if cfg.zfsSupport then pkgs.grub2_light.override { zfsSupport = true; }
     else if cfg.trustedBoot.enable
          then if cfg.trustedBoot.isHPLaptop
               then pkgs.trustedGrub-for-HP
               else pkgs.trustedGrub
-         else pkgs.grub2;
+         else pkgs.grub2_light;
 
   grub =
     # Don't include GRUB if we're only generating a GRUB menu (e.g.,


### PR DESCRIPTION
Since the default grub2 package has ZFS enabled and this was the one
that got used for NixOS and it's not being overridden, every NixOS user
gets the ZFS dependencies, even when they're not using ZFS at all.

This PR effectively removes 150MB from the system closure on a default minimal setup. Bringing the closure size for an empty `configuration.nix` from 1049MB to 903MB (tested with `nix path-info -S` of a `nix-build nixos -A config.system.build.toplevel`).

#### Can it break anything?
This switches `grub2` for `grub2_minimal` for NixOS. Since the latter is being defined like this https://github.com/NixOS/nixpkgs/blob/ad112ca0a48a25ba760a616a5eb18b85e0a82559/pkgs/top-level/all-packages.nix#L2833-L2835

and it's being overridden with `zfsSupport = true` when a ZFS filesystem is being used
https://github.com/NixOS/nixpkgs/blob/ad112ca0a48a25ba760a616a5eb18b85e0a82559/nixos/modules/system/boot/loader/grub/grub.nix#L12
(`grub2_light` for this PR), this can only break systems who relied on ZFS support using NixOS' non-fixed grub derivation propagated through here https://github.com/NixOS/nixpkgs/blob/ad112ca0a48a25ba760a616a5eb18b85e0a82559/nixos/modules/system/boot/loader/grub/grub.nix#L561-L567

Ping @aszlig @symphorien

###### Things done

I ran the NixOS test `installer.zfsroot` successfully. Also tried to run `installer.simpleUefiGrub`, but it failed for [some unrelated networking issue](https://gist.github.com/Infinisil/a20ff95ac0f7f436b178ae520f9a74f7).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

