### PR TITLE
pyrescene: init at 0.7

### DIFF
--- a/pkgs/applications/misc/pyrescene/default.nix
+++ b/pkgs/applications/misc/pyrescene/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "pyrescene-${version}";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/Gfy/pyrescene/get/${version}.tar.gz";
+    sha256 = "0cx25y150vvqk38j46i7g0npnvhh89drpjz2b0nlxhy6770g5025";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "port of ReScene .NET to the Python programming language";
+    longDescription = ''
+      ReScene is a mechanism for backing up and restoring the metadata from
+      "scene" released RAR files. RAR archive volumes are rebuild using the
+      stored metadata in the SRR file and the extracted files from the RAR
+      archive.
+    '';
+    homepage = http://rescene.wikidot.com/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4646,6 +4646,8 @@ with pkgs;
 
   pygmentex = callPackage ../tools/typesetting/pygmentex { };
 
+  pyrescene = callPackage ../applications/misc/pyrescene { };
+
   pythonIRClib = pythonPackages.pythonIRClib;
 
   pythonSexy = pythonPackages.libsexy;


### PR DESCRIPTION
###### Motivation for this change

Small python utility to manage scene releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

