### PR TITLE
pythonPackages.flask-autoindex: 2018-06-28 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/flask-autoindex/default.nix
+++ b/pkgs/development/python-modules/flask-autoindex/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , flask
 , flask-silk
 , future
@@ -8,16 +8,11 @@
 
 buildPythonPackage rec {
   pname = "Flask-AutoIndex";
-  version = "2018-06-28";
+  version = "0.6.1";
 
-  # master fixes various issues (binary generation, flask syntax) and has no
-  # major changes
-  # new release requested: https://github.com/sublee/flask-autoindex/issues/38
-  src = fetchFromGitHub {
-    owner = "sublee";
-    repo = "flask-autoindex";
-    rev = "e3d449a89d56bf4c171c7c8d90af028e579782cf";
-    sha256 = "0bwq2nid4h8vrxspggk064vra4wd804cl2ryyx4j2d1dyywmgjgy";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0v87sa073hmj64f47sazbiw08kyxsxay100bd5084jwq7c1y92d7";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

This doesn't introduce any functional changes, just moving back from a master build to a release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

