### PR TITLE
 multimc: create compatibility symlink to fix desktop icon (18.03)

### DIFF
--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -4,12 +4,12 @@ let
   libpath = with xorg; stdenv.lib.makeLibraryPath [ libX11 libXext libXcursor libXrandr libXxf86vm libpulseaudio ];
 in stdenv.mkDerivation rec {
   name = "multimc-${version}";
-  version = "0.6.1";
+  version = "0.6.2";
   src = fetchFromGitHub {
     owner = "MultiMC";
     repo = "MultiMC5";
     rev = version;
-    sha256 = "0glsf4vfir8w24bpinf3cx2ninrcp7hpq9cl463wl78dvqfg47kx";
+    sha256 = "07jrr6si8nzfqwf073zhgw47y6snib23ad3imh1ik1nn5r7wqy3c";
     fetchSubmodules = true;
   };
   nativeBuildInputs = [ cmake file makeWrapper ];
@@ -18,6 +18,9 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
+    mkdir -p $out/share/{applications,pixmaps}
+    cp ../application/resources/multimc/scalable/multimc.svg $out/share/pixmaps
+    cp ../application/package/linux/multimc.desktop $out/share/applications
     wrapProgram $out/bin/MultiMC --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH /run/opengl-driver/lib:${libpath} --prefix PATH : ${jdk}/bin/
   '';
 

--- a/pkgs/games/multimc/default.nix
+++ b/pkgs/games/multimc/default.nix
@@ -22,6 +22,12 @@ in stdenv.mkDerivation rec {
     cp ../application/resources/multimc/scalable/multimc.svg $out/share/pixmaps
     cp ../application/package/linux/multimc.desktop $out/share/applications
     wrapProgram $out/bin/MultiMC --add-flags "-d \$HOME/.multimc/" --set GAME_LIBRARY_PATH /run/opengl-driver/lib:${libpath} --prefix PATH : ${jdk}/bin/
+
+    # As of https://github.com/MultiMC/MultiMC5/blob/7ea1d68244fdae1e7672fb84199ee71e168b31ca/application/package/linux/multimc.desktop,
+    # the desktop icon refers to `multimc`, but the executable actually gets
+    # installed as `MultiMC`. Create compatibility symlink to fix the desktop
+    # icon.
+    ln -sf $out/bin/MultiMC $out/bin/multimc
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
close #42784 for 18.03
This also includes an update -> 0.6.2 which I thought would be safe to do here also.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

