### PR TITLE
zoom-us: set qt plugin paths in wrapper

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -3,7 +3,7 @@
 , dbus, glib, libGL, libX11, libXfixes, libuuid, libxcb, qtbase, qtdeclarative
 , qtlocation, qtquickcontrols2, qtscript, qtwebchannel, qtwebengine
 # Runtime
-, libjpeg_turbo, pciutils, procps
+, libjpeg_turbo, pciutils, procps, qtimageformats
 , pulseaudioSupport ? true, libpulseaudio ? null
 }:
 
@@ -30,7 +30,7 @@ in stdenv.mkDerivation {
   buildInputs = [
     dbus glib libGL libX11 libXfixes libuuid libxcb qtbase qtdeclarative
     qtlocation qtquickcontrols2 qtscript qtwebchannel qtwebengine
-    libjpeg_turbo pciutils procps
+    libjpeg_turbo
   ];
 
   runtimeDependencies = optional pulseaudioSupport libpulseaudio;
@@ -70,6 +70,8 @@ in stdenv.mkDerivation {
       makeWrapper $packagePath/zoom $out/bin/zoom-us \
         --prefix PATH : "${makeBinPath [ pciutils procps ]}" \
         --set QSG_INFO 1 \
+        --set QT_QPA_PLATFORM_PLUGIN_PATH ${qtbase.bin}/lib/qt-${qtbase.qtCompatVersion}/plugins/platforms \
+        --set QT_PLUGIN_PATH ${qtbase.bin}/${qtbase.qtPluginPrefix}:${qtimageformats}/${qtbase.qtPluginPrefix} \
         --run "cd $packagePath"
 
       runHook postInstall
@@ -92,7 +94,7 @@ in stdenv.mkDerivation {
     description = "zoom.us video conferencing application";
     license = stdenv.lib.licenses.unfree;
     platforms = builtins.attrNames srcs;
-    maintainers = with stdenv.lib.maintainers; [ danbst ];
+    maintainers = with stdenv.lib.maintainers; [ danbst tadfisher ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Set `QT_QPA_PLATFORM_PLUGIN_PATH` and `QT_PLUGIN_PATH` in the wrapper script to address https://github.com/NixOS/nixpkgs/pull/42922#issuecomment-403212690.

Remove `procps` and `pciutils` from `buildInputs` to address https://github.com/NixOS/nixpkgs/pull/42922#pullrequestreview-135203500.

Add myself to maintainers to address https://github.com/NixOS/nixpkgs/pull/42742#issuecomment-403212248.

cc maintainers: @danbst

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

