### PR TITLE
mosdepth: init 0.2.3

### DIFF
--- a/pkgs/applications/science/biology/mosdepth/default.nix
+++ b/pkgs/applications/science/biology/mosdepth/default.nix
@@ -1,0 +1,42 @@
+{stdenv, fetchFromGitHub, nim, htslib, patchelf, pcre}:
+
+let
+  hts-nim = fetchFromGitHub {
+    owner = "brentp";
+    repo = "hts-nim";
+    rev = "9cd83e30522ab64cd71eb8209be4154aa5579ce1";
+    sha256 = "10g408idy14667varq1syf06rrbpk63i3ib7i5dh1md4ib19av6f";
+  };
+
+  docopt = fetchFromGitHub {
+    owner = "docopt";
+    repo = "docopt.nim";
+    rev = "v0.6.5";
+    sha256 = "0yx79m4jkdcazwlky55nwf39zj5kdhymrrdrjq29mahiwx83x5zr";
+  };
+
+in stdenv.mkDerivation rec {
+  name = "mosdepth-${version}";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "brentp";
+    repo = "mosdepth";
+    rev = "v${version}";
+    sha256 = "1b9frrwhcvay3alhn0d02jccc2qlbij1732hzq9nhwnr4kvsvxx7";
+  };
+
+  buildInputs = [ nim ];
+
+  buildPhase = "nim -p:${hts-nim}/src -p:${docopt}/src c -d:release mosdepth.nim";
+  installPhase = "install -Dt $out/bin mosdepth";
+  fixupPhase = "patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ stdenv.cc.cc htslib pcre ]} $out/bin/mosdepth";
+
+  meta = with stdenv.lib; {
+    description = "fast BAM/CRAM depth calculation for WGS, exome, or targeted sequencing.";
+    license = licenses.mit;
+    homepage = https://github.com/brentp/mosdepth;
+    maintainers = with maintainers; [ jbedo ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20255,6 +20255,8 @@ with pkgs;
 
   minimap2 = callPackage ../applications/science/biology/minimap2 { };
 
+  mosdepth = callPackage ../applications/science/biology/mosdepth { };
+
   ncbi_tools = callPackage ../applications/science/biology/ncbi-tools { };
 
   paml = callPackage ../applications/science/biology/paml { };


### PR DESCRIPTION
###### Motivation for this change
mosdepth: init 0.2.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

