### PR TITLE
texlive: Propagate biber binary

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -4,7 +4,7 @@
 , freetype, t1lib, gd, libXaw, icu, ghostscript, ed, libXt, libXpm, libXmu, libXext
 , xextproto, perl, libSM, ruby, expat, curl, libjpeg, python, fontconfig, pkgconfig
 , poppler, libpaper, graphite2, zziplib, harfbuzz, texinfo, potrace, gmp, mpfr
-, xpdf, cairo, pixman, xorg, clisp
+, xpdf, cairo, pixman, xorg, clisp, biber
 , makeWrapper
 }:
 
@@ -261,6 +261,7 @@ dvipng = stdenv.mkDerivation {
 };
 
 
+inherit biber;
 bibtexu = bibtex8;
 bibtex8 = stdenv.mkDerivation {
   name = "texlive-bibtex-x.bin-${version}";


### PR DESCRIPTION
###### Motivation for this change
Closes #41752

Ping @vcunat @lovek323 @raskin @jwiegley 

Increases closure size of `texlive.combined.scheme-full` from 2.83GB to 2.88GB

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

