### PR TITLE
vscode: 1.24.1 -> 1.25.0

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, callPackage, fetchurl, unzip, atomEnv, makeDesktopItem,
-  makeWrapper, libXScrnSaver, libxkbfile, libsecret }:
+  gtk2, makeWrapper, libXScrnSaver, libxkbfile, libsecret }:
 
 let
-  version = "1.24.1";
+  version = "1.25.0";
   channel = "stable";
 
   plat = {
@@ -12,15 +12,16 @@ let
   }.${stdenv.system};
 
   sha256 = {
-    "i686-linux" = "189chqdimijjzydb8sp3yyi19fijsivyxrdddy8raaj7qkwq0maa";
-    "x86_64-linux" = "1944v54pfpfkq5jjnfrhndcwndsnvavd9qih1i2pq16mgaizmib2";
-    "x86_64-darwin" = "09sn22j40hax9v6ai99pfj67ymzkk82yqf8j33bg8byk4fgrz9jg";
+    "i686-linux" = "1dgn9swqax54pn5ykk97zdkkzyj46jambmnkb67cn44p29bw9s9m";
+    "x86_64-linux" = "0w2lzif7iilibvwhvg13gxarwz41qsb72s8hvj87mk5iqfdms1px";
+    "x86_64-darwin" = "08xhwvggflzh9lfc5s3jgrqb49yz4jdfii8sfq6v8w3c6yy8cdly";
   }.${stdenv.system};
 
   archive_fmt = if stdenv.system == "x86_64-darwin" then "zip" else "tar.gz";
 
   rpath = lib.concatStringsSep ":" [
     atomEnv.libPath
+    "${lib.makeLibraryPath [gtk2]}"
     "${lib.makeLibraryPath [libsecret]}/libsecret-1.so.0"
     "${lib.makeLibraryPath [libXScrnSaver]}/libXss.so.1"
     "${lib.makeLibraryPath [libxkbfile]}/libxkbfile.so.1"


### PR DESCRIPTION
Also includes missing lib, libgtk-x11-2.0.so.0

###### Motivation for this change
Resolves executable error: `error while loading shared libraries: libgtk-x11-2.0.so.0: cannot open shared object file: No such file or directory`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

