### PR TITLE
patchwork-classic: fix typo in package name

### DIFF
--- a/pkgs/applications/networking/ssb/patchwork-classic/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork-classic/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   version = "2.12.0";
 
-  name = "patchwork-clasic-${version}";
+  name = "patchwork-classic-${version}";
 
   src = fetchurl {
     url    = "https://github.com/ssbc/patchwork-classic-electron/releases/download/v2.12.0/ssb-patchwork-electron_2.12.0_linux-amd64.deb";


### PR DESCRIPTION
There was a typo.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

