### PR TITLE
watch: 0.2.0 -> procps-ng.version (now 3.3.15)

### DIFF
--- a/pkgs/os-specific/linux/procps/watch.nix
+++ b/pkgs/os-specific/linux/procps/watch.nix
@@ -10,6 +10,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = https://sourceforge.net/projects/procps/;
     description = "Utility for watch the output of a given command at intervals";
-    platforms = stdenv.lib.platforms.unix;
+    inherit (procps-ng.meta) platforms;
   };
 }

--- a/pkgs/os-specific/linux/procps/watch.nix
+++ b/pkgs/os-specific/linux/procps/watch.nix
@@ -1,21 +1,11 @@
-{ stdenv, fetchurl, ncurses }:
+{ stdenv, procps-ng }:
 
 stdenv.mkDerivation {
-  name = "watch-0.2.0";
+  name = "watch-${procps-ng.version}";
 
-  src = fetchurl {
-    url = http://procps.sourceforge.net/procps-3.2.8.tar.gz;
-    sha256 = "0d8mki0q4yamnkk4533kx8mc0jd879573srxhg6r2fs3lkc6iv8i";
-  };
+  unpackPhase = "true";
 
-  buildInputs = [ ncurses ];
-
-  makeFlags = "watch usrbin_execdir=$(out)/bin" +
-              (if stdenv.isDarwin then " PKG_LDFLAGS=" else "");
-
-  enableParallelBuilding = true;
-
-  installPhase = "mkdir $out; mkdir -p $out/bin; cp -p watch $out/bin";
+  installPhase = "install -D ${procps-ng}/bin/watch $out/bin/watch";
 
   meta = {
     homepage = https://sourceforge.net/projects/procps/;


### PR DESCRIPTION
###### Motivation for this change

```watch``` seems outdated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

