### PR TITLE
zookeeper: server fixes

### DIFF
--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
     cp -R conf docs lib ${name}.jar $out
     mkdir -p $out/bin
     cp -R bin/{zkCli,zkCleanup,zkEnv,zkServer}.sh $out/bin
+    patchShebangs $out/bin
     for i in $out/bin/{zkCli,zkCleanup,zkServer}.sh; do
       wrapProgram $i \
         --set JAVA_HOME "${jre}" \

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     cp -R conf docs lib ${name}.jar $out
     mkdir -p $out/bin
     cp -R bin/{zkCli,zkCleanup,zkEnv,zkServer}.sh $out/bin
-    for i in $out/bin/{zkCli,zkCleanup}.sh; do
+    for i in $out/bin/{zkCli,zkCleanup,zkServer}.sh; do
       wrapProgram $i \
         --set JAVA_HOME "${jre}" \
         --prefix PATH : "${bash}/bin"


### PR DESCRIPTION
The following pull request patches zookeeper, so running server with `zkServer.sh`
becomes usable:

- Wrap `zkServer.sh`, so server can find paths
- Patch shebangs in output scripts, which makes running zookeeper server pure