### PR TITLE
wcc: init unstable at 2018-04-05

### DIFF
--- a/pkgs/development/compilers/wcc/default.nix
+++ b/pkgs/development/compilers/wcc/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, capstone, libbfd, libelf, libiberty, readline }:
+
+stdenv.mkDerivation rec {
+  name = "wcc-unstable-${version}";
+  version = "2018-04-05";
+
+  src = fetchFromGitHub {
+    owner = "endrazine";
+    repo = "wcc";
+    rev = "f141963ff193d7e1931d41acde36d20d7221e74f";
+    sha256 = "1f0w869x0176n5nsq7m70r344gv5qvfmk7b58syc0jls8ghmjvb4";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ capstone libbfd libelf libiberty readline ];
+
+  postPatch = ''
+    sed -i src/wsh/include/libwitch/wsh.h src/wsh/scripts/INDEX \
+      -e "s#/usr/share/wcc#$out/share/wcc#"
+  '';
+
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  preInstall = ''
+    mkdir -p $out/usr/bin
+  '';
+
+  postInstall = ''
+    mv $out/usr/* $out
+    rmdir $out/usr
+    mkdir -p $out/share/man/man1
+    cp doc/manpages/*.1 $out/share/man/man1/
+  '';
+
+  preFixup = ''
+    # Let patchShebangs rewrite shebangs with wsh.
+    PATH+=:$out/bin
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/endrazine/wcc;
+    description = "Witchcraft compiler collection: tools to convert and script ELF files";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ orivej ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7113,6 +7113,8 @@ with pkgs;
 
   valadoc = callPackage ../development/tools/valadoc { };
 
+  wcc = callPackage ../development/compilers/wcc { };
+
   wla-dx = callPackage ../development/compilers/wla-dx { };
 
   wrapCCWith =


### PR DESCRIPTION
###### Motivation for this change

This adds the tools that, among other things, can convert ELF shared objects to ELF static objects, pointed out by @dezgeg at https://github.com/NixOS/nixpkgs/pull/41935#issuecomment-397618055

`wsh` does not seem to be able to find symbols in any library other than `libc`, but everything else works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).