### PR TITLE
pdfcrack: init 0.16

### DIFF
--- a/pkgs/tools/security/pdfcrack/default.nix
+++ b/pkgs/tools/security/pdfcrack/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "pdfcrack-${version}";
+  version = "0.16";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/pdfcrack/pdfcrack/pdfcrack-${version}.tar.gz";
+    sha256 = "1vvkrg3niinz0j9wwm31laxgmd7wdz201kn82b3dbksc0w1v4rbq";
+  };
+
+  installPhase = ''
+    install -Dt $out/bin pdfcrack
+  '';
+
+  meta = with lib; {
+    homepage = http://pdfcrack.sourceforge.net/;
+    description = "Small command line driven tool for recovering passwords and content from PDF files";
+    license = with licenses; [ gpl2 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ qoelet ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4435,6 +4435,8 @@ with pkgs;
 
   pdf-redact-tools = callPackage ../tools/graphics/pdfredacttools { };
 
+  pdfcrack = callPackage ../tools/security/pdfcrack { };
+
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };
 
   fmodex = callPackage ../games/zandronum/fmod.nix { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

