### PR TITLE
libfive: init at 2018-07-01

### DIFF
--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, eigen3_3,
+zlib, libpng, boost, qt5, guile
+}:
+
+stdenv.mkDerivation rec {
+  name = "libfive-${version}";
+  version = "2018-07-01";
+
+  src = fetchFromGitHub {
+    owner  = "libfive";
+    repo   = "libfive";
+    rev    = "0f517dde9521d751310a22f85ee69b2c84690267";
+    sha256 = "0bfxysf5f4ripgcv546il8wnw5p0d4s75kdjlwvj32549537hlz0";
+  };
+  nativeBuildInputs = [ cmake ninja pkgconfig ];
+  buildInputs = [ eigen3_3 zlib libpng boost qt5.qtimageformats guile ];
+
+  # Link "Studio" binary to "libfive-studio" to be more obvious:
+  postFixup = ''
+    ln -s "$out/bin/Studio" "$out/bin/libfive-studio"
+  '';
+  
+  meta = with stdenv.lib; {
+    description = "Infrastructure for solid modeling with F-Reps in C, C++, and Guile";
+    homepage = https://libfive.com/;
+    maintainers = with maintainers; [ hodapp ];
+    license = licenses.lgpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10158,6 +10158,8 @@ with pkgs;
 
   libf2c = callPackage ../development/libraries/libf2c {};
 
+  libfive = callPackage ../development/libraries/libfive {};
+
   libfixposix = callPackage ../development/libraries/libfixposix {};
 
   libffcall = callPackage ../development/libraries/libffcall { };


### PR DESCRIPTION
###### Motivation for this change

The usual: Needed this package and figured I'd add a derivation.

Should [build on Mac](https://github.com/libfive/libfive#mac) but I've nothing to test this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
  - libfive-studio is still susceptible to https://github.com/NixOS/nixpkgs/issues/37864 but I don't think there is anything I can fix in the package itself to avoid this.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

