### PR TITLE
Typo in nixos/tests/taskserver.nix

### DIFF
--- a/nixos/tests/taskserver.nix
+++ b/nixos/tests/taskserver.nix
@@ -18,7 +18,7 @@ import ./make-test.nix ({ pkgs, ... }: let
     crlTemplate = pkgs.writeText "snakeoil-crl.template" ''
       expiration_days = -1
     '';
-    userCertTemplace = pkgs.writeText "snakoil-user-cert.template" ''
+    userCertTemplate = pkgs.writeText "snakeoil-user-cert.template" ''
       organization = snakeoil
       cn = server
       expiration_days = -1
@@ -49,7 +49,7 @@ import ./make-test.nix ({ pkgs, ... }: let
     certtool -p --bits 4096 | sed -n \
       -e '/^----* *BEGIN/,/^----* *END/p' > "$out/alice.key"
 
-    certtool -c --template "$userCertTemplace" \
+    certtool -c --template "$userCertTemplate" \
                 --load-privkey "$out/alice.key" \
                 --load-ca-privkey ca.key \
                 --load-ca-certificate "$cacert" \


### PR DESCRIPTION
`snakoil` -> `snakeoil`

