### PR TITLE
android-studio: added libGL as a dependency

### DIFF
--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -16,6 +16,7 @@
 , fontconfig
 , freetype
 , libpulseaudio
+, libGL
 , libX11
 , libXext
 , libXi
@@ -97,6 +98,7 @@ let
           # For Android emulator
           libpulseaudio
           libX11
+          libGL
 
           # For GTKLookAndFeel
           gtk2


### PR DESCRIPTION
Without it, when starting an android emulator in some cases results in the
cryptic, "KVM is required to run this AVD. Unknown Error"

Fixes #41703

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)

[tim@yellowhat:/tmp]$ nix path-info -S /nix/store/4w909w03cins88cqakrfcym01x18sq6s-android-studio-3.1.3.0
/nix/store/4w909w03cins88cqakrfcym01x18sq6s-android-studio-3.1.3.0	 2031010152

[tim@yellowhat:/tmp]$ nix path-info -S /nix/store/4im0dc58zpy4av98ydcylvjaxbsxmmjg-android-studio-3.1.3.0
/nix/store/4im0dc58zpy4av98ydcylvjaxbsxmmjg-android-studio-3.1.3.0	 2031011264


- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

