### PR TITLE
lib.generators.toPlist: add floats

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -177,13 +177,15 @@ rec {
 
   # PLIST handling
   toPlist = {}: v: let
-    expr = ind: x: with builtins;
-      if isNull x then "" else
-      if isBool x then bool ind x else
-      if isInt x then int ind x else
+    isFloat = builtins.isFloat or (x: false);
+    expr = ind: x:  with builtins;
+      if isNull x   then "" else
+      if isBool x   then bool ind x else
+      if isInt x    then int ind x else
       if isString x then str ind x else
-      if isList x then list ind x else
-      if isAttrs x then attrs ind x else
+      if isList x   then list ind x else
+      if isAttrs x  then attrs ind x else
+      if isFloat x  then float ind x else
       abort "generators.toPlist: should never happen (v = ${v})";
 
     literal = ind: x: ind + x;
@@ -192,6 +194,7 @@ rec {
     int = ind: x: literal ind "<integer>${toString x}</integer>";
     str = ind: x: literal ind "<string>${x}</string>";
     key = ind: x: literal ind "<key>${x}</key>";
+    float = ind: x: literal ind "<real>${toString x}</real>";
 
     indent = ind: expr "\t${ind}";
 


### PR DESCRIPTION
Nix now supports floats & we can pretty easily map them to Plist’s
<real></real> type. Note that I am unsure how this affects older
version of Nix that may or may not have builtins.isFloat available.
Make sure this satisfies minver.nix’s "1.11" requirement.

/cc @3noch