### PR TITLE
[staging] pango: 1.40.14 -> 1.42.1

### DIFF
--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, libXft, cairo, harfbuzz
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libXft, cairo, harfbuzz, fribidi
 , libintl, gobjectIntrospection, darwin
 }:
 
 with stdenv.lib;
 
 let
-  ver_maj = "1.40";
-  ver_min = "14";
+  ver_maj = "1.42";
+  ver_min = "1";
 in
 stdenv.mkDerivation rec {
   name = "pango-${ver_maj}.${ver_min}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/pango/${ver_maj}/${name}.tar.xz";
-    sha256 = "90af1beaa7bf9e4c52db29ec251ec4fd0a8f2cc185d521ad1f88d01b3a6a17e3";
+    sha256 = "0cnfgcya3wbs9m8g44cl5ww6wbp6qbw96qvsgkr8ymwqn9b6fnli";
   };
 
   outputs = [ "bin" "dev" "out" "devdoc" ];
@@ -25,16 +25,9 @@ stdenv.mkDerivation rec {
        CoreGraphics
        CoreText
     ]);
-  propagatedBuildInputs = [ cairo harfbuzz libXft libintl ];
+  propagatedBuildInputs = [ cairo harfbuzz libXft libintl fribidi ];
 
   enableParallelBuilding = true;
-
-  doCheck = false; # test-layout fails on 1.40.3 (fails to find font config)
-  # jww (2014-05-05): The tests currently fail on Darwin:
-  #
-  # ERROR:testiter.c:139:iter_char_test: assertion failed: (extents.width == x1 - x0)
-  # .../bin/sh: line 5: 14823 Abort trap: 6 srcdir=. PANGO_RC_FILE=./pangorc ${dir}$tst
-  # FAIL: testiter
 
   configureFlags = optional stdenv.isDarwin "--without-x";
 


### PR DESCRIPTION
###### Motivation for this change

new version, tests passed (at least on ```x86_64-linux```)