### PR TITLE
wireshark: export QT_PLUGIN_PATH in shellHook

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -91,6 +91,7 @@ in stdenv.mkDerivation {
   shellHook = ''
     # to be able to run the resulting binary
     export WIRESHARK_RUN_FROM_BUILD_DIRECTORY=1
+    export QT_PLUGIN_PATH=${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
...else program fails with:
This application failed to start because it could not find or load the Qt platform plugin "xcb"
in "".

###### Motivation for this change
I am fixing a bug in wireshark within a nix-shell and could not start the dev wireshark due to this error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

