### PR TITLE
gnome3.tracker update

### DIFF
--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -7,15 +7,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "tracker-miners";
-  version = "2.0.4";
+  version = "2.0.5";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "0mp9m2waii583sjgr61m1ni6py6dry11r0rzidgvw1g4cxhn89j6";
+    sha256 = "00k8nb8dbkjnqjk12gcs5n2cm6yny553qildsm5b2c8nfs1w16b4";
   };
-
-  # https://github.com/NixOS/nixpkgs/issues/39547
-  LIBRARY_PATH = stdenv.lib.makeLibraryPath [ giflib ];
 
   nativeBuildInputs = [
     intltool
@@ -71,30 +68,10 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       inherit (gnome3) tracker;
     })
-    # https://bugzilla.gnome.org/show_bug.cgi?id=795573
-    (fetchurl {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=371422;
-      sha256 = "1rzwzrc7q73k42s1j1iw52chy10w6y3xksfrzg2l42nn9wk7n281";
-    })
-    # https://bugzilla.gnome.org/show_bug.cgi?id=795574
-    (fetchurl {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=371423;
-      sha256 = "0b2ck8z4b2yrgwg4v9jsac5n8h3a91qkp90vv17wxcvr4v50fg48";
-    })
-    # https://bugzilla.gnome.org/show_bug.cgi?id=795575
-    (fetchurl {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=371424;
-      sha256 = "03i29fabxrpraydh7712vdrc571qmiq0l4axj24gbi6h77xn7mxc";
-    })
     # https://bugzilla.gnome.org/show_bug.cgi?id=795576
     (fetchurl {
       url = https://bugzilla.gnome.org/attachment.cgi?id=371427;
       sha256 = "187flswvzymjfxwfrrhizb1cvs780zm39aa3i2vwa5fbllr7kcpf";
-    })
-    # https://bugzilla.gnome.org/show_bug.cgi?id=795577
-    (fetchurl {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=371425;
-      sha256 = "05m629469jr2lm2cjs54n7xwyim2d5rwwvdjxzcwh5qpfjds5phm";
     })
   ];
 
@@ -114,7 +91,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
   '';
-  
+
   # https://bugzilla.gnome.org/show_bug.cgi?id=796145
   postFixup = ''
     rm $out/share/tracker/miners/org.freedesktop.Tracker1.Miner.RSS.service

--- a/pkgs/desktops/gnome-3/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker/default.nix
@@ -4,7 +4,7 @@
 
 let
   pname = "tracker";
-  version = "2.0.3";
+  version = "2.0.4";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "1005w90vhk1cl8g6kxpy2vdzbskw2jskfjcl42lngv18q5sb4bss";
+    sha256 = "1mfc5lv820kr7ssi7hldn25gmshh65k19kh478qjsnb64sshsbyf";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
An update that allows us to simplify the expressions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

