### PR TITLE
buildah: 0.12 -> 1.1

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -1,15 +1,15 @@
 { stdenv, lib, buildGoPackage, fetchFromGitHub, runCommand
-, gpgme, libgpgerror, devicemapper, btrfs-progs, pkgconfig, ostree, libselinux
+, gpgme, libgpgerror, devicemapper, btrfs-progs, pkgconfig, ostree, libselinux, libseccomp
 , go-md2man }:
 
 let
-  version = "0.12";
+  version = "1.1";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "projectatomic";
     repo = "buildah";
-    sha256 = "0xyq7rv0lj6bxwh2rnf44w9gjcqbdkfcdff88023b9vlsc8h4k0m";
+    sha256 = "0pc7bzcaafrz56glygzhnbilgaz4ca2kmklw8njfgamffbw4d54p";
   };
   goPackagePath = "github.com/projectatomic/buildah";
 
@@ -22,8 +22,11 @@ in buildGoPackage rec {
   inherit goPackagePath;
   excludedPackages = [ "tests" ];
 
+  # Optimizations break compilation of libseccomp c bindings
+  hardeningDisable = [ "fortify" ];
+
   nativeBuildInputs = [ pkgconfig go-md2man.bin ];
-  buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs ostree libselinux ];
+  buildInputs = [ gpgme libgpgerror devicemapper btrfs-progs ostree libselinux libseccomp ];
 
   # Copied from the skopeo package, doesn’t seem to make a difference?
   # If something related to these libs failed, uncomment these lines.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

