### PR TITLE
qtox: 1.15.0 -> 1.16.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -7,7 +7,7 @@
 , AVFoundation ? null }:
 
 let
-  version = "1.15.0";
+  version = "1.16.1";
   rev = "v${version}";
 
 in mkDerivation rec {
@@ -16,7 +16,7 @@ in mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "qTox";
     repo   = "qTox";
-    sha256 = "1garwnlmg452b0bwx36rsh08s15q3zylb26l01iiwg4l9vcaldh9";
+    sha256 = "05cz67yvdqjv1dmqycnc5rd0275zh94wyaa7sqdkr1iw8k5h955n";
     inherit rev;
   };
 

--- a/pkgs/development/libraries/libtoxcore/default.nix
+++ b/pkgs/development/libraries/libtoxcore/default.nix
@@ -51,7 +51,7 @@ in rec {
   };
 
   libtoxcore_0_2 = generic {
-    version = "0.2.2";
-    sha256 = "1463grbbv009pj2g6dbnyk4lr871vw41962m63v21mmp6dkrr7r5";
+    version = "0.2.3";
+    sha256 = "1z8638cmxssc4jvbf64x549m84pz28729xbxc4c4ss1k792x30ya";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

libtoxcore is updated at the same time and according to ```nox-review``` all packages depending on libtoxcore are working as planned.

Cc: @viric @jgeerds @akaWolf

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

