### PR TITLE
theme-jade1: 3.2 -> 3.3

### DIFF
--- a/pkgs/misc/themes/jade1/default.nix
+++ b/pkgs/misc/themes/jade1/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "theme-jade1-${version}";
-  version = "3.2";
+  version = "3.3";
 
   src = fetchFromGitHub {
     owner = "madmaxms";
     repo = "theme-jade-1";
     rev = "v${version}";
-    sha256 = "0lf8cawn2s2x1b9af0cznhqzx3dsr8h18srcwjz7af3y5daxf311";
+    sha256 = "06w06dvzs1llmzpyz3c5yycsw3gslsgikalfcq5l92d72z4kzfw7";
   };
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];


### PR DESCRIPTION
###### Motivation for this change

- Update to version [3.3](https://github.com/madmaxms/theme-jade-1/releases/tag/v3.3)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).