### PR TITLE
recoll: Add support to build without QT

### DIFF
--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -2,7 +2,8 @@
 , qt4, xapian, file, python, perl
 , djvulibre, groff, libxslt, unzip, poppler_utils, antiword, catdoc, lyx
 , libwpd, unrtf, untex
-, ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconv }:
+, ghostscript, gawk, gnugrep, gnused, gnutar, gzip, libiconv, zlib
+, withGui ? true }:
 
 assert stdenv.system != "powerpc-linux";
 
@@ -15,10 +16,13 @@ stdenv.mkDerivation rec {
     sha256 = "186bj8zx2xw9hwrzvzxdgdin9nj7msiqh5j57w5g7j4abdlsisjn";
   };
 
-  configureFlags = [ "--enable-recollq" ] ++
-    (if stdenv.isLinux then [ "--with-inotify" ] else [ "--without-inotify" ]);
+  configureFlags = [ "--enable-recollq" ]
+    ++ lib.optionals (!withGui) [ "--disable-qtgui" "--disable-x11mon" ]
+    ++ (if stdenv.isLinux then [ "--with-inotify" ] else [ "--without-inotify" ]);
 
-  buildInputs = [ qt4 xapian file python bison ];
+  buildInputs = [ xapian file python bison zlib ]
+    ++ lib.optional withGui qt4
+    ++ lib.optional stdenv.isDarwin libiconv;
 
   patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i 's/-Wl,--no-undefined -Wl,--warn-unresolved-symbols//' Makefile.am


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

