### PR TITLE
ocamlPackages.janeStreet: 0.10 -> 0.11

### DIFF
--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -1,5 +1,6 @@
 { stdenv, buildOcaml, fetchurl, ocamlbuild, findlib
-, jbuilder, sexplib, ppx_sexp_conv, ppx_deriving }:
+, jbuilder, sexplib, ppx_sexp_conv
+}:
 
 buildOcaml rec {
   name = "ipaddr";
@@ -10,8 +11,8 @@ buildOcaml rec {
     sha256 = "1amb1pbm9ybpxy6190qygpj6nmbzzs2r6vx4xh5r6v89szx9rfxw";
   };
 
-  buildInputs = [ findlib ocamlbuild jbuilder ppx_sexp_conv ];
-  propagatedBuildInputs = [ ppx_deriving sexplib ];
+  buildInputs = [ findlib ocamlbuild jbuilder ];
+  propagatedBuildInputs = [ ppx_sexp_conv sexplib ];
 
   inherit (jbuilder) installPhase;
 

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -1,330 +1,326 @@
 { stdenv, lib, janePackage, ocaml, ocamlbuild, angstrom, cryptokit, ctypes,
   magic-mime, ocaml-migrate-parsetree, octavius, ounit, ppx_deriving, re,
-  zarith, num, openssl }:
+  zarith, num, openssl
+, ppxlib
+}:
 
 rec {
 
-  # Jane Street packages, up to ppx_core
+  ocaml-compiler-libs = janePackage {
+    name = "ocaml-compiler-libs";
+    hash = "03jds7bszh8wwpfwxb3dg0gyr1j1872wxwx1xqhry5ir0i84bg0s";
+    meta.description = "OCaml compiler libraries repackaged";
+  };
+
+  sexplib0 = janePackage {
+    name = "sexplib0";
+    meta.description = "Library containing the definition of S-expressions and some base converters";
+    hash = "07v3ggyss7xhfv14bjk1n87sr42iqwj4cgjiv2lcdfkqk49i2bmi";
+  };
+
+  parsexp = janePackage {
+    name = "parsexp";
+    hash = "1nyq23s5igd8cf3n4qxprjvhbmb6ighb3fy5mw7hxl0mdgsw5fvz";
+    propagatedBuildInputs = [ sexplib0 ];
+    meta.description = "S-expression parsing library";
+  };
 
   sexplib = janePackage {
     name = "sexplib";
-    meta.description = "Automated S-expression conversion";
-    hash = "1agw649n0rnf6h4y2dr1zs1970nncxgjmf90848vbxv8y9im4yy2";
-    propagatedBuildInputs = [ num ];
+    meta.description = "Library for serializing OCaml values to and from S-expressions";
+    hash = "1qfl0m04rpcjvc4yw1hzh6r16jpwmap0sa9ax6zjji67dz4szpyb";
+    propagatedBuildInputs = [ num parsexp ];
   };
 
   base = janePackage {
     name = "base";
-    hash = "13brvkkj76syh8ws1k3lnvk88jvc6jxx16nsq5ysh558db91v5x7";
-    propagatedBuildInputs = [ sexplib ];
+    hash = "0ad5xcyds2lwy9dk7gqwygxk5y769ckrgrjcykdalwdh8qfbi6nf";
+    propagatedBuildInputs = [ sexplib0 ];
     meta.description = "Full standard library replacement for OCaml";
-  };
-
-  ocaml-compiler-libs = janePackage {
-    name = "ocaml-compiler-libs";
-    hash = "0dg9jgwwir99y28bki17cqf3v30apd7cf0qdi8hfwb5pkgp9zdng";
-    meta.description = "OCaml compiler libraries repackaged";
-  };
-
-  ppx_ast = janePackage {
-    name = "ppx_ast";
-    hash = "02jsi9b200071i4x0w358by09xabw9v13q7xrx6cdshqxw0q97kf";
-    propagatedBuildInputs = [ ocaml-compiler-libs ocaml-migrate-parsetree ];
-    meta.description = "OCaml AST used by Jane Street ppx rewriters";
-  };
-
-  ppx_traverse_builtins = janePackage {
-    name = "ppx_traverse_builtins";
-    hash = "0hhw565cwjlr1cwpgkfj0v2kc0lqxyjcrmi9q3hx3344biql8q17";
-    meta.description = "Builtins for Ppx_traverse";
   };
 
   stdio = janePackage {
     name = "stdio";
-    hash = "0ydhy4f89f00n0pfgk8fanj6chzx433qnlcrxnddzg4d3dhb4254";
-    propagatedBuildInputs = [ base sexplib ];
+    hash = "1facajqhvq34g2wrg368y0ajxd6lrj5b3lyzyj0jhdmraxajjcwn";
+    propagatedBuildInputs = [ base ];
     meta.description = "Standard IO library for OCaml";
   };
 
-  ppx_core = janePackage {
-    name = "ppx_core";
-    hash = "0fm26bgf10gk8xl6j4xvwa5s7nmns8rlx7iblb7haj4dxc0qsjhd";
-    propagatedBuildInputs = [ ppx_ast ppx_traverse_builtins stdio ];
-    meta.description = "Jane Street's standard library for ppx rewriters";
-  };
-
-  # Jane Street packages, up to ppx_base
-
-  ppx_optcomp = janePackage {
-    name = "ppx_optcomp";
-    hash = "134anhlh32s5yjjbiqsrmjw51i08pyghzccmrwg1bipl64q55m6n";
-    propagatedBuildInputs = [ ppx_core ];
-    meta.description = "Optional compilation for OCaml";
-  };
-
-  ppx_driver = janePackage {
-    name = "ppx_driver";
-    hash = "0kzijcsq32wf33f4spgja3w5jb9s8wnzmr6lpm8lahw05g80q8nj";
-    buildInputs = [ ocamlbuild ];
-    propagatedBuildInputs = [ ppx_optcomp ];
-    meta.description = "Feature-full driver for OCaml AST transformers";
-  };
-
-  ppx_metaquot = janePackage {
-    name = "ppx_metaquot";
-    hash = "1wb8pl5v57yy1g0g61mvgnxgn2ix2r5skiz33g8hdjvx91pbgmv4";
-    propagatedBuildInputs = [ ppx_driver ];
-    meta.description = "Metaquotations for ppx_ast";
-  };
-
-  ppx_type_conv = janePackage {
-    name = "ppx_type_conv";
-    hash = "0xvn00fzj8lb41slkl91p9z62byg0rlnygdxf4xvrqglg04wa9cz";
-    propagatedBuildInputs = [ ppx_metaquot ppx_deriving ];
-    meta.description = "Support Library for type-driven code generators";
-  };
-
-  ppx_sexp_conv = janePackage {
-    name = "ppx_sexp_conv";
-    hash = "0kvbm34wbxrcpvrrbh5wq4kzx4yb67iidzcq5x1d4bygvp8x2lzd";
-    propagatedBuildInputs = [ ppx_type_conv sexplib ];
-    meta.description = "Generation of S-expression conversion functions from type definitions";
+  configurator = janePackage {
+    name = "configurator";
+    hash = "0h686630cscav7pil8c3w0gbh6rj4b41dvbnwmicmlkc746q5bfk";
+    propagatedBuildInputs = [ stdio ];
+    meta.description = "Helper library for gathering system configuration";
   };
 
   ppx_compare = janePackage {
     name = "ppx_compare";
-    hash = "1fjrb7bz7wrykf4pm7s4s32030jdw65hi7kzd22ibd1afnkz3xw1";
-    propagatedBuildInputs = [ ppx_type_conv ];
+    version = "0.11.1";
+    hash = "06bq4m1bsm4jlx4g7wh5m99qky7xm4c2g52kaz6pv25hdn5agi2m";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ base ppx_deriving ];
     meta.description = "Generation of comparison functions from types";
   };
 
-  ppx_enumerate = janePackage {
-    name = "ppx_enumerate";
-    hash = "1b4q1h19bh2xdxgqwdmn5kv95lyvpyf6mfh2fswagf2ajyfshksx";
-    propagatedBuildInputs = [ ppx_type_conv ];
-    meta.description = "Generate a list containing all values of a finite type";
-  };
-
-  ppx_hash = janePackage {
-    name = "ppx_hash";
-    hash = "12yln0gpf21ifr205qxk7dn83bsj07zhmak2xsjap7xkq4k8g9gc";
-    propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
-    meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
-  };
-
-  ppx_js_style = janePackage {
-    name = "ppx_js_style";
-    hash = "11i2cwavbbplhsl5n4zmgpr8gjc4ixa5016vc72y8h78g71jj18n";
-    propagatedBuildInputs = [ ppx_metaquot octavius ];
-    meta.description = "Code style checker for Jane Street Packages";
-  };
-
-  ppx_base = janePackage {
-    name = "ppx_base";
-    hash = "1rk7dlnhl30prda9q34ic0xv375i52j47bkr664ry3ghklxx6d8y";
-    propagatedBuildInputs = [ ppx_enumerate ppx_hash ppx_js_style ];
-    meta.description = "Base set of ppx rewriters";
-  };
-
-  # Jane Street packages, up to ppx_bin_prot
-
-  fieldslib = janePackage {
-    name = "fieldslib";
-    hash = "19l05d7hhc74zg48hj0m7sips8z3vpara1f0lvd8h7n46wpbs608";
-    propagatedBuildInputs = [ ppx_driver ];
-    meta.description = "OCaml record fields as first class values";
+  ppx_sexp_conv = janePackage {
+    name = "ppx_sexp_conv";
+    version = "0.11.2";
+    hash = "0pqwnqy1xp309wvdcaax4lg02yk64lq2w03mbgfvf6ps5ry4gis9";
+    propagatedBuildInputs = [ sexplib0 ppxlib ppx_deriving ];
+    meta.description = "Generation of S-expression conversion functions from type definitions";
   };
 
   variantslib = janePackage {
     name = "variantslib";
-    hash = "0j1qlz7g8ny1qf3a7d38v2a7sxiis1nwcxkvz0myfsc3dkn716an";
-    propagatedBuildInputs = [ ppx_driver ];
+    hash = "0hbsk34ghc28h8pzbma923ma2bgnz8lzrgcqqx9bzg161jl4s4r3";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ base ];
     meta.description = "OCaml variants as first class values";
-  };
-
-  ppx_traverse = janePackage {
-    name = "ppx_traverse";
-    hash = "1ps7s4vwvzik9wvmwd0i3a1sjgm0xx32yivc2r8ix9qqwylvjllq";
-    propagatedBuildInputs = [ ppx_type_conv ];
-    meta.description = "Automatic generation of open recursion classes";
-  };
-
-  ppx_custom_printf = janePackage {
-    name = "ppx_custom_printf";
-    hash = "113dvmiy07lb6mf0f88avf4cfkix4q029xqi2w0h26xngp88s31p";
-    propagatedBuildInputs = [ ppx_sexp_conv ppx_traverse ];
-    meta.description = "Printf-style format-strings for user-defined string conversion";
-  };
-
-  ppx_fields_conv = janePackage {
-    name = "ppx_fields_conv";
-    hash = "1df095qczkzclmdcs1nrm89wswnxivn9kvn6sw65jpvryfkf5v5k";
-    propagatedBuildInputs = [ fieldslib ppx_type_conv ];
-    meta.description = "Generation of accessor and iteration functions for OCaml records";
   };
 
   ppx_variants_conv = janePackage {
     name = "ppx_variants_conv";
-    hash = "1l19rkclf65f8snw2v0yibkvk28by241dkp6jb0076dyghbln451";
-    propagatedBuildInputs = [ ppx_type_conv variantslib ];
+    version = "0.11.1";
+    hash = "1yc0gsds5m2nv39zga8nnrca2n75rkqy5dz4xj1635ybz20hhbjd";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ ppx_deriving variantslib ];
     meta.description = "Generation of accessor and iteration functions for OCaml variant types";
+  };
+
+  fieldslib = janePackage {
+    name = "fieldslib";
+    hash = "1yvjvfax56lmn2lxbykcmhgmxypws1vp9lhnyb8bhbavsv8yc6da";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "OCaml record fields as first class values";
+  };
+
+  ppx_fields_conv = janePackage {
+    name = "ppx_fields_conv";
+    hash = "1bb9cmn4js7p3qh8skzyik1pcz6sj1k4xkhf12fg1bjmb5fd0jx1";
+    propagatedBuildInputs = [ fieldslib ];
+    meta.description = "Generation of accessor and iteration functions for OCaml records";
+  };
+
+  ppx_custom_printf = janePackage {
+    name = "ppx_custom_printf";
+    hash = "1dvjzvaxhx53jqwrrlxdckwl1azrhs9kvwb48mhgd0jnz65ny726";
+    propagatedBuildInputs = [ ppx_sexp_conv ];
+    meta.description = "Printf-style format-strings for user-defined string conversion";
   };
 
   bin_prot = janePackage {
     name = "bin_prot";
-    hash = "1yyjpwr2s5l8sm9j77a4cmr92rdx73iy3fwqyxf7dr8hfrmd938v";
+    hash = "1mgbyzsr8h0y4s4j9dv7hsdrxyzhhjww5khwg2spi2my7ia95m0l";
     propagatedBuildInputs = [ ppx_compare ppx_custom_printf ppx_fields_conv ppx_variants_conv ];
     meta.description = "Binary protocol generator";
   };
 
