### PR TITLE
particl-core: 0.16.0.5 -> 0.16.1.0

### DIFF
--- a/pkgs/applications/altcoins/particl/particl-core.nix
+++ b/pkgs/applications/altcoins/particl/particl-core.nix
@@ -19,11 +19,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "particl-core-${version}";
-  version     = "0.16.0.5";
+  version     = "0.16.1.0";
 
   src = fetchurl {
     url = "https://github.com/particl/particl-core/archive/v${version}.tar.gz";
-    sha256 = "070crn6nnzrbcaj30w0qbybpm9kfd2ghnvmxp29gckgknw6n0vam";
+    sha256 = "0rfqywyrl6cgxn3ba91zsa88ph2yf9d1vn706xpyz19pfb6mjfbg";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

