### PR TITLE
pciutils: use standardized equivalent for canonicalize_file_name

### DIFF
--- a/pkgs/tools/system/pciutils/default.nix
+++ b/pkgs/tools/system/pciutils/default.nix
@@ -22,6 +22,16 @@ stdenv.mkDerivation rec {
 
   installTargets = "install install-lib";
 
+  # Use standardized and equivalent realpath(path, NULL) instead of canonicalize_file_name(path).
+  # This is documented to be equivalent, see `man 3 canonicalize_file_name`.
+  # Fixes w/musl.
+  # Upstream PR: https://github.com/pciutils/pciutils/pull/6
+  postPatch = ''
+    substituteInPlace lib/sysfs.c \
+      --replace "canonicalize_file_name(path)" \
+                "realpath(path, NULL)"
+  '';
+
   # Get rid of update-pciids as it won't work.
   postInstall = "rm $out/sbin/update-pciids $out/man/man8/update-pciids.8";
 


### PR DESCRIPTION
Fixes w/musl.



Update broke build w/musl, fix by using equivalent standard method.

Unusually "clear-cut" fix, see `man 3 canonicalize_file_name`.

Will be sending upstream momentarily...


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---