### PR TITLE
ocamlPackages.ocaml-migrate-parsetree: 1.0.7 -> 1.0.11

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-migrate-parsetree/default.nix
@@ -6,24 +6,19 @@ else
 
 stdenv.mkDerivation rec {
    name = "ocaml${ocaml.version}-ocaml-migrate-parsetree-${version}";
-   version = "1.0.7";
+   version = "1.0.11";
 
    src = fetchFromGitHub {
-     owner = "let-def";
+     owner = "ocaml-ppx";
      repo = "ocaml-migrate-parsetree";
      rev = "v${version}";
-     sha256 = "0v1h943xv5bd8qy5mr8pvyjbgamhs59nkgr94j3vznabrcfqzkh7";
+     sha256 = "05kbgs9n1x64fk6g3wbjnwjd17w10k3k8dzglnc45xg4hr7z651n";
    };
 
    buildInputs = [ ocaml findlib ocamlbuild jbuilder ];
    propagatedBuildInputs = [ result ];
 
-   installPhase = ''
-     for p in *.install
-     do
-       ${jbuilder.installPhase} $p
-     done
-   '';
+   inherit (jbuilder) installPhase;
 
    meta = {
      description = "Convert OCaml parsetrees between different major versions";


### PR DESCRIPTION
###### Motivation for this change

#42738

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

