### PR TITLE
antibody: 3.5.0 -> 3.5.1

### DIFF
--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "antibody-${version}";
-  version = "3.5.0";
+  version = "3.5.1";
   rev = "v${version}";
   
   goPackagePath = "github.com/getantibody/antibody";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner  = "getantibody";
     repo   = "antibody";
-    sha256 = "0x9wfki7cl3cm9h21zj37196gwdzgllfgqmgy9n86m82wbla6slb";
+    sha256 = "0bqq59vnnm80jiqlhn7wfyzj96nkv8k9zp8i4sgcj8gvk1zq2lbc";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change


###### Things done
The usual

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
31666408
31684616
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

