### PR TITLE
Add license to cpdf

### DIFF
--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -24,10 +24,11 @@ stdenv.mkDerivation {
     cp cpdfmanual.pdf $out/share/doc/cpdf/
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://www.coherentpdf.com/;
     platforms = ocaml.meta.platforms or [];
     description = "PDF Command Line Tools";
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = licenses.unfree;
+    maintainers = [ maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

cpdf currently has no license specified. The upstream repo has a "free for non-commercial use" license: https://github.com/johnwhitington/cpdf-source/blob/master/LICENSE

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

