### PR TITLE
nghttp2: backport fix for CVE-2018-1000168 [18.03]

### DIFF
--- a/pkgs/development/libraries/nghttp2/CVE-2018-1000168.patch
+++ b/pkgs/development/libraries/nghttp2/CVE-2018-1000168.patch
@@ -1,0 +1,22 @@
+From b1bd6035e884b3d83748914a3b5f2a8e52a78a2f Mon Sep 17 00:00:00 2001
+From: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+Date: Sat, 7 Apr 2018 00:27:55 +0900
+Subject: [PATCH] Fix frame handling
+
+---
+source: https://github.com/nghttp2/nghttp2/commit/b1bd6035e884b3d83748914a3b5f2a8e52a78a2f
+
+diff --git a/lib/nghttp2_frame.c b/lib/nghttp2_frame.c
+index 210df0584..fa7cb6953 100644
+--- a/lib/nghttp2_frame.c
++++ b/lib/nghttp2_frame.c
+@@ -215,6 +215,9 @@ void nghttp2_frame_altsvc_free(nghttp2_extension *frame, nghttp2_mem *mem) {
+   nghttp2_ext_altsvc *altsvc;
+ 
+   altsvc = frame->payload;
++  if (altsvc == NULL) {
++    return;
++  }
+   /* We use the same buffer for altsvc->origin and
+      altsvc->field_value. */
+   nghttp2_mem_free(mem, altsvc->origin);

--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
     sha256 = "18ys6p39yvm9wjjzhhlw35c9m8f5gf4dk9jbshibj19q4js1pnv9";
   };
 
+  patches = [
+    ./CVE-2018-1000168.patch
+  ];
+
   outputs = [ "bin" "out" "dev" "lib" ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
backports commit https://github.com/nghttp2/nghttp2/commit/b1bd6035e884b3d83748914a3b5f2a8e52a78a2f

This fixes  CVE-2018-1000168 according to 
https://security-tracker.debian.org/tracker/CVE-2018-1000168
cc https://github.com/NixOS/nixpkgs/issues/42883

I dropped the test part of the patch because the expression has `doCheck = false`.

The patch is copied into nixpkgs because fetchpatch depends on nghttp2 via curl which creates a circular dependency.

I only tested compilation of nghttp2 and curl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

