### PR TITLE
ocamlPackages.ezjsonm: 0.4.3 -> 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/ezjsonm/default.nix
+++ b/pkgs/development/ocaml-modules/ezjsonm/default.nix
@@ -1,20 +1,21 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, jsonm, hex, sexplib, lwt }:
+{ stdenv, fetchzip, ocaml, findlib, jbuilder, jsonm, hex, sexplib }:
 
-let version = "0.4.3"; in
+let version = "0.6.0"; in
 
 stdenv.mkDerivation {
-  name = "ocaml-ezjsonm-${version}";
+  name = "ocaml${ocaml.version}-ezjsonm-${version}";
 
   src = fetchzip {
     url = "https://github.com/mirage/ezjsonm/archive/${version}.tar.gz";
-    sha256 = "1y6p3ga6vj1wx5dyns7hjgd0qgrrn2hnn323a7y5didgci5pybls";
+    sha256 = "18g64lhai0bz65b9fil12vlgfpwa9b5apj7x6d7n4zzm18qfazvj";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild lwt ];
+  buildInputs = [ ocaml findlib jbuilder ];
   propagatedBuildInputs = [ jsonm hex sexplib ];
-  createFindlibDestdir = true;
 
-  configureFlags = "--enable-lwt";
+  buildPhase = "jbuilder build -p ezjsonm";
+
+  inherit (jbuilder) installPhase;
 
   meta = {
     description = "An easy interface on top of the Jsonm library";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -231,9 +231,7 @@ let
 
     estring = callPackage ../development/ocaml-modules/estring { };
 
-    ezjsonm = callPackage ../development/ocaml-modules/ezjsonm {
-      lwt = ocaml_lwt;
-    };
+    ezjsonm = callPackage ../development/ocaml-modules/ezjsonm { };
 
     facile = callPackage ../development/ocaml-modules/facile { };
 


### PR DESCRIPTION
Compatibility with OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

