### PR TITLE
pythonPackages.grpcio-tools: init at 1.13.0

### DIFF
--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchPypi, lib, six, protobuf, grpc, grpcio}:
+
+buildPythonPackage rec {
+  pname = "grpcio-tools";
+  version = "1.13.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ck6818kb4nb6skm9lqg492brqs7kfk65f4hh2c7h7c8pkbrpcw1";
+  };
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [ six protobuf grpc grpcio ];
+
+  meta = with stdenv.lib; {
+    description = "Protobuf code generator for gRPC";
+    license = lib.licenses.asl20;
+    homepage = "https://grpc.io/grpc/python/";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6261,6 +6261,8 @@ in {
 
   grpcio = callPackage ../development/python-modules/grpcio { };
 
+  grpcio-tools = callPackage ../development/python-modules/grpcio-tools { };
+
   gspread = buildPythonPackage rec {
     version = "0.2.3";
     name = "gspread-${version}";


### PR DESCRIPTION
###### Motivation for this change

The seemingly only [documented](https://grpc.io/docs/tutorials/basic/python.html#generating-client-and-server-code) way of generating python grpc code is via the protoc python module, which is contained in this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
