### PR TITLE
Fixes `stripDirs` use after signature change

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -164,7 +164,7 @@ let
 
       # Strip binaries further than normal.
       chmod -R u+w $out
-      stripDirs "lib bin" "-s"
+      stripDirs "$STRIP" "lib bin" "-s"
 
       # Run patchelf to make the programs refer to the copied libraries.
       find $out/bin $out/lib -type f | while read i; do

--- a/pkgs/development/compilers/openjdk/10.nix
+++ b/pkgs/development/compilers/openjdk/10.nix
@@ -142,7 +142,7 @@ let
 
     # FIXME: this is unnecessary once the multiple-outputs branch is merged.
     preFixup = ''
-      prefix=$jre stripDirs "$stripDebugList" "''${stripDebugFlags:--S}"
+      prefix=$jre stripDirs "$STRIP" "$stripDebugList" "''${stripDebugFlags:--S}"
       patchELF $jre
       propagatedBuildInputs+=" $jre"
 

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -206,7 +206,7 @@ let
 
     # FIXME: this is unnecessary once the multiple-outputs branch is merged.
     preFixup = ''
-      prefix=$jre stripDirs "$stripDebugList" "''${stripDebugFlags:--S}"
+      prefix=$jre stripDirs "$STRIP" "$stripDebugList" "''${stripDebugFlags:--S}"
       patchELF $jre
       propagatedBuildInputs+=" $jre"
 


### PR DESCRIPTION
###### Motivation for this change

Since a1cdc2011ed049cf8a7a0f2f7909d401dc8d9457, `stripDirs` now takes an addition prefixed parameters, the strip command to run.

It turns out, there were two additional users of `stripDirs` inside the whole of `<nixpkgs>`, they are `openjdk` and `stage-1.nix`. The way the command was changed made it so that the stripping *wasn't done anymore*.

This adds `$STRIP` as the first parameter to `stripDirs`, which I believe makes it equivalent to its older behaviour.

###### Testing done

 * Using `mobile-nixos`, which has the same `stage-1` steps changed here, a `boot.img` was reduced from 17M to 9M.
 * Ran `nixos/tests/boot-stage1.nix`
 * `jar` from `openjdk8` runs... (don't have more extensive tests I know of)
 * Currently building `openjdk10`

`nix-path-info -S` Before:

```
/nix/store/bmz3h4vb4f7h5v1qwk72hgibvflmx9k0-openjdk-8u172b11      327843824
/nix/store/qwzms0kzmpjgfb8d43wja3nvvmznyx0q-openjdk-10.0.1-b10    708972096
```

`nix-path-info -S` After:

```
/nix/store/9rzm9xmq7harjjc4c6rjlp7q0hrnf2ml-openjdk-8u172b11      327843072
/nix/store/8ilbvds7rmkgs1mmmrmnnqa0pqlb7gwa-openjdk-10.0.1-b10    708962000
```


###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ❌ other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ❌ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

 * cc @edolstra this affects stage-1
 * cc @Ericson2314 due to changes to the behaviour of `stripDirs`
