### PR TITLE
termtekst: init -> 1.0

### DIFF
--- a/pkgs/misc/emulators/termtekst/default.nix
+++ b/pkgs/misc/emulators/termtekst/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, python3Packages, ncurses }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "termtekst";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "zevv";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1gm7j5d49a60wm7px82b76f610i8pl8ccz4r6qsz90z4mp3lyw9b";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ ncurses requests ];
+
+  patchPhase = ''
+    substituteInPlace setup.py \
+      --replace "assert" "assert 1==1 #"
+    substituteInPlace src/tt \
+      --replace "locale.setlocale" "#locale.setlocale"
+    '';
+
+  meta = with lib; {
+    description = ''Console NOS Teletekst viewer in Python'';
+    longDescription = ''
+      Small Python app using curses to display Dutch NOS Teletekst on
+      the Linux console. The original Teletekst font includes 2x6
+      raster graphics glyphs which have no representation in unicode;
+      as a workaround the braille set is abused to approximate the
+      graphics.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14916,6 +14916,8 @@ with pkgs;
 
   terminus_font_ttf = callPackage ../data/fonts/terminus-font-ttf { };
 
+  termtekst = callPackage ../misc/emulators/termtekst { };
+
   tex-gyre = callPackages ../data/fonts/tex-gyre { };
 
   tex-gyre-math = callPackages ../data/fonts/tex-gyre-math { };


### PR DESCRIPTION
###### Motivation for this change

After all these years, Teletekst (Dutch equivalent of Ceefax) still is one of the fastest way to learn about news, weather etc. Plus, this nimble implementation runs on the terminal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

