### PR TITLE
gnu-pw-mgr: init 2.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3185,6 +3185,11 @@
     github = "qknight";
     name = "Joachim Schiele";
   };
+  qoelet = {
+    email = "kenny@machinesung.com";
+    github = "qoelet";
+    name = "Kenny Shen";
+  };
   ragge = {
     email = "r.dahlen@gmail.com";
     github = "ragnard";

--- a/pkgs/tools/security/gnu-pw-mgr/default.nix
+++ b/pkgs/tools/security/gnu-pw-mgr/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, lib, fetchurl, gnulib }:
+
+stdenv.mkDerivation rec {
+  name = "gnu-pw-mgr-${version}";
+  version = "2.3.2";
+  src = fetchurl {
+    url = "http://ftp.gnu.org/gnu/gnu-pw-mgr/${name}.tar.xz";
+    sha256 = "0x60g0syqpd107l8w4bl213imy2lspm4kz1j18yr1sh10rdxlgxd";
+  };
+
+  buildInputs = [ gnulib ];
+
+  meta = with lib; {
+    homepage = https://www.gnu.org/software/gnu-pw-mgr/;
+    description = "A password manager designed to make it easy to reconstruct difficult passwords";
+    license = with licenses; [ gpl3Plus lgpl3Plus ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ qoelet ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2704,6 +2704,8 @@ with pkgs;
   # must have AquaTerm installed separately
   gnuplot_aquaterm = gnuplot.override { aquaterm = true; };
 
+  gnu-pw-mgr = callPackage ../tools/security/gnu-pw-mgr { };
+
   gnused = callPackage ../tools/text/gnused { };
   # This is an easy work-around for [:space:] problems.
   gnused_422 = callPackage ../tools/text/gnused/422.nix { };


### PR DESCRIPTION
###### Motivation for this change

gnu-pw-mgr: init 2.3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

