### PR TITLE
nix: use boehmgc with enableLargeConfig = true

### DIFF
--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, libatomic_ops, enableLargeConfig ? false
+{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, libatomic_ops
+, enableLargeConfig ? false # doc: https://github.com/ivmai/bdwgc/blob/v7.6.6/doc/README.macros#L179
 , buildPlatform, hostPlatform
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21138,6 +21138,7 @@ with pkgs;
       storeDir = config.nix.storeDir or "/nix/store";
       stateDir = config.nix.stateDir or "/nix/var";
       curl = curl_7_59;
+      boehmgc = boehmgc.override { enableLargeConfig = true; };
       })
     nix
     nix1


### PR DESCRIPTION
From source-code comment I expect we should be fine with that setting:
/* overflows at roughly 128 GB  */
Fixes #43015 and also similar issues, hopefully.

