### PR TITLE
virtualbox: 5.2.8 -> 5.2.12 (18.03)

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -21,10 +21,10 @@ let
   buildType = "release";
   # Manually sha256sum the extensionPack file, must be hex!
   # Do not forget to update the hash in ./guest-additions/default.nix!
-  extpack = "355ea5fe047f751534720c65398b44290d53f389e0f5f66818f3f36746631d26";
-  extpackRev = "121009";
-  main = "ee2759d47b0b4ac81b8b671c9485c87fb2db12c097b3e7e69b94c1291a8084e8";
-  version = "5.2.8";
+  extpack = "5eef217dbe0a8e8caf383ea8db83344517af0f9093041b5345c8468a427b327b";
+  extpackRev = "122406";
+  main = "1k14ngz1gcz02qwbpzfp4kgxv8s24js8pwd5nyyqs6jpxx6557pd";
+  version = "5.2.10";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -23,8 +23,8 @@ let
   # Do not forget to update the hash in ./guest-additions/default.nix!
   extpack = "5eef217dbe0a8e8caf383ea8db83344517af0f9093041b5345c8468a427b327b";
   extpackRev = "122406";
-  main = "1k14ngz1gcz02qwbpzfp4kgxv8s24js8pwd5nyyqs6jpxx6557pd";
-  version = "5.2.10";
+  main = "0n1lip8lkz4qqq5ml47xldsx41919ncfh060i7yj51bhas604q6s";
+  version = "5.2.12";
 
   # See https://github.com/NixOS/nixpkgs/issues/672 for details
   extensionPack = requireFile rec {

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -21,8 +21,8 @@ let
   buildType = "release";
   # Manually sha256sum the extensionPack file, must be hex!
   # Do not forget to update the hash in ./guest-additions/default.nix!
-  extpack = "5eef217dbe0a8e8caf383ea8db83344517af0f9093041b5345c8468a427b327b";
-  extpackRev = "122406";
+  extpack = "4c36d129f17dcab2bb37292022f1b1adfefa5f32a3161b0d5d40784bc8acf4d0";
+  extpackRev = "122591";
   main = "0n1lip8lkz4qqq5ml47xldsx41919ncfh060i7yj51bhas604q6s";
   version = "5.2.12";
 

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "04q8d2dxhkkqbghqidcwv6mx57fqpp92smh7gnaxb7vqqskb9dl0";
+    sha256 = "b81d283d9ef88a44e7ac8983422bead0823c825cbfe80417423bd12de91b8046";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";


### PR DESCRIPTION
###### Motivation for this change

Backports VirtualBox 5.2.12 through cherry-picks since it is required for using under [kernel 4.17](https://github.com/NixOS/nixpkgs/pull/43235).

Furthermore, having up-to-date software like VirtualBox seems like a good idea.

###### Things done

Dogfooding it here!

Tested it works both under 4.14 and 4.17.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - 🆖 other Linux distributions
- ✔️ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

```
 $ nix path-info -S $(nix-build -A virtualbox --no-out-link)
/nix/store/z8l8zpnv502n6yiqhpnyk2a3p9j4w7x9-virtualbox-5.2.12     758515504
```

---

