### PR TITLE
livepeer: init at 0.2.4

### DIFF
--- a/pkgs/servers/livepeer/default.nix
+++ b/pkgs/servers/livepeer/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, buildGoPackage
+, pkgconfig, ffmpeg
+}:
+
+buildGoPackage rec {
+  name = "livepeer-${version}";
+  version = "0.2.4";
+
+  goPackagePath = "github.com/livepeer/go-livepeer";
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "livepeer";
+    repo = "go-livepeer";
+    rev = version;
+    sha256 = "07vhw787wq5q4xm7zvswjdsmr20pwfa39wfkgamb7hkrffn3k2ia";
+  };
+
+  buildInputs = [ pkgconfig ffmpeg ];
+
+  # XXX This removes the -O2 flag, to avoid errors like:
+  #   cgo-dwarf-inference:2:8: error: enumerator value for '__cgo_enum__0' is not an integer constant
+  # This is a workaround for nixpkgs+golang BUG https://github.com/NixOS/nixpkgs/issues/25959
+  hardeningDisable = [ "fortify" ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Official Go implementation of the Livepeer protocol";
+    homepage = http://livepeer.org;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ elitak ];
+  };
+}

--- a/pkgs/servers/livepeer/deps.nix
+++ b/pkgs/servers/livepeer/deps.nix
@@ -1,0 +1,20 @@
+[
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath = "github.com/ericxtang/m3u8";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ericxtang/m3u8";
+      rev = "575aeb9f754a5dabcc03d4aa0ed05ecaee26499e";
+      sha256 = "08811y4kg6rgj40v80cwjcwhy094qrfigdwjsgr8d6bn64cf9fz2";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12752,6 +12752,8 @@ with pkgs;
 
   lighttpd = callPackage ../servers/http/lighttpd { };
 
+  livepeer = callPackage ../servers/livepeer { ffmpeg = ffmpeg_3; };
+
   lwan = callPackage ../servers/http/lwan { };
 
   labelImg = callPackage ../applications/science/machine-learning/labelimg { };


### PR DESCRIPTION
###### Motivation for this change
Adding livepeer service binaries; will work on nixos module in a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