+  jane-street-headers = janePackage {
+    name = "jane-street-headers";
+    hash = "0kij4c7qxrja787f3sm3z6mzr322486h2djrlyhnl66vp8hrv8si";
+    meta.description = "Jane Street header files";
+  };
+
   ppx_here = janePackage {
     name = "ppx_here";
-    hash = "0ysx25ai7mpzxfpbswd9k38hpxhjm12bj0iw5ghvhdjnnn07kwcv";
-    propagatedBuildInputs = [ ppx_driver ];
+    hash = "04njv8s4n54x9rg0012ymd6y6lrnqprnh0f0f6s0jcp79q7mv43i";
+    buildInputs = [ ppxlib ];
     meta.description = "Expands [%here] into its location";
   };
 
-  ppx_bin_prot = janePackage {
-    name = "ppx_bin_prot";
-    hash = "06n7gs51847p75baay9ar8n15ynqzhdbnwd8xvp8vxs6krr6wpfd";
-    propagatedBuildInputs = [ ppx_here bin_prot ];
-    meta.description = "Generation of bin_prot readers and writers from types";
-  };
-
-  # Jane Street packages, up to ppx_jane
-
   ppx_assert = janePackage {
     name = "ppx_assert";
-    hash = "09xrcs2sk1a9vjn16bd1cpz3b52kbck7fhc7zrz24lv121wspiaj";
-    propagatedBuildInputs = [ ppx_sexp_conv ppx_here ppx_compare ];
+    hash = "0qbdrl0rj0midnb6sdyaz00s0d4nb8zrrdf565lcdsi1rbnyrzan";
+    buildInputs = [ ppx_here ];
+    propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
     meta.description = "Assert-like extension nodes that raise useful errors on failure";
+  };
+
+  ppx_hash = janePackage {
+    version = "0.11.1";
+    name = "ppx_hash";
+    hash = "1p0ic6aijxlrdggpmycj12q3cy9xksbq2vq727215maz4snvlf5p";
+    propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
+    meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
   };
 
   ppx_inline_test = janePackage {
     name = "ppx_inline_test";
-    hash = "0ar4lpl3zwb7k1f4clqsw1hyzwa104gf118a2i89c4hvj2721jwf";
-    propagatedBuildInputs = [ ppx_metaquot ];
+    hash = "11n94fz1asjf5vqdgriv0pvsa5lbfpqcyk525c7816w23vskcvq6";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ base ];
     meta.description = "Syntax extension for writing in-line tests in OCaml code";
