### PR TITLE
Add `pkgs.haskell.lib.packagesFromDirectory` utility

### DIFF
--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -387,7 +387,7 @@ rec {
   #
   # packagesFromDirectory : Directory -> HaskellPackageOverrideSet
   packagesFromDirectory =
-    { directory }:
+    { directory, ... }:
 
     self: super:
       let

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -382,4 +382,23 @@ rec {
           allPkgconfigDepends;
       };
 
+  # Utility to convert a directory full of `cabal2nix`-generated files into a
+  # package override set
+  #
+  # readDirectory : Directory -> HaskellPackageOverrideSet
+  readDirectory =
+    directory:
+
+    self: super:
+      let
+        haskellPaths = builtins.attrNames (builtins.readDir directory);
+
+        toKeyVal = file: {
+          name  = builtins.replaceStrings [ ".nix" ] [ "" ] file;
+
+          value = self.callPackage (directory + "/${file}") { };
+        };
+
+      in
+        builtins.listToAttrs (map toKeyVal haskellPaths);
 }

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -387,7 +387,7 @@ rec {
   #
   # readDirectory : Directory -> HaskellPackageOverrideSet
   readDirectory =
-    directory:
+    { directory }:
 
     self: super:
       let

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -385,8 +385,8 @@ rec {
   # Utility to convert a directory full of `cabal2nix`-generated files into a
   # package override set
   #
-  # readDirectory : Directory -> HaskellPackageOverrideSet
-  readDirectory =
+  # packagesFromDirectory : Directory -> HaskellPackageOverrideSet
+  packagesFromDirectory =
     { directory }:
 
     self: super:

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -385,7 +385,7 @@ rec {
   # Utility to convert a directory full of `cabal2nix`-generated files into a
   # package override set
   #
-  # packagesFromDirectory : Directory -> HaskellPackageOverrideSet
+  # packagesFromDirectory : { directory : Directory, ... } -> HaskellPackageOverrideSet
   packagesFromDirectory =
     { directory, ... }:
 


### PR DESCRIPTION
###### Motivation for this change

This adds a `readDirectory` utility that can be used to "slurp" a directory
full of `cabal2nix`-generated files and transform them into a Haskell package
override set.  The main use of this is so that users don't have to write:

```
{ overrides = self: super: {
    foo = self.callPackage ./path/to/foo.nix { };

    bar = self.callPackage ./path/to/bar.nix { };

    ...
  };
}
```

Instead, they can write:

```
{ overrides = pkgs.haskell.lib.readDirectory ./path/to;
}
```

This is a an alternative to `packageSourceOverrides` which primarily addresses
the following use cases:

* The desired package is not yet available in `all-cabal-hashes` (perhaps the
  user is pinned to an older revision of `nixpkgs`)
* The default `cabal2nix` invocation used by `packageSourceOverrides`
  does not use the desired `cabal2nix` flags
* The user wants to avoid the use of import-from-derivation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

