### PR TITLE
tree-wide: users.extraUsers -> users.users, users.extraGroups -> users.groups

### DIFF
--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -215,11 +215,11 @@ in
     );
 
     users = mkIf cfg.daemon.enable {
-      extraGroups.nslcd = {
+      groups.nslcd = {
         gid = config.ids.gids.nslcd;
       };
 
-      extraUsers.nslcd = {
+      users.nslcd = {
         uid = config.ids.uids.nslcd;
         description = "nslcd user.";
         group = "nslcd";

--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -264,7 +264,7 @@ in {
     })
 
     (mkIf systemWide {
-      users.extraUsers.pulse = {
+      users.users.pulse = {
         # For some reason, PulseAudio wants UID == GID.
         uid = assert uid == gid; uid;
         group = "pulse";
@@ -274,7 +274,7 @@ in {
         createHome = true;
       };
 
-      users.extraGroups.pulse.gid = gid;
+      users.groups.pulse.gid = gid;
 
       systemd.services.pulseaudio = {
         description = "PulseAudio System-Wide Server";

--- a/nixos/modules/hardware/nitrokey.nix
+++ b/nixos/modules/hardware/nitrokey.nix
@@ -36,6 +36,6 @@ in
         { inherit (cfg) group; }
       ))
     ];
-    users.extraGroups."${cfg.group}" = {};
+    users.groups."${cfg.group}" = {};
   };
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -30,7 +30,7 @@ with lib;
   boot.loader.grub.memtest86.enable = true;
 
   # Allow the user to log in as root without a password.
-  users.extraUsers.root.initialHashedPassword = "";
+  users.users.root.initialHashedPassword = "";
 
   system.nixos.stateVersion = mkDefault "18.03";
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -34,7 +34,7 @@ in
   boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
   # FIXME: this probably should be in installation-device.nix
-  users.extraUsers.root.initialHashedPassword = "";
+  users.users.root.initialHashedPassword = "";
 
   sdImage = {
     populateBootCommands = let

--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -35,7 +35,7 @@ in
   boot.kernelParams = ["console=ttyS0,115200n8" "console=ttymxc0,115200n8" "console=ttyAMA0,115200n8" "console=ttyO0,115200n8" "console=ttySAC2,115200n8" "console=tty0"];
 
   # FIXME: this probably should be in installation-device.nix
-  users.extraUsers.root.initialHashedPassword = "";
+  users.users.root.initialHashedPassword = "";
 
   sdImage = {
     populateBootCommands = let

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
@@ -28,7 +28,7 @@ in
   boot.kernelPackages = pkgs.linuxPackages_rpi;
 
   # FIXME: this probably should be in installation-device.nix
-  users.extraUsers.root.initialHashedPassword = "";
+  users.users.root.initialHashedPassword = "";
 
   sdImage = {
     populateBootCommands = let

--- a/nixos/modules/installer/netboot/netboot-base.nix
+++ b/nixos/modules/installer/netboot/netboot-base.nix
@@ -16,5 +16,5 @@ with lib;
     ];
 
   # Allow the user to log in as root without a password.
-  users.extraUsers.root.initialHashedPassword = "";
+  users.users.root.initialHashedPassword = "";
 }

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -619,7 +619,7 @@ $bootLoaderConfig
   # services.xserver.desktopManager.plasma5.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
-  # users.extraUsers.guest = {
+  # users.users.guest = {
   #   isNormalUser = true;
   #   uid = 1000;
   # };

--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -14,7 +14,7 @@ with lib;
   boot.loader.grub.fsIdentifier = "provided";
 
   # Allow mounting of shared folders.
-  users.extraUsers.demo.extraGroups = [ "vboxsf" ];
+  users.users.demo.extraGroups = [ "vboxsf" ];
 
   # Add some more video drivers to give X11 a shot at working in
   # VMware and QEMU.

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -101,7 +101,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups = mkIf isMLocate { mlocate = {}; };
+    users.groups = mkIf isMLocate { mlocate = {}; };
 
     security.wrappers = mkIf isMLocate {
       locate = {

--- a/nixos/modules/profiles/demo.nix
+++ b/nixos/modules/profiles/demo.nix
@@ -3,7 +3,7 @@
 {
   imports = [ ./graphical.nix ];
 
-  users.extraUsers.demo =
+  users.users.demo =
     { isNormalUser = true;
       description = "Demo user account";
       extraGroups = [ "wheel" ];

--- a/nixos/modules/programs/adb.nix
+++ b/nixos/modules/programs/adb.nix
@@ -14,7 +14,7 @@ with lib;
         description = ''
           Whether to configure system to use Android Debug Bridge (adb).
           To grant access to a user, it must be part of adbusers group:
-          <code>users.extraUsers.alice.extraGroups = ["adbusers"];</code>
+          <code>users.users.alice.extraGroups = ["adbusers"];</code>
         '';
         relatedPackages = [ ["androidenv" "platformTools"] ];
       };
@@ -25,6 +25,6 @@ with lib;
   config = mkIf config.programs.adb.enable {
     services.udev.packages = [ pkgs.android-udev-rules ];
     environment.systemPackages = [ pkgs.androidenv.platformTools ];
-    users.extraGroups.adbusers = {};
+    users.groups.adbusers = {};
   };
 }

--- a/nixos/modules/programs/gphoto2.nix
+++ b/nixos/modules/programs/gphoto2.nix
@@ -15,7 +15,7 @@ with lib;
           Whether to configure system to use gphoto2.
           To grant digital camera access to a user, the user must
           be part of the camera group:
-          <code>users.extraUsers.alice.extraGroups = ["camera"];</code>
+          <code>users.users.alice.extraGroups = ["camera"];</code>
         '';
       };
     };
@@ -25,6 +25,6 @@ with lib;
   config = mkIf config.programs.gphoto2.enable {
     services.udev.packages = [ pkgs.libgphoto2 ];
     environment.systemPackages = [ pkgs.gphoto2 ];
-    users.extraGroups.camera = {};
+    users.groups.camera = {};
   };
 }

--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -73,7 +73,7 @@ in {
       permissions = "u+rx,g+rx";
     };
 
-    users.extraGroups.sway = {};
+    users.groups.sway = {};
     security.pam.services.swaylock = {};
 
     hardware.opengl.enable = mkDefault true;

--- a/nixos/modules/programs/wireshark.nix
+++ b/nixos/modules/programs/wireshark.nix
@@ -29,7 +29,7 @@ in {
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ wireshark ];
-    users.extraGroups.wireshark = {};
+    users.groups.wireshark = {};
 
     security.wrappers.dumpcap = {
       source = "${wireshark}/bin/dumpcap";

--- a/nixos/modules/security/pam_mount.nix
+++ b/nixos/modules/security/pam_mount.nix
@@ -40,7 +40,7 @@ in
       target = "security/pam_mount.conf.xml";
       source =
         let
-          extraUserVolumes = filterAttrs (n: u: u.cryptHomeLuks != null) config.users.extraUsers;
+          extraUserVolumes = filterAttrs (n: u: u.cryptHomeLuks != null) config.users.users;
           userVolumeEntry = user: "<volume user=\"${user.name}\" path=\"${user.cryptHomeLuks}\" mountpoint=\"${user.home}\" />\n";
         in
          pkgs.writeText "pam_mount.conf.xml" ''

--- a/nixos/modules/security/polkit.nix
+++ b/nixos/modules/security/polkit.nix
@@ -94,7 +94,7 @@ in
         rm -rf /var/lib/{polkit-1,PolicyKit}
       '';
 
-    users.extraUsers.polkituser = {
+    users.users.polkituser = {
       description = "PolKit daemon";
       uid = config.ids.uids.polkituser;
     };

--- a/nixos/modules/security/rtkit.nix
+++ b/nixos/modules/security/rtkit.nix
@@ -34,7 +34,7 @@ with lib;
 
     services.dbus.packages = [ pkgs.rtkit ];
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "rtkit";
         uid = config.ids.uids.rtkit;
         description = "RealtimeKit daemon";

--- a/nixos/modules/services/admin/oxidized.nix
+++ b/nixos/modules/services/admin/oxidized.nix
@@ -83,8 +83,8 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups.${cfg.group} = { };
-    users.extraUsers.${cfg.user} = {
+    users.groups.${cfg.group} = { };
+    users.users.${cfg.user} = {
       description = "Oxidized service user";
       group = cfg.group;
       home = cfg.dataDir;

--- a/nixos/modules/services/amqp/activemq/default.nix
+++ b/nixos/modules/services/amqp/activemq/default.nix
@@ -93,13 +93,13 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.activemq = {
+    users.users.activemq = {
       description = "ActiveMQ server user";
       group = "activemq";
       uid = config.ids.uids.activemq;
     };
 
-    users.extraGroups.activemq.gid = config.ids.gids.activemq;
+    users.groups.activemq.gid = config.ids.gids.activemq;
 
     systemd.services.activemq_init = {
       wantedBy = [ "activemq.service" ];

--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -83,7 +83,7 @@ in {
 
     environment.systemPackages = [ pkgs.rabbitmq_server ];
 
-    users.extraUsers.rabbitmq = {
+    users.users.rabbitmq = {
       description = "RabbitMQ server user";
       home = "${cfg.dataDir}";
       createHome = true;
@@ -91,7 +91,7 @@ in {
       uid = config.ids.uids.rabbitmq;
     };
 
-    users.extraGroups.rabbitmq.gid = config.ids.gids.rabbitmq;
+    users.groups.rabbitmq.gid = config.ids.gids.rabbitmq;
 
     systemd.services.rabbitmq = {
       description = "RabbitMQ Server";

--- a/nixos/modules/services/audio/liquidsoap.nix
+++ b/nixos/modules/services/audio/liquidsoap.nix
@@ -57,7 +57,7 @@ in
 
   config = mkIf (builtins.length streams != 0) {
 
-    users.extraUsers.liquidsoap = {
+    users.users.liquidsoap = {
       uid = config.ids.uids.liquidsoap;
       group = "liquidsoap";
       extraGroups = [ "audio" ];
@@ -66,7 +66,7 @@ in
       createHome = true;
     };
 
-    users.extraGroups.liquidsoap.gid = config.ids.gids.liquidsoap;
+    users.groups.liquidsoap.gid = config.ids.gids.liquidsoap;
 
     systemd.services = builtins.listToAttrs ( map streamService streams );
   };

--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -93,7 +93,7 @@ in {
       };
     };
 
-    users.extraUsers.mopidy = {
+    users.users.mopidy = {
       inherit uid;
       group = "mopidy";
       extraGroups = [ "audio" ];
@@ -101,7 +101,7 @@ in {
       home = "${cfg.dataDir}";
     };
 
-    users.extraGroups.mopidy.gid = gid;
+    users.groups.mopidy.gid = gid;
 
   };
 

--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -184,7 +184,7 @@ in {
       };
     };
 
-    users.extraUsers = optionalAttrs (cfg.user == name) (singleton {
+    users.users = optionalAttrs (cfg.user == name) (singleton {
       inherit uid;
       inherit name;
       group = cfg.group;
@@ -193,7 +193,7 @@ in {
       home = "${cfg.dataDir}";
     });
 
-    users.extraGroups = optionalAttrs (cfg.group == name) (singleton {
+    users.groups = optionalAttrs (cfg.group == name) (singleton {
       inherit name;
       gid = gid;
     });

--- a/nixos/modules/services/audio/squeezelite.nix
+++ b/nixos/modules/services/audio/squeezelite.nix
@@ -54,7 +54,7 @@ in {
       };
     };
 
-    users.extraUsers.squeezelite= {
+    users.users.squeezelite= {
       inherit uid;
       group = "nogroup";
       extraGroups = [ "audio" ];

--- a/nixos/modules/services/backup/bacula.nix
+++ b/nixos/modules/services/backup/bacula.nix
@@ -397,7 +397,7 @@ in {
 
     environment.systemPackages = [ pkgs.bacula ];
 
-    users.extraUsers.bacula = {
+    users.users.bacula = {
       group = "bacula";
       uid = config.ids.uids.bacula;
       home = "${libDir}";
@@ -406,6 +406,6 @@ in {
       shell = "${pkgs.bash}/bin/bash";
     };
 
-    users.extraGroups.bacula.gid = config.ids.gids.bacula;
+    users.groups.bacula.gid = config.ids.gids.bacula;
   };
 }

--- a/nixos/modules/services/backup/duplicati.nix
+++ b/nixos/modules/services/backup/duplicati.nix
@@ -44,13 +44,13 @@ in
       };
     };
 
-    users.extraUsers.duplicati = {
+    users.users.duplicati = {
       uid = config.ids.uids.duplicati;
       home = "/var/lib/duplicati";
       createHome = true;
       group = "duplicati";
     };
-    users.extraGroups.duplicati.gid = config.ids.gids.duplicati;
+    users.groups.duplicati.gid = config.ids.gids.duplicati;
 
   };
 }

--- a/nixos/modules/services/backup/mysql-backup.nix
+++ b/nixos/modules/services/backup/mysql-backup.nix
@@ -84,7 +84,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers = optionalAttrs (cfg.user == defaultUser) (singleton
+    users.users = optionalAttrs (cfg.user == defaultUser) (singleton
       { name = defaultUser;
         isSystemUser = true;
         createHome = false;

--- a/nixos/modules/services/backup/restic-rest-server.nix
+++ b/nixos/modules/services/backup/restic-rest-server.nix
@@ -95,13 +95,13 @@ in
       };
     };
 
-    users.extraUsers.restic = {
+    users.users.restic = {
       group = "restic";
       home = cfg.dataDir;
       createHome = true;
       uid = config.ids.uids.restic;
     };
 
-    users.extraGroups.restic.gid = config.ids.uids.restic;
+    users.groups.restic.gid = config.ids.uids.restic;
   };
 }

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -1145,7 +1145,7 @@ in {
       ];
 
       environment.systemPackages = [ cfg.package ];
-      users.extraUsers = singleton {
+      users.users = singleton {
         name = "kubernetes";
         uid = config.ids.uids.kubernetes;
         description = "Kubernetes user";
@@ -1154,7 +1154,7 @@ in {
         home = cfg.dataDir;
         createHome = true;
       };
-      users.extraGroups.kubernetes.gid = config.ids.gids.kubernetes;
+      users.groups.kubernetes.gid = config.ids.gids.kubernetes;
 
 			# dns addon is enabled by default
       services.kubernetes.addons.dns.enable = mkDefault true;

--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -191,11 +191,11 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups = optional (cfg.group == "buildbot") {
+    users.groups = optional (cfg.group == "buildbot") {
       name = "buildbot";
     };
 
-    users.extraUsers = optional (cfg.user == "buildbot") {
+    users.users = optional (cfg.user == "buildbot") {
       name = "buildbot";
       description = "Buildbot User.";
       isNormalUser = true;

--- a/nixos/modules/services/continuous-integration/buildbot/worker.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/worker.nix
@@ -84,11 +84,11 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups = optional (cfg.group == "bbworker") {
+    users.groups = optional (cfg.group == "bbworker") {
       name = "bbworker";
     };
 
-    users.extraUsers = optional (cfg.user == "bbworker") {
+    users.users = optional (cfg.user == "bbworker") {
       name = "bbworker";
       description = "Buildbot Worker User.";
       isNormalUser = true;

--- a/nixos/modules/services/continuous-integration/buildkite-agent.nix
+++ b/nixos/modules/services/continuous-integration/buildkite-agent.nix
@@ -185,7 +185,7 @@ in
   };
 
   config = mkIf config.services.buildkite-agent.enable {
-    users.extraUsers.buildkite-agent =
+    users.users.buildkite-agent =
       { name = "buildkite-agent";
         home = cfg.dataDir;
         createHome = true;

--- a/nixos/modules/services/continuous-integration/gitlab-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner.nix
@@ -134,7 +134,7 @@ in
     # Make the gitlab-runner command availabe so users can query the runner
     environment.systemPackages = [ cfg.package ];
 
-    users.extraUsers.gitlab-runner = {
+    users.users.gitlab-runner = {
       group = "gitlab-runner";
       extraGroups = optional hasDocker "docker";
       uid = config.ids.uids.gitlab-runner;
@@ -142,6 +142,6 @@ in
       createHome = true;
     };
 
-    users.extraGroups.gitlab-runner.gid = config.ids.gids.gitlab-runner;
+    users.groups.gitlab-runner.gid = config.ids.gids.gitlab-runner;
   };
 }

--- a/nixos/modules/services/continuous-integration/gocd-agent/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-agent/default.nix
@@ -135,12 +135,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups = optional (cfg.group == "gocd-agent") {
+    users.groups = optional (cfg.group == "gocd-agent") {
       name = "gocd-agent";
       gid = config.ids.gids.gocd-agent;
     };
 
-    users.extraUsers = optional (cfg.user == "gocd-agent") {
+    users.users = optional (cfg.user == "gocd-agent") {
       name = "gocd-agent";
       description = "gocd-agent user";
       createHome = true;

--- a/nixos/modules/services/continuous-integration/gocd-server/default.nix
+++ b/nixos/modules/services/continuous-integration/gocd-server/default.nix
@@ -113,8 +113,8 @@ in {
 
       extraOptions = mkOption {
         default = [ ];
-        example = [ 
-          "-X debug" 
+        example = [
+          "-X debug"
           "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"
           "-verbose:gc"
           "-Xloggc:go-server-gc.log"
@@ -143,12 +143,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups = optional (cfg.group == "gocd-server") {
+    users.groups = optional (cfg.group == "gocd-server") {
       name = "gocd-server";
       gid = config.ids.gids.gocd-server;
     };
 
-    users.extraUsers = optional (cfg.user == "gocd-server") {
+    users.users = optional (cfg.user == "gocd-server") {
       name = "gocd-server";
       description = "gocd-server user";
       createHome = true;

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -194,11 +194,11 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraGroups.hydra = {
+    users.groups.hydra = {
       gid = config.ids.gids.hydra;
     };
 
-    users.extraUsers.hydra =
+    users.users.hydra =
       { description = "Hydra";
         group = "hydra";
         createHome = true;
@@ -207,7 +207,7 @@ in
         uid = config.ids.uids.hydra;
       };
 
-    users.extraUsers.hydra-queue-runner =
+    users.users.hydra-queue-runner =
       { description = "Hydra queue runner";
         group = "hydra";
         useDefaultShell = true;
@@ -215,7 +215,7 @@ in
         uid = config.ids.uids.hydra-queue-runner;
       };
 
-    users.extraUsers.hydra-www =
+    users.users.hydra-www =
       { description = "Hydra web server";
         group = "hydra";
         useDefaultShell = true;

--- a/nixos/modules/services/continuous-integration/jenkins/default.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/default.nix
@@ -150,12 +150,12 @@ in {
       pkgs.dejavu_fonts
     ];
 
-    users.extraGroups = optional (cfg.group == "jenkins") {
+    users.groups = optional (cfg.group == "jenkins") {
       name = "jenkins";
       gid = config.ids.gids.jenkins;
     };
 
-    users.extraUsers = optional (cfg.user == "jenkins") {
+    users.users = optional (cfg.user == "jenkins") {
       name = "jenkins";
       description = "jenkins user";
       createHome = true;

--- a/nixos/modules/services/continuous-integration/jenkins/slave.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/slave.nix
@@ -50,12 +50,12 @@ in {
   };
 
   config = mkIf (cfg.enable && !masterCfg.enable) {
-    users.extraGroups = optional (cfg.group == "jenkins") {
+    users.groups = optional (cfg.group == "jenkins") {
       name = "jenkins";
       gid = config.ids.gids.jenkins;
     };
 
-    users.extraUsers = optional (cfg.user == "jenkins") {
+    users.users = optional (cfg.user == "jenkins") {
       name = "jenkins";
       description = "jenkins user";
       createHome = true;

--- a/nixos/modules/services/databases/4store-endpoint.nix
+++ b/nixos/modules/services/databases/4store-endpoint.nix
@@ -52,7 +52,7 @@ with lib;
         message = "Must specify 4Store database name";
       };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = endpointUser;
         uid = config.ids.uids.fourstorehttp;
         description = "4Store SPARQL endpoint user";

--- a/nixos/modules/services/databases/4store.nix
+++ b/nixos/modules/services/databases/4store.nix
@@ -43,7 +43,7 @@ with lib;
         message = "Must specify 4Store database name.";
       };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = fourStoreUser;
         uid = config.ids.uids.fourstore;
         description = "4Store database user";

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -420,7 +420,7 @@ in {
       9160
     ];
 
-    users.extraUsers.cassandra =
+    users.users.cassandra =
       if config.ids.uids ? "cassandra"
       then { uid = config.ids.uids.cassandra; } // cassandraUser
       else cassandraUser ;

--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -27,14 +27,14 @@ with lib;
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.clickhouse = {
+    users.users.clickhouse = {
       name = "clickhouse";
       uid = config.ids.uids.clickhouse;
       group = "clickhouse";
       description = "ClickHouse server user";
     };
 
-    users.extraGroups.clickhouse.gid = config.ids.gids.clickhouse;
+    users.groups.clickhouse.gid = config.ids.gids.clickhouse;
 
     systemd.services.clickhouse = {
       description = "ClickHouse server";

--- a/nixos/modules/services/databases/couchdb.nix
+++ b/nixos/modules/services/databases/couchdb.nix
@@ -198,13 +198,13 @@ in {
       };
     };
 
-    users.extraUsers.couchdb = {
+    users.users.couchdb = {
       description = "CouchDB Server user";
       group = "couchdb";
       uid = config.ids.uids.couchdb;
     };
 
-    users.extraGroups.couchdb.gid = config.ids.gids.couchdb;
+    users.groups.couchdb.gid = config.ids.gids.couchdb;
 
   };
 }

--- a/nixos/modules/services/databases/firebird.nix
+++ b/nixos/modules/services/databases/firebird.nix
@@ -154,13 +154,13 @@ in
       # there are some additional settings which should be reviewed
     '';
 
-    users.extraUsers.firebird = {
+    users.users.firebird = {
       description = "Firebird server user";
       group = "firebird";
       uid = config.ids.uids.firebird;
     };
 
-    users.extraGroups.firebird.gid = config.ids.gids.firebird;
+    users.groups.firebird.gid = config.ids.gids.firebird;
 
   };
 }

--- a/nixos/modules/services/databases/foundationdb.nix
+++ b/nixos/modules/services/databases/foundationdb.nix
@@ -325,14 +325,14 @@ in
 
     environment.systemPackages = [ pkg ];
 
-    users.extraUsers = optionalAttrs (cfg.user == "foundationdb") (singleton
+    users.users = optionalAttrs (cfg.user == "foundationdb") (singleton
       { name        = "foundationdb";
         description = "FoundationDB User";
         uid         = config.ids.uids.foundationdb;
         group       = cfg.group;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "foundationdb") (singleton
+    users.groups = optionalAttrs (cfg.group == "foundationdb") (singleton
       { name = "foundationdb";
         gid  = config.ids.gids.foundationdb;
       });

--- a/nixos/modules/services/databases/hbase.nix
+++ b/nixos/modules/services/databases/hbase.nix
@@ -122,13 +122,13 @@ in {
       };
     };
 
-    users.extraUsers.hbase = {
+    users.users.hbase = {
       description = "HBase Server user";
       group = "hbase";
       uid = config.ids.uids.hbase;
     };
 
-    users.extraGroups.hbase.gid = config.ids.gids.hbase;
+    users.groups.hbase.gid = config.ids.gids.hbase;
 
   };
 }

--- a/nixos/modules/services/databases/influxdb.nix
+++ b/nixos/modules/services/databases/influxdb.nix
@@ -182,13 +182,13 @@ in
         '';
     };
 
-    users.extraUsers = optional (cfg.user == "influxdb") {
+    users.users = optional (cfg.user == "influxdb") {
       name = "influxdb";
       uid = config.ids.uids.influxdb;
       description = "Influxdb daemon user";
     };
 
-    users.extraGroups = optional (cfg.group == "influxdb") {
+    users.groups = optional (cfg.group == "influxdb") {
       name = "influxdb";
       gid = config.ids.gids.influxdb;
     };

--- a/nixos/modules/services/databases/memcached.nix
+++ b/nixos/modules/services/databases/memcached.nix
@@ -64,7 +64,7 @@ in
 
   config = mkIf config.services.memcached.enable {
 
-    users.extraUsers = optional (cfg.user == "memcached") {
+    users.users = optional (cfg.user == "memcached") {
       name = "memcached";
       description = "Memcached server user";
     };

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -93,7 +93,7 @@ in
 
   config = mkIf config.services.mongodb.enable {
 
-    users.extraUsers.mongodb = mkIf (cfg.user == "mongodb")
+    users.users.mongodb = mkIf (cfg.user == "mongodb")
       { name = "mongodb";
         uid = config.ids.uids.mongodb;
         description = "MongoDB server user";

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -221,13 +221,13 @@ in
       mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then "/var/lib/mysql"
                  else "/var/mysql");
 
-    users.extraUsers.mysql = {
+    users.users.mysql = {
       description = "MySQL server user";
       group = "mysql";
       uid = config.ids.uids.mysql;
     };
 
-    users.extraGroups.mysql.gid = config.ids.gids.mysql;
+    users.groups.mysql.gid = config.ids.gids.mysql;
 
     environment.systemPackages = [mysql];
 

--- a/nixos/modules/services/databases/neo4j.nix
+++ b/nixos/modules/services/databases/neo4j.nix
@@ -139,7 +139,7 @@ in {
 
     environment.systemPackages = [ cfg.package ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "neo4j";
       uid = config.ids.uids.neo4j;
       description = "Neo4j daemon user";

--- a/nixos/modules/services/databases/openldap.nix
+++ b/nixos/modules/services/databases/openldap.nix
@@ -145,13 +145,13 @@ in
           "${configOpts}";
     };
 
-    users.extraUsers.openldap =
+    users.users.openldap =
       { name = cfg.user;
         group = cfg.group;
         uid = config.ids.uids.openldap;
       };
 
-    users.extraGroups.openldap =
+    users.groups.openldap =
       { name = cfg.group;
         gid = config.ids.gids.openldap;
       };

--- a/nixos/modules/services/databases/opentsdb.nix
+++ b/nixos/modules/services/databases/opentsdb.nix
@@ -97,13 +97,13 @@ in {
       };
     };
 
-    users.extraUsers.opentsdb = {
+    users.users.opentsdb = {
       description = "OpenTSDB Server user";
       group = "opentsdb";
       uid = config.ids.uids.opentsdb;
     };
 
-    users.extraGroups.opentsdb.gid = config.ids.gids.opentsdb;
+    users.groups.opentsdb.gid = config.ids.gids.opentsdb;
 
   };
 }

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -183,14 +183,14 @@ in
         host  all all ::1/128      md5
       '';
 
-    users.extraUsers.postgres =
+    users.users.postgres =
       { name = "postgres";
         uid = config.ids.uids.postgres;
         group = "postgres";
         description = "PostgreSQL server user";
       };
 
-    users.extraGroups.postgres.gid = config.ids.gids.postgres;
+    users.groups.postgres.gid = config.ids.gids.postgres;
 
     environment.systemPackages = [ postgresql ];
 

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -217,7 +217,7 @@ in
       allowedTCPPorts = [ cfg.port ];
     };
 
-    users.extraUsers.redis =
+    users.users.redis =
       { name = cfg.user;
         description = "Redis database user";
       };

--- a/nixos/modules/services/databases/rethinkdb.nix
+++ b/nixos/modules/services/databases/rethinkdb.nix
@@ -96,12 +96,12 @@ in
       '';
     };
 
-    users.extraUsers.rethinkdb = mkIf (cfg.user == "rethinkdb")
+    users.users.rethinkdb = mkIf (cfg.user == "rethinkdb")
       { name = "rethinkdb";
         description = "RethinkDB server user";
       };
 
-    users.extraGroups = optionalAttrs (cfg.group == "rethinkdb") (singleton
+    users.groups = optionalAttrs (cfg.group == "rethinkdb") (singleton
       { name = "rethinkdb";
       });
 

--- a/nixos/modules/services/databases/riak-cs.nix
+++ b/nixos/modules/services/databases/riak-cs.nix
@@ -145,7 +145,7 @@ in
       ${cfg.extraAdvancedConfig}
     '';
 
-    users.extraUsers.riak-cs = {
+    users.users.riak-cs = {
       name = "riak-cs";
       uid = config.ids.uids.riak-cs;
       group = "riak";

--- a/nixos/modules/services/databases/riak.nix
+++ b/nixos/modules/services/databases/riak.nix
@@ -102,14 +102,14 @@ in
       ${cfg.extraAdvancedConfig}
     '';
 
-    users.extraUsers.riak = {
+    users.users.riak = {
       name = "riak";
       uid = config.ids.uids.riak;
       group = "riak";
       description = "Riak server user";
     };
 
-    users.extraGroups.riak.gid = config.ids.gids.riak;
+    users.groups.riak.gid = config.ids.gids.riak;
 
     systemd.services.riak = {
       description = "Riak Server";

--- a/nixos/modules/services/databases/stanchion.nix
+++ b/nixos/modules/services/databases/stanchion.nix
@@ -143,14 +143,14 @@ in
       ${cfg.extraConfig}
     '';
 
-    users.extraUsers.stanchion = {
+    users.users.stanchion = {
       name = "stanchion";
       uid = config.ids.uids.stanchion;
       group = "stanchion";
       description = "Stanchion server user";
     };
 
-    users.extraGroups.stanchion.gid = config.ids.gids.stanchion;
+    users.groups.stanchion.gid = config.ids.gids.stanchion;
 
     systemd.services.stanchion = {
       description = "Stanchion Server";

--- a/nixos/modules/services/databases/virtuoso.nix
+++ b/nixos/modules/services/databases/virtuoso.nix
@@ -54,7 +54,7 @@ with lib;
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = virtuosoUser;
         uid = config.ids.uids.virtuoso;
         description = "virtuoso user";

--- a/nixos/modules/services/editors/infinoted.nix
+++ b/nixos/modules/services/editors/infinoted.nix
@@ -111,12 +111,12 @@ in {
   };
 
   config = mkIf (cfg.enable) {
-    users.extraUsers = optional (cfg.user == "infinoted")
+    users.users = optional (cfg.user == "infinoted")
       { name = "infinoted";
         description = "Infinoted user";
         group = cfg.group;
       };
-    users.extraGroups = optional (cfg.group == "infinoted")
+    users.groups = optional (cfg.group == "infinoted")
       { name = "infinoted";
       };
   

--- a/nixos/modules/services/games/minecraft-server.nix
+++ b/nixos/modules/services/games/minecraft-server.nix
@@ -45,7 +45,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.minecraft = {
+    users.users.minecraft = {
       description     = "Minecraft Server Service user";
       home            = cfg.dataDir;
       createHome      = true;

--- a/nixos/modules/services/games/minetest-server.nix
+++ b/nixos/modules/services/games/minetest-server.nix
@@ -79,7 +79,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.minetest = {
+    users.users.minetest = {
       description     = "Minetest Server Service user";
       home            = "/var/lib/minetest";
       createHome      = true;

--- a/nixos/modules/services/games/terraria.nix
+++ b/nixos/modules/services/games/terraria.nix
@@ -105,14 +105,14 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.terraria = {
+    users.users.terraria = {
       description = "Terraria server service user";
       home        = "/var/lib/terraria";
       createHome  = true;
       uid         = config.ids.uids.terraria;
     };
 
-    users.extraGroups.terraria = {
+    users.groups.terraria = {
       gid = config.ids.gids.terraria;
       members = [ "terraria" ];
     };

--- a/nixos/modules/services/hardware/sane.nix
+++ b/nixos/modules/services/hardware/sane.nix
@@ -124,7 +124,7 @@ in
       environment.sessionVariables = env;
       services.udev.packages = backends;
 
-      users.extraGroups."scanner".gid = config.ids.gids.scanner;
+      users.groups."scanner".gid = config.ids.gids.scanner;
     })
 
     (mkIf config.services.saned.enable {
@@ -152,7 +152,7 @@ in
         };
       };
 
-      users.extraUsers."scanner" = {
+      users.users."scanner" = {
         uid = config.ids.uids.scanner;
         group = "scanner";
       };

--- a/nixos/modules/services/hardware/tcsd.nix
+++ b/nixos/modules/services/hardware/tcsd.nix
@@ -137,13 +137,13 @@ in
       serviceConfig.ExecStart = "${pkgs.trousers}/sbin/tcsd -f -c ${tcsdConf}";
     };
 
-    users.extraUsers = optionalAttrs (cfg.user == "tss") (singleton
+    users.users = optionalAttrs (cfg.user == "tss") (singleton
       { name = "tss";
         group = "tss";
         uid = config.ids.uids.tss;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "tss") (singleton
+    users.groups = optionalAttrs (cfg.group == "tss") (singleton
       { name = "tss";
         gid = config.ids.gids.tss;
       });

--- a/nixos/modules/services/hardware/usbmuxd.nix
+++ b/nixos/modules/services/hardware/usbmuxd.nix
@@ -43,13 +43,13 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = optional (cfg.user == defaultUserGroup) {
+    users.users = optional (cfg.user == defaultUserGroup) {
       name = cfg.user;
       description = "usbmuxd user";
       group = cfg.group;
     };
 
-    users.extraGroups = optional (cfg.group == defaultUserGroup) {
+    users.groups = optional (cfg.group == defaultUserGroup) {
       name = cfg.group;
     };
 

--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -127,7 +127,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = mkIf (cfg.user == "graylog") {
+    users.users = mkIf (cfg.user == "graylog") {
       graylog = {
         uid = config.ids.uids.graylog;
         description = "Graylog server daemon user";

--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -197,7 +197,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.${user} = {
+    users.users.${user} = {
       isSystemUser = true;
       createHome = true;
       home = dataDir;

--- a/nixos/modules/services/logging/logcheck.nix
+++ b/nixos/modules/services/logging/logcheck.nix
@@ -213,7 +213,7 @@ in
         mapAttrsToList writeIgnoreRule cfg.ignore
         ++ mapAttrsToList writeIgnoreCronRule cfg.ignoreCron;
 
-    users.extraUsers = optionalAttrs (cfg.user == "logcheck") (singleton
+    users.users = optionalAttrs (cfg.user == "logcheck") (singleton
       { name = "logcheck";
         uid = config.ids.uids.logcheck;
         shell = "/bin/sh";

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -309,7 +309,7 @@ in
      ++ optional cfg.enablePop3 "pop3"
      ++ optional cfg.enableLmtp "lmtp";
 
-    users.extraUsers = [
+    users.users = [
       { name = "dovenull";
         uid = config.ids.uids.dovenull2;
         description = "Dovecot user for untrusted logins";
@@ -328,7 +328,7 @@ in
            group = cfg.mailGroup;
          });
 
-    users.extraGroups = optional (cfg.group == "dovecot2")
+    users.groups = optional (cfg.group == "dovecot2")
       { name = "dovecot2";
         gid = config.ids.gids.dovecot2;
       }

--- a/nixos/modules/services/mail/dspam.nix
+++ b/nixos/modules/services/mail/dspam.nix
@@ -86,13 +86,13 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      users.extraUsers = optionalAttrs (cfg.user == "dspam") (singleton
+      users.users = optionalAttrs (cfg.user == "dspam") (singleton
         { name = "dspam";
           group = cfg.group;
           uid = config.ids.uids.dspam;
         });
 
-      users.extraGroups = optionalAttrs (cfg.group == "dspam") (singleton
+      users.groups = optionalAttrs (cfg.group == "dspam") (singleton
         { name = "dspam";
           gid = config.ids.gids.dspam;
         });

--- a/nixos/modules/services/mail/exim.nix
+++ b/nixos/modules/services/mail/exim.nix
@@ -77,14 +77,14 @@ in
       systemPackages = [ exim ];
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = cfg.user;
       description = "Exim mail transfer agent user";
       uid = config.ids.uids.exim;
       group = cfg.group;
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = cfg.group;
       gid = config.ids.gids.exim;
     };

--- a/nixos/modules/services/mail/mailhog.nix
+++ b/nixos/modules/services/mail/mailhog.nix
@@ -24,7 +24,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.mailhog = {
+    users.users.mailhog = {
       name = cfg.user;
       description = "MailHog service user";
     };

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -94,7 +94,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = cfg.user;
       description = "mlmmj user";
       home = stateDir;
@@ -104,7 +104,7 @@ in
       useDefaultShell = true;
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = cfg.group;
       gid = config.ids.gids.mlmmj;
     };

--- a/nixos/modules/services/mail/nullmailer.nix
+++ b/nixos/modules/services/mail/nullmailer.nix
@@ -201,13 +201,13 @@ with lib;
     };
 
     users = {
-      extraUsers = singleton {
+      users = singleton {
         name = cfg.user;
         description = "Nullmailer relay-only mta user";
         group = cfg.group;
       };
 
-      extraGroups = singleton {
+      groups = singleton {
         name = cfg.group;
       };
     };

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -88,13 +88,13 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = optionalAttrs (cfg.user == "opendkim") (singleton
+    users.users = optionalAttrs (cfg.user == "opendkim") (singleton
       { name = "opendkim";
         group = cfg.group;
         uid = config.ids.uids.opendkim;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "opendkim") (singleton
+    users.groups = optionalAttrs (cfg.group == "opendkim") (singleton
       { name = "opendkim";
         gid = config.ids.gids.opendkim;
       });

--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -83,12 +83,12 @@ in {
   ###### implementation
 
   config = mkIf cfg.enable {
-    users.extraGroups = {
+    users.groups = {
       smtpd.gid = config.ids.gids.smtpd;
       smtpq.gid = config.ids.gids.smtpq;
     };
 
-    users.extraUsers = {
+    users.users = {
       smtpd = {
         description = "OpenSMTPD process user";
         uid = config.ids.uids.smtpd;

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -616,14 +616,14 @@ in
         setgid = true;
       };
 
-      users.extraUsers = optional (user == "postfix")
+      users.users = optional (user == "postfix")
         { name = "postfix";
           description = "Postfix mail server user";
           uid = config.ids.uids.postfix;
           group = group;
         };
 
-      users.extraGroups =
+      users.groups =
         optional (group == "postfix")
         { name = group;
           gid = config.ids.gids.postfix;

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -136,14 +136,14 @@ in {
     environment.systemPackages = [ pkgs.postgrey ];
 
     users = {
-      extraUsers = {
+      users = {
         postgrey = {
           description = "Postgrey Daemon";
           uid = config.ids.uids.postgrey;
           group = "postgrey";
         };
       };
-      extraGroups = {
+      groups = {
         postgrey = {
           gid = config.ids.gids.postgrey;
         };

--- a/nixos/modules/services/mail/postsrsd.nix
+++ b/nixos/modules/services/mail/postsrsd.nix
@@ -90,13 +90,13 @@ in {
 
     services.postsrsd.domain = mkDefault config.networking.hostName;
 
-    users.extraUsers = optionalAttrs (cfg.user == "postsrsd") (singleton
+    users.users = optionalAttrs (cfg.user == "postsrsd") (singleton
       { name = "postsrsd";
         group = cfg.group;
         uid = config.ids.uids.postsrsd;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "postsrsd") (singleton
+    users.groups = optionalAttrs (cfg.group == "postsrsd") (singleton
       { name = "postsrsd";
         gid = config.ids.gids.postsrsd;
       });

--- a/nixos/modules/services/mail/rmilter.nix
+++ b/nixos/modules/services/mail/rmilter.nix
@@ -194,14 +194,14 @@ in
 
     (mkIf cfg.enable {
 
-      users.extraUsers = singleton {
+      users.users = singleton {
         name = cfg.user;
         description = "rmilter daemon";
         uid = config.ids.uids.rmilter;
         group = cfg.group;
       };
 
-      users.extraGroups = singleton {
+      users.groups = singleton {
         name = cfg.group;
         gid = config.ids.gids.rmilter;
       };
@@ -238,12 +238,12 @@ in
     })
 
     (mkIf (cfg.enable && cfg.rspamd.enable && rspamdCfg.enable) {
-      users.extraUsers.${cfg.user}.extraGroups = [ rspamdCfg.group ];
+      users.users.${cfg.user}.extraGroups = [ rspamdCfg.group ];
     })
 
     (mkIf (cfg.enable && cfg.postfix.enable) {
       services.postfix.extraConfig = cfg.postfix.configFragment;
-      users.extraUsers.${postfixCfg.user}.extraGroups = [ cfg.group ];
+      users.users.${postfixCfg.user}.extraGroups = [ cfg.group ];
     })
   ];
 }

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -282,14 +282,14 @@ in
     # Allow users to run 'rspamc' and 'rspamadm'.
     environment.systemPackages = [ pkgs.rspamd ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = cfg.user;
       description = "rspamd daemon";
       uid = config.ids.uids.rspamd;
       group = cfg.group;
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = cfg.group;
       gid = config.ids.gids.rspamd;
     };

--- a/nixos/modules/services/mail/spamassassin.nix
+++ b/nixos/modules/services/mail/spamassassin.nix
@@ -128,14 +128,14 @@ in
       systemPackages = [ pkgs.spamassassin ];
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "spamd";
       description = "Spam Assassin Daemon";
       uid = config.ids.uids.spamd;
       group = "spamd";
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = "spamd";
       gid = config.ids.gids.spamd;
     };

--- a/nixos/modules/services/misc/airsonic.nix
+++ b/nixos/modules/services/misc/airsonic.nix
@@ -107,7 +107,7 @@ in {
       };
     };
 
-    users.extraUsers.airsonic = {
+    users.users.airsonic = {
       description = "Airsonic service user";
       name = cfg.user;
       home = cfg.home;

--- a/nixos/modules/services/misc/apache-kafka.nix
+++ b/nixos/modules/services/misc/apache-kafka.nix
@@ -124,7 +124,7 @@ in {
 
     environment.systemPackages = [cfg.package];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "apache-kafka";
       uid = config.ids.uids.apache-kafka;
       description = "Apache Kafka daemon user";

--- a/nixos/modules/services/misc/bepasty.nix
+++ b/nixos/modules/services/misc/bepasty.nix
@@ -168,14 +168,14 @@ in
         })
     ) cfg.servers;
 
-    users.extraUsers = [{
+    users.users = [{
       uid = config.ids.uids.bepasty;
       name = user;
       group = group;
       home = default_home;
     }];
 
-    users.extraGroups = [{
+    users.groups = [{
       name = group;
       gid = config.ids.gids.bepasty;
     }];

--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -49,12 +49,12 @@ in
 
     environment.systemPackages = [ pkgs.calibre ];
 
-    users.extraUsers.calibre-server = {
+    users.users.calibre-server = {
         uid = config.ids.uids.calibre-server;
         group = "calibre-server";
       };
 
-    users.extraGroups.calibre-server = {
+    users.groups.calibre-server = {
         gid = config.ids.gids.calibre-server;
       };
 

--- a/nixos/modules/services/misc/cfdyndns.nix
+++ b/nixos/modules/services/misc/cfdyndns.nix
@@ -54,14 +54,14 @@ in
       };
     };
 
-    users.extraUsers = {
+    users.users = {
       cfdyndns = {
         group = "cfdyndns";
         uid = config.ids.uids.cfdyndns;
       };
     };
 
-    users.extraGroups = {
+    users.groups = {
       cfdyndns = {
         gid = config.ids.gids.cfdyndns;
       };

--- a/nixos/modules/services/misc/cgminer.nix
+++ b/nixos/modules/services/misc/cgminer.nix
@@ -110,7 +110,7 @@ in
 
   config = mkIf config.services.cgminer.enable {
 
-    users.extraUsers = optionalAttrs (cfg.user == "cgminer") (singleton
+    users.users = optionalAttrs (cfg.user == "cgminer") (singleton
       { name = "cgminer";
         uid = config.ids.uids.cgminer;
         description = "Cgminer user";

--- a/nixos/modules/services/misc/couchpotato.nix
+++ b/nixos/modules/services/misc/couchpotato.nix
@@ -34,7 +34,7 @@ in
       };
     };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "couchpotato";
         group = "couchpotato";
         home = "/var/lib/couchpotato/";
@@ -42,7 +42,7 @@ in
         uid = config.ids.uids.couchpotato;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "couchpotato";
         gid = config.ids.gids.couchpotato;
       };

--- a/nixos/modules/services/misc/dictd.nix
+++ b/nixos/modules/services/misc/dictd.nix
@@ -45,7 +45,7 @@ in
     # get the command line client on system path to make some use of the service
     environment.systemPackages = [ pkgs.dict ];
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "dictd";
         group = "dictd";
         description = "DICT.org dictd server";
@@ -53,7 +53,7 @@ in
         uid = config.ids.uids.dictd;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "dictd";
         gid = config.ids.gids.dictd;
       };

--- a/nixos/modules/services/misc/disnix.nix
+++ b/nixos/modules/services/misc/disnix.nix
@@ -71,7 +71,7 @@ in
       ++ optional cfg.useWebServiceInterface "${pkgs.dbus_java}/share/java/dbus.jar";
     services.tomcat.webapps = optional cfg.useWebServiceInterface pkgs.DisnixWebService;
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "disnix";
         gid = config.ids.gids.disnix;
       };

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -140,7 +140,7 @@ in {
       startAt = optional cfg.enableGarbageCollect cfg.garbageCollectDates;
     };
 
-    users.extraUsers.docker-registry = {
+    users.users.docker-registry = {
       createHome = true;
       home = cfg.storagePath;
     };

--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -54,14 +54,14 @@ in
       };
     };
 
-    users.extraUsers = mkIf (cfg.user == "emby") {
+    users.users = mkIf (cfg.user == "emby") {
       emby = {
         group = cfg.group;
         uid = config.ids.uids.emby;
       };
     };
 
-    users.extraGroups = mkIf (cfg.group == "emby") {
+    users.groups = mkIf (cfg.group == "emby") {
       emby = {
         gid = config.ids.gids.emby;
       };

--- a/nixos/modules/services/misc/errbot.nix
+++ b/nixos/modules/services/misc/errbot.nix
@@ -76,8 +76,8 @@ in {
   };
 
   config = mkIf (cfg.instances != {}) {
-    users.extraUsers.errbot.group = "errbot";
-    users.extraGroups.errbot = {};
+    users.users.errbot.group = "errbot";
+    users.groups.errbot = {};
 
     systemd.services = mapAttrs' (name: instanceCfg: nameValuePair "errbot-${name}" (
     let

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -188,7 +188,7 @@ in {
 
     environment.systemPackages = [ pkgs.etcdctl ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "etcd";
       uid = config.ids.uids.etcd;
       description = "Etcd daemon user";

--- a/nixos/modules/services/misc/exhibitor.nix
+++ b/nixos/modules/services/misc/exhibitor.nix
@@ -408,7 +408,7 @@ in
         chmod -R u+w ${cfg.baseDir}/zookeeper/conf
       '';
     };
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "zookeeper";
       uid = config.ids.uids.zookeeper;
       description = "Zookeeper daemon user";

--- a/nixos/modules/services/misc/felix.nix
+++ b/nixos/modules/services/misc/felix.nix
@@ -47,12 +47,12 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "osgi";
         gid = config.ids.gids.osgi;
       };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "osgi";
         uid = config.ids.uids.osgi;
         description = "OSGi user";

--- a/nixos/modules/services/misc/folding-at-home.nix
+++ b/nixos/modules/services/misc/folding-at-home.nix
@@ -42,7 +42,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = fahUser;
         uid = config.ids.uids.foldingathome;
         description = "Folding@Home user";

--- a/nixos/modules/services/misc/gammu-smsd.nix
+++ b/nixos/modules/services/misc/gammu-smsd.nix
@@ -200,7 +200,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.${cfg.user} = {
+    users.users.${cfg.user} = {
       description = "gammu-smsd user";
       uid = config.ids.uids.gammu-smsd;
       extraGroups = [ "${cfg.device.group}" ];

--- a/nixos/modules/services/misc/geoip-updater.nix
+++ b/nixos/modules/services/misc/geoip-updater.nix
@@ -251,7 +251,7 @@ in
       }
     ];
 
-    users.extraUsers.geoip = {
+    users.users.geoip = {
       group = "root";
       description = "GeoIP database updater";
       uid = config.ids.uids.geoip;

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -337,7 +337,7 @@ in
     };
 
     users = mkIf (cfg.user == "gitea") {
-      extraUsers.gitea = {
+      users.gitea = {
         description = "Gitea Service";
         home = cfg.stateDir;
         createHome = true;

--- a/nixos/modules/services/misc/gitit.nix
+++ b/nixos/modules/services/misc/gitit.nix
@@ -645,15 +645,15 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.gitit = {
-      group = config.users.extraGroups.gitit.name;
+    users.users.gitit = {
+      group = config.users.groups.gitit.name;
       description = "Gitit user";
       home = homeDir;
       createHome = true;
       uid = config.ids.uids.gitit;
     };
 
-    users.extraGroups.gitit.gid = config.ids.gids.gitit;
+    users.groups.gitit.gid = config.ids.gids.gitit;
 
     systemd.services.gitit = let
       uid = toString config.ids.uids.gitit;
@@ -715,8 +715,8 @@ NAMED
       '';
 
       serviceConfig = {
-        User = config.users.extraUsers.gitit.name;
-        Group = config.users.extraGroups.gitit.name;
+        User = config.users.users.gitit.name;
+        Group = config.users.groups.gitit.name;
         ExecStart = with cfg; gititSh haskellPackages extraPackages;
       };
     };

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -444,7 +444,7 @@ in {
     # Use postfix to send out mails.
     services.postfix.enable = mkDefault true;
 
-    users.extraUsers = [
+    users.users = [
       { name = cfg.user;
         group = cfg.group;
         home = "${cfg.statePath}/home";
@@ -453,7 +453,7 @@ in {
       }
     ];
 
-    users.extraGroups = [
+    users.groups = [
       { name = cfg.group;
         gid = config.ids.gids.gitlab;
       }

--- a/nixos/modules/services/misc/gitolite.nix
+++ b/nixos/modules/services/misc/gitolite.nix
@@ -140,7 +140,7 @@ in
       push( @{$RC{ENABLE}}, 'git-annex-shell ua');
     '';
 
-    users.extraUsers.${cfg.user} = {
+    users.users.${cfg.user} = {
       description     = "Gitolite user";
       home            = cfg.dataDir;
       createHome      = true;
@@ -148,7 +148,7 @@ in
       group           = cfg.group;
       useDefaultShell = true;
     };
-    users.extraGroups."${cfg.group}".gid = config.ids.gids.gitolite;
+    users.groups."${cfg.group}".gid = config.ids.gids.gitolite;
 
     systemd.services."gitolite-init" = {
       description = "Gitolite initialization";

--- a/nixos/modules/services/misc/gogs.nix
+++ b/nixos/modules/services/misc/gogs.nix
@@ -254,7 +254,7 @@ in
     };
 
     users = mkIf (cfg.user == "gogs") {
-      extraUsers.gogs = {
+      users.gogs = {
         description = "Go Git Service";
         uid = config.ids.uids.gogs;
         group = "gogs";
@@ -262,7 +262,7 @@ in
         createHome = true;
         shell = pkgs.bash;
       };
-      extraGroups.gogs.gid = config.ids.gids.gogs;
+      groups.gogs.gid = config.ids.gids.gogs;
     };
 
     warnings = optional (cfg.database.password != "")

--- a/nixos/modules/services/misc/gollum.nix
+++ b/nixos/modules/services/misc/gollum.nix
@@ -93,8 +93,8 @@ in
       '';
 
       serviceConfig = {
-        User = config.users.extraUsers.gollum.name;
-        Group = config.users.extraGroups.gollum.name;
+        User = config.users.users.gollum.name;
+        Group = config.users.groups.gollum.name;
         PermissionsStartOnly = true;
         ExecStart = ''
           ${pkgs.gollum}/bin/gollum \

--- a/nixos/modules/services/misc/gpsd.nix
+++ b/nixos/modules/services/misc/gpsd.nix
@@ -78,14 +78,14 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "gpsd";
         inherit uid;
         description = "gpsd daemon user";
         home = "/var/empty";
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "gpsd";
         inherit gid;
       };

--- a/nixos/modules/services/misc/home-assistant.nix
+++ b/nixos/modules/services/misc/home-assistant.nix
@@ -170,13 +170,13 @@ in {
       after = wants;
     };
 
-    users.extraUsers.hass = {
+    users.users.hass = {
       home = cfg.configDir;
       createHome = true;
       group = "hass";
       uid = config.ids.uids.hass;
     };
 
-    users.extraGroups.hass.gid = config.ids.gids.hass;
+    users.groups.hass.gid = config.ids.gids.hass;
   };
 }

--- a/nixos/modules/services/misc/ihaskell.nix
+++ b/nixos/modules/services/misc/ihaskell.nix
@@ -38,23 +38,23 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.ihaskell = {
-      group = config.users.extraGroups.ihaskell.name;
+    users.users.ihaskell = {
+      group = config.users.groups.ihaskell.name;
       description = "IHaskell user";
       home = "/var/lib/ihaskell";
       createHome = true;
       uid = config.ids.uids.ihaskell;
     };
 
-    users.extraGroups.ihaskell.gid = config.ids.gids.ihaskell;
+    users.groups.ihaskell.gid = config.ids.gids.ihaskell;
 
     systemd.services.ihaskell = {
       description = "IHaskell notebook instance";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        User = config.users.extraUsers.ihaskell.name;
-        Group = config.users.extraGroups.ihaskell.name;
+        User = config.users.users.ihaskell.name;
+        Group = config.users.groups.ihaskell.name;
         ExecStart = "${pkgs.runtimeShell} -c \"cd $HOME;${ihaskell}/bin/ihaskell-notebook\"";
       };
     };

--- a/nixos/modules/services/misc/jackett.nix
+++ b/nixos/modules/services/misc/jackett.nix
@@ -36,12 +36,12 @@ in
       };
     };
 
-    users.extraUsers.jackett = {
+    users.users.jackett = {
       uid = config.ids.uids.jackett;
       home = "/var/lib/jackett";
       group = "jackett";
     };
-    users.extraGroups.jackett.gid = config.ids.gids.jackett;
+    users.groups.jackett.gid = config.ids.gids.jackett;
 
   };
 }

--- a/nixos/modules/services/misc/mathics.nix
+++ b/nixos/modules/services/misc/mathics.nix
@@ -26,23 +26,23 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.mathics = {
-      group = config.users.extraGroups.mathics.name;
+    users.users.mathics = {
+      group = config.users.groups.mathics.name;
       description = "Mathics user";
       home = "/var/lib/mathics";
       createHome = true;
       uid = config.ids.uids.mathics;
     };
 
-    users.extraGroups.mathics.gid = config.ids.gids.mathics;
+    users.groups.mathics.gid = config.ids.gids.mathics;
 
     systemd.services.mathics = {
       description = "Mathics notebook server";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
       serviceConfig = {
-        User = config.users.extraUsers.mathics.name;
-        Group = config.users.extraGroups.mathics.name;
+        User = config.users.users.mathics.name;
+        Group = config.users.groups.mathics.name;
         ExecStart = concatStringsSep " " [
           "${pkgs.mathics}/bin/mathicsserver"
           "--port" (toString cfg.port)

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -635,7 +635,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers = [
+    users.users = [
       { name = "matrix-synapse";
         group = "matrix-synapse";
         home = cfg.dataDir;
@@ -644,7 +644,7 @@ in {
         uid = config.ids.uids.matrix-synapse;
       } ];
 
-    users.extraGroups = [
+    users.groups = [
       { name = "matrix-synapse";
         gid = config.ids.gids.matrix-synapse;
       } ];

--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -267,12 +267,12 @@ in {
       serviceConfig.User = "${cfg.user}";
     };
 
-    users.extraGroups = optionalAttrs (cfg.group == "mediatomb") (singleton {
+    users.groups = optionalAttrs (cfg.group == "mediatomb") (singleton {
       name = "mediatomb";
       gid = gid;
     });
 
-    users.extraUsers = optionalAttrs (cfg.user == "mediatomb") (singleton {
+    users.users = optionalAttrs (cfg.user == "mediatomb") (singleton {
       name = "mediatomb";
       isSystemUser = true;
       group = cfg.group;

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -131,10 +131,10 @@ in
         description = "
           If set, Nix will perform builds in a sandboxed environment that it
           will set up automatically for each build. This prevents impurities
-          in builds by disallowing access to dependencies outside of the Nix 
-          store by using network and mount namespaces in a chroot environment. 
-          This isn't enabled by default for possible performance impacts due to 
-          the initial setup time of a sandbox for each build. It doesn't affect 
+          in builds by disallowing access to dependencies outside of the Nix
+          store by using network and mount namespaces in a chroot environment.
+          This isn't enabled by default for possible performance impacts due to
+          the initial setup time of a sandbox for each build. It doesn't affect
           derivation hashes, so changing this option will not trigger a rebuild
           of packages.
         ";
@@ -450,7 +450,7 @@ in
 
     nix.nrBuildUsers = mkDefault (lib.max 32 cfg.maxJobs);
 
-    users.extraUsers = nixbldUsers;
+    users.users = nixbldUsers;
 
     services.xserver.displayManager.hiddenUsers = map ({ name, ... }: name) nixbldUsers;
 

--- a/nixos/modules/services/misc/nix-ssh-serve.nix
+++ b/nixos/modules/services/misc/nix-ssh-serve.nix
@@ -36,7 +36,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.nix-ssh = {
+    users.users.nix-ssh = {
       description = "Nix SSH store user";
       uid = config.ids.uids.nix-ssh;
       useDefaultShell = true;
@@ -55,7 +55,7 @@ in {
       Match All
     '';
 
-    users.extraUsers.nix-ssh.openssh.authorizedKeys.keys = cfg.keys;
+    users.users.nix-ssh.openssh.authorizedKeys.keys = cfg.keys;
 
   };
 }

--- a/nixos/modules/services/misc/nzbget.nix
+++ b/nixos/modules/services/misc/nzbget.nix
@@ -86,14 +86,14 @@ let
       };
     };
 
-    users.extraUsers = mkIf (cfg.user == "nzbget") {
+    users.users = mkIf (cfg.user == "nzbget") {
       nzbget = {
         group = cfg.group;
         uid = config.ids.uids.nzbget;
       };
     };
 
-    users.extraGroups = mkIf (cfg.group == "nzbget") {
+    users.groups = mkIf (cfg.group == "nzbget") {
       nzbget = {
         gid = config.ids.gids.nzbget;
       };

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -86,13 +86,13 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = optionalAttrs (cfg.user == "octoprint") (singleton
+    users.users = optionalAttrs (cfg.user == "octoprint") (singleton
       { name = "octoprint";
         group = cfg.group;
         uid = config.ids.uids.octoprint;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "octoprint") (singleton
+    users.groups = optionalAttrs (cfg.group == "octoprint") (singleton
       { name = "octoprint";
         gid = config.ids.gids.octoprint;
       });

--- a/nixos/modules/services/misc/osrm.nix
+++ b/nixos/modules/services/misc/osrm.nix
@@ -69,7 +69,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        User = config.users.extraUsers.osrm.name;
+        User = config.users.users.osrm.name;
         ExecStart = ''
           ${pkgs.osrm-backend}/bin/osrm-routed \
             --ip ${cfg.address} \

--- a/nixos/modules/services/misc/plex.nix
+++ b/nixos/modules/services/misc/plex.nix
@@ -157,14 +157,14 @@ in
       allowedUDPPorts = [ 1900 5353 32410 32412 32413 32414 ];
     };
 
-    users.extraUsers = mkIf (cfg.user == "plex") {
+    users.users = mkIf (cfg.user == "plex") {
       plex = {
         group = cfg.group;
         uid = config.ids.uids.plex;
       };
     };
 
-    users.extraGroups = mkIf (cfg.group == "plex") {
+    users.groups = mkIf (cfg.group == "plex") {
       plex = {
         gid = config.ids.gids.plex;
       };

--- a/nixos/modules/services/misc/plexpy.nix
+++ b/nixos/modules/services/misc/plexpy.nix
@@ -74,7 +74,7 @@ in
       };
     };
 
-    users.extraUsers = mkIf (cfg.user == "plexpy") {
+    users.users = mkIf (cfg.user == "plexpy") {
       plexpy = { group = cfg.group; uid = config.ids.uids.plexpy; };
     };
   };

--- a/nixos/modules/services/misc/pykms.nix
+++ b/nixos/modules/services/misc/pykms.nix
@@ -73,7 +73,7 @@ in {
     };
 
     users = {
-      extraUsers.pykms = {
+      users.pykms = {
         name = "pykms";
         group = "pykms";
         home  = home;
@@ -82,7 +82,7 @@ in {
         description = "PyKMS daemon user";
       };
 
-      extraGroups.pykms = {
+      groups.pykms = {
         gid = config.ids.gids.pykms;
       };
     };

--- a/nixos/modules/services/misc/radarr.nix
+++ b/nixos/modules/services/misc/radarr.nix
@@ -36,12 +36,12 @@ in
       };
     };
 
-    users.extraUsers.radarr = {
+    users.users.radarr = {
       uid = config.ids.uids.radarr;
       home = "/var/lib/radarr";
       group = "radarr";
     };
-    users.extraGroups.radarr.gid = config.ids.gids.radarr;
+    users.groups.radarr.gid = config.ids.gids.radarr;
 
   };
 }

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -128,13 +128,13 @@ in {
       }
     ];
 
-    users.extraUsers = [
+    users.users = [
       { name = "redmine";
         group = "redmine";
         uid = config.ids.uids.redmine;
       } ];
 
-    users.extraGroups = [
+    users.groups = [
       { name = "redmine";
         gid = config.ids.gids.redmine;
       } ];

--- a/nixos/modules/services/misc/ripple-data-api.nix
+++ b/nixos/modules/services/misc/ripple-data-api.nix
@@ -185,7 +185,7 @@ in {
       ];
     };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "ripple-data-api";
         description = "Ripple data api user";
         uid = config.ids.uids.ripple-data-api;

--- a/nixos/modules/services/misc/rippled.nix
+++ b/nixos/modules/services/misc/rippled.nix
@@ -406,7 +406,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "rippled";
         description = "Ripple server user";
         uid = config.ids.uids.rippled;

--- a/nixos/modules/services/misc/serviio.nix
+++ b/nixos/modules/services/misc/serviio.nix
@@ -63,7 +63,7 @@ in {
       };
     };
 
-    users.extraUsers = [
+    users.users = [
       { 
         name = "serviio";
         group = "serviio";
@@ -74,7 +74,7 @@ in {
       }
     ];
 
-    users.extraGroups = [
+    users.groups = [
       { name = "serviio";} 
     ];
 

--- a/nixos/modules/services/misc/siproxd.nix
+++ b/nixos/modules/services/misc/siproxd.nix
@@ -161,7 +161,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "siproxyd";
       uid = config.ids.uids.siproxd;
     };

--- a/nixos/modules/services/misc/sonarr.nix
+++ b/nixos/modules/services/misc/sonarr.nix
@@ -36,12 +36,12 @@ in
       };
     };
 
-    users.extraUsers.sonarr = {
+    users.users.sonarr = {
       uid = config.ids.uids.sonarr;
       home = "/var/lib/sonarr";
       group = "sonarr";
     };
-    users.extraGroups.sonarr.gid = config.ids.gids.sonarr;
+    users.groups.sonarr.gid = config.ids.gids.sonarr;
 
   };
 }

--- a/nixos/modules/services/misc/subsonic.nix
+++ b/nixos/modules/services/misc/subsonic.nix
@@ -130,7 +130,7 @@ let cfg = config.services.subsonic; in {
                 ! [ -e "${cfg.home}" ] &&
                 [ -d "$oldHome" ] &&
                 [ $(${pkgs.coreutils}/bin/stat -c %u "$oldHome") -eq \
-                    ${toString config.users.extraUsers.subsonic.uid} ]; then
+                    ${toString config.users.users.subsonic.uid} ]; then
             logger Moving "$oldHome" to "${cfg.home}"
             ${pkgs.coreutils}/bin/mv -T "$oldHome" "${cfg.home}"
         fi
@@ -152,7 +152,7 @@ let cfg = config.services.subsonic; in {
       };
     };
 
-    users.extraUsers.subsonic = {
+    users.users.subsonic = {
       description = "Subsonic daemon user";
       home = cfg.home;
       createHome = true;
@@ -160,6 +160,6 @@ let cfg = config.services.subsonic; in {
       uid = config.ids.uids.subsonic;
     };
 
-    users.extraGroups.subsonic.gid = config.ids.gids.subsonic;
+    users.groups.subsonic.gid = config.ids.gids.subsonic;
   };
 }

--- a/nixos/modules/services/misc/uhub.nix
+++ b/nixos/modules/services/misc/uhub.nix
@@ -161,11 +161,11 @@ in
   config = mkIf cfg.enable {
 
     users = {
-      extraUsers = singleton {
+      users = singleton {
         name = "uhub";
         uid = config.ids.uids.uhub;
       };
-      extraGroups = singleton {
+      groups = singleton {
         name = "uhub";
         gid = config.ids.gids.uhub;
       };

--- a/nixos/modules/services/misc/zookeeper.nix
+++ b/nixos/modules/services/misc/zookeeper.nix
@@ -144,7 +144,7 @@ in {
       '';
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "zookeeper";
       uid = config.ids.uids.zookeeper;
       description = "Zookeeper daemon user";

--- a/nixos/modules/services/monitoring/bosun.nix
+++ b/nixos/modules/services/monitoring/bosun.nix
@@ -153,13 +153,13 @@ in {
       };
     };
 
-    users.extraUsers.bosun = {
+    users.users.bosun = {
       description = "bosun user";
       group = "bosun";
       uid = config.ids.uids.bosun;
     };
 
-    users.extraGroups.bosun.gid = config.ids.gids.bosun;
+    users.groups.bosun.gid = config.ids.gids.bosun;
 
   };
 

--- a/nixos/modules/services/monitoring/collectd.nix
+++ b/nixos/modules/services/monitoring/collectd.nix
@@ -97,7 +97,7 @@ in {
       '';
     };
 
-    users.extraUsers = optional (cfg.user == "collectd") {
+    users.users = optional (cfg.user == "collectd") {
       name = "collectd";
     };
   };

--- a/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
+++ b/nixos/modules/services/monitoring/dd-agent/dd-agent.nix
@@ -178,7 +178,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs."dd-agent" pkgs.sysstat pkgs.procps ];
 
-    users.extraUsers.datadog = {
+    users.users.datadog = {
       description = "Datadog Agent User";
       uid = config.ids.uids.datadog;
       group = "datadog";
@@ -186,7 +186,7 @@ in {
       createHome = true;
     };
 
-    users.extraGroups.datadog.gid = config.ids.gids.datadog;
+    users.groups.datadog.gid = config.ids.gids.datadog;
 
     systemd.services.dd-agent = {
       description = "Datadog agent monitor";

--- a/nixos/modules/services/monitoring/fusion-inventory.nix
+++ b/nixos/modules/services/monitoring/fusion-inventory.nix
@@ -46,7 +46,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "fusion-inventory";
       description = "FusionInventory user";
     };

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -265,7 +265,7 @@ in {
       '';
     };
 
-    users.extraUsers.grafana = {
+    users.users.grafana = {
       uid = config.ids.uids.grafana;
       description = "Grafana user";
       home = cfg.dataDir;

--- a/nixos/modules/services/monitoring/graphite.nix
+++ b/nixos/modules/services/monitoring/graphite.nix
@@ -638,13 +638,13 @@ in {
       cfg.web.enable || cfg.api.enable ||
       cfg.seyren.enable || cfg.pager.enable || cfg.beacon.enable
      ) {
-      users.extraUsers = singleton {
+      users.users = singleton {
         name = "graphite";
         uid = config.ids.uids.graphite;
         description = "Graphite daemon user";
         home = dataDir;
       };
-      users.extraGroups.graphite.gid = config.ids.gids.graphite;
+      users.groups.graphite.gid = config.ids.gids.graphite;
     })
   ];
 }

--- a/nixos/modules/services/monitoring/heapster.nix
+++ b/nixos/modules/services/monitoring/heapster.nix
@@ -49,7 +49,7 @@ in {
       };
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "heapster";
       uid = config.ids.uids.heapster;
       description = "Heapster user";

--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -150,14 +150,14 @@ in
 
     environment.systemPackages = [ pkgs.munin ];
 
-    users.extraUsers = [{
+    users.users = [{
       name = "munin";
       description = "Munin monitoring user";
       group = "munin";
       uid = config.ids.uids.munin;
     }];
 
-    users.extraGroups = [{
+    users.groups = [{
       name = "munin";
       gid = config.ids.gids.munin;
     }];

--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -143,7 +143,7 @@ in
 
 
   config = mkIf cfg.enable {
-    users.extraUsers.nagios = {
+    users.users.nagios = {
       description = "Nagios user ";
       uid         = config.ids.uids.nagios;
       home        = nagiosState;

--- a/nixos/modules/services/monitoring/netdata.nix
+++ b/nixos/modules/services/monitoring/netdata.nix
@@ -100,11 +100,11 @@ in {
     };
 
 
-    users.extraUsers = optional (cfg.user == defaultUser) {
+    users.users = optional (cfg.user == defaultUser) {
       name = defaultUser;
     };
 
-    users.extraGroups = optional (cfg.group == defaultUser) {
+    users.groups = optional (cfg.group == defaultUser) {
       name = defaultUser;
     };
 

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -471,8 +471,8 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups.${promGroup}.gid = config.ids.gids.prometheus;
-    users.extraUsers.${promUser} = {
+    users.groups.${promGroup}.gid = config.ids.gids.prometheus;
+    users.users.${promUser} = {
       description = "Prometheus daemon user";
       uid = config.ids.uids.prometheus;
       group = promGroup;

--- a/nixos/modules/services/monitoring/riemann-dash.nix
+++ b/nixos/modules/services/monitoring/riemann-dash.nix
@@ -51,9 +51,9 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraGroups.riemanndash.gid = config.ids.gids.riemanndash;
+    users.groups.riemanndash.gid = config.ids.gids.riemanndash;
 
-    users.extraUsers.riemanndash = {
+    users.users.riemanndash = {
       description = "riemann-dash daemon user";
       uid = config.ids.uids.riemanndash;
       group = "riemanndash";

--- a/nixos/modules/services/monitoring/riemann-tools.nix
+++ b/nixos/modules/services/monitoring/riemann-tools.nix
@@ -40,9 +40,9 @@ in {
 
   config = mkIf cfg.enableHealth {
 
-    users.extraGroups.riemanntools.gid = config.ids.gids.riemanntools;
+    users.groups.riemanntools.gid = config.ids.gids.riemanntools;
 
-    users.extraUsers.riemanntools = {
+    users.users.riemanntools = {
       description = "riemann-tools daemon user";
       uid = config.ids.uids.riemanntools;
       group = "riemanntools";

--- a/nixos/modules/services/monitoring/riemann.nix
+++ b/nixos/modules/services/monitoring/riemann.nix
@@ -69,9 +69,9 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraGroups.riemann.gid = config.ids.gids.riemann;
+    users.groups.riemann.gid = config.ids.gids.riemann;
 
-    users.extraUsers.riemann = {
+    users.users.riemann = {
       description = "riemann daemon user";
       uid = config.ids.uids.riemann;
       group = "riemann";

--- a/nixos/modules/services/monitoring/scollector.nix
+++ b/nixos/modules/services/monitoring/scollector.nix
@@ -123,13 +123,13 @@ in {
       };
     };
 
-    users.extraUsers.scollector = {
+    users.users.scollector = {
       description = "scollector user";
       group = "scollector";
       uid = config.ids.uids.scollector;
     };
 
-    users.extraGroups.scollector.gid = config.ids.gids.scollector;
+    users.groups.scollector.gid = config.ids.gids.scollector;
 
   };
 

--- a/nixos/modules/services/monitoring/statsd.nix
+++ b/nixos/modules/services/monitoring/statsd.nix
@@ -125,7 +125,7 @@ in
       message = "Only builtin backends (graphite, console, repeater) or backends enumerated in `pkgs.nodePackages` are allowed!";
     }) cfg.backends;
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "statsd";
       uid = config.ids.uids.statsd;
       description = "Statsd daemon user";

--- a/nixos/modules/services/monitoring/telegraf.nix
+++ b/nixos/modules/services/monitoring/telegraf.nix
@@ -62,7 +62,7 @@ in {
       };
     };
 
-    users.extraUsers = [{
+    users.users = [{
       name = "telegraf";
       uid = config.ids.uids.telegraf;
       description = "telegraf daemon user";

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -259,7 +259,7 @@ in
 
 
 /*
-    users.extraUsers = [
+    users.users = [
       { name = "nut";
         uid = 84;
         home = "/var/lib/nut";
@@ -269,7 +269,7 @@ in
       }
     ];
 
-    users.extraGroups = [
+    users.groups = [
       { name = "nut";
         gid = 84;
       }

--- a/nixos/modules/services/monitoring/vnstat.nix
+++ b/nixos/modules/services/monitoring/vnstat.nix
@@ -16,7 +16,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.vnstatd = {
+    users.users.vnstatd = {
       isSystemUser = true;
       description = "vnstat daemon user";
       home = "/var/lib/vnstat";

--- a/nixos/modules/services/monitoring/zabbix-agent.nix
+++ b/nixos/modules/services/monitoring/zabbix-agent.nix
@@ -68,7 +68,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = mkIf (!config.services.zabbixServer.enable) (singleton
+    users.users = mkIf (!config.services.zabbixServer.enable) (singleton
       { name = "zabbix";
         uid = config.ids.uids.zabbix;
         description = "Zabbix daemon user";

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -85,7 +85,7 @@ in
 
     services.postgresql.enable = useLocalPostgres;
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "zabbix";
         uid = config.ids.uids.zabbix;
         description = "Zabbix daemon user";

--- a/nixos/modules/services/network-filesystems/ceph.nix
+++ b/nixos/modules/services/network-filesystems/ceph.nix
@@ -332,13 +332,13 @@ in
       in
         generators.toINI {} totalConfig;
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "ceph";
       uid = config.ids.uids.ceph;
       description = "Ceph daemon user";
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = "ceph";
       gid = config.ids.gids.ceph;
     };

--- a/nixos/modules/services/network-filesystems/davfs2.nix
+++ b/nixos/modules/services/network-filesystems/davfs2.nix
@@ -57,12 +57,12 @@ in
     environment.systemPackages = [ pkgs.davfs2 ];
     environment.etc."davfs2/davfs2.conf".source = cfgFile;
 
-    users.extraGroups = optionalAttrs (cfg.davGroup == "davfs2") (singleton {
+    users.groups = optionalAttrs (cfg.davGroup == "davfs2") (singleton {
       name = "davfs2";
       gid = config.ids.gids.davfs2;
     });
 
-    users.extraUsers = optionalAttrs (cfg.davUser == "davfs2") (singleton {
+    users.users = optionalAttrs (cfg.davUser == "davfs2") (singleton {
       name = "davfs2";
       createHome = false;
       group = cfg.davGroup;

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -212,7 +212,7 @@ in {
       user_allow_other
     ''; };
 
-    users.extraUsers = mkIf (cfg.user == "ipfs") {
+    users.users = mkIf (cfg.user == "ipfs") {
       ipfs = {
         group = cfg.group;
         home = cfg.dataDir;
@@ -222,7 +222,7 @@ in {
       };
     };
 
-    users.extraGroups = mkIf (cfg.group == "ipfs") {
+    users.groups = mkIf (cfg.group == "ipfs") {
       ipfs.gid = config.ids.gids.ipfs;
     };
 

--- a/nixos/modules/services/network-filesystems/tahoe.nix
+++ b/nixos/modules/services/network-filesystems/tahoe.nix
@@ -255,7 +255,7 @@ in
               cp /etc/tahoe-lafs/introducer-"${node}".cfg ${lib.escapeShellArg nodedir}/tahoe.cfg
             '';
           });
-        users.extraUsers = flip mapAttrs' cfg.introducers (node: _:
+        users.users = flip mapAttrs' cfg.introducers (node: _:
           nameValuePair "tahoe.introducer-${node}" {
             description = "Tahoe node user for introducer ${node}";
             isSystemUser = true;
@@ -355,7 +355,7 @@ in
               cp /etc/tahoe-lafs/${lib.escapeShellArg node}.cfg ${lib.escapeShellArg nodedir}/tahoe.cfg
             '';
           });
-        users.extraUsers = flip mapAttrs' cfg.nodes (node: _:
+        users.users = flip mapAttrs' cfg.nodes (node: _:
           nameValuePair "tahoe.${node}" {
             description = "Tahoe node user for node ${node}";
             isSystemUser = true;

--- a/nixos/modules/services/network-filesystems/xtreemfs.nix
+++ b/nixos/modules/services/network-filesystems/xtreemfs.nix
@@ -432,14 +432,14 @@ in
 
     environment.systemPackages = [ xtreemfs ];
 
-    users.extraUsers.xtreemfs =
+    users.users.xtreemfs =
       { uid = config.ids.uids.xtreemfs;
         description = "XtreemFS user";
         createHome = true;
         home = home;
       };
 
-    users.extraGroups.xtreemfs =
+    users.groups.xtreemfs =
       { gid = config.ids.gids.xtreemfs;
       };
 

--- a/nixos/modules/services/network-filesystems/yandex-disk.nix
+++ b/nixos/modules/services/network-filesystems/yandex-disk.nix
@@ -73,7 +73,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = mkIf (cfg.user == null) [ {
+    users.users = mkIf (cfg.user == null) [ {
       name = u;
       uid = config.ids.uids.yandexdisk;
       group = "nogroup";

--- a/nixos/modules/services/networking/amuled.nix
+++ b/nixos/modules/services/networking/amuled.nix
@@ -45,14 +45,14 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = mkIf (cfg.user == null) [
+    users.users = mkIf (cfg.user == null) [
       { name = "amule";
         description = "AMule daemon";
         group = "amule";
         uid = config.ids.uids.amule;
       } ];
 
-    users.extraGroups = mkIf (cfg.user == null) [
+    users.groups = mkIf (cfg.user == null) [
       { name = "amule";
         gid = config.ids.gids.amule;
       } ];

--- a/nixos/modules/services/networking/aria2.nix
+++ b/nixos/modules/services/networking/aria2.nix
@@ -92,7 +92,7 @@ in
       allowedTCPPorts = [ config.services.aria2.rpcListenPort ];
     };
 
-    users.extraUsers.aria2 = {
+    users.users.aria2 = {
       group = "aria2";
       uid = config.ids.uids.aria2;
       description = "aria2 user";
@@ -100,7 +100,7 @@ in
       createHome = false;
     };
 
-    users.extraGroups.aria2.gid = config.ids.gids.aria2;
+    users.groups.aria2.gid = config.ids.gids.aria2;
 
     systemd.services.aria2 = {
       description = "aria2 Service";

--- a/nixos/modules/services/networking/asterisk.nix
+++ b/nixos/modules/services/networking/asterisk.nix
@@ -211,7 +211,7 @@ in
 
     environment.etc.asterisk.source = asteriskEtc;
 
-    users.extraUsers.asterisk =
+    users.users.asterisk =
       { name = asteriskUser;
         group = asteriskGroup;
         uid = config.ids.uids.asterisk;
@@ -219,7 +219,7 @@ in
         home = varlibdir;
       };
 
-    users.extraGroups.asterisk =
+    users.groups.asterisk =
       { name = asteriskGroup;
         gid = config.ids.gids.asterisk;
       };

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -187,14 +187,14 @@ in
 
     services.avahi.hostName = mkDefault config.networking.hostName;
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "avahi";
         uid = config.ids.uids.avahi;
         description = "`avahi-daemon' privilege separation user";
         home = "/var/empty";
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "avahi";
         gid = config.ids.gids.avahi;
       };

--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -170,7 +170,7 @@ in
 
   config = mkIf config.services.bind.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = bindUser;
         uid = config.ids.uids.bind;
         description = "BIND daemon user";

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -60,11 +60,11 @@ let
           };
         };
         users = {
-          extraUsers.${variant} = {
+          users.${variant} = {
             description = "BIRD Internet Routing Daemon user";
             group = variant;
           };
-          extraGroups.${variant} = {};
+          groups.${variant} = {};
         };
       };
     };

--- a/nixos/modules/services/networking/bitlbee.nix
+++ b/nixos/modules/services/networking/bitlbee.nix
@@ -149,7 +149,7 @@ in
 
   config = mkIf config.services.bitlbee.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "bitlbee";
         uid = bitlbeeUid;
         description = "BitlBee user";
@@ -157,7 +157,7 @@ in
         createHome = true;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "bitlbee";
         gid = config.ids.gids.bitlbee;
       };

--- a/nixos/modules/services/networking/btsync.nix
+++ b/nixos/modules/services/networking/btsync.nix
@@ -284,7 +284,7 @@ in
 
     services.btsync.package = mkOptionDefault pkgs.bittorrentSync14;
 
-    users.extraUsers.btsync = {
+    users.users.btsync = {
       description     = "Bittorrent Sync Service user";
       home            = cfg.storagePath;
       createHome      = true;
@@ -292,7 +292,7 @@ in
       group           = "btsync";
     };
 
-    users.extraGroups = [
+    users.groups = [
       { name = "btsync";
       }];
 

--- a/nixos/modules/services/networking/charybdis.nix
+++ b/nixos/modules/services/networking/charybdis.nix
@@ -71,14 +71,14 @@ in
 
   config = mkIf cfg.enable (lib.mkMerge [
     {
-      users.extraUsers = singleton {
+      users.users = singleton {
         name = cfg.user;
         description = "Charybdis IRC daemon user";
         uid = config.ids.uids.ircd;
         group = cfg.group;
       };
 
-      users.extraGroups = singleton {
+      users.groups = singleton {
         name = cfg.group;
         gid = config.ids.gids.ircd;
       };

--- a/nixos/modules/services/networking/chrony.nix
+++ b/nixos/modules/services/networking/chrony.nix
@@ -96,12 +96,12 @@ in
     # Make chronyc available in the system path
     environment.systemPackages = [ pkgs.chrony ];
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "chrony";
         gid = config.ids.gids.chrony;
       };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "chrony";
         uid = config.ids.uids.chrony;
         group = "chrony";

--- a/nixos/modules/services/networking/cntlm.nix
+++ b/nixos/modules/services/networking/cntlm.nix
@@ -117,7 +117,7 @@ in
       };
     };
 
-    users.extraUsers.cntlm = {
+    users.users.cntlm = {
       name = "cntlm";
       description = "cntlm system-wide daemon";
       isSystemUser = true;

--- a/nixos/modules/services/networking/consul.nix
+++ b/nixos/modules/services/networking/consul.nix
@@ -155,7 +155,7 @@ in
   config = mkIf cfg.enable (
     mkMerge [{
 
-      users.extraUsers."consul" = {
+      users.users."consul" = {
         description = "Consul agent daemon user";
         uid = config.ids.uids.consul;
         # The shell is needed for health checks

--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -294,12 +294,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers = [
+    users.users = [
       { name = "turnserver";
         uid = config.ids.uids.turnserver;
         description = "coturn TURN server user";
       } ];
-    users.extraGroups = [
+    users.groups = [
       { name = "turnserver";
         gid = config.ids.gids.turnserver;
         members = [ "turnserver" ];

--- a/nixos/modules/services/networking/dhcpd.nix
+++ b/nixos/modules/services/networking/dhcpd.nix
@@ -197,7 +197,7 @@ in
   config = mkIf (cfg4.enable || cfg6.enable) {
 
     users = {
-      extraUsers.dhcpd = {
+      users.dhcpd = {
         uid = config.ids.uids.dhcpd;
         description = "DHCP daemon user";
       };

--- a/nixos/modules/services/networking/dnscache.nix
+++ b/nixos/modules/services/networking/dnscache.nix
@@ -84,7 +84,7 @@ in {
 
   config = mkIf config.services.dnscache.enable {
     environment.systemPackages = [ pkgs.djbdns ];
-    users.extraUsers.dnscache = {};
+    users.users.dnscache = {};
 
     systemd.services.dnscache = {
       description = "djbdns dnscache server";

--- a/nixos/modules/services/networking/dnschain.nix
+++ b/nixos/modules/services/networking/dnschain.nix
@@ -141,7 +141,7 @@ in
         dns = "127.0.0.1:${toString cfg.dns.port}";
       };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = username;
       description = "DNSChain daemon user";
       home = dataDir;

--- a/nixos/modules/services/networking/dnsmasq.nix
+++ b/nixos/modules/services/networking/dnsmasq.nix
@@ -86,7 +86,7 @@ in
 
     services.dbus.packages = [ dnsmasq ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "dnsmasq";
       uid = config.ids.uids.dnsmasq;
       description = "Dnsmasq daemon user";

--- a/nixos/modules/services/networking/ejabberd.nix
+++ b/nixos/modules/services/networking/ejabberd.nix
@@ -94,7 +94,7 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    users.extraUsers = optionalAttrs (cfg.user == "ejabberd") (singleton
+    users.users = optionalAttrs (cfg.user == "ejabberd") (singleton
       { name = "ejabberd";
         group = cfg.group;
         home = cfg.spoolDir;
@@ -102,7 +102,7 @@ in {
         uid = config.ids.uids.ejabberd;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "ejabberd") (singleton
+    users.groups = optionalAttrs (cfg.group == "ejabberd") (singleton
       { name = "ejabberd";
         gid = config.ids.gids.ejabberd;
       });

--- a/nixos/modules/services/networking/freenet.nix
+++ b/nixos/modules/services/networking/freenet.nix
@@ -50,7 +50,7 @@ in
       serviceConfig.Nice = cfg.nice;
     };
 
-    users.extraUsers.freenet = {
+    users.users.freenet = {
       group = "freenet";
       description = "Freenet daemon user";
       home = varDir;
@@ -58,7 +58,7 @@ in
       uid = config.ids.uids.freenet;
     };
 
-    users.extraGroups.freenet.gid = config.ids.gids.freenet;
+    users.groups.freenet.gid = config.ids.gids.freenet;
   };
 
 }

--- a/nixos/modules/services/networking/freeradius.nix
+++ b/nixos/modules/services/networking/freeradius.nix
@@ -59,7 +59,7 @@ in
   config = mkIf (cfg.enable) {
 
     users = {
-      extraUsers.radius = {
+      users.radius = {
         /*uid = config.ids.uids.radius;*/
         description = "Radius daemon user";
       };

--- a/nixos/modules/services/networking/gale.nix
+++ b/nixos/modules/services/networking/gale.nix
@@ -104,7 +104,7 @@ in
          systemPackages = [ pkgs.gale ];
        };
 
-       users.extraUsers = [{
+       users.users = [{
          name = cfg.user;
          description = "Gale daemon";
          uid = config.ids.uids.gale;
@@ -113,7 +113,7 @@ in
          createHome = true;
        }];
 
-       users.extraGroups = [{
+       users.groups = [{
          name = cfg.group;
          gid = config.ids.gids.gale;
        }];

--- a/nixos/modules/services/networking/gateone.nix
+++ b/nixos/modules/services/networking/gateone.nix
@@ -23,12 +23,12 @@ config = mkIf cfg.enable {
   environment.systemPackages = with pkgs.pythonPackages; [
     gateone pkgs.openssh pkgs.procps pkgs.coreutils pkgs.cacert];
 
-  users.extraUsers.gateone = {
+  users.users.gateone = {
     description = "GateOne privilege separation user";
     uid = config.ids.uids.gateone;
     home = cfg.settingsDir;
   };
-  users.extraGroups.gateone.gid = config.ids.gids.gateone;
+  users.groups.gateone.gid = config.ids.gids.gateone;
 
   systemd.services.gateone = with pkgs; {
     description = "GateOne web-based terminal";

--- a/nixos/modules/services/networking/git-daemon.nix
+++ b/nixos/modules/services/networking/git-daemon.nix
@@ -104,13 +104,13 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = if cfg.user != "git" then {} else singleton
+    users.users = if cfg.user != "git" then {} else singleton
       { name = "git";
         uid = config.ids.uids.git;
         description = "Git daemon user";
       };
 
-    users.extraGroups = if cfg.group != "git" then {} else singleton
+    users.groups = if cfg.group != "git" then {} else singleton
       { name = "git";
         gid = config.ids.gids.git;
       };

--- a/nixos/modules/services/networking/gnunet.nix
+++ b/nixos/modules/services/networking/gnunet.nix
@@ -126,7 +126,7 @@ in
 
   config = mkIf config.services.gnunet.enable {
 
-    users.extraUsers.gnunet = {
+    users.users.gnunet = {
       group = "gnunet";
       description = "GNUnet User";
       home = homeDir;
@@ -134,7 +134,7 @@ in
       uid = config.ids.uids.gnunet;
     };
 
-    users.extraGroups.gnunet.gid = config.ids.gids.gnunet;
+    users.groups.gnunet.gid = config.ids.gids.gnunet;
 
     # The user tools that talk to `gnunetd' should come from the same source,
     # so install them globally.

--- a/nixos/modules/services/networking/hans.nix
+++ b/nixos/modules/services/networking/hans.nix
@@ -135,7 +135,7 @@ in
       };
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = hansUser;
       description = "Hans daemon user";
     };

--- a/nixos/modules/services/networking/haproxy.nix
+++ b/nixos/modules/services/networking/haproxy.nix
@@ -52,11 +52,11 @@ with lib;
 
     environment.systemPackages = [ pkgs.haproxy ];
 
-    users.extraUsers.haproxy = {
+    users.users.haproxy = {
       group = "haproxy";
       uid = config.ids.uids.haproxy;
     };
 
-    users.extraGroups.haproxy.gid = config.ids.uids.haproxy;
+    users.groups.haproxy.gid = config.ids.uids.haproxy;
   };
 }

--- a/nixos/modules/services/networking/i2p.nix
+++ b/nixos/modules/services/networking/i2p.nix
@@ -11,14 +11,14 @@ in {
 
   ###### implementation
   config = mkIf cfg.enable {
-    users.extraUsers.i2p = {
+    users.users.i2p = {
       group = "i2p";
       description = "i2p User";
       home = homeDir;
       createHome = true;
       uid = config.ids.uids.i2p;
     };
-    users.extraGroups.i2p.gid = config.ids.gids.i2p;
+    users.groups.i2p.gid = config.ids.gids.i2p;
     systemd.services.i2p = {
       description = "I2P router with administration interface for hidden services";
       after = [ "network.target" ];

--- a/nixos/modules/services/networking/i2pd.nix
+++ b/nixos/modules/services/networking/i2pd.nix
@@ -456,7 +456,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.i2pd = {
+    users.users.i2pd = {
       group = "i2pd";
       description = "I2Pd User";
       home = homeDir;
@@ -464,7 +464,7 @@ in
       uid = config.ids.uids.i2pd;
     };
 
-    users.extraGroups.i2pd.gid = config.ids.gids.i2pd;
+    users.groups.i2pd.gid = config.ids.gids.i2pd;
 
     systemd.services.i2pd = {
       description = "Minimal I2P router";

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -140,11 +140,11 @@ in
       };
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = iodinedUser;
       uid = config.ids.uids.iodined;
       description = "Iodine daemon user";
     };
-    users.extraGroups.iodined.gid = config.ids.gids.iodined;
+    users.groups.iodined.gid = config.ids.gids.iodined;
   };
 }

--- a/nixos/modules/services/networking/ircd-hybrid/default.nix
+++ b/nixos/modules/services/networking/ircd-hybrid/default.nix
@@ -112,14 +112,14 @@ in
 
   config = mkIf config.services.ircdHybrid.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "ircd";
         description = "IRCD owner";
         group = "ircd";
         uid = config.ids.uids.ircd;
       };
 
-    users.extraGroups.ircd.gid = config.ids.gids.ircd;
+    users.groups.ircd.gid = config.ids.gids.ircd;
 
     systemd.services."ircd-hybrid" = {
       description = "IRCD Hybrid server";

--- a/nixos/modules/services/networking/kippo.nix
+++ b/nixos/modules/services/networking/kippo.nix
@@ -73,12 +73,12 @@ rec {
         ${cfg.extraConfig}
     '';
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "kippo";
       description = "kippo web server privilege separation user";
       uid = 108; # why does config.ids.uids.kippo give an error?
     };
-    users.extraGroups = singleton { name = "kippo";gid=108; };
+    users.groups = singleton { name = "kippo";gid=108; };
 
     systemd.services.kippo = with pkgs; {
       description = "Kippo Web Server";

--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -62,13 +62,13 @@ in
   config = mkIf cfg.enable {
     environment.etc."kresd.conf".source = configFile; # not required
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "kresd";
         uid = config.ids.uids.kresd;
         group = "kresd";
         description = "Knot-resolver daemon user";
       };
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "kresd";
         gid = config.ids.gids.kresd;
       };

--- a/nixos/modules/services/networking/lambdabot.nix
+++ b/nixos/modules/services/networking/lambdabot.nix
@@ -67,7 +67,7 @@ in
       };
     };
 
-    users.extraUsers.lambdabot = {
+    users.users.lambdabot = {
       group = "lambdabot";
       description = "Lambdabot daemon user";
       home = "/var/lib/lambdabot";
@@ -75,7 +75,7 @@ in
       uid = config.ids.uids.lambdabot;
     };
 
-    users.extraGroups.lambdabot.gid = config.ids.gids.lambdabot;
+    users.groups.lambdabot.gid = config.ids.gids.lambdabot;
 
   };
 

--- a/nixos/modules/services/networking/lldpd.nix
+++ b/nixos/modules/services/networking/lldpd.nix
@@ -20,13 +20,13 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers._lldpd = {
+    users.users._lldpd = {
       description = "lldpd user";
       group = "_lldpd";
       home = "/var/run/lldpd";
       isSystemUser = true;
     };
-    users.extraGroups._lldpd = {};
+    users.groups._lldpd = {};
 
     environment.systemPackages = [ pkgs.lldpd ];
     systemd.packages = [ pkgs.lldpd ];

--- a/nixos/modules/services/networking/mailpile.nix
+++ b/nixos/modules/services/networking/mailpile.nix
@@ -41,14 +41,14 @@ in
 
   config = mkIf config.services.mailpile.enable {
 
-    users.extraUsers.mailpile =
+    users.users.mailpile =
       { uid = config.ids.uids.mailpile;
         description = "Mailpile user";
         createHome = true;
         home = "/var/lib/mailpile";
       };
 
-    users.extraGroups.mailpile =
+    users.groups.mailpile =
       { gid = config.ids.gids.mailpile;
       };
 

--- a/nixos/modules/services/networking/matterbridge.nix
+++ b/nixos/modules/services/networking/matterbridge.nix
@@ -92,12 +92,12 @@ in
     warnings = optional options.services.matterbridge.configFile.isDefined
       "The option services.matterbridge.configFile is insecure and should be replaced with services.matterbridge.configPath";
 
-    users.extraUsers = optional (cfg.user == "matterbridge")
+    users.users = optional (cfg.user == "matterbridge")
       { name = "matterbridge";
         group = "matterbridge";
       };
 
-    users.extraGroups = optional (cfg.group == "matterbridge")
+    users.groups = optional (cfg.group == "matterbridge")
       { name = "matterbridge";
       };
 

--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -84,13 +84,13 @@ in
         '') cfg.mediaDirs}
       '';
 
-    users.extraUsers.minidlna = {
+    users.users.minidlna = {
       description = "MiniDLNA daemon user";
       group = "minidlna";
       uid = config.ids.uids.minidlna;
     };
 
-    users.extraGroups.minidlna.gid = config.ids.gids.minidlna;
+    users.groups.minidlna.gid = config.ids.gids.minidlna;
 
     systemd.services.minidlna =
       { description = "MiniDLNA Server";

--- a/nixos/modules/services/networking/mjpg-streamer.nix
+++ b/nixos/modules/services/networking/mjpg-streamer.nix
@@ -49,7 +49,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = optional (cfg.user == "mjpg-streamer") {
+    users.users = optional (cfg.user == "mjpg-streamer") {
       name = "mjpg-streamer";
       uid = config.ids.uids.mjpg-streamer;
       group = cfg.group;

--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -197,7 +197,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "monero";
       uid  = config.ids.uids.monero;
       description = "Monero daemon user";
@@ -205,7 +205,7 @@ in
       createHome = true;
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = "monero";
       gid  = config.ids.gids.monero;
     };

--- a/nixos/modules/services/networking/morty.nix
+++ b/nixos/modules/services/networking/morty.nix
@@ -72,7 +72,7 @@ in
 
   config = mkIf config.services.morty.enable {
 
-    users.extraUsers.morty =
+    users.users.morty =
       { description = "Morty user";
         createHome = true;
         home = "/var/lib/morty";

--- a/nixos/modules/services/networking/mosquitto.nix
+++ b/nixos/modules/services/networking/mosquitto.nix
@@ -218,7 +218,7 @@ in
         ) cfg.users);
     };
 
-    users.extraUsers.mosquitto = {
+    users.users.mosquitto = {
       description = "Mosquitto MQTT Broker Daemon owner";
       group = "mosquitto";
       uid = config.ids.uids.mosquitto;
@@ -226,7 +226,7 @@ in
       createHome = true;
     };
 
-    users.extraGroups.mosquitto.gid = config.ids.gids.mosquitto;
+    users.groups.mosquitto.gid = config.ids.gids.mosquitto;
 
   };
 }

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -238,7 +238,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.murmur = {
+    users.users.murmur = {
       description     = "Murmur Service user";
       home            = "/var/lib/murmur";
       createHome      = true;

--- a/nixos/modules/services/networking/namecoind.nix
+++ b/nixos/modules/services/networking/namecoind.nix
@@ -153,7 +153,7 @@ in
       config = ${configFile}
     '';
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "namecoin";
       uid  = config.ids.uids.namecoin;
       description = "Namecoin daemon user";
@@ -161,7 +161,7 @@ in
       createHome = true;
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = "namecoin";
       gid  = config.ids.gids.namecoin;
     };

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -366,7 +366,7 @@ in {
 
     environment.systemPackages = cfg.packages;
 
-    users.extraGroups = [{
+    users.groups = [{
       name = "networkmanager";
       gid = config.ids.gids.networkmanager;
     }
@@ -374,7 +374,7 @@ in {
       name = "nm-openvpn";
       gid = config.ids.gids.nm-openvpn;
     }];
-    users.extraUsers = [{
+    users.users = [{
       name = "nm-openvpn";
       uid = config.ids.uids.nm-openvpn;
       extraGroups = [ "networkmanager" ];

--- a/nixos/modules/services/networking/ngircd.nix
+++ b/nixos/modules/services/networking/ngircd.nix
@@ -51,7 +51,7 @@ in {
       serviceConfig.User = "ngircd";
     };
 
-    users.extraUsers.ngircd = {
+    users.users.ngircd = {
       uid = config.ids.uids.ngircd;
       description = "ngircd user.";
     };

--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -64,7 +64,7 @@ in
       };
     };
 
-    users.extraUsers.nix-serve = {
+    users.users.nix-serve = {
       description = "Nix-serve user";
       uid = config.ids.uids.nix-serve;
     };

--- a/nixos/modules/services/networking/nntp-proxy.nix
+++ b/nixos/modules/services/networking/nntp-proxy.nix
@@ -210,7 +210,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = proxyUser;
         uid = config.ids.uids.nntp-proxy;
         description = "NNTP-Proxy daemon user";

--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -897,12 +897,12 @@ in
 
     environment.systemPackages = [ nsdPkg ];
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = username;
       gid = config.ids.gids.nsd;
     };
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = username;
       description = "NSD service user";
       home = stateDir;

--- a/nixos/modules/services/networking/ntpd.nix
+++ b/nixos/modules/services/networking/ntpd.nix
@@ -67,7 +67,7 @@ in
     environment.systemPackages = [ pkgs.ntp ];
     services.timesyncd.enable = mkForce false;
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = ntpUser;
         uid = config.ids.uids.ntp;
         description = "NTP daemon user";

--- a/nixos/modules/services/networking/nylon.nix
+++ b/nixos/modules/services/networking/nylon.nix
@@ -151,7 +151,7 @@ in
 
   config = mkIf (length(enabledNylons) > 0) {
 
-    users.extraUsers.nylon = {
+    users.users.nylon = {
       group = "nylon";
       description = "Nylon SOCKS Proxy";
       home = homeDir;
@@ -159,7 +159,7 @@ in
       uid = config.ids.uids.nylon;
     };
 
-    users.extraGroups.nylon.gid = config.ids.gids.nylon;
+    users.groups.nylon.gid = config.ids.gids.nylon;
 
     systemd.services = fold (a: b: a // b) {} nylonUnits;
 

--- a/nixos/modules/services/networking/oidentd.nix
+++ b/nixos/modules/services/networking/oidentd.nix
@@ -32,13 +32,13 @@ with lib;
           optionalString config.networking.enableIPv6 " -a ::";
     };
 
-    users.extraUsers.oidentd = {
+    users.users.oidentd = {
       description = "Ident Protocol daemon user";
       group = "oidentd";
       uid = config.ids.uids.oidentd;
     };
 
-    users.extraGroups.oidentd.gid = config.ids.gids.oidentd;
+    users.groups.oidentd.gid = config.ids.gids.oidentd;
 
   };
 

--- a/nixos/modules/services/networking/openntpd.nix
+++ b/nixos/modules/services/networking/openntpd.nix
@@ -59,7 +59,7 @@ in
 
     environment.etc."ntpd.conf".text = configFile;
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "ntp";
       uid = config.ids.uids.ntp;
       description = "OpenNTP daemon user";

--- a/nixos/modules/services/networking/owamp.nix
+++ b/nixos/modules/services/networking/owamp.nix
@@ -17,13 +17,13 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "owamp";
       group = "owamp";
       description = "Owamp daemon";
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = "owamp";
     };
 

--- a/nixos/modules/services/networking/pdns-recursor.nix
+++ b/nixos/modules/services/networking/pdns-recursor.nix
@@ -128,7 +128,7 @@ in {
 
   config = mkIf cfg.enable {
 
-    users.extraUsers."${username}" = {
+    users.users."${username}" = {
       home = dataDir;
       createHome = true;
       uid = config.ids.uids.pdns-recursor;

--- a/nixos/modules/services/networking/pdnsd.nix
+++ b/nixos/modules/services/networking/pdnsd.nix
@@ -62,14 +62,14 @@ in
     };
 
   config = mkIf cfg.enable {
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = pdnsdUser;
       uid = config.ids.uids.pdnsd;
       group = pdnsdGroup;
       description = "pdnsd user";
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = pdnsdGroup;
       gid = config.ids.gids.pdnsd;
     };

--- a/nixos/modules/services/networking/polipo.nix
+++ b/nixos/modules/services/networking/polipo.nix
@@ -85,7 +85,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "polipo";
         uid = config.ids.uids.polipo;
         description = "Polipo caching proxy user";
@@ -93,7 +93,7 @@ in
         createHome = true;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "polipo";
         gid = config.ids.gids.polipo;
         members = [ "polipo" ];

--- a/nixos/modules/services/networking/prayer.nix
+++ b/nixos/modules/services/networking/prayer.nix
@@ -72,14 +72,14 @@ in
   config = mkIf config.services.prayer.enable {
     environment.systemPackages = [ prayer ];
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = prayerUser;
         uid = config.ids.uids.prayer;
         description = "Prayer daemon user";
         home = stateDir;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = prayerGroup;
         gid = config.ids.gids.prayer;
       };

--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -487,7 +487,7 @@ in
         '') cfg.virtualHosts) }
     '';
 
-    users.extraUsers.prosody = mkIf (cfg.user == "prosody") {
+    users.users.prosody = mkIf (cfg.user == "prosody") {
       uid = config.ids.uids.prosody;
       description = "Prosody user";
       createHome = true;
@@ -495,7 +495,7 @@ in
       home = "${cfg.dataDir}";
     };
 
-    users.extraGroups.prosody = mkIf (cfg.group == "prosody") {
+    users.groups.prosody = mkIf (cfg.group == "prosody") {
       gid = config.ids.gids.prosody;
     };
 

--- a/nixos/modules/services/networking/quassel.nix
+++ b/nixos/modules/services/networking/quassel.nix
@@ -72,14 +72,14 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = mkIf (cfg.user == null) [
+    users.users = mkIf (cfg.user == null) [
       { name = "quassel";
         description = "Quassel IRC client daemon";
         group = "quassel";
         uid = config.ids.uids.quassel;
       }];
 
-    users.extraGroups = mkIf (cfg.user == null) [
+    users.groups = mkIf (cfg.user == null) [
       { name = "quassel";
         gid = config.ids.gids.quassel;
       }];

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -59,7 +59,7 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "radicale";
         uid = config.ids.uids.radicale;
         description = "radicale user";
@@ -67,7 +67,7 @@ in
         createHome = true;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "radicale";
         gid = config.ids.gids.radicale;
       };

--- a/nixos/modules/services/networking/radvd.nix
+++ b/nixos/modules/services/networking/radvd.nix
@@ -52,7 +52,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.radvd =
+    users.users.radvd =
       { uid = config.ids.uids.radvd;
         description = "Router Advertisement Daemon User";
       };

--- a/nixos/modules/services/networking/rdnssd.nix
+++ b/nixos/modules/services/networking/rdnssd.nix
@@ -64,7 +64,7 @@ in
       };
     };
 
-    users.extraUsers.rdnssd = {
+    users.users.rdnssd = {
       description = "RDNSSD Daemon User";
       uid = config.ids.uids.rdnssd;
     };

--- a/nixos/modules/services/networking/resilio.nix
+++ b/nixos/modules/services/networking/resilio.nix
@@ -236,7 +236,7 @@ in
         }
       ];
 
-    users.extraUsers.rslsync = {
+    users.users.rslsync = {
       description     = "Resilio Sync Service user";
       home            = cfg.storagePath;
       createHome      = true;
@@ -244,7 +244,7 @@ in
       group           = "rslsync";
     };
 
-    users.extraGroups = [ { name = "rslsync"; } ];
+    users.groups = [ { name = "rslsync"; } ];
 
     systemd.services.resilio = with pkgs; {
       description = "Resilio Sync Service";

--- a/nixos/modules/services/networking/rpcbind.nix
+++ b/nixos/modules/services/networking/rpcbind.nix
@@ -37,7 +37,7 @@ with lib;
       wantedBy = [ "multi-user.target" ];
     };
 
-    users.extraUsers.rpc = {
+    users.users.rpc = {
       group = "nogroup";
       uid = config.ids.uids.rpc;
     };

--- a/nixos/modules/services/networking/sabnzbd.nix
+++ b/nixos/modules/services/networking/sabnzbd.nix
@@ -41,7 +41,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.sabnzbd = {
+    users.users.sabnzbd = {
           uid = config.ids.uids.sabnzbd;
           group = "sabnzbd";
           description = "sabnzbd user";
@@ -49,7 +49,7 @@ in
           createHome = true;
     };
 
-    users.extraGroups.sabnzbd = {
+    users.groups.sabnzbd = {
       gid = config.ids.gids.sabnzbd;
     };
 

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -47,14 +47,14 @@ in
 
   config = mkIf config.services.searx.enable {
 
-    users.extraUsers.searx =
+    users.users.searx =
       { uid = config.ids.uids.searx;
         description = "Searx user";
         createHome = true;
         home = "/var/lib/searx";
       };
 
-    users.extraGroups.searx =
+    users.groups.searx =
       { gid = config.ids.gids.searx;
       };
 

--- a/nixos/modules/services/networking/seeks.nix
+++ b/nixos/modules/services/networking/seeks.nix
@@ -46,14 +46,14 @@ in
 
   config = mkIf config.services.seeks.enable {
 
-    users.extraUsers.seeks =
+    users.users.seeks =
       { uid = config.ids.uids.seeks;
         description = "Seeks user";
         createHome = true;
         home = "/var/lib/seeks";
       };
 
-    users.extraGroups.seeks =
+    users.groups.seeks =
       { gid = config.ids.gids.seeks;
       };
 

--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -55,7 +55,7 @@ in
     services.avahi.publish.enable = true;
     services.avahi.publish.userServices = true;
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = cfg.user;
         description = "Shairport user";
         isSystemUser = true;

--- a/nixos/modules/services/networking/shout.nix
+++ b/nixos/modules/services/networking/shout.nix
@@ -82,7 +82,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "shout";
       uid = config.ids.uids.shout;
       description = "Shout daemon user";

--- a/nixos/modules/services/networking/smokeping.nix
+++ b/nixos/modules/services/networking/smokeping.nix
@@ -278,7 +278,7 @@ in
       "fping6".source = "${pkgs.fping}/bin/fping6";
     };
     environment.systemPackages = [ pkgs.fping ];
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = cfg.user;
       isNormalUser = false;
       isSystemUser = true;

--- a/nixos/modules/services/networking/sniproxy.nix
+++ b/nixos/modules/services/networking/sniproxy.nix
@@ -82,14 +82,14 @@ in
       };
     };
 
-    users.extraUsers = mkIf (cfg.user == "sniproxy") {
+    users.users = mkIf (cfg.user == "sniproxy") {
       sniproxy = {
         group = cfg.group;
         uid = config.ids.uids.sniproxy;
       };
     };
 
-    users.extraGroups = mkIf (cfg.group == "sniproxy") {
+    users.groups = mkIf (cfg.group == "sniproxy") {
       sniproxy = {
         gid = config.ids.gids.sniproxy;
       };

--- a/nixos/modules/services/networking/spiped.nix
+++ b/nixos/modules/services/networking/spiped.nix
@@ -171,8 +171,8 @@ in
       message   = "A pipe must either encrypt or decrypt";
     }) cfg.config;
 
-    users.extraGroups.spiped.gid = config.ids.gids.spiped;
-    users.extraUsers.spiped = {
+    users.groups.spiped.gid = config.ids.gids.spiped;
+    users.users.spiped = {
       description = "Secure Pipe Service user";
       group       = "spiped";
       uid         = config.ids.uids.spiped;

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -49,7 +49,7 @@ let
         ${concatMapStrings (f: readFile f + "\n") u.openssh.authorizedKeys.keyFiles}
       '';
     };
-    usersWithKeys = attrValues (flip filterAttrs config.users.extraUsers (n: u:
+    usersWithKeys = attrValues (flip filterAttrs config.users.users (n: u:
       length u.openssh.authorizedKeys.keys != 0 || length u.openssh.authorizedKeys.keyFiles != 0
     ));
   in listToAttrs (map mkAuthKeyFile usersWithKeys);
@@ -326,7 +326,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.sshd =
+    users.users.sshd =
       { isSystemUser = true;
         description = "SSH privilege separation user";
       };

--- a/nixos/modules/services/networking/supybot.nix
+++ b/nixos/modules/services/networking/supybot.nix
@@ -45,7 +45,7 @@ in
 
     environment.systemPackages = [ pkgs.pythonPackages.limnoria ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "supybot";
       uid = config.ids.uids.supybot;
       group = "supybot";
@@ -54,7 +54,7 @@ in
       createHome = true;
     };
 
-    users.extraGroups.supybot = {
+    users.groups.supybot = {
       name = "supybot";
       gid = config.ids.gids.supybot;
     };

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -103,7 +103,7 @@ in {
     systemd.packages = [ pkgs.syncthing ];
 
     users = mkIf (cfg.user == defaultUser) {
-      extraUsers."${defaultUser}" =
+      users."${defaultUser}" =
         { group = cfg.group;
           home  = cfg.dataDir;
           createHome = true;
@@ -111,7 +111,7 @@ in {
           description = "Syncthing daemon user";
         };
 
-      extraGroups."${defaultUser}".gid =
+      groups."${defaultUser}".gid =
         config.ids.gids.syncthing;
     };
 

--- a/nixos/modules/services/networking/tcpcrypt.nix
+++ b/nixos/modules/services/networking/tcpcrypt.nix
@@ -29,7 +29,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "tcpcryptd";
       uid = config.ids.uids.tcpcryptd;
       description = "tcpcrypt daemon user";

--- a/nixos/modules/services/networking/tinc.nix
+++ b/nixos/modules/services/networking/tinc.nix
@@ -209,7 +209,7 @@ in
       };
     in [ cli-wrappers ];
 
-    users.extraUsers = flip mapAttrs' cfg.networks (network: _:
+    users.users = flip mapAttrs' cfg.networks (network: _:
       nameValuePair ("tinc.${network}") ({
         description = "Tinc daemon user for ${network}";
         isSystemUser = true;

--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -32,7 +32,7 @@ with lib;
   config = mkIf config.services.tinydns.enable {
     environment.systemPackages = [ pkgs.djbdns ];
 
-    users.extraUsers.tinydns = {};
+    users.users.tinydns = {};
 
     systemd.services.tinydns = {
       description = "djbdns tinydns server";

--- a/nixos/modules/services/networking/tox-bootstrapd.nix
+++ b/nixos/modules/services/networking/tox-bootstrapd.nix
@@ -56,7 +56,7 @@ in
 
   config = mkIf config.services.toxBootstrapd.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "tox-bootstrapd";
         uid = config.ids.uids.tox-bootstrapd;
         description = "Tox bootstrap daemon user";

--- a/nixos/modules/services/networking/toxvpn.nix
+++ b/nixos/modules/services/networking/toxvpn.nix
@@ -57,7 +57,7 @@ with lib;
 
     environment.systemPackages = [ pkgs.toxvpn ];
 
-    users.extraUsers = {
+    users.users = {
       toxvpn = {
         uid        = config.ids.uids.toxvpn;
         home       = "/var/lib/toxvpn";

--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let cfg     = config.services.tvheadend;
-    pidFile = "${config.users.extraUsers.tvheadend.home}/tvheadend.pid";
+    pidFile = "${config.users.users.tvheadend.home}/tvheadend.pid";
 in
 
 {
@@ -25,7 +25,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.tvheadend = {
+    users.users.tvheadend = {
       description = "Tvheadend Service user";
       home        = "/var/lib/tvheadend";
       createHome  = true;

--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -114,7 +114,7 @@ in
 
   config = mkIf cfg.enable {
 
-    users.extraUsers.unifi = {
+    users.users.unifi = {
       uid = config.ids.uids.unifi;
       description = "UniFi controller daemon user";
       home = "${stateDir}";

--- a/nixos/modules/services/networking/vsftpd.nix
+++ b/nixos/modules/services/networking/vsftpd.nix
@@ -193,7 +193,7 @@ in
         message = "vsftpd: If forceLocalLoginsSSL or forceLocalDataSSL is true then a rsaCertFile must be provided!";
       };
 
-    users.extraUsers =
+    users.users =
       [ { name = "vsftpd";
           uid = config.ids.uids.vsftpd;
           description = "VSFTPD user";
@@ -207,7 +207,7 @@ in
           home = cfg.anonymousUserHome;
         };
 
-    users.extraGroups.ftp.gid = config.ids.gids.ftp;
+    users.groups.ftp.gid = config.ids.gids.ftp;
 
     # If you really have to access root via FTP use mkOverride or userlistDeny
     # = false and whitelist root

--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -402,7 +402,7 @@ in
       script = "${pkgs.znc}/bin/znc --foreground --datadir ${cfg.dataDir} ${toString cfg.extraFlags}";
     };
 
-    users.extraUsers = optional (cfg.user == defaultUser)
+    users.users = optional (cfg.user == defaultUser)
       { name = defaultUser;
         description = "ZNC server daemon owner";
         group = defaultUser;
@@ -411,7 +411,7 @@ in
         createHome = true;
       };
 
-    users.extraGroups = optional (cfg.user == defaultUser)
+    users.groups = optional (cfg.user == defaultUser)
       { name = defaultUser;
         gid = config.ids.gids.znc;
         members = [ defaultUser ];

--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -268,7 +268,7 @@ in
 
   config = mkIf config.services.printing.enable {
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "cups";
         uid = config.ids.uids.cups;
         group = "lp";

--- a/nixos/modules/services/scheduling/atd.nix
+++ b/nixos/modules/services/scheduling/atd.nix
@@ -57,14 +57,14 @@ in
 
     security.pam.services.atd = {};
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "atd";
         uid = config.ids.uids.atd;
         description = "atd user";
         home = "/var/empty";
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "atd";
         gid = config.ids.gids.atd;
       };

--- a/nixos/modules/services/scheduling/chronos.nix
+++ b/nixos/modules/services/scheduling/chronos.nix
@@ -49,6 +49,6 @@ in {
       };
     };
 
-    users.extraUsers.chronos.uid = config.ids.uids.chronos;
+    users.users.chronos.uid = config.ids.uids.chronos;
   };
 }

--- a/nixos/modules/services/scheduling/fcron.nix
+++ b/nixos/modules/services/scheduling/fcron.nix
@@ -115,7 +115,7 @@ in
       ];
 
     environment.systemPackages = [ pkgs.fcron ];
-    users.extraUsers.fcron = {
+    users.users.fcron = {
       uid = config.ids.uids.fcron;
       home = "/var/spool/fcron";
       group = "fcron";

--- a/nixos/modules/services/scheduling/marathon.nix
+++ b/nixos/modules/services/scheduling/marathon.nix
@@ -93,6 +93,6 @@ in {
       };
     };
 
-    users.extraUsers.${cfg.user} = { };
+    users.users.${cfg.user} = { };
   };
 }

--- a/nixos/modules/services/search/hound.nix
+++ b/nixos/modules/services/search/hound.nix
@@ -88,12 +88,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    users.extraGroups = optional (cfg.group == "hound") {
+    users.groups = optional (cfg.group == "hound") {
       name = "hound";
       gid = config.ids.gids.hound;
     };
 
-    users.extraUsers = optional (cfg.user == "hound") {
+    users.users = optional (cfg.user == "hound") {
       name = "hound";
       description = "hound code search";
       createHome = true;

--- a/nixos/modules/services/search/kibana.nix
+++ b/nixos/modules/services/search/kibana.nix
@@ -193,7 +193,7 @@ in {
 
     environment.systemPackages = [ cfg.package ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = "kibana";
       uid = config.ids.uids.kibana;
       description = "Kibana service user";

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -79,7 +79,7 @@ in
   config = mkIf (cfg.updater.enable || cfg.daemon.enable) {
     environment.systemPackages = [ pkg ];
 
-    users.extraUsers = singleton {
+    users.users = singleton {
       name = clamavUser;
       uid = config.ids.uids.clamav;
       group = clamavGroup;
@@ -87,7 +87,7 @@ in
       home = stateDir;
     };
 
-    users.extraGroups = singleton {
+    users.groups = singleton {
       name = clamavGroup;
       gid = config.ids.gids.clamav;
     };

--- a/nixos/modules/services/security/fprot.nix
+++ b/nixos/modules/services/security/fprot.nix
@@ -53,14 +53,14 @@ in {
       target = "f-prot.conf";
     };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = fprotUser;
         uid = config.ids.uids.fprot;
         description = "F-Prot daemon user";
         home = stateDir;
       };
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = fprotGroup;
         gid = config.ids.gids.fprot;
       };

--- a/nixos/modules/services/security/oauth2_proxy.nix
+++ b/nixos/modules/services/security/oauth2_proxy.nix
@@ -544,7 +544,7 @@ in
       cookie.secret = mkDefault null;
     };
 
-    users.extraUsers.oauth2_proxy = {
+    users.users.oauth2_proxy = {
       description = "OAuth2 Proxy";
     };
 

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -686,8 +686,8 @@ in
         always create a container/VM with a separate Tor daemon instance.
       '';
 
-    users.extraGroups.tor.gid = config.ids.gids.tor;
-    users.extraUsers.tor =
+    users.groups.tor.gid = config.ids.gids.tor;
+    users.users.tor =
       { description = "Tor Daemon User";
         createHome  = true;
         home        = torDirectory;

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -97,13 +97,13 @@ in
       }
     ];
 
-    users.extraUsers.vault = {
+    users.users.vault = {
       name = "vault";
       group = "vault";
       uid = config.ids.uids.vault;
       description = "Vault daemon user";
     };
-    users.extraGroups.vault.gid = config.ids.gids.vault;
+    users.groups.vault.gid = config.ids.gids.vault;
 
     systemd.services.vault = {
       description = "Vault server daemon";

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -71,14 +71,14 @@ in
         target = "dbus-1";
       };
 
-    users.extraUsers.messagebus = {
+    users.users.messagebus = {
       uid = config.ids.uids.messagebus;
       description = "D-Bus system message bus daemon user";
       home = homeDir;
       group = "messagebus";
     };
 
-    users.extraGroups.messagebus.gid = config.ids.gids.messagebus;
+    users.groups.messagebus.gid = config.ids.gids.messagebus;
 
     systemd.packages = [ pkgs.dbus.daemon ];
 

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -41,7 +41,7 @@ in
   config = mkIf cfg.enable {
     environment.etc."nscd.conf".text = cfg.config;
 
-    users.extraUsers.nscd =
+    users.users.nscd =
       { isSystemUser = true;
         description = "Name service cache daemon user";
       };

--- a/nixos/modules/services/system/uptimed.nix
+++ b/nixos/modules/services/system/uptimed.nix
@@ -20,7 +20,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.uptimed = {
+    users.users.uptimed = {
       description = "Uptimed daemon user";
       home        = stateDir;
       createHome  = true;

--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -55,7 +55,7 @@ in {
 
     environment.systemPackages = [ pkgs.deluge ];
 
-    users.extraUsers.deluge = {
+    users.users.deluge = {
       group = "deluge";
       uid = config.ids.uids.deluge;
       home = "/var/lib/deluge/";
@@ -63,6 +63,6 @@ in {
       description = "Deluge Daemon user";
     };
 
-    users.extraGroups.deluge.gid = config.ids.gids.deluge;
+    users.groups.deluge.gid = config.ids.gids.deluge;
   };
 }

--- a/nixos/modules/services/torrent/peerflix.nix
+++ b/nixos/modules/services/torrent/peerflix.nix
@@ -58,6 +58,6 @@ in {
       };
     };
 
-    users.extraUsers.peerflix.uid = config.ids.uids.peerflix;
+    users.users.peerflix.uid = config.ids.uids.peerflix;
   };
 }

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -113,8 +113,8 @@ in
     # It's useful to have transmission in path, e.g. for remote control
     environment.systemPackages = [ pkgs.transmission ];
 
-    users.extraGroups.transmission.gid = config.ids.gids.transmission;
-    users.extraUsers.transmission = {
+    users.groups.transmission.gid = config.ids.gids.transmission;
+    users.users.transmission = {
       group = "transmission";
       uid = config.ids.uids.transmission;
       description = "Transmission BitTorrent user";

--- a/nixos/modules/services/web-apps/atlassian/confluence.nix
+++ b/nixos/modules/services/web-apps/atlassian/confluence.nix
@@ -137,12 +137,12 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers."${cfg.user}" = {
+    users.users."${cfg.user}" = {
       isSystemUser = true;
       group = cfg.group;
     };
 
-    users.extraGroups."${cfg.group}" = {};
+    users.groups."${cfg.group}" = {};
 
     systemd.services.confluence = {
       description = "Atlassian Confluence";

--- a/nixos/modules/services/web-apps/atlassian/crowd.nix
+++ b/nixos/modules/services/web-apps/atlassian/crowd.nix
@@ -103,12 +103,12 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers."${cfg.user}" = {
+    users.users."${cfg.user}" = {
       isSystemUser = true;
       group = cfg.group;
     };
 
-    users.extraGroups."${cfg.group}" = {};
+    users.groups."${cfg.group}" = {};
 
     systemd.services.atlassian-crowd = {
       description = "Atlassian Crowd";

--- a/nixos/modules/services/web-apps/atlassian/jira.nix
+++ b/nixos/modules/services/web-apps/atlassian/jira.nix
@@ -141,12 +141,12 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers."${cfg.user}" = {
+    users.users."${cfg.user}" = {
       isSystemUser = true;
       group = cfg.group;
     };
 
-    users.extraGroups."${cfg.group}" = {};
+    users.groups."${cfg.group}" = {};
 
     systemd.services.atlassian-jira = {
       description = "Atlassian JIRA";

--- a/nixos/modules/services/web-apps/frab.nix
+++ b/nixos/modules/services/web-apps/frab.nix
@@ -174,14 +174,14 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ frab-rake ];
 
-    users.extraUsers = [
+    users.users = [
       { name = cfg.user;
         group = cfg.group;
         home = "${cfg.statePath}";
       }
     ];
 
-    users.extraGroups = [ { name = cfg.group; } ];
+    users.groups = [ { name = cfg.group; } ];
 
     systemd.services.frab = {
       after = [ "network.target" "gitlab.service" ];

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -109,13 +109,13 @@ in {
         message = "Either services.matomo.nginx or services.matomo.nginx.webServerUser is mandatory";
     }];
 
-    users.extraUsers.${user} = {
+    users.users.${user} = {
       isSystemUser = true;
       createHome = true;
       home = dataDir;
       group  = user;
     };
-    users.extraGroups.${user} = {};
+    users.groups.${user} = {};
 
     systemd.services.matomo_setup_update = {
       # everything needs to set up and up to date before matomo php files are executed

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -146,14 +146,14 @@ in
 
   config = mkMerge [
     (mkIf cfg.enable {
-      users.extraUsers = optionalAttrs (cfg.user == "mattermost") (singleton {
+      users.users = optionalAttrs (cfg.user == "mattermost") (singleton {
         name = "mattermost";
         group = cfg.group;
         uid = config.ids.uids.mattermost;
         home = cfg.statePath;
       });
 
-      users.extraGroups = optionalAttrs (cfg.group == "mattermost") (singleton {
+      users.groups = optionalAttrs (cfg.group == "mattermost") (singleton {
         name = "mattermost";
         gid = config.ids.gids.mattermost;
       });

--- a/nixos/modules/services/web-apps/nexus.nix
+++ b/nixos/modules/services/web-apps/nexus.nix
@@ -80,12 +80,12 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers."${cfg.user}" = {
+    users.users."${cfg.user}" = {
       isSystemUser = true;
       group = cfg.group;
     };
 
-    users.extraGroups."${cfg.group}" = {};
+    users.groups."${cfg.group}" = {};
 
     systemd.services.nexus = {
       description = "Sonatype Nexus3";

--- a/nixos/modules/services/web-apps/restya-board.nix
+++ b/nixos/modules/services/web-apps/restya-board.nix
@@ -358,13 +358,13 @@ in
       '';
     };
 
-    users.extraUsers.restya-board = {
+    users.users.restya-board = {
       isSystemUser = true;
       createHome = false;
       home = runDir;
       group  = "restya-board";
     };
-    users.extraGroups.restya-board = {};
+    users.groups.restya-board = {};
 
     services.postgresql.enable = mkIf (isNull cfg.database.host) true;
 

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -624,8 +624,8 @@ let
     };
 
     users = optionalAttrs (cfg.user == "tt_rss") {
-      extraUsers.tt_rss.group = "tt_rss";
-      extraGroups.tt_rss = {};
+      users.tt_rss.group = "tt_rss";
+      groups.tt_rss = {};
     };
   };
 }

--- a/nixos/modules/services/web-apps/virtlyst.nix
+++ b/nixos/modules/services/web-apps/virtlyst.nix
@@ -50,7 +50,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.extraUsers.virtlyst = {
+    users.users.virtlyst = {
       home = stateDir;
       createHome = true;
       group = mkIf config.virtualisation.libvirtd.enable "libvirtd";

--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -658,14 +658,14 @@ in
 
     warnings = map (cfg: ''apache-httpd's port option is deprecated. Use listen = [{/*ip = "*"; */ port = ${toString cfg.port}";}]; instead'' ) (lib.filter (cfg: cfg.port != 0) allHosts);
 
-    users.extraUsers = optionalAttrs (mainCfg.user == "wwwrun") (singleton
+    users.users = optionalAttrs (mainCfg.user == "wwwrun") (singleton
       { name = "wwwrun";
         group = mainCfg.group;
         description = "Apache httpd user";
         uid = config.ids.uids.wwwrun;
       });
 
-    users.extraGroups = optionalAttrs (mainCfg.group == "wwwrun") (singleton
+    users.groups = optionalAttrs (mainCfg.group == "wwwrun") (singleton
       { name = "wwwrun";
         gid = config.ids.gids.wwwrun;
       });

--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -93,13 +93,13 @@ in {
       };
     };
 
-    users.extraUsers.caddy = {
+    users.users.caddy = {
       group = "caddy";
       uid = config.ids.uids.caddy;
       home = cfg.dataDir;
       createHome = true;
     };
 
-    users.extraGroups.caddy.gid = config.ids.uids.caddy;
+    users.groups.caddy.gid = config.ids.uids.caddy;
   };
 }

--- a/nixos/modules/services/web-servers/hitch/default.nix
+++ b/nixos/modules/services/web-servers/hitch/default.nix
@@ -102,7 +102,7 @@ with lib;
 
     environment.systemPackages = [ pkgs.hitch ];
 
-    users.extraUsers.hitch.group = "hitch";
-    users.extraGroups.hitch = {};
+    users.users.hitch.group = "hitch";
+    users.groups.hitch = {};
   };
 }

--- a/nixos/modules/services/web-servers/lighttpd/default.nix
+++ b/nixos/modules/services/web-servers/lighttpd/default.nix
@@ -245,12 +245,12 @@ in
       serviceConfig.KillSignal = "SIGINT";
     };
 
-    users.extraUsers.lighttpd = {
+    users.users.lighttpd = {
       group = "lighttpd";
       description = "lighttpd web server privilege separation user";
       uid = config.ids.uids.lighttpd;
     };
 
-    users.extraGroups.lighttpd.gid = config.ids.gids.lighttpd;
+    users.groups.lighttpd.gid = config.ids.gids.lighttpd;
   };
 }

--- a/nixos/modules/services/web-servers/lighttpd/inginious.nix
+++ b/nixos/modules/services/web-servers/lighttpd/inginious.nix
@@ -194,7 +194,7 @@ in
           storageDriver = mkDefault "overlay";
         };
 
-        users.extraUsers."lighttpd".extraGroups = [ "docker" ];
+        users.users."lighttpd".extraGroups = [ "docker" ];
 
         # Ensure that docker has pulled the required images.
         systemd.services.inginious-prefetch = {

--- a/nixos/modules/services/web-servers/meguca.nix
+++ b/nixos/modules/services/web-servers/meguca.nix
@@ -139,7 +139,7 @@ in
     };
 
     users = {
-      extraUsers.meguca = {
+      users.meguca = {
         description = "meguca server service user";
         home = cfg.baseDir;
         createHome = true;
@@ -147,7 +147,7 @@ in
         uid = config.ids.uids.meguca;
       };
 
-      extraGroups.meguca = {
+      groups.meguca = {
         gid = config.ids.gids.meguca;
         members = [ "meguca" ];
       };

--- a/nixos/modules/services/web-servers/mighttpd2.nix
+++ b/nixos/modules/services/web-servers/mighttpd2.nix
@@ -119,13 +119,13 @@ in {
       };
     };
 
-    users.extraUsers.mighttpd2 = {
+    users.users.mighttpd2 = {
       group = "mighttpd2";
       uid = config.ids.uids.mighttpd2;
       isSystemUser = true;
     };
 
-    users.extraGroups.mighttpd2.gid = config.ids.gids.mighttpd2;
+    users.groups.mighttpd2.gid = config.ids.gids.mighttpd2;
   };
 
   meta.maintainers = with lib.maintainers; [ fgaz ];

--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -101,11 +101,11 @@ in
       };
     };
 
-    users.extraUsers.minio = {
+    users.users.minio = {
       group = "minio";
       uid = config.ids.uids.minio;
     };
 
-    users.extraGroups.minio.gid = config.ids.uids.minio;
+    users.groups.minio.gid = config.ids.uids.minio;
   };
 }

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -613,13 +613,13 @@ in
         listToAttrs acmePairs
     );
 
-    users.extraUsers = optionalAttrs (cfg.user == "nginx") (singleton
+    users.users = optionalAttrs (cfg.user == "nginx") (singleton
       { name = "nginx";
         group = cfg.group;
         uid = config.ids.uids.nginx;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "nginx") (singleton
+    users.groups = optionalAttrs (cfg.group == "nginx") (singleton
       { name = "nginx";
         gid = config.ids.gids.nginx;
       });

--- a/nixos/modules/services/web-servers/tomcat.nix
+++ b/nixos/modules/services/web-servers/tomcat.nix
@@ -166,12 +166,12 @@ in
 
   config = mkIf config.services.tomcat.enable {
 
-    users.extraGroups = singleton
+    users.groups = singleton
       { name = "tomcat";
         gid = config.ids.gids.tomcat;
       };
 
-    users.extraUsers = singleton
+    users.users = singleton
       { name = "tomcat";
         uid = config.ids.uids.tomcat;
         description = "Tomcat user";

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -114,12 +114,12 @@ in {
       };
     };
 
-    users.extraUsers.traefik = {
+    users.users.traefik = {
       group = "traefik";
       home = cfg.dataDir;
       createHome = true;
     };
 
-    users.extraGroups.traefik = {};
+    users.groups.traefik = {};
   };
 }

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -150,13 +150,13 @@ in {
       };
     };
 
-    users.extraUsers = optionalAttrs (cfg.user == "uwsgi") (singleton
+    users.users = optionalAttrs (cfg.user == "uwsgi") (singleton
       { name = "uwsgi";
         group = cfg.group;
         uid = config.ids.uids.uwsgi;
       });
 
-    users.extraGroups = optionalAttrs (cfg.group == "uwsgi") (singleton
+    users.groups = optionalAttrs (cfg.group == "uwsgi") (singleton
       { name = "uwsgi";
         gid = config.ids.gids.uwsgi;
       });

--- a/nixos/modules/services/web-servers/varnish/default.nix
+++ b/nixos/modules/services/web-servers/varnish/default.nix
@@ -103,11 +103,11 @@ in
       })
     ];
 
-    users.extraUsers.varnish = {
+    users.users.varnish = {
       group = "varnish";
       uid = config.ids.uids.varnish;
     };
 
-    users.extraGroups.varnish.gid = config.ids.uids.varnish;
+    users.groups.varnish.gid = config.ids.uids.varnish;
   };
 }

--- a/nixos/modules/services/web-servers/zope2.nix
+++ b/nixos/modules/services/web-servers/zope2.nix
@@ -103,7 +103,7 @@ in
 
   config = mkIf (cfg.instances != {}) {
 
-    users.extraUsers.zope2.uid = config.ids.uids.zope2;
+    users.users.zope2.uid = config.ids.uids.zope2;
 
     systemd.services =
       let

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -89,7 +89,7 @@ in
 
     services.xserver.displayManager.slim.enable = false;
 
-    users.extraUsers.gdm =
+    users.users.gdm =
       { name = "gdm";
         uid = config.ids.uids.gdm;
         group = "gdm";
@@ -97,7 +97,7 @@ in
         description = "GDM user";
       };
 
-    users.extraGroups.gdm.gid = config.ids.gids.gdm;
+    users.groups.gdm.gid = config.ids.gids.gdm;
 
     # GDM needs different xserverArgs, presumable because using wayland by default.
     services.xserver.tty = null;

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -42,7 +42,7 @@ let
     ''
       [LightDM]
       ${optionalString cfg.greeter.enable ''
-        greeter-user = ${config.users.extraUsers.lightdm.name}
+        greeter-user = ${config.users.users.lightdm.name}
         greeters-directory = ${cfg.greeter.package}
       ''}
       sessions-directory = ${dmcfg.session.desktops}
@@ -252,14 +252,14 @@ in
         session  include   lightdm
     '';
 
-    users.extraUsers.lightdm = {
+    users.users.lightdm = {
       createHome = true;
       home = "/var/lib/lightdm-data";
       group = "lightdm";
       uid = config.ids.uids.lightdm;
     };
 
-    users.extraGroups.lightdm.gid = config.ids.gids.lightdm;
+    users.groups.lightdm.gid = config.ids.gids.lightdm;
     services.xserver.tty     = null; # We might start multiple X servers so let the tty increment themselves..
     services.xserver.display = null; # We specify our own display (and logfile) in xserver-wrapper up there
   };

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -268,7 +268,7 @@ in
       '';
     };
 
-    users.extraUsers.sddm = {
+    users.users.sddm = {
       createHome = true;
       home = "/var/lib/sddm";
       group = "sddm";
@@ -277,7 +277,7 @@ in
 
     environment.etc."sddm.conf".source = cfgFile;
 
-    users.extraGroups.sddm.gid = config.ids.gids.sddm;
+    users.groups.sddm.gid = config.ids.gids.sddm;
 
     environment.systemPackages = [ sddm ];
     services.dbus.packages = [ sddm ];

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -79,7 +79,7 @@ in
 
     boot.initrd.network.ssh.authorizedKeys = mkOption {
       type = types.listOf types.str;
-      default = config.users.extraUsers.root.openssh.authorizedKeys.keys;
+      default = config.users.users.root.openssh.authorizedKeys.keys;
       description = ''
         Authorized keys for the root user on initrd.
       '';

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -798,13 +798,13 @@ in
         mkdir -m 0700 -p /var/log/journal
       '';
 
-    users.extraUsers.systemd-network.uid = config.ids.uids.systemd-network;
-    users.extraGroups.systemd-network.gid = config.ids.gids.systemd-network;
-    users.extraUsers.systemd-resolve.uid = config.ids.uids.systemd-resolve;
-    users.extraGroups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
+    users.users.systemd-network.uid = config.ids.uids.systemd-network;
+    users.groups.systemd-network.gid = config.ids.gids.systemd-network;
+    users.users.systemd-resolve.uid = config.ids.uids.systemd-resolve;
+    users.groups.systemd-resolve.gid = config.ids.gids.systemd-resolve;
 
     # Target for ‘charon send-keys’ to hook into.
-    users.extraGroups.keys.gid = config.ids.gids.keys;
+    users.groups.keys.gid = config.ids.gids.keys;
 
     systemd.targets.keys =
       { description = "Security Keys";
@@ -840,9 +840,9 @@ in
         "TMPFS_XATTR" "SECCOMP"
       ];
 
-    users.extraGroups.systemd-journal.gid = config.ids.gids.systemd-journal;
-    users.extraUsers.systemd-journal-gateway.uid = config.ids.uids.systemd-journal-gateway;
-    users.extraGroups.systemd-journal-gateway.gid = config.ids.gids.systemd-journal-gateway;
+    users.groups.systemd-journal.gid = config.ids.gids.systemd-journal;
+    users.users.systemd-journal-gateway.uid = config.ids.uids.systemd-journal-gateway;
+    users.groups.systemd-journal-gateway.gid = config.ids.gids.systemd-journal-gateway;
 
     # Generate timer units for all services that have a ‘startAt’ value.
     systemd.timers =

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -37,8 +37,8 @@ with lib;
       NTP=${concatStringsSep " " config.services.timesyncd.servers}
     '';
 
-    users.extraUsers.systemd-timesync.uid = config.ids.uids.systemd-timesync;
-    users.extraGroups.systemd-timesync.gid = config.ids.gids.systemd-timesync;
+    users.users.systemd-timesync.uid = config.ids.uids.systemd-timesync;
+    users.groups.systemd-timesync.gid = config.ids.gids.systemd-timesync;
 
   };
 

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -126,7 +126,7 @@ in
     networking.usePredictableInterfaceNames = false;
 
     # Make it easy to log in as root when running the test interactively.
-    users.extraUsers.root.initialHashedPassword = mkOverride 150 "";
+    users.users.root.initialHashedPassword = mkOverride 150 "";
 
     services.xserver.displayManager.job.logToJournal = true;
 

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -141,7 +141,7 @@ in
 
   config = mkIf cfg.enable (mkMerge [{
       environment.systemPackages = [ cfg.package ];
-      users.extraGroups.docker.gid = config.ids.gids.docker;
+      users.groups.docker.gid = config.ids.gids.docker;
       systemd.packages = [ cfg.package ];
 
       systemd.services.docker = {

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -108,7 +108,7 @@ in {
 
     boot.kernelModules = [ "tun" ];
 
-    users.extraGroups.libvirtd.gid = config.ids.gids.libvirtd;
+    users.groups.libvirtd.gid = config.ids.gids.libvirtd;
 
     systemd.packages = [ pkgs.libvirt ];
 

--- a/nixos/modules/virtualisation/lxc-container.nix
+++ b/nixos/modules/virtualisation/lxc-container.nix
@@ -8,7 +8,7 @@ with lib;
   ];
 
   # Allow the user to login as root without password.
-  users.extraUsers.root.initialHashedPassword = mkOverride 150 "";
+  users.users.root.initialHashedPassword = mkOverride 150 "";
 
   # Some more help text.
   services.mingetty.helpLine =

--- a/nixos/modules/virtualisation/lxd.nix
+++ b/nixos/modules/virtualisation/lxd.nix
@@ -73,9 +73,9 @@ in
 
     };
 
-    users.extraGroups.lxd.gid = config.ids.gids.lxd;
+    users.groups.lxd.gid = config.ids.gids.lxd;
 
-    users.extraUsers.root = {
+    users.users.root = {
       subUidRanges = [ { startUid = 1000000; count = 65536; } ];
       subGidRanges = [ { startGid = 1000000; count = 65536; } ];
     };

--- a/nixos/modules/virtualisation/rkt.nix
+++ b/nixos/modules/virtualisation/rkt.nix
@@ -59,6 +59,6 @@ in
       };
     };
 
-    users.extraGroups.rkt = {};
+    users.groups.rkt = {};
   };
 }

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -44,7 +44,7 @@ in
     boot.supportedFilesystems = [ "vboxsf" ];
     boot.initrd.supportedFilesystems = [ "vboxsf" ];
 
-    users.extraGroups.vboxsf.gid = config.ids.gids.vboxsf;
+    users.groups.vboxsf.gid = config.ids.gids.vboxsf;
 
     systemd.services.virtualbox =
       { description = "VirtualBox Guest Services";

--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -86,7 +86,7 @@ in
       "VirtualBox"
     ]));
 
-    users.extraGroups.vboxusers.gid = config.ids.gids.vboxusers;
+    users.groups.vboxusers.gid = config.ids.gids.vboxusers;
 
     services.udev.extraRules =
       ''

--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -9,7 +9,7 @@ import ./make-test.nix ({ pkgs, lib, ... }:
   machine =
     { config, pkgs, ... }:
     { services.atd.enable = true;
-      users.extraUsers.alice = { isNormalUser = true; };
+      users.users.alice = { isNormalUser = true; };
     };
 
   # "at" has a resolution of 1 minute

--- a/nixos/tests/common/user-account.nix
+++ b/nixos/tests/common/user-account.nix
@@ -1,12 +1,12 @@
 { lib, ... }:
 
-{ users.extraUsers.alice =
+{ users.users.alice =
     { isNormalUser = true;
       description = "Alice Foobar";
       password = "foobar";
     };
 
-  users.extraUsers.bob =
+  users.users.bob =
     { isNormalUser = true;
       description = "Bob Foobar";
       password = "foobar";

--- a/nixos/tests/gitolite.nix
+++ b/nixos/tests/gitolite.nix
@@ -78,8 +78,8 @@ in
             # there's nobody around that can input password
             PreferredAuthentications publickey
         '';
-        users.extraUsers.alice = { isNormalUser = true; };
-        users.extraUsers.bob = { isNormalUser = true; };
+        users.users.alice = { isNormalUser = true; };
+        users.users.bob = { isNormalUser = true; };
       };
 
   };

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -43,7 +43,7 @@ let
           boot.loader.systemd-boot.enable = true;
         ''}
 
-        users.extraUsers.alice = {
+        users.users.alice = {
           isNormalUser = true;
           home = "/home/alice";
           description = "Alice Foobar";

--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -18,7 +18,7 @@ import ./make-test.nix ({ pkgs, ...} : {
         # should have no effect
         services.jenkinsSlave.enable = true;
 
-        users.extraUsers.jenkins.extraGroups = [ "users" ];
+        users.users.jenkins.extraGroups = [ "users" ];
 
         systemd.services.jenkins.serviceConfig.TimeoutStartSec = "6min";
       };
@@ -27,7 +27,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       { config, pkgs, ... }:
       { services.jenkinsSlave.enable = true;
 
-        users.extraUsers.jenkins.extraGroups = [ "users" ];
+        users.users.jenkins.extraGroups = [ "users" ];
       };
 
   };

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -16,7 +16,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   enableOCR = true;
 
   testScript = { nodes, ... }: let
-    user = nodes.machine.config.users.extraUsers.alice;
+    user = nodes.machine.config.users.users.alice;
   in ''
     startAll;
     $machine->waitForText(qr/${user.description}/);

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -17,7 +17,7 @@ in {
         services.openssh.enable = true;
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
-        users.extraUsers.root.openssh.authorizedKeys.keys = [
+        users.users.root.openssh.authorizedKeys.keys = [
           snakeOilPublicKey
         ];
       };
@@ -29,7 +29,7 @@ in {
         services.openssh = { enable = true; startWhenNeeded = true; };
         security.pam.services.sshd.limits =
           [ { domain = "*"; item = "memlock"; type = "-"; value = 1024; } ];
-        users.extraUsers.root.openssh.authorizedKeys.keys = [
+        users.users.root.openssh.authorizedKeys.keys = [
           snakeOilPublicKey
         ];
       };

--- a/nixos/tests/pam-oath-login.nix
+++ b/nixos/tests/pam-oath-login.nix
@@ -30,7 +30,7 @@ in
         enable = true;
       };
 
-      users.extraUsers.alice = {
+      users.users.alice = {
         isNormalUser = true;
         name = "alice";
         uid = 1000;

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -41,7 +41,7 @@ import ./make-test.nix ({ pkgs, ...} :
   enableOCR = true;
 
   testScript = { nodes, ... }: let
-    user = nodes.machine.config.users.extraUsers.alice;
+    user = nodes.machine.config.users.users.alice;
     xdo = "${pkgs.xdotool}/bin/xdotool";
   in ''
     startAll;

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -21,7 +21,7 @@ let
       enableOCR = true;
 
       testScript = { nodes, ... }: let
-        user = nodes.machine.config.users.extraUsers.alice;
+        user = nodes.machine.config.users.users.alice;
       in ''
         startAll;
         $machine->waitForText(qr/select your user/i);

--- a/nixos/tests/slim.nix
+++ b/nixos/tests/slim.nix
@@ -48,7 +48,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   enableOCR = true;
 
   testScript = { nodes, ... }: let
-    user = nodes.machine.config.users.extraUsers.alice;
+    user = nodes.machine.config.users.users.alice;
   in ''
     startAll;
     $machine->waitForText(qr/Username:/);

--- a/nixos/tests/sudo.nix
+++ b/nixos/tests/sudo.nix
@@ -14,7 +14,7 @@ in
       { config, lib, pkgs, ... }:
       with lib;
       {
-        users.extraGroups = { foobar = {}; barfoo = {}; baz = { gid = 1337; }; };
+        users.groups = { foobar = {}; barfoo = {}; baz = { gid = 1337; }; };
         users.users = {
           test0 = { isNormalUser = true; extraGroups = [ "wheel" ]; };
           test1 = { isNormalUser = true; password = password; };

--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -334,7 +334,7 @@ let
       virtualisation.memorySize = 2048;
       virtualisation.virtualbox.host.enable = true;
       services.xserver.displayManager.auto.user = "alice";
-      users.extraUsers.alice.extraGroups = let
+      users.users.alice.extraGroups = let
         inherit (config.virtualisation.virtualbox.host) enableHardening;
       in lib.mkIf enableHardening (lib.singleton "vboxusers");
     };


### PR DESCRIPTION
###### Motivation for this change
Followup of #42746, now replacing usages of `users.extraUsers` and `users.extraGroups` with `users.users` and `users.groups`.

This is more than a quick search/replace, as there's valid uses for `extraGroups` (either as option in other modules or as `users.users.<name?>.extraGroups`, so please have a very cautious look.
I did run some tests on my machine, but can't run all.

/cc @volth, @xeji 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

