### PR TITLE
pythonPackages.pdfx: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/pdfx/default.nix
+++ b/pkgs/development/python-modules/pdfx/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pdfminer, chardet, pytest }:
+
+buildPythonPackage rec {
+  pname = "pdfx";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "metachris";
+    repo = "pdfx";
+    rev = "v${version}";
+    sha256 = "1183k4h5qdf8y0imbir9ja3yzzsvdmqgbv3bi6dnkgr1wy2xfr0v";
+  };
+
+  # Remove after https://github.com/metachris/pdfx/pull/28
+  prePatch = ''
+    sed -i -e "s|pdfminer2|pdfminer.six|" setup.py
+  '';
+
+  propagatedBuildInputs = [ pdfminer chardet ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Extract references (pdf, url, doi, arxiv) and metadata from a PDF";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -335,6 +335,8 @@ in {
 
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };
 
+  pdfx = callPackage ../development/python-modules/pdfx { };
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

