### PR TITLE
HEIF support

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, pkgconfig, libtool
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg
-, lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp
+, lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp, libheif
 , ApplicationServices
 , buildPlatform, hostPlatform
 }:
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ zlib fontconfig freetype ghostscript
-      libpng libtiff libxml2
+      libpng libtiff libxml2 libheif
     ]
     ++ lib.optionals (!hostPlatform.isMinGW)
       [ openexr librsvg openjpeg ]

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, pkgconfig, libtool
 , bzip2, zlib, libX11, libXext, libXt, fontconfig, freetype, ghostscript, libjpeg
-, lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp, fftw
+, lcms2, openexr, libpng, librsvg, libtiff, libxml2, openjpeg, libwebp, fftw, libheif, libde265
 , ApplicationServices
 , buildPlatform, hostPlatform
 }:
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ zlib fontconfig freetype ghostscript
-      libpng libtiff libxml2
+      libpng libtiff libxml2 libheif libde265
     ]
     ++ lib.optionals (!hostPlatform.isMinGW)
       [ openexr librsvg openjpeg ]

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -2,7 +2,7 @@
 , pango, cairo, freetype, fontconfig, lcms, libpng, libjpeg, poppler, poppler_data, libtiff
 , libmng, librsvg, libwmf, zlib, libzip, ghostscript, aalib, shared-mime-info
 , python2Packages, libexif, gettext, xorg, glib-networking, libmypaint, gexiv2
-, harfbuzz, mypaint-brushes, libwebp, libgudev, openexr
+, harfbuzz, mypaint-brushes, libwebp, libheif, libgudev, openexr
 , AppKit, Cocoa, gtk-mac-integration }:
 
 let
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     babl gegl gtk2 glib gdk_pixbuf pango cairo gexiv2 harfbuzz isocodes
     freetype fontconfig lcms libpng libjpeg poppler poppler_data libtiff openexr
-    libmng librsvg libwmf zlib libzip ghostscript aalib shared-mime-info libwebp
+    libmng librsvg libwmf zlib libzip ghostscript aalib shared-mime-info libwebp libheif
     python pygtk libexif xorg.libXpm glib-networking libmypaint mypaint-brushes
   ] ++ stdenv.lib.optionals stdenv.isDarwin [ AppKit Cocoa gtk-mac-integration ]
     ++ stdenv.lib.optionals stdenv.isLinux [ libgudev ];

--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -2,7 +2,7 @@
 , karchive, kconfig, kwidgetsaddons, kcompletion, kcoreaddons
 , kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
 , kio, kcrash
-, boost, libraw, fftw, eigen, exiv2, lcms2, gsl, openexr
+, boost, libraw, fftw, eigen, exiv2, libheif, lcms2, gsl, openexr, giflib
 , openjpeg, opencolorio, vc, poppler_qt5, curl, ilmbase
 , qtmultimedia, qtx11extras
 , python3
@@ -22,7 +22,7 @@ mkDerivation rec {
   buildInputs = [
     karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
     ki18n kitemmodels kitemviews kwindowsystem kio kcrash
-    boost libraw fftw eigen exiv2 lcms2 gsl openexr
+    boost libraw fftw eigen exiv2 lcms2 gsl openexr libheif giflib
     openjpeg opencolorio vc poppler_qt5 curl ilmbase
     qtmultimedia qtx11extras
     python3

--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -5,15 +5,16 @@
 , boost, libraw, fftw, eigen, exiv2, lcms2, gsl, openexr
 , openjpeg, opencolorio, vc, poppler_qt5, curl, ilmbase
 , qtmultimedia, qtx11extras
+, python3
 }:
 
 mkDerivation rec {
   name = "krita-${version}";
-  version = "4.0.3";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "https://download.kde.org/stable/krita/${version}/${name}.tar.gz";
-    sha256 = "0zmn29dzqncc80pvy9ymgyzqw8x1ryq8b4x5mr4sz15iyj7xgspr";
+    sha256 = "1mbyybc7h3sblbaklvz0cci3ys4zcyi616fgdn06p62v2vw2sybq";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
@@ -24,6 +25,7 @@ mkDerivation rec {
     boost libraw fftw eigen exiv2 lcms2 gsl openexr
     openjpeg opencolorio vc poppler_qt5 curl ilmbase
     qtmultimedia qtx11extras
+    python3
   ];
 
   NIX_CFLAGS_COMPILE = [ "-I${ilmbase.dev}/include/OpenEXR" ];

--- a/pkgs/development/libraries/libde265/default.nix
+++ b/pkgs/development/libraries/libde265/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.3";
+  name = "libde265-${version}";
+
+  src = fetchFromGitHub {
+    owner = "strukturag";
+    repo = "libde265";
+    rev = "v${version}";
+    sha256 = "049g77f6c5sbk1h534zi9akj3y5h8zwnca5c9kqqjkn7f17irk10";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  meta = {
+    homepage = "https://github.com/strukturag/libde265";
+    description = "Open h.265 video codec implementation";
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ gebner ];
+  };
+
+}

--- a/pkgs/development/libraries/libheif/default.nix
+++ b/pkgs/development/libraries/libheif/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, libde265, x265, pkgconfig, libpng, libjpeg }:
+
+stdenv.mkDerivation rec {
+  version = "1.3.2";
+  name = "libheif-${version}";
+
+  src = fetchFromGitHub {
+    owner = "strukturag";
+    repo = "libheif";
+    rev = "v${version}";
+    sha256 = "0hk8mzig2kp5f94j4jwqxzjrm7ffk16ffvxl92rf0afsh6vgnz7w";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libde265 x265 libpng libjpeg ];
+  propagatedBuildInputs = [ x265 ];
+
+  meta = {
+    homepage = "http://www.libheif.org/";
+    description = "ISO/IEC 23008-12:2017 HEIF image file format decoder and encoder";
+    license = stdenv.lib.licenses.lgpl3;
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ gebner ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10018,6 +10018,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
+  libde265 = callPackage ../development/libraries/libde265 {};
+
   libdevil = callPackage ../development/libraries/libdevil {
     inherit (darwin.apple_sdk.frameworks) OpenGL;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10234,6 +10234,8 @@ with pkgs;
 
   libhdhomerun = callPackage ../development/libraries/libhdhomerun { };
 
+  libheif = callPackage ../development/libraries/libheif {};
+
   libhttpseverywhere = callPackage ../development/libraries/libhttpseverywhere { };
 
   libHX = callPackage ../development/libraries/libHX { };


### PR DESCRIPTION
###### Motivation for this change

[HEIF](https://nokiatech.github.io/heif/) is a new image format.  This PR adds the libheif library, and enables HEIF support in imagemagick, gimp, and krita.

Mainly waiting for ofborg to determine whether this should go to staging.  Closure size increase is between 3-6 megabytes (1-3%).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

