### PR TITLE
boomerang: 2018-01-18 -> 2018-07-03

### DIFF
--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "boomerang-${version}";
-  version = "0.4.0-alpha-2018-01-18";
+  version = "0.4.0-alpha-2018-07-03";
 
   src = fetchFromGitHub {
     owner = "ceeac";
     repo = "boomerang";
-    rev = "b4ff8d573407a8ed6365d4bfe53d2d47d983e393";
-    sha256 = "0x17vlm6y1paa49fi3pmzz7vzdqms19qkr274hkq32ql342b6i6x";
+    rev = "377ff2d7db93d892c925e2d3e61aef818371ce7d";
+    sha256 = "1ljbyj3b8xckr1wihyii3h576zgq0q88vli0ylpr3p4jxy5sm57j";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Update by ~6 months of improvements :).

See upstream for issue discussing release tag,
looks like we should continue to follow git for now.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---