### PR TITLE
Revert removal of `linux_testing_bcachefs` from "linux: remove versions unmaintained upstream"

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
+++ b/pkgs/os-specific/linux/kernel/linux-testing-bcachefs.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPackages, hostPlatform, fetchgit, perl, buildLinux, ... } @ args:
+
+buildLinux (args // rec {
+  version = "4.15.2018.02.09";
+  modDirVersion = "4.15.0";
+  extraMeta.branch = "master";
+  extraMeta.maintainers = [ stdenv.lib.maintainers.davidak ];
+
+  src = fetchgit {
+    url = "https://evilpiepirate.org/git/bcachefs.git";
+    rev = "4506cd5ead31209a6a646c2412cbc7be735ebda4";
+    sha256 = "0fcyf3y27k2lga5na4dhdyc47br840gkqynv8gix297pqxgidrib";
+  };
+
+  extraConfig = ''
+    BCACHEFS_FS m
+  '';
+
+  # Should the testing kernels ever be built on Hydra?
+  extraMeta.hydraPlatforms = [];
+
+} // (args.argsOverride or {}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13327,6 +13327,18 @@ with pkgs;
       ];
   };
 
+  linux_testing_bcachefs = callPackage ../os-specific/linux/kernel/linux-testing-bcachefs.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.modinst_arg_list_too_long
+      ]
+      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      [ kernelPatches.mips_fpureg_emu
+        kernelPatches.mips_fpu_sigill
+        kernelPatches.mips_ext3_n32
+      ];
+  };
+
   linux_riscv = callPackage ../os-specific/linux/kernel/linux-riscv.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
@@ -13529,6 +13541,9 @@ with pkgs;
       };
     };
     in tinyLinuxPackages.kernel;
+
+  # Build a kernel with bcachefs module
+  linuxPackages_testing_bcachefs = recurseIntoAttrs (linuxPackagesFor pkgs.linux_testing_bcachefs);
 
   # Build a kernel for Xen dom0
   linuxPackages_xen_dom0 = recurseIntoAttrs (linuxPackagesFor (pkgs.linux.override { features.xen_dom0=true; }));


### PR DESCRIPTION
Revert removal of `linux_testing_bcachefs` from "linux: remove versions unmaintained upstream"

This reverts parts of commit 298e170b36b79f4c6b19816a7abbf8392a490840.

###### Motivation for this change

Some users were relying on `linux_testing_bcachefs` to build and boot their systems:

 * Fixes #43253
 * https://github.com/NixOS/nixpkgs/blob/release-18.03/nixos/modules/tasks/filesystems/bcachefs.nix

This commit is a `git revert --no-commit 298e170b36b79f4c6b19816a7abbf8392a490840` with careful work to only pick back the relevant bits.

I have not personally tested this other than evaluating and compiling. I am assuming it will work since this is a revert. Furthermore, I am not dogfooding this.

Finally, I'm not 100% sure of the reason for removing `linux_testing_bcachefs` in 18.03. If there is any reason not to put it back, close this. I have made the fix mainly because I could.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ❌ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ❌ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Size impact should be minimal, probably nil when comparing to what the size was before the removal.

---

