### PR TITLE
Lua: define packages for 5.3.x; update lpeg module

### DIFF
--- a/pkgs/development/interpreters/lua-5/5.3.nix
+++ b/pkgs/development/interpreters/lua-5/5.3.nix
@@ -5,11 +5,11 @@
 stdenv.mkDerivation rec {
   name = "lua-${version}";
   luaversion = "5.3";
-  version = "${luaversion}.4";
+  version = "${luaversion}.5";
 
   src = fetchurl {
     url = "https://www.lua.org/ftp/${name}.tar.gz";
-    sha256 = "0320a8dg3aci4hxla380dx1ifkw8gj4gbw5c4dz41g1kh98sm0gn";
+    sha256 = "0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac";
   };
 
   buildInputs = [ readline ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7308,6 +7308,7 @@ with pkgs;
 
   lua51Packages = recurseIntoAttrs (callPackage ./lua-packages.nix { lua = lua5_1; });
   lua52Packages = recurseIntoAttrs (callPackage ./lua-packages.nix { lua = lua5_2; });
+  lua53Packages = recurseIntoAttrs (callPackage ./lua-packages.nix { lua = lua5_3; });
   luajitPackages = recurseIntoAttrs (callPackage ./lua-packages.nix { lua = luajit; });
 
   luaPackages = lua52Packages;

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -83,6 +83,8 @@ let
 
     buildFlags = stdenv.lib.optionalString stdenv.isDarwin "macosx";
 
+    disabled = isLua53;
+
     postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
       substituteInPlace Makefile --replace 10.4 10.5
     '';
@@ -220,7 +222,7 @@ let
         EXPAT_INC="-I${expat.dev}/include");
     '';
 
-    disabled = isLuaJIT;
+    disabled = isLua53 || isLuaJIT;
 
     meta = with stdenv.lib; {
       description = "SAX XML parser based on the Expat library";
@@ -500,7 +502,7 @@ let
     patches = [ ../development/lua-modules/zip.patch ];
 
     # Does not currently work under Lua 5.2 or LuaJIT.
-    disabled = isLua52 || isLuaJIT;
+    disabled = isLua52 || isLua53 || isLuaJIT;
 
     meta = with stdenv.lib; {
       description = "Lua library to read files stored inside zip files";
@@ -620,6 +622,8 @@ let
       rev = version;
       sha256 = "05k8zs8nsdmlwja3hdhckwknf7ww5cvbp3sxhk2xd1i3ij6aa10b";
     };
+
+    disabled = isLua53;
 
     buildInputs = [ sqlite ];
 

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -15,6 +15,7 @@
 let
   isLua51 = lua.luaversion == "5.1";
   isLua52 = lua.luaversion == "5.2";
+  isLua53 = lua.luaversion == "5.3";
   isLuaJIT = (builtins.parseDrvName lua.name).name == "luajit";
 
   platformString =
@@ -640,11 +641,11 @@ let
 
   lpeg = buildLuaPackage rec {
     name = "lpeg-${version}";
-    version = "0.12";
+    version = "1.0.1";
 
     src = fetchurl {
       url = "http://www.inf.puc-rio.br/~roberto/lpeg/${name}.tar.gz";
-      sha256 = "0xlbfw1w7l65a5qhnx5sfw327hkq1zcj8xmg4glfw6fj9ha4b9gg";
+      sha256 = "62d9f7a9ea3c1f215c77e0cadd8534c6ad9af0fb711c3f89188a8891c72f026b";
     };
 
     preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

Most Lua packages are only available for legacy versions of Lua despite
the 5.3 series interpreter having been out for years now. That needs to
change.

Also the *lpeg* package in nixpkgs is rather archaic; the most recent version
1.0.1 was released in early 2017.

###### Things done

- Define *lua53Packages*.
- Compile-test already defined packages and disable those that wouldn’t build.
- Update lpeg to 1.0.1.
- Test some existing (non-public) Lua projects (all using lpeg).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

