### PR TITLE
haskell: Split boot libraries into individual outputs (take 2)

### DIFF
--- a/pkgs/development/compilers/ghc/7.10.3.nix
+++ b/pkgs/development/compilers/ghc/7.10.3.nix
@@ -194,8 +194,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit bootPackages;
-    inherit bootPkgs;
-    inherit targetPrefix;
+    inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
     inherit enableShared;

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -201,8 +201,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit bootPackages;
-    inherit bootPkgs;
-    inherit targetPrefix;
+    inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
     inherit enableShared;

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -1,5 +1,6 @@
 { stdenv, targetPackages
 , buildPlatform, hostPlatform, targetPlatform
+, haskellLib
 
 # build-tools
 , bootPkgs, alex, happy, hscolour
@@ -41,6 +42,16 @@ let
   targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
+
+  bootPackages = [
+    "Cabal" "array" "base" "binary" "bytestring" "containers"
+    "deepseq" "directory" "filepath" /*"ghc"*/ "ghc-boot" "ghc-boot-th"
+    "ghc-compact" "ghc-prim" "ghci" "haskeline" "hoopl" "hpc"
+    "integer-gmp" "pretty" "process" "rts" "template-haskell" "terminfo"
+    "time" "transformers" "unix" "xhtml"
+  ];
+
+  inherit (haskellLib) toOutputName;
 
   buildMK = ''
     BuildFlavour = ${ghcFlavour}
@@ -88,7 +99,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "doc" ] ++ map toOutputName bootPackages;
 
   patches = [
     (fetchpatch { # Fix STRIP to be substituted from configure
@@ -209,6 +220,15 @@ stdenv.mkDerivation rec {
       paxmark m "$bin"
     done
 
+    # Make boot packages usable as individual dependencies
+  '' + stdenv.lib.concatMapStringsSep "\n" (lib: ''
+    libOut="''$${toOutputName lib}"
+    libConfDir="$libOut/lib/ghc-${version}/package.conf.d"
+    mkdir -p "$libConfDir"
+    find "$out/lib/ghc-${version}/package.conf.d/" -regex '.*/${lib}-[0-9.]*.conf' -exec \
+      mv {} "$libConfDir"/ \;
+  '') bootPackages + ''
+
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
@@ -221,7 +241,9 @@ stdenv.mkDerivation rec {
   '';
 
   passthru = {
-    inherit bootPkgs targetPrefix;
+    inherit bootPackages;
+    inherit bootPkgs;
+    inherit targetPrefix;
 
     inherit llvmPackages;
     inherit enableShared;

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -242,8 +242,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit bootPackages;
-    inherit bootPkgs;
-    inherit targetPrefix;
+    inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
     inherit enableShared;

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -1,5 +1,6 @@
 { stdenv, targetPackages
 , buildPlatform, hostPlatform, targetPlatform
+, haskellLib
 
 # build-tools
 , bootPkgs, alex, happy, hscolour
@@ -39,6 +40,17 @@ let
   targetPrefix = stdenv.lib.optionalString
     (targetPlatform != hostPlatform)
     "${targetPlatform.config}-";
+
+  bootPackages = [
+    "Cabal" "array" "base" "binary" "bytestring" "containers"
+    "deepseq" "directory" "filepath" /*"ghc"*/ "ghc-boot" "ghc-boot-th"
+    "ghc-compact" "ghc-prim" "ghci" "haskeline" "hpc" "integer-gmp"
+    "mtl" "parsec" "pretty" "process" "rts" "stm"
+    "template-haskell" "terminfo" "text" "time" "transformers" "unix"
+    "xhtml"
+  ];
+
+  inherit (haskellLib) toOutputName;
 
   buildMK = ''
     BuildFlavour = ${ghcFlavour}
@@ -86,7 +98,7 @@ stdenv.mkDerivation (rec {
 
   enableParallelBuilding = true;
 
-  outputs = [ "out" "doc" ];
+  outputs = [ "out" "doc" ] ++ map toOutputName bootPackages;
 
   patches = [(fetchpatch {
     url = "https://git.haskell.org/hsc2hs.git/patch/738f3666c878ee9e79c3d5e819ef8b3460288edf";
@@ -181,6 +193,15 @@ stdenv.mkDerivation (rec {
       paxmark m "$bin"
     done
 
+    # Make boot packages usable as individual dependencies
+  '' + stdenv.lib.concatMapStringsSep "\n" (lib: ''
+    libOut="''$${toOutputName lib}"
+    libConfDir="$libOut/lib/ghc-${version}/package.conf.d"
+    mkdir -p "$libConfDir"
+    find "$out/lib/ghc-${version}/package.conf.d/" -regex '.*/${lib}-[0-9.]*.conf' -exec \
+      mv {} "$libConfDir"/ \;
+  '') bootPackages + ''
+
     # Install the bash completion file.
     install -D -m 444 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
 
@@ -193,7 +214,9 @@ stdenv.mkDerivation (rec {
   '';
 
   passthru = {
-    inherit bootPkgs targetPrefix;
+    inherit bootPackages;
+    inherit bootPkgs;
+    inherit targetPrefix;
 
     inherit llvmPackages;
     inherit enableShared;

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -215,8 +215,7 @@ stdenv.mkDerivation (rec {
 
   passthru = {
     inherit bootPackages;
-    inherit bootPkgs;
-    inherit targetPrefix;
+    inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;
     inherit enableShared;

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -45,9 +45,9 @@ let
     "Cabal" "array" "base" "binary" "bytestring" "containers"
     "deepseq" "directory" "filepath" /*"ghc"*/ "ghc-boot" "ghc-boot-th"
     "ghc-compact" "ghc-heap" "ghc-prim" "ghci" "haskeline" "hpc"
-    "integer-gmp" "mtl" "parsec" "pretty" "process" "rts"
-    "stm" "template-haskell" "terminfo" "text" "time" "transformers"
-    "unix" "xhtml"
+    "integer-gmp" "libiserv" "mtl" "parsec" "pretty" "process"
+    "rts" "stm" "template-haskell" "terminfo" "text" "time"
+    "transformers" "unix" "xhtml"
   ];
 
   inherit (haskellLib) toOutputName;

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -208,6 +208,7 @@ stdenv.mkDerivation (rec {
   '';
 
   passthru = {
+    inherit bootPackages;
     inherit bootPkgs targetPrefix;
 
     inherit llvmPackages;

--- a/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-7.10.x.nix
@@ -7,35 +7,6 @@ self: super: {
   # Suitable LLVM version.
   llvmPackages = pkgs.llvmPackages_35;
 
-  # Disable GHC 7.10.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bin-package-db = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hoopl = null;
-  hpc = null;
-  integer-gmp = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  template-haskell = null;
-  terminfo = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
   # Build jailbreak-cabal with the latest version of Cabal.
   jailbreak-cabal = super.jailbreak-cabal.override { Cabal = self.Cabal_1_24_2_0; };
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -7,34 +7,6 @@ self: super: {
   # Suitable LLVM version.
   llvmPackages = pkgs.llvmPackages_37;
 
-  # Disable GHC 8.0.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hoopl = null;
-  hpc = null;
-  integer-gmp = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  template-haskell = null;
-  terminfo = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
   # https://github.com/bmillwood/applicative-quoters/issues/6
   applicative-quoters = appendPatch super.applicative-quoters (pkgs.fetchpatch {
     url = "https://patch-diff.githubusercontent.com/raw/bmillwood/applicative-quoters/pull/7.patch";

--- a/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.2.x.nix
@@ -7,35 +7,6 @@ self: super: {
   # Suitable LLVM version.
   llvmPackages = pkgs.llvmPackages_39;
 
-  # Disable GHC 8.2.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-compact = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hoopl = null;
-  hpc = null;
-  integer-gmp = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  template-haskell = null;
-  terminfo = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
   # Make sure we can still build Cabal 1.x.
   Cabal_1_24_2_0 = overrideCabal super.Cabal_1_24_2_0 (drv: {
     prePatch = "sed -i -e 's/process.*< 1.5,/process,/g' Cabal.cabal";

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -7,41 +7,6 @@ self: super: {
   # Use the latest LLVM.
   inherit (pkgs) llvmPackages;
 
-  # Disable GHC 8.4.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-compact = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hpc = null;
-  integer-gmp = null;
-  mtl = null;
-  parsec = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  stm = null;
-  template-haskell = null;
-  terminfo = null;
-  text = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
-  # Use to be a core-library, but no longer is since GHC 8.4.x.
-  hoopl = self.hoopl_3_10_2_2;
-
   doctest = dontCheck super.doctest_0_16_0;  # tests depend on very recent QuickCheck
   hackage-db = super.hackage-db_2_0_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.4.x.nix
@@ -7,6 +7,9 @@ self: super: {
   # Use the latest LLVM.
   inherit (pkgs) llvmPackages;
 
+  # Use to be a core-library, but no longer is since GHC 8.4.x.
+  hoopl = self.hoopl_3_10_2_2;
+
   doctest = dontCheck super.doctest_0_16_0;  # tests depend on very recent QuickCheck
   hackage-db = super.hackage-db_2_0_1;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -7,40 +7,6 @@ self: super: {
   # Use the latest LLVM.
   inherit (pkgs) llvmPackages;
 
-  # Disable GHC 8.6.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-compact = null;
-  ghc-heap = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hpc = null;
-  integer-gmp = null;
-  libiserv = null;
-  mtl = null;
-  parsec = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  stm = null;
-  template-haskell = null;
-  terminfo = null;
-  text = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
   # Use to be a core-library, but no longer is since GHC 8.4.x.
   hoopl = self.hoopl_3_10_2_2;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-head.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-head.nix
@@ -7,36 +7,6 @@ self: super: {
   # Use the latest LLVM.
   inherit (pkgs) llvmPackages;
 
-  # Disable GHC 7.11.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bin-package-db = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-compact = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hoopl = null;
-  hpc = null;
-  integer-gmp = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  template-haskell = null;
-  terminfo = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
   # jailbreak-cabal can use the native Cabal library.
   jailbreak-cabal = pkgs.haskell.packages.ghc802.jailbreak-cabal;
 

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -382,4 +382,8 @@ rec {
           allPkgconfigDepends;
       };
 
+  # Convert a haskell package name to a valid output name.
+  # Output names cannot contain dashes because they are mapped to shell variables.
+  toOutputName = builtins.replaceStrings ["-"] ["_"];
+
 }

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -158,7 +158,10 @@ let
       '';
     });
 
-in genAttrs (ghc.passthru.bootPackages or []) (name: ghc."${haskellLib.toOutputName name}") //
+  extractBootPackage = ghc: name:
+    ghc."${haskellLib.toOutputName name}" // { isHaskellLibrary = true; };
+
+in genAttrs (ghc.bootPackages or []) (extractBootPackage ghc) //
 
    package-set { inherit pkgs stdenv callPackage; } self // {
 

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -158,7 +158,9 @@ let
       '';
     });
 
-in package-set { inherit pkgs stdenv callPackage; } self // {
+in genAttrs (ghc.passthru.bootPackages or []) (name: ghc."${haskellLib.toOutputName name}") //
+
+   package-set { inherit pkgs stdenv callPackage; } self // {
 
     inherit mkDerivation callPackage haskellSrc2nix hackage2nix;
 
@@ -256,7 +258,6 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
         installPhase = "echo $nativeBuildInputs $buildInputs > $out";
       });
 
-  } // genAttrs (ghc.passthru.bootPackages or []) (name: ghc."${haskellLib.toOutputName name}") // {
     ghc = ghc // {
       withPackages = ghcWithPackages;
       withHoogle = ghcWithHoogle;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -42,16 +42,22 @@ in rec {
 
   compiler = {
 
-    ghc7103Binary = callPackage ../development/compilers/ghc/7.10.3-binary.nix { };
-    ghc821Binary = callPackage ../development/compilers/ghc/8.2.1-binary.nix { };
+    ghc7103Binary = callPackage ../development/compilers/ghc/7.10.3-binary.nix {
+      inherit haskellLib;
+    };
+    ghc821Binary = callPackage ../development/compilers/ghc/8.2.1-binary.nix {
+      inherit haskellLib;
+    };
 
     ghc7103 = callPackage ../development/compilers/ghc/7.10.3.nix rec {
+      inherit haskellLib;
       bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour;
       buildLlvmPackages = buildPackages.llvmPackages_35;
       llvmPackages = pkgs.llvmPackages_35;
     };
     ghc802 = callPackage ../development/compilers/ghc/8.0.2.nix rec {
+      inherit haskellLib;
       bootPkgs = packages.ghc7103Binary;
       inherit (bootPkgs) hscolour;
       sphinx = pkgs.python27Packages.sphinx;
@@ -59,6 +65,7 @@ in rec {
       llvmPackages = pkgs.llvmPackages_37;
     };
     ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix rec {
+      inherit haskellLib;
       bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) hscolour alex happy;
       inherit buildPlatform targetPlatform;
@@ -67,18 +74,21 @@ in rec {
       llvmPackages = pkgs.llvmPackages_39;
     };
     ghc843 = callPackage ../development/compilers/ghc/8.4.3.nix rec {
+      inherit haskellLib;
       bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) alex happy hscolour;
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
     };
     ghc861 = callPackage ../development/compilers/ghc/8.6.1.nix rec {
+      inherit haskellLib;
       bootPkgs = packages.ghc822;
       inherit (bootPkgs) alex happy hscolour;
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
+      inherit haskellLib;
       bootPkgs = packages.ghc821Binary;
       inherit (bootPkgs) alex happy hscolour;
       buildLlvmPackages = buildPackages.llvmPackages_5;


### PR DESCRIPTION
This is like #43017 (fix for #42069), but:

1. Rebased onto master (now with GHC 8.6)
2. Does only the bare minimum, only moves packages to individual outputs.

I am still not sure what to do with ghcjs (and whether anything needs to be done at all).

@Ericson2314