### PR TITLE
Introduce "wrapCommand" builder

### DIFF
--- a/maintainers/scripts/nix-generate-from-cpan.nix
+++ b/maintainers/scripts/nix-generate-from-cpan.nix
@@ -1,25 +1,16 @@
-{ stdenv, makeWrapper, perl, perlPackages }:
+{ wrapCommand, lib, perl, perlPackages }:
 
-stdenv.mkDerivation {
-  name = "nix-generate-from-cpan-3";
-
+wrapCommand "nix-generate-from-cpan" {
+  version = "3";
   buildInputs = with perlPackages; [
-    makeWrapper perl CPANMeta GetoptLongDescriptive CPANPLUS Readonly Log4Perl
+    perl CPANMeta GetoptLongDescriptive CPANPLUS Readonly Log4Perl
   ];
-
-  phases = [ "installPhase" ];
-
-  installPhase =
-    ''
-      mkdir -p $out/bin
-      cp ${./nix-generate-from-cpan.pl} $out/bin/nix-generate-from-cpan
-      patchShebangs $out/bin/nix-generate-from-cpan
-      wrapProgram $out/bin/nix-generate-from-cpan --set PERL5LIB $PERL5LIB
-    '';
-
-  meta = {
-    maintainers = with stdenv.lib.maintainers; [ eelco rycee ];
+  executable = "${perl}/bin/perl";
+  makeWrapperArgs = [ "--set PERL5LIB $PERL5LIB"
+                      "--add-flags ${./nix-generate-from-cpan.pl}"];
+  meta = with lib; {
+    maintainers = with maintainers; [ eelco rycee ];
     description = "Utility to generate a Nix expression for a Perl package from CPAN";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/maintainers/scripts/nixpkgs-lint.nix
+++ b/maintainers/scripts/nixpkgs-lint.nix
@@ -1,23 +1,14 @@
-{ stdenv, makeWrapper, perl, perlPackages }:
+{ wrapCommand, lib, perl, perlPackages }:
 
-stdenv.mkDerivation {
-  name = "nixpkgs-lint-1";
-
-  buildInputs = [ makeWrapper perl perlPackages.XMLSimple ];
-
-  unpackPhase = "true";
-  buildPhase = "true";
-
-  installPhase =
-    ''
-      mkdir -p $out/bin
-      cp ${./nixpkgs-lint.pl} $out/bin/nixpkgs-lint
-      wrapProgram $out/bin/nixpkgs-lint --set PERL5LIB $PERL5LIB
-    '';
-
-  meta = {
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+wrapCommand "nixpkgs-lint" {
+  version = "1";
+  buildInputs = [ perl perlPackages.XMLSimple ];
+  executable = "${perl}/bin/perl";
+  makeWrapperArgs = [ "--set PERL5LIB $PERL5LIB"
+                      "--add-flags ${./nixpkgs-lint.pl}" ];
+  meta = with lib; {
+    maintainers = [ maintainers.eelco ];
     description = "A utility for Nixpkgs contributors to check Nixpkgs for common errors";
-    platforms = stdenv.lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/gollum/default.nix
+++ b/pkgs/applications/misc/gollum/default.nix
@@ -1,28 +1,17 @@
-{ stdenv, bundlerEnv, ruby, makeWrapper
-, git }:
+{ wrapCommand, bundlerEnv, ruby, git, lib }:
 
-stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+let
   pname = "gollum";
-  version = (import ./gemset.nix).gollum.version;
-
-  nativeBuildInputs = [ makeWrapper ];
-
   env = bundlerEnv {
-    name = "${name}-gems";
+    name = "${pname}-gems";
     inherit pname ruby;
     gemdir = ./.;
   };
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/gollum $out/bin/gollum \
-      --prefix PATH ":" ${stdenv.lib.makeBinPath [ git ]}
-  '';
-
-  meta = with stdenv.lib; {
+in wrapCommand pname {
+  inherit (env.gems.gollum) version;
+  executable = "${env}/bin/gollum";
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ git ]}" ];
+  meta = with lib; {
     description = "A simple, Git-powered wiki";
     homepage = https://github.com/gollum/gollum;
     license = licenses.mit;

--- a/pkgs/applications/office/ppl-address-book/default.nix
+++ b/pkgs/applications/office/ppl-address-book/default.nix
@@ -1,30 +1,15 @@
-{ stdenv, lib, bundlerEnv, ruby, makeWrapper, which }:
+{ wrapCommand, lib, bundlerEnv, ruby, which }:
 
 let
-  pname = "ppl-address-book";
-
-  version = (import ./gemset.nix).ppl.version;
-
   env = bundlerEnv rec {
-    name = "${pname}-env-${version}";
+    name = "ppl-env";
     inherit ruby;
     gemdir = ./.;
-
     gemConfig.rugged = attrs: { buildInputs = [ which ]; };
   };
-
-in stdenv.mkDerivation {
-  name = "${pname}-${version}";
-
-  phases = [ "installPhase" ];
-
-  buildInputs = [ env makeWrapper ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/ppl $out/bin/ppl
-  '';
-
+in wrapCommand "ppl" {
+  inherit (env.gems.ppl) version;
+  executable = "${env}/bin/ppl";
   meta = with lib; {
     description = "Address book software for command-line users";
     homepage    = http://ppladdressbook.org/;
@@ -32,5 +17,4 @@ in stdenv.mkDerivation {
     maintainers = with maintainers; [ chris-martin ];
     platforms   = platforms.unix;
   };
-
 }

--- a/pkgs/applications/science/biology/picard-tools/default.nix
+++ b/pkgs/applications/science/biology/picard-tools/default.nix
@@ -1,26 +1,16 @@
-{stdenv, fetchurl, jre, makeWrapper}:
+{ wrapCommand, fetchurl, jre, lib }:
 
-stdenv.mkDerivation rec {
-  name = "picard-tools-${version}";
+let
   version = "2.18.7";
-
-  src = fetchurl {
+  jar = fetchurl {
     url = "https://github.com/broadinstitute/picard/releases/download/${version}/picard.jar";
     sha256 = "00p5wmd3kb7pr3yvsqz660fsk845dwgj76bllwjfrbiscjdyhy9f";
   };
-
-  buildInputs = [ jre makeWrapper ];
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/libexec/picard
-    cp $src $out/libexec/picard/picard.jar
-    mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/picard --add-flags "-jar $out/libexec/picard/picard.jar"
-  '';
-
-  meta = with stdenv.lib; {
+in wrapCommand "picard" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = [ "--add-flags -jar" "--add-flags ${jar}"];
+  meta = with lib; {
     description = "Tools for high-throughput sequencing (HTS) data and formats such as SAM/BAM/CRAM and VCF.";
     license = licenses.mit;
     homepage = https://broadinstitute.github.io/picard/;

--- a/pkgs/applications/science/biology/varscan/default.nix
+++ b/pkgs/applications/science/biology/varscan/default.nix
@@ -1,24 +1,15 @@
-{stdenv, fetchurl, jre, makeWrapper}:
+{stdenv, fetchurl, jre, wrapCommand}:
 
-stdenv.mkDerivation rec {
-  name = "varscan-${version}";
+let
   version = "2.4.2";
-
-  src = fetchurl {
+  jar = fetchurl {
     url = "https://github.com/dkoboldt/varscan/releases/download/${version}/VarScan.v${version}.jar";
     sha256 = "0cfhshinyqgwc6i7zf8lhbfybyly2x5anrz824zyvdhzz5i69zrl";
   };
-
-  buildInputs = [ jre makeWrapper ];
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/libexec/varscan
-    cp $src $out/libexec/varscan/varscan.jar
-    mkdir -p $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/varscan --add-flags "-jar $out/libexec/varscan/varscan.jar"
-  '';
+in wrapCommand "varscan" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = [ "--add-flags -jar" "--add-flags ${jar}" ];
 
   meta = with stdenv.lib; {
     description = "Variant calling and somatic mutation/CNV detection for next-generation sequencing data";
@@ -32,5 +23,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ jbedo ];
     platforms = platforms.all;
   };
-
 }

--- a/pkgs/applications/science/logic/logisim/default.nix
+++ b/pkgs/applications/science/logic/logisim/default.nix
@@ -1,28 +1,19 @@
-{ stdenv, fetchurl, jre, makeWrapper }:
+{ wrapCommand, lib, fetchurl, jre, makeWrapper }:
 
-let version = "2.7.1"; in
-
-stdenv.mkDerivation {
-  name = "logisim-${version}";
-  
-  src = fetchurl {
+let
+  version = "2.7.1";
+  jar = fetchurl {
     url = "mirror://sourceforge/project/circuit/2.7.x/${version}/logisim-generic-${version}.jar";
     sha256 = "1hkvc9zc7qmvjbl9579p84hw3n8wl3275246xlzj136i5b0phain";
   };
-  
-  phases = [ "installPhase" ];
-
-  nativeBuildInputs = [makeWrapper];
-
-  installPhase = ''
-    mkdir -pv $out/bin
-    makeWrapper ${jre}/bin/java $out/bin/logisim --add-flags "-jar $src"
-  '';
-  
-  meta = {
+in wrapCommand "logisim" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = [ "--add-flags -jar" "--add-flags ${jar}" ];
+  meta = with lib; {
     homepage = http://ozark.hendrix.edu/~burch/logisim;
     description = "Educational tool for designing and simulating digital logic circuits";
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2Plus;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/programming/plm/default.nix
+++ b/pkgs/applications/science/programming/plm/default.nix
@@ -1,36 +1,26 @@
-{stdenv, fetchurl, makeWrapper, jre, gcc, valgrind}:
+{ lib, wrapCommand, fetchurl, jre, gcc, valgrind }:
 # gcc and valgrind are not strict dependencies, they could be made
 # optional. They are here because plm can only help you learn C if you
 # have them installed.
-stdenv.mkDerivation rec {
+
+let
   major = "2";
   minor = "5";
-  version = "${major}-${minor}";
-  name = "plm-${version}";
-
-  src = fetchurl {
+  version = "${major}.${minor}";
+  jar = fetchurl {
     url = "http://webloria.loria.fr/~quinson/Teaching/PLM/plm-${major}_${minor}.jar";
     sha256 = "0m17cxa3nxi2cbswqvlfzp0mlfi3wrkw8ry2xhkxy6aqzm2mlgcc";
-    name = "${name}.jar";
   };
-
-  buildInputs = [ makeWrapper jre gcc valgrind ];
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p "$prefix/bin"
-
-    makeWrapper ${jre}/bin/java $out/bin/plm \
-      --add-flags "-jar $src" \
-      --prefix PATH : "$PATH"
-  '';
-
-  meta = with stdenv.lib; {
+in wrapCommand "plm" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = [ "--add-flags -jar" "--add-flags ${jar}"
+                      "--prefix PATH : ${lib.makeBinPath [gcc valgrind]}"];
+  meta = with lib; {
     description = "Free cross-platform programming exerciser";
     homepage = http://webloria.loria.fr/~quinson/Teaching/PLM/;
     license = licenses.gpl3;
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/applications/search/grepm/default.nix
+++ b/pkgs/applications/search/grepm/default.nix
@@ -1,29 +1,16 @@
-{ stdenv, fetchurl, perlPackages, mutt }:
+{ wrapCommand, bash, fetchurl, perlPackages, mutt, lib }:
 
-stdenv.mkDerivation rec {
-  name = "grepm-${version}";
-  version = "0.6";
-
+let
   src = fetchurl {
     url = "http://www.barsnick.net/sw/grepm";
     sha256 = "0ppprhfw06779hz1b10qvq62gsw73shccsav982dyi6xmqb6jqji";
   };
-
-  phases = [ "installPhase" ];
-
-  buildInputs = [ perlPackages.grepmail mutt ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp -a $src $out/bin/grepm
-    chmod +x $out/bin/grepm
-    sed -i \
-      -e "s:^grepmail:${perlPackages.grepmail}/bin/grepmail:" \
-      -e "s:^\( *\)mutt:\1${mutt}/bin/mutt:" \
-      $out/bin/grepm
-  '';
-  
-  meta = with stdenv.lib; {
+in wrapCommand "grepm" {
+  version = "0.6";
+  executable = "${bash}/bin/bash";
+  makeWrapperArgs = [ "--add-flags ${src}"
+                      "--prefix PATH : ${lib.makeBinPath [perlPackages.grepmail mutt]}"];
+  meta = with lib; {
     description = "Wrapper for grepmail utilizing mutt";
     homepage = http://www.barsnick.net/sw/grepm.html;
     license = licenses.free;

--- a/pkgs/build-support/default.nix
+++ b/pkgs/build-support/default.nix
@@ -1,0 +1,12 @@
+{ lib, stdenv, stdenvNoCC, lndir }:
+
+let
+  trivialBuilders = import ./trivial-builders.nix {
+    inherit lib stdenv stdenvNoCC lndir;
+  };
+
+  setupHooks = import ./setup-hooks {
+    inherit (trivialBuilders) makeSetupHook writeScript;
+  };
+
+in trivialBuilders // setupHooks

--- a/pkgs/build-support/default.nix
+++ b/pkgs/build-support/default.nix
@@ -3,6 +3,7 @@
 let
   trivialBuilders = import ./trivial-builders.nix {
     inherit lib stdenv stdenvNoCC lndir;
+    inherit (setupHooks) makeWrapper;
   };
 
   setupHooks = import ./setup-hooks {

--- a/pkgs/build-support/setup-hooks/default.nix
+++ b/pkgs/build-support/setup-hooks/default.nix
@@ -1,0 +1,45 @@
+{ makeSetupHook, writeScript }:
+
+rec {
+
+  makeWrapper = makeSetupHook { deps = [ dieHook ]; } ./make-wrapper.sh;
+
+  ensureNewerSourcesHook = { year }: makeSetupHook {}
+    (writeScript "ensure-newer-sources-hook.sh" ''
+      postUnpackHooks+=(_ensureNewerSources)
+      _ensureNewerSources() {
+        find "$sourceRoot" '!' -newermt '${year}-01-01' \
+          -exec touch -h -d '${year}-01-02' '{}' '+'
+      }
+    '');
+
+  # Zip file format only allows times after year 1980, which makes
+  # e.g. Python wheel building fail with: ValueError: ZIP does not
+  # support timestamps before 1980
+  ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };
+
+  dieHook = makeSetupHook {} ./die.sh;
+
+  ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; } ./ld-is-cc-hook.sh;
+
+  setJavaClassPath = makeSetupHook { } ./set-java-classpath.sh;
+
+  fixDarwinDylibNames = makeSetupHook { } ./fix-darwin-dylib-names.sh;
+
+  keepBuildTree = makeSetupHook { } ./keep-build-tree.sh;
+
+  enableGCOVInstrumentation = makeSetupHook { }
+    ./enable-coverage-instrumentation.sh;
+
+  findXMLCatalogs = makeSetupHook { } ./find-xml-catalogs.sh;
+
+  separateDebugInfo = makeSetupHook { } ./separate-debug-info.sh;
+
+  setupDebugInfoDirs = makeSetupHook { } ./setup-debug-info-dirs.sh;
+
+  useOldCXXAbi = makeSetupHook { } ./use-old-cxx-abi.sh;
+
+  pruneLibtoolFiles = makeSetupHook { name = "prune-libtool-files"; }
+    ./prune-libtool-files.sh;
+
+}

--- a/pkgs/development/tools/apktool/default.nix
+++ b/pkgs/development/tools/apktool/default.nix
@@ -1,32 +1,20 @@
-{ stdenv, fetchurl, makeWrapper, jre, buildTools }:
+{ wrapCommand, fetchurl, jre, buildTools, lib }:
 
-stdenv.mkDerivation rec {
-  name = "apktool-${version}";
-  version = "2.3.3";
-
-  src = fetchurl {
+let
+  jar = fetchurl {
     urls = [
       "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${version}.jar"
       "https://github.com/iBotPeaches/Apktool/releases/download/v${version}/apktool_${version}.jar"
     ];
     sha256 = "1wjpn1wxg8fid2mch5ili35xqvasa3pk8h1xaiygw5idpxh3cm0f";
   };
-
-  phases = [ "installPhase" ];
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  sourceRoot = ".";
-
-  installPhase = ''
-    install -D ${src} "$out/libexec/apktool/apktool.jar"
-    mkdir -p "$out/bin"
-    makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
-        --add-flags "-jar $out/libexec/apktool/apktool.jar" \
-        --prefix PATH : "${buildTools}/build-tools/25.0.1/"
-  '';
-
-  meta = with stdenv.lib; {
+  version = "2.3.3";
+in wrapCommand "apktool" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = ["--add-flags -jar" "--add-flags ${jar}"
+                     "--prefix PATH : ${buildTools}/build-tools/25.0.1"];
+  meta = with lib; {
     description = "A tool for reverse engineering Android apk files";
     homepage    = https://ibotpeaches.github.io/Apktool/;
     license     = licenses.asl20;

--- a/pkgs/development/tools/continuous-integration/cide/default.nix
+++ b/pkgs/development/tools/continuous-integration/cide/default.nix
@@ -1,25 +1,14 @@
-{ stdenv, lib, bundlerEnv, makeWrapper, docker, git, gnutar, gzip }:
+{ wrapCommand, lib, bundlerEnv, makeWrapper, docker, git, gnutar, gzip }:
 
-stdenv.mkDerivation rec {
-  name = "cide-${version}";
-  version = "0.9.0";
-
+let
   env = bundlerEnv {
-    name = "${name}-gems";
-
+    name = "cide-gems";
     gemdir = ./.;
   };
-
-  phases = ["installPhase"];
-
-  buildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/cide $out/bin/cide \
-      --set PATH ${stdenv.lib.makeBinPath [ docker git gnutar gzip ]}
-  '';
-
+in wrapCommand "cide" {
+  inherit (env.gems.cide) version;
+  executable = "${env}/bin/cide";
+  makeWrapperArgs = ["--set PATH ${lib.makeBinPath [ docker git gnutar gzip ]}"];
   meta = with lib; {
     description = "Isolated test runner with Docker";
     homepage    = http://zimbatm.github.io/cide/;

--- a/pkgs/development/tools/jsduck/default.nix
+++ b/pkgs/development/tools/jsduck/default.nix
@@ -15,7 +15,7 @@ in wrapCommand pname {
     description = "Simple JavaScript Duckumentation generator.";
     homepage    = https://github.com/senchalabs/jsduck;
     license     = with licenses; gpl3;
-    maintainers = with stdenv.lib.maintainers; [ periklis ];
+    maintainers = with maintainers; [ periklis ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/jsduck/default.nix
+++ b/pkgs/development/tools/jsduck/default.nix
@@ -1,26 +1,16 @@
-{ stdenv, lib, bundlerEnv, makeWrapper, }:
+{ wrapCommand, lib, bundlerEnv }:
 
-stdenv.mkDerivation rec {
+let
   pname = "jsduck";
-  name = "${pname}-${version}";
-  version = "5.3.4";
-
   env = bundlerEnv {
-    name = "${pname}";
+    name = pname;
     gemfile = ./Gemfile;
     lockfile = ./Gemfile.lock;
     gemset = ./gemset.nix;
   };
-
-  phases = [ "installPhase" ];
-
-  buildInputs = [ env makeWrapper ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/jsduck $out/bin/jsduck
-  '';
-
+in wrapCommand pname {
+  inherit (env.gems.jsduck) version;
+  executable = "${env}/bin/jsduck";
   meta = with lib; {
     description = "Simple JavaScript Duckumentation generator.";
     homepage    = https://github.com/senchalabs/jsduck;

--- a/pkgs/development/tools/misc/watson-ruby/default.nix
+++ b/pkgs/development/tools/misc/watson-ruby/default.nix
@@ -1,25 +1,16 @@
-{ stdenv, bundlerEnv, ruby }:
+{ wrapCommand, lib, bundlerEnv, ruby }:
 
-
-stdenv.mkDerivation rec {
-  name = "watson-ruby-${version}";
-  version = (import ./gemset.nix).watson-ruby.version;
-
-  env = bundlerEnv rec {
-    name = "watson-ruby-gems-${version}";
+let
+  env = bundlerEnv {
+    name = "watson-ruby-gems";
     inherit ruby;
     # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
     gemdir = ./.;
   };
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    ln -s ${env}/bin/watson $out/bin/watson
-  '';
-
-  meta = with stdenv.lib; {
+in wrapCommand "watson" {
+  inherit (env.gems.watson-ruby) version;
+  executable = "${env}/bin/watson";
+  meta = with lib; {
     description = "An inline issue manager";
     homepage    = http://goosecode.com/watson/;
     license     = with licenses; mit;

--- a/pkgs/development/tools/rhc/default.nix
+++ b/pkgs/development/tools/rhc/default.nix
@@ -1,27 +1,15 @@
-{ lib, bundlerEnv, ruby, stdenv, makeWrapper }:
+{ lib, bundlerEnv, ruby, wrapCommand }:
 
-stdenv.mkDerivation rec {
-  name = "rhc-1.38.7";
-
+let
   env = bundlerEnv {
-    name = "rhc-1.38.7-gems";
-
+    name = "rhc-gems";
     inherit ruby;
-
     gemdir = ./.;
   };
-
-  buildInputs = [ makeWrapper ];
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/rhc $out/bin/rhc
-  '';
-
+in wrapCommand "rhc" {
+  inherit (env.gems.rhc) version;
+  executable = "${env}/bin/rhc";
   meta = with lib; {
-    broken = true; # requires ruby 2.2
     homepage = https://github.com/openshift/rhc;
     description = "OpenShift client tools";
     license = licenses.asl20;

--- a/pkgs/development/tools/ronn/default.nix
+++ b/pkgs/development/tools/ronn/default.nix
@@ -1,24 +1,14 @@
-{ stdenv, lib, bundlerEnv, makeWrapper, groff }:
+{ wrapCommand, lib, bundlerEnv, makeWrapper, groff }:
 
-stdenv.mkDerivation rec {
-  name = "ronn-${version}";
-  version = env.gems.ronn.version;
-
+let
   env = bundlerEnv rec {
     name = "ronn-gems";
     gemdir = ./.;
   };
-
-  phases = ["installPhase"];
-
-  buildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/ronn $out/bin/ronn \
-      --set PATH ${groff}/bin
-  '';
-
+in wrapCommand "ronn" {
+  version = env.gems.ronn.version;
+  executable = "${env}/bin/ronn";
+  makeWrapperArgs = ["--set PATH ${groff}/bin"];
   meta = with lib; {
     description = "markdown-based tool for building manpages";
     homepage = https://rtomayko.github.io/ronn/;

--- a/pkgs/servers/monitoring/seyren/default.nix
+++ b/pkgs/servers/monitoring/seyren/default.nix
@@ -1,24 +1,17 @@
-{ stdenv, fetchurl, makeWrapper, jre }:
+{ wrapCommand, fetchurl, lib, makeWrapper, jre }:
 
-stdenv.mkDerivation rec {
-  name = "seyren-${version}";
+let
   version = "1.1.0";
-
-  src = fetchurl {
+  jar = fetchurl {
     url = "https://github.com/scobal/seyren/releases/download/${version}/seyren-${version}.jar";
     sha256 = "10m64zdci4swlvivii1jnmrwfi461af3xvn0xvwvy7i8kyb56vrr";
   };
 
-  phases = ["installPhase"];
-
-  buildInputs = [ makeWrapper jre ];
-
-  installPhase = ''
-    mkdir -p "$out"/bin
-    makeWrapper "${jre}/bin/java" "$out"/bin/seyren --add-flags "-jar $src"
-  '';
-
-  meta = with stdenv.lib; {
+in wrapCommand "seyren" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = [ "--add-flags -jar" "--add-flags ${jar}" ];
+  meta = with lib; {
     description = "An alerting dashboard for Graphite";
     homepage = https://github.com/scobal/seyren;
     license = licenses.asl20;

--- a/pkgs/tools/misc/emv/default.nix
+++ b/pkgs/tools/misc/emv/default.nix
@@ -1,26 +1,18 @@
-{ stdenv, fetchurl }:
+{ wrapCommand, lib, bash, fetchurl }:
 
-stdenv.mkDerivation rec {
-  name = "emv-${version}";
-  version = "1.95";
-
+let
   src = fetchurl {
     url = "http://www.i0i0.de/toolchest/emv";
     sha256 = "7e0e12afa45ef5ed8025e5f2c6deea0ff5f512644a721f7b1b95b63406a8f7ce";
   };
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -pv $out/bin
-    cp $src $out/bin/emv
-    chmod +x $out/bin/emv
-  '';
-
-  meta = {
+in wrapCommand "emv" {
+  version = "1.95";
+  executable = "${bash}/bin/bash";
+  makeWrapperArgs = [ "--add-flags ${src}" ];
+  meta = with lib; {
     homepage = http://www.i0i0.de/toolchest/emv;
     description = "Editor Move: Rename files with your favourite text editor";
-    license = stdenv.lib.licenses.publicDomain;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/plantuml/default.nix
+++ b/pkgs/tools/misc/plantuml/default.nix
@@ -1,32 +1,17 @@
-{ stdenv, fetchurl, jre, graphviz }:
+{ wrapCommand, lib, fetchurl, jre, graphviz }:
 
-stdenv.mkDerivation rec {
-  version = "1.2017.18";
-  name = "plantuml-${version}";
-
-  src = fetchurl {
+let
+  jar = fetchurl {
     url = "mirror://sourceforge/project/plantuml/${version}/plantuml.${version}.jar";
     sha256 = "0ssfg6lpk41ydhxhi6y6c9ca3hpql6gg3bxjws8vrx9s3s6r5rb0";
   };
-
-  # It's only a .jar file and a shell wrapper
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p "$out/bin"
-    mkdir -p "$out/lib"
-
-    cp "$src" "$out/lib/plantuml.jar"
-
-    cat > "$out/bin/plantuml" << EOF
-    #!${stdenv.shell}
-    export GRAPHVIZ_DOT="${graphviz}/bin/dot"
-    exec "${jre}/bin/java" -jar "$out/lib/plantuml.jar" "\$@"
-    EOF
-    chmod a+x "$out/bin/plantuml"
-  '';
-
-  meta = with stdenv.lib; {
+  version = "1.2017.18";
+in wrapCommand "plantuml" {
+  inherit version;
+  executable = "${jre}/bin/java";
+  makeWrapperArgs = [ "--add-flags -jar" "--add-flags $jar"
+                      "--set GRAPHVIZ_DOT ${graphviz}/bin/dot"];
+  meta = with lib; {
     description = "Draw UML diagrams using a simple and human readable text description";
     homepage = http://plantuml.sourceforge.net/;
     # "java -jar plantuml.jar -license" says GPLv3 or later

--- a/pkgs/tools/misc/pws/default.nix
+++ b/pkgs/tools/misc/pws/default.nix
@@ -1,26 +1,15 @@
-{ stdenv, lib, bundlerEnv, ruby, xsel, makeWrapper }:
+{ wrapCommand, lib, bundlerEnv, ruby, xsel }:
 
-stdenv.mkDerivation rec {
-  name = "pws-1.0.6";
-
+let
   env = bundlerEnv {
-    name = "${name}-gems";
-
+    name = "pws-gems";
     inherit ruby;
-
     gemdir = ./.;
   };
-
-  buildInputs = [ makeWrapper ];
-
-  phases = ["installPhase"];
-
-  installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${env}/bin/pws $out/bin/pws \
-      --set PATH '"${xsel}/bin/:$PATH"'
-  '';
-
+in wrapCommand "pws" {
+  inherit (env.gems.pws) version;
+  executable = "${env}/bin/pws";
+  makeWrapperArgs = ["--prefix PATH ${xsel}/bin"];
   meta = with lib; {
     description = "Command-line password safe";
     homepage    = https://github.com/janlelis/pws;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -69,19 +69,6 @@ with pkgs;
     { name = "auto-patchelf-hook"; deps = [ file ]; }
     ../build-support/setup-hooks/auto-patchelf.sh;
 
-  ensureNewerSourcesHook = { year }: makeSetupHook {}
-    (writeScript "ensure-newer-sources-hook.sh" ''
-      postUnpackHooks+=(_ensureNewerSources)
-      _ensureNewerSources() {
-        '${findutils}/bin/find' "$sourceRoot" \
-          '!' -newermt '${year}-01-01' -exec touch -h -d '${year}-01-02' '{}' '+'
-      }
-    '');
-
-  # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
-  # ValueError: ZIP does not support timestamps before 1980
-  ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };
-
   updateAutotoolsGnuConfigScriptsHook = makeSetupHook
     { substitutions = { gnu_config = gnu-config;}; }
     ../build-support/setup-hooks/update-autotools-gnu-config-scripts.sh;
@@ -106,8 +93,6 @@ with pkgs;
   };
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
-
-  dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;
 
   digitalbitbox = libsForQt5.callPackage ../applications/misc/digitalbitbox { };
 
@@ -294,9 +279,6 @@ with pkgs;
     inherit url;
   };
 
-  ld-is-cc-hook = makeSetupHook { name = "ld-is-cc-hook"; }
-    ../build-support/setup-hooks/ld-is-cc-hook.sh;
-
   libredirect = callPackage ../build-support/libredirect { };
 
   madonctl = callPackage ../applications/misc/madonctl { };
@@ -310,9 +292,6 @@ with pkgs;
       inherit contents compressor prepend;
     };
 
-  makeWrapper = makeSetupHook { deps = [ dieHook ]; }
-                              ../build-support/setup-hooks/make-wrapper.sh;
-
   makeModulesClosure = { kernel, firmware, rootModules, allowMissing ? false }:
     callPackage ../build-support/kernel/modules-closure.nix {
       inherit kernel firmware rootModules allowMissing;
@@ -323,9 +302,6 @@ with pkgs;
   nixBufferBuilders = import ../build-support/emacs/buffer.nix { inherit (pkgs) lib writeText; inherit (emacsPackagesNg) inherit-local; };
 
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
-
-  pruneLibtoolFiles = makeSetupHook { name = "prune-libtool-files"; }
-    ../build-support/setup-hooks/prune-libtool-files.sh;
 
   closureInfo = callPackage ../build-support/closure-info.nix { };
 
@@ -353,14 +329,6 @@ with pkgs;
 
   inherit (lib.systems) platforms;
 
-  setJavaClassPath = makeSetupHook { } ../build-support/setup-hooks/set-java-classpath.sh;
-
-  fixDarwinDylibNames = makeSetupHook { } ../build-support/setup-hooks/fix-darwin-dylib-names.sh;
-
-  keepBuildTree = makeSetupHook { } ../build-support/setup-hooks/keep-build-tree.sh;
-
-  enableGCOVInstrumentation = makeSetupHook { } ../build-support/setup-hooks/enable-coverage-instrumentation.sh;
-
   makeGCOVReport = makeSetupHook
     { deps = [ pkgs.lcov pkgs.enableGCOVInstrumentation ]; }
     ../build-support/setup-hooks/make-coverage-analysis-report.sh;
@@ -368,17 +336,9 @@ with pkgs;
   # intended to be used like nix-build -E 'with <nixpkgs> {}; enableDebugging fooPackage'
   enableDebugging = pkg: pkg.override { stdenv = stdenvAdapters.keepDebugInfo pkg.stdenv; };
 
-  findXMLCatalogs = makeSetupHook { } ../build-support/setup-hooks/find-xml-catalogs.sh;
-
   wrapGAppsHook = makeSetupHook {
     deps = [ gnome3.dconf.lib gnome3.gtk librsvg makeWrapper ];
   } ../build-support/setup-hooks/wrap-gapps-hook.sh;
-
-  separateDebugInfo = makeSetupHook { } ../build-support/setup-hooks/separate-debug-info.sh;
-
-  setupDebugInfoDirs = makeSetupHook { } ../build-support/setup-hooks/setup-debug-info-dirs.sh;
-
-  useOldCXXAbi = makeSetupHook { } ../build-support/setup-hooks/use-old-cxx-abi.sh;
 
   ical2org = callPackage ../tools/misc/ical2org {};
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -326,26 +326,16 @@ let
     configureFlags = [ "--with-v8js=${pkgs.v8_6_x}" ];
   };
 
-  composer = pkgs.stdenv.mkDerivation rec {
-    name = "composer-${version}";
-    version = "1.6.5";
-
-    src = pkgs.fetchurl {
+  composer = let
+    phar = pkgs.fetchurl {
       url = "https://getcomposer.org/download/${version}/composer.phar";
       sha256 = "0d1lpvq8wylh5qgxhbqb5r7j3c6qk0bz4b5vg187jsl6z6fvxgk7";
     };
-
-    unpackPhase = ":";
-
-    buildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/composer/composer.phar
-      makeWrapper ${php}/bin/php $out/bin/composer \
-        --add-flags "$out/libexec/composer/composer.phar"
-    '';
-
+    version = "1.6.5";
+  in pkgs.wrapCommand "composer" {
+    inherit version;
+    executable = "${php}/bin/php";
+    makeWrapperArgs = ["--add-flags ${phar}"];
     meta = with pkgs.lib; {
       description = "Dependency Manager for PHP";
       license = licenses.mit;
@@ -354,25 +344,16 @@ let
     };
   };
 
-  box = pkgs.stdenv.mkDerivation rec {
-    name = "box-${version}";
+  box = let
     version = "2.7.5";
-
-    src = pkgs.fetchurl {
+    phar = pkgs.fetchurl {
       url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
       sha256 = "1zmxdadrv0i2l8cz7xb38gnfmfyljpsaz2nnkjzqzksdmncbgd18";
     };
-
-    phases = [ "installPhase" ];
-    buildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/box/box.phar
-      makeWrapper ${php}/bin/php $out/bin/box \
-        --add-flags "-d phar.readonly=0 $out/libexec/box/box.phar"
-    '';
-
+  in pkgs.wrapCommand "box" {
+    inherit version;
+    executable = "${php}/bin/php";
+    makeWrapperArgs = ["--add-flags ${phar}"];
     meta = with pkgs.lib; {
       description = "An application for building and managing Phars";
       license = licenses.mit;
@@ -381,25 +362,16 @@ let
     };
   };
 
-  php-cs-fixer = pkgs.stdenv.mkDerivation rec {
-    name = "php-cs-fixer-${version}";
-    version = "2.12.1";
-
-    src = pkgs.fetchurl {
+  php-cs-fixer = let
+    phar = pkgs.fetchurl {
       url = "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${version}/php-cs-fixer.phar";
       sha256 = "1ifwb30wddp5blqnrkdmf0x11dk7nbxj4z2v5403fn7wfhgvibd2";
     };
-
-    phases = [ "installPhase" ];
-    buildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/php-cs-fixer/php-cs-fixer.phar
-      makeWrapper ${php}/bin/php $out/bin/php-cs-fixer \
-        --add-flags "$out/libexec/php-cs-fixer/php-cs-fixer.phar"
-    '';
-
+    version = "2.12.1";
+  in pkgs.wrapCommand "php-cs-fixer" {
+    inherit version;
+    executable = "${php}/bin/php";
+    makeWrapperArgs = ["--add-flags ${phar}"];
     meta = with pkgs.lib; {
       description = "A tool to automatically fix PHP coding standards issues";
       license = licenses.mit;
@@ -441,25 +413,16 @@ let
     };
   };
 
-  phpcs = pkgs.stdenv.mkDerivation rec {
-    name = "phpcs-${version}";
-    version = "3.3.0";
-
-    src = pkgs.fetchurl {
+  phpcs = let
+    phar = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";
       sha256 = "1zl35vcq8dmspsj7ww338h30ah75dg91j6a1dy8avkzw5zljqi4h";
     };
-
-    phases = [ "installPhase" ];
-    buildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/phpcs/phpcs.phar
-      makeWrapper ${php}/bin/php $out/bin/phpcs \
-        --add-flags "$out/libexec/phpcs/phpcs.phar"
-    '';
-
+    version = "3.3.0";
+  in pkgs.wrapCommand "phpcs" {
+    inherit version;
+    executable = "${php}/bin/php";
+    makeWrapperArgs = [ "--add-flags ${phar}" ];
     meta = with pkgs.lib; {
       description = "PHP coding standard tool";
       license = licenses.bsd3;
@@ -468,25 +431,16 @@ let
     };
   };
 
-  phpcbf = pkgs.stdenv.mkDerivation rec {
-    name = "phpcbf-${version}";
+  phpcbf = let
     version = "3.3.0";
-
-    src = pkgs.fetchurl {
+    phar = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcbf.phar";
       sha256 = "1ah065gzmr11njp1if5bc4b19f4izilqwr06m84yb7af18qr77ls";
     };
-
-    phases = [ "installPhase" ];
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/phpcbf/phpcbf.phar
-      makeWrapper ${php}/bin/php $out/bin/phpcbf \
-        --add-flags "$out/libexec/phpcbf/phpcbf.phar"
-    '';
-
+  in wrapCommand "phpcbf" {
+    inherit version;
+    executable = "${php}/bin/php";
+    makeWrapperArgs = ["--add-flags ${phar}"];
     meta = with pkgs.lib; {
       description = "PHP coding standard beautifier and fixer";
       license = licenses.bsd3;

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -437,7 +437,7 @@ let
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcbf.phar";
       sha256 = "1ah065gzmr11njp1if5bc4b19f4izilqwr06m84yb7af18qr77ls";
     };
-  in wrapCommand "phpcbf" {
+  in pkgs.wrapCommand "phpcbf" {
     inherit version;
     executable = "${php}/bin/php";
     makeWrapperArgs = ["--add-flags ${phar}"];

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -64,8 +64,8 @@ let
       stdenvAdapters = res;
     };
 
-  trivialBuilders = self: super:
-    import ../build-support/trivial-builders.nix {
+  buildSupport = self: super:
+    import ../build-support {
       inherit lib; inherit (self) stdenv stdenvNoCC; inherit (self.xorg) lndir;
     };
 
@@ -149,7 +149,7 @@ let
     stdenvBootstappingAndPlatforms
     platformCompat
     stdenvAdapters
-    trivialBuilders
+    buildSupport
     splice
     allPackages
     extraPkgs


### PR DESCRIPTION
###### Motivation for this change
"wrapCommand" is an abstraction of somethings fairly common in Nixpkgs where single binary is produced from a single source file. This happens frequently when using something like .jar or .phar files as well as in some of the Ruby things.

This should lead to less code & maintenance.

wrapCommand needs to use makeWrapper to work, so I had to move it from all-packages.nix into a new setup-hooks/default.nix file that will be used pulled in from stage.nix.