### PR TITLE
gsignond: init at 1.0.7

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -233,6 +233,7 @@
   ./services/desktops/dleyna-server.nix
   ./services/desktops/flatpak.nix
   ./services/desktops/geoclue2.nix
+  ./services/desktops/gsignond.nix
   ./services/desktops/pipewire.nix
   ./services/desktops/gnome3/at-spi2-core.nix
   ./services/desktops/gnome3/chrome-gnome-shell.nix

--- a/nixos/modules/services/desktops/gsignond.nix
+++ b/nixos/modules/services/desktops/gsignond.nix
@@ -1,0 +1,43 @@
+# Accounts-SSO gSignOn daemon
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  package = pkgs.gsignond.override { plugins = config.services.gsignond.plugins; };
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.gsignond = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable gSignOn daemon, a DBus service
+          which performs user authentication on behalf of its clients.
+        '';
+      };
+
+      plugins = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+          What plugins to use with the gSignOn daemon.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+  config = mkIf config.services.gsignond.enable {
+    environment.etc."gsignond.conf".source = "${package}/etc/gsignond.conf";
+    services.dbus.packages = [ package ];
+  };
+
+}

--- a/pkgs/development/libraries/gsignond/conf.patch
+++ b/pkgs/development/libraries/gsignond/conf.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index cb1e0df..d90c85c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -95,6 +95,6 @@ endif
+ configure_file(
+     input: 'gsignond.conf.in',
+     configuration: conf_data,
+-    install_dir: sysconf_dir,
++    install_dir: 'etc/',
+     output: 'gsignond.conf'
+ )

