### PR TITLE
Rework stage.nix's extraPkgs

### DIFF
--- a/pkgs/applications/science/programming/scyther/default.nix
+++ b/pkgs/applications/science/programming/scyther/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildEnv, callPackage_i686, fetchFromGitHub, python27Packages, graphviz
+{ stdenv, lib, buildEnv, pkgsi686Linux, fetchFromGitHub, python27Packages, graphviz
 , includeGUI ? true
 , includeProtocols ? true
 }:
@@ -20,7 +20,7 @@ let
     platforms = platforms.linux;
   };
 
-  cli = callPackage_i686 ./cli.nix {
+  cli = pkgsi686Linux.callPackage ./cli.nix {
     inherit version src meta;
   };
 
@@ -47,7 +47,7 @@ let
       python27Packages.wxPython
       graphviz
     ];
- 
+
     installPhase = ''
       mkdir -p "$out"/gui "$out"/bin
       cp -r gui/* "$out"/gui

--- a/pkgs/development/pharo/vm/default.nix
+++ b/pkgs/development/pharo/vm/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, callPackage, callPackage_i686, makeWrapper, ...} @pkgs:
+{ stdenv, callPackage, pkgsi686Linux, makeWrapper, ...} @pkgs:
 
 let
-  i686    = callPackage_i686 ./vms.nix {};
+  i686    = pkgsi686Linux.callPackage ./vms.nix {};
   native  = callPackage ./vms.nix {};
 in
 
@@ -11,5 +11,3 @@ rec {
   spur64 = if stdenv.is64bit then native.spur else "none";
   multi-vm-wrapper  = callPackage ../wrapper { inherit cog32 spur32 spur64; };
 }
-
-

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -1,10 +1,10 @@
-{stdenv, fetchurl, unzip, autoreconfHook, libtool, makeWrapper, cups, ghostscript, callPackage_i686 }:
+{stdenv, fetchurl, unzip, autoreconfHook, libtool, makeWrapper, cups, ghostscript, pkgsi686Linux }:
 
 let
 
-  i686_NIX_GCC = callPackage_i686 ({gcc}: gcc) {};
-  i686_libxml2 = callPackage_i686 ({libxml2}: libxml2) {};
-  i686_glibc = callPackage_i686 ({glibc}: glibc) {};
+  i686_NIX_GCC = pkgsi686Linux.callPackage ({gcc}: gcc) {};
+  i686_libxml2 = pkgsi686Linux.callPackage ({libxml2}: libxml2) {};
+  i686_glibc = pkgsi686Linux.callPackage ({glibc}: glibc) {};
 
   src_canon = fetchurl {
     url = "https://files.canon-europe.com/files/soft45378/software/o147jen_linuxufrII_0290.zip";

--- a/pkgs/misc/emulators/wine/packages.nix
+++ b/pkgs/misc/emulators/wine/packages.nix
@@ -1,11 +1,11 @@
-{ system, stdenv, stdenv_32bit, lib, pkgs, pkgsi686Linux, callPackage, callPackage_i686,
+{ system, stdenv, stdenv_32bit, lib, pkgs, pkgsi686Linux, callPackage,
   wineRelease ? "stable",
   supportFlags
 }:
 
 let src = lib.getAttr wineRelease (callPackage ./sources.nix {});
 in with src; {
-  wine32 = callPackage_i686 ./base.nix {
+  wine32 = pkgsi686Linux.callPackage ./base.nix {
     name = "wine-${version}";
     inherit src version supportFlags;
     pkgArches = [ pkgsi686Linux ];
@@ -33,4 +33,3 @@ in with src; {
     platforms = [ "x86_64-linux" ];
   };
 }
-

--- a/pkgs/os-specific/gnu/default.nix
+++ b/pkgs/os-specific/gnu/default.nix
@@ -3,7 +3,7 @@
 args@{ fetchgit, stdenv, autoconf, automake, automake111x, libtool
 , texinfo, glibcCross, hurdPartedCross, libuuid, samba
 , gccCrossStageStatic, gcc
-, forceSystem, newScope, platform, config
+, pkgsi686Linux, newScope, platform, config
 , targetPlatform, buildPlatform
 , overrides ? {}
 , buildPackages, pkgs
@@ -90,7 +90,7 @@ let
     mig = callPackage ./mig {
       # Build natively, but force use of a 32-bit environment because we're
       # targeting `i586-pc-gnu'.
-      stdenv = (forceSystem "i686-linux" "i386").stdenv;
+      stdenv = pkgsi686Linux.stdenv;
     };
 
     # XXX: Use this one for its `.crossDrv'.  Using the one above from

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -12,7 +12,7 @@
 , patches ? []
 }:
 
-{ stdenv, callPackage, callPackage_i686, fetchurl, fetchpatch
+{ stdenv, callPackage, pkgsi686Linux, fetchurl, fetchpatch
 , kernel ? null, xorg, zlib, perl, nukeReferences
 , # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
@@ -70,7 +70,7 @@ let
     disallowedReferences = optional (!libsOnly) [ kernel.dev ];
 
     passthru = {
-      settings = (if settings32Bit then callPackage_i686 else callPackage) (import ./settings.nix self settingsSha256) {
+      settings = (if settings32Bit then pkgsi686Linux.callPackage else callPackage) (import ./settings.nix self settingsSha256) {
         withGtk2 = preferGtk2;
         withGtk3 = !preferGtk2;
       };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2391,7 +2391,7 @@ with pkgs;
 
   flamerobin = callPackage ../applications/misc/flamerobin { };
 
-  flashtool = callPackage_i686 ../development/mobile/flashtool {
+  flashtool = pkgsi686Linux.callPackage ../development/mobile/flashtool {
     platformTools = androidenv.platformTools;
   };
 
@@ -2405,7 +2405,7 @@ with pkgs;
 
   flvstreamer = callPackage ../tools/networking/flvstreamer { };
 
-  hmetis = callPackage_i686 ../applications/science/math/hmetis { };
+  hmetis = pkgsi686Linux.callPackage ../applications/science/math/hmetis { };
 
   libbsd = callPackage ../development/libraries/libbsd { };
 
@@ -2801,13 +2801,13 @@ with pkgs;
 
   groonga = callPackage ../servers/search/groonga { };
 
-  grub = callPackage_i686 ../tools/misc/grub {
+  grub = pkgsi686Linux.callPackage ../tools/misc/grub {
     buggyBiosCDSupport = config.grub.buggyBiosCDSupport or true;
   };
 
-  trustedGrub = callPackage_i686 ../tools/misc/grub/trusted.nix { };
+  trustedGrub = pkgsi686Linux.callPackage ../tools/misc/grub/trusted.nix { };
 
-  trustedGrub-for-HP = callPackage_i686 ../tools/misc/grub/trusted.nix { for_HP_laptop = true; };
+  trustedGrub-for-HP = pkgsi686Linux.callPackage ../tools/misc/grub/trusted.nix { for_HP_laptop = true; };
 
   grub2 = grub2_full;
 
@@ -3287,7 +3287,7 @@ with pkgs;
 
   kbdd = callPackage ../applications/window-managers/kbdd { };
 
-  kdbplus = callPackage_i686 ../applications/misc/kdbplus { };
+  kdbplus = pkgsi686Linux.callPackage ../applications/misc/kdbplus { };
 
   kde2-decoration = libsForQt5.callPackage ../misc/themes/kde2 { };
 
@@ -3406,7 +3406,7 @@ with pkgs;
 
   kippo = callPackage ../servers/kippo { };
 
-  kzipmix = callPackage_i686 ../tools/compression/kzipmix { };
+  kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };
 
   mailcatcher = callPackage ../development/web/mailcatcher { };
 
@@ -6173,7 +6173,7 @@ with pkgs;
 
   cmdstan = callPackage ../development/compilers/cmdstan { };
 
-  cmucl_binary = callPackage_i686 ../development/compilers/cmucl/binary.nix { };
+  cmucl_binary = pkgsi686Linux.callPackage ../development/compilers/cmucl/binary.nix { };
 
   compcert = callPackage ../development/compilers/compcert { };
 
@@ -6480,25 +6480,25 @@ with pkgs;
 
   gcl_2_6_13_pre = callPackage ../development/compilers/gcl/2.6.13-pre.nix { };
 
-  gcc-arm-embedded-4_7 = callPackage_i686 ../development/compilers/gcc-arm-embedded {
+  gcc-arm-embedded-4_7 = pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
     version = "4.7-2013q3-20130916";
     releaseType = "update";
     sha256 = "1bd9bi9q80xn2rpy0rn1vvj70rh15kb7dmah0qs4q2rv78fqj40d";
     ncurses = pkgsi686Linux.ncurses5;
   };
-  gcc-arm-embedded-4_8 = callPackage_i686 ../development/compilers/gcc-arm-embedded {
+  gcc-arm-embedded-4_8 = pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
     version = "4.8-2014q1-20140314";
     releaseType = "update";
     sha256 = "ce92859550819d4a3d1a6e2672ea64882b30afa2c08cf67fa8e1d93788c2c577";
     ncurses = pkgsi686Linux.ncurses5;
   };
-  gcc-arm-embedded-4_9 = callPackage_i686 ../development/compilers/gcc-arm-embedded {
+  gcc-arm-embedded-4_9 = pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
     version = "4.9-2015q1-20150306";
     releaseType = "update";
     sha256 = "c5e0025b065750bbd76b5357b4fc8606d88afbac9ff55b8a82927b4b96178154";
     ncurses = pkgsi686Linux.ncurses5;
   };
-  gcc-arm-embedded-5 = pkgs.callPackage_i686 ../development/compilers/gcc-arm-embedded {
+  gcc-arm-embedded-5 = pkgs.pkgsi686Linux.callPackage ../development/compilers/gcc-arm-embedded {
     dirName = "5.0";
     subdirName = "5-2016-q2-update";
     version = "5.4-2016q2-20160622";
@@ -6864,7 +6864,7 @@ with pkgs;
   manticore = callPackage ../development/compilers/manticore { };
 
   mentorToolchains = recurseIntoAttrs (
-    callPackage_i686 ../development/compilers/mentor {}
+    pkgsi686Linux.callPackage ../development/compilers/mentor {}
   );
 
   mercury = callPackage ../development/compilers/mercury { };
@@ -7051,7 +7051,7 @@ with pkgs;
   smlnjBootstrap = callPackage ../development/compilers/smlnj/bootstrap.nix { };
   smlnj = if stdenv.isDarwin
             then callPackage ../development/compilers/smlnj { }
-            else callPackage_i686 ../development/compilers/smlnj { };
+            else pkgsi686Linux.callPackage ../development/compilers/smlnj { };
 
   solc = callPackage ../development/compilers/solc { };
 
@@ -7560,7 +7560,7 @@ with pkgs;
 
   scheme48 = callPackage ../development/interpreters/scheme48 { };
 
-  self = callPackage_i686 ../development/interpreters/self { };
+  self = pkgsi686Linux.callPackage ../development/interpreters/self { };
 
   spark = spark_22;
   spark_22 = callPackage ../applications/networking/cluster/spark { version = "2.2.1"; };
@@ -15000,7 +15000,7 @@ with pkgs;
       requests requests_toolbelt sqlalchemy fusepy;
   };
 
-  adobe-reader = callPackage_i686 ../applications/misc/adobe-reader { };
+  adobe-reader = pkgsi686Linux.callPackage ../applications/misc/adobe-reader { };
 
   masterpdfeditor = libsForQt5.callPackage ../applications/misc/masterpdfeditor { };
 
@@ -16671,7 +16671,7 @@ with pkgs;
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 
-  inferno = callPackage_i686 ../applications/inferno { };
+  inferno = pkgsi686Linux.callPackage ../applications/inferno { };
 
   inginious = callPackage ../servers/inginious {};
 
@@ -16794,7 +16794,7 @@ with pkgs;
 
   keepnote = callPackage ../applications/office/keepnote { };
 
-  kega-fusion = callPackage_i686 ../misc/emulators/kega-fusion { };
+  kega-fusion = pkgsi686Linux.callPackage ../misc/emulators/kega-fusion { };
 
   kermit = callPackage ../tools/misc/kermit { };
 
@@ -17593,7 +17593,7 @@ with pkgs;
     ffmpeg = ffmpeg_2;
   };
 
-  pcsx2 = callPackage_i686 ../misc/emulators/pcsx2 { };
+  pcsx2 = pkgsi686Linux.callPackage ../misc/emulators/pcsx2 { };
 
   pekwm = callPackage ../applications/window-managers/pekwm { };
 
@@ -19826,7 +19826,7 @@ with pkgs;
 
   terraria-server = callPackage ../games/terraria-server { };
 
-  tibia = callPackage_i686 ../games/tibia { };
+  tibia = pkgsi686Linux.callPackage ../games/tibia { };
 
   tintin = callPackage ../games/tintin { };
 
@@ -19895,7 +19895,7 @@ with pkgs;
 
   vectoroids = callPackage ../games/vectoroids { };
 
-  vessel = callPackage_i686 ../games/vessel { };
+  vessel = pkgsi686Linux.callPackage ../games/vessel { };
 
   vms-empire = callPackage ../games/vms-empire { };
 
@@ -20885,7 +20885,7 @@ with pkgs;
 
   bootil = callPackage ../development/libraries/bootil { };
 
-  brgenml1lpr = callPackage_i686 ../misc/cups/drivers/brgenml1lpr {};
+  brgenml1lpr = pkgsi686Linux.callPackage ../misc/cups/drivers/brgenml1lpr {};
 
   brgenml1cupswrapper = callPackage ../misc/cups/drivers/brgenml1cupswrapper {};
 
@@ -20934,10 +20934,10 @@ with pkgs;
 
   cups-bjnp = callPackage ../misc/cups/drivers/cups-bjnp { };
 
-  cups-brother-hl1110 = callPackage_i686 ../misc/cups/drivers/hl1110 { };
+  cups-brother-hl1110 = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1110 { };
 
   # this driver ships with pre-compiled 32-bit binary libraries
-  cnijfilter_2_80 = callPackage_i686 ../misc/cups/drivers/cnijfilter_2_80 { };
+  cnijfilter_2_80 = pkgsi686Linux.callPackage ../misc/cups/drivers/cnijfilter_2_80 { };
 
   cnijfilter_4_00 = callPackage ../misc/cups/drivers/cnijfilter_4_00 {
     libusb = libusb1;
@@ -21027,7 +21027,7 @@ with pkgs;
 
   gammu = callPackage ../applications/misc/gammu { };
 
-  gensgs = callPackage_i686 ../misc/emulators/gens-gs { };
+  gensgs = pkgsi686Linux.callPackage ../misc/emulators/gens-gs { };
 
   ghostscript = callPackage ../misc/ghostscript rec {
     cupsSupport = config.ghostscript.cups or (!stdenv.isDarwin);
@@ -21366,13 +21366,13 @@ with pkgs;
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
-  mfcj470dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj470dwlpr { };
+  mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 
   mfcj6510dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj6510dwcupswrapper { };
-  mfcj6510dwlpr = callPackage_i686 ../misc/cups/drivers/mfcj6510dwlpr { };
+  mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };
 
   mfcl2700dncupswrapper = callPackage ../misc/cups/drivers/mfcl2700dncupswrapper { };
-  mfcl2700dnlpr = callPackage_i686 ../misc/cups/drivers/mfcl2700dnlpr { };
+  mfcl2700dnlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcl2700dnlpr { };
 
   mfcl2720dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2720dwcupswrapper { };
   mfcl2720dwlpr = callPackage ../misc/cups/drivers/mfcl2720dwlpr { };
@@ -21678,7 +21678,7 @@ with pkgs;
     callPackage ../applications/networking/znc/modules.nix { }
   );
 
-  zsnes = callPackage_i686 ../misc/emulators/zsnes { };
+  zsnes = pkgsi686Linux.callPackage ../misc/emulators/zsnes { };
 
   xcpc = callPackage ../misc/emulators/xcpc { };
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -137,7 +137,7 @@ let
     # All packages built with the Musl libc. This will override the
     # default GNU libc on Linux systems. Non-Linux systems are not
     # supported.
-    pkgsMusl = nixpkgsFun {
+    pkgsMusl = if stdenv.hostPlatform.isLinux then nixpkgsFun {
       localSystem = {
         parsed = stdenv.hostPlatform.parsed // {
           abi = {
@@ -147,11 +147,11 @@ let
           }.${stdenv.hostPlatform.parsed.abi.name} or lib.systems.parse.abis.musl;
         };
       };
-    };
+    } else throw "Musl libc only supports Linux systems.";
 
     # All packages built for i686 Linux.
     # Used by wine, firefox with debugging version of Flash, ...
-    pkgsi686Linux = nixpkgsFun {
+    pkgsi686Linux = assert stdenv.hostPlatform.isLinux; nixpkgsFun {
       localSystem = {
         parsed = stdenv.hostPlatform.parsed // {
           cpu = lib.systems.parse.cpuTypes.i686;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -124,31 +124,7 @@ let
   # - pkgsCross.<system> where system is a member of lib.systems.examples
   # - pkgsMusl
   # - pkgsi686Linux
-  #
-  # In addition some utility functions are included for creating the
-  # above sets.
-  #
-  # - forceLibc
-  # - forceSystem
-  otherPackageSets = self: super: {
-    # This maps each entry in lib.systems.examples to its own package
-    # set. Each of these will contain all packages cross compiled for
-    # that target system. For instance, pkgsCross.rasberryPi.hello,
-    # will refer to the "hello" package built for the ARM6-based
-    # Raspberry Pi.
-    pkgsCross = lib.mapAttrs (n: crossSystem:
-                              nixpkgsFun { inherit crossSystem; })
-                              lib.systems.examples;
-
-    # All packages built with the Musl libc. This will override the
-    # default GNU libc on Linux systems. Non-Linux systems are not
-    # supported.
-    pkgsMusl = self.forceLibc "musl";
-
-    # All packages built for i686 Linux.
-    # Used by wine, firefox with debugging version of Flash, ...
-    pkgsi686Linux = self.forceSystem "i686-linux" "i386";
-
+  otherPackageSets = self: super: let
     # Override default libc. Currently this is only useful on Linux
     # systems where you have the choice between Musl & Glibc. In the
     # future it may work for other things.
@@ -166,6 +142,24 @@ let
         platform = stdenv.hostPlatform.platform // { inherit kernelArch; };
       };
     };
+  in {
+    # This maps each entry in lib.systems.examples to its own package
+    # set. Each of these will contain all packages cross compiled for
+    # that target system. For instance, pkgsCross.rasberryPi.hello,
+    # will refer to the "hello" package built for the ARM6-based
+    # Raspberry Pi.
+    pkgsCross = lib.mapAttrs (n: crossSystem:
+                              nixpkgsFun { inherit crossSystem; })
+                              lib.systems.examples;
+
+    # All packages built with the Musl libc. This will override the
+    # default GNU libc on Linux systems. Non-Linux systems are not
+    # supported.
+    pkgsMusl = forceLibc "musl";
+
+    # All packages built for i686 Linux.
+    # Used by wine, firefox with debugging version of Flash, ...
+    pkgsi686Linux = forceSystem "i686-linux" "i386";
   };
 
   # The complete chain of package set builders, applied from top to bottom.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -130,8 +130,6 @@ let
   #
   # - forceLibc
   # - forceSystem
-  #
-  # For legacy purposes, callPackage_i686 is also included here.
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for
@@ -168,9 +166,6 @@ let
         platform = stdenv.hostPlatform.platform // { inherit kernelArch; };
       };
     };
-
-    # Legacy attributes that are slated for removal...
-    callPackage_i686 = self.pkgsi686Linux.callPackage;
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
I have renamed the overlay to “otherPackageSets” because I think that
is more descriptive.

pkgsLocal has been removed because there were concerns that it would
be confusing. None of the other names seemed very useful so I think it
is best to avoid it altogether. pkgsCross is still included,
hopefully, that will not have as much confusion.

pkgsMusl is now available for building Musl packages. It will give you
packages bulit with the Musl libc.

Also added more documentation.

/cc @dezgeg @Ericson2314 @dtzWill
