### PR TITLE
pps-tools: init at v1.0.2, enable for chrony, gpsd, ntp

### DIFF
--- a/pkgs/os-specific/linux/pps-tools/default.nix
+++ b/pkgs/os-specific/linux/pps-tools/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  baseName = "pps-tools";
+  version = "1.0.2";
+  name = "${baseName}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "redlab-i";
+    repo = "${baseName}";
+    rev = "v${version}";
+    sha256 = "1yh9g0l59dkq4ci0wbb03qin3c3cizfngmn9jy1vwm5zm6axlxhf";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $dev/include
+    mkdir -p $out/{usr/bin,usr/include/sys}
+    make install DESTDIR=$out
+    mv $out/usr/bin/* $out/bin
+    mv $out/usr/include/* $dev/include/
+    rm -rf $out/usr/
+  '';
+
+  meta = with stdenv.lib;{
+    description = "User-space tools for LinuxPPS";
+    homepage = http://linuxpps.org/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sorki ];
+  };
+}

--- a/pkgs/servers/gpsd/0002-scons-envs-patch.patch
+++ b/pkgs/servers/gpsd/0002-scons-envs-patch.patch
@@ -1,0 +1,11 @@
+--- b/SConstruct	2018-07-03 23:13:51.986746857 +0200
++++ a/SConstruct	2018-07-03 23:14:50.495252914 +0200
+@@ -221,7 +221,7 @@
+     'STAGING_PREFIX',  # Required by the OpenWRT and CeroWrt builds.
+     'WRITE_PAD',       # So we can test WRITE_PAD values on the fly.
+     )
+-envs = {}
++envs = os.environ
+ for var in import_env:
+     if var in os.environ:
+         envs[var] = os.environ[var]

--- a/pkgs/servers/gpsd/default.nix
+++ b/pkgs/servers/gpsd/default.nix
@@ -2,6 +2,7 @@
 , ncurses, libX11, libXt, libXpm, libXaw, libXext
 , libusb1, docbook_xml_dtd_412, docbook_xsl, bc
 , libxslt, xmlto, gpsdUser ? "gpsd", gpsdGroup ? "dialout"
+, pps-tools
 , python2Packages
 }:
 
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     python2Packages.python dbus dbus-glib ncurses libX11 libXt libXpm libXaw libXext
-    libxslt libusb1
+    libxslt libusb1 pps-tools
   ];
 
   pythonPath = [
@@ -37,6 +38,8 @@ stdenv.mkDerivation rec {
 
     # TODO: remove the patch with the next release
     ./0001-Use-pkgconfig-for-dbus-library.patch
+    # to be able to find pps-tools
+    ./0002-scons-envs-patch.patch
   ];
 
   # - leapfetch=no disables going online at build time to fetch leap-seconds
@@ -44,9 +47,15 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     patchShebangs .
     sed -e "s|systemd_dir = .*|systemd_dir = '$out/lib/systemd/system'|" -i SConstruct
-    scons prefix="$out" leapfetch=no gpsd_user=${gpsdUser} gpsd_group=${gpsdGroup} \
-        systemd=yes udevdir="$out/lib/udev" \
-        python_libdir="$out/lib/${python2Packages.python.libPrefix}/site-packages"
+    scons \
+      -j $NIX_BUILD_CORES \
+      prefix="$out" \
+      leapfetch=no \
+      gpsd_user=${gpsdUser} \
+      gpsd_group=${gpsdGroup} \
+      systemd=yes \
+      udevdir="$out/lib/udev" \
+      python_libdir="$out/lib/${python2Packages.python.libPrefix}/site-packages"
   '';
 
   checkPhase = ''

--- a/pkgs/tools/networking/chrony/default.nix
+++ b/pkgs/tools/networking/chrony/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libcap, readline, texinfo, nss, nspr
-, libseccomp }:
+, libseccomp, pps-tools }:
 
 assert stdenv.isLinux -> libcap != null;
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ readline texinfo nss nspr ]
-    ++ stdenv.lib.optionals stdenv.isLinux [ libcap libseccomp ];
+    ++ stdenv.lib.optionals stdenv.isLinux [ libcap libseccomp pps-tools ];
   nativeBuildInputs = [ pkgconfig ];
 
   hardeningEnable = [ "pie" ];

--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, openssl, perl, libcap ? null, libseccomp ? null }:
+{ stdenv, lib, fetchurl, openssl, perl, libcap ? null, libseccomp ? null, pps-tools }:
 
 assert stdenv.isLinux -> libcap != null;
 assert stdenv.isLinux -> libseccomp != null;
@@ -28,7 +28,9 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional stdenv.isLinux "--enable-linuxcaps"
     ++ stdenv.lib.optional withSeccomp "--enable-libseccomp";
 
-  buildInputs = [ libcap openssl perl ] ++ lib.optional withSeccomp libseccomp;
+  buildInputs = [ libcap openssl perl ]
+    ++ lib.optional withSeccomp libseccomp
+    ++ lib.optional stdenv.isLinux pps-tools;
 
   hardeningEnable = [ "pie" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14237,6 +14237,8 @@ with pkgs;
 
   powertop = callPackage ../os-specific/linux/powertop { };
 
+  pps-tools = callPackage ../os-specific/linux/pps-tools { };
+
   prayer = callPackage ../servers/prayer { };
 
   procps-ng = if stdenv.isLinux then callPackage ../os-specific/linux/procps-ng { }


### PR DESCRIPTION
###### Motivation for this change

Enable PPS support

###### Things done

Packaged pps-tools, enabled in supported apps.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

