### PR TITLE
rPackages.rhdf5: fix installation

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -749,6 +749,10 @@ let
       patches = [ ./patches/BayesXsrc.patch ];
     });
 
+    rhdf5 = old.rhdf5.overrideDerivation (attrs: {
+      patches = [ ./patches/rhdf5.patch ];
+    });
+
     rJava = old.rJava.overrideDerivation (attrs: {
       preConfigure = ''
         export JAVA_CPPFLAGS=-I${pkgs.jdk}/include/

--- a/pkgs/development/r-modules/patches/rhdf5.patch
+++ b/pkgs/development/r-modules/patches/rhdf5.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index e3e21e8..3d947b6 100755
+--- a/configure
++++ b/configure
+@@ -2859,6 +2859,7 @@ fi;
+ 
+ echo "building the bundled hdf5 library...";
+ cd ${BASEPBNAME};
++sed -i 's#/bin/mv#mv#' configure
+ ./configure  --with-pic --enable-shared=no CXX="${CXX}" CXXFLAGS="${CXXFLAGS}" CC="${CC}" CFLAGS="${CFLAGS}" F77="${F77}"
+ $MAKE lib
+ cd ../../


### PR DESCRIPTION
Fix #42878

###### Motivation for this change

Fix installation of `rPackages.rhdf5`. This affects multiple other packages as they depend on `rhdf5` directly or indirectly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

