### PR TITLE
Update Python documentation overlay

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1029,7 +1029,7 @@ To alter a python package using overlays, you would use the following approach:
 
 ```nix
 self: super:
-rec {
+{
   python = super.python.override {
     packageOverrides = python-self: python-super: {
       bepasty-server = python-super.bepasty-server.overrideAttrs ( oldAttrs: {
@@ -1041,7 +1041,7 @@ rec {
       });
     };
   };
-  pythonPackages = python.pkgs;
+  pythonPackages = self.python.pkgs;
 }
 ```
 


### PR DESCRIPTION
Using a recursive attribute set is not recommended.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

