### PR TITLE
Revert "haskell generic-builder: Use strictDeps always"

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -5,7 +5,7 @@
 # stripLen acts as the -p parameter when applying a patch.
 
 { lib, fetchurl, patchutils }:
-{ stripLen ? 0, extraPrefix ? null, excludes ? [], includes ? [], ... }@args:
+{ stripLen ? 0, extraPrefix ? null, excludes ? [], ... }@args:
 
 fetchurl ({
   postFetch = ''
@@ -24,9 +24,7 @@ fetchurl ({
     ${patchutils}/bin/filterdiff \
       -p1 \
       ${builtins.toString (builtins.map (x: "-x ${x}") excludes)} \
-      ${builtins.toString (builtins.map (x: "-i ${x}") includes)} \
       "$tmpfile" > "$out"
     ${args.postFetch or ""}
   '';
-  meta.broken = excludes != [] && includes != [];
-} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "includes" "postFetch"])
+} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "postFetch"])

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -25,22 +25,6 @@ self: super: {
   haskeline = null;
   hoopl = self.hoopl_3_10_2_2;   # no longer a core library in GHC 8.4.x
   hpc = null;
-
-  # A few things for hspec*:
-  #
-  #   1. Break cycles for test
-  #
-  #   2. https://github.com/hspec/hspec/pull/355 The buildTool will be properly
-  #      cabal2nixed when run on the patched cabal file.
-  hspec = let
-    breakCycles = super.hspec_2_5_3.override { stringbuilder = dontCheck self.stringbuilder; };
-  in addTestToolDepend breakCycles self.hspec-meta;
-  hspec-core = let
-    breakCycles = super.hspec-core_2_5_3.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
-  in addTestToolDepend breakCycles self.hspec-meta;
-  hspec-discover = addTestToolDepend super.hspec-discover_2_5_3 self.hspec-meta;
-  hspec-smallcheck = addTestToolDepend self.hspec-smallcheck_0_5_2 self.hspec-meta;
-
   integer-gmp = null;
   mtl = null;
   parsec = null;
@@ -412,7 +396,11 @@ self: super: {
   dhall = self.dhall_1_14_0;
   dhall_1_13_0 = doJailbreak super.dhall_1_14_0;  # support ansi-terminal 0.8.x
   HaTeX = self.HaTeX_3_19_0_0;
-  hpack = addTestBuildDepend self.hpack_0_28_2 super.hspec-discover;
+  hpack = self.hpack_0_28_2;
+  hspec = dontCheck super.hspec_2_5_3;
+  hspec-core = dontCheck super.hspec-core_2_5_3;
+  hspec-discover = self.hspec-discover_2_5_3;
+  hspec-smallcheck = self.hspec-smallcheck_0_5_2;
   matrix = self.matrix_0_3_6_1;
   pandoc = self.pandoc_2_2_1;
   pandoc-types = self.pandoc-types_1_17_5_1;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -53,7 +53,7 @@ self: super: builtins.intersectAttrs super {
 
   # Use the default version of mysql to build this package (which is actually mariadb).
   # test phase requires networking
-  mysql = dontCheck (addBuildTool (super.mysql.override { mysql = pkgs.mysql.connector-c; }) pkgs.mysql);
+  mysql = dontCheck (super.mysql.override { mysql = pkgs.mysql.connector-c; });
 
   # CUDA needs help finding the SDK headers and libraries.
   cuda = overrideCabal super.cuda (drv: {
@@ -516,12 +516,4 @@ self: super: builtins.intersectAttrs super {
   # Tests require a browser: https://github.com/ku-fpg/blank-canvas/issues/73
   blank-canvas = dontCheck super.blank-canvas;
   blank-canvas_0_6_2 = dontCheck super.blank-canvas_0_6_2;
-
-  # Custom setup needs pg_config
-  HDBC-postgresql = addBuildTool super.HDBC-postgresql pkgs.postgresql;
-
-  # Custom setup needs sdl-config
-  SDL = addBuildTool super.SDL pkgs.SDL;
-  neat-interpolation = addBuildTool super.neat-interpolation self.HTF;
-  hnix = addBuildTool super.hnix pkgs.nix;
 }

--- a/pkgs/development/haskell-modules/default.nix
+++ b/pkgs/development/haskell-modules/default.nix
@@ -1,4 +1,4 @@
-{ buildPackages, pkgs, stdenv, lib, haskellLib, ghc, all-cabal-hashes
+{ pkgs, stdenv, lib, haskellLib, ghc, all-cabal-hashes
 , buildHaskellPackages
 , compilerConfig ? (self: super: {})
 , packageSetConfig ? (self: super: {})
@@ -18,7 +18,7 @@ let
     inherit stdenv haskellLib ghc buildHaskellPackages extensible-self all-cabal-hashes;
   };
 
-  commonConfiguration = configurationCommon { inherit buildPackages pkgs haskellLib; };
+  commonConfiguration = configurationCommon { inherit pkgs haskellLib; };
   nixConfiguration = configurationNix { inherit pkgs haskellLib; };
 
   extensible-self = makeExtensible

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -182,14 +182,12 @@ let
   depsBuildBuild = [ nativeGhc ];
   nativeBuildInputs = [ ghc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
                       setupHaskellDepends ++
-                      buildTools ++ libraryToolDepends ++ executableToolDepends ++
-                      optionals doCheck testToolDepends ++
-                      optionals doBenchmark benchmarkToolDepends;
+                      buildTools ++ libraryToolDepends ++ executableToolDepends;
   propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends ++ libraryFrameworkDepends;
   otherBuildInputs = extraLibraries ++ librarySystemDepends ++ executableSystemDepends ++ executableFrameworkDepends ++
                      allPkgconfigDepends ++
-                     optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testFrameworkDepends) ++
-                     optionals doBenchmark (benchmarkDepends ++ benchmarkHaskellDepends ++ benchmarkSystemDepends ++ benchmarkFrameworkDepends);
+                     optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testToolDepends ++ testFrameworkDepends) ++
+                     optionals doBenchmark (benchmarkDepends ++ benchmarkHaskellDepends ++ benchmarkSystemDepends ++ benchmarkToolDepends ++ benchmarkFrameworkDepends);
 
   allBuildInputs = propagatedBuildInputs ++ otherBuildInputs;
 
@@ -233,7 +231,6 @@ stdenv.mkDerivation ({
 
   inherit src;
 
-  strictDeps = true;
   inherit depsBuildBuild nativeBuildInputs;
   buildInputs = otherBuildInputs ++ optionals (!hasActiveLibrary) propagatedBuildInputs;
   propagatedBuildInputs = optionals hasActiveLibrary propagatedBuildInputs;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -143,12 +143,6 @@ rec {
   addBuildTool = drv: x: addBuildTools drv [x];
   addBuildTools = drv: xs: overrideCabal drv (drv: { buildTools = (drv.buildTools or []) ++ xs; });
 
-  addTestToolDepend = drv: x: addTestToolDepends drv [x];
-  addTestToolDepends = drv: xs: overrideCabal drv (drv: { testToolDepends = (drv.testToolDepends or []) ++ xs; });
-
-  addBenchmarkToolDepend = drv: x: addBenchmarkToolDepends drv [x];
-  addBenchmarkToolDepends = drv: xs: overrideCabal drv (drv: { benchmarkToolDepends = (drv.benchmarkToolDepends or []) ++ xs; });
-
   addExtraLibrary = drv: x: addExtraLibraries drv [x];
   addExtraLibraries = drv: xs: overrideCabal drv (drv: { extraLibraries = (drv.extraLibraries or []) ++ xs; });
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#41420.

I am sorry, but that huge lists of overrides in `configuration-common.nix` is completely unmaintainable. This is no tenable solution. We need another way to address these failures, preferably by fixing `cabal2nix` so that it generates proper Nix expressions in the first place.