### PR TITLE
pass "exclude" args to mksquashfs for storage-deficient devices

### DIFF
--- a/nixos/lib/make-squashfs.nix
+++ b/nixos/lib/make-squashfs.nix
@@ -1,5 +1,5 @@
 { stdenv, squashfsTools, closureInfo
-
+, excludeWildcards ? []
 , # The root directory of the squashfs filesystem is filled with the
   # closures of the Nix store paths listed here.
   storeContents ? []
@@ -20,6 +20,7 @@ stdenv.mkDerivation {
 
       # Generate the squashfs image.
       mksquashfs nix-path-registration $(cat $closureInfo/store-paths) $out \
-        -keep-as-directory -all-root -b 1048576 -comp xz -Xdict-size 100%
+        -keep-as-directory -all-root -b 1048576 -comp xz -Xdict-size 100% \
+        -wildcards ${stdenv.lib.concatStringsSep " " (map (f: "-e '${f}' ") excludeWildcards)}
     '';
 }


### PR DESCRIPTION
###### Motivation for this change

This is debatable and I do not claim that the current behaviour is wrong.  But: when building NixWRT images for storage-starved systems (one of my routers has 4MB flash) it is convenient to be able to say, for example, "exclude lib*.a and man pages" without having to hack  every derivation that currently installs them.

```
  squashfs = pkgs.callPackage <nixpkgs/nixos/lib/make-squashfs.nix> {
    storeContents = packagesToInstall ;
    excludeWildcards = [ "... lib*.a" "... man/man[1-9]" ];
  };
```

Maybe it's generally useful, maybe it's a bit niche.  If the latter, would you accept a more general patch to add any options at all to the `mksquashfs` call?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

