### PR TITLE
warzone2100: fix build

### DIFF
--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, perl, unzip, zip, which, pkgconfig
-, qtbase, qtscript, SDL2, libtheora, openal, glew, physfs, fribidi
+, qtbase, qtscript, SDL2, libtheora, openal, glew, physfs, fribidi, libXrandr
 , withVideos ? false
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     sha256 = "10kmpr4cby95zwqsl1zwx95d9achli6khq7flv6xmrq30a39xazw";
   };
 
-  buildInputs = [ qtbase qtscript SDL2 libtheora openal glew physfs fribidi ];
+  buildInputs = [ qtbase qtscript SDL2 libtheora openal glew physfs fribidi libXrandr ];
   nativeBuildInputs = [ perl zip unzip pkgconfig ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
had this error: https://hydra.nixos.org/build/76816508
now it builds, can't test it though at the moment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

