### PR TITLE
add hmetis package

### DIFF
--- a/pkgs/applications/science/math/hmetis/default.nix
+++ b/pkgs/applications/science/math/hmetis/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, ghostscript }:
+
+stdenv.mkDerivation rec {
+  name = "hmetis-${version}";
+  version = "1.5";
+
+  src = fetchurl {
+    url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/hmetis/hmetis-${version}-linux.tar.gz";
+    sha256 = "e835a098c046e9c26cecb8addfea4d18ff25214e49585ffd87038e72819be7e1";
+  };
+
+  nativeBuildInputs = [ ghostscript ];
+
+  binaryFiles = "hmetis khmetis shmetis";
+
+  patchPhase = ''
+    for binaryfile in $binaryFiles; do
+      patchelf \
+        --set-interpreter ${stdenv.glibc}/lib/ld-linux.so.2 \
+        --set-rpath ${stdenv.glibc}/lib \
+        $binaryfile
+    done
+  '';
+
+  buildPhase = ''
+    gs -sOutputFile=manual.pdf -sDEVICE=pdfwrite -SNOPAUSE -dBATCH manual.ps
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/doc/hmetis $out/lib
+    mv $binaryFiles $out/bin
+    mv manual.pdf $out/share/doc/hmetis
+    mv libhmetis.a $out/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "hMETIS is a set of programs for partitioning hypergraphs";
+    homepage = http://glaros.dtc.umn.edu/gkhome/metis/hmetis/overview;
+    license = licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2421,6 +2421,8 @@ with pkgs;
   fluentd = callPackage ../tools/misc/fluentd { };
 
   flvstreamer = callPackage ../tools/networking/flvstreamer { };
+  
+  hmetis = callPackage_i686 ../applications/science/math/hmetis { };
 
   libbsd = callPackage ../development/libraries/libbsd { };
 


### PR DESCRIPTION
###### Motivation for this change

add hmetis package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

