### PR TITLE
androidndk: Use `callPackage` to support overriding the `fullNdk` option

### DIFF
--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -224,7 +224,7 @@ rec {
 
   androidsdk_latest = androidsdk_8_0;
 
-  androidndk_10e = import ./androidndk.nix {
+  androidndk_10e = pkgs.callPackage ./androidndk.nix {
     inherit (buildPackages)
       unzip makeWrapper;
     inherit (pkgs)
@@ -235,7 +235,7 @@ rec {
     sha256 = "032j3sgk93bjbkny84i17ph61dhjmsax9ddqng1zbi2p7dgl0pzf";
   };
 
-  androidndk_16b = import ./androidndk.nix {
+  androidndk_16b = pkgs.callPackage ./androidndk.nix {
     inherit (buildPackages)
        unzip makeWrapper;
     inherit (pkgs)
@@ -246,7 +246,7 @@ rec {
     sha256 = "00frcnvpcsngv00p6l2vxj4cwi2mwcm9lnjvm3zv4wrp6pss9pmw";
   };
 
-  androidndk_17 = import ./androidndk.nix {
+  androidndk_17 = pkgs.callPackage ./androidndk.nix {
     inherit (buildPackages)
       unzip makeWrapper;
     inherit (pkgs)


### PR DESCRIPTION
###### Motivation for this change
I wanted to override the `fullNdk` option.

@matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

