### PR TITLE
maintainers/scripts/update-python-libraries: compare versions semantically instead of lexicographically

### DIFF
--- a/maintainers/scripts/update-python-libraries
+++ b/maintainers/scripts/update-python-libraries
@@ -262,7 +262,7 @@ def _update_package(path, target):
     if new_version == version:
         logging.info("Path {}: no update available for {}.".format(path, pname))
         return False
-    elif new_version <= version:
+    elif Version(new_version) <= Version(version):
         raise ValueError("downgrade for {}.".format(pname))
     if not new_sha256:
         raise ValueError("no file available for {}.".format(pname))


### PR DESCRIPTION
###### Motivation for this change
I just had the case that an update `0.9.9 -> 0.9.10` was available, but regarded as a downgrade by the script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

