### PR TITLE
boost: disable system Python.framework detection

### DIFF
--- a/pkgs/development/libraries/boost/darwin-no-system-python.patch
+++ b/pkgs/development/libraries/boost/darwin-no-system-python.patch
@@ -1,0 +1,45 @@
+diff --git a/tools/build/src/tools/python.jam b/tools/build/src/tools/python.jam
+index 273b28a..2d2031e 100644
+--- a/tools/build/src/tools/python.jam
++++ b/tools/build/src/tools/python.jam
+@@ -428,13 +428,7 @@ local rule windows-installed-pythons ( version ? )
+ 
+ local rule darwin-installed-pythons ( version ? )
+ {
+-    version ?= $(.version-countdown) ;
+-
+-    local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
+-          : Python.framework ] ;
+-
+-    return $(prefix)/Versions/$(version)/bin/python ;
++    return ;
+ }
+ 
+ 
+@@ -890,25 +884,6 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
+ 
+     # See if we can find a framework directory on darwin.
+     local framework-directory ;
+-    if $(target-os) = darwin
+-    {
+-        # Search upward for the framework directory.
+-        local framework-directory = $(libraries[-1]) ;
+-        while $(framework-directory:D=) && $(framework-directory:D=) != Python.framework
+-        {
+-            framework-directory = $(framework-directory:D) ;
+-        }
+-
+-        if $(framework-directory:D=) = Python.framework
+-        {
+-            debug-message framework directory is \"$(framework-directory)\" ;
+-        }
+-        else
+-        {
+-            debug-message "no framework directory found; using library path" ;
+-            framework-directory = ;
+-        }
+-    }
+ 
+     local dll-path = $(libraries) ;
+ 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -87,11 +87,13 @@ stdenv.mkDerivation {
   inherit src;
 
   patchFlags = optionalString (hostPlatform.libc == "msvcrt") "-p0";
-  patches = patches ++ optional (hostPlatform.libc == "msvcrt") (fetchurl {
-    url = "https://svn.boost.org/trac/boost/raw-attachment/tickaet/7262/"
-        + "boost-mingw.patch";
-    sha256 = "0s32kwll66k50w6r5np1y5g907b7lcpsjhfgr7rsw7q5syhzddyj";
-  });
+  patches = patches
+    ++ optional stdenv.isDarwin ./darwin-no-system-python.patch
+    ++ optional (hostPlatform.libc == "msvcrt") (fetchurl {
+      url = "https://svn.boost.org/trac/boost/raw-attachment/tickaet/7262/"
+          + "boost-mingw.patch";
+      sha256 = "0s32kwll66k50w6r5np1y5g907b7lcpsjhfgr7rsw7q5syhzddyj";
+    });
 
   meta = {
     homepage = http://boost.org/;


### PR DESCRIPTION
###### Motivation for this change

There doesn't seem to be a `--without-python` flag and since the system
framework is always available the build tries to enable python support
while we have it disabled by default and explicitly don't pass in the
python headers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
    - [ ] boost155 (patch doesn't apply)
    - [x] boost159
    - [x] boost160
    - [ ] boost162 (still fails)
    - [x] boost163
    - [x] boost164
    - [x] boost165
    - [x] boost166
    - [x] boost167
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