+  };
+
+  ppx_sexp_message = janePackage {
+    name = "ppx_sexp_message";
+    hash = "0d94pf0mrmyp905ncgj4w6cc6zpm4nlib6nclslhgs89pxpzg6a0";
+    buildInputs = [ ppx_here ];
+    propagatedBuildInputs = [ ppx_sexp_conv ];
+    meta.description = "A ppx rewriter for easy construction of s-expressions";
   };
 
   typerep = janePackage {
     name = "typerep";
-    hash = "11na0kag6aggckx7326zq8hh9pzymkwqfxsd25fswskk5lpnvwqv";
+    hash = "00j4by75fl9niqvlpiyw6ymlmlmgfzysm8w25cj5wsfsh4yrgr74";
     propagatedBuildInputs = [ base ];
     meta.description = "Runtime types for OCaml";
   };
 
+  ppx_typerep_conv = janePackage {
+    version = "0.11.1";
+    name = "ppx_typerep_conv";
+    hash = "0a13dpfrrg0rsm8qni1bh7pqcda30l70z8r6yzi5a64bmwk7g5ah";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ ppx_deriving typerep ];
+    meta.description = "Generation of runtime types from type declarations";
+  };
+
+  ppx_js_style = janePackage {
+    name = "ppx_js_style";
+    hash = "1cwqyrkykc8wi60grbid1w072fcvf7k0hd387jz7mxfw44qyb85g";
+    propagatedBuildInputs = [ ppxlib octavius ];
+    meta.description = "Code style checker for Jane Street Packages";
+  };
+
+  ppx_enumerate = janePackage {
+    version = "0.11.1";
+    name = "ppx_enumerate";
+    hash = "0spx9k1v7vjjb6sigbfs69yndgq76v114jhxvzjmffw7q989cyhr";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ ppx_deriving ];
+    meta.description = "Generate a list containing all values of a finite type";
+  };
+
+  ppx_base = janePackage {
+    name = "ppx_base";
+    hash = "079caqjbxk1d33hy69017n3dwslqy52alvzjddwpdjb04vjadlk6";
+    propagatedBuildInputs = [ ppx_compare ppx_enumerate ppx_hash ppx_js_style ];
+    meta.description = "Base set of ppx rewriters";
+  };
+
   ppx_bench = janePackage {
     name = "ppx_bench";
-    hash = "17l5shhi613l02yfipyr4hna3lj94kn6zy746rvsgcibyc7nybq6";
-    propagatedBuildInputs = [ ppx_inline_test ];
+    hash = "0z98r6y4lpj6dy265m771ylx126hq3v1zjsk74yqvpwwd63gx3jz";
+    buildInputs = [ ppxlib ppx_inline_test ];
     meta.description = "Syntax extension for writing in-line benchmarks in OCaml code";
+  };
+
+  ppx_bin_prot = janePackage {
+    version = "0.11.1";
+    name = "ppx_bin_prot";
+    hash = "1h60i75bzvhna1axyn662gyrzhh441l79vl142d235i5x31dmnkz";
+    buildInputs = [ ppxlib ppx_here ];
+    propagatedBuildInputs = [ bin_prot ];
+    meta.description = "Generation of bin_prot readers and writers from types";
   };
 
   ppx_expect = janePackage {
     name = "ppx_expect";
-    hash = "0qq07iqfsbksklwn7rr1wdz79kji0iyq5qkyfwxrxm0ci9fz0h1w";
-    propagatedBuildInputs = [ ppx_inline_test ppx_fields_conv ppx_custom_printf ppx_assert ppx_variants_conv re ];
+    hash = "1g0r67vfw9jr75pybiw4ysfiswlzyfpbj0gl91rx62gqdhjh1pga";
+    buildInputs = [ ppx_assert ppx_custom_printf ppx_fields_conv ppx_here ppx_variants_conv re ];
+    propagatedBuildInputs = [ fieldslib ppx_compare ppx_inline_test ppx_sexp_conv ];
     meta.description = "Cram like framework for OCaml";
   };
 
   ppx_fail = janePackage {
     name = "ppx_fail";
-    hash = "0cwz16xy5s0ijm9y98lh9089ic7wd161njpdncgsxy6lgsjawap2";
-    propagatedBuildInputs = [ ppx_here ppx_metaquot ];
+    hash = "0d0xadcl7mhp81kspcd2b0nh75h34w5a6s6j9qskjjbjif87wiix";
+    buildInputs = [ ppxlib ppx_here ];
     meta.description = "Add location to calls to failwiths";
   };
 
   ppx_let = janePackage {
     name = "ppx_let";
-    hash = "0smdxkjh4nxrf3mwzfvkjbymvwbz04v70k2gwxsaz5f6wvnhyvmm";
-    propagatedBuildInputs = [ ppx_driver ];
+    hash = "1ckzwljlb78cdf6xxd24nddnmsihvjrnq75r1b255aj3xgkzsygx";
+    buildInputs = [ ppxlib ];
     meta.description = "Monadic let-bindings";
+  };
+
+  ppx_optcomp = janePackage {
+    name = "ppx_optcomp";
+    hash = "1rahkjq6vpffs7wdz1crgbxkdnlfkj1i3j12c2andy4fhj49glcm";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ ppx_deriving ];
+    meta.description = "Optional compilation for OCaml";
   };
 
   ppx_optional = janePackage {
     name = "ppx_optional";
-    hash = "1qmc0yzp9jab8yndxs0ca3qx35wyhfwiknqk0gfjmar2ji87zlzn";
-    propagatedBuildInputs = [ ppx_metaquot ];
+    hash = "0aw3hvrsdjpw4ik7rf15ghak31vhdr1lgpphr18mj76rnlrhirmx";
+    propagatedBuildInputs = [ ppxlib ];
     meta.description = "Pattern matching on flat options";
   };
 
   ppx_pipebang = janePackage {
     name = "ppx_pipebang";
-    hash = "0lzw6qc9f9g7zkbhhp4603b3mj3jvca4phx40f95d49y370325qx";
-    propagatedBuildInputs = [ ppx_metaquot ];
+    hash = "0smgq587amlr3hivbbg153p83dj37w30cssp9cffc0v8kg84lfhr";
+    buildInputs = [ ppxlib ];
     meta.description = "A ppx rewriter that inlines reverse application operators |> and |!";
-  };
-
-  ppx_sexp_message = janePackage {
-    name = "ppx_sexp_message";
-    hash = "1gddia4ry2pmnh4qj5855a044lqs23g5h038bkny73xg7w06jhrk";
-    propagatedBuildInputs = [ ppx_sexp_conv ppx_here ];
-    meta.description = "A ppx rewriter for easy construction of s-expressions";
   };
 
   ppx_sexp_value = janePackage {
     name = "ppx_sexp_value";
-    hash = "1xd5ln997wka8x4dba58yh525a5f36sklngg2z7iyiss7xi4yg7i";
-    propagatedBuildInputs = [ ppx_sexp_conv ppx_here ];
+    hash = "107zwb580nrmc0l03dl3y3hf12s3c1vv8b8mz6sa4k5afp3s9nkl";
+    buildInputs = [ ppx_here ];
+    propagatedBuildInputs = [ ppx_sexp_conv ];
     meta.description = "A ppx rewriter that simplifies building s-expressions from OCaml values";
-  };
-
-  ppx_typerep_conv = janePackage {
-    name = "ppx_typerep_conv";
-    hash = "1bk8zgagf6q5lb7icsrbzs05c8dz1gij0clzk39am40l83zs3ain";
-    propagatedBuildInputs = [ ppx_type_conv typerep ];
-    meta.description = "Generation of runtime types from type declarations";
   };
 
   ppx_jane = janePackage {
     name = "ppx_jane";
-    hash = "1lhzcfh129dc54bkg16rnldi97682nlzdr8a47ham3hg2kkab8kr";
-    propagatedBuildInputs = [ ppx_base ppx_bench ppx_bin_prot ppx_expect ppx_fail ppx_let ppx_optional ppx_pipebang ppx_sexp_message ppx_sexp_value ppx_typerep_conv ];
+    hash = "0l1p6llaa60mrc5p9400cqv9yy6h76x5wfq3z1cx5xawy0yz4vlb";
+    buildInputs = [ ppxlib ];
+    propagatedBuildInputs = [ ppx_assert ppx_base ppx_bench ppx_bin_prot ppx_expect ppx_fail ppx_here ppx_let ppx_optcomp ppx_optional ppx_pipebang ppx_sexp_message ppx_sexp_value ppx_typerep_conv ];
     meta.description = "Standard Jane Street ppx rewriters";
   };
 
