### PR TITLE
triggerhappy: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3791,6 +3791,11 @@
     github = "Radvendii";
     name = "Taeer Bar-Yam";
   };
+  taha = {
+    email = "xrcrod@gmail.com";
+    github = "tgharib";
+    name = "Taha Gharib";
+  };
   tailhook = {
     email = "paul@colomiets.name";
     github = "tailhook";

--- a/pkgs/tools/inputmethods/triggerhappy/default.nix
+++ b/pkgs/tools/inputmethods/triggerhappy/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, perl }:
+
+stdenv.mkDerivation rec {
+  name = "triggerhappy-${version}";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "https://github.com/wertarbyte/triggerhappy/archive/release/${version}.tar.gz";
+    sha256 = "af0fc196202f2d35153be401769a9ad9107b5b6387146cfa8895ae9cafad631c";
+  };
+
+  buildInputs = [ perl ];
+  installFlags = [ "DESTDIR=$(out)" ];  
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "/usr/" "/"
+    substituteInPlace Makefile --replace "/sbin/" "/bin/"
+  '';
+
+  postInstall = ''
+    install -D -m 644 -t "$out/etc/triggerhappy/triggers.d" "triggerhappy.conf.examples"
+    install -D -m 644 -t "$out/usr/lib/systemd/system" "systemd/triggerhappy.service" "systemd/triggerhappy.socket"
+    install -D -m 644 -t "$out/usr/lib/udev/rules.d" "udev/triggerhappy-udev.rules"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A lightweight hotkey daemon";
+    longDescription = ''
+      Triggerhappy is a hotkey daemon developed with small and embedded systems in
+      mind, e.g. linux based routers. It attaches to the input device files and
+      interprets the event data received and executes scripts configured in its
+      configuration.
+    '';
+    homepage = https://github.com/wertarbyte/triggerhappy/;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.taha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5440,6 +5440,8 @@ with pkgs;
 
   trickle = callPackage ../tools/networking/trickle {};
 
+  triggerhappy = callPackage ../tools/inputmethods/triggerhappy {};
+
   trousers = callPackage ../tools/security/trousers { };
 
   tryton = callPackage ../applications/office/tryton { };


### PR DESCRIPTION
###### Motivation for this change

Added triggerhappy hotkey daemon to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

