### PR TITLE
dockerTools.examples: explicitly set image tag to fix docker-tools tests

### DIFF
--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -13,6 +13,7 @@ rec {
   # 1. basic example
   bash = buildImage {
     name = "bash";
+    tag = "latest";
     contents = pkgs.bashInteractive;
   };
 
@@ -65,6 +66,7 @@ rec {
   in
   buildImage {
     name = "nginx-container";
+    tag = "latest";
     contents = pkgs.nginx;
 
     runAsRoot = ''
@@ -106,6 +108,7 @@ rec {
   # docker run -it --rm nix nix-store -qR $(nix-build '<nixpkgs>' -A nix)
   nix = buildImageWithNixDb {
     name = "nix";
+    tag = "latest";
     contents = [
       # nix-store uses cat program to display results as specified by
       # the image env variable NIX_PAGER.
@@ -121,6 +124,7 @@ rec {
   # dockerTools chain.
   onTopOfPulledImage = buildImage {
     name = "onTopOfPulledImage";
+    tag = "latest";
     fromImage = nixFromDockerHub;
     contents = [ pkgs.hello ];
   };
@@ -129,6 +133,7 @@ rec {
   # See issue #34779 and PR #40947 for details.
   runAsRootExtraCommands = pkgs.dockerTools.buildImage {
     name = "runAsRootExtraCommands";
+    tag = "latest";
     contents = [ pkgs.coreutils ];
     # The parens here are to create problematic bash to embed and eval. In case
     # this is *embedded* into the script (with nix expansion) the initial quotes


### PR DESCRIPTION
docker-tools tests load images without specifying any tag
value. Docker then uses the image with tag "latest" which doesn't
exist anymore since commit 39e678e24e38f1f374eaf5463b424ebdf75df9af.

###### Motivation for this change
Fixes #42781 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

