### PR TITLE
pythonPackages.sumo: init at 1.0.9 ( And other packages that sumo depends on)

### DIFF
--- a/pkgs/development/python-modules/palettable/default.nix
+++ b/pkgs/development/python-modules/palettable/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "palettable";
+  version = "3.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0685b223a236bb7e2a900ef7a855ccf9a4027361c8acf400f3b350ea51870f80";
+  };
+
+  checkInputs = [ pytest ];
+ 
+  checkPhase = ''
+    pytest 
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library of color palettes";
+    homepage = https://jiffyclub.github.io/palettable/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/development/python-modules/phonopy/default.nix
+++ b/pkgs/development/python-modules/phonopy/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, python, fetchPypi, numpy, pyyaml, matplotlib, h5py }:
+
+buildPythonPackage rec {
+  pname = "phonopy";
+  version = "1.13.2.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "23970ecdf698e743f9204711e8edfbb33c97667f5f88c7bda3322abbc91d0682";
+  };
+
+  propagatedBuildInputs = [ numpy pyyaml matplotlib h5py ];
+  
+  checkPhase = ''
+    cd test/phonopy
+    ${python.interpreter} -m unittest discover -b
+    cd ../..
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A package for phonon calculations at harmonic and quasi-harmonic levels";
+    homepage = https://atztogo.github.io/phonopy/;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, glibcLocales, numpy, pydispatcher, sympy, requests, monty, ruamel_yaml, six, scipy, tabulate, enum34, matplotlib, palettable, spglib, pandas }:
+
+buildPythonPackage rec {
+  pname = "pymatgen";
+  version = "2018.6.27";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8078af7fda4f9a07f1e389ffe08de3511213acdf9fb2ed9f9ffe89b9b12b8568";
+  };
+
+  nativeBuildInputs = [ glibcLocales ];
+  propagatedBuildInputs = [ numpy pydispatcher sympy requests monty ruamel_yaml six scipy tabulate enum34 matplotlib palettable spglib pandas ];
+  
+  # No tests in pypi tarball.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A robust materials analysis code that defines core object representations for structures and molecules";
+    homepage = http://pymatgen.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/development/python-modules/sumo/default.nix
+++ b/pkgs/development/python-modules/sumo/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, scipy, spglib, pymatgen, h5py, matplotlib, seekpath, phonopy }:
+
+buildPythonPackage rec {
+  pname = "sumo";
+  version = "1.0.9";
+
+  # No tests in Pypi tarball
+  src = fetchFromGitHub {
+    owner = "SMTG-UCL";
+    repo = "sumo";
+    rev = "v${version}";
+    sha256 = "1zw86qp9ycw2k0anw6pzvwgd3zds0z2cwy0s663zhiv9mnb5hx1n";
+  };
+
+  propagatedBuildInputs = [ numpy scipy spglib pymatgen h5py matplotlib seekpath phonopy ];
+  
+  meta = with stdenv.lib; {
+    description = "Toolkit for plotting and analysis of ab initio solid-state calculation data";
+    homepage = https://github.com/SMTG-UCL/sumo;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -348,6 +348,8 @@ in {
 
   pdfx = callPackage ../development/python-modules/pdfx { };
 
+  phonopy = callPackage ../development/python-modules/phonopy { };
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -424,6 +424,8 @@ in {
   };
 
   pykerberos = callPackage ../development/python-modules/pykerberos { };
+  
+  pymatgen = callPackage ../development/python-modules/pymatgen { };
 
   pynisher = callPackage ../development/python-modules/pynisher { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -503,6 +503,8 @@ in {
 
   spglib = callPackage ../development/python-modules/spglib { };
 
+  sumo = callPackage ../development/python-modules/sumo { };
+
   supervise_api = callPackage ../development/python-modules/supervise_api { };
 
   syncserver = callPackage ../development/python-modules/syncserver {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -340,6 +340,8 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
+  palettable = callPackage ../development/python-modules/palettable { };
+
   pdf2image = callPackage ../development/python-modules/pdf2image { };
 
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };


### PR DESCRIPTION
sumo: init at 1.0.9, phonopy: init at 1.13.2.13, pymatgen: init at 2018.6.27, palettable:init at 3.1.1
For pymatgen, test are available in Github repo but the repo is 150 MB of size. I also had a problem running them because of an issue i couldn't understand. if any one can take a look and help me understand the issue would be great.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

