### PR TITLE
barrier: fix compilation on Qt 5.11

### DIFF
--- a/pkgs/applications/misc/barrier/default.nix
+++ b/pkgs/applications/misc/barrier/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, curl, xorg, avahi, qt5,
+{ stdenv, fetchpatch, fetchurl, cmake, curl, xorg, avahi, qt5,
   avahiWithLibdnssdCompat ? avahi.override { withLibdnssdCompat = true; }
 }:
 
@@ -13,9 +13,18 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake curl xorg.libX11 xorg.libXext xorg.libXtst avahiWithLibdnssdCompat ];
   propagatedBuildInputs = with qt5; [ qtbase ];
 
+  patches = [
+    # Fix compilation on Qt 5.11
+    # Patch should be removed on next version bump from 2.1.1!
+    (fetchpatch {
+      url = "https://github.com/debauchee/barrier/commit/a956cad0da23f544b874888c6c3540dc7f8f22cf.patch";
+      sha256 = "0x5045bdks1f9casp0v7svx9ml1gxhkhw5sqc7xk36h184m24a21";
+    })
+  ];
+
   postFixup = ''
-      substituteInPlace "$out/share/applications/barrier.desktop" --replace "Exec=barrier" "Exec=$out/bin/barrier"
-    '';
+    substituteInPlace "$out/share/applications/barrier.desktop" --replace "Exec=barrier" "Exec=$out/bin/barrier"
+  '';
 
   meta = {
     description = "Open-source KVM software";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

