### PR TITLE
heroku: 3.43.16 -> 7.5.7

### DIFF
--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -1,70 +1,22 @@
-{ stdenv, lib, fetchurl, makeWrapper, buildGoPackage, fetchFromGitHub
-, nodejs-6_x, postgresql, ruby }:
+{ stdenv, fetchFromGitHub, mkYarnPackage }:
 
-with stdenv.lib;
+mkYarnPackage rec {
+  name = "heroku-${version}";
+  version = "7.5.7";
 
-let
-  cli = buildGoPackage rec {
-    name = "cli-${version}";
-    version = "5.6.32";
-
-    goPackagePath = "github.com/heroku/cli";
-
-    src = fetchFromGitHub {
-      owner  = "heroku";
-      repo   = "cli";
-      rev    = "v${version}";
-      sha256 = "062aa79mv2njjb0ix7isbz6646wxmsldv27bsz5v2pbv597km0vz";
-    };
-
-    buildFlagsArray = ''
-      -ldflags=
-        -X=main.Version=${version}
-        -X=main.Channel=stable
-        -X=main.Autoupdate=no
-    '';
-
-    preCheck = ''
-      export HOME=/tmp
-    '';
-
-    doCheck = true;
+  src = fetchFromGitHub {
+    owner = "heroku";
+    repo = "cli";
+    rev = "v${version}";
+    sha256 = "1dnljah456z02d8nsyksg9w9pg35b8vk7q9zqygp84qbghz5pkdc";
   };
 
-in stdenv.mkDerivation rec {
-  name = "heroku-${version}";
-  version = "3.43.16";
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://toolbelt.heroku.com;
     description = "Everything you need to get started using Heroku";
     maintainers = with maintainers; [ aflatter mirdhyn peterhoeg ];
     license = licenses.mit;
     platforms = with platforms; unix;
-    broken = true; # Outdated function, not supported upstream. https://github.com/NixOS/nixpkgs/issues/27447
+    hydraPlatforms = []; # https://github.com/NixOS/nixpkgs/issues/20637
   };
-
-  binPath = lib.makeBinPath [ postgresql ruby ];
-
-  buildInputs = [ makeWrapper ];
-
-  doUnpack = false;
-
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-${version}.tgz";
-    sha256 = "08pai3cjaj7wshhyjcmkvyr1qxv5ab980whcm406798ng8f91hn7";
-  };
-
-  installPhase = ''
-    mkdir -p $out
-
-    tar xzf $src -C $out --strip-components=1
-    install -Dm755 ${cli}/bin/cli $out/share/heroku/cli/bin/heroku
-
-    wrapProgram $out/bin/heroku \
-      --set HEROKU_NODE_PATH ${nodejs-6_x}/bin/node \
-      --set XDG_DATA_HOME    $out/share \
-      --set XDG_DATA_DIRS    $out/share \
-      --prefix PATH : ${binPath}
-  '';
 }

--- a/pkgs/development/tools/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix/default.nix
@@ -131,8 +131,8 @@ let
   }@attrs:
     let
       package = lib.importJSON packageJSON;
-      pname = package.name;
-      version = package.version;
+      pname = package.name or name;
+      version = package.version or attrs.version;
       deps = mkYarnModules {
         name = "${pname}-modules-${version}";
         preBuild = yarnPreBuild;


### PR DESCRIPTION
```
$ nix-build -A heroku -I ~/dev
these derivations will be built:
  /nix/store/q29iva8k02b1gzkm63p7g131rjj4nrad-heroku-7.5.7-modules-7.5.7.drv
  /nix/store/nyjs1jjlq5a56jrk6q0adwsai9cl1ggq-heroku-7.5.7.drv
building '/nix/store/q29iva8k02b1gzkm63p7g131rjj4nrad-heroku-7.5.7-modules-7.5.7.drv'...
configuring
building
yarn config v1.8.0
success Set "yarn-offline-mirror" to "/nix/store/j0xn98mmavzazn7q0md8jc9jmfkkrmlp-offline".
Done in 0.03s.
yarn install v1.8.0
[1/4] Resolving packages...
[2/4] Fetching packages...
error An unexpected error occurred: "EACCES: permission denied, unlink '/nix/store/j0xn98mmavzazn7q0md8jc9jmfkkrmlp-offline/semver-5.5.0.tgz'".
info If you think this is a bug, please open a bug report with the information provided in "/build/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
builder for '/nix/store/q29iva8k02b1gzkm63p7g131rjj4nrad-heroku-7.5.7-modules-7.5.7.drv' failed with exit code 1
cannot build derivation '/nix/store/nyjs1jjlq5a56jrk6q0adwsai9cl1ggq-heroku-7.5.7.drv': 1 dependencies couldn't be built
error: build of '/nix/store/nyjs1jjlq5a56jrk6q0adwsai9cl1ggq-heroku-7.5.7.drv' failed
```
For some reason, yarn is unlinking the symlink which fails since it has no permission to do so.

Best workaround to use heroku seems to be https://github.com/NixOS/nixpkgs/pull/25983#issuecomment-387913836