### PR TITLE
termtosvg: init at 0.3.0

### DIFF
--- a/pkgs/tools/misc/termtosvg/default.nix
+++ b/pkgs/tools/misc/termtosvg/default.nix
@@ -1,0 +1,27 @@
+{ lib, python3, fetchFromGitHub }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "termtosvg";
+  version = "0.3.0";
+
+  # tests are not available when fetching from pypi
+  src = fetchFromGitHub {
+    owner = "nbedos";
+    repo = pname;
+    rev = version;
+    sha256 = "09hw0467pyfj5gwn3768b3rvs5ch3wb1kaax7zsqjd7mw2qh0cjw";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ svgwrite pyte ];
+
+  checkInputs = [ python3.pkgs.mock ];
+  preCheck = "export HOME=$(mktemp -d)";
+  postCheck = "unset HOME";
+
+  meta = with lib; {
+    homepage = https://github.com/nbedos/termtosvg;
+    description = "Record terminal sessions as SVG animations";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ma27 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18421,6 +18421,8 @@ with pkgs;
     vte = gnome3.vte-ng;
   };
 
+  termtosvg = callPackage ../tools/misc/termtosvg { };
+
   tesseract = callPackage ../applications/graphics/tesseract { };
   tesseract_4 = lowPrio (callPackage ../applications/graphics/tesseract/4.x.nix { });
 


### PR DESCRIPTION
###### Motivation for this change

`termtosvg` makes screencasts and writes them into a SVG file. The app
can be used on CLI entirely.

Closes #42921

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

