### PR TITLE
pythonPackages.sounddevice: fixed portaudio library path

### DIFF
--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -4,15 +4,16 @@
 , cffi
 , numpy
 , portaudio
+, substituteAll
 }:
 
 buildPythonPackage rec {
   pname = "sounddevice";
-  version = "0.3.9";
+  version = "0.3.11";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1c9e833f8c8ccc67c0291c3448b29e9acc548fe56d15ee6f7fdd7037e00319f8";
+    sha256 = "0pfcbgbl77nggchxb2i5rb78m7hpgn65aqpz99yfx1fgfbmy9yg1";
   };
 
   propagatedBuildInputs = [ cffi numpy portaudio ];
@@ -20,9 +21,12 @@ buildPythonPackage rec {
   # No tests included nor upstream available.
   doCheck = false;
 
-  prePatch = ''
-    substituteInPlace src/sounddevice.py --replace "'portaudio'" "'${portaudio}/lib/libportaudio.so.2'"
-  '';
+  patches = [
+    (substituteAll {
+      src = ./fix-portaudio-library-path.patch;
+      portaudio = "${portaudio}/lib/libportaudio.so.2";
+    })
+  ];
 
   meta = {
     description = "Play and Record Sound with Python";

--- a/pkgs/development/python-modules/sounddevice/fix-portaudio-library-path.patch
+++ b/pkgs/development/python-modules/sounddevice/fix-portaudio-library-path.patch
@@ -1,0 +1,34 @@
+diff --git a/sounddevice.py b/sounddevice.py
+index f03476c..5745b6e 100644
+--- a/sounddevice.py
++++ b/sounddevice.py
+@@ -58,28 +58,7 @@ from ctypes.util import find_library as _find_library
+ from _sounddevice import ffi as _ffi
+
+
+-try:
+-    for _libname in (
+-            'portaudio',  # Default name on POSIX systems
+-            'bin\\libportaudio-2.dll',  # DLL from conda-forge
+-            ):
+-        _libname = _find_library(_libname)
+-        if _libname is not None:
+-            break
+-    else:
+-        raise OSError('PortAudio library not found')
+-    _lib = _ffi.dlopen(_libname)
+-except OSError:
+-    if _platform.system() == 'Darwin':
+-        _libname = 'libportaudio.dylib'
+-    elif _platform.system() == 'Windows':
+-        _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
+-    else:
+-        raise
+-    import _sounddevice_data
+-    _libname = _os.path.join(
+-        next(iter(_sounddevice_data.__path__)), 'portaudio-binaries', _libname)
+-    _lib = _ffi.dlopen(_libname)
++_lib = _ffi.dlopen('@portaudio@')
+
+ _sampleformats = {
+     'float32': _lib.paFloat32,


### PR DESCRIPTION
###### Motivation for this change

The path to the portaudio library is patched in sounddevice.py library. Problem is that sounddevice passes the path through a function `_find_library` that will try to find the *relative* library name somewhere on the filesystem. Unfortunately that function doesn't support the *absolute* library path that is patched in, and gives back `None`. Removing the `_find_library` function call resolves this issue.

To replicate this error put below content in a file `default.nix`:
```
with import <nixpkgs> {};

stdenv.mkDerivation rec {
  name = "env";
  env = buildEnv { name = name; paths = buildInputs; };
  builder = builtins.toFile "builder.sh" ''
    source $stdenv/setup; ln -s $env $out
  '';

  buildInputs = [
    portaudio
    python36
    python36Packages.sounddevice
  ];

  shellHook = ''
  '';
}
```

Then in the same directory run `nix-shell --run python3`
```
>>> import sounddevice
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nix/store/ilm5zca38dxnyrsk8q5x91rl93jlzwk0-sounddevice/lib/python3.6/site-packages/sounddevice.py", line 2678, in <module>
    _initialize()
  File "/nix/store/ilm5zca38dxnyrsk8q5x91rl93jlzwk0-sounddevice/lib/python3.6/site-packages/sounddevice.py", line 2634, in _initialize
    _check(_lib.Pa_Initialize(), 'Error initializing PortAudio')
ffi.error: symbol 'Pa_Initialize' not found in library '<None>': python3: undefined symbol: Pa_Initialize
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

