### PR TITLE
anonscm.debian.org_gcc6.patch-not-found - replace anonscm.debian.org …

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/1.8.5.nix
+++ b/pkgs/development/interpreters/spidermonkey/1.8.5.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       name = "gcc6.patch";
-      url = "https://anonscm.debian.org/cgit/collab-maint/mozjs.git/plain/debian/patches/fix-811665.patch?id=00b15c7841968ab4f7fec409a6b93fa5e1e1d32e";
+      url = "https://sources.debian.org/data/main/m/mozjs/1.8.5-1.0.0+dfsg-6/debian/patches/fix-811665.patch";
       sha256 = "1q8477xqxiy5d8376k5902l45gd0qkd4nxmhl8vr6rr1pxfcny99";
     })
   ] ++ stdenv.lib.optionals stdenv.isAarch32 [


### PR DESCRIPTION
…with sources.debian.org

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

