### PR TITLE
 lib: concatMap and mapAttrs to be builtins

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -195,8 +195,9 @@ rec {
           { x = "foo"; y = "bar"; }
        => { x = "x-foo"; y = "y-bar"; }
   */
-  mapAttrs = f: set:
-    listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set));
+  mapAttrs = builtins.mapAttrs or
+    (f: set:
+      listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set)));
 
 
   /* Like `mapAttrs', but allows the name of each attribute to be

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -101,7 +101,7 @@ rec {
        concatMap (x: [x] ++ ["z"]) ["a" "b"]
        => [ "a" "z" "b" "z" ]
   */
-  concatMap = f: list: concatLists (map f list);
+  concatMap = builtins.concatMap or (f: list: concatLists (map f list));
 
   /* Flatten the argument into a single list; that is, nested lists are
      spliced into the top-level lists.


### PR DESCRIPTION
###### Motivation for this change

prepare for ```concatMap``` and ```mapAttrs``` to be builtins

(to reduce Nix memory consumption when evaluating big ```nixpkgs```, PR https://github.com/NixOS/nix/pull/2273)