### PR TITLE
stdenv: enable colors

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -203,6 +203,8 @@ rec {
             ++ optional (elem "host"   configurePlatforms) "--host=${stdenv.hostPlatform.config}"
             ++ optional (elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}";
 
+          CLICOLOR_FORCE = 1;
+
         } // lib.optionalAttrs (hardeningDisable != [] || hardeningEnable != []) {
           NIX_HARDENING_ENABLE = enabledHardeningOptions;
         } // lib.optionalAttrs (outputs' != [ "out" ]) {


### PR DESCRIPTION
Since the builds are running in the sandbox, there can't be a way for a
tool like cmake to correctly detect whether the output is a tty or not,
so colors will be disabled in all cases, even when you build with
`nix-build` and see the lines scrolling by in your terminal.

To have colors we therefore need to force it to use them with the
dedicated env var. Note that simply running `CLICOLOR_FORCE=1 cmake ...`
won't do it, we need to actually `export` it, so subprocesses can see
it.

I used `aws-sdk-cpp` to test it on (note that if you run cmake from this PR, it will first take a while to compile cmake itself, which will still be uncolored).

###### Motivation for this change
Colors can be very useful to quickly spot errors/warnings in a build. Here is a recording of a comparison of a build with and without colors: https://asciinema.org/a/WNDtvyeRH5cDmq0EqiZrpN5M0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

