### PR TITLE
pscircle: init at v1.0.0

### DIFF
--- a/pkgs/os-specific/linux/pscircle/default.nix
+++ b/pkgs/os-specific/linux/pscircle/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitLab, meson, pkgconfig, ninja, cairo }:
+
+stdenv.mkDerivation rec {
+  name = "pscircle-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    owner = "mildlyparallel";
+    repo = "pscircle";
+    rev = "v${version}";
+    sha256 = "188d0db62215pycmx2qfmbbjpmih03vigsz2j448zhsbyxapavv3";
+  };
+
+  buildInputs = [
+      meson
+      pkgconfig
+      cairo
+      ninja
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://gitlab.com/mildlyparallel/pscircle;
+    description = "Visualize Linux processes in a form of a radial tree";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ldesgoui ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4624,6 +4624,8 @@ with pkgs;
 
   ps3netsrv = callPackage ../servers/ps3netsrv { };
 
+  pscircle = callPackage ../os-specific/linux/pscircle { };
+
   psmisc = callPackage ../os-specific/linux/psmisc { };
 
   pssh = callPackage ../tools/networking/pssh { };


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.com/mildlyparallel/pscircle compiled from source

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

