### PR TITLE
gauche: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/development/interpreters/gauche/default.nix
+++ b/pkgs/development/interpreters/gauche/default.nix
@@ -1,23 +1,29 @@
-{ stdenv, fetchurl, pkgconfig, texinfo, libiconv, gdbm, openssl, zlib }:
+{ stdenv, fetchurl, pkgconfig, texinfo, libiconv, gdbm, openssl, zlib
+, mbedtls, cacert
+}:
 
 stdenv.mkDerivation rec {
   name = "gauche-${version}";
-  version = "0.9.5";
+  version = "0.9.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/gauche/Gauche-${version}.tgz";
-    sha256 = "0g77nik15whm5frxb7l0pwzd95qlq949dym5pn5p04p17lhm72jc";
+    sha256 = "1bwwwvyxsrp2a4cfib6hn0hcgwzmp2znylm088w09f331miji2fd";
   };
 
   nativeBuildInputs = [ pkgconfig texinfo ];
 
-  buildInputs = [ libiconv gdbm openssl zlib ];
+  buildInputs = [ libiconv gdbm openssl zlib mbedtls cacert ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
 
   configureFlags = [
-    "--enable-multibyte=utf-8"
     "--with-iconv=${libiconv}"
     "--with-dbm=gdbm"
     "--with-zlib=${zlib}"
+    "--with-ca-bundle=$SSL_CERT_FILE"
     # TODO: Enable slib
     #       Current slib in nixpkgs is specialized to Guile
     # "--with-slib=${slibGuile}/lib/slib"


### PR DESCRIPTION
- Support mbedtls
- UTF-8 encoding is default

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

