### PR TITLE
wire-desktop: 3.0.2816 -> 3.2.2840

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -39,7 +39,7 @@ let
     xorg.libxcb
   ];
 
-  version = "3.0.2816";
+  version = "3.2.2840";
 
   plat = {
     "i686-linux" = "i386";
@@ -47,8 +47,8 @@ let
   }.${stdenv.system};
 
   sha256 = {
-    "i686-linux" = "1ds807j1b8dk9hrnzbg4g9mvn44abw24pxrqns9ai62mh3hvi65p";
-    "x86_64-linux" = "13pyyp2c8q0v0ni2hzh2jnbd3i96q68314glbmy4kyh7vm9427lc";
+    "i686-linux" = "071ddh2d8wmiybwafwyb97962zj358l0fq7g2r44231653sgybvq";
+    "x86_64-linux" = "0qp9ms94smnm7k47b0n0jdzvnm1b7gj25hyinsfc6lghrb6jqw3r";
   }.${stdenv.system};
 
 in


### PR DESCRIPTION
###### Motivation for this change
There's an update.

Here's the [release notes](https://medium.com/wire-news/wire-for-linux-3-2-2840-57fe28eb0c1d)
and also a [comparison](https://github.com/wireapp/wire-desktop/compare/release%2F3.0.2816...release%2F3.2.2840) to the prior release.

The issues with strange text artifacts seems to have been corrected also.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
556194384
405147904
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
I did not test this on **i686-linux**

