### PR TITLE
gf2x: 1.1 -> 1.2

### DIFF
--- a/pkgs/development/libraries/gf2x/default.nix
+++ b/pkgs/development/libraries/gf2x/default.nix
@@ -1,18 +1,19 @@
 {stdenv, fetchurl}:
 stdenv.mkDerivation rec {
   name = "gf2x-${version}";
-  version = "1.1";
+  version = "1.2";
 
-  # or fetchFromGitHub(owner,repo,rev) or fetchgit(rev)
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/30873/gf2x-1.1.tar.gz";
-    sha256 = "17w4b39j9dvri5s278pxi8ha7mf47j87kq1lr802l4408rh02gqd";
+    # find link to latest version (with file id) here: https://gforge.inria.fr/projects/gf2x/
+    url = "https://gforge.inria.fr/frs/download.php/file/36934/gf2x-1.2.tar.gz";
+    sha256 = "0d6vh1mxskvv3bxl6byp7gxxw3zzpkldrxnyajhnl05m0gx7yhk1";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = ''Routines for fast arithmetic in GF(2)[x]'';
-    license = stdenv.lib.licenses.gpl2Plus;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = ["x86_64-linux"];
+    homepage = http://gf2x.gforge.inria.fr;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Trying to upgrade ntl and adding gf2x support in the process. That requires up to date gf2x.

@7c6f434c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

