### PR TITLE
Idris: Wrap with IDRIS_CC

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -31,10 +31,9 @@
 
     # Idris wrapper with specified compiler and library paths, used to build packages
 
-    idris =
-        (pkgs.callPackage ./idris-wrapper.nix {})
-          idris-no-deps
-          { path = [ pkgs.gcc ]; lib = [pkgs.gmp]; };
+    idris = pkgs.callPackage ./idris-wrapper.nix {
+      inherit idris-no-deps;
+    };
 
     # Utilities for building packages
 

--- a/pkgs/development/idris-modules/idris-wrapper.nix
+++ b/pkgs/development/idris-modules/idris-wrapper.nix
@@ -1,15 +1,12 @@
-{ symlinkJoin, makeWrapper, stdenv, gcc }: idris: { path, lib }:
+{ lib, symlinkJoin, makeWrapper, idris-no-deps, gcc, gmp }:
 
 symlinkJoin {
-  name = idris.name;
-  src = idris.src;
-  paths = [ idris ];
+  inherit (idris-no-deps) name src meta;
+  paths = [ idris-no-deps ];
   buildInputs = [ makeWrapper ];
-  meta.platforms = idris.meta.platforms;
   postBuild = ''
     wrapProgram $out/bin/idris \
-      --run 'export IDRIS_CC=''${IDRIS_CC:-${stdenv.lib.getBin gcc}/bin/gcc}' \
-      --suffix PATH : ${ stdenv.lib.makeBinPath path } \
-      --suffix LIBRARY_PATH : ${stdenv.lib.makeLibraryPath lib}
-      '';
-  }
+      --run 'export IDRIS_CC=''${IDRIS_CC:-${lib.getBin gcc}/bin/gcc}' \
+      --suffix LIBRARY_PATH : ${lib.makeLibraryPath [ gmp ]}
+  '';
+}

--- a/pkgs/development/idris-modules/idris-wrapper.nix
+++ b/pkgs/development/idris-modules/idris-wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, makeWrapper, stdenv }: idris: { path, lib }:
+{ symlinkJoin, makeWrapper, stdenv, gcc }: idris: { path, lib }:
 
 symlinkJoin {
   name = idris.name;
@@ -8,6 +8,7 @@ symlinkJoin {
   meta.platforms = idris.meta.platforms;
   postBuild = ''
     wrapProgram $out/bin/idris \
+      --run 'export IDRIS_CC=''${IDRIS_CC:-${stdenv.lib.getBin gcc}/bin/gcc}' \
       --suffix PATH : ${ stdenv.lib.makeBinPath path } \
       --suffix LIBRARY_PATH : ${stdenv.lib.makeLibraryPath lib}
       '';


### PR DESCRIPTION
###### Motivation for this change
Previously idris used the C compiler from PATH for the C backend, which
means that the results and whether it even succeeds can vary between
systems (e.g. if a Nix-built Idris was used on a super old Linux system,
the cc installed there might not even work for Idris' C).

To make this more predictable, this commit sets the IDRIS_CC env var,
which Idris will prefer over searching in PATH, to a Nix-provided gcc
executable, given that it is not already set, so it's still possible to
override.

This closes #42785

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

