### PR TITLE
plasma-workspace: Add patch for missing systemmonitor exec line

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-workspace/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-workspace/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, lib,
+  mkDerivation, lib, fetchpatch,
 
   extra-cmake-modules, kdoctools,
 
@@ -66,7 +66,13 @@ mkDerivation {
   # Add upstream patches to the list below. For new patchs, particularly if not
   # submitted upstream, please make a pull request and add it to
   # ./plasma-workspace.patch.
-  patches = [ ./plasma-workspace.patch ];
+  patches = [
+    ./plasma-workspace.patch
+    (fetchpatch {
+      url = "https://github.com/KDE/plasma-workspace/commit/11e570d861858f3b3e2694e5f9ec242d7f9f12b9.patch";
+      sha256 = "1vk9yacb59k0v5mgbpgmciflca9r0ll4wh1d83ffx2y2v8sqwiv2";
+    })
+  ];
 
   preConfigure = ''
     NIX_CFLAGS_COMPILE+=" -DNIXPKGS_KDOSTARTUPCONFIG5=\"''${!outputBin}/bin/kdostartupconfig5\""


### PR DESCRIPTION
###### Motivation for this change


###### Things done

@peterhoeg @adisbladis 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

