### PR TITLE
kitty: 0.10.1 -> 0.11.2

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -1,11 +1,13 @@
 { stdenv, fetchFromGitHub, pkgs, python3Packages, glfw, libunistring, harfbuzz,
   fontconfig, zlib, pkgconfig, ncurses, imagemagick, makeWrapper, xsel,
   libstartup_notification, libX11, libXrandr, libXinerama, libXcursor,
-  libxkbcommon, libXi, libXext }:
+  libxkbcommon, libXi, libXext, wayland-protocols, wayland,
+  which
+}:
 
 with python3Packages;
 buildPythonApplication rec {
-  version = "0.10.1";
+  version = "0.11.2";
   name = "kitty-${version}";
   format = "other";
 
@@ -13,19 +15,24 @@ buildPythonApplication rec {
     owner = "kovidgoyal";
     repo = "kitty";
     rev = "v${version}";
-    sha256 = "1xwrrj0g70hh8zsjbd05x0js776xlf7c6mdsmrqlw4y7jfnlgl45";
+    sha256 = "0vmxgyxrgaqijwd51ldd8pkz7jn9hdcfib1dqr0ai614286v69hw";
   };
 
   buildInputs = [
     fontconfig glfw ncurses libunistring harfbuzz libX11
     libXrandr libXinerama libXcursor libxkbcommon libXi libXext
+    wayland-protocols wayland
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig which sphinx ];
 
   postPatch = ''
     substituteInPlace kitty/utils.py \
       --replace "find_library('startup-notification-1')" "'${libstartup_notification}/lib/libstartup-notification-1.so'"
+
+    substituteInPlace docs/Makefile \
+      --replace 'python3 .. +launch $(shell which sphinx-build)' \
+                'PYTHONPATH=$PYTHONPATH:.. HOME=$TMPDIR/nowhere $(shell which sphinx-build)'
     '';
 
   buildPhase = ''


### PR DESCRIPTION
Version bump!

https://sw.kovidgoyal.net/kitty/changelog.html


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


In order to test on my 18.03-based NixOS machine I had to also pull in glibcLocales from master;
this is the same issue we're seeing everywhere but here instead of warning causes error.