### PR TITLE
gnuradio: fix issues with last pr

### DIFF
--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, writeText, makeWrapper
 # Dependencies documented @ https://gnuradio.org/doc/doxygen/build_guide.html
 # => core dependencies
-, ninja, cmake, pkgconfig, git, boost, cppunit, fftw
+, cmake, pkgconfig, git, boost, cppunit, fftw
 # => python wrappers
 # May be able to upgrade to swig3
 , python, swig2, numpy, scipy, matplotlib
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake pkgconfig git makeWrapper cppunit orc ninja
+    cmake pkgconfig git makeWrapper cppunit orc
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/gnuradio/default.nix
+++ b/pkgs/applications/misc/gnuradio/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     owner = "gnuradio";
     repo = "gnuradio";
     rev = "v${version}";
-    sha256 = "0fqxn1k41xqd52i5z528zdhkn52i9z5hl6cc75ggdx9iqxhvb3jj";
+    sha256 = "1qpa53axqavdv2ykby7rwh7xmhvv964xq1d7rcvbwkry7dngrbib";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fixes arglist error and hash error from #41431
cc @matthewbauer 
Again, sorry about that. :/
nox-review completed on my macOS and NixOS machine
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

