### PR TITLE
write_stylus: init at 209

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2938,6 +2938,11 @@
     github = "oxij";
     name = "Jan Malakhovski";
   };
+  oyren = {
+    email = "m.scheuren@oyra.eu";
+    github = "oyren";
+    name = "Moritz Scheuren";
+  };
   pSub = {
     email = "mail@pascal-wittmann.de";
     github = "pSub";

--- a/pkgs/applications/graphics/write_stylus/default.nix
+++ b/pkgs/applications/graphics/write_stylus/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, lib, qtbase, qtsvg,  makeWrapper, fetchurl, makeDesktopItem }:
+stdenv.mkDerivation rec {
+  name = "write_stylus-${version}";
+  version = "209";
+
+  desktopItem = makeDesktopItem {
+    name = "Write";
+    exec = "Write";
+    comment = "a word processor for hadwriting";
+    desktopName = "Write";
+    genericName = "Write";
+    categories = "Office;Graphics";
+  };
+
+  src = fetchurl {
+    url = "http://www.styluslabs.com/write/write${version}.tar.gz";
+    sha256 = "1p6glp4vdpwl8hmhypayc4cvs3j9jfmjfhhrgqm2xkgl5bfbv2qd";
+  };
+  sourceRoot = ".";
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R Write $out/
+    # symlink the binary to bin/
+    ln -s $out/Write/Write $out/bin/Write
+
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+  '';
+  preFixup = let
+    libPath = lib.makeLibraryPath [
+      qtbase        # libQt5PrintSupport.so.5
+      qtsvg         # libQt5Svg.so.5
+      stdenv.cc.cc.lib  # libstdc++.so.6
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/Write/Write
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.styluslabs.com/;
+    description = "Write is a word processor for handwriting.";
+    platforms = platforms.linux;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with maintainers; [ oyren ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18818,6 +18818,8 @@ with pkgs;
     erlang = erlangR18;
   };
 
+  write_stylus = libsForQt5.callPackage ../applications/graphics/write_stylus { };
+
   alsamixer.app = callPackage ../applications/window-managers/windowmaker/dockapps/alsamixer.app.nix { };
 
   wllvm = callPackage  ../development/tools/wllvm { };


### PR DESCRIPTION
Write from http://www.styluslabs.com/ is a word processor for handwriting.

###### Motivation for this change
Add Write so everyone can use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

