### PR TITLE
networkmanagerapplet: 1.8.10 -> 1.8.14

### DIFF
--- a/pkgs/tools/networking/network-manager/applet.nix
+++ b/pkgs/tools/networking/network-manager/applet.nix
@@ -6,18 +6,18 @@
 
 let
   pname = "network-manager-applet";
-  version = "1.8.10";
+  version = "1.8.14";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1hy9ni2rwpy68h7jhn5lm2s1zm1vjchfy8lwj8fpm7xlx3x4pp0a";
+    sha256 = "1js0i2kwfklahsn77qgxzdscy33drrlym3mrj1qhlw0zf8ri56ya";
   };
 
   mesonFlags = [
     "-Dselinux=false"
-    "-Dappindicator=true"
+    "-Dappindicator=yes"
     "-Dgcr=${if withGnome then "true" else "false"}"
   ];
 


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/network-manager-applet/blob/1.8.14/NEWS
(includes 1.8.12 changes as well)

In particular after nixos-rebuild'ing against master,
I found nm-applet (1.8.10) crashed regularly when trying to connect to my VPN.

Update seems to fix this behavior. \o/


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---