### PR TITLE
pythonPackages.matrix-client: 0.2.0 -> 0.3.2

### DIFF
--- a/pkgs/development/python-modules/matrix-client/default.nix
+++ b/pkgs/development/python-modules/matrix-client/default.nix
@@ -2,25 +2,21 @@
 , buildPythonPackage
 , fetchPypi
 , requests
-, tox, pytest, flake8, responses
+, pytest, pytestrunner, responses
 }:
 
 buildPythonPackage rec {
-  pname = "matrix-client";
-  version = "0.2.0";
+  pname = "matrix_client";
+  version = "0.3.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b96e87adf1bc2270166b2a4cff1320d2ef283779ea8b3c4edd0d9051fc7b7924";
+    sha256 = "1mgjd0ymf9mvqjkvgx3xjhxap7rzdmpa21wfy0cxbw2xcswcrqyw";
   };
 
-  checkInputs = [ tox pytest flake8 responses ];
+  checkInputs = [ pytest pytestrunner responses ];
 
   propagatedBuildInputs = [ requests ];
-
-  checkPhase = ''
-    pytest
-  '';
 
   meta = with stdenv.lib; {
     description = "Matrix Client-Server SDK";


### PR DESCRIPTION
###### Motivation for this change

Update and rename (it's ```matrix_client``` on pypi, not ```matrix-client```).

Tests are ~~~running~~~ done.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