-  # Jane Street packages, up to core
-
-  configurator = janePackage {
-    name = "configurator";
-    hash = "0lydjj4r21ipmc91hyf91mjjvcibk4r7ipan8bqfzb5l490r95rp";
-    propagatedBuildInputs = [ base stdio ];
-    meta.description = "Helper library for gathering system configuration";
-  };
-
-  jane-street-headers = janePackage {
-    name = "jane-street-headers";
-    hash = "1sqyqzhgi52vq33i8ha2pmjg026qiqmpaqmibs3pfj4jsscwl842";
-    meta.description = "Jane Street header files";
+  splittable_random = janePackage {
+    name = "splittable_random";
+    hash = "1yrvpm6g62f8k6ihccxhfxpvmxbqxhi7p790a8jkdmyfdd1l6z73";
+    propagatedBuildInputs = [ ppx_jane ];
+    meta.description = "PRNG that can be split into independent streams";
   };
 
   core_kernel = janePackage {
     name = "core_kernel";
-    hash = "00iqd9wcana2blgdih1lq9zqd31agr6az912bhsklyarvvcn9hcb";
-    propagatedBuildInputs = [ configurator jane-street-headers ppx_jane ];
+    hash = "0xaw8189i9z72fvzbxfv1qrf4wvj8v45bl7g3z7ynsqkvh6smr7d";
+    propagatedBuildInputs = [ configurator jane-street-headers sexplib splittable_random ];
     meta.description = "Jane Street's standard library overlay (kernel)";
   };
 
   spawn = janePackage {
+    version = "0.12.0";
     name = "spawn";
-    hash = "1av1pjkiqq3nz0rjmykiylhf0iv6d1ssvqqj6wcc3c0bzvgyih0p";
+    hash = "0amgj7g9sjlbjivn1mg7yjdmxd21hgp4a0ak2zrm95dmm4gi846i";
     meta.description = "Spawning sub-processes";
   };
 
   core = janePackage {
+    version = "0.11.1";
     name = "core";
-    hash = "06cra34rlqpmxh4f3v1vps9fs7hy90jjnipdvcf9z8cn925mdj46";
+    hash = "0wa2dsfk5m5wlhz915664y9h08idijj5s41hyg8n54dhihvxw2ci";
     propagatedBuildInputs = [ core_kernel spawn ];
     meta.description = "Jane Street's standard library overlay";
   };
 
-  # Jane Street packages, up to core_extended
+  textutils_kernel = janePackage {
+    name = "textutils_kernel";
+    hash = "0s1ps7h54vgl76pll3y5qa1bw8f4h8wxc8mg8jq6bz8vxvl0dfv4";
+    propagatedBuildInputs = [ core_kernel ];
+    meta.description = "The subset of textutils using only core_kernel and working in javascript";
+  };
+
+  textutils = janePackage {
+    name = "textutils";
+    hash = "1jmhpaihnndf4pr8xsk7ws70n4mvv34ry0ggqqpfs3wb2vkcdg6j";
+    propagatedBuildInputs = [ core textutils_kernel ];
+    meta.description = "Text output utilities";
+  };
 
   re2 = janePackage {
     name = "re2";
-    version = "0.10.1";
-    hash = "1d39brryfaj5fqp1kzw67n1bvfxv28xi058mk5il14wj40y5ldh1";
+    hash = "0bl65d0nmvr7k1mkkcc4aai86l5qzgn1xxwmszshpwhaz87cqghd";
     propagatedBuildInputs = [ core_kernel ];
     meta = {
       description = "OCaml bindings for RE2";
@@ -332,274 +328,291 @@ rec {
     };
   };
 
-  textutils = janePackage {
-    name = "textutils";
-    hash = "0mnmrp8kd443qx9gahrwr04a8q4hskcad2i1k9amiypbwy566s37";
-    propagatedBuildInputs = [ core textutils_kernel ];
-    meta.description = "Text output utilities";
-  };
-
-  textutils_kernel = janePackage {
-    name = "textutils_kernel";
-    hash = "0w7nf7sycffff318fxr42ss1fxa3bsy9kj7y27dl1whrajip9mb7";
-    propagatedBuildInputs = [ core_kernel ocaml-migrate-parsetree ];
-    meta.description = "The subset of textutils using only core_kernel and working in javascript";
-  };
-
   core_extended = janePackage {
     name = "core_extended";
-    hash = "0g9adnr68l4ggayilmvz9nnf2slvnp0jzknjrxk10cab72l97rv4";
-    propagatedBuildInputs = [ core re2 textutils ];
+    hash = "1fvnr6zkpbl48dl7nn3j1dpsrr6bi00iqh282wg5lgdhcsjbc0dy";
+    propagatedBuildInputs = [ core re re2 textutils ];
     postPatch = ''
       patchShebangs src/discover.sh
     '';
-    meta = {
-      description = "Jane Street Capital's standard library overlay";
-    };
+    meta.description = "Jane Street Capital's standard library overlay";
   };
-
-  # Jane Street async packages
 
   async_kernel = janePackage {
     name = "async_kernel";
-    hash = "09dzfyfmjf9894yimf1fpnc2l1v342f51a2wjr3d23pw6xnbcrl0";
+    hash = "1drxawih7vhhb1mhd291698ly7yb38qzif82jk1adqcvwdb547af";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (core)";
   };
 
+  protocol_version_header = janePackage {
+    name = "protocol_version_header";
+    hash = "159qmkb0dsfmr1lv2ly50aqszpm24bvrm3sw07n2zhkxgy6q613z";
+    propagatedBuildInputs = [ core_kernel ocaml-migrate-parsetree ];
+    meta.description = "Protocol aware version negotiation";
+  };
+
   async_rpc_kernel = janePackage {
     name = "async_rpc_kernel";
-    hash = "1ardfr4vwbzc41qa2ccmzp15m9w3nbdl9cy4crvm87fi0ngkhixy";
+    hash = "0wl7kp30qxkalk91q5pja9agsvvmdjvb2q7s3m79dlvwwi11l33y";
     propagatedBuildInputs = [ core_kernel async_kernel protocol_version_header ];
     meta.description = "Platform-independent core of Async RPC library";
   };
 
   async_unix = janePackage {
     name = "async_unix";
-    hash = "151pn0543fwvi5gkdkbd05v8y9gjbxi1n69r4jxzc0bh842xx4xz";
+    hash = "1y5za5fdh0x82zdjigxci9zm9jnpfd2lfgpjcq4rih3s28f16sf7";
     propagatedBuildInputs = [ core async_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (unix)";
   };
 
   async_extra = janePackage {
     name = "async_extra";
-    hash = "0vf3nfj8h7vnigs8l8m1bsg6w3szgaylaps6mbl4dsaihxdc732n";
+    hash = "1qac95zlvq34fh2wbwbw0vdzxnba6si8lkal7n09y2lzpwvsifx3";
     propagatedBuildInputs = [ async_rpc_kernel async_unix ];
     meta.description = "Jane Street's asynchronous execution library (extra)";
   };
 
   async = janePackage {
     name = "async";
-    hash = "05ldvyw75648qrjx7q794m9llmlnqklh97lc09fv8biw515dby3d";
+    hash = "1i05hzk4mhzj1mw98b2bdbxhnq03jvhkkkw4d948i6265jzrrbv5";
     propagatedBuildInputs = [ async_extra ];
     meta.description = "Jane Street Capital's asynchronous execution library";
   };
 
   async_find = janePackage {
     name = "async_find";
-    hash = "05cpnz1m09h276cq6v3bh7da4iai14gmlh4cnh64v41f8hssw63s";
+    hash = "0s0qafx74ri1vr2vv3iy1j7s3p6gp7vyg0mw5g17iafk0w6lv2iq";
     propagatedBuildInputs = [ async ];
     meta.description = "Directory traversal with Async";
   };
 
   async_interactive = janePackage {
     name = "async_interactive";
-    hash = "1h2419l6nlqph3ipp5zdwyq55d3s602i4bv4jhsridmzy6cxxdxs";
+    hash = "01rlfcylpiak6a2n6q3chp73cvkhvb65n906dj0flmxmagn7dxd1";
     propagatedBuildInputs = [ async ];
     meta.description = "Utilities for building simple command-line based user interfaces";
   };
 
   async_parallel = janePackage {
     name = "async_parallel";
-    hash = "0r8q73v26w3grj9n9wyrf65cq9w6pfzrmg9iswsy4jjb5r02bpr5";
+    hash = "0hak8ba3rfzqhz5hz2annqmsv5bkqzdihhafp0f58ryrlskafwag";
     propagatedBuildInputs = [ async ];
     meta.description = "Distributed computing library";
   };
 
   async_shell = janePackage {
     name = "async_shell";
-    hash = "1snkr944l3a627k23yh8f0lr900dpg2aym2l59fpp75s29pyk5md";
+    hash = "1jb01ygfnhabsy72xlcg11vp7rr37sg555sm0k3yxl4r5az3y2ay";
     propagatedBuildInputs = [ core_extended async ];
-    meta = {
-      description = "Shell helpers for Async";
-    };
+    meta.description = "Shell helpers for Async";
   };
 
   async_ssl = janePackage {
     name = "async_ssl";
-    hash = "1cb9wpmgifa5vj9gadbav6bq6vxcm3g0jc6wxnkj3hgvnj35j2vy";
+    hash = "1p83fzfla4rb820irdrz3f2hp8kq5zrhw47rqmfv6qydlca1bq64";
     propagatedBuildInputs = [ async ctypes openssl ];
     meta.description = "Async wrappers for SSL";
   };
 
-  # Jane Street packages, up to expect_test_helpers
-
   sexp_pretty = janePackage {
     name = "sexp_pretty";
-    hash = "106r91ahzdr8yvphs1s3ck8r89c4qhpcl9q6j5rbxrbihgb71i8d";
-    propagatedBuildInputs = [ ppx_base re ];
+    hash = "0xskahjggbwvvb82fn0jp1didxbgpmgks76xhwp9s3vqkhgz6918";
+    propagatedBuildInputs = [ ppx_base re sexplib ];
     meta.description = "S-expression pretty-printer";
   };
 
   expect_test_helpers_kernel = janePackage {
     name = "expect_test_helpers_kernel";
-    hash = "027pwfkdnz8rzgg9dqa4x2ir0zn8lav7gh64cih35r455xbfnvpr";
+    hash = "0m113vq4m1xm3wmwa08r6qjc7p5f0y3ss8s4i2z591ycgs2fxzlj";
     propagatedBuildInputs = [ core_kernel sexp_pretty ];
     meta.description = "Helpers for writing expectation tests";
   };
 
   expect_test_helpers = janePackage {
     name = "expect_test_helpers";
-    hash = "0rzsgj8h73gx18sz1a1d3pbrjkb0vd6shl1h71n4xl05njcfb73r";
+    hash = "13n6h7mimwkbsjdix96ghfrmxjd036m4h4zgl8qag00aacqclvpi";
     propagatedBuildInputs = [ async expect_test_helpers_kernel ];
     meta.description = "Async helpers for writing expectation tests";
   };
 
-  # Miscellaneous Jane Street packages
-
   bignum = janePackage {
     name = "bignum";
-    hash = "0vs52aqq7pwazgv35zdd66c5v5ha1wrgrcmzc17c2qbswy8wcc37";
+    hash = "0hqd88fb90rsj1wjj4k79gigcf31c6a45msasw99zzifzppr3w3f";
     propagatedBuildInputs = [ core_kernel zarith num ];
     meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
   };
 
   cinaps = janePackage {
     name = "cinaps";
-    hash = "1mwllcakvsirxpbwcqlglwqkiz8cks7vbjf1jvngs9703mx1xdcy";
+    hash = "0f8cx4xkkk4wqpcbvva8kxdndbgawljp17dwppc6zpjpkjl8s84j";
     propagatedBuildInputs = [ re ];
     meta.description = "Trivial Metaprogramming tool using the OCaml toplevel";
   };
 
   command_rpc = janePackage {
     name = "command_rpc";
-    hash = "0lq1vcz8qyyqabrz9isw2pw50663lwmq4w3187jp99ygar9lk5n2";
+    hash = "111v4km0ds8ixmpmwg9ck36ap97400mqzhijf57kj6wfwgzcmr2g";
     propagatedBuildInputs = [ async ];
     meta.description = "Utilities for Versioned RPC communication with a child process over stdin and stdout";
   };
 
+  # Deprecated libraries
+
+  ppx_ast = janePackage {
+    name = "ppx_ast";
+    hash = "125bzswcwr3nb26ss8ydh8z4218c8fi3s2kvgqp1j1fhc5wwzqgj";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  ppx_core = janePackage {
+    name = "ppx_core";
+    hash = "11hgm9mxig4cm3c827f6dns9mjv3pf8g6skf10x0gw9xnp1dmzmx";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  ppx_driver = janePackage {
+    name = "ppx_driver";
+    hash = "00kfx6js2kxk57k4v7hiqvwk7h35whgjihnxf75m82rnaf4yzvfi";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  ppx_metaquot = janePackage {
+    name = "ppx_metaquot";
+    hash = "1vz8bi56jsz8w0894vgbfsfvmdyh5k1dgv45l8vhkks0s7d3ldji";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  ppx_traverse = janePackage {
+    name = "ppx_traverse";
+    hash = "1p2n5da4mxh9fk4gvxlibc706bs5xwkbppxd1x0ip1vln5pabbq5";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  ppx_traverse_builtins = janePackage {
+    name = "ppx_traverse_builtins";
+    hash = "0qlf7i8h8k3a9h8nhb0ki3y1knr6wgbm24f1qaqni53fpvzv0pfb";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  ppx_type_conv = janePackage {
+    name = "ppx_type_conv";
+    hash = "04dbrglqqhkas25cpjz8xhjcbpk141c35qggzw66bn69izczfmaf";
+    propagatedBuildInputs = [ ppxlib ];
+    meta.description = "Deprecated (see ppxlib)";
+  };
+
+  # Miscellaneous Jane Street packages
+
   core_bench = janePackage {
     name = "core_bench";
-    hash = "1py68z848gj5wdmknqmzdb6zg65k5zchv6i6vzygi5nszn3zzwgc";
+    hash = "10i28ssfdqxxhq0rvnlp581lr1cq2apkhmm8j83fksjkmbxcrasc";
     propagatedBuildInputs = [ core_extended ];
-    meta = {
-      description = "Micro-benchmarking library for OCaml";
-    };
+    meta.description = "Micro-benchmarking library for OCaml";
   };
 
   core_profiler = janePackage {
     name = "core_profiler";
-    hash = "1vqkb8fzhs0k94k78whjnsznj85qa18kp0bq73mdkffz9562hdyr";
+    hash = "1kaaw3jp3qarbd9rgpjfb9md0dqblf2bxiqb245sqmx4c1346v1c";
     propagatedBuildInputs = [ core_extended ];
-    meta = {
-      description = "Profiling library";
-    };
+    meta.description = "Profiling library";
   };
 
   csvfields = janePackage {
     name = "csvfields";
-    hash = "1qvcm2xkpw5ca5za2dfvz154h6kzm565wvynh7fffvrj2q719flm";
+    hash = "10zw4fjlniivfdzzz79lnbvcjnhk5y16m1p8mn4xbs23n6mbix0f";
     propagatedBuildInputs = [ core expect_test_helpers ];
     meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
   };
 
   ecaml = janePackage {
     name = "ecaml";
-    hash = "1h8m8nznsyc8md8f5rx3845lpl37ijqpxkpd52w92xy5hlc9bk1k";
+    hash = "1is5156q59s427x3q5nh9wsi8h1x77670bmyilqxasy39yway7g8";
     propagatedBuildInputs = [ async expect_test_helpers_kernel ];
     meta.description = "Writing Emacs plugin in OCaml";
   };
 
   email_message = janePackage {
     name = "email_message";
-    hash = "0p56lak1ynqmimapsz529ankgdyd5yk90c0193q8fzv7fvvrzkzd";
+    hash = "131jd72k4s8cdbgg6gyg7w5v8mphdlvdx4fgvh8d9a1m7kkvbxfg";
     propagatedBuildInputs = [ async angstrom core_extended cryptokit magic-mime ounit ];
-    meta = {
-      description = "E-mail message parser";
-    };
+    meta.description = "E-mail message parser";
   };
 
   incremental_kernel = janePackage {
     name = "incremental_kernel";
-    hash = "15xw3l07fdqk5sla37fdvfnwykvq6fyrj9b2lwhc29rq0444m1yz";
+    hash = "02arw8blpmnzlw5jlvavyvpgh3s9q0j9mhi2byz0x8cxknqvvasg";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Library for incremental computations depending only on core_kernel";
   };
 
   incremental = janePackage {
     name = "incremental";
-    hash = "14hh7kxj70bpgylnx1fj3s5c40d12sgcb11cnh1xh7nwm190a9c2";
+    hash = "1xchd3v4kj56wixjrsnj7m7l0374cgkzybihs2b62mn65xf6n7ki";
     propagatedBuildInputs = [ core incremental_kernel ];
     meta.description = "Library for incremental computations";
   };
 
   incr_map = janePackage {
     name = "incr_map";
-    hash = "0s6c7f8a80s7bnjxcs7mdgm45i24d1j0vw4i2j884z1ssjrk33hw";
+    hash = "01vx9aldxpigz5ah9h337xcw73a7r8449v8l2xbralljhs0zglx9";
     propagatedBuildInputs = [ incremental_kernel ];
     meta.description = "Helpers for incremental operations on map like data structures";
   };
 
   ocaml_plugin = janePackage {
     name = "ocaml_plugin";
-    hash = "0b63ciajc9hcjs3pl0chlj475y60i3l5mjzaiqmyz1pryfqpri7r";
+    hash = "0fal5j59qkbksg6ak1ngn92pcgg3f9gwfaglpxb7l6bck20kaigp";
     buildInputs = [ ocamlbuild ];
     propagatedBuildInputs = [ async ];
     meta.description = "Automatically build and dynlink ocaml source files";
   };
 
-  parsexp = janePackage {
-    name = "parsexp";
-    hash = "1k1z6kyp7c53l0wspz6qpvbb46bbr6aimnr06y6y1prxrpazm62w";
-    propagatedBuildInputs = [ ppx_compare ppx_fields_conv ppx_js_style ppx_sexp_value ];
-    meta.description = "S-expression parsing library";
-  };
-
   parsexp_io = janePackage {
     name = "parsexp_io";
-    hash = "0l9jrfm1zz0y6bfxla2s0fwjlvs9361ky83z3xwdlc48fgzks3a5";
-    propagatedBuildInputs = [ parsexp ];
+    hash = "0rhdl40jiirvv6fhgjk50n8wzs3jly5d8dyyyfgpjgl39mwkjjnb";
+    propagatedBuildInputs = [ parsexp ppx_js_style ];
     meta.description = "S-expression parsing library (IO functions)";
   };
 
   patience_diff = janePackage {
     name = "patience_diff";
-    hash = "11ws6hsalmq7zc7wp37mj7zs3qaqkq4zlnwr06ybryv6vz62xj1l";
+    hash = "0q7a64fgg97qcd6d8c45gyz63x5vq004axxqvvfg92b8f3x2plx4";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Tool and library implementing patience diff";
   };
 
   posixat = janePackage {
     name = "posixat";
-    hash = "0dmjzbpbmzl94h4c1gk6k75wglnvk1kqcm4zs4nb9hy2ja8ldl9x";
-    propagatedBuildInputs = [ ppx_sexp_conv ];
+    hash = "04rs4sl0r4rg9m6l9kkqkmc4n87sv4a4w9ibq4zsjk9j4n6r2df8";
+    propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv sexplib ];
     meta.description = "Binding to the posix *at functions";
-  };
-
-  protocol_version_header = janePackage {
-    name = "protocol_version_header";
-    hash = "1vl1kfn8n1zdm3vh7228c58vprac4v7mpqks60k8rnzjj4w2mj1n";
-    propagatedBuildInputs = [ core_kernel ocaml-migrate-parsetree ];
-    meta.description = "Protocol aware version negotiation";
   };
 
   rpc_parallel = janePackage {
     name = "rpc_parallel";
-    hash = "01nyjqgdj351ykdaqqpaljwzac48x824lzfpma64lbp6plqmjlbf";
+    hash = "13dx59x73i8mkwv2qkh8gx6kk8arlvghj57k1jdscdmzmyqc9gvn";
     propagatedBuildInputs = [ async ];
     meta.description = "Type-safe library for building parallel applications";
   };
 
   shexp = janePackage {
+    version = "0.11.1";
     name = "shexp";
-    hash = "1ck5gcsdp93194bw6d1i116zplyaqrz1r36h6mvrw5x7i2549n9p";
+    hash = "06yssp7bsmabaxvw9bqxyrsji1gkvl7if5adba3v6h4kilqy7rqg";
     propagatedBuildInputs = [ posixat spawn ];
     meta.description = "Process library and s-expression based shell";
   };
 
   topological_sort = janePackage {
     name = "topological_sort";
-    hash = "08w1dx30frj2bxxk8djl23cd43sassjkrmissyhagn9fmq2l904m";
+    hash = "1qnz5b1rs45lsl1ycxd1lglpmh8444gy5khhdp5fvxy987zkzklz";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Topological sort algorithm";
   };

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, ocaml, jbuilder, findlib, defaultVersion ? "0.10.0" }:
+{ stdenv, fetchFromGitHub, ocaml, jbuilder, findlib, defaultVersion ? "0.11.0" }:
 
 { name, version ? defaultVersion, buildInputs ? [], hash, meta, ...}@args:
 

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, topkg
+{ stdenv, fetchurl, fetchpatch, ocaml, findlib, ocamlbuild, topkg
 , cpuid, ocb-stubblr
-, cstruct, zarith, ppx_sexp_conv, sexplib
+, cstruct, zarith, ppx_sexp_conv
 , cstruct-lwt ? null
 }:
 
@@ -11,16 +11,34 @@ stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-nocrypto-${version}";
   version = "0.5.4";
 
-  src = fetchFromGitHub {
-    owner  = "mirleft";
-    repo   = "ocaml-nocrypto";
-    rev    = "v${version}";
-    sha256 = "0nhnlpbqh3mf9y2cxivlvfb70yfbdpvg6jslzq64xblpgjyg443p";
+  src = fetchurl {
+    url = "https://github.com/mirleft/ocaml-nocrypto/releases/download/v${version}/nocrypto-${version}.tbz";
+    sha256 = "0zshi9hlhcz61n5z1k6fx6rsi0pl4xgahsyl2jp0crqkaf3hqwlg";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg cpuid ocb-stubblr
-    ppx_sexp_conv ];
-  propagatedBuildInputs = [ cstruct zarith sexplib ] ++ optional withLwt cstruct-lwt;
+  unpackCmd = "tar xjf $curSrc";
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0001-add-missing-runtime-dependencies-in-_tags.patch";
+      sha256 = "1asybwj3rl07b4q4cxwy80a7j17j0i5vzz77p38hymilhc2ky7xn";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0002-add-ppx_sexp_conv-as-a-runtime-dependency-in-the-pac.patch";
+      sha256 = "0zmp64n5fgkawpkyw0vv0bg0i2c3xbsxqy17vwy92nf5rbardi1r";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0003-Auto-detect-ppx_sexp_conv-runtime-library.patch";
+      sha256 = "0lngbg5gyd5gs56lbjh6g86cps1y8x1xsqzi0vi1v28al1gn5dhw";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/ocaml/opam-repository/master/packages/nocrypto/nocrypto.0.5.4-1/files/0004-pack-package-workaround-ocamlbuild-272.patch";
+      sha256 = "16k0w78plvqhl17qiqq1mckxhhcdysqgs94l54a1bn0l6fx3rvb9";
+    })
+  ];
+
+  buildInputs = [ ocaml findlib ocamlbuild topkg cpuid ocb-stubblr ];
+  propagatedBuildInputs = [ cstruct ppx_sexp_conv zarith ] ++ optional withLwt cstruct-lwt;
 
   buildPhase = "${topkg.buildPhase} --with-lwt ${boolToString withLwt}";
   inherit (topkg) installPhase;

--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder
+, ocaml-compiler-libs, ocaml-migrate-parsetree, ppx_derivers, stdio
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.3.0";
+  name = "ocaml${ocaml.version}-ppxlib-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-ppx";
+    repo = "ppxlib";
+    rev = version;
+    sha256 = "0csp49jh7zgjnqh46mxbf322whlbmgy7v1a12nvxh97qg6i5fvsy";
+  };
+
+  buildInputs = [ ocaml findlib jbuilder ];
+
+  propagatedBuildInputs = [
+    ocaml-compiler-libs ocaml-migrate-parsetree ppx_derivers stdio
+  ];
+
+  buildPhase = "jbuilder build";
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    description = "Comprehensive ppx tool set";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+
+}

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -6,6 +6,10 @@ with stdenv.lib;
 
 let withLwt = lwt != null; in
 
+if !versionAtLeast ocaml.version "4.04"
+then throw "tls is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   version = "0.9.0";
   name = "ocaml${ocaml.version}-tls-${version}";

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, ocaml, findlib, jbuilder, ppx_sexp_conv, ounit
-, ppx_deriving, re, sexplib, stringext
+, re, sexplib, stringext
 }:
 
 stdenv.mkDerivation rec {
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "tar -xjf $curSrc";
 
-  buildInputs = [ ocaml findlib jbuilder ppx_sexp_conv ounit ];
-  propagatedBuildInputs = [ ppx_deriving re sexplib stringext ];
+  buildInputs = [ ocaml findlib jbuilder ounit ];
+  propagatedBuildInputs = [ ppx_sexp_conv re sexplib stringext ];
 
   buildPhase = "jbuilder build";
 

--- a/pkgs/tools/misc/patdiff/default.nix
+++ b/pkgs/tools/misc/patdiff/default.nix
@@ -4,7 +4,7 @@ with ocamlPackages;
 
 janePackage {
   name = "patdiff";
-  hash = "04kl9h7j3pzpyic8p34b8i9vpf6qn7ixp077d8i44cpbymdqdn96";
+  hash = "02cdn5j5brbp4n2rpxprzxfakjbl7n2llixg7m632bih3ppmfcq1";
   buildInputs = [ core_extended expect_test_helpers patience_diff ocaml_pcre ];
   meta = {
     description = "File Diff using the Patience Diff algorithm";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -56,6 +56,17 @@ let
 
     bap = callPackage ../development/ocaml-modules/bap {
       inherit (janeStreet_0_9_0) core_kernel ppx_jane parsexp;
+      ezjsonm = ezjsonm.override {
+        inherit (janeStreet_0_9_0) sexplib;
+        hex = hex.override {
+          cstruct = cstruct.override {
+            inherit (janeStreet_0_9_0) sexplib;
+          };
+        };
+      };
+      uri = uri.override {
+        inherit (janeStreet_0_9_0) ppx_sexp_conv sexplib;
+      };
     };
 
     batteries = callPackage ../development/ocaml-modules/batteries { };
@@ -531,6 +542,8 @@ let
     piqi = callPackage ../development/ocaml-modules/piqi { };
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
+    ppxlib = callPackage ../development/ocaml-modules/ppxlib { };
+
     psmt2-frontend = callPackage ../development/ocaml-modules/psmt2-frontend { };
 
     psq = callPackage ../development/ocaml-modules/psq { };
@@ -735,7 +748,7 @@ let
     janeStreet = import ../development/ocaml-modules/janestreet {
       inherit lib janePackage ocaml ocamlbuild angstrom ctypes cryptokit;
       inherit magic-mime num ocaml-migrate-parsetree octavius ounit;
-      inherit ppx_deriving re zarith;
+      inherit ppx_deriving re zarith ppxlib;
       inherit (pkgs) stdenv openssl;
     };
     


### PR DESCRIPTION
###### Motivation for this change

#42738

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

