### PR TITLE
bliss: fix header location

### DIFF
--- a/pkgs/applications/science/math/bliss/default.nix
+++ b/pkgs/applications/science/math/bliss/default.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation rec {
     mv html/* COPYING* $out/share/doc/bliss
     mv *.a $out/lib
     mv *.h *.hh $out/include/bliss
-    export BLISS_DIR=$out
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/math/bliss/default.nix
+++ b/pkgs/applications/science/math/bliss/default.nix
@@ -21,11 +21,12 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/doc/bliss $out/lib $out/include
+    mkdir -p $out/bin $out/share/doc/bliss $out/lib $out/include/bliss
     mv bliss $out/bin 
     mv html/* COPYING* $out/share/doc/bliss
     mv *.a $out/lib
-    mv *.h *.hh $out/include
+    mv *.h *.hh $out/include/bliss
+    export BLISS_DIR=$out
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

In order to be detected automatically, the bliss include directory is expected by dependent packages (scipoptsuite) to have a certain structure which is imposed by the present commit. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

