### PR TITLE
passff-host: init at 1.0.2

### DIFF
--- a/pkgs/tools/security/passff-host/default.nix
+++ b/pkgs/tools/security/passff-host/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, python3, pass }:
+
+stdenv.mkDerivation rec {
+  name = "passff-host-${version}";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "passff";
+    repo = "passff-host";
+    rev = version;
+    sha256 = "1zks34rg9i8vphjrj1h80y5rijadx33z911qxa7pslf7ahmjqdv3";
+  };
+
+  buildInputs = [ python3 ];
+
+  patchPhase = ''
+    sed -i 's#COMMAND      = "pass"#COMMAND = "${pass}/bin/pass"#' src/passff.py
+  '';
+
+  preBuild = "cd src";
+  postBuild = "cd ..";
+
+  installPhase = ''
+    install -D bin/testing/passff.py $out/share/passff-host/passff.py
+    cp bin/testing/passff.json $out/share/passff-host/passff.json
+    substituteInPlace $out/share/passff-host/passff.json \
+      --replace PLACEHOLDER $out/share/passff-host/passff.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Host app for the WebExtension PassFF";
+    homepage = https://github.com/passff/passff-host;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nadrieril ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -688,6 +688,8 @@ with pkgs;
 
   browserpass = callPackage ../tools/security/browserpass { };
 
+  passff-host = callPackage ../tools/security/passff-host { };
+
   oracle-instantclient = callPackage ../development/libraries/oracle-instantclient { };
 
   kwakd = callPackage ../servers/kwakd { };


### PR DESCRIPTION
###### Motivation for this change
This package is the host app for the Firefox extension PassFF. It is similar to browserpass but has a different set of features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

