### PR TITLE
qsyncthingtray: fix compile with Qt 5.11

### DIFF
--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -28,6 +28,10 @@ mkDerivation rec {
     name = "support_native_browser.patch";
     url = "https://patch-diff.githubusercontent.com/raw/sieren/QSyncthingTray/pull/225.patch";
     sha256 = "0w665xdlsbjxs977pdpzaclxpswf7xys1q3rxriz181lhk2y66yy";
+  }) (fetchpatch {
+    name = "fix-compile-qt-5-11.patch";
+    url = https://github.com/sieren/QSyncthingTray/commit/849061e5edd694513ea93424423cd34752d309e2.patch;
+    sha256 = "11r24bzp1w18mmgvqplaws8699zpw69f3nvcdfz32f2hvdc7dsks";
   }) ] ++ lib.optional (!preferQWebView && !preferNative) ./qsyncthingtray-0.5.8-qt-5.6.3.patch;
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

qsyncthingtray fails to compile with Qt 5.11 because of the lack of qt5_use_modules.
Grab a patch from upstream.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

