### PR TITLE
[18.03] linux-hardened: Adjust for Linux 4.17

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -55,6 +55,9 @@ ${optionalString (versionOlder version "4.11") ''
 # via the selinux=0 boot parameter.
 ${optionalString (versionAtLeast version "4.12") ''
   SECURITY_SELINUX_DISABLE n
+''}
+
+${optionalString ((versionAtLeast version "4.12") && (versionOlder version "4.17")) ''
   SECURITY_WRITABLE_HOOKS n
 ''}
 

--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -28,7 +28,9 @@ ${optionalString (stdenv.platform.kernelArch == "x86_64") ''
   # Reduce attack surface by disabling various emulations
   IA32_EMULATION n
   X86_X32 n
-  MODIFY_LDT_SYSCALL? n
+  ${optionalString (versionOlder version "4.17") ''
+    MODIFY_LDT_SYSCALL? n
+  ''}
 
   VMAP_STACK y # Catch kernel stack overflows
 


### PR DESCRIPTION
###### Motivation for this change

Backport hardened config fixes for Linux 4.17 as a consequence of #43235.

cc @vcunat @samueldr @NeQuissimus 

Checked that `linux_latest_hardened` builds with this locally.
