### PR TITLE
[staging] substitute(): --subst-var was silently coercing to "" if the variable does not exist.

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -661,6 +661,10 @@ substituteStream() {
                     echo "substituteStream(): ERROR: substitution variables must be valid Bash names, \"$varName\" isn't." >&2
                     return 1
                 fi
+                if [ -z ${!varName+x} ]; then
+                    echo "substituteStream(): ERROR: variable \$$varName is unset" >&2
+                    return 1
+                fi
                 pattern="@$varName@"
                 replacement="${!varName}"
                 ;;


### PR DESCRIPTION
###### Motivation for this change

From @Profpatsch's [comment](https://github.com/NixOS/nixpkgs/pull/35304#issuecomment-367723420): 
> It looks to me like there’s other funny business going on, like --subst-var silently coercing to "" if the variable does not exist.

As that PR is abandoned, this small feature needs its own PR

