### PR TITLE
syncplay: 1.5.3 -> 1.5.5

### DIFF
--- a/pkgs/applications/networking/syncplay/default.nix
+++ b/pkgs/applications/networking/syncplay/default.nix
@@ -2,23 +2,18 @@
 
 python2Packages.buildPythonApplication rec {
   name = "syncplay-${version}";
-  version = "1.5.3";
+  version = "1.5.5";
 
   format = "other";
 
   src = fetchurl {
-    url = https://github.com/Syncplay/syncplay/archive/v1.5.3.tar.gz;
-    sha256 = "1yk0aajskhk6czpjshf9a9pzp3rafh5cgdcyyz8pwpk4ca9zyzfv";
+    url = https://github.com/Syncplay/syncplay/archive/v1.5.5.tar.gz;
+    sha256 = "0g12hm84c48fjrmwljl0ii62f55vm6fk2mv8vna7fadabmk6dwhr";
   };
 
   propagatedBuildInputs = with python2Packages; [ pyside twisted ];
 
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
-
-  postInstall = ''
-    mkdir -p $out/lib/python2.7/site-packages
-    mv $out/lib/syncplay/syncplay $out/lib/python2.7/site-packages/
-  '';
+  makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     homepage = https://syncplay.pl/;


### PR DESCRIPTION
Leave syncplay to install to the correct directory rather than moving
folders around to make it work.

###### Motivation for this change
Update the latest version of syncplay as well as using `PREFIX` instead of `DESTDIR` to ensure syncplay installs everything correctly. Previously, the resources would be in the wrong folder and no icons would show in syncplay.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ryantm 

replaces #43155 