### PR TITLE
anydesk: fix application shortcut

### DIFF
--- a/pkgs/applications/networking/remote/anydesk/default.nix
+++ b/pkgs/applications/networking/remote/anydesk/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, makeWrapper
-, cairo, gdk_pixbuf, glib, gnome2, gtk2, pango, xorg
+{ stdenv, fetchurl, autoPatchelfHook, makeWrapper, makeDesktopItem
+, atk, cairo, freetype, gdk_pixbuf, glib, gnome2, gtk2, libGLU_combined, pango, xorg
 , lsb-release }:
 
 let
@@ -13,6 +13,18 @@ let
     "i686-linux"   = "i686";
   }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
+  description = "Desktop sharing application, providing remote support and online meetings";
+
+  desktopItem = makeDesktopItem rec {
+    name = "anydesk";
+    exec = "@out@/bin/anydesk";
+    icon = "anydesk";
+    desktopName = "anydesk";
+    genericName = description;
+    categories = "Application;Network;";
+    startupNotify = "false";
+  };
+
 in stdenv.mkDerivation rec {
   name = "anydesk-${version}";
   version = "2.9.4";
@@ -22,35 +34,43 @@ in stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  libPath = stdenv.lib.makeLibraryPath ([
-    cairo gdk_pixbuf glib gtk2 stdenv.cc.cc pango
-    gnome2.gtkglext
+  buildInputs = [
+    atk cairo gdk_pixbuf glib gtk2 stdenv.cc.cc pango
+    gnome2.gtkglext libGLU_combined
   ] ++ (with xorg; [
-    libxcb libX11 libXdamage libXext libXfixes libXi
+    libxcb libX11 libXdamage libXext libXfixes libXi libXmu
     libXrandr libXtst
-  ]));
+  ]);
 
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/{bin,share/icons/hicolor,share/doc/anydesk}
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/{applications,doc/anydesk,icons/hicolor}
     install -m755 anydesk $out/bin/anydesk
     cp changelog copyright README $out/share/doc/anydesk
     cp -r icons/* $out/share/icons/hicolor/
+    cp ${desktopItem}/share/applications/*.desktop $out/share/applications
+
+    runHook postInstall
   '';
 
   postFixup = ''
     patchelf \
       --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
-      --set-rpath "${libPath}" \
+      --set-rpath "${stdenv.lib.makeLibraryPath buildInputs}" \
       $out/bin/anydesk
 
     wrapProgram $out/bin/anydesk \
       --prefix PATH : ${stdenv.lib.makeBinPath [ lsb-release ]}
+
+    substituteInPlace $out/share/applications/*.desktop \
+      --subst-var out
   '';
 
   meta = with stdenv.lib; {
-    description = "Desktop sharing application, providing remote support and online meetings";
+    inherit description;
     homepage = http://www.anydesk.com;
     license = licenses.unfree;
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Missing application shortcut - fixes #43110

Cc @SagnikSRHUSE

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

