### PR TITLE
Add Brother MFC-L2740DW drivers

### DIFF
--- a/pkgs/misc/cups/drivers/mfcl2740dwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2740dwcupswrapper/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchurl, dpkg, makeWrapper, coreutils, gnugrep, gnused, perl, mfcl2740dwlpr }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl2740dwcupswrapper-${version}";
+  version = "3.2.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101726/${name}.i386.deb";
+    sha256 = "078453e19f20ab6c7fc4d63c3e09f162f3d1410c04c23a294b6ffbd720b35ffb";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = "dpkg-deb -x $src $out";
+
+  installPhase = ''
+    basedir=${mfcl2740dwlpr}/opt/brother/Printers/MFCL2740DW
+    dir=$out/opt/brother/Printers/MFCL2740DW
+
+    substituteInPlace $dir/cupswrapper/brother_lpdwrapper_MFCL2740DW \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "basedir =~" "basedir = \"$basedir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL2740DW\"; #"
+
+    substituteInPlace $dir/cupswrapper/paperconfigml1 \
+      --replace /usr/bin/perl ${perl}/bin/perl
+
+    wrapProgram $dir/cupswrapper/brother_lpdwrapper_MFCL2740DW \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln $dir/cupswrapper/brother_lpdwrapper_MFCL2740DW $out/lib/cups/filter
+    ln $dir/cupswrapper/brother-MFCL2740DW-cups-en.ppd $out/share/cups/model
+  '';
+
+  meta = {
+    description = "Brother MFC-L2740DW CUPS wrapper driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ stdenv.lib.maintainers.enzime ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcl2740dwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2740dwlpr/default.nix
@@ -1,0 +1,43 @@
+{ pkgsi686Linux, stdenv, fetchurl, dpkg, makeWrapper, coreutils, ghostscript, gnugrep, gnused, which, perl }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl2740dwlpr-${version}";
+  version = "3.2.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101727/${name}.i386.deb";
+    sha256 = "10a2bc672bd54e718b478f3afc7e47d451557f7d5513167d3ad349a3d00bffaf";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  unpackPhase = "dpkg-deb -x $src $out";
+
+  installPhase = ''
+    dir=$out/opt/brother/Printers/MFCL2740DW
+
+    substituteInPlace $dir/lpd/filter_MFCL2740DW \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"MFCL2740DW\"; #"
+
+    wrapProgram $dir/lpd/filter_MFCL2740DW \
+      --prefix PATH : ${stdenv.lib.makeBinPath [
+        coreutils ghostscript gnugrep gnused which
+      ]}
+
+    # need to use i686 glibc here, these are 32bit proprietary binaries
+    interpreter=${pkgsi686Linux.glibc}/lib/ld-linux.so.2
+    patchelf --set-interpreter "$interpreter" $dir/inf/braddprinter
+    patchelf --set-interpreter "$interpreter" $dir/lpd/brprintconflsr3
+    patchelf --set-interpreter "$interpreter" $dir/lpd/rawtobr3
+  '';
+
+  meta = {
+    description = "Brother MFC-L2740DW lpr driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.unfree;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = [ stdenv.lib.maintainers.enzime ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21393,6 +21393,8 @@ with pkgs;
   mfcl2720dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2720dwcupswrapper { };
   mfcl2720dwlpr = callPackage ../misc/cups/drivers/mfcl2720dwlpr { };
 
+  mfcl2740dwlpr = callPackage ../misc/cups/drivers/mfcl2740dwlpr { };
+
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
   samsung-unified-linux-driver = callPackage ../misc/cups/drivers/samsung/4.00.39 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21393,6 +21393,7 @@ with pkgs;
   mfcl2720dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2720dwcupswrapper { };
   mfcl2720dwlpr = callPackage ../misc/cups/drivers/mfcl2720dwlpr { };
 
+  mfcl2740dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2740dwcupswrapper { };
   mfcl2740dwlpr = callPackage ../misc/cups/drivers/mfcl2740dwlpr { };
 
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };


### PR DESCRIPTION
###### Motivation for this change

Add drivers for Brother MFC-L2740DW printers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

