### PR TITLE
config.skipAliases: also disable vim, git, xfce and gnome3 aliases

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -1,7 +1,7 @@
 /* All git-relates tools live here, in a separate attribute set so that users
  * can get a fast overview over what's available.
  */
-args @ {pkgs}: with args; with pkgs;
+args @ {config, lib, pkgs}: with args; with pkgs;
 let
   gitBase = callPackage ./git {
     texinfo = texinfo5;
@@ -17,8 +17,7 @@ let
     ];
   };
 
-in
-rec {
+  self = rec {
   # Try to keep this generally alphabetized
 
   bfg-repo-cleaner = callPackage ./bfg-repo-cleaner { };
@@ -48,7 +47,6 @@ rec {
   }));
 
   git-annex = pkgs.haskellPackages.git-annex;
-  gitAnnex = git-annex;
 
   git-annex-metadata-gui = libsForQt5.callPackage ./git-annex-metadata-gui {
     inherit (python3Packages) buildPythonApplication pyqt5 git-annex-adapter;
@@ -132,6 +130,10 @@ rec {
 
   transcrypt = callPackage ./transcrypt { };
 
+} // lib.optionalAttrs (config.skipAliases or false == false) (with self; {
   # aliases
+  gitAnnex = git-annex;
   svn_all_fast_export = svn-all-fast-export;
-}
+});
+in
+  self

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -130,7 +130,7 @@ let
 
   transcrypt = callPackage ./transcrypt { };
 
-} // lib.optionalAttrs (config.skipAliases or false == false) (with self; {
+} // lib.optionalAttrs (config.allowAliases or true) (with self; {
   # aliases
   gitAnnex = git-annex;
   svn_all_fast_export = svn-all-fast-export;

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -391,7 +391,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gnome-packagekit = callPackage ./misc/gnome-packagekit { };
 
-} // lib.optionalAttrs (config.skipAliases or false == false) {
+} // lib.optionalAttrs (config.allowAliases or true) {
 #### Legacy aliases
 
   evolution_data_server = evolution-data-server; # added 2018-02-25

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib }:
+{ config, pkgs, lib }:
 
 lib.makeScope pkgs.newScope (self: with self; {
   # Convert a version to branch (3.26.18 → 3.26)
@@ -391,6 +391,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   gnome-packagekit = callPackage ./misc/gnome-packagekit { };
 
+} // lib.optionalAttrs (config.skipAliases or false == false) {
 #### Legacy aliases
 
   evolution_data_server = evolution-data-server; # added 2018-02-25

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs }:
+{ config, lib, pkgs }:
 
 lib.makeScope pkgs.newScope (self: with self; {
   #### NixOS support
@@ -159,6 +159,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfce4_power_manager_gtk3 = xfce4-power-manager.override { withGtk3 = true; };
 
+} // lib.optionalAttrs (config.skipAliases or false == false) {
   #### ALIASES - added 2018-01
 
   terminal = xfce4-terminal;

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -159,7 +159,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfce4_power_manager_gtk3 = xfce4-power-manager.override { withGtk3 = true; };
 
-} // lib.optionalAttrs (config.skipAliases or false == false) {
+} // lib.optionalAttrs (config.allowAliases or true) {
   #### ALIASES - added 2018-01
 
   terminal = xfce4-terminal;

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1,5 +1,5 @@
 # TODO check that no license information gets lost
