### PR TITLE
options.i18n.inputMethod.package: fix type

### DIFF
--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -50,7 +50,7 @@ in
 
       package = mkOption {
         internal = true;
-        type     = types.path;
+        type     = types.nullOr types.path;
         default  = null;
         description = ''
           The input method method package.


### PR DESCRIPTION
###### Motivation for this change

A function which enumerates options crashed on this ```default = null``` when ```null``` is not allowed by the type
