### PR TITLE
gtkspell3: add valaSupport

### DIFF
--- a/pkgs/development/libraries/gtkspell/3.nix
+++ b/pkgs/development/libraries/gtkspell/3.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gtk3, aspell, pkgconfig, enchant, isocodes, intltool, gobjectIntrospection}:
+{stdenv, fetchurl, gtk3, aspell, pkgconfig, enchant, isocodes, intltool, gobjectIntrospection, vala}:
 
 stdenv.mkDerivation rec {
   name = "gtkspell-${version}";
@@ -11,11 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "09jdicmpipmj4v84gnkqwbmj4lh8v0i6pn967rb9jx4zg2ia9x54";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
+  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection vala ];
   buildInputs = [ aspell gtk3 enchant isocodes ];
   propagatedBuildInputs = [ enchant ];
 
-  configureFlags = [ "--enable-introspection" ];
+  configureFlags = [
+    "--enable-introspection"
+    "--enable-vala"
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://gtkspell.sourceforge.net/;


### PR DESCRIPTION
###### Motivation for this change
I was packaging [elementary-code](https://github.com/elementary/code) and it cried about gtkspell3 not having vala support.

cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

