### PR TITLE
dwarf-fortress: Fix themes & package Legends Browser

### DIFF
--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -32,6 +32,8 @@ let
 
     dwarf-therapist = callPackage ./dwarf-therapist/wrapper.nix { };
 
+    legends-browser = callPackage ./legends-browser {};
+
     themes = callPackage ./themes {
       stdenv = stdenvNoCC;
     };

--- a/pkgs/games/dwarf-fortress/legends-browser/default.nix
+++ b/pkgs/games/dwarf-fortress/legends-browser/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, jre }:
+
+stdenv.mkDerivation rec {
+  name = "legends-browser-${version}";
+  version = "1.17.1";
+
+  src = fetchurl {
+    url = "https://github.com/robertjanetzko/LegendsBrowser/releases/download/${version}/legendsbrowser-${version}.jar";
+    sha256 = "05b4ksbl4481rh3ykfirbp6wvxhppcd5mvclhn9995gsrcaj8gx9";
+  };
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s $src $out/legends-browser.jar
+    echo "${jre}/bin/java -jar $out/legends-browser.jar" > $out/bin/legends-browser
+    chmod a+x $out/bin/legends-browser
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A multi-platform, open source, java-based legends viewer for dwarf fortress";
+    maintainers = with maintainers; [ Baughn ];
+    license = licenses.mit;
+    platforms = platforms.all;
+    homepage = https://github.com/robertjanetzko/LegendsBrowser;
+  };
+}

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -17,15 +17,15 @@ let
     else theme;
 
   # These are in inverse order for first packages to override the next ones.
-  pkgs = lib.optional (theme != null) ptheme
-         ++ lib.optional enableDFHack dfhack_
+  themePkg = lib.optional (theme != null) ptheme;
+  pkgs = lib.optional enableDFHack dfhack_
          ++ lib.optional enableSoundSense soundSense
          ++ [ dwarf-fortress-original ];
 
   env = buildEnv {
     name = "dwarf-fortress-env-${dwarf-fortress-original.dfVersion}";
 
-    paths = pkgs;
+    paths = themePkg ++ pkgs;
     pathsToLink = [ "/" "/hack" "/hack/scripts" ];
     ignoreCollisions = true;
 


### PR DESCRIPTION
###### Motivation for this change

Theme support was broken, throwing errors if used.

Legends-browser is useful, and a good addition to the pack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

