### PR TITLE
dwarf-fortress: Run legends-browser with a suitable working directory

### DIFF
--- a/pkgs/games/dwarf-fortress/legends-browser/default.nix
+++ b/pkgs/games/dwarf-fortress/legends-browser/default.nix
@@ -1,24 +1,32 @@
-{ stdenv, fetchurl, jre }:
+{ stdenvNoCC, buildEnv, writeShellScriptBin, fetchurl, jre }:
 
-stdenv.mkDerivation rec {
+let
   name = "legends-browser-${version}";
   version = "1.17.1";
 
-  src = fetchurl {
+  jar = fetchurl {
     url = "https://github.com/robertjanetzko/LegendsBrowser/releases/download/${version}/legendsbrowser-${version}.jar";
     sha256 = "05b4ksbl4481rh3ykfirbp6wvxhppcd5mvclhn9995gsrcaj8gx9";
   };
-
-  unpackPhase = "true";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    ln -s $src $out/legends-browser.jar
-    echo "${jre}/bin/java -jar $out/legends-browser.jar" > $out/bin/legends-browser
-    chmod a+x $out/bin/legends-browser
+  
+  script = writeShellScriptBin "legends-browser" ''
+    set -eu
+    BASE="$HOME/.local/share/df_linux/legends-browser/"
+    mkdir -p "$BASE"
+    cd "$BASE"
+    if [[ ! -e legendsbrowser.properties ]]; then
+      echo 'Creating initial configuration for legends-browser'
+      echo "last=$(cd ..; pwd)" > legendsbrowser.properties
+    fi
+    ${jre}/bin/java -jar ${jar}
   '';
+in
 
-  meta = with stdenv.lib; {
+buildEnv {
+  inherit name;
+  paths = [ script ];
+
+  meta = with stdenvNoCC.lib; {
     description = "A multi-platform, open source, java-based legends viewer for dwarf fortress";
     maintainers = with maintainers; [ Baughn ];
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

It turns out that legends-browser leaves its configuration file in the current directory, whatever that is.

This wrapper makes sure it'll use df_linux, where all the other tools put theirs, and also sets a correct initial world-load path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

