### PR TITLE
ocamlPackages.iri: init at 0.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/iri/default.nix
+++ b/pkgs/development/ocaml-modules/iri/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitLab, ocaml, findlib
+, sedlex, uunf, uutf
+}:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "iri is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.4.0";
+  name = "ocaml${ocaml.version}-iri-${version}";
+
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = "zoggy";
+    repo = "ocaml-iri";
+    rev = version;
+    sha256 = "0fsmfmzmyggm0h77a7mb0n41vqi6q4ln1xzsv72zbvysa7l8w84q";
+  };
+
+  buildInputs = [ ocaml findlib ];
+
+  propagatedBuildInputs = [ sedlex uunf uutf ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    description = "IRI (RFC3987) native OCaml implementation";
+    license = stdenv.lib.licenses.lgpl3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools_versioned/default.nix
@@ -1,10 +1,8 @@
-{ stdenv, buildOcaml, fetchFromGitHub, ocaml-migrate-parsetree }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocaml-migrate-parsetree }:
 
-buildOcaml rec {
-  name = "ppx_tools_versioned";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ppx_tools_versioned-${version}";
   version = "5.1";
-
-  minimumSupportedOcamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "let-def";
@@ -12,6 +10,8 @@ buildOcaml rec {
     rev = version;
     sha256 = "1c7kvca67qpyr4hiy492yik5x31lmkhyhy5wpl0l0fbx7fr7l624";
   };
+
+  buildInputs = [ ocaml findlib ];
 
   propagatedBuildInputs = [ ocaml-migrate-parsetree ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -321,6 +321,8 @@ let
 
     inifiles = callPackage ../development/ocaml-modules/inifiles { };
 
+    iri = callPackage ../development/ocaml-modules/iri { };
+
     jingoo = callPackage ../development/ocaml-modules/jingoo {
       pcre = ocaml_pcre;
     };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

