### PR TITLE
lib: add float option type

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -102,7 +102,7 @@ rec {
   # Pull in some builtins not included elsewhere.
   inherit (builtins)
     pathExists readFile isBool
-    isInt add sub lessThan
+    isInt isFloat add sub lessThan
     seq deepSeq genericClosure;
 
   inherit (lib.strings) fileContents;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -167,6 +167,13 @@ rec {
         # s32 = sign 32 4294967296;
       };
 
+    float = mkOptionType rec {
+        name = "float";
+        description = "floating point number";
+        check = isFloat;
+        merge = mergeOneOption;
+    };
+
     str = mkOptionType {
       name = "str";
       description = "string";


### PR DESCRIPTION
###### Motivation for this change

Add float option type which is now supported by nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

