### PR TITLE
buildSupport: add helpers for verifying code signatures

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchzip, fetchpgpkey, verifySignatureHook }:
 
 stdenv.mkDerivation rec {
   name = "1password-${version}";
@@ -23,6 +23,19 @@ stdenv.mkDerivation rec {
         stripRoot = false;
       }
     else throw "Architecture not supported";
+
+  nativeBuildInputs = [ verifySignatureHook ];
+
+  signaturePublicKey = fetchpgpkey {
+    url = https://keybase.io/1password/pgp_keys.asc;
+    fingerprint = "3FEF9748469ADBE15DA7CA80AC2D62742012EA22";
+    sha256 = "1v9gic59a3qim3fcffq77jrswycww4m1rd885lk5xgwr0qnqr019";
+  };
+
+  doCheck = true;
+  checkPhase = ''
+    verifySignature op.sig op
+  '';
 
   installPhase = ''
     install -D op $out/bin/op

--- a/pkgs/build-support/fetchpgpkey/default.nix
+++ b/pkgs/build-support/fetchpgpkey/default.nix
@@ -1,0 +1,29 @@
+# This function downloads a PGP public key and verifies its fingerprint
+# Because it is based on fetchurl, it will still require a sha256
+# in addition to the fingerprint
+
+{ lib, fetchurl, gnupg }:
+
+{
+  fingerprint
+, ... } @ args:
+
+lib.overrideDerivation (fetchurl ({
+
+  name = "pubkey-${fingerprint}";
+
+  postFetch =
+    ''
+      # extract fingerprint
+      fpr=$(cat "$downloadedFile" | gpg --homedir . --import --import-options show-only --with-colons 2>/dev/null | grep -m 1 '^fpr' | cut -d: -f 10)
+      # verify
+      if [ "$fpr" == "${fingerprint}" ]; then
+        echo "key fingerprint $fpr verified"
+      else
+        echo "key fingerprint mismatch: got $fpr, expected ${fingerprint}"
+        exit 1
+      fi
+    '';
+
+} // removeAttrs args [ "fingerprint" ] ))
+(x: {nativeBuildInputs = x.nativeBuildInputs++ [gnupg];})

--- a/pkgs/build-support/setup-hooks/verify-signature.sh
+++ b/pkgs/build-support/setup-hooks/verify-signature.sh
@@ -1,0 +1,45 @@
+# Helper functions for verifying (detached) PGP signatures
+
+# importPublicKey
+# Add PGP public key contained in ${publicKey} to the keyring.
+# All imported keys will be trusted by verifySig
+_importPublicKey() {
+  if [ -z "$signaturePublicKey" ]; then
+    echo "error: verifySignatureHook requires signaturePublicKey" >&2
+    exit 1
+  fi
+  gpg -q --import "$signaturePublicKey"
+}
+
+
+# verifySignature SIGFILE DATAFILE UNCOMPRESS
+# verify the signature SIGFILE for the file DATAFILE
+# if DATAFILE is omitted, it is derived from SIGFILE by dropping the .asc or .sig suffix
+# if UNCOMPRESS is set, uncompress DATAFILE before verification
+verifySignature() {
+  if [ -z "$3" ]; then
+    gpgv --keyring pubring.kbx "$1" "$2" || exit 1
+  else
+    gunzip -c "$2" | gpgv --keyring pubring.kbx "$1" - || exit 1
+  fi
+}
+
+
+# verifySrcSignature 
+# verify the signature $srcSignature for source file $src
+verifySrcSignature() {
+  _importPublicKey
+  [ -z "$srcSignature" ] && return
+  verifySignature "$srcSignature" "$src" "$signatureUncompressed"
+}
+
+
+# setup
+
+# create temporary gpg homedir
+export GNUPGHOME=$(readlink -f .gnupgtmp)
+rm -rf $GNUPGHOME # make sure it's a fresh empty dir
+mkdir -p -m 700 $GNUPGHOME
+
+# automatically check the signature before unpack if srcSignature is set
+preUnpackHooks+=(verifySrcSignature)

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, fetchurl, python, pkgconfig, perl, libxslt, docbook_xsl
 , fetchpatch
+, fetchpgpkey
+, verifySignatureHook
 , docbook_xml_dtd_42, docbook_xml_dtd_45, readline, talloc
 , popt, iniparser, libbsd, libarchive, libiconv, gettext
 , krb5Full, zlib, openldap, cups, pam, avahi, acl, libaio, fam, libceph, glusterfs
@@ -29,6 +31,20 @@ stdenv.mkDerivation rec {
     sha256 = "0vkxqp3wh7bpn1fd45lznmrpn2ma1fq75yq28vi08rggr07y7v8y";
   };
 
+  srcSignature = fetchurl {
+    url = "mirror://samba/pub/samba/stable/${name}.tar.asc";
+    sha256 = "0wpcbwbs1bj1y0amhn0z29v55f2hhmzc5p8n7sbwg9kaf0hc5mz5";
+  };
+  signatureUncompressed = true;
+
+  signaturePublicKey = fetchpgpkey {
+    url = https://download.samba.org/pub/samba/samba-pubkey.asc;
+    sha256 = "1fndhq0c34va34z137gvsl9gpwjv30b06makfx8cq5vrmgiax1x1";
+    fingerprint = "52FBC0B86D954B0843324CDC6F33915B6568B7EA";
+  };
+
+  nativeBuildInputs = [ verifySignatureHook ];
+
   outputs = [ "out" "dev" "man" ];
 
   patches =
@@ -40,6 +56,7 @@ stdenv.mkDerivation rec {
         sha256 = "0r6q34vjj0bdzmcbnrkad9rww58k4krbwicv4gs1g3dj49skpvd6";
       })
     ];
+
 
   buildInputs =
     [ python pkgconfig perl libxslt docbook_xsl docbook_xml_dtd_42 /*

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -172,6 +172,8 @@ with pkgs;
 
   fetchpatch = callPackage ../build-support/fetchpatch { };
 
+  fetchpgpkey = callPackage ../build-support/fetchpgpkey { };
+
   fetchs3 = callPackage ../build-support/fetchs3 { };
 
   fetchsvn = callPackage ../build-support/fetchsvn {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -86,6 +86,10 @@ with pkgs;
     { substitutions = { gnu_config = gnu-config;}; }
     ../build-support/setup-hooks/update-autotools-gnu-config-scripts.sh;
 
+  verifySignatureHook = makeSetupHook
+    { name = "verify-signature-hook"; deps = [ gnupg ]; }
+    ../build-support/setup-hooks/verify-signature.sh;
+
   gogUnpackHook = makeSetupHook {
     name = "gog-unpack-hook";
     deps = [ innoextract file-rename ]; }


### PR DESCRIPTION
###### Motivation for this change

Many projects provide signed source tarballs or signed binaries, which are currently not checked in nixpkgs. While it's not perfect, I believe that checking signatures provides some security advantage our typical "TOFU" workflow of implicitly trusting changed sha256 hashes.

The main reason is that, as opposed to sha256 hashes, public keys are usually long term, so we can invest more time to verify them initially, and after doing this once, malicious changes are more likely to be spotted.

This PR proposes some simple helpers for checking code signatures. It also provides some examples on how to use them.

###### Things done

- `fetchpgpkey` is an extension of `fetchurl` that fetches a PGP public key to the nix store and verifies its fingerprint with `gpg`. It still needs a sha256 because it is based on `fetchurl`.  (I have experimented with an alternative implementation using `builtins.fetchurl` and just a fingerprint, no sha256, but that is not strictly a fixed-output derivation).

- `verifySignatureHook` sets up signature verification and adds a `preUnpackHook` to automatically verify the signature `srcSignature` of `src` with `signaturePublicKey` when present. Verification can also be triggered manually using the shell functions defined in the hook.

- Implemented 3 different examples for various use cases of the hook. These examples are for demonstartion and may or may not be merged with this PR. 

    - `samba4`: the tarball is signed, but the signature is for the uncompressed tar archive. The hook has an option for this.
    - `tor-browser-bundle-bin`: provides signed tarballs but there's not standard unpack phase, so the verification must be triggered manually in `buildCommand`
    -  `1password`: the tarball contains a signed binary and the signature file, so verification is done in `checkPhase` here.

###### Possible future work

Enhance `fetchgit` to verify signed revisions using `git verify-commit`.

---

cc @matthewbauer @jb55 @garbas 