### PR TITLE
gradle-completion: init at 1.3.1

### DIFF
--- a/pkgs/shells/zsh/gradle-completion/default.nix
+++ b/pkgs/shells/zsh/gradle-completion/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "gradle-completion-${version}";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "gradle";
+    repo = "gradle-completion";
+    rev = "v${version}";
+    sha256 = "02vv360r78ckwc6r4xbhmy5dxz6l9ya4lq9c62zh12ciq94y9kgx";
+  };
+
+  # we just move two files into $out,
+  # this shouldn't bother Hydra.
+  preferLocalBuild = true;
+
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    install -Dm0644 ./_gradle $out/share/zsh/site-functions/_gradle
+    install -Dm0644 ./gradle-completion.bash $out/share/bash-completion/completions/gradle
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Gradle tab completion for bash and zsh";
+    homepage = https://github.com/gradle/gradle-completion;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6036,6 +6036,8 @@ with pkgs;
 
   bash-completion = callPackage ../shells/bash/bash-completion { };
 
+  gradle-completion = callPackage ../shells/zsh/gradle-completion { };
+
   nix-bash-completions = callPackage ../shells/bash/nix-bash-completions { };
 
   dash = callPackage ../shells/dash { };


### PR DESCRIPTION
###### Motivation for this change

This package adds completion scripts for `gradle` on the `bash` and
`zsh` shells.

The completions can be enabled like this:

``` nix
{ pkgs, ... }:
{
  environment.systemPackages = [ pkgs.gradle pkgs.gradle-completion ];
  programs.zsh.enable = true;
}
```

The package stores the scripts into the expected directories in
`$out/share` to ensure that the shells can easily find their scripts.

Closes #42799

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

