### PR TITLE
python.pkgs.pybrowserid: move expression and  0.9.2 -> 0.14.0

### DIFF
--- a/pkgs/development/python-modules/pybrowserid/default.nix
+++ b/pkgs/development/python-modules/pybrowserid/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, requests, mock }:
+
+buildPythonPackage rec {
+  pname = "PyBrowserID";
+  version = "0.14.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qvi79kfb8x9kxkm5lw2mp42hm82cpps1xknmsb5ghkwx1lpc8kc";
+  };
+
+  propagatedBuildInputs = [ requests ];
+
+  checkInputs = [ mock ];
+
+  meta = with stdenv.lib; {
+    description = "Python library for the BrowserID Protocol";
+    homepage    = https://github.com/mozilla/PyBrowserID;
+    license     = licenses.mpl20;
+    maintainers = with maintainers; [ worldofpeace ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15507,28 +15507,7 @@ EOF
 
   libarcus = callPackage ../development/python-modules/libarcus { };
 
-  pybrowserid = buildPythonPackage rec {
-    name = "PyBrowserID-${version}";
-    version = "0.9.2";
-    disabled = isPy3k; # Errors in the test suite.
-
-    src = pkgs.fetchgit {
-      url = https://github.com/mozilla/PyBrowserID.git;
-      rev = "refs/tags/${version}";
-      sha256 = "0zsljr45gm8a4c0lxh6mgfc60a5fijhs4pwijb9fdkq16zw0pmf0";
-    };
-
-    doCheck = false;  # some tests use networking
-
-    buildInputs = with self; [ mock unittest2 ];
-    propagatedBuildInputs = with self; [ requests ];
-
-    meta = {
-      description = "Python library for the BrowserID Protocol";
-      homepage    = "https://github.com/mozilla/PyBrowserID";
-      license     = licenses.mpl20;
-    };
-  };
+  pybrowserid = callPackage ../development/python-modules/pybrowserid { };
 
   pyzmq = callPackage ../development/python-modules/pyzmq { };
 


### PR DESCRIPTION
###### Motivation for this change
Some cleaning

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

