### PR TITLE
pythonPackages.backports_shutil_get_terminal_size: 1.0 -> 2018-06-30

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -104,13 +104,6 @@ stdenv.mkDerivation rec {
     # https://trac.sagemath.org/ticket/24935
     ./patches/sphinx-1.7.patch
 
-    # https://trac.sagemath.org/ticket/25320
-    (fetchpatch {
-      name = "zero_division_error_formatting.patch";
-      url = "https://git.sagemath.org/sage.git/patch/?h=f79070ddd09fa0ad6b340b097bd8d690a7aa35f0";
-      sha256 = "02wsc3wbp8g8dk5jcjyv18d9v537h3zp5v8lwir46j4na4kj0dlb";
-    })
-
     # Adapt hashes to new boost version
     # https://trac.sagemath.org/ticket/22243
     # (this ticket doesn't only upgrade boost but also avoids this problem in the future)

--- a/pkgs/development/python-modules/backports_shutil_get_terminal_size/default.nix
+++ b/pkgs/development/python-modules/backports_shutil_get_terminal_size/default.nix
@@ -1,26 +1,35 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pytest
 , pythonOlder
 }:
 
 if !(pythonOlder "3.3") then null else buildPythonPackage rec {
   pname = "backports.shutil_get_terminal_size";
-  version = "1.0.0";
+  version = "unstable-2016-02-21";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "713e7a8228ae80341c70586d1cc0a8caa5207346927e23d09dcbcaf18eadec80";
+  # there have been numerous fixes commited since the initial release.
+  # Most notably fixing a problem where the backport would always return
+  # terminal size 0. See https://trac.sagemath.org/ticket/25320#comment:5.
+  # Unfortunately the maintainer seems inactive and has not responded to
+  # a request for a new release since 2016:
+  # https://github.com/chrippa/backports.shutil_get_terminal_size/issues/7
+  src = fetchFromGitHub {
+    owner = "chrippa";
+    repo = "backports.shutil_get_terminal_size";
+    rev = "159e269450dbf37c3a837f6ea7e628d59acbb96a";
+    sha256 = "17sgv8vg0xxfdnca45l1mmwwvj29gich5c8kqznnj51kfccch7sg";
   };
 
   checkInputs = [
     pytest
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A backport of the get_terminal_size function from Python 3.3’s shutil.";
     homepage = https://github.com/chrippa/backports.shutil_get_terminal_size;
-    license = with lib.licenses; [ mit ];
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ timokau ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

@FRidh do you think it is acceptable to build from master, given that the released version seems pretty broken and there hasn't been any change in years?

There is a discussion [here](https://trac.sagemath.org/ticket/25320#comment:5) but it is rather lengthy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

