### PR TITLE
vscode: 1.24.0 -> 1.24.1

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -2,7 +2,7 @@
   makeWrapper, libXScrnSaver, libxkbfile, libsecret }:
 
 let
-  version = "1.24.0";
+  version = "1.24.1";
   channel = "stable";
 
   plat = {
@@ -12,9 +12,9 @@ let
   }.${stdenv.system};
 
   sha256 = {
-    "i686-linux" = "17dvyp31kf12mfs6z3cm8rxfrvrmbrk9gbsk3z7v284z64dry9vz";
-    "x86_64-linux" = "11m50lb0hvnmvb3qdixgpvdzcljzm94qxl41240g4qh4a36qvr1j";
-    "x86_64-darwin" = "1wm6h3f8b33rky5nlrvwx4qx0k9h72aabiz6sm27x1wrs486p3lf";
+    "i686-linux" = "189chqdimijjzydb8sp3yyi19fijsivyxrdddy8raaj7qkwq0maa";
+    "x86_64-linux" = "1944v54pfpfkq5jjnfrhndcwndsnvavd9qih1i2pq16mgaizmib2";
+    "x86_64-darwin" = "09sn22j40hax9v6ai99pfj67ymzkk82yqf8j33bg8byk4fgrz9jg";
   }.${stdenv.system};
 
   archive_fmt = if stdenv.system == "x86_64-darwin" then "zip" else "tar.gz";


### PR DESCRIPTION
###### Motivation for this change

Minor update, tested on Linux x86_64 omly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

