### PR TITLE
pstoedit: patch to ensure gs-9.22 compatibilty

### DIFF
--- a/pkgs/tools/graphics/pstoedit/default.nix
+++ b/pkgs/tools/graphics/pstoedit/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "147jkgvm9n6mbkl6ndqnm9x74x5y9agbxkfwj0jrw6yxyhxx2cdd";
   };
 
+  #
+  # Turn on "-rdb" option (REALLYDELAYBIND) by default to ensure compatibility with gs-9.22
+  #
+  patches = [ ./pstoedit-gs-9.22-compat.patch  ];
+
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ zlib ghostscript imagemagick plotutils gd libjpeg libwebp ]

--- a/pkgs/tools/graphics/pstoedit/pstoedit-gs-9.22-compat.patch
+++ b/pkgs/tools/graphics/pstoedit/pstoedit-gs-9.22-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/src/pstoeditoptions.h b/src/pstoeditoptions.h
+index 7846883..0fb6a6f 100755
+--- a/src/pstoeditoptions.h
++++ b/src/pstoeditoptions.h
+@@ -453,7 +453,7 @@ private:
+ 		"Later versions of Ghostscript will probably support -dDELAYBIND again. "
+ 		"But also in that case the security risk remains. So be careful with what "
+ 		"files you process with pstoedit and Ghostscript.",
+-		false),	//
++		true),	//
+ #endif
+ 	pagetoextract		(true, "-page","page number",g_t,"extract a specific page: 0 means all pages",
+ 		"Select a single page from a multi-page PostScript or PDF file.",


### PR DESCRIPTION
###### Motivation for this change
`pstoedit` calls ghostscript with the `DELAYBIND` option. This option is not support anymore
in gs-9.22. It is now called `REALLYDELAYBIND`. Newer versions of `pstoedit` add a compatibility switch
(`-rdb`) to activate the new option. However, programs like inkscape, which call `pstoedit` in the background do not know about this requirement and will fail eventually (i.e. `gs` refuses to the take old  `DELAYBIND` option).

With this patch typesetting LaTex formulas in `inkscape` works again.

###### Things done
Introduce patch to turn on `-rdb` command line option by default.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @MarcWeber 