### PR TITLE
spoofer: init at 1.3.2

### DIFF
--- a/pkgs/tools/networking/spoofer/default.nix
+++ b/pkgs/tools/networking/spoofer/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, pkgconfig, protobuf, openssl, libpcap, traceroute
+, withGUI ? false, qt5 }:
+
+let inherit (stdenv.lib) optional optionalString;
+in
+
+stdenv.mkDerivation rec {
+  pname = "spoofer";
+  version = "1.3.2";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://www.caida.org/projects/spoofer/downloads/${name}.tar.gz";
+    sha256 = "05297dyyq8bdpbr3zz974l7vm766lq1bsxvzp5pa4jfpvnj7cl1g";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl protobuf libpcap traceroute ]
+                ++ optional withGUI qt5.qtbase ;
+
+  meta = with stdenv.lib; {
+    homepage = https://www.caida.org/projects/spoofer;
+    description = "Assess and report on deployment of source address validation";
+    longDescription = ''
+      Spoofer is a new client-server system for Windows, MacOS, and
+      UNIX-like systems that periodically tests a network's ability to
+      both send and receive packets with forged source IP addresses
+      (spoofed packets). This can be used to produce reports and
+      visualizations to inform operators, response teams, and policy
+      analysts. The system measures different types of forged
+      addresses, including private and neighboring addresses.  The
+      test results allows to analyze characteristics of networks
+      deploying source address validation (e.g., network location,
+      business type).
+    '';
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ leenaars];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8514,6 +8514,10 @@ with pkgs;
     flex = flex_2_5_35;
   };
 
+  spoofer = callPackage ../tools/networking/spoofer { };
+
+  spoofer-gui = callPackage ../tools/networking/spoofer { withGUI = true; };
+
   sqlitebrowser = libsForQt5.callPackage ../development/tools/database/sqlitebrowser { };
 
   sselp = callPackage ../tools/X11/sselp{ };


### PR DESCRIPTION
###### Motivation for this change

A useful research tool by CAIDA for those wishing to understand spoofing.
The license information comes from http://www.caida.org/tools/, as it is not included in
the tarball.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