-{ fetchurl, stdenv, python, git, go, cmake, vim, vimUtils, perl, ruby
+{ config, lib, fetchurl, stdenv, python, git, go, cmake, vim, vimUtils, perl, ruby
 , which, fetchgit, llvmPackages, rustPlatform
 , xkb_switch, rustracerd, fzf, skim
 , python3, boost, icu, ncurses
@@ -14,9 +14,9 @@ let
 
   _skim = skim;
 
-inherit (vimUtils.override {inherit vim;}) rtpPath addRtp buildVimPlugin
-  buildVimPluginFrom2Nix vimHelpTags;
-in
+  inherit (vimUtils.override {inherit vim;}) rtpPath addRtp buildVimPlugin
+    buildVimPluginFrom2Nix vimHelpTags;
+
 
 # TL;DR
 # Add your plugin to ./vim-plugin-names
@@ -32,7 +32,7 @@ in
 # Documentation & usage see vim-utils.nix.
 # attribute names should be the same as used by vim-pi to make dependency
 # resolution work
-rec {
+  self = rec {
   # This is not a plugin, it provides bin/vim-open-buffer-with-plugins-derivations
   # which recreates this the following derivations based on ./vim-plugin-names
   pluginnames2nix = vimUtils.pluginnames2Nix {
@@ -52,114 +52,6 @@ rec {
 
   # Section II
   # Update with vimUtils.vimPlugins.pluginnames2Nix command
-
-  # aliasess
-  airline             = vim-airline;
-  alternative         = a-vim; # backwards compat, added 2014-10-21
-  bats                = bats-vim;
-  calendar            = calendar-vim;
-  coffee-script       = vim-coffee-script;
-  coffeeScript        = coffee-script; # backwards compat, added 2014-10-18
-  Solarized           = vim-colors-solarized;
-  solarized           = vim-colors-solarized;
-  colors-solarized    = vim-colors-solarized;
-  caw                 = caw-vim;
-  colorsamplerpack    = Colour_Sampler_Pack;
-  Colour_Sampler_Pack = Colour-Sampler-Pack;
-  command_T           = command-t; # backwards compat, added 2014-10-18
-  commentary          = vim-commentary;
-  committia           = committia-vim-git;
-  concealedyank       = concealedyank-vim;
-  context-filetype    = context_filetype-vim;
-  Cosco               = cosco-vim;
-  css_color_5056      = vim-css-color;
-  CSApprox            = csapprox;
-  csv                 = csv-vim;
-  ctrlp               = ctrlp-vim;
-  cute-python         = vim-cute-python-git;
-  denite              = denite-nvim;
-  easy-align          = vim-easy-align;
-  easygit             = vim-easygit;
-  easymotion          = vim-easymotion;
-  echodoc             = echodoc-vim;
-  eighties            = vim-eighties;
-  extradite           = vim-extradite;
-  fugitive            = vim-fugitive;
-  ghc-mod-vim         = ghcmod-vim;
-  ghcmod              = ghcmod-vim;
-  goyo                = goyo-vim;
-  Gist                = gist-vim;
-  gitgutter           = vim-gitgutter;
-  gundo               = gundo-vim;
-  Gundo               = gundo-vim; # backwards compat, added 2015-10-03
-  haskellConceal      = haskellconceal; # backwards compat, added 2014-10-18
-  haskellConcealPlus  = vim-haskellConcealPlus;
-  haskellconceal      = vim-haskellconceal;
-  hier                = vim-hier;
-  hlint-refactor      = hlint-refactor-vim;
-  hoogle              = vim-hoogle;
-  Hoogle              = vim-hoogle;
-  ipython             = vim-ipython;
-  latex-live-preview  = vim-latex-live-preview;
-  mayansmoke          = mayansmoke-git;
-  multiple-cursors    = vim-multiple-cursors;
-  necoGhc             = neco-ghc; # backwards compat, added 2014-10-18
-  neocomplete         = neocomplete-vim;
-  neoinclude          = neoinclude-vim;
-  neomru              = neomru-vim;
-  neosnippet          = neosnippet-vim;
-  neoyank             = neoyank-vim-git;
-  The_NERD_Commenter  = nerdcommenter;
-  The_NERD_tree       = nerdtree;
-  open-browser        = open-browser-vim;
-  pathogen            = vim-pathogen;
-  peskcolor           = peskcolor-vim-git;
-  polyglot            = vim-polyglot;
-  prettyprint         = vim-prettyprint;
-  quickrun            = vim-quickrun;
-  rainbow_parentheses = rainbow_parentheses-vim;
-  repeat              = vim-repeat;
-  riv                 = riv-vim;
-  rhubarb             = vim-rhubarb;
-  sensible            = vim-sensible;
-  signature           = vim-signature;
-  snipmate            = vim-snipmate;
-  sourcemap           = sourcemap-vim;
-  "sourcemap.vim"     = sourcemap-vim;
-  surround            = vim-surround;
-  sleuth              = vim-sleuth;
-  solidity            = vim-solidity;
-  stylish-haskell     = vim-stylish-haskell;
-  stylishHaskell      = stylish-haskell; # backwards compat, added 2014-10-18
-  Supertab            = supertab;
-  Syntastic           = syntastic;
-  SyntaxRange         = vim-SyntaxRange;
-  table-mode          = vim-table-mode;
-  taglist             = taglist-vim;
-  tabpagebuffer       = tabpagebuffer-vim;
-  tabpagecd           = vim-tabpagecd;
-  Tabular             = tabular;
-  Tagbar              = tagbar;
-  thumbnail           = thumbnail-vim;
-  tlib                = tlib_vim;
-  tmux-navigator      = vim-tmux-navigator;
-  tmuxNavigator       = tmux-navigator; # backwards compat, added 2014-10-18
-  tslime              = tslime-vim;
-  unite               = unite-vim;
-  UltiSnips           = ultisnips;
-  vim-grepper         = vim-grepper-git;
-  vim-test            = vim-test-git;
-  vimproc             = vimproc-vim;
-  vimshell            = vimshell-vim;
-  vinegar             = vim-vinegar;
-  watchdogs           = vim-watchdogs;
-  WebAPI              = webapi-vim;
-  wombat256           = wombat256-vim; # backwards compat, added 2015-7-8
-  yankring            = YankRing-vim;
-  Yankring            = YankRing-vim;
-  YouCompleteMe       = youcompleteme;
-  xterm-color-table   = xterm-color-table-vim;
-  zeavim              = zeavim-vim;
 
   fzfWrapper = buildVimPluginFrom2Nix {
     name = fzf.name;
@@ -3320,4 +3212,115 @@ rec {
     dependencies = [];
 
   };
-}
+
+} // lib.optionalAttrs (config.skipAliases or false == false) (with self; {
+
+  # aliasess
+  airline             = vim-airline;
+  alternative         = a-vim; # backwards compat, added 2014-10-21
+  bats                = bats-vim;
+  calendar            = calendar-vim;
+  coffee-script       = vim-coffee-script;
+  coffeeScript        = coffee-script; # backwards compat, added 2014-10-18
+  Solarized           = vim-colors-solarized;
+  solarized           = vim-colors-solarized;
+  colors-solarized    = vim-colors-solarized;
+  caw                 = caw-vim;
+  colorsamplerpack    = Colour_Sampler_Pack;
+  Colour_Sampler_Pack = Colour-Sampler-Pack;
+  command_T           = command-t; # backwards compat, added 2014-10-18
+  commentary          = vim-commentary;
+  committia           = committia-vim-git;
+  concealedyank       = concealedyank-vim;
+  context-filetype    = context_filetype-vim;
+  Cosco               = cosco-vim;
+  css_color_5056      = vim-css-color;
+  CSApprox            = csapprox;
+  csv                 = csv-vim;
+  ctrlp               = ctrlp-vim;
+  cute-python         = vim-cute-python-git;
+  denite              = denite-nvim;
+  easy-align          = vim-easy-align;
+  easygit             = vim-easygit;
+  easymotion          = vim-easymotion;
+  echodoc             = echodoc-vim;
+  eighties            = vim-eighties;
+  extradite           = vim-extradite;
+  fugitive            = vim-fugitive;
+  ghc-mod-vim         = ghcmod-vim;
+  ghcmod              = ghcmod-vim;
+  goyo                = goyo-vim;
+  Gist                = gist-vim;
+  gitgutter           = vim-gitgutter;
+  gundo               = gundo-vim;
+  Gundo               = gundo-vim; # backwards compat, added 2015-10-03
+  haskellConceal      = haskellconceal; # backwards compat, added 2014-10-18
+  haskellConcealPlus  = vim-haskellConcealPlus;
+  haskellconceal      = vim-haskellconceal;
+  hier                = vim-hier;
+  hlint-refactor      = hlint-refactor-vim;
+  hoogle              = vim-hoogle;
+  Hoogle              = vim-hoogle;
+  ipython             = vim-ipython;
+  latex-live-preview  = vim-latex-live-preview;
+  mayansmoke          = mayansmoke-git;
+  multiple-cursors    = vim-multiple-cursors;
+  necoGhc             = neco-ghc; # backwards compat, added 2014-10-18
+  neocomplete         = neocomplete-vim;
+  neoinclude          = neoinclude-vim;
+  neomru              = neomru-vim;
+  neosnippet          = neosnippet-vim;
+  neoyank             = neoyank-vim-git;
+  The_NERD_Commenter  = nerdcommenter;
+  The_NERD_tree       = nerdtree;
+  open-browser        = open-browser-vim;
+  pathogen            = vim-pathogen;
+  peskcolor           = peskcolor-vim-git;
+  polyglot            = vim-polyglot;
+  prettyprint         = vim-prettyprint;
+  quickrun            = vim-quickrun;
+  rainbow_parentheses = rainbow_parentheses-vim;
+  repeat              = vim-repeat;
+  riv                 = riv-vim;
+  rhubarb             = vim-rhubarb;
+  sensible            = vim-sensible;
+  signature           = vim-signature;
+  snipmate            = vim-snipmate;
+  sourcemap           = sourcemap-vim;
+  "sourcemap.vim"     = sourcemap-vim;
+  surround            = vim-surround;
+  sleuth              = vim-sleuth;
+  solidity            = vim-solidity;
+  stylish-haskell     = vim-stylish-haskell;
+  stylishHaskell      = stylish-haskell; # backwards compat, added 2014-10-18
+  Supertab            = supertab;
+  Syntastic           = syntastic;
+  SyntaxRange         = vim-SyntaxRange;
+  table-mode          = vim-table-mode;
+  taglist             = taglist-vim;
+  tabpagebuffer       = tabpagebuffer-vim;
+  tabpagecd           = vim-tabpagecd;
+  Tabular             = tabular;
+  Tagbar              = tagbar;
+  thumbnail           = thumbnail-vim;
+  tlib                = tlib_vim;
+  tmux-navigator      = vim-tmux-navigator;
+  tmuxNavigator       = tmux-navigator; # backwards compat, added 2014-10-18
+  tslime              = tslime-vim;
+  unite               = unite-vim;
+  UltiSnips           = ultisnips;
+  vim-grepper         = vim-grepper-git;
+  vim-test            = vim-test-git;
+  vimproc             = vimproc-vim;
+  vimshell            = vimshell-vim;
+  vinegar             = vim-vinegar;
+  watchdogs           = vim-watchdogs;
+  WebAPI              = webapi-vim;
+  wombat256           = wombat256-vim; # backwards compat, added 2015-7-8
+  yankring            = YankRing-vim;
+  Yankring            = YankRing-vim;
+  YouCompleteMe       = youcompleteme;
+  xterm-color-table   = xterm-color-table-vim;
+  zeavim              = zeavim-vim;
+});
+in self

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -3213,7 +3213,7 @@ let
 
   };
 
-} // lib.optionalAttrs (config.skipAliases or false == false) (with self; {
+} // lib.optionalAttrs (config.allowAliases or true) (with self; {
 
   # aliasess
   airline             = vim-airline;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17909,7 +17909,7 @@ let self = _self // overrides; _self = with self; {
     };
   };
 
-} // stdenv.lib.optionalAttrs (config.skipAliases or false == false) {
+} // stdenv.lib.optionalAttrs (config.allowAliases or true) {
   autodie = null; # part of Perl
   AutoLoader = null; # part of Perl 5.22
   constant = null; # part of Perl 5.22

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -97,8 +97,7 @@ let
       res self;
     in res;
 
-  aliases = self: super: if config.skipAliases or false then {}
-                         else import ./aliases.nix lib self super;
+  aliases = self: super: lib.optionalAttrs (config.allowAliases or true) (import ./aliases.nix lib self super);
 
   # stdenvOverrides is used to avoid having multiple of versions
   # of certain dependencies that were used in bootstrapping the


### PR DESCRIPTION
###### Motivation for this change

add possibility to disable aliases with ```config.skipAliases``` introduced in #39686

Small clean-up, no rebuild at all.

cc @matthewbauer 