### PR TITLE
linux: Backports linux kernel 4.17 to 18.03

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -116,7 +116,6 @@ with stdenv.lib;
   # Enable various subsystems.
   ACCESSIBILITY y # Accessibility support
   AUXDISPLAY y # Auxiliary Display support
-  DONGLE y # Serial dongle support
   HIPPI y
   MTD_COMPLEX_MAPPINGS y # needed for many devices
   SCSI_LOWLEVEL y # enable lots of SCSI devices
@@ -125,6 +124,9 @@ with stdenv.lib;
   SPI y # needed for many devices
   SPI_MASTER y
   WAN y
+  ${optionalString (versionOlder version "4.17") ''
+    DONGLE y # Serial dongle support
+  ''}
 
   # Networking options.
   NET y
@@ -421,7 +423,9 @@ with stdenv.lib;
   ${optionalString (versionAtLeast version "4.3") ''
     IDLE_PAGE_TRACKING y
   ''}
-  IRDA_ULTRA y # Ultra (connectionless) protocol
+  ${optionalString (versionOlder version "4.17") ''
+    IRDA_ULTRA y # Ultra (connectionless) protocol
+  ''}
   JOYSTICK_IFORCE_232? y # I-Force Serial joysticks and wheels
   JOYSTICK_IFORCE_USB? y # I-Force USB joysticks and wheels
   JOYSTICK_XPAD_FF? y # X-Box gamepad rumble support

--- a/pkgs/os-specific/linux/kernel/linux-4.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.17.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPackages, hostPlatform, fetchurl, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "4.17";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+  modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+    sha256 = "04yd7hnsdyaq4xmrgg7509qjf09k1dy6k1p8qqfrdspajvc1valz";
+  };
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.17.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.17.2";
+  version = "4.17.3";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "173vv0fwykpxhldrr7z83d1wl3ly5mc21nd68f2ycjfw9mpwvssc";
+    sha256 = "1z8zja786x5dxwm69zgfkwsvfwjfznwbclf76301c2fd4wjancmg";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.17.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.17.3";
+  version = "4.17.4";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "1z8zja786x5dxwm69zgfkwsvfwjfznwbclf76301c2fd4wjancmg";
+    sha256 = "0n5by04hshjdc8mh86yg4zkq9y6hhvjx78ialda9ysv2ac63gmk6";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.17.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.17";
+  version = "4.17.1";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "04yd7hnsdyaq4xmrgg7509qjf09k1dy6k1p8qqfrdspajvc1valz";
+    sha256 = "0w3hma7k4nwjp1zsfgn2i18dsmmdn1lxccqx3vapwsz6pjy3ygy9";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.17.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.17.1";
+  version = "4.17.2";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0w3hma7k4nwjp1zsfgn2i18dsmmdn1lxccqx3vapwsz6pjy3ygy9";
+    sha256 = "173vv0fwykpxhldrr7z83d1wl3ly5mc21nd68f2ycjfw9mpwvssc";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-4.17.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.17.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.17.4";
+  version = "4.17.5";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0n5by04hshjdc8mh86yg4zkq9y6hhvjx78ialda9ysv2ac63gmk6";
+    sha256 = "1brfnabv5lprghfyxpdr0b5z2sqdygh50j61swrk6wzzbmk0ci9z";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13316,6 +13316,17 @@ with pkgs;
       ];
   };
 
+  linux_4_17 = callPackage ../os-specific/linux/kernel/linux-4.17.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+        # when adding a new linux version
+        # kernelPatches.cpu-cgroup-v2."4.11"
+        kernelPatches.modinst_arg_list_too_long
+        kernelPatches.bcm2835_mmal_v4l2_camera_driver # Only needed for 4.16!
+      ];
+  };
+
   linux_riscv = callPackage ../os-specific/linux/kernel/linux-riscv.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
@@ -13484,7 +13495,7 @@ with pkgs;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!
-  linuxPackages_latest = linuxPackages_4_14;
+  linuxPackages_latest = linuxPackages_4_17;
   linux_latest = linuxPackages_latest.kernel;
 
   # Build the kernel modules for the some of the kernels.
@@ -13494,6 +13505,7 @@ with pkgs;
   linuxPackages_4_4 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_4);
   linuxPackages_4_9 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_9);
   linuxPackages_4_14 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_14);
+  linuxPackages_4_17 = recurseIntoAttrs (linuxPackagesFor pkgs.linux_4_17);
   # Don't forget to update linuxPackages_latest!
 
   # Intentionally lacks recurseIntoAttrs, as -rc kernels will quite likely break out-of-tree modules and cause failed Hydra builds.


### PR DESCRIPTION
###### Motivation for this change

`linuxPackages_latest` [was (understandably) downgraded from 4.16 to 4.14, since the 4.16 series isn't supported anymore](https://github.com/NixOS/nixpkgs/commit/298e170b36b79f4c6b19816a7abbf8392a490840).

The commit message was:

> It would be nice to have 4.17, but ATM it won't build;
> some changes in the (shared) kernel config would be needed.

Here I have backported with cherry-picked conflict-resolved the relevant commits to make 4.17 build for 18.03, and the relevant updates. Do tell if keeping the whole commit history cherry-picked is too much.

###### Testing done

I am currently dogfooding the use of 4.17 on 18.03 with this branch on my machine.

I don't know of NixOS tests that test `linuxPackages_latest`. I don't know either if one of tests can be used to test another kernel.

I have not tested most packages depending on the kernel, except the default settings [+ VirtualBox](https://github.com/NixOS/nixpkgs/pull/43237).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ❌ other Linux distributions
- ❓ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- 🆖 Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Determined the impact on package closure size (by running `nix path-info -S` before and after) **new package, closure sizes goes from 0 to 66304848**.
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

