### PR TITLE
source-han-code-jp: init at 2.011R

### DIFF
--- a/pkgs/data/fonts/source-han-code-jp/default.nix
+++ b/pkgs/data/fonts/source-han-code-jp/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip }:
+
+let
+  pname = "source-han-code-jp";
+  version = "2.011R";
+in fetchzip {
+  name = "${pname}-${version}";
+
+  url = "https://github.com/adobe-fonts/${pname}/archive/${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "184vrjkymcm29k1cx00cdvjchzqr1w17925lmh85f0frx7vwljcd";
+
+  meta = {
+    description = "A monospaced Latin font suitable for coding";
+    maintainers = with stdenv.lib.maintainers; [ mt-caret ];
+    platforms = with stdenv.lib.platforms; all;
+    homepage = https://blogs.adobe.com/CCJKType/2015/06/source-han-code-jp.html;
+    license = stdenv.lib.licenses.ofl;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14887,6 +14887,8 @@ with pkgs;
 
   source-serif-pro = callPackage ../data/fonts/source-serif-pro { };
 
+  source-han-code-jp = callPackage ../data/fonts/source-han-code-jp { };
+
   sourceHanSansPackages = callPackage ../data/fonts/source-han-sans { };
   source-han-sans-japanese = sourceHanSansPackages.japanese;
   source-han-sans-korean = sourceHanSansPackages.korean;


### PR DESCRIPTION
###### Motivation for this change

A font for coding with good Japanese character set support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