--- a/pkgs/development/libraries/gsignond/default.nix
+++ b/pkgs/development/libraries/gsignond/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, glib, glib-networking
+, sqlite, gobjectIntrospection, vala, gtk-doc, libsecret, docbook_xsl
+, docbook_xml_dtd_43, docbook_xml_dtd_45, glibcLocales, makeWrapper
+, symlinkJoin, gsignondPlugins, plugins }:
+
+let
+unwrapped = stdenv.mkDerivation rec {
+  pname = "gsignond";
+  version = "39022c86ddb5062a10fb0503ad9d81a8e532d527";
+
+  name = "${pname}-2018-10-04";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = pname;
+    rev = version;
+    sha256 = "1gw8vbj3j6wxqy759z97arm8lnqhmraw9s2frv3ar6crnfhlidff";
+  };
+
+  nativeBuildInputs = [
+    docbook_xml_dtd_43
+    docbook_xml_dtd_45
+    docbook_xsl
+    glibcLocales
+    gobjectIntrospection
+    gtk-doc
+    meson
+    ninja
+    pkgconfig
+    vala
+  ];
+
+  buildInputs = [
+    glib
+    glib-networking
+    libsecret
+  ];
+
+  propagatedBuildInputs = [ sqlite ];
+
+  mesonFlags = [
+    "-Dbus_type=session"
+    "-Dextension=desktop"
+  ];
+
+  LC_ALL = "en_US.UTF-8";
+
+  patches = [
+    ./conf.patch
+    ./plugin-load-env.patch
+  ];
+
+  meta = with stdenv.lib; {
+    description = "D-Bus service which performs user authentication on behalf of its clients";
+    homepage = https://gitlab.com/accounts-sso/gsignond;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+};
+
+in if plugins == [] then unwrapped
+    else import ./wrapper.nix {
+      inherit stdenv makeWrapper symlinkJoin gsignondPlugins plugins;
+      gsignond = unwrapped;
+    }
+

--- a/pkgs/development/libraries/gsignond/plugin-load-env.patch
+++ b/pkgs/development/libraries/gsignond/plugin-load-env.patch
@@ -1,0 +1,35 @@
+diff --git a/src/gplugind/gsignond-plugin-loader.c b/src/gplugind/gsignond-plugin-loader.c
+index 5497b32..979e1b4 100644
+--- a/src/gplugind/gsignond-plugin-loader.c
++++ b/src/gplugind/gsignond-plugin-loader.c
+@@ -38,11 +38,10 @@ gsignond_load_plugin (
+     gchar *plugin_filename;
+     GSignondPlugin *plugin;
+ 
+-#   ifdef ENABLE_DEBUG
+     const gchar *env_val = g_getenv("SSO_GPLUGINS_DIR");
+     if (env_val)
+         plugin_path = env_val;
+-#   endif
++
+     plugin_filename = g_module_build_path (plugin_path, plugin_type);
+     plugin = gsignond_load_plugin_with_filename (plugin_type,
+                                                  plugin_filename);
+diff --git a/src/gplugind/main.c b/src/gplugind/main.c
+index 1c6cdb6..c85c623 100644
+--- a/src/gplugind/main.c
++++ b/src/gplugind/main.c
+@@ -93,11 +93,11 @@ _install_sighandlers (GMainLoop *main_loop)
+ static const gchar* _plugin_path(void)
+ {
+     const gchar *plugin_path = GSIGNOND_GPLUGINS_DIR;
+-#   ifdef ENABLE_DEBUG
++
+     const gchar *env_val = g_getenv("SSO_GPLUGINS_DIR");
+     if (env_val)
+         plugin_path = env_val;
+-#   endif
++
+     return plugin_path;
+ }
+ 

--- a/pkgs/development/libraries/gsignond/plugins/lastfm.nix
+++ b/pkgs/development/libraries/gsignond/plugins/lastfm.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, vala, glib, gsignond, json-glib, libsoup, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gsignond-plugin-lastfm-${version}";
+  version = "2018-05-07";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "gsignond-plugin-lastfm";
+    rev = "0a7a5f8511282e45cfe35987b81f27f158f0648c";
+    sha256 = "0ay6ir9zg9l0264x5xwd7c6j8qmwlhrifkkkjd1yrjh9sqxyfj7f";
+  };
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    vala
+  ];
+
+  buildInputs = [
+    glib
+    gsignond
+    json-glib
+    libsoup
+  ];
+
+  PKG_CONFIG_GSIGNOND_GPLUGINSDIR = "${placeholder "out"}/lib/gsignond/gplugins";
+
+  meta = with stdenv.lib; {
+    description = "Plugin for the Accounts-SSO gSignOn daemon handles the Last.FM credentials.";
+    homepage = https://gitlab.com/accounts-sso/gsignond-plugin-lastfm;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gsignond/plugins/mail.nix
+++ b/pkgs/development/libraries/gsignond/plugins/mail.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitLab, pkgconfig, meson, ninja, vala, glib, gsignond, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gsignond-plugin-mail-${version}";
+  version = "2018-10-04";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "gsignond-plugin-mail";
+    rev = "fbc6f34b246fec4ad2b37c696f8de7fdb9bde346";
+    sha256 = "1wvwz7qiwvj8iixprip3qd8lplzfnwcjfrbg2vd8xfsvid2zbviw";
+  };
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    vala
+  ];
+
+  buildInputs = [
+    glib
+    gsignond
+  ];
+
+  PKG_CONFIG_GSIGNOND_GPLUGINSDIR = "${placeholder "out"}/lib/gsignond/gplugins";
+
+  meta = with stdenv.lib; {
+    description = "Plugin for the Accounts-SSO gSignOn daemon that handles the E-Mail credentials.";
+    homepage = https://gitlab.com/accounts-sso/gsignond-plugin-mail;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gsignond/plugins/oauth.nix
+++ b/pkgs/development/libraries/gsignond/plugins/oauth.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitLab, fetchpatch, pkgconfig, meson, ninja, glib, gsignond, check
+, json-glib, libsoup, gnutls, gtk-doc, docbook_xml_dtd_43, docbook_xml_dtd_45
+, docbook_xsl, glibcLocales, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gsignond-plugin-oauth-${version}";
+  version = "2018-10-15";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "gsignond-plugin-oa";
+    rev = "d471cebfd7c50567b1244277a9559f18f8d58691";
+    sha256 = "00axl8wwp2arc6h4bpr4m3ik2hy8an0lbm48q2a9r94krmq56hnx";
+  };
+
+  nativeBuildInputs = [
+    check
+    docbook_xml_dtd_43
+    docbook_xml_dtd_45
+    docbook_xsl
+    glibcLocales
+    gobjectIntrospection
+    gtk-doc
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    glib
+    gnutls
+    gsignond
+    json-glib
+    libsoup
+  ];
+
+  LC_ALL = "en_US.UTF-8";
+
+  PKG_CONFIG_GSIGNOND_GPLUGINSDIR = "${placeholder "out"}/lib/gsignond/gplugins";
+
+  meta = with stdenv.lib; {
+    description = "Plugin for the Accounts-SSO gSignOn daemon that handles the OAuth 1.0 and 2.0 authentication protocols.";
+    homepage = https://gitlab.com/accounts-sso/gsignond-plugin-oa;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gsignond/plugins/sasl.nix
+++ b/pkgs/development/libraries/gsignond/plugins/sasl.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitLab, fetchpatch, pkgconfig, meson, ninja, glib, gsignond, gsasl, check
+, gtk-doc, docbook_xml_dtd_43, docbook_xml_dtd_45, docbook_xsl, glibcLocales, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  name = "gsignond-plugin-sasl-${version}";
+  version = "2018-10-15";
+
+  src = fetchFromGitLab {
+    owner = "accounts-sso";
+    repo = "gsignond-plugin-sasl";
+    rev = "b304c70b7dad9368b23b1205122d10de684c896a";
+    sha256 = "0knzw7c2fm2kzs1gxbrm4kk67522w9cpwqj7xvn86473068k90va";
+  };
+
+  nativeBuildInputs = [
+    check
+    docbook_xml_dtd_43
+    docbook_xml_dtd_45
+    docbook_xsl
+    glibcLocales
+    gobjectIntrospection
+    gtk-doc
+    meson
+    ninja
+    pkgconfig
+  ];
+
+  buildInputs = [
+    glib
+    gsasl
+    gsignond
+  ];
+
+  LC_ALL = "en_US.UTF-8";
+
+  PKG_CONFIG_GSIGNOND_GPLUGINSDIR = "${placeholder "out"}/lib/gsignond/gplugins";
+
+  meta = with stdenv.lib; {
+    description = "Plugin for the Accounts-SSO gSignOn daemon that handles the SASL authentication protocol.";
+    homepage = https://gitlab.com/accounts-sso/gsignond-plugin-sasl;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/gsignond/wrapper.nix
+++ b/pkgs/development/libraries/gsignond/wrapper.nix
@@ -1,0 +1,23 @@
+{ stdenv, makeWrapper, symlinkJoin, gsignond, gsignondPlugins, plugins }:
+
+symlinkJoin {
+  name = "gsignond-with-plugins-${gsignond.version}";
+
+  paths = [ gsignond ] ++ plugins;
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/gsignond \
+      --set SSO_GPLUGINS_DIR "$out/lib/gsignond/gplugins"
+
+    rm $out/share/dbus-1/services/com.google.code.AccountsSSO.gSingleSignOn.service
+    rm $out/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service
+
+    substitute ${gsignond}/share/dbus-1/services/com.google.code.AccountsSSO.gSingleSignOn.service $out/share/dbus-1/services/com.google.code.AccountsSSO.gSingleSignOn.service \
+      --replace ${gsignond} $out
+
+    substitute ${gsignond}/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service $out/share/dbus-1/services/com.google.code.AccountsSSO.SingleSignOn.service \
+      --replace ${gsignond} $out
+  '';
+}

--- a/pkgs/development/libraries/libsignon-glib/default.nix
+++ b/pkgs/development/libraries/libsignon-glib/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchgit, pkgconfig, meson, ninja, vala, python3, gtk-doc, docbook_xsl, docbook_xml_dtd_43, docbook_xml_dtd_412, glib, check, gobjectIntrospection }:
+
+stdenv.mkDerivation rec {
+  pname = "libsignon-glib";
+  version = "3639a2e90447e4640a03a44972560afe8f61aa48";
+
+  name = "${pname}-2018-10-24";
+
+  outputs = [ "out" "dev" "devdoc" "py" ];
+
+  src = fetchgit {
+    url = "https://gitlab.com/accounts-sso/${pname}";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "1cq19zbsx4c57dc5gp3shp8lzcr1hw2ynylpn1nkvfyyrx80m60w";
+  };
+
+  nativeBuildInputs = [
+    check
+    docbook_xml_dtd_412
+    docbook_xml_dtd_43
+    docbook_xsl
+    gobjectIntrospection
+    gtk-doc
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+  ];
+
+  buildInputs = [
+    glib
+    python3.pkgs.pygobject3
+  ];
+
+  mesonFlags = [
+    "-Dintrospection=true"
+    "-Dpy-overrides-dir=${placeholder "py"}/${python3.sitePackages}/gi/overrides"
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/gen-error-map.py
+    patchShebangs build-aux/gen-error-map.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      A library for managing single signon credentials which can be used from GLib applications
+    '';
+    homepage = https://gitlab.com/accounts-sso/libsignon-glib;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12770,6 +12770,10 @@ with pkgs;
     plugins = [];
   };
 
+  gsignondPlugins = {
+    sasl = callPackage ../development/libraries/gsignond/plugins/sasl.nix { };
+  };
+
   ### DEVELOPMENT / LIBRARIES / AGDA
 
   agda = callPackage ../build-support/agda {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12772,6 +12772,7 @@ with pkgs;
 
   gsignondPlugins = {
     sasl = callPackage ../development/libraries/gsignond/plugins/sasl.nix { };
+    oauth = callPackage ../development/libraries/gsignond/plugins/oauth.nix { };
   };
 
   ### DEVELOPMENT / LIBRARIES / AGDA

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10534,6 +10534,8 @@ with pkgs;
 
   libsignal-protocol-c = callPackage ../development/libraries/libsignal-protocol-c { };
 
+  libsignon-glib = callPackage ../development/libraries/libsignon-glib { };
+
   libsoundio = callPackage ../development/libraries/libsoundio {
     inherit (darwin.apple_sdk.frameworks) AudioUnit;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12766,6 +12766,10 @@ with pkgs;
 
   zziplib = callPackage ../development/libraries/zziplib { };
 
+  gsignond = callPackage ../development/libraries/gsignond {
+    plugins = [];
+  };
+
   ### DEVELOPMENT / LIBRARIES / AGDA
 
   agda = callPackage ../build-support/agda {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12774,6 +12774,7 @@ with pkgs;
     sasl = callPackage ../development/libraries/gsignond/plugins/sasl.nix { };
     oauth = callPackage ../development/libraries/gsignond/plugins/oauth.nix { };
     lastfm = callPackage ../development/libraries/gsignond/plugins/lastfm.nix { };
+    mail = callPackages ../development/libraries/gsignond/plugins/mail.nix { };
   };
 
   ### DEVELOPMENT / LIBRARIES / AGDA

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12773,6 +12773,7 @@ with pkgs;
   gsignondPlugins = {
     sasl = callPackage ../development/libraries/gsignond/plugins/sasl.nix { };
     oauth = callPackage ../development/libraries/gsignond/plugins/oauth.nix { };
+    lastfm = callPackage ../development/libraries/gsignond/plugins/lastfm.nix { };
   };
 
   ### DEVELOPMENT / LIBRARIES / AGDA


### PR DESCRIPTION
###### Motivation for this change
Needed this for elementary packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

