### PR TITLE
flow: 0.72.0 -> 0.75.0

### DIFF
--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -4,15 +4,22 @@
 with lib;
 
 stdenv.mkDerivation rec {
-  version = "0.72.0";
+  version = "0.75.0";
   name = "flow-${version}";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "flow";
     rev = "v${version}";
-    sha256 = "1lfnl1crwkygzbv3l85n30dqsfz627xrnmn4z3zxh7lazir5h8b8";
+    sha256 = "0xrcjjk16w6anpy58qa4la1jyfjs0xg5xkp58slhai996wqif24k";
   };
+
+  # lwt.log is being split out into a separate package, so this can be
+  # removed once nixpkgs is updated.
+  # See https://github.com/ocsigen/lwt/issues/453#issuecomment-352897664
+  postPatch = ''
+    substituteInPlace Makefile --replace lwt_log lwt.log
+  '';
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
###### Motivation for this change

Using newer version at work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

