### PR TITLE
Revert "pkgs/top-level/release.nix.nix: Use fetchGit if possible"

### DIFF
--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -8,11 +8,7 @@
 
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
-{ nixpkgs ?
-    if builtins.pathExists ../../.git then
-      fetchGit ../..
-    else
-      { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
 , officialRelease ? false
   # The platforms for which we build Nixpkgs.
 , supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]


### PR DESCRIPTION
This reverts commit 67d0a57ef9eedde69192e08db77751c1c1062e0e.

which caused evaluation errors in restricted eval mode, producing:

error: access to URI
'/var/lib/ofborg/checkout/repo/38dca4e3aa6bca43ea96d2fcc04e8229/mr-est/eval-1-lassulus.ewr1.nix.ci' is
forbidden in restricted mode

cc @edolstra 