### PR TITLE
 seafile-client: 6.1.8 -> 6.2.1

### DIFF
--- a/pkgs/applications/networking/seafile-client/default.nix
+++ b/pkgs/applications/networking/seafile-client/default.nix
@@ -5,14 +5,14 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "6.1.8";
+  version = "6.2.1";
   name = "seafile-client-${version}";
 
   src = fetchFromGitHub {
     owner = "haiwen";
     repo = "seafile-client";
     rev = "v${version}";
-    sha256 = "0gy7jfxr5f8qvbqj80g7fzaw9b3vax750c4z5cr7f43rv99284pc";
+    sha256 = "02nzihs720pmgr5139s7fz88f7gm19dn1x2kqdpi81k7gdwqq0bp";
   };
 
   nativeBuildInputs = [ pkgconfig cmake makeWrapper ];

--- a/pkgs/development/libraries/libsearpc/default.nix
+++ b/pkgs/development/libraries/libsearpc/default.nix
@@ -1,15 +1,15 @@
-{stdenv, fetchurl, automake, autoconf, pkgconfig, libtool, python2Packages, glib, jansson}:
+{stdenv, fetchFromGitHub, automake, autoconf, pkgconfig, libtool, python2Packages, glib, jansson}:
 
-stdenv.mkDerivation rec
-{
-  version = "3.0.7";
-  seafileVersion = "6.1.0";
+stdenv.mkDerivation rec {
+  version = "3.0.8";
   name = "libsearpc-${version}";
 
-  src = fetchurl
-  {
-    url = "https://github.com/haiwen/libsearpc/archive/v${version}.tar.gz";
-    sha256 = "0fdrgksdwd4qxp7qvh75y39dy52h2f5wfjbqr00h3rwkbx4npvpg";
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "libsearpc";
+    # Tag is missing: https://github.com/haiwen/libsearpc/commit/12a01268825e9c7e17794c58c367e3b4db912ad9
+    rev = "12a01268825e9c7e17794c58c367e3b4db912ad9";
+    sha256 = "00ck1hl1x0pn22q3ba32dq3ckc4nrsg58irsmrnmalqbsffhcim0";
   };
 
   patches = [ ./libsearpc.pc.patch ];
@@ -18,12 +18,13 @@ stdenv.mkDerivation rec
   buildInputs = [ automake autoconf libtool python2Packages.python python2Packages.simplejson ];
   propagatedBuildInputs = [ glib jansson ];
 
+  postPatch = "patchShebangs autogen.sh";
+
   preConfigure = "./autogen.sh";
 
   buildPhase = "make -j1";
 
-  meta =
-  {
+  meta = {
     homepage = https://github.com/haiwen/libsearpc;
     description = "A simple and easy-to-use C language RPC framework (including both server side & client side) based on GObject System";
     license = stdenv.lib.licenses.lgpl3;

--- a/pkgs/misc/seafile-shared/default.nix
+++ b/pkgs/misc/seafile-shared/default.nix
@@ -1,12 +1,14 @@
-{stdenv, fetchurl, which, autoreconfHook, pkgconfig, curl, vala, python, intltool, fuse, ccnet}:
+{stdenv, fetchFromGitHub, which, autoreconfHook, pkgconfig, curl, vala, python, intltool, fuse, ccnet}:
 
 stdenv.mkDerivation rec {
-  version = "6.1.0";
+  version = "6.2.1";
   name = "seafile-shared-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/haiwen/seafile/archive/v${version}.tar.gz";
-    sha256 = "03zvxk25311xgn383k54qvvpr8xbnl1vxd99fg4ca9yg5rmir1q6";
+  src = fetchFromGitHub {
+    owner = "haiwen";
+    repo = "seafile";
+    rev = "v${version}";
+    sha256 = "199ivh6fbz4sgbz15mr6m8985yky5n3z6vpcpnh2ldjx4277gq68";
   };
 
   nativeBuildInputs = [ pkgconfig which autoreconfHook vala intltool ];
@@ -17,13 +19,6 @@ stdenv.mkDerivation rec {
     "--disable-server"
     "--disable-console"
   ];
-
-  postInstall = ''
-    # Remove seafile binary
-    rm -rf "$out/bin/seafile"
-    # Remove cli client binary
-    rm -rf "$out/bin/seaf-cli"
-  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/haiwen/seafile;


### PR DESCRIPTION
###### Motivation for this change
fixes #42772 

~Note that this is untested due to the issue with running applications built against different Qt versions.~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

