### PR TITLE
Vendor python type_getattro patch.

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -71,11 +71,7 @@ let
       # "`type_getattro()` calls `tp_descr_get(self, obj, type)` without actually owning a reference to "self".
       # In very rare cases, this can cause a segmentation fault if "self" is deleted by the descriptor."
       # https://github.com/python/cpython/pull/6118
-      (fetchpatch {
-        name = "type_getattro.patch";
-        url = "https://github.com/python/cpython/pull/6118/commits/8c6da2d7e7e719c40fb539b7f7cb7583cccc5527.patch";
-        sha256 = "11v9yx20hs3jmw0wggzvmw39qs4mxay4kb8iq2qjydwy9ya61nrd";
-      })
+      ./type_getattro.patch
     ] ++ optionals (x11Support && stdenv.isDarwin) [
       ./use-correct-tcl-tk-on-darwin.patch
     ] ++ optionals stdenv.isLinux [

--- a/pkgs/development/interpreters/python/cpython/2.7/type_getattro.patch
+++ b/pkgs/development/interpreters/python/cpython/2.7/type_getattro.patch
@@ -1,0 +1,80 @@
+From 16e18070ed39782a1edcf86205dd26a31d3875cd Mon Sep 17 00:00:00 2001
+From: Jeroen Demeyer <jdemeyer@cage.ugent.be>
+Date: Wed, 14 Mar 2018 21:02:22 +0100
+Subject: [PATCH] bpo-25750: fix refcounts in type_getattro()
+
+When calling tp_descr_get(self, obj, type),
+make sure that we own a reference to "self"
+---
+ .../2018-03-14-21-42-17.bpo-25750.lxgkQz.rst            |  2 ++
+ Objects/typeobject.c                                    | 17 +++++++++++------
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Core and Builtins/2018-03-14-21-42-17.bpo-25750.lxgkQz.rst
+
+diff --git a/Misc/NEWS.d/next/Core and Builtins/2018-03-14-21-42-17.bpo-25750.lxgkQz.rst b/Misc/NEWS.d/next/Core and Builtins/2018-03-14-21-42-17.bpo-25750.lxgkQz.rst
+new file mode 100644
+index 000000000000..09ffb368b7c6
+--- /dev/null
++++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-14-21-42-17.bpo-25750.lxgkQz.rst	
+@@ -0,0 +1,2 @@
++Fix rare Python crash due to bad refcounting in ``type_getattro()`` if a
++descriptor deletes itself from the class. Patch by Jeroen Demeyer.
+diff --git a/Objects/typeobject.c b/Objects/typeobject.c
+index a7a9d7bf9fc3..f4cc6dfcdb30 100644
+--- a/Objects/typeobject.c
++++ b/Objects/typeobject.c
+@@ -3137,6 +3137,7 @@ type_getattro(PyTypeObject *type, PyObject *name)
+     PyTypeObject *metatype = Py_TYPE(type);
+     PyObject *meta_attribute, *attribute;
+     descrgetfunc meta_get;
++    PyObject* res;
+ 
+     if (!PyUnicode_Check(name)) {
+         PyErr_Format(PyExc_TypeError,
+@@ -3158,6 +3159,7 @@ type_getattro(PyTypeObject *type, PyObject *name)
+     meta_attribute = _PyType_Lookup(metatype, name);
+ 
+     if (meta_attribute != NULL) {
++        Py_INCREF(meta_attribute);
+         meta_get = Py_TYPE(meta_attribute)->tp_descr_get;
+ 
+         if (meta_get != NULL && PyDescr_IsData(meta_attribute)) {
+@@ -3165,10 +3167,11 @@ type_getattro(PyTypeObject *type, PyObject *name)
+              * writes. Assume the attribute is not overridden in
+              * type's tp_dict (and bases): call the descriptor now.
+              */
+-            return meta_get(meta_attribute, (PyObject *)type,
+-                            (PyObject *)metatype);
++            res = meta_get(meta_attribute, (PyObject *)type,
++                           (PyObject *)metatype);
++            Py_DECREF(meta_attribute);
++            return res;
+         }
+-        Py_INCREF(meta_attribute);
+     }
+ 
+     /* No data descriptor found on metatype. Look in tp_dict of this
+@@ -3176,6 +3179,7 @@ type_getattro(PyTypeObject *type, PyObject *name)
+     attribute = _PyType_Lookup(type, name);
+     if (attribute != NULL) {
+         /* Implement descriptor functionality, if any */
++        Py_INCREF(attribute);
+         descrgetfunc local_get = Py_TYPE(attribute)->tp_descr_get;
+ 
+         Py_XDECREF(meta_attribute);
+@@ -3183,11 +3187,12 @@ type_getattro(PyTypeObject *type, PyObject *name)
+         if (local_get != NULL) {
+             /* NULL 2nd argument indicates the descriptor was
+              * found on the target object itself (or a base)  */
+-            return local_get(attribute, (PyObject *)NULL,
+-                             (PyObject *)type);
++            res = local_get(attribute, (PyObject *)NULL,
++                            (PyObject *)type);
++            Py_DECREF(attribute);
++            return res;
+         }
+ 
+-        Py_INCREF(attribute);
+         return attribute;
+     }
+ 


### PR DESCRIPTION
###### Motivation for this change
Prior to this, builds of Python 2.7 were failing most likely due to a rebase in the upstream pull request from which it was being retrieved previously (https://github.com/python/cpython/pull/6118).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (in progress)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

