### PR TITLE
sixpair: init at 2007-04-18

### DIFF
--- a/pkgs/tools/misc/sixpair/default.nix
+++ b/pkgs/tools/misc/sixpair/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, libusb }:
+stdenv.mkDerivation {
+  name = "sixpair-2007-04-18";
+
+  src = fetchurl {
+    url = http://www.pabr.org/sixlinux/sixpair.c;
+    sha256 = "1b0a3k7gs544cbji7n29jxlrsscwfx6s1r2sgwdl6hmkc1l9gagr";
+  };
+
+  # hcitool is depricated
+  patches = [ ./hcitool.patch ];
+
+  buildInputs = [ libusb ];
+
+  unpackPhase = ''
+    cp $src sixpair.c
+  '';
+
+  buildPhase = ''
+    cc -o sixpair sixpair.c -lusb
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp sixpair $out/bin/sixpair
+  '';
+
+  meta = {
+    description = "Pair with SIXAXIS controllers over USB";
+    longDescription = ''
+      This command-line utility searches USB buses for SIXAXIS controllers and tells them to connect to a new Bluetooth master.
+    '';
+    homepage = http://www.pabr.org/sixlinux/;
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = [ stdenv.lib.maintainers.tomsmeets ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/sixpair/hcitool.patch
+++ b/pkgs/tools/misc/sixpair/hcitool.patch
@@ -1,0 +1,19 @@
+diff --git a/sixpair.c b/sixpair.c
+index b009a6f..78b7ef0 100644
+--- a/sixpair.c
++++ b/sixpair.c
+@@ -76,11 +76,11 @@ void process_device(int argc, char **argv, struct usb_device *dev,
+       exit(1);
+     }
+   } else {
+-    FILE *f = popen("hcitool dev", "r");
++    FILE *f = popen("bluetoothctl list", "r");
+     if ( !f ||
+-	 fscanf(f, "%*s\n%*s %x:%x:%x:%x:%x:%x",
++	 fscanf(f, "%*s %x:%x:%x:%x:%x:%x",
+ 		&mac[0],&mac[1],&mac[2],&mac[3],&mac[4],&mac[5]) != 6 ) {
+-      printf("Unable to retrieve local bd_addr from `hcitool dev`.\n");
++      printf("Unable to retrieve local bd_addr from `bluetoothctl list`.\n");
+       printf("Please enable Bluetooth or specify an address manually.\n");
+       exit(1);
+     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5040,6 +5040,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
   };
 
+  sixpair = callPackage ../tools/misc/sixpair {};
+
   skippy-xd = callPackage ../tools/X11/skippy-xd {};
 
   sks = callPackage ../servers/sks { inherit (ocamlPackages_4_02) ocaml camlp4; };


### PR DESCRIPTION
###### Motivation for this change

This is a small c program used for pairing with a wireless PlayStation 3 controller via Bluetooth.
I included a patch that replaces the deprecated 'hcitool' command with 'bluetoothctl'.

For further info visit: http://www.pabr.org/sixlinux/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

