### PR TITLE
nixos/security.sudo: Document ordering of extraRules

### DIFF
--- a/nixos/modules/security/sudo.nix
+++ b/nixos/modules/security/sudo.nix
@@ -66,6 +66,9 @@ in
     security.sudo.extraRules = mkOption {
       description = ''
         Define specific rules to be in the <filename>sudoers</filename> file.
+        More specific rules should come after more general ones in order to
+        yield the expected behavior. You can use mkBefore/mkAfter to ensure
+        this is the case when configuration options are merged.
       '';
       default = [];
       example = [


### PR DESCRIPTION
Expand `security.sudo.extraRules.description` to document the impact that order has on rule precedence. Call out the fact that `mkBefore`/`mkAfter` can be used to ensure configuration options are merged in a way that yields the desired behavior.

###### Motivation for this change

The order of sudoers entries is significant. The man page for sudoers(5) notes:
>  Where there are multiple matches, the last match is used (which is not necessarily the most specific match).

This module adds a rule for group "wheel" matching all commands. If you wanted to add a more specific rule allowing members of the "wheel" group to run command `foo` without a password, you'd need to use `mkAfter` to ensure your rule comes after the more general rule.
```
extraRules = lib.mkAfter [
  {
    groups = [ "wheel" ];
    commands = [
      {
        command = "${pkgs.foo}/bin/foo";
        options = [ "NOPASSWD" "SETENV" ];
      }
    ]
  }
];
```
Otherwise, when configuration options are merged, if the general rule ends up after the specific rule, it will dictate the behavior even when running the `foo` command.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

