### PR TITLE
networking: Fix timeout when `lo` has aliased IPs

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1053,7 +1053,7 @@ in
       };
     } // (listToAttrs (flip map interfaces (i:
       let
-        deviceDependency = if config.boot.isContainer
+        deviceDependency = if (config.boot.isContainer || i.name == "lo")
           then []
           else [ (subsystemDevice i.name) ];
       in


### PR DESCRIPTION
With a config like

    {
      networking.interfaces."lo".ip4 = [
        { address = "10.8.8.8"; prefixLength = 32; }
      ];
    }

a nixos-rebuild switch would take a long time, and you'd see:

    $ systemctl list-jobs
       JOB UNIT                                TYPE  STATE
    734400 network-interfaces.target           start waiting
    734450 sys-subsystem-net-devices-lo.device start running
    734449 network-link-lo.service             start waiting

and:

    systemd[1]: sys-subsystem-net-devices-lo.device: Job sys-subsystem-net-devices-lo.device/star>
    systemd[1]: sys-subsystem-net-devices-lo.device: Job sys-subsystem-net-devices-lo.device/star>
    systemd[1]: Timed out waiting for device sys-subsystem-net-devices-lo.device.

This removes the device dependency for `lo` and fixes this bug.

Closes #7227

cc @Mic92 @copumpkin @dhess 

This should be backported to 18.03.