### PR TITLE
polkit: 0.113 -> 0.115

### DIFF
--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -13,21 +13,13 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "polkit-0.114";
+  name = "polkit-0.115";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/polkit/releases/${name}.tar.gz";
-    sha256 = "1rpdx1vymkn5d8g2vrb7c8h4v60mq5smjjg29mwzsn6pcxrh1x5x";
+    sha256 = "0c91y61y4gy6p91cwbzg32dhavw4b7fflg370rimqhdxpzdfr1rg";
   };
 
-  patches = [
-    # to remove on 0.115 release
-    (fetchpatch {
-      name = "format-security.patch";
-      url = "https://cgit.freedesktop.org/polkit/patch/?id=373705b35e7f6c7dc83de5e0a3ce11ecd15d0409";
-      sha256 = "03fb5039d62cljxi84ir4420p4m1455q022dxamql1mvq3n38mwg";
-    })
-  ];
 
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     sed -i -e "s/-Wl,--as-needed//" configure.ac

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -1,47 +1,31 @@
-{ stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig, glib, expat, pam
-, intltool, spidermonkey_17 , gobjectIntrospection, libxslt, docbook_xsl
-, docbook_xml_dtd_412, gtk-doc
+{ stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig, glib, expat, pam, perl
+, intltool, spidermonkey_52 , gobjectIntrospection, libxslt, docbook_xsl, dbus
+, docbook_xml_dtd_412, gtk-doc, coreutils
 , useSystemd ? stdenv.isLinux, systemd
-, doCheck ? false
+, doCheck ? stdenv.isLinux
 }:
 
 let
 
-  system = "/var/run/current-system/sw";
+  system = "/run/current-system/sw";
   setuid = "/run/wrappers/bin"; #TODO: from <nixos> config.security.wrapperDir;
-
-  foolVars = {
-    SYSCONF = "/etc";
-    DATA = "${system}/share"; # to find share/polkit-1/actions of other apps at runtime
-  };
 
 in
 
 stdenv.mkDerivation rec {
-  name = "polkit-0.113";
+  name = "polkit-0.114";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/polkit/releases/${name}.tar.gz";
-    sha256 = "109w86kfqrgz83g9ivggplmgc77rz8kx8646izvm2jb57h4rbh71";
+    sha256 = "1rpdx1vymkn5d8g2vrb7c8h4v60mq5smjjg29mwzsn6pcxrh1x5x";
   };
 
   patches = [
+    # to remove on 0.115 release
     (fetchpatch {
-      url = "http://src.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-agent-leaks.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
-      sha256 = "1cxnhj0y30g7ldqq1y6zwsbdwcx7h97d3mpd3h5jy7dhg3h9ym91";
-    })
-    (fetchpatch {
-      url = "http://src.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-polkitpermission-leak.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
-      sha256 = "1h1rkd4avqyyr8q6836zzr3w10jf521gcqnvhrhzwdpgp1ay4si7";
-    })
-    (fetchpatch {
-      url = "http://src.fedoraproject.org/cgit/rpms/polkit.git/plain/polkit-0.113-itstool.patch?id=fa6fd575804de92886c95d3bc2b7eb2abcd13760";
-      sha256 = "0bxmjwp8ahy1y5g1l0kxmld0l3mlvb2l0i5n1qabia3d5iyjkyfh";
-    })
-    (fetchpatch {
-      name = "netgroup-optional.patch";
-      url = "https://bugs.freedesktop.org/attachment.cgi?id=118753";
-      sha256 = "1zq51dhmqi9zi86bj9dq4i4pxlxm41k3k4a091j07bd78cjba038";
+      name = "format-security.patch";
+      url = "https://cgit.freedesktop.org/polkit/patch/?id=373705b35e7f6c7dc83de5e0a3ce11ecd15d0409";
+      sha256 = "03fb5039d62cljxi84ir4420p4m1455q022dxamql1mvq3n38mwg";
     })
   ];
 
@@ -52,35 +36,34 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ]; # small man pages in $bin
 
   nativeBuildInputs =
-    [ gtk-doc pkgconfig autoreconfHook intltool gobjectIntrospection ]
+    [ gtk-doc pkgconfig autoreconfHook intltool gobjectIntrospection perl ]
     ++ [ libxslt docbook_xsl docbook_xml_dtd_412 ]; # man pages
   buildInputs =
-    [ glib expat pam spidermonkey_17 gobjectIntrospection ]
+    [ glib expat pam spidermonkey_52 gobjectIntrospection ]
     ++ stdenv.lib.optional useSystemd systemd;
 
-  # Ugly hack to overwrite hardcoded directories
-  # TODO: investigate a proper patch which will be accepted upstream
-  # After update it's good to check the sources via:
-  #   grep '\<PACKAGE_' '--include=*.[ch]' -R
-  CFLAGS = stdenv.lib.concatStringsSep " "
-    ( map (var: ''-DPACKAGE_${var}_DIR=\""${builtins.getAttr var foolVars}"\"'')
-        (builtins.attrNames foolVars) );
+  NIX_CFLAGS_COMPILE = " -Wno-deprecated-declarations "; # for polkit 0.114 and glib 2.56
 
   preConfigure = ''
+    chmod +x test/mocklibc/bin/mocklibc{,-test}.in
     patchShebangs .
-  '' + stdenv.lib.optionalString useSystemd /* bogus chroot detection */ ''
-    sed '/libsystemd autoconfigured/s/.*/:/' -i configure
-  ''
+
     # ‘libpolkit-agent-1.so’ should call the setuid wrapper on
     # NixOS.  Hard-coding the path is kinda ugly.  Maybe we can just
     # call through $PATH, but that might have security implications.
-  + ''
     substituteInPlace src/polkitagent/polkitagentsession.c \
       --replace   'PACKAGE_PREFIX "/lib/polkit-1/'   '"${setuid}/'
+    substituteInPlace test/data/etc/polkit-1/rules.d/10-testing.rules \
+      --replace   /bin/true ${coreutils}/bin/true \
+      --replace   /bin/false ${coreutils}/bin/false
+
+  '' + stdenv.lib.optionalString useSystemd /* bogus chroot detection */ ''
+    sed '/libsystemd autoconfigured/s/.*/:/' -i configure
   '';
 
   configureFlags = [
-    #"--libexecdir=$(out)/libexec/polkit-1" # this and localstatedir are ignored by configure
+    "--datadir=${system}/share"
+    "--sysconfdir=/etc"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
     "--with-polkitd-user=polkituser" #TODO? <nixos> config.ids.uids.polkituser
     "--with-os-type=NixOS" # not recognized but prevents impurities on non-NixOS
@@ -96,7 +79,14 @@ stdenv.mkDerivation rec {
     paxmark mr test/polkitbackend/.libs/polkitbackendjsauthoritytest
   '';
 
+  installFlags=["datadir=$(out)/share" "sysconfdir=$(out)/etc"];
+
   inherit doCheck;
+  checkInputs = [dbus];
+  checkPhase = ''
+    # tests need access to the system bus
+    dbus-run-session --config-file=${./system_bus.conf} -- sh -c 'DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS make check'
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/polkit;

--- a/pkgs/development/libraries/polkit/system_bus.conf
+++ b/pkgs/development/libraries/polkit/system_bus.conf
@@ -1,0 +1,58 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <!-- Our well-known bus type, do not change this -->
+  <type>system</type>
+
+  <!-- Fork into daemon mode -->
+  <fork/>
+
+  <!-- Enable logging to syslog -->
+  <syslog/>
+
+  <!-- Only allow socket-credentials-based authentication -->
+  <auth>EXTERNAL</auth>
+
+  <!-- Only listen on a local socket. (abstract=/path/to/socket 
+       means use abstract namespace, don't really create filesystem 
+       file; only Linux supports this. Use path=/whatever on other 
+       systems.) -->
+  <listen>unix:path=/tmp/system_bus_socket</listen>
+
+  <policy context="default">
+    <!-- All users can connect to system bus -->
+    <allow user="*"/>
+
+    <!-- Holes must be punched in service configuration files for
+         name ownership and sending method calls -->
+    <deny own="*"/>
+    <deny send_type="method_call"/>
+
+    <!-- Signals and reply messages (method returns, errors) are allowed
+         by default -->
+    <allow send_type="signal"/>
+    <allow send_requested_reply="true" send_type="method_return"/>
+    <allow send_requested_reply="true" send_type="error"/>
+
+    <!-- All messages may be received by default -->
+    <allow receive_type="method_call"/>
+    <allow receive_type="method_return"/>
+    <allow receive_type="error"/>
+    <allow receive_type="signal"/>
+
+    <!-- Allow anyone to talk to the message bus -->
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus" />
+    <allow send_destination="org.freedesktop.DBus"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <!-- But disallow some specific bus services -->
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus"
+          send_member="UpdateActivationEnvironment"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.DBus.Debug.Stats"/>
+    <deny send_destination="org.freedesktop.DBus"
+          send_interface="org.freedesktop.systemd1.Activator"/>
+  </policy>
+
+</busconfig>


### PR DESCRIPTION
###### Motivation for this change

I am affected by a bug fixed in 0.114 (https://bugs.freedesktop.org/show_bug.cgi?id=96977 )



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s): udisks
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


###### Other considerations

All fedora patches have been merged upstream.
Tests pass and have been enabled on linux.

cc @dtzWill regarding musl support: https://github.com/NixOS/nixpkgs/commit/551f0702c24536e4918c6239de9f32772a6ef165 introduced a musl patch (source
https://bugs.freedesktop.org/show_bug.cgi?id=50145 ) but this patch does not apply anymore, and
this other bug https://bugs.freedesktop.org/show_bug.cgi?id=75187 introduced similar changes.
I tried building polkit on musl:
```
nix-build . -A polkit --arg crossSystem '(import <nixpkgs> {}).lib.systems.examples.musl64'
```
but this fails to build dependencies ( `/nix/store/b0q57pcgkn2z185nrk2dx6lyjys18xqy-bsd-compat-netbsd-7.1.2-x86_64-unknown-linux-musl.drv` ).
So I chose to drop the patch completely. As of now we don't need it since dependencies don't build.

