### PR TITLE
Idris packages clean ups and updates

### DIFF
--- a/pkgs/development/idris-modules/array.nix
+++ b/pkgs/development/idris-modules/array.nix
@@ -1,17 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
-build-idris-package  {
+build-idris-package {
   name = "array";
   version = "2016-10-14";
-
-  idrisDeps = [ prelude base ];
-
-  extraBuildInputs = [ idris ];
 
   src = fetchFromGitHub {
     owner = "idris-hackers";
@@ -25,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/idris-hackers/idris-array;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/bi.nix
+++ b/pkgs/development/idris-modules/bi.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , pruviloj
 , lib
-, idris
 }:
 build-idris-package  {
   name = "bi";
   version = "2018-06-25";
 
-  idrisDeps = [ prelude contrib pruviloj ];
+  idrisDeps = [ contrib pruviloj ];
 
   src = fetchFromGitHub {
     owner = "sbp";
@@ -24,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/sbp/idris-bi;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/bifunctors.nix
+++ b/pkgs/development/idris-modules/bifunctors.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "bifunctors";
   version = "2017-02-07";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "japesinator";
@@ -26,6 +21,5 @@ build-idris-package  {
     description = "A small bifunctor library for idris";
     homepage = https://github.com/japesinator/Idris-Bifunctors;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/build-builtin-package.nix
+++ b/pkgs/development/idris-modules/build-builtin-package.nix
@@ -10,6 +10,8 @@ build-idris-package {
   inherit name version;
   inherit (idris) src;
 
+  includePreludeBase = false;
+
   idrisDeps = deps;
 
   postUnpack = ''

--- a/pkgs/development/idris-modules/build-builtin-package.nix
+++ b/pkgs/development/idris-modules/build-builtin-package.nix
@@ -10,7 +10,8 @@ build-idris-package {
   inherit name version;
   inherit (idris) src;
 
-  includePreludeBase = false;
+  noPrelude = true;
+  noBase = true;
 
   idrisDeps = deps;
 

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation ({
 
   installPhase = ''
     ${idris-with-packages}/bin/idris --install *.ipkg --ibcsubdir $out/libs
+    IDRIS_DOC_PATH=$out/doc ${idris-with-packages}/bin/idris --installdoc *.ipkg
   '';
 
   buildInputs = [ gmp ] ++ extraBuildInputs;

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -1,23 +1,26 @@
 # Build an idris package
-{ stdenv, idrisPackages, gmp }:
+{ stdenv, lib, idrisPackages, gmp }:
   { idrisDeps ? []
+  , includePreludeBase ? true
   , name
   , version
-  , src
-  , meta
   , extraBuildInputs ? []
-  , postUnpack ? ""
-  , doCheck ? true
-  }:
+  , ...
+  }@attrs:
 let
-  idris-with-packages = idrisPackages.with-packages idrisDeps;
+  idrisDeps' = idrisDeps ++ lib.optionals includePreludeBase (with idrisPackages; [ prelude base ]);
+  idris-with-packages = idrisPackages.with-packages idrisDeps';
+  newAttrs = builtins.removeAttrs attrs [ "idrisDeps" "extraBuildInputs" "name" "version" ] // {
+    meta = attrs.meta // {
+      platforms = attrs.meta.platforms or idrisPackages.idris.meta.platforms;
+    };
+  };
 in
 stdenv.mkDerivation ({
-
   name = "${name}-${version}";
 
-  inherit postUnpack src doCheck meta;
-
+  buildInputs = [ idris-with-packages gmp ] ++ extraBuildInputs;
+  propagatedBuildInputs = idrisDeps';
 
   # Some packages use the style
   # opts = -i ../../path/to/package
@@ -27,21 +30,18 @@ stdenv.mkDerivation ({
   '';
 
   buildPhase = ''
-    ${idris-with-packages}/bin/idris --build *.ipkg
+    idris --build *.ipkg
   '';
 
   checkPhase = ''
     if grep -q test *.ipkg; then
-      ${idris-with-packages}/bin/idris --testpkg *.ipkg
+      idris --testpkg *.ipkg
     fi
   '';
 
   installPhase = ''
-    ${idris-with-packages}/bin/idris --install *.ipkg --ibcsubdir $out/libs
-    IDRIS_DOC_PATH=$out/doc ${idris-with-packages}/bin/idris --installdoc *.ipkg
+    idris --install *.ipkg --ibcsubdir $out/libs
+    IDRIS_DOC_PATH=$out/doc idris --installdoc *.ipkg || true
   '';
 
-  buildInputs = [ gmp ] ++ extraBuildInputs;
-
-  propagatedBuildInputs = idrisDeps;
-})
+} // newAttrs)

--- a/pkgs/development/idris-modules/bytes.nix
+++ b/pkgs/development/idris-modules/bytes.nix
@@ -1,17 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "bytes";
   version = "2018-02-10";
-
-  idrisDeps = [ prelude ];
-
-  extraBuildInputs = [ idris ];
 
   src = fetchFromGitHub {
     owner = "ziman";
@@ -24,6 +17,5 @@ build-idris-package  {
     description = "FFI-based byte buffers for Idris";
     homepage = https://github.com/ziman/idris-bytes;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/canvas.nix
+++ b/pkgs/development/idris-modules/canvas.nix
@@ -1,14 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
 build-idris-package  {
   name = "canvas";
   version = "2017-11-09";
-
-  idrisDeps = [ prelude ];
 
   src = fetchFromGitHub {
     owner = "JinWuZhao";
@@ -21,6 +17,5 @@ build-idris-package  {
     description = "Idris FFI binding for html5 canvas 2d api";
     homepage = https://github.com/JinWuZhao/idriscanvas;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/categories.nix
+++ b/pkgs/development/idris-modules/categories.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "categories";
   version = "2017-03-01";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "danilkolikov";
@@ -22,6 +17,5 @@ build-idris-package  {
     description = "Category Theory";
     homepage = https://github.com/danilkolikov/categories;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/categories.nix
+++ b/pkgs/development/idris-modules/categories.nix
@@ -4,13 +4,14 @@
 }:
 build-idris-package  {
   name = "categories";
-  version = "2017-03-01";
+  version = "2018-07-02";
 
+  # https://github.com/danilkolikov/categories/pull/5
   src = fetchFromGitHub {
-    owner = "danilkolikov";
+    owner = "infinisil";
     repo = "categories";
-    rev = "933fe418d154e10df39ddb09a74419cb4c4a57e8";
-    sha256 = "1dmpcv13zh7j4k6s2nlpf08gmpawaqaqkbqbg8zrgw253piwb0ci";
+    rev = "9722d62297e5025431e91b271ab09c5d14867236";
+    sha256 = "1bbmm8zif5d5wckdaddw6q3c39w6ms1cxrlrmkdn7bik88dawff2";
   };
 
   meta = {

--- a/pkgs/development/idris-modules/coda.nix
+++ b/pkgs/development/idris-modules/coda.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "coda";
   version = "2018-01-25";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "ostera";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/ostera/idris-coda;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/comonad.nix
+++ b/pkgs/development/idris-modules/comonad.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "comonad";
   version = "2018-02-26";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "vmchale";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/vmchale/comonad;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/composition.nix
+++ b/pkgs/development/idris-modules/composition.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , hezarfen
 , lib
-, idris
 }:
 build-idris-package  {
   name = "composition";
   version = "2017-11-12";
 
-  idrisDeps = [ prelude hezarfen ];
+  idrisDeps = [ hezarfen ];
 
   src = fetchFromGitHub {
     owner = "vmchale";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/vmchale/composition;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/config.nix
+++ b/pkgs/development/idris-modules/config.nix
@@ -1,18 +1,16 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , containers
 , lightyear
 , test
 , lib
-, idris
 }:
 build-idris-package  {
   name = "config";
   version = "2017-11-06";
 
-  idrisDeps = [ prelude effects containers lightyear test ];
+  idrisDeps = [ effects containers lightyear test ];
 
   src = fetchFromGitHub {
     owner = "benclifford";
@@ -26,6 +24,5 @@ build-idris-package  {
     homepage = https://github.com/benclifford/idris-config;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/console.nix
+++ b/pkgs/development/idris-modules/console.nix
@@ -1,17 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , idrisscript
 , hrtime
 , webgl
 , lib
-, idris
 }:
 build-idris-package  {
   name = "console";
   version = "2017-04-20";
 
-  idrisDeps = [ prelude idrisscript hrtime webgl ];
+  idrisDeps = [ idrisscript hrtime webgl ];
 
   src = fetchFromGitHub {
     owner = "pierrebeaucamp";
@@ -25,6 +23,5 @@ build-idris-package  {
     homepage = https://github.com/pierrebeaucamp/idris-console;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/containers.nix
+++ b/pkgs/development/idris-modules/containers.nix
@@ -1,17 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , test
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "containers";
   version = "2017-09-10";
 
-  idrisDeps = [ prelude effects test ];
+  idrisDeps = [ effects test ];
 
   src = fetchFromGitHub {
     owner = "jfdm";
@@ -29,6 +26,5 @@ build-idris-package  {
     homepage = https://github.com/jfdm/idris-containers;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/cube.nix
+++ b/pkgs/development/idris-modules/cube.nix
@@ -1,16 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "cube";
   version = "2017-07-05";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "aatxe";
@@ -24,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/aatxe/cube.idr;
     license = lib.licenses.agpl3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/curses.nix
+++ b/pkgs/development/idris-modules/curses.nix
@@ -1,18 +1,16 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 , ncurses
 }:
 build-idris-package  {
   name = "curses";
   version = "2017-10-12";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
-  extraBuildInputs = [ ncurses.out ncurses.dev ];
+  extraBuildInputs = [ ncurses ];
 
   postUnpack = ''
     sed -i 's/^libs = curses$/libs = ncurses/g' source/curses.ipkg
@@ -31,6 +29,5 @@ build-idris-package  {
     homepage = https://github.com/JakobBruenker/curses-idris;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/data.nix
+++ b/pkgs/development/idris-modules/data.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "data";
   version = "2018-03-19";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "jdevuyst";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/jdevuyst/idris-data;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/derive.nix
+++ b/pkgs/development/idris-modules/derive.nix
@@ -6,15 +6,16 @@
 }:
 build-idris-package  {
   name = "derive";
-  version = "2018-02-15";
+  version = "2018-07-02";
 
   idrisDeps = [ contrib pruviloj ];
 
+  # https://github.com/david-christiansen/derive-all-the-instances/pull/9
   src = fetchFromGitHub {
-    owner = "davlum";
+    owner = "infinisil";
     repo = "derive-all-the-instances";
-    rev = "2c8956807bd094ba33569227de921c6726401c42";
-    sha256 = "0l7263s04r52ql292vnnx2kngld6s1dipmaz5na7m82lj9p4x17y";
+    rev = "61c3e12e26f599379299fcbb9c40a81bfc3e0604";
+    sha256 = "0g2lb8nrwqwf3gm5fir43cxz6db84n19xiwkv8cmmqc1fgy6v0qn";
   };
 
   meta = {

--- a/pkgs/development/idris-modules/derive.nix
+++ b/pkgs/development/idris-modules/derive.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , pruviloj
 , lib
-, idris
 }:
 build-idris-package  {
   name = "derive";
   version = "2018-02-15";
 
-  idrisDeps = [ prelude contrib pruviloj ];
+  idrisDeps = [ contrib pruviloj ];
 
   src = fetchFromGitHub {
     owner = "davlum";
@@ -24,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/davlum/derive-all-the-instances;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/descncrunch.nix
+++ b/pkgs/development/idris-modules/descncrunch.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , pruviloj
 , lib
-, idris
 }:
 build-idris-package  {
   name = "descncrunch";
   version = "2017-11-15";
 
-  idrisDeps = [ prelude pruviloj ];
+  idrisDeps = [ pruviloj ];
 
   src = fetchFromGitHub {
     owner = "ahmadsalim";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/ahmadsalim/desc-n-crunch;
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/descncrunch.nix
+++ b/pkgs/development/idris-modules/descncrunch.nix
@@ -21,5 +21,6 @@ build-idris-package  {
     homepage = https://github.com/ahmadsalim/desc-n-crunch;
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.brainrape ];
+    broken = true;
   };
 }

--- a/pkgs/development/idris-modules/dict.nix
+++ b/pkgs/development/idris-modules/dict.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "dict";
   version = "2016-12-26";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "be5invis";
@@ -27,6 +25,5 @@ build-idris-package  {
     homepage = https://github.com/be5invis/idris-dict;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/dom.nix
+++ b/pkgs/development/idris-modules/dom.nix
@@ -1,17 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , idrisscript
 , html
 , xhr
 , lib
-, idris
 }:
 build-idris-package  {
   name = "dom";
   version = "2017-04-22";
 
-  idrisDeps = [ prelude idrisscript html xhr ];
+  idrisDeps = [ idrisscript html xhr ];
 
   src = fetchFromGitHub {
     owner = "pierrebeaucamp";
@@ -25,6 +23,5 @@ build-idris-package  {
     homepage = https://github.com/pierrebeaucamp/idris-dom;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/electron.nix
+++ b/pkgs/development/idris-modules/electron.nix
@@ -1,18 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , jheiling-extras
 , jheiling-js
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "electron";
   version = "2016-03-07";
 
-  idrisDeps = [ prelude contrib jheiling-extras jheiling-js ];
+  idrisDeps = [ contrib jheiling-extras jheiling-js ];
 
   src = fetchFromGitHub {
     owner = "jheiling";
@@ -31,6 +28,5 @@ build-idris-package  {
     homepage = https://github.com/jheiling/idris-electron;
     license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/eternal.nix
+++ b/pkgs/development/idris-modules/eternal.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 }:
 build-idris-package  {
   name = "eternal";
   version = "2018-01-25";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
   src = fetchFromGitHub {
     owner = "Heather";
@@ -30,6 +28,5 @@ build-idris-package  {
     homepage = https://github.com/Heather/Control.Eternal.Idris;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/eternal.nix
+++ b/pkgs/development/idris-modules/eternal.nix
@@ -5,15 +5,15 @@
 }:
 build-idris-package  {
   name = "eternal";
-  version = "2018-01-25";
+  version = "2018-07-02";
 
   idrisDeps = [ effects ];
 
   src = fetchFromGitHub {
     owner = "Heather";
     repo = "Control.Eternal.Idris";
-    rev = "7ead56ce6065b55104460ace945adbce38fb13eb";
-    sha256 = "0b4zys4mhl6r4rbpdxr7n2n20cdc0nkh4lm8n5v4wxkmjzna5cpd";
+    rev = "2f84b0dd49a7a29a2f852ba96cabfe8322e0852b";
+    sha256 = "1x8cwngiqi05f3wll0niznm47jj2byivx4mh5xf4sb47kciwkxvs";
   };
 
   postUnpack = ''

--- a/pkgs/development/idris-modules/farrp.nix
+++ b/pkgs/development/idris-modules/farrp.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 }:
 build-idris-package  {
   name = "farrp";
   version = "2018-02-13";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
   src = fetchFromGitHub {
     owner = "lambda-11235";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/lambda-11235/FarRP;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/free.nix
+++ b/pkgs/development/idris-modules/free.nix
@@ -1,14 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
 build-idris-package  {
   name = "free";
   version = "2017-07-03";
-
-  idrisDeps = [ prelude ];
 
   src = fetchFromGitHub {
     owner = "idris-hackers";
@@ -22,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/idris-hackers/idris-free;
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/fsm.nix
+++ b/pkgs/development/idris-modules/fsm.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "fsm";
   version = "2017-04-16";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "ctford";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/ctford/flying-spaghetti-monster;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/glfw.nix
+++ b/pkgs/development/idris-modules/glfw.nix
@@ -1,17 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 , pkgs
 }:
-
 build-idris-package  {
   name = "glfw";
   version = "2016-12-05";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
   extraBuildInputs = [ pkgs.glfw ];
 
@@ -27,6 +24,5 @@ build-idris-package  {
     homepage = https://github.com/eckart/glfw-idris;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/graphviz.nix
+++ b/pkgs/development/idris-modules/graphviz.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitLab
-, prelude
 , lightyear
 , lib
-, idris
 }:
 build-idris-package  {
   name = "graphviz";
   version = "2017-01-16";
 
-  idrisDeps = [ prelude lightyear ];
+  idrisDeps = [ lightyear ];
 
   src = fetchFromGitLab {
     owner = "mgttlinger";
@@ -27,6 +25,5 @@ build-idris-package  {
     homepage = https://github.com/mgttlinger/idris-graphviz;
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/hamt.nix
+++ b/pkgs/development/idris-modules/hamt.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , effects
 , lib
-, idris
 }:
 build-idris-package  {
   name = "idris-hamt";
   version = "2016-11-15";
 
-  idrisDeps = [ prelude contrib effects ];
+  idrisDeps = [ contrib effects ];
 
   src = fetchFromGitHub {
     owner = "bamboo";
@@ -24,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/bamboo/idris-hamt;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/heyting-algebra.nix
+++ b/pkgs/development/idris-modules/heyting-algebra.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "heyting-algebra";
   version = "2017-08-18";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "Risto-Stevcev";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/Risto-Stevcev/idris-heyting-algebra;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/hezarfen.nix
+++ b/pkgs/development/idris-modules/hezarfen.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "hezarfen";
   version = "2018-02-03";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "joom";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/joom/hezarfen;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/hrtime.nix
+++ b/pkgs/development/idris-modules/hrtime.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , idrisscript
 , lib
-, idris
 }:
 build-idris-package  {
   name = "hrtime";
   version = "2017-04-16";
 
-  idrisDeps = [ prelude idrisscript ];
+  idrisDeps = [ idrisscript ];
 
   src = fetchFromGitHub {
     owner = "pierrebeaucamp";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/pierrebeaucamp/idris-hrtime;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/html.nix
+++ b/pkgs/development/idris-modules/html.nix
@@ -1,17 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , idrisscript
 , hrtime
 , webgl
 , lib
-, idris
 }:
 build-idris-package  {
   name = "html";
   version = "2017-04-23";
 
-  idrisDeps = [ prelude idrisscript hrtime webgl ];
+  idrisDeps = [ idrisscript hrtime webgl ];
 
   src = fetchFromGitHub {
     owner = "pierrebeaucamp";
@@ -29,6 +27,5 @@ build-idris-package  {
     homepage = https://github.com/pierrebeaucamp/idris-html;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/http.nix
+++ b/pkgs/development/idris-modules/http.nix
@@ -1,17 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lightyear
 , bytes
 , lib
-, idris
 }:
 build-idris-package  {
   name = "http";
   version = "2018-02-25";
 
-  idrisDeps = [ prelude contrib lightyear bytes ];
+  idrisDeps = [ contrib lightyear bytes ];
 
   src = fetchFromGitHub {
     owner = "uwap";
@@ -25,6 +23,5 @@ build-idris-package  {
     homepage = https://github.com/uwap/idris-http;
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/http4idris.nix
+++ b/pkgs/development/idris-modules/http4idris.nix
@@ -1,16 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "http4idris";
   version = "2018-01-16";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "A1kmm";
@@ -24,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/A1kmm/http4idris;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/iaia.nix
+++ b/pkgs/development/idris-modules/iaia.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "iaia";
   version = "2017-11-10";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "sellout";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/sellout/Iaia;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/idrishighlighter.nix
+++ b/pkgs/development/idris-modules/idrishighlighter.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lightyear
 , lib
-, idris
 }:
 build-idris-package  {
   name = "idrishighlighter";
   version = "2018-02-22";
 
-  idrisDeps = [ prelude effects lightyear ];
+  idrisDeps = [ effects lightyear ];
 
   src = fetchFromGitHub {
     owner = "david-christiansen";
@@ -24,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/david-christiansen/idris-code-highlighter;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/idrisscript.nix
+++ b/pkgs/development/idris-modules/idrisscript.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "idrisscript";
   version = "2017-07-01";
-
-  idrisDeps = [ prelude ];
 
   src = fetchFromGitHub {
     owner = "idris-hackers";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/idris-hackers/IdrisScript;
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/ipkgparser.nix
+++ b/pkgs/development/idris-modules/ipkgparser.nix
@@ -1,17 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , effects
 , lightyear
 , lib
-, idris
 }:
 build-idris-package  {
   name = "ipkgparser";
   version = "2017-11-14";
 
-  idrisDeps = [ prelude contrib effects lightyear ];
+  idrisDeps = [ contrib effects lightyear ];
 
   src = fetchFromGitHub {
     owner = "emptyflash";
@@ -24,6 +22,5 @@ build-idris-package  {
     description = "Parser for Idris iPkg files written in Idris using Lightyear";
     homepage = https://github.com/emptyflash/idris-ipkg-parser;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/jheiling-extras.nix
+++ b/pkgs/development/idris-modules/jheiling-extras.nix
@@ -1,16 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "extras";
   version = "2018-03-06";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "jheiling";
@@ -24,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/jheiling/idris-extras;
     license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/jheiling-js.nix
+++ b/pkgs/development/idris-modules/jheiling-js.nix
@@ -1,17 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , jheiling-extras
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "jheiling-js";
   version = "2016-03-09";
 
-  idrisDeps = [ prelude contrib jheiling-extras ];
+  idrisDeps = [ contrib jheiling-extras ];
 
   src = fetchFromGitHub {
     owner = "jheiling";
@@ -25,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/jheiling/idris-js;
     license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/js.nix
+++ b/pkgs/development/idris-modules/js.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , pruviloj
 , lib
-, idris
 }:
 build-idris-package  {
   name = "js";
   version = "2018-11-27";
 
-  idrisDeps = [ prelude contrib pruviloj ];
+  idrisDeps = [ contrib pruviloj ];
 
   src = fetchFromGitHub {
     owner = "rbarreiro";
@@ -24,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/rbarreiro/idrisjs;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/lens.nix
+++ b/pkgs/development/idris-modules/lens.nix
@@ -1,16 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , bifunctors
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "lens";
   version = "2017-09-25";
 
-  idrisDeps = [ prelude bifunctors ];
+  idrisDeps = [ bifunctors ];
 
   src = fetchFromGitHub {
     owner = "HuwCampbell";
@@ -24,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/HuwCampbell/idris-lens;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/lightyear.nix
+++ b/pkgs/development/idris-modules/lightyear.nix
@@ -1,17 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , effects
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "lightyear";
   version = "2017-09-10";
 
-  idrisDeps = [ prelude base effects ];
+  idrisDeps = [ effects ];
 
   src = fetchFromGitHub {
     owner = "ziman";
@@ -25,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/ziman/lightyear;
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ siddharthist brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/logic.nix
+++ b/pkgs/development/idris-modules/logic.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , bifunctors
 , lib
-, idris
 }:
 build-idris-package  {
   name = "logic";
   version = "2016-12-02";
 
-  idrisDeps = [ prelude bifunctors ];
+  idrisDeps = [ bifunctors ];
 
   src = fetchFromGitHub {
     owner = "yurrriq";
@@ -26,6 +24,5 @@ build-idris-package  {
     homepage = https://github.com/yurrriq/idris-logic;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/mapping.nix
+++ b/pkgs/development/idris-modules/mapping.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "mapping";
   version = "2018-02-27";
-
-  idrisDeps = [ prelude ];
 
   src = fetchFromGitHub {
     owner = "zaoqi";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/zaoqi/Mapping.idr;
     license = lib.licenses.agpl3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/mhd.nix
+++ b/pkgs/development/idris-modules/mhd.nix
@@ -1,18 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , effects
 , libmicrohttpd
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "mhd";
   version = "2016-04-22";
 
-  idrisDeps = [ prelude contrib effects ];
+  idrisDeps = [ contrib effects ];
 
   extraBuildInputs = [ libmicrohttpd ];
 
@@ -28,6 +25,5 @@ build-idris-package  {
     homepage = https://github.com/colin-adams/idris-libmicrohttpd;
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/pacman.nix
+++ b/pkgs/development/idris-modules/pacman.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , sdl2
 , lib
-, idris
 }:
 build-idris-package  {
   name = "pacman";
   version = "2017-11-10";
 
-  idrisDeps = [ prelude contrib sdl2 ];
+  idrisDeps = [ contrib sdl2 ];
 
   src = fetchFromGitHub {
     owner = "jdublu10";
@@ -27,6 +25,5 @@ build-idris-package  {
     description = "Proof that Idris is pacman complete";
     homepage = https://github.com/jdublu10/pacman;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/patricia.nix
+++ b/pkgs/development/idris-modules/patricia.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , specdris
 , lib
-, idris
 }:
 build-idris-package  {
   name = "patricia";
   version = "2017-10-27";
 
-  idrisDeps = [ prelude specdris ];
+  idrisDeps = [ specdris ];
 
   src = fetchFromGitHub {
     owner = "ChShersh";
@@ -27,6 +25,5 @@ build-idris-package  {
     homepage = https://github.com/ChShersh/idris-patricia;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/permutations.nix
+++ b/pkgs/development/idris-modules/permutations.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "permutations";
   version = "2018-01-19";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "vmchale";
@@ -27,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/vmchale/permutations;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/pfds.nix
+++ b/pkgs/development/idris-modules/pfds.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "pfds";
   version = "2017-09-25";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "timjb";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/timjb/idris-pfds;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/pipes.nix
+++ b/pkgs/development/idris-modules/pipes.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "pipes";
   version = "2017-12-02";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "QuentinDuval";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/QuentinDuval/IdrisPipes;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/posix.nix
+++ b/pkgs/development/idris-modules/posix.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "posix";
   version = "2017-11-18";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "idris-hackers";
@@ -25,6 +20,5 @@ build-idris-package  {
     description = "System POSIX bindings for Idris.";
     homepage = https://github.com/idris-hackers/idris-posix;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/protobuf.nix
+++ b/pkgs/development/idris-modules/protobuf.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lightyear
 , lib
-, idris
 }:
 build-idris-package  {
   name = "protobuf";
   version = "2017-08-12";
 
-  idrisDeps = [ prelude lightyear ];
+  idrisDeps = [ lightyear ];
 
   src = fetchFromGitHub {
     owner = "artagnon";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/artagnon/idris-protobuf;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/rationals.nix
+++ b/pkgs/development/idris-modules/rationals.nix
@@ -1,16 +1,13 @@
-{ curl
-, build-idris-package
+{ build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package {
   name = "rationals";
   version = "2017-04-29";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "mcgordonite";
@@ -22,7 +19,6 @@ build-idris-package {
   meta = {
     description = "An idris rational number type built from paths in the Stern Brocot tree";
     homepage = https://github.com/mcgordonite/idris-binary-rationals;
-    inherit (idris.meta) platforms;
     maintainers = [ lib.maintainers.brainrape ];
   };
 }

--- a/pkgs/development/idris-modules/recursion_schemes.nix
+++ b/pkgs/development/idris-modules/recursion_schemes.nix
@@ -1,19 +1,17 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , free
 , composition
 , comonad
 , bifunctors
 , hezarfen
 , lib
-, idris
 }:
 build-idris-package  {
   name = "recursion_schemes";
   version = "2018-01-19";
 
-  idrisDeps = [ prelude free composition comonad bifunctors hezarfen ];
+  idrisDeps = [ free composition comonad bifunctors hezarfen ];
 
   src = fetchFromGitHub {
     owner = "vmchale";
@@ -31,6 +29,5 @@ build-idris-package  {
     homepage = https://github.com/vmchale/recursion_schemes;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/refined.nix
+++ b/pkgs/development/idris-modules/refined.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "refined";
   version = "2017-12-28";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "janschultecom";
@@ -27,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/janschultecom/idris-refined;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/sdl.nix
+++ b/pkgs/development/idris-modules/sdl.nix
@@ -1,20 +1,17 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 , SDL
 , SDL_gfx
 }:
-
 build-idris-package  {
   name = "sdl";
   version = "2017-03-24";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
-  extraBuildInputs = [ idris SDL SDL_gfx ];
+  extraBuildInputs = [ SDL SDL_gfx ];
 
   src = fetchFromGitHub {
     owner = "edwinb";
@@ -27,6 +24,5 @@ build-idris-package  {
     description = "SDL-idris framework for Idris";
     homepage = https://github.com/edwinb/SDL-idris;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/sdl.nix
+++ b/pkgs/development/idris-modules/sdl.nix
@@ -24,5 +24,7 @@ build-idris-package  {
     description = "SDL-idris framework for Idris";
     homepage = https://github.com/edwinb/SDL-idris;
     maintainers = [ lib.maintainers.brainrape ];
+    # Can't find file sdlrun.o
+    broken = true;
   };
 }

--- a/pkgs/development/idris-modules/sdl2.nix
+++ b/pkgs/development/idris-modules/sdl2.nix
@@ -1,21 +1,18 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 , pkgconfig
 , SDL2
 , SDL2_gfx
 }:
-
 build-idris-package  {
   name = "sdl2";
   version = "2018-01-19";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
-  extraBuildInputs = [ idris pkgconfig SDL2 SDL2_gfx ];
+  extraBuildInputs = [ pkgconfig SDL2 SDL2_gfx ];
 
   src = fetchFromGitHub {
     owner = "steshaw";
@@ -28,6 +25,5 @@ build-idris-package  {
     description = "SDL2 binding for Idris";
     homepage = https://github.com/steshaw/idris-sdl2;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/sdl2.nix
+++ b/pkgs/development/idris-modules/sdl2.nix
@@ -25,5 +25,7 @@ build-idris-package  {
     description = "SDL2 binding for Idris";
     homepage = https://github.com/steshaw/idris-sdl2;
     maintainers = [ lib.maintainers.brainrape ];
+    # Can't find file sdl2.o
+    broken = true;
   };
 }

--- a/pkgs/development/idris-modules/semidirect.nix
+++ b/pkgs/development/idris-modules/semidirect.nix
@@ -6,15 +6,15 @@
 }:
 build-idris-package  {
   name = "semidirect";
-  version = "2018-02-06";
+  version = "2018-07-02";
 
   idrisDeps = [ contrib patricia ];
 
   src = fetchFromGitHub {
     owner = "clayrat";
     repo = "idris-semidirect";
-    rev = "884c26c095784f8fd489c323d6673f2a8710a741";
-    sha256 = "0w36xkfxsqm6r91f0vs6qpmallrfwa09ql8i317xwm86nfk7akj9";
+    rev = "e19c58f7a25c53bba2ab058821e038bae3c093d2";
+    sha256 = "0182r9z34kbv3l78pw4qf48ng3hqj4sqzy53074mb0b2c3pikcrl";
   };
 
   meta = {

--- a/pkgs/development/idris-modules/semidirect.nix
+++ b/pkgs/development/idris-modules/semidirect.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , patricia
 , lib
-, idris
 }:
 build-idris-package  {
   name = "semidirect";
   version = "2018-02-06";
 
-  idrisDeps = [ prelude contrib patricia ];
+  idrisDeps = [ contrib patricia ];
 
   src = fetchFromGitHub {
     owner = "clayrat";
@@ -23,6 +21,5 @@ build-idris-package  {
     description = "Semidirect products in Idris";
     homepage = https://github.com/clayrat/idris-semidirect;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/setoids.nix
+++ b/pkgs/development/idris-modules/setoids.nix
@@ -1,14 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
 build-idris-package  {
   name = "setoids";
   version = "2017-03-13";
-
-  idrisDeps = [ prelude ];
 
   src = fetchFromGitHub {
     owner = "danilkolikov";
@@ -21,6 +17,5 @@ build-idris-package  {
     description = "Idris proofs for extensional equalities";
     homepage = https://github.com/danilkolikov/setoids;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/setoids.nix
+++ b/pkgs/development/idris-modules/setoids.nix
@@ -1,16 +1,19 @@
 { build-idris-package
 , fetchFromGitHub
+, contrib
 , lib
 }:
 build-idris-package  {
   name = "setoids";
-  version = "2017-03-13";
+  version = "2018-06-18";
+
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "danilkolikov";
     repo = "setoids";
-    rev = "a50cfc010cb4321cc9b7988c0a4f387d83d34839";
-    sha256 = "0q0h2qj9vylkm16h70l78l2p5xjkx4qmg2a2ixfl8vq8b1zm8gch";
+    rev = "41b4af3b1a537d9471107a639ad77c7abee2de18";
+    sha256 = "0fl1g59s16vnrdnplps5ncv27j7a93nxp9cmqp2iavjxlzlzin1v";
   };
 
   meta = {

--- a/pkgs/development/idris-modules/smproc.nix
+++ b/pkgs/development/idris-modules/smproc.nix
@@ -1,16 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "smproc";
   version = "2018-02-08";
 
-  idrisDeps = [ prelude base contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "jameshaydon";
@@ -24,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/jameshaydon/smproc;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/snippets.nix
+++ b/pkgs/development/idris-modules/snippets.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "snippets";
   version = "2018-03-17";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "palladin";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/palladin/idris-snippets;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/software_foundations.nix
+++ b/pkgs/development/idris-modules/software_foundations.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , pruviloj
 , lib
-, idris
 }:
 build-idris-package  {
   name = "software_foundations";
   version = "2017-11-04";
 
-  idrisDeps = [ prelude pruviloj ];
+  idrisDeps = [ pruviloj ];
 
   src = fetchFromGitHub {
     owner = "idris-hackers";
@@ -22,6 +20,5 @@ build-idris-package  {
     description = "Code for Software Foundations in Idris";
     homepage = https://github.com/idris-hackers/software-foundations;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/specdris.nix
+++ b/pkgs/development/idris-modules/specdris.nix
@@ -1,23 +1,20 @@
 { build-idris-package
-, fetchgit
-, prelude
-, base
+, fetchFromGitHub
 , effects
 , lib
-, idris
 }:
-
 build-idris-package {
   name = "specdris";
   version = "2018-01-23";
 
-  src = fetchgit {
-    url = "https://github.com/pheymann/specdris";
+  src = fetchFromGitHub {
+    owner = "pheymann";
+    repo = "specdris";
     rev = "625f88f5e118e53f30bcf5e5f3dcf48eb268ac21";
     sha256 = "1gc717xf4i7z75aqazy5wqm7b1dqfyx5pprdypxz1h3980m67fsa";
   };
 
-  idrisDeps = [ prelude base effects idris ];
+  idrisDeps = [ effects ];
 
   # tests use a different ipkg and directory structure
   doCheck = false;

--- a/pkgs/development/idris-modules/tap.nix
+++ b/pkgs/development/idris-modules/tap.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "tap";
   version = "2017-04-08";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "ostera";
@@ -27,6 +25,5 @@ build-idris-package  {
     homepage = https://github.com/ostera/tap-idris;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/test.nix
+++ b/pkgs/development/idris-modules/test.nix
@@ -1,16 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "test";
   version = "2017-03-30";
 
-  idrisDeps = [ prelude effects ];
+  idrisDeps = [ effects ];
 
   src = fetchFromGitHub {
     owner = "jfdm";
@@ -19,7 +16,6 @@ build-idris-package  {
     sha256 = "1pmyhs3jx6wd0pzjd3igfxb9zjs8pqmk4ah352bxjrqdnhqwrl51";
   };
 
-
   doCheck = false;
 
   meta = {
@@ -27,6 +23,5 @@ build-idris-package  {
     homepage = https://github.com/jfdm/idris-testing;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/tlhydra.nix
+++ b/pkgs/development/idris-modules/tlhydra.nix
@@ -1,18 +1,15 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , effects
 , contrib
 , lightyear
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "tlhydra";
   version = "2017-13-26";
 
-  idrisDeps = [ prelude effects contrib lightyear ];
+  idrisDeps = [ effects contrib lightyear ];
 
   src = fetchFromGitHub {
     owner = "Termina1";
@@ -25,6 +22,5 @@ build-idris-package  {
     description = "Idris parser and serializer/deserealizer for TL language";
     homepage = https://github.com/Termina1/tlhydra;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/tomladris.nix
+++ b/pkgs/development/idris-modules/tomladris.nix
@@ -1,17 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lightyear
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "tomladris";
   version = "2017-11-14";
 
-  idrisDeps = [ prelude lightyear contrib ];
+  idrisDeps = [ lightyear contrib ];
 
   src = fetchFromGitHub {
     owner = "emptyflash";
@@ -25,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/emptyflash/tomladris;
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ siddharthist brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/tp.nix
+++ b/pkgs/development/idris-modules/tp.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "tp";
   version = "2017-08-15";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "superfunc";
@@ -26,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/superfunc/tp;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/tparsec.nix
+++ b/pkgs/development/idris-modules/tparsec.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , lib
-, idris
 }:
-
 build-idris-package  {
   name = "tparsec";
   version = "2017-12-12";
-
-  idrisDeps = [ prelude ];
 
   src = fetchFromGitHub {
     owner = "gallais";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/gallais/idris-tparsec;
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/tparsec.nix
+++ b/pkgs/development/idris-modules/tparsec.nix
@@ -4,13 +4,13 @@
 }:
 build-idris-package  {
   name = "tparsec";
-  version = "2017-12-12";
+  version = "2018-06-26";
 
   src = fetchFromGitHub {
     owner = "gallais";
     repo = "idris-tparsec";
-    rev = "fb87d08f8f58c934f37d8324b43b0979abcf2183";
-    sha256 = "0362076bfs976gqki4b4pxblhnk4xglgx5v2aycjpxsxlpxh6cfd";
+    rev = "ca32d1a83f3de95f8979d48016e79d010f47b3c2";
+    sha256 = "1zjzk8xjmyyx1qwrdwwg7yjzcgj5wkbwpx8a3wpbj5sv4b5s2r30";
   };
 
   meta = {

--- a/pkgs/development/idris-modules/transducers.nix
+++ b/pkgs/development/idris-modules/transducers.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "transducers";
   version = "2017-07-28";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "QuentinDuval";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/QuentinDuval/IdrisReducers;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/trees.nix
+++ b/pkgs/development/idris-modules/trees.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , bi
 , lib
-, idris
 }:
 build-idris-package  {
   name = "trees";
   version = "2018-03-19";
 
-  idrisDeps = [ prelude contrib bi ];
+  idrisDeps = [ contrib bi ];
 
   src = fetchFromGitHub {
     owner = "clayrat";
@@ -23,6 +21,5 @@ build-idris-package  {
     description = "Trees in Idris";
     homepage = https://github.com/clayrat/idris-trees;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/union_type.nix
+++ b/pkgs/development/idris-modules/union_type.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "union_type";
   version = "2018-01-30";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "berewt";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/berewt/UnionType;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/vdom.nix
+++ b/pkgs/development/idris-modules/vdom.nix
@@ -1,15 +1,10 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package  {
   name = "vdom";
   version = "0.6.0";
-
-  idrisDeps = [ prelude base ];
 
   src = fetchFromGitHub {
     owner = "brandondyck";
@@ -23,6 +18,5 @@ build-idris-package  {
     homepage = https://github.com/brandondyck/idris-vdom;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/vecspace.nix
+++ b/pkgs/development/idris-modules/vecspace.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lib
-, idris
 }:
 build-idris-package  {
   name = "vecspace";
   version = "2018-01-12";
 
-  idrisDeps = [ prelude contrib ];
+  idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
     owner = "clayrat";
@@ -22,6 +20,5 @@ build-idris-package  {
     description = "Abstract vector spaces in Idris";
     homepage = https://github.com/clayrat/idris-vecspace;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/webgl.nix
+++ b/pkgs/development/idris-modules/webgl.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , idrisscript
 , lib
-, idris
 }:
 build-idris-package  {
   name = "webgl";
   version = "2017-05-08";
 
-  idrisDeps = [ prelude idrisscript ];
+  idrisDeps = [ idrisscript ];
 
   src = fetchFromGitHub {
     owner = "pierrebeaucamp";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/pierrebeaucamp/idris-webgl;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/with-packages.nix
+++ b/pkgs/development/idris-modules/with-packages.nix
@@ -15,6 +15,6 @@ stdenv.lib.appendToName "with-packages" (symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/idris \
       --set IDRIS_LIBRARY_PATH $out/libs
-      '';
+  '';
 
 })

--- a/pkgs/development/idris-modules/wl-pprint.nix
+++ b/pkgs/development/idris-modules/wl-pprint.nix
@@ -1,9 +1,6 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
-, base
 , lib
-, idris
 }:
 build-idris-package {
   name = "wl-pprint";
@@ -16,12 +13,9 @@ build-idris-package {
     sha256 = "0ifp76cqg340jkkzanx69vg76qivv53vh1lzv9zkp5f49prkwl5d";
   };
 
-  idrisDeps = [ prelude base ];
-
   meta = {
     description = "Wadler-Leijen pretty-printing library";
     homepage = https://github.com/shayan-najd/wl-pprint;
     license = lib.licenses.bsd2;
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/wyvern.nix
+++ b/pkgs/development/idris-modules/wyvern.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , effects
 , lib
-, idris
 }:
 build-idris-package  {
   name = "wyvern";
   version = "2017-06-26";
 
-  idrisDeps = [ prelude contrib effects ];
+  idrisDeps = [ contrib effects ];
 
   src = fetchFromGitHub {
     owner = "ericqweinstein";
@@ -28,6 +26,5 @@ build-idris-package  {
     homepage = https://github.com/ericqweinstein/wyvern;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/xhr.nix
+++ b/pkgs/development/idris-modules/xhr.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , idrisscript
 , lib
-, idris
 }:
 build-idris-package  {
   name = "xhr";
   version = "2017-04-22";
 
-  idrisDeps = [ prelude idrisscript ];
+  idrisDeps = [ idrisscript ];
 
   src = fetchFromGitHub {
     owner = "pierrebeaucamp";
@@ -23,6 +21,5 @@ build-idris-package  {
     homepage = https://github.com/pierrebeaucamp/idris-xhr;
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/yaml.nix
+++ b/pkgs/development/idris-modules/yaml.nix
@@ -1,16 +1,14 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , contrib
 , lightyear
 , lib
-, idris
 }:
 build-idris-package  {
   name = "yaml";
   version = "2018-01-25";
 
-  idrisDeps = [ prelude contrib lightyear ];
+  idrisDeps = [ contrib lightyear ];
 
   src = fetchFromGitHub {
     owner = "Heather";
@@ -24,6 +22,5 @@ build-idris-package  {
     homepage = https://github.com/Heather/Idris.Yaml;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }

--- a/pkgs/development/idris-modules/yampa.nix
+++ b/pkgs/development/idris-modules/yampa.nix
@@ -1,15 +1,13 @@
 { build-idris-package
 , fetchFromGitHub
-, prelude
 , bifunctors
 , lib
-, idris
 }:
 build-idris-package  {
   name = "yampa";
   version = "2016-07-05";
 
-  idrisDeps = [ prelude bifunctors ];
+  idrisDeps = [ bifunctors ];
 
   src = fetchFromGitHub {
     owner = "BartAdv";
@@ -22,6 +20,5 @@ build-idris-package  {
     description = "Idris implementation of Yampa FRP library as described in Reactive Programming through Dependent Types";
     homepage = https://github.com/BartAdv/idris-yampa;
     maintainers = [ lib.maintainers.brainrape ];
-    inherit (idris.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
1. Installs Idris package documentation
2. Have `prelude` and `base` as default dependencies, have `idris` as a `buildInput`, propagate Idris' `meta.platforms` to all packages
3. Clean up Idris packages via 2.
4. Mark some packages as broken
5. Fix some packages that were broken (mainly due to Idris 1.3 not allowing upper case identifiers)
6. Fix some builds via my own forks

I recommend reviewing by commit, they represent above points in order. Edit: Right now it seems that GitHub somehow messed up the order.. it's correct directly viewed on [my branch](https://github.com/Infinisil/nixpkgs/commits/fix/idris-forks)

For 6., these are the upstream PRs:
- [ ] https://github.com/danilkolikov/categories/pull/5
- [ ] https://github.com/david-christiansen/derive-all-the-instances/pull/9
- [x] https://github.com/Heather/Control.Eternal.Idris/pull/1
- [x] https://github.com/clayrat/idris-semidirect/pull/1 or <s>https://github.com/clayrat/idris-semidirect/pull/2</s>

This PR should **not be merged for 1 week** (That's what the WIP indicates), to give the above PR's time to be merged, at which point I'll replace my fork with the master version. I propose to use my fork if it takes longer than that.

Ping @brainrape @shlevy @ttuegel 

###### Things done

All `idrisPackages` that aren't broken (or have a broken dependency) now build successfully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

