### PR TITLE
whitebox-tools: init at 0.9.0

### DIFF
--- a/pkgs/applications/gis/whitebox-tools/default.nix
+++ b/pkgs/applications/gis/whitebox-tools/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, rustPlatform , fetchFromGitHub, Security }:
+rustPlatform.buildRustPackage rec {
+  name = "whitebox_tools-${version}";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "jblindsay";
+    repo = "whitebox-tools";
+    rev = "6221cdf327be70f0ee4f2053b76bfa01c3f37caa";
+    sha256 = "1423ga964mz7qkl88vkcm8qfprsksx04aq4sz9v5ghnmdzzvl89x";
+  };
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
+
+  cargoSha256 = "1gbgirng21ak0kl3fiyr6lxwzrjd5v79gcrbzf941nb8y8rlvz7k";
+
+  meta = with stdenv.lib; {
+    description = "An advanced geospatial data analysis platform";
+    homepage = http://www.uoguelph.ca/~hydrogeo/WhiteboxTools/index.html;
+    license = licenses.mit;
+    maintainers = [ maintainers.mpickering ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18861,6 +18861,10 @@ with pkgs;
     freerdp = freerdp_legacy;
   };
 
+  whitebox-tools = callPackage ../applications/gis/whitebox-tools {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   windowlab = callPackage ../applications/window-managers/windowlab { };
 
   windowmaker = callPackage ../applications/window-managers/windowmaker { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

