### PR TITLE
pythonPackages.keyutils: fix build

### DIFF
--- a/pkgs/development/python-modules/keyutils/default.nix
+++ b/pkgs/development/python-modules/keyutils/default.nix
@@ -1,17 +1,19 @@
-{ lib, buildPythonPackage, fetchPypi, keyutils, pytestrunner }:
+{ lib, buildPythonPackage, fetchFromGitHub, keyutils, pytestrunner, pytest }:
 
 buildPythonPackage rec {
   pname = "keyutils";
   version = "0.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "0dskys71vkn59vlsfs1ljli0qnzk7b10iv4pawxawnk2hvyjrf10";
+  # github version comes bundled with tests
+  src = fetchFromGitHub {
+    owner = "sassoftware";
+    repo = "python-keyutils";
+    rev = "v${version}";
+    sha256 = "1gga60w8sb3r5bxa0bfp7d7wzg6s3db5y7aizr14p2pvp92d8bdi";
   };
 
-  checkInputs = [ keyutils pytestrunner ];
-
-  doCheck = false;
+  buildInputs = [ keyutils ];
+  checkInputs = [ pytest pytestrunner ];
 
   meta = {
     description = "A set of python bindings for keyutils";


### PR DESCRIPTION
###### Motivation for this change

Fixes the Hydra CI build of `python{3,2}Packages.keyutils` on `nixpkgs.`
This patch changes the source retrieval to fetchFromGitHub as the PYPI
tarball doesn't come with tests for the check phase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

