### PR TITLE
openblas: backport fix

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, gfortran, perl, which, config, coreutils
+{ stdenv, fetchFromGitHub, fetchpatch, gfortran, perl, which, config, coreutils
 # Most packages depending on openblas expect integer width to match
 # pointer width, but some expect to use 32-bit integers always
 # (for compatibility with reference BLAS).
@@ -80,10 +80,11 @@ in
 stdenv.mkDerivation rec {
   name = "openblas-${version}";
   version = "0.3.1";
-  src = fetchurl {
-    url = "https://github.com/xianyi/OpenBLAS/archive/v${version}.tar.gz";
-    sha256 = "0czbs2afmcxxij1ivqrm04p0qcksg5fravjifhydvb7k6mpraphz";
-    name = "openblas-${version}.tar.gz";
+  src = fetchFromGitHub {
+    owner = "xianyi";
+    repo = "OpenBLAS";
+    rev = "v${version}";
+    sha256 = "1dkwp4gz1hzpmhzks9y9ipb4c5h0r6c7yff62x3s8x9z6f8knaqc";
   };
 
   inherit blas64;
@@ -117,7 +118,14 @@ stdenv.mkDerivation rec {
     ] ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "musl") "NO_AFFINITY=1"
     ++ mapAttrsToList (var: val: var + "=" + val) config;
 
-  patches = []; # TODO: Remove on next mass-rebuild
+    patches = [
+      # Backport of https://github.com/xianyi/OpenBLAS/pull/1667, which
+      # is causing problems and was already accepted upstream.
+      (fetchpatch {
+        url = "https://github.com/xianyi/OpenBLAS/commit/5f2a3c05cd0e3872be3c5686b9da6b627658eeb7.patch";
+        sha256 = "1qvxhk92likrshw6z6hjqxvkblwzgsbzis2b2f71bsvx9174qfk1";
+      })
+    ];
 
   doCheck = true;
   checkTarget = "tests";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/xianyi/OpenBLAS/issues/1666

Causing test failures in cvxopt and (according to an openblas issue) numpy.

Also see https://github.com/cvxopt/cvxopt/issues/122.

@ttuegel 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

