### PR TITLE
darwin: fix Libsystem compatibility for macOS 10.14

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/reexported_libraries
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/reexported_libraries
@@ -19,7 +19,7 @@
 
 /usr/lib/system/libsystem_configuration.dylib
 /usr/lib/system/libsystem_coreservices.dylib
-# /usr/lib/system/libsystem_coretls.dylib # Removed in 10.13
+# /usr/lib/system/libsystem_coretls.dylib  # Removed in 10.13
 /usr/lib/system/libsystem_dnssd.dylib
 /usr/lib/system/libsystem_info.dylib
 
@@ -28,7 +28,7 @@
 
 /usr/lib/system/libsystem_m.dylib
 /usr/lib/system/libsystem_malloc.dylib
-/usr/lib/system/libsystem_network.dylib
+# /usr/lib/system/libsystem_network.dylib  # Removed in 10.14
 /usr/lib/system/libsystem_networkextension.dylib
 /usr/lib/system/libsystem_notify.dylib
 /usr/lib/system/libsystem_platform.dylib

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_c_symbols
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_c_symbols
@@ -51,8 +51,6 @@ ___bt_setcur
 ___bt_split
 ___bt_sync
 ___buf_free
-___cVersionNumber
-___cVersionString
 ___call_hash
 ___cleanup
 ___cmp_D2A

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/system_kernel_symbols
@@ -57,8 +57,6 @@ ___ioctl
 ___iopolicysys
 ___kdebug_trace
 ___kdebug_trace64
-___kernelVersionNumber
-___kernelVersionString
 ___kill
 ___lchown
 ___libkernel_init

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -178,6 +178,9 @@ in rec {
   unpack = stdenv.mkDerivation (bootstrapFiles // {
     name = "unpack";
 
+    reexportedLibrariesFile =
+      ../../os-specific/darwin/apple-source-releases/Libsystem/reexported_libraries;
+
     # This is by necessity a near-duplicate of unpack-bootstrap-tools.sh. If we refer to it directly,
     # we can't make any changes to it due to our testing stdenv depending on it. Think of this as the
     # unpack-bootstrap-tools.sh for the next round of bootstrap tools.
@@ -209,7 +212,7 @@ in rec {
         $out/lib/system/libsystem_kernel.dylib
 
       # TODO: this logic basically duplicates similar logic in the Libsystem expression. Deduplicate them!
-      libs=$(otool -arch x86_64 -L /usr/lib/libSystem.dylib | tail -n +3 | awk '{ print $1 }')
+      libs=$(cat $reexportedLibrariesFile | grep -v '^#')
 
       for i in $libs; do
         if [ "$i" != "/usr/lib/system/libsystem_kernel.dylib" ] && [ "$i" != "/usr/lib/system/libsystem_c.dylib" ]; then


### PR DESCRIPTION
###### Motivation for this change

Similar to coretls, libsystem_networking.dylib has been removed in 10.14 so we shouldn't reexport it. Our current bootstrap tarball still references it but that's not a problem in most cases (currently doesn't work 10.13 either) and the changes are already in place to build a new one that will.

Also updated stdenvBootstrapTools.unpack since that's what is tested on hydra.

@copumpkin Why do we reconstruct `libSystem.B.dylib` after unpacking instead of including it in the tarball?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] stdenv
  - [x] bootstrap tools
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
