### PR TITLE
gomuks: 2018-05-14 -> 2018-7-10

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gomuks/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gomuks/default.nix
@@ -2,15 +2,15 @@
 
 buildGo110Package rec {
   name = "gomuks-${version}";
-  version = "2018-05-16";
+  version = "2018-07-10";
 
   goPackagePath = "maunium.net/go/gomuks";
 
   src = fetchFromGitHub {
     owner = "tulir";
     repo = "gomuks";
-    rev = "512ca88804268bf58a754e8a02be556f953db317";
-    sha256 = "1bpgjkpvqqks3ljw9s0hm5pgscjs4rjy8rfpl2444m4rbpz1xvmr";
+    rev = "68db26bcace31297471641fe95f8882e301f5699";
+    sha256 = "0dagdvsvn8nwqsvjbqk1c6gg2q1m40869nayrkwm3ndg2xkfdpm6";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Routine update, fixing a crash on sync

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

