### PR TITLE
Asterisk xmpp support

### DIFF
--- a/pkgs/development/libraries/iksemel/default.nix
+++ b/pkgs/development/libraries/iksemel/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, autoreconfHook, libtool, pkgconfig, gnutls, fetchFromGitHub, texinfo }:
+
+stdenv.mkDerivation rec {
+  name = "iksemel-${version}";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "timothytylee";
+    repo = "iksemel-1.4";
+    rev = "v${version}";
+    sha256 = "1xv302p344hnpxqcgs3z6wwxhrik39ckgfw5cjyrw0dkf316z9yh";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook libtool texinfo ];
+  buildInputs = [ gnutls ];
+
+  meta = with stdenv.lib; {
+    description = "XML parser for jabber";
+
+    homepage = https://github.com/timothytylee/iksemel-1.4;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ disassembler ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -2,7 +2,7 @@
   jansson, libxml2, libxslt, ncurses, openssl, sqlite,
   utillinux, dmidecode, libuuid, newt,
   lua, speex,
-  srtp, wget, curl
+  srtp, wget, curl, iksemel
 }:
 
 let
@@ -10,7 +10,7 @@ let
     inherit version;
     name = "asterisk-${version}";
 
-    buildInputs = [ jansson libxml2 libxslt ncurses openssl sqlite utillinux dmidecode libuuid newt lua speex srtp wget curl ];
+    buildInputs = [ jansson libxml2 libxslt ncurses openssl sqlite utillinux dmidecode libuuid newt lua speex srtp wget curl iksemel ];
 
     patches = [
       # We want the Makefile to install the default /var skeleton

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16606,6 +16606,8 @@ with pkgs;
     inherit (perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig;}; }) PerlMagick;
   };
 
+  iksemel = callPackage ../development/libraries/iksemel { };
+
   imagej = callPackage ../applications/graphics/imagej { };
 
   imagemagick_light = imagemagick.override {


### PR DESCRIPTION
###### Motivation for this change
Adds iksemel package and compiles asterisk with it in buildInputs so asterisk can work with google voice.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

