### PR TITLE
 python.pkgs.vobject: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -1,24 +1,36 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub
-, vobject, mock, tox, pytestcov, pytest-django, pytest, shortuuid
-, django, six
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder
+, six, typing
+, django, shortuuid, python-dateutil, pytest
+, pytest-django, pytestcov, mock, vobject
+, werkzeug, glibcLocales
 }:
 
 buildPythonPackage rec {
   pname = "django-extensions";
-  version = "1.8.1";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
-    owner = "${pname}";
-    repo = "${pname}";
-    rev = "${version}";
-    sha256 = "08rd9zswvjb9dixzyd3p3l3hw3wwhqkgyjvid65niybzjl1xdb5h";
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "1xf84wq7ab1zfb3nmf4qgw6mjf5xafjwr3175dyrqrrn6cpvcr4a";
   };
 
-  buildInputs = [ vobject mock tox pytestcov pytest-django pytest shortuuid ];
+  postPatch = ''
+    substituteInPlace setup.py --replace "'tox'," ""
+  '';
 
-  propagatedBuildInputs = [ django six ];
+  propagatedBuildInputs = [ six ] ++ lib.optional (pythonOlder "3.5") typing;
 
-  meta = with stdenv.lib; {
+  checkInputs = [
+    django shortuuid python-dateutil pytest
+    pytest-django pytestcov mock vobject
+    werkzeug glibcLocales
+  ];
+
+  LC_ALL = "en_US.UTF-8";
+
+  meta = with lib; {
     description = "A collection of custom extensions for the Django Framework";
     homepage = https://github.com/django-extensions/django-extensions;
     license = licenses.mit;

--- a/pkgs/development/python-modules/google-api-python-client/default.nix
+++ b/pkgs/development/python-modules/google-api-python-client/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi
-, httplib2, six, google-auth-httplib2, uritemplate }:
+, httplib2, google_auth, google-auth-httplib2, six, uritemplate, oauth2client }:
 
 buildPythonPackage rec {
   pname = "google-api-python-client";
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   # No tests included in archive
   doCheck = false;
 
-  propagatedBuildInputs = [ httplib2 google-auth-httplib2 six uritemplate ];
+  propagatedBuildInputs = [ httplib2 google_auth google-auth-httplib2 six uritemplate oauth2client ];
 
   meta = with lib; {
     description = "The core Python library for accessing Google APIs";

--- a/pkgs/development/python-modules/vobject/default.nix
+++ b/pkgs/development/python-modules/vobject/default.nix
@@ -1,12 +1,12 @@
 { lib, buildPythonPackage, fetchPypi, isPyPy, python, dateutil }:
 
 buildPythonPackage rec {
-  version = "0.9.5";
+  version = "0.9.6";
   pname = "vobject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f56cae196303d875682b9648b4bb43ffc769d2f0f800958e0a506af867b1243";
+    sha256 = "cd9ede4363f83c06ba8d8f1541c736efa5c46f9a431430002b2f84f4f4e674d8";
   };
 
   disabled = isPyPy;

--- a/pkgs/servers/radicale/default.nix
+++ b/pkgs/servers/radicale/default.nix
@@ -7,12 +7,20 @@ let
   python = python3.override {
     packageOverrides = self: super: {
 
-      # https://github.com/eventable/vobject/issues/112
+      # Packages pinned in setup.py.
+      # Starting with next release, a vendored version of vobject will be used.
       python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
         version = "2.6.1";
         src = oldAttrs.src.override {
           inherit version;
           sha256 = "891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca";
+        };
+      });
+      vobject = super.vobject.overridePythonAttrs (oldAttrs: rec {
+        version = "0.9.5";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0f56cae196303d875682b9648b4bb43ffc769d2f0f800958e0a506af867b1243";
         };
       });
 

--- a/pkgs/tools/misc/papis/default.nix
+++ b/pkgs/tools/misc/papis/default.nix
@@ -7,14 +7,14 @@ let
 
 in python.pkgs.buildPythonApplication rec {
   pname = "papis";
-  version = "0.5.3";
+  version = "0.6";
 
   # Missing tests on Pypi
   src = fetchFromGitHub {
     owner = "papis";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1yc4ilb7bw099pi2vwawyf8mi0n1kp87wgwgwcwc841ibq62q8ic";
+    sha256 = "0zy8q154zhpqb75c775nwq3mdl1szhzhkfi0nvyjmzfgsv2g1wa2";
   };
 
   postPatch = ''
@@ -26,7 +26,7 @@ in python.pkgs.buildPythonApplication rec {
     argcomplete arxiv2bib beautifulsoup4 bibtexparser
     configparser dmenu-python habanero papis-python-rofi
     pylibgen prompt_toolkit pyparser python_magic pyyaml
-    requests unidecode urwid vobject tkinter
+    requests unidecode urwid vobject tkinter whoosh
     vim
   ];
 

--- a/pkgs/tools/misc/papis/default.nix
+++ b/pkgs/tools/misc/papis/default.nix
@@ -3,20 +3,7 @@
 }:
 
 let
-  python = python3.override {
-    packageOverrides = self: super: {
-
-      # https://github.com/eventable/vobject/issues/112
-      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
-        version = "2.6.1";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca";
-        };
-      });
-
-    };
-  };
+  python = python3;
 
 in python.pkgs.buildPythonApplication rec {
   pname = "papis";


### PR DESCRIPTION
###### Motivation for this change
Vobject now works with python-dateutil 2.7.
See also #42782.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

