### PR TITLE
cataclysm-dda{,-git}: move common attributes to common.nix

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -59,6 +59,7 @@ let
       '';
       homepage = https://cataclysmdda.org/;
       license = licenses.cc-by-sa-30;
+      maintainers = with maintainers; [ mnacamura ];
       platforms = platforms.unix;
     };
   };

--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -1,0 +1,96 @@
+{ stdenv, fetchFromGitHub, pkgconfig, gettext, lua, ncurses
+, tiles, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, freetype, Cocoa
+, debug
+}:
+
+let
+  inherit (stdenv.lib) optionals;
+
+  cursesDeps = [ gettext lua ncurses ];
+
+  tilesDeps = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf freetype ]
+    ++ optionals stdenv.isDarwin [ Cocoa ];
+
+  common = {
+    nativeBuildInputs = [ pkgconfig ];
+
+    buildInputs = cursesDeps ++ optionals tiles tilesDeps;
+
+    postPatch = ''
+      patchShebangs .
+    '';
+
+    makeFlags = [
+      "PREFIX=$(out)" "LUA=1" "USE_HOME_DIR=1" "LANGUAGES=all"
+    ] ++ optionals (!debug) [
+      "RELEASE=1"
+    ] ++ optionals tiles [
+      "TILES=1" "SOUND=1"
+    ] ++ optionals stdenv.isDarwin [
+      "NATIVE=osx" "CLANG=1"
+    ];
+
+    dontStrip = debug;
+
+    meta = with stdenv.lib; {
+      description = "A free, post apocalyptic, zombie infested rogue-like";
+      longDescription = ''
+        Cataclysm: Dark Days Ahead is a roguelike set in a post-apocalyptic world.
+        Surviving is difficult: you have been thrown, ill-equipped, into a
+        landscape now riddled with monstrosities of which flesh eating zombies are
+        neither the strangest nor the deadliest.
+
+        Yet with care and a little luck, many things are possible. You may try to
+        eke out an existence in the forests silently executing threats and
+        providing sustenance with your longbow. You can ride into town in a
+        jerry-rigged vehicle, all guns blazing, to settle matters in a fug of
+        smoke from your molotovs. You could take a more measured approach and
+        construct an impregnable fortress, surrounded by traps to protect you from
+        the horrors without. The longer you survive, the more skilled and adapted
+        you will get and the better equipped and armed to deal with the threats
+        you are presented with.
+
+        In the course of your ordeal there will be opportunities and temptations
+        to improve or change your very nature. There are tales of survivors fitted
+        with extraordinary cybernetics giving great power and stories too of
+        gravely mutated survivors who, warped by their ingestion of exotic
+        substances or radiation, now more closely resemble insects, birds or fish
+        than their original form.
+      '';
+      homepage = https://cataclysmdda.org/;
+      license = licenses.cc-by-sa-30;
+      platforms = platforms.unix;
+    };
+  };
+
+  utils = {
+    fetchFromCleverRaven = { rev, sha256 }:
+    fetchFromGitHub {
+      owner = "CleverRaven";
+      repo = "Cataclysm-DDA";
+      inherit rev sha256;
+    };
+
+    installXDGAppLauncher = ''
+      launcher="$out/share/applications/cataclysm-dda.desktop"
+      install -D -m 444 data/xdg/com.cataclysmdda.cataclysm-dda.desktop -T "$launcher"
+      sed -i "$launcher" -e "s,\(Exec=\)\(cataclysm-tiles\),\1$out/bin/\2,"
+      install -D -m 444 data/xdg/cataclysm-dda.svg -t $out/share/icons/hicolor/scalable/apps
+    '';
+
+    installMacOSAppLauncher = ''
+      app=$out/Applications/Cataclysm.app
+      install -D -m 444 data/osx/Info.plist -t $app/Contents
+      install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources
+      mkdir $app/Contents/MacOS
+      launcher=$app/Contents/MacOS/Cataclysm.sh
+      cat << EOF > $launcher
+      #!${stdenv.shell}
+      $out/bin/cataclysm-tiles
+      EOF
+      chmod 555 $launcher
+    '';
+  };
+in
+
+{ inherit common utils; }

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (common // rec {
   # Disable, possible problems with hydra
   #enableParallelBuilding = true;
 
-  meta = common.meta // {
-    maintainers = with stdenv.lib.maintainers; [ skeidel ];
+  meta = with stdenv.lib.maintainers; common.meta // {
+    maintainers = common.meta.maintainers ++ [ skeidel ];
   };
 })

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,43 +1,30 @@
-{ fetchFromGitHub, stdenv, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
-SDL2_mixer, freetype, gettext, Cocoa, libicns,
-tiles ? true }:
+{ stdenv, callPackage, ncurses
+, tiles ? true, Cocoa, libicns
+, debug ? false
+}:
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.lib) optionals optionalString;
+  inherit (callPackage ./common.nix { inherit tiles Cocoa debug; }) common utils;
+  inherit (utils) fetchFromCleverRaven installMacOSAppLauncher;
+in
+
+stdenv.mkDerivation (common // rec {
   version = "0.C";
   name = "cataclysm-dda-${version}";
 
-  src = fetchFromGitHub {
-    owner = "CleverRaven";
-    repo = "Cataclysm-DDA";
+  src = fetchFromCleverRaven {
     rev = "${version}";
     sha256 = "03sdzsk4qdq99qckq0axbsvg1apn6xizscd8pwp5w6kq2fyj5xkv";
   };
 
-  nativeBuildInputs = [ pkgconfig ]
-    ++ stdenv.lib.optionals (tiles && stdenv.isDarwin) [ libicns ];
-
-  buildInputs = with stdenv.lib; [ ncurses lua gettext ]
-    ++ optionals tiles [ SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype ]
-    ++ optionals (tiles && stdenv.isDarwin) [ Cocoa ];
+  nativeBuildInputs = common.nativeBuildInputs
+    ++ optionals (tiles && stdenv.isDarwin) [ libicns ];
 
   patches = [ ./patches/fix_locale_dir.patch ];
 
-  postPatch = ''
-    patchShebangs .
-  '';
-
-  makeFlags = with stdenv.lib; [
-    "PREFIX=$(out)"
-    "LUA=1"
-    "RELEASE=1"
-    "USE_HOME_DIR=1"
-    # "LANGUAGES=all"  # vanilla C:DDA installs all translations even without this flag!
-  ] ++ optionals tiles [
-    "TILES=1"
-    "SOUND=1"
-  ] ++ optionals stdenv.isDarwin [
-    "NATIVE=osx"
-    "CLANG=1"
+  makeFlags = common.makeFlags
+    ++ optionals stdenv.isDarwin [
     "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above
   ] ++ optionals stdenv.cc.isGNU [
     "WARNINGS+=-Wno-deprecated-declarations"
@@ -46,57 +33,20 @@ stdenv.mkDerivation rec {
     "WARNINGS+=-Wno-inconsistent-missing-override"
   ];
 
-  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-Wno-user-defined-warnings";
+  NIX_CFLAGS_COMPILE = optionalString stdenv.cc.isClang "-Wno-user-defined-warnings";
 
-  postBuild = stdenv.lib.optionalString (tiles && stdenv.isDarwin) ''
+  postBuild = optionalString (tiles && stdenv.isDarwin) ''
     # iconutil on macOS is not available in nixpkgs
     png2icns data/osx/AppIcon.icns data/osx/AppIcon.iconset/*
   '';
 
-  postInstall = stdenv.lib.optionalString (tiles && stdenv.isDarwin) ''
-    app=$out/Applications/Cataclysm.app
-    install -D -m 444 data/osx/Info.plist -t $app/Contents
-    install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources
-    mkdir $app/Contents/MacOS
-    launcher=$app/Contents/MacOS/Cataclysm.sh
-    cat << SCRIPT > $launcher
-    #!/bin/sh
-    $out/bin/cataclysm-tiles
-    SCRIPT
-    chmod 555 $launcher
-  '';
+  postInstall = optionalString (tiles && stdenv.isDarwin)
+    installMacOSAppLauncher;
 
   # Disable, possible problems with hydra
   #enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
-    description = "A free, post apocalyptic, zombie infested rogue-like";
-    longDescription = ''
-      Cataclysm: Dark Days Ahead is a roguelike set in a post-apocalyptic world.
-      Surviving is difficult: you have been thrown, ill-equipped, into a
-      landscape now riddled with monstrosities of which flesh eating zombies are
-      neither the strangest nor the deadliest.
-
-      Yet with care and a little luck, many things are possible. You may try to
-      eke out an existence in the forests silently executing threats and
-      providing sustenance with your longbow. You can ride into town in a
-      jerry-rigged vehicle, all guns blazing, to settle matters in a fug of
-      smoke from your molotovs. You could take a more measured approach and
-      construct an impregnable fortress, surrounded by traps to protect you from
-      the horrors without. The longer you survive, the more skilled and adapted
-      you will get and the better equipped and armed to deal with the threats
-      you are presented with.
-
-      In the course of your ordeal there will be opportunities and temptations
-      to improve or change your very nature. There are tales of survivors fitted
-      with extraordinary cybernetics giving great power and stories too of
-      gravely mutated survivors who, warped by their ingestion of exotic
-      substances or radiation, now more closely resemble insects, birds or fish
-      than their original form.
-    '';
-    homepage = https://cataclysmdda.org/;
-    license = licenses.cc-by-sa-30;
-    maintainers = [ maintainers.skeidel ];
-    platforms = platforms.unix;
+  meta = common.meta // {
+    maintainers = with stdenv.lib.maintainers; [ skeidel ];
   };
-}
+})

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -1,100 +1,44 @@
-{ fetchFromGitHub, stdenv, pkgconfig, ncurses, lua, SDL2, SDL2_image, SDL2_ttf,
-SDL2_mixer, freetype, gettext, CoreFoundation, Cocoa,
-tiles ? true, debug ? false }:
+{ stdenv, callPackage
+, tiles ? true, Cocoa, CoreFoundation
+, debug ? false
+}:
 
-stdenv.mkDerivation rec {
+let
+  inherit (stdenv.lib) optionals optionalString substring;
+  inherit (callPackage ./common.nix { inherit tiles Cocoa debug; }) common utils;
+  inherit (utils) fetchFromCleverRaven installXDGAppLauncher installMacOSAppLauncher;
+in
+
+stdenv.mkDerivation (common // rec {
   version = "2018-07-15";
   name = "cataclysm-dda-git-${version}";
 
-  src = fetchFromGitHub {
-    owner = "CleverRaven";
-    repo = "Cataclysm-DDA";
+  src = fetchFromCleverRaven {
     rev = "e1e5d81";
     sha256 = "198wfj8l1p8xlwicj92cq237pzv2ha9pcf240y7ijhjpmlc9jkr1";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-
-  buildInputs = with stdenv.lib; [ ncurses lua gettext ]
-    ++ optionals stdenv.isDarwin [ CoreFoundation ]
-    ++ optionals tiles [ SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype ]
-    ++ optionals (tiles && stdenv.isDarwin) [ Cocoa ];
+  buildInputs = common.buildInputs
+    ++ optionals stdenv.isDarwin [ CoreFoundation ];
 
   patches = [ ./patches/fix_locale_dir_git.patch ];
 
-  postPatch = ''
-    patchShebangs .
-    sed -i data/xdg/com.cataclysmdda.cataclysm-dda.desktop \
-        -e "s,\(Exec=\)\(cataclysm-tiles\),\1$out/bin/\2,"
-  '';
-
-  makeFlags = with stdenv.lib; [
-    "PREFIX=$(out)"
-    "LUA=1"
-    "USE_HOME_DIR=1"
-    "LANGUAGES=all"
+  makeFlags = common.makeFlags ++ [
     "VERSION=git-${version}-${substring 0 8 src.rev}"
-  ] ++ optionals tiles [
-    "TILES=1"
-    "SOUND=1"
-  ] ++ optionals stdenv.isDarwin [
-    "NATIVE=osx"
-    "CLANG=1"
-  ] ++ optionals (! debug) [
-    "RELEASE=1"
   ];
 
-  postInstall = with stdenv.lib; optionalString (tiles && !stdenv.isDarwin) ''
-    install -D -m 444 data/xdg/com.cataclysmdda.cataclysm-dda.desktop -T $out/share/applications/cataclysm-dda.desktop
-    install -D -m 444 data/xdg/cataclysm-dda.svg -t $out/share/icons/hicolor/scalable/apps
-  '' + optionalString (tiles && stdenv.isDarwin) ''
-    app=$out/Applications/Cataclysm.app
-    install -D -m 444 data/osx/Info.plist -t $app/Contents
-    install -D -m 444 data/osx/AppIcon.icns -t $app/Contents/Resources
-    mkdir $app/Contents/MacOS
-    launcher=$app/Contents/MacOS/Cataclysm.sh
-    cat << SCRIPT > $launcher
-    #!/bin/sh
-    $out/bin/cataclysm-tiles
-    SCRIPT
-    chmod 555 $launcher
-  '';
+  postInstall = optionalString tiles
+  ( if !stdenv.isDarwin
+    then installXDGAppLauncher
+    else installMacOSAppLauncher
+  );
 
   # https://hydra.nixos.org/build/65193254
   # src/weather_data.cpp:203:1: fatal error: opening dependency file obj/tiles/weather_data.d: No such file or directory
   # make: *** [Makefile:687: obj/tiles/weather_data.o] Error 1
   enableParallelBuilding = false;
 
-  dontStrip = debug;
-
-  meta = with stdenv.lib; {
-    description = "A free, post apocalyptic, zombie infested rogue-like";
-    longDescription = ''
-      Cataclysm: Dark Days Ahead is a roguelike set in a post-apocalyptic world.
-      Surviving is difficult: you have been thrown, ill-equipped, into a
-      landscape now riddled with monstrosities of which flesh eating zombies are
-      neither the strangest nor the deadliest.
-
-      Yet with care and a little luck, many things are possible. You may try to
-      eke out an existence in the forests silently executing threats and
-      providing sustenance with your longbow. You can ride into town in a
-      jerry-rigged vehicle, all guns blazing, to settle matters in a fug of
-      smoke from your molotovs. You could take a more measured approach and
-      construct an impregnable fortress, surrounded by traps to protect you from
-      the horrors without. The longer you survive, the more skilled and adapted
-      you will get and the better equipped and armed to deal with the threats
-      you are presented with.
-
-      In the course of your ordeal there will be opportunities and temptations
-      to improve or change your very nature. There are tales of survivors fitted
-      with extraordinary cybernetics giving great power and stories too of
-      gravely mutated survivors who, warped by their ingestion of exotic
-      substances or radiation, now more closely resemble insects, birds or fish
-      than their original form.
-    '';
-    maintainers = with maintainers; [ rardiol ];
-    homepage = https://cataclysmdda.org/;
-    license = licenses.cc-by-sa-30;
-    platforms = platforms.unix;
+  meta = common.meta // {
+    maintainers = with stdenv.lib.maintainers; [ rardiol ];
   };
-}
+})

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (common // rec {
   # make: *** [Makefile:687: obj/tiles/weather_data.o] Error 1
   enableParallelBuilding = false;
 
-  meta = common.meta // {
-    maintainers = with stdenv.lib.maintainers; [ rardiol ];
+  meta = with stdenv.lib.maintainers; common.meta // {
+    maintainers = common.meta.maintainers ++ [ rardiol ];
   };
 })


### PR DESCRIPTION
###### Motivation for this change

In the derivations of cataclysm-dda{,-git}, most attributes overlap between the two versions. It would be better to put them into a common tool box.
<s>I would like to update the git version as well.</s>
EDIT: #43578 has already bumped version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

