### PR TITLE
notify-osd-customizable: init at 0.9.35+16.04.20160415

### DIFF
--- a/pkgs/applications/misc/notify-osd-customizable/default.nix
+++ b/pkgs/applications/misc/notify-osd-customizable/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, dbus-glib
+, fetchurl
+, glib
+, gnome3
+, libnotify
+, libtool
+, libwnck3
+, makeWrapper
+, pkgconfig
+}:
+
+let baseURI = "https://launchpad.net/~leolik/+archive/leolik";
+in stdenv.mkDerivation rec {
+  name = "notify-osd-${version}";
+  version = "0.9.35+16.04.20160415";
+
+  src = fetchurl {
+    url = "${baseURI}/+files/notify-osd_${version}-0ubuntu1-leolik~ppa0.tar.gz";
+    sha256 = "026dr46jh3xc4103wnslzy7pxbxkkpflh52c59j8vzwaa7bvvzkv";
+    name = "notify-osd-customizable.tar.gz";
+  };
+
+  preConfigure = "./autogen.sh --libexecdir=$(out)/bin";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    glib libwnck3 libnotify dbus-glib makeWrapper
+    gnome3.gsettings-desktop-schemas gnome3.gnome-common
+    libtool
+  ];
+
+  configureFlags = "--libexecdir=$(out)/bin";
+
+  preFixup = ''
+    wrapProgram "$out/bin/notify-osd" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Daemon that displays passive pop-up notifications";
+    homepage = https://launchpad.net/notify-osd;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.imalison ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4222,6 +4222,8 @@ with pkgs;
 
   notify-osd = callPackage ../applications/misc/notify-osd { };
 
+  notify-osd-customizable = callPackage ../applications/misc/notify-osd-customizable { };
+
   nox = callPackage ../tools/package-management/nox { };
 
   nq = callPackage ../tools/system/nq { };


### PR DESCRIPTION
###### Motivation for this change

The notify-osd that exists in nixpkgs is not customizable at all. This version allows the user configure notify-osd in ~/.notify-osd. Just for reference, the aur also has a separate version of notify-osd that is pulled from this PPA:

https://aur.archlinux.org/packages/notify-osd-customizable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
-  [x] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A new package] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

