### PR TITLE
appleseed, structure-synth, luxcorerender: libGLU instead of mesa_glu

### DIFF
--- a/pkgs/development/compilers/seexpr/default.nix
+++ b/pkgs/development/compilers/seexpr/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, libpng, zlib, qt4,
-bison, flex, mesa_glu, pythonPackages
+bison, flex, libGLU, pythonPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0a44k56jf6dl36fwgg4zpc252wq5lf9cblg74mp73k82hxw439l4";
   };
 
-  buildInputs = [ cmake mesa_glu libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
+  buildInputs = [ cmake libGLU libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
   meta = with stdenv.lib; {
     description = "Embeddable expression evaluation engine from Disney Animation";
     homepage = https://www.disneyanimation.com/technology/seexpr.html;

--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, guile,
-eigen3_3, libpng, python, mesa_glu, qt4, openexr, openimageio,
+eigen3_3, libpng, python, libGLU, qt4, openexr, openimageio,
 opencolorio, xercesc, ilmbase, osl, seexpr
 }:
 
@@ -17,7 +17,7 @@ in stdenv.mkDerivation rec {
   };
   buildInputs = [
     cmake pkgconfig boost_static guile eigen3_3 libpng python
-    mesa_glu qt4 openexr openimageio opencolorio xercesc
+    libGLU qt4 openexr openimageio opencolorio xercesc
     osl seexpr
   ];
 

--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, python35
 , tbb, openimageio, libjpeg, libpng, zlib, libtiff, ilmbase
 , freetype, openexr, libXdmcp, libxkbcommon, epoxy, at-spi2-core
-, dbus, doxygen, qt5, c-blosc, mesa_glu, gnome3, pcre
+, dbus, doxygen, qt5, c-blosc, libGLU, gnome3, pcre
 , bison, flex, libpthreadstubs, libX11
 , embree2, makeWrapper, gsettings_desktop_schemas, glib
 , withOpenCL ? true , opencl-headers, ocl-icd, opencl-clhpp
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
   buildInputs =
    [ embree2 pkgconfig cmake zlib boost_static libjpeg
      libtiff libpng ilmbase freetype openexr openimageio
-     tbb qt5.full c-blosc mesa_glu pcre bison
+     tbb qt5.full c-blosc libGLU pcre bison
      flex libX11 libpthreadstubs python35 libXdmcp libxkbcommon
      epoxy at-spi2-core dbus doxygen
      # needed for GSETTINGS_SCHEMAS_PATH

--- a/pkgs/tools/graphics/structure-synth/default.nix
+++ b/pkgs/tools/graphics/structure-synth/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, unzip, mesa_glu, makeWrapper }:
+{ stdenv, fetchurl, qt4, qmake4Hook, unzip, libGLU, makeWrapper }:
 
 stdenv.mkDerivation rec {
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1kiammx46719az6jzrav8yrwz82nk4m72ybj0kpbnvp9wfl3swbb";
   };
 
-  buildInputs = [ qt4 unzip mesa_glu makeWrapper ];
+  buildInputs = [ qt4 unzip libGLU makeWrapper ];
   nativeBuildInputs = [ qmake4Hook ];
 
   # Thanks to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=672000#15:


### PR DESCRIPTION
###### Motivation for this change

In the process of making my PRs (https://github.com/NixOS/nixpkgs/pull/42334, https://github.com/NixOS/nixpkgs/pull/42343, https://github.com/NixOS/nixpkgs/pull/42534) I was following some older examples which used mesa_glu in order to fix some problem, but libGLU appears to now be the "proper" way (even if equivalent). This updates those packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

