### PR TITLE
pyre: init at 0.0.8

### DIFF
--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchFromGitHub, ocamlPackages, makeWrapper, writeScript }:
+let
+  # Manually set version - the setup script requires
+  # hg and git + keeping the .git directory around.
+  version = "0.0.8";
+  versionFile = writeScript "version.ml" ''
+    cat > "./version.ml" <<EOF
+    let build_info () =
+    "pyre-nixpkgs ${version}"
+    let version () =
+    "${version}"
+    EOF
+  '';
+in stdenv.mkDerivation {
+  name = "pyre-${version}";
+
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "pyre-check";
+    rev = "v${version}";
+    sha256 = "0c4km27xnzsqcqvjqxmqak37x473z6azlbldy7f05ghkms7mchrw";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = with ocamlPackages; [
+    ocaml
+    findlib
+    menhir
+    yojson
+    core
+    sedlex
+    ppx_deriving_yojson
+    ocamlbuild
+    ppxlib
+  ];
+
+  buildPhase = ''
+    # build requires HOME to be set
+    export HOME=.
+
+    # "external" because https://github.com/facebook/pyre-check/pull/8/files
+    sed "s/%VERSION%/external ${version}/" Makefile.template > Makefile
+
+    cp ${versionFile} ./scripts/generate-version-number.sh
+
+    mkdir $(pwd)/build
+    export OCAMLFIND_DESTDIR=$(pwd)/build
+    export OCAMLPATH=$OCAMLPATH:$(pwd)/build
+    make release
+  '';
+
+  checkPhase = ''
+    make test
+  '';
+
+  # Note that we're not installing the typeshed yet.
+  # Improvement for a future version.
+  installPhase = ''
+    mkdir -p $out/bin
+    cp _build/all/main.native $out/bin/pyre
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A performant type-checker for Python 3";
+    homepage = https://pyre-check.org;
+    license = licenses.mit;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ teh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6578,6 +6578,10 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_06;
   };
 
+  pyre = callPackage ../development/tools/pyre {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_06;
+  };
+
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
   glslang = callPackage ../development/compilers/glslang { };


### PR DESCRIPTION
###### Motivation for this change

Working version of https://github.com/NixOS/nixpkgs/pull/40809

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

