### PR TITLE
pythonPackages.dkimpy: 0.6.2 -> 0.8.1

### DIFF
--- a/pkgs/development/python-modules/authres/default.nix
+++ b/pkgs/development/python-modules/authres/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchPypi, buildPythonPackage, python }:
+
+buildPythonPackage rec {
+  pname = "authres";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1mcllhrwr23hwa2jn3m15k29ks1205ymwafjzchh8ma664hnzv6v";
+  };
+
+  checkPhase = ''
+    # run doctests
+    ${python.interpreter} -m authres
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Email Authentication-Results Headers generation and parsing for Python/Python3";
+    longDescription = ''
+      Python module that implements various internet RFC's: 5451/7001/7601
+      Authentication-Results Headers generation and parsing for
+      Python/Python3.
+    '';
+    homepage = https://launchpad.net/authres;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/development/python-modules/dkimpy/default.nix
+++ b/pkgs/development/python-modules/dkimpy/default.nix
@@ -1,38 +1,25 @@
-{ stdenv, fetchurl, openssl, makeWrapper, buildPythonApplication
-, pytest, dnspython }:
+{ stdenv, fetchPypi, openssl, makeWrapper, buildPythonPackage
+, pytest, dnspython, pynacl, authres, python }:
 
-let
-  majorversion = "0.6";
-  minorversion = "2";
-in buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "dkimpy";
-  version = "${majorversion}.${minorversion}";
+  version = "0.8.1";
 
-  src = fetchurl {
-    url = "https://launchpad.net/${pname}/${majorversion}/${majorversion}.${minorversion}/+download/${pname}-${version}.tar.gz";
-    sha256 = "1hagz8qk0v4ijfbcdq4z28bpgr2mkpr498z76i1vam2d50chmakl";
-  };
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "125xakqg2j5jp4k5kafpnpazh9d97ysgayrsgpvm3nkdj4g8hw1j";
+};
 
   checkInputs = [ pytest ];
-  propagatedBuildInputs =  [ openssl dnspython ];
+  propagatedBuildInputs =  [ openssl dnspython pynacl authres ];
 
   patchPhase = ''
-    substituteInPlace dknewkey.py --replace \
+    substituteInPlace dkim/dknewkey.py --replace \
       /usr/bin/openssl ${openssl}/bin/openssl
   '';
 
   checkPhase = ''
-    python ./test.py
-  '';
-
-  postInstall = ''
-    mkdir -p $out/bin $out/libexec
-    mv $out/bin/*.py $out/libexec
-    makeWrapper "$out/libexec/dkimverify.py" $out/bin/dkimverify
-    makeWrapper "$out/libexec/dkimsign.py" $out/bin/dkimsign
-    makeWrapper "$out/libexec/arcverify.py" $out/bin/arcverify
-    makeWrapper "$out/libexec/arcsign.py" $out/bin/arcsign
-    makeWrapper "$out/libexec/dknewkey.py" $out/bin/dknewkey
+    ${python.interpreter} ./test.py
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -615,7 +615,7 @@ with pkgs;
 
   dgsh = callPackage ../shells/dgsh { };
 
-  dkimpy = pythonPackages.dkimpy;
+  dkimpy = with pythonPackages; toPythonApplication dkimpy;
 
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -195,6 +195,8 @@ in {
     inherit (pkgs) augeas;
   };
 
+  authres = callPackage ../development/python-modules/authres { };
+
   autograd = callPackage ../development/python-modules/autograd { };
 
   automat = callPackage ../development/python-modules/automat { };


### PR DESCRIPTION
###### Motivation for this change

Bumped version. Packaged dependency (authres) as separate commit.
Note that dkimpy both serves as a library and contains a set of tools.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

