### PR TITLE
ispc: llvm_4 -> llvm_6, fix luxcorerender

### DIFF
--- a/pkgs/development/compilers/ispc/default.nix
+++ b/pkgs/development/compilers/ispc/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, bash, which, m4, python, bison, flex, llvmPackages,
+{stdenv, fetchFromGitHub, fetchpatch, bash, which, m4, python, bison, flex, llvmPackages,
 testedTargets ? ["sse2" "host"] # the default test target is sse4, but that is not supported by all Hydra agents
 }:
 
@@ -30,6 +30,13 @@ stdenv.mkDerivation rec {
     flex
     llvm
     llvmPackages.clang-unwrapped # we need to link against libclang, so we need the unwrapped
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/ispc/ispc/commit/d504641f5af9d5992e7c8f0ed42c1063a39ede5b.patch;
+      sha256 = "192q3gyvam79469bmlwf0jpfi2y4f8hl2vgcvjngsqhvscwira0s";
+    })
   ];
 
   postPatch = "sed -i -e 's/\\/bin\\///g' -e 's/-lcurses/-lncurses/g' Makefile";

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -80,6 +80,8 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
     "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+
+    "-DLLVM_ENABLE_DUMP=ON"
   ]
   ++ stdenv.lib.optional enableSharedLibraries
     "-DLLVM_LINK_LLVM_DYLIB=ON"

--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -10,6 +10,7 @@
 let boost_static = boost165.override {
       python = python35;
       enableStatic = true;
+      enablePython = true;
     };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9711,8 +9711,8 @@ with pkgs;
   isocodes = callPackage ../development/libraries/iso-codes { };
 
   ispc = callPackage ../development/compilers/ispc {
-    llvmPackages = llvmPackages_4;
-    stdenv = llvmPackages_4.stdenv;
+    llvmPackages = llvmPackages_6;
+    stdenv = llvmPackages_6.stdenv;
   };
 
   isso = callPackage ../servers/isso { };


### PR DESCRIPTION
Also build llvm_6 with `*::dump()` methods enabled,
(mostly `Value::dump` I think?) since they're needed
by ispc but are generally useful as well.

Presumably the resulting ISPC still works,
since expressions using it build properly...
but sanity-check from someone would be appreciated :).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---