### PR TITLE
nixos/nixos-option: don't abort in case of evaluation errors

### DIFF
--- a/nixos/modules/installer/tools/nixos-option.sh
+++ b/nixos/modules/installer/tools/nixos-option.sh
@@ -16,6 +16,7 @@ verbose=false
 nixPath=""
 
 option=""
+exit_code=0
 
 argfun=""
 for arg; do
@@ -74,8 +75,13 @@ fi
 #############################
 
 evalNix(){
+  # disable `-e` flag, it's possible that the evaluation of `nix-instantiate` fails (e.g. due to broken pkgs)
+  set +e
   result=$(nix-instantiate ${nixPath:+$nixPath} - --eval-only "$@" 2>&1)
-  if test $? -eq 0; then
+  exit_code=$?
+  set -e
+
+  if test $exit_code -eq 0; then
       cat <<EOF
 $result
 EOF
@@ -87,7 +93,7 @@ EOF
 ' <<EOF
 $result
 EOF
-      return 1;
+    exit_code=1
   fi
 }
 
@@ -317,3 +323,5 @@ else
     echo $result
   fi
 fi
+
+exit $exit_code


### PR DESCRIPTION
###### Motivation for this change

When running e.g. `nixos-option boot.kernelPackages` I get an output
like this on the current unstable channel (18.09pre144959.be1461fc0ab):

```
$ nixos-option boot.kernelPackages
Value:
*exit 1*
```

This is fairly counter-intuitive as I have no clue what might went
wrong. `strace` delivers an output like this:

```
read(3, "error: Package \342\200\230cryptodev-linu"..., 128) = 128
read(3, "ux/cryptodev/default.nix:22 is m"..., 128) = 128
read(3, "lowBroken = true; }\nin configura"..., 128) = 128
read(3, "you can add\n  { allowBroken = tr"..., 128) = 128
read(3, "n)\n", 128)                    = 3
read(3, "", 128)                        = 0
```

`nixos-option` evaluates the system config using `nix-instantiate` which
might break when the evaluation fails (e.g. due to broken or unfree
packages that are prohibited to evaluate by default). The script aborts
due to the shebang `@shell@ -e`.

In order to ensure that no unexpected
behavior occurs due to removing `-e` from the interpreter the easiest
way to work around this was to wrap `nix-instantiate` in `evalNix()`
with a `set +e`. The function checks the success of the evaluation with
`$?` in the end. Additionally `evalNix` shouldn't break, if one
evaluation (e.g. the values that contain a package set by default) to
return additional information like a description.

With the change `nixos-option boot.kernelPackages` delivers the
following output for me:

```
Value:
error: Package ‘cryptodev-linux-1.9-4.14.52’ in /nix/store/47z2s8cwppymmgzw6n7pbcashikyk5jk-nixos/nixos/pkgs/os-specific/linux/cryptodev/default.nix:22 is marked as broken, refusing to evaluate.

Default:
{ __unfix__ = <LAMBDA>; acpi_call = <CODE>; amdgpu-pro = <CODE>; ati_drivers_x11 = <CODE>; batman_adv = <CODE>; bbswitch = <CODE>; bcc = <CODE>; beegfs-module = <CODE>; blcr = <CODE>; broadcom_sta = <CODE>; callPackage = <CODE>; cpupower = <CODE>; cryptodev = <CODE>; dpdk = <CODE>; e1000e = <CODE>; ena = <CODE>; evdi = <CODE>; exfat-nofuse = <CODE>; extend = <CODE>; facetimehd = <CODE>; fusionio-vsl = <CODE>; hyperv-daemons = <CODE>; ixgbevf = <CODE>; jool = <CODE>; kernel = <CODE>; lttng-modules = <CODE>; mba6x_bl = <CODE>; mwprocapture = <CODE>; mxu11x0 = <CODE>; ndiswrapper = <CODE>; netatop = <CODE>; nvidiaPackages = <CODE>; nvidia_x11 = <CODE>; nvidia_x11_beta = <CODE>; nvidia_x11_legacy304 = <CODE>; nvidia_x11_legacy340 = <CODE>; nvidiabl = <CODE>; odp-dpdk = <CODE>; openafs = <CODE>; openafs_1_8 = <CODE>; perf = <CODE>; phc-intel = <CODE>; pktgen = <CODE>; ply = <CODE>; prl-tools = <CODE>; recurseForDerivations = true; rtl8192eu = <CODE>; rtl8723bs = <CODE>; rtl8812au = <CODE>; rtl8814au = <CODE>; rtlwifi_new = <CODE>; sch_cake = <CODE>; spl = <CODE>; splLegacyCrypto = <CODE>; splStable = <CODE>; splUnstable = <CODE>; stdenv = <CODE>; sysdig = <CODE>; systemtap = <CODE>; tbs = <CODE>; tmon = <CODE>; tp_smapi = <CODE>; usbip = <CODE>; v4l2loopback = <CODE>; v86d = <CODE>; vhba = <CODE>; virtualbox = <CODE>; virtualboxGuestAdditions = <CODE>; wireguard = <CODE>; x86_energy_perf_policy = <CODE>; zfs = <CODE>; zfsLegacyCrypto = <CODE>; zfsStable = <CODE>; zfsUnstable = <CODE>; }

Example:
{ _type = "literalExample"; text = "pkgs.linuxPackages_2_6_25"; }

Description:

"This option allows you to override the Linux kernel used by\nNixOS. Since things like external kernel module packages are\ntied to the kernel you're using, it also overrides those.\nThis option is a function that takes Nixpkgs as an argument\n(as a convenience), and returns an attribute set containing at\nthe very least an attribute <varname>kernel</varname>.\nAdditional attributes may be needed depending on your\nconfiguration. For instance, if you use the NVIDIA X driver,\nthen it also needs to contain an attribute\n<varname>nvidia_x11</varname>.\n"

Declared by:
  "/nix/var/nix/profiles/per-user/root/channels/nixos/nixpkgs/nixos/modules/system/boot/kernel.nix"

Defined by:
  "/home/ma27/Projects/nixos-config/system/boot.nix"
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

