### PR TITLE
cmake: fix build with libuv 1.21 (on staging)

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig
+{ stdenv, fetchurl, fetchpatch, pkgconfig
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
 , majorVersion ? "3.11"
 # darwin attributes
@@ -57,6 +57,11 @@ stdenv.mkDerivation rec {
 
   # Don't search in non-Nix locations such as /usr, but do search in our libc.
   patches = [ ./search-path-3.9.patch ]
+    ++ optional (versionOlder version "3.12") (fetchpatch {
+      name = "cmake-3.11-libuv-1.21.patch";
+      url = https://gitlab.kitware.com/cmake/cmake/commit/889033b5c6847cf1f7bd789384405d59dc333bf6.patch;
+      sha256 = "0683zbyb3bicaxqzrj4wgdan6x08k30m20kkmpjvw30nr6a8r6xq";
+    })
     # Don't depend on frameworks.
     ++ optional (useSharedLibraries && majorVersion == "3.11") ./application-services.patch  # TODO: remove conditional
     ++ optional stdenv.isCygwin ./3.2.2-cygwin.patch;


### PR DESCRIPTION
###### Motivation for this change

Fixes build of cmake 3.11, 3.10 and 3.9 with libuv 1.21 (on staging since #42986).

Upstream will release the fix with cmake 3.12.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
