### PR TITLE
sqlitebrowser: fix build

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,5 +1,6 @@
-{ mkDerivation, lib, fetchFromGitHub, cmake, antlr
-, qtbase, qttools, qscintilla, sqlite }:
+{ mkDerivation, lib, fetchFromGitHub, qmake, antlr, qscintilla
+, qtbase, qttools, sqlite
+}:
 
 mkDerivation rec {
   version = "3.10.1";
@@ -12,11 +13,20 @@ mkDerivation rec {
     sha256 = "1brzam8yv6sbdmbqsp7vglhd6wlx49g2ap8llr271zrkld4k3kar";
   };
 
+  patches = [
+    ./no-custom-qscintilla.patch
+  ];
+
   buildInputs = [ qtbase qscintilla sqlite ];
 
-  nativeBuildInputs = [ cmake antlr qttools ];
+  nativeBuildInputs = [ qmake antlr qttools ];
 
   enableParallelBuilding = true;
+
+  qmakeFlags = [
+    "QMAKE_RELEASE=${qttools.dev}/bin/lrelease"
+    "QMAKE_LUPDATE=${qttools.dev}/bin/lupdate"
+  ];
 
   # We have to patch out Test and PrintSupport to make this work with Qt 5.9
   # It can go when the application supports 5.9
@@ -29,11 +39,15 @@ mkDerivation rec {
       --replace PrintSupport ""
   '';
 
+  preInstall = ''
+    substituteInPlace "src/src.pro" --replace "/usr/local" $out
+  '';
+
   meta = with lib; {
     description = "DB Browser for SQLite";
     homepage = http://sqlitebrowser.org/;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ma27 ];
     platforms = platforms.linux; # can only test on linux
   };
 }

--- a/pkgs/development/tools/database/sqlitebrowser/no-custom-qscintilla.patch
+++ b/pkgs/development/tools/database/sqlitebrowser/no-custom-qscintilla.patch
@@ -1,0 +1,10 @@
+diff --git a/sqlitebrowser.pro b/sqlitebrowser.pro
+index 95d4e89..78d526c 100644
+--- a/sqlitebrowser.pro
++++ b/sqlitebrowser.pro
+@@ -5,5 +5,4 @@ CONFIG += debug_and_release
+ SUBDIRS = libs/antlr-2.7.7/antlr.pro \
+     libs/qhexedit/qhexedit.pro \
+     libs/qcustomplot-source/qcustomplot.pro \
+-    libs/qscintilla/Qt4Qt5/qscintilla.pro \
+     src


### PR DESCRIPTION
###### Motivation for this change

This patch slightly cleans up the `sqlitebrowser` derivation and
switches from a cmake-based build to a qmake build using
`qmakeConfigurePhase` and the corresponding hook.

QMake is far more suitable for QT-based builds (and suggested e.g. here
https://github.com/NixOS/nixpkgs/issues/42320#issuecomment-401791602),
furthermore the CMake build suffers from issues like missing commands
including `qt5_use_modules`.

Fixes #42320
See https://hydra.nixos.org/build/76952038

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

