### PR TITLE
dwarf-fortress: TWBT & Lazy Pack

### DIFF
--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -31,6 +31,8 @@ let
 
     legends-browser = callPackage ./legends-browser {};
 
+    twbt = callPackage ./twbt {};
+
     themes = callPackage ./themes {
       stdenv = stdenvNoCC;
     };

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -1,9 +1,32 @@
-{ pkgs, stdenv, stdenvNoCC, gccStdenv }:
+{ pkgs, stdenv, stdenvNoCC, buildEnv, gccStdenv }:
+
+# To whomever it may concern:
+#
+# This directory menaces with spikes of Nix code. It is terrifying.
+#
+# If this is your first time here, you should probably install the dwarf-fortress-full package,
+# for instance with `environment.systempackages = [ pkgs.dwarf-fortress.dwarf-fortress-full ];`.
+#
+# You can adjust its settings by using override, or compile your own package by
+# using the other packages here. Take a look at lazy-pack.nix to get an idea of
+# how.
+#
+# You will find the configuration files in ~/.local/share/df_linux/data/init. If
+# you un-symlink them and edit, then the scripts will avoid overwriting your
+# changes on later launches, but consider extending the wrapper with your
+# desired options instead.
+#
+# Although both dfhack and dwarf therapist are included in the lazy pack, you
+# can only use one at a time. DFHack does have therapist-like features, so this
+# may or may not be a problem.
 
 let
   callPackage = pkgs.newScope self;
 
   self = rec {
+
+    dwarf-fortress-full = callPackage ./lazy-pack.nix { };
+
     dwarf-fortress-original = callPackage ./game.nix { };
 
     dfhack = callPackage ./dfhack {
@@ -13,7 +36,7 @@ let
 
     soundSense = callPackage ./soundsense.nix { };
 
-    # unfuck is linux-only right now, we will just use it there
+    # unfuck is linux-only right now, we will only use it there.
     dwarf-fortress-unfuck = if stdenv.isLinux then callPackage ./unfuck.nix { }
                                  else null;
 

--- a/pkgs/games/dwarf-fortress/lazy-pack.nix
+++ b/pkgs/games/dwarf-fortress/lazy-pack.nix
@@ -1,0 +1,36 @@
+{ stdenvNoCC, lib, buildEnv, callPackage
+, dwarf-fortress, themes
+  # This package should, at any given time, provide an opinionated "optimal"
+  # DF experience. It's the equivalent of the Lazy Newbie Pack, that is, and
+  # should contain every utility available.
+, enableDFHack ? stdenvNoCC.isLinux
+, enableTWBT ? enableDFHack
+, enableSoundSense ? true
+, enableStoneSense ? false  # StoneSense is currently broken.
+, enableDwarfTherapist ? true, dwarf-therapist
+, enableLegendsBrowser ? true, legends-browser
+, theme ? themes.phoebus
+# General config options:
+, enableIntro ? true
+, enableTruetype ? true
+, enableFPS ? false
+}:
+
+buildEnv {
+  name = "dwarf-fortress-full";
+  paths = [
+    (dwarf-fortress.override {
+      inherit enableDFHack enableTWBT enableSoundSense enableStoneSense theme
+              enableIntro enableTruetype enableFPS;
+    })]
+    ++ lib.optional enableDwarfTherapist dwarf-therapist
+    ++ lib.optional enableLegendsBrowser legends-browser;
+
+  meta = with stdenvNoCC.lib; {
+    description = "An opinionated wrapper for Dwarf Fortress";
+    maintainers = with maintainers; [ Baughn ];
+    license = licenses.mit;
+    platforms = platforms.all;
+    homepage = https://github.com/NixOS/nixpkgs/;
+  };
+}

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -3,12 +3,12 @@
 
 stdenvNoCC.mkDerivation rec {
   name = "twbt-${version}";
-  version = "6.46";
-  dfVersion = "0.44.10";
+  version = "6.49";
+  dfVersion = "0.44.11";
 
   src = fetchurl {
     url = "https://github.com/mifki/df-twbt/releases/download/v${version}/twbt-${version}-linux.zip";
-    sha256 = "1a4k26z5n547k5j3ij2kx834963rc8vwgwcmbmzmhi893bryb1k6";
+    sha256 = "1qjkc7k33qhxj2g18njzasccjqsis5y8zrw5vl90h4rs3i8ld9xz";
   };
 
   sourceRoot = ".";

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -1,0 +1,35 @@
+{ stdenvNoCC, fetchurl, unzip }:
+
+
+stdenvNoCC.mkDerivation rec {
+  name = "twbt-${version}";
+  version = "6.46";
+  dfVersion = "0.44.10";
+
+  src = fetchurl {
+    url = "https://github.com/mifki/df-twbt/releases/download/v${version}/twbt-${version}-linux.zip";
+    sha256 = "1a4k26z5n547k5j3ij2kx834963rc8vwgwcmbmzmhi893bryb1k6";
+  };
+
+  sourceRoot = ".";
+
+  outputs = [ "lib" "art" "out" ];
+
+  buildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir -p $lib/hack/{plugins,lua} $art/data/art
+    cp -a */twbt.plug.so $lib/hack/plugins/
+    cp -a *.lua $lib/hack/lua/
+    cp -a *.png $art/data/art/
+  '';
+
+  
+  meta = with stdenvNoCC.lib; {
+    description = "A plugin for Dwarf Fortress / DFHack that improves various aspects the game interface.";
+    maintainers = with maintainers; [ Baughn ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+    homepage = https://github.com/mifki/df-twbt;
+  };
+}

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -5,6 +5,10 @@
 , enableTWBT ? false, twbt
 , themes ? {}
 , theme ? null
+# General config options:
+, enableIntro ? true
+, enableTruetype ? true
+, enableFPS ? false
 }:
 
 let
@@ -36,11 +40,24 @@ let
     pathsToLink = [ "/" "/hack" "/hack/scripts" ];
     ignoreCollisions = true;
 
-    postBuild = lib.optionalString enableDFHack ''
+    postBuild = ''
+      # De-symlink init.txt
+      cp $out/data/init/init.txt init.txt
+      rm $out/data/init/init.txt
+      mv init.txt $out/data/init/init.txt
+    '' + lib.optionalString enableDFHack ''
       rm $out/hack/symbols.xml
       substitute ${dfhack_}/hack/symbols.xml $out/hack/symbols.xml \
         --replace $(cat ${dwarf-fortress-original}/hash.md5.orig) \
                   $(cat ${dwarf-fortress-original}/hash.md5)
+    '' + lib.optionalString enableTWBT ''
+      substituteInPlace $out/data/init/init.txt \
+        --replace '[PRINT_MODE:2D]' '[PRINT_MODE:TWBT]'
+    '' + ''
+      substituteInPlace $out/data/init/init.txt \
+        --replace '[INTRO:YES]' '[INTRO:${unBool enableIntro}]' \
+        --replace '[TRUETYPE:YES]' '[TRUETYPE:${unBool enableTruetype}]' \
+        --replace '[FPS:NO]' '[FPS:${unBool enableFPS}]'
     '';
   };
 in

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -2,6 +2,7 @@
 , enableDFHack ? false, dfhack
 , enableSoundSense ? false, soundSense, jdk
 , enableStoneSense ? false
+, enableTWBT ? false, twbt
 , themes ? {}
 , theme ? null
 }:
@@ -9,6 +10,7 @@
 let
   dfhack_ = dfhack.override {
     inherit enableStoneSense;
+    inherit enableTWBT;
   };
 
   ptheme =
@@ -16,10 +18,15 @@ let
     then builtins.getAttr theme themes
     else theme;
 
+  twbtOnlyWithDFHack = assert (enableDFHack || !enableTWBT); true;
+
+  unBool = b: if b then "YES" else "NO";
+
   # These are in inverse order for first packages to override the next ones.
   themePkg = lib.optional (theme != null) ptheme;
   pkgs = lib.optional enableDFHack dfhack_
          ++ lib.optional enableSoundSense soundSense
+         ++ lib.optional enableTWBT twbt.art
          ++ [ dwarf-fortress-original ];
 
   env = buildEnv {


### PR DESCRIPTION
###### Motivation for this change

The DF directory menaces with spikes of Nix code. It's difficult for a new user to know how to use it.

This adds `dwarf-fortress-full`, an admittedly opinionated configuration that should suffice as a starting point, and may suffice in general.

It also adds the TWBT plugin to dfhack, which makes text look nicer in general.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

