### PR TITLE
home-assistant: 0.72.1 -> 0.73.0

### DIFF
--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.72.1";
+  version = "0.73.0";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -113,6 +113,7 @@
     "binary_sensor.pilight" = ps: with ps; [  ];
     "binary_sensor.ping" = ps: with ps; [  ];
     "binary_sensor.qwikswitch" = ps: with ps; [  ];
+    "binary_sensor.rachio" = ps: with ps; [  ];
     "binary_sensor.raincloud" = ps: with ps; [  ];
     "binary_sensor.rainmachine" = ps: with ps; [  ];
     "binary_sensor.random" = ps: with ps; [  ];
@@ -205,6 +206,7 @@
     "climate.generic_thermostat" = ps: with ps; [  ];
     "climate.heatmiser" = ps: with ps; [  ];
     "climate.hive" = ps: with ps; [  ];
+    "climate.homekit_controller" = ps: with ps; [  ];
     "climate.homematic" = ps: with ps; [ pyhomematic ];
     "climate.homematicip_cloud" = ps: with ps; [  ];
     "climate.honeywell" = ps: with ps; [  ];
@@ -609,7 +611,7 @@
     "media_player.samsungtv" = ps: with ps; [ wakeonlan ];
     "media_player.snapcast" = ps: with ps; [  ];
     "media_player.songpal" = ps: with ps; [  ];
-    "media_player.sonos" = ps: with ps; [  ];
+    "media_player.sonos" = ps: with ps; [ soco ];
     "media_player.soundtouch" = ps: with ps; [ libsoundtouch ];
     "media_player.spotify" = ps: with ps; [ aiohttp-cors ];
     "media_player.squeezebox" = ps: with ps; [  ];
@@ -635,6 +637,9 @@
     "mychevy" = ps: with ps; [  ];
     "mycroft" = ps: with ps; [  ];
     "mysensors" = ps: with ps; [  ];
+    "mysensors.const" = ps: with ps; [  ];
+    "mysensors.device" = ps: with ps; [  ];
+    "mysensors.gateway" = ps: with ps; [  ];
     "namecheapdns" = ps: with ps; [  ];
     "neato" = ps: with ps; [  ];
     "nest" = ps: with ps; [  ];
@@ -715,6 +720,7 @@
     "proximity" = ps: with ps; [  ];
     "python_script" = ps: with ps; [  ];
     "qwikswitch" = ps: with ps; [  ];
+    "rachio" = ps: with ps; [  ];
     "rainbird" = ps: with ps; [  ];
     "raincloud" = ps: with ps; [  ];
     "rainmachine" = ps: with ps; [  ];
@@ -1031,7 +1037,7 @@
     "sleepiq" = ps: with ps; [  ];
     "smappee" = ps: with ps; [  ];
     "snips" = ps: with ps; [ paho-mqtt ];
-    "sonos" = ps: with ps; [  ];
+    "sonos" = ps: with ps; [ soco ];
     "spaceapi" = ps: with ps; [ aiohttp-cors ];
     "spc" = ps: with ps; [ websockets ];
     "splunk" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -16,26 +16,10 @@ let
         };
       });
       requests = super.requests.overridePythonAttrs (oldAttrs: rec {
-        version = "2.18.4";
+        version = "2.19.1";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "0zi3v9nsmv9j27d0c0m1dvqyvaxz53g8m0aa1h3qanxs4irkwi4w";
-        };
-      });
-      # Required by requests==2.18.4
-      urllib3 = super.urllib3.overridePythonAttrs (oldAttrs: rec {
-        version = "1.22";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0kyvc9zdlxr5r96bng5rhm9a6sfqidrbvvkz64s76qs5267dli6c";
-        };
-      });
-      # Required by requests==2.18.4
-      idna = super.idna.overridePythonAttrs (oldAttrs: rec {
-        version = "2.6";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "13qaab6d0s15gknz8v3zbcfmbj6v86hn9pjxgkdf62ch13imssic";
+          sha256 = "ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a";
         };
       });
       voluptuous = super.voluptuous.overridePythonAttrs (oldAttrs: rec {
@@ -84,7 +68,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.72.1";
+  hassVersion = "0.73.0";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -99,7 +83,7 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "05r55hdai0qwgpj2f2qqngks7qmz4lqcfbh2c1symfyigv7m634r";
+    sha256 = "1rj0glwqs8rzp8k2n82fjvidig5wbgkrl00mxvs5vbrpldd79kxq";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180622.1";
+  version = "20180704.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1kzz1cmnpmsnrbc9amjcg8rb4a544xx2mpq4g23si6rk46b7n0x7";
+    sha256 = "eb6c0f330e4320092de708750675e3e973038a8b05928734b71a38d5a3ee66cf";
   };
 
   propagatedBuildInputs = [ user-agents ];


### PR DESCRIPTION
###### Motivation for this change
https://www.home-assistant.io/blog/2018/07/06/release-73/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg 