### PR TITLE
qt511.qtbase: fix darwin build

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -41,6 +41,8 @@ let
       ./qtbase.patch
       ./qtbase-darwin.patch
       ./qtbase-revert-no-macos10.10.patch
+    ] ++ optionals stdenv.isDarwin [
+      ./qtbase-darwin-nseventtype.patch
     ];
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];

--- a/pkgs/development/libraries/qt-5/5.11/qtbase-darwin-nseventtype.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtbase-darwin-nseventtype.patch
@@ -1,0 +1,13 @@
+--- a/src/plugins/platforms/cocoa/qcocoawindow.mm
++++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
+@@ -404,8 +404,8 @@ void QCocoaWindow::setVisible(bool visible)
+                         removeMonitor();
+                         monitor = [NSEvent addGlobalMonitorForEventsMatchingMask:NSLeftMouseDownMask|NSRightMouseDownMask|NSOtherMouseDownMask|NSMouseMovedMask handler:^(NSEvent *e) {
+                             QPointF localPoint = QCocoaScreen::mapFromNative([NSEvent mouseLocation]);
+-                            const auto button = e.type == NSEventTypeMouseMoved ? Qt::NoButton : cocoaButton2QtButton([e buttonNumber]);
+-                            const auto eventType = e.type == NSEventTypeMouseMoved ? QEvent::MouseMove : QEvent::MouseButtonPress;
++                            const auto button = e.type == NSMouseMoved ? Qt::NoButton : cocoaButton2QtButton([e buttonNumber]);
++                            const auto eventType = e.type == NSMouseMoved ? QEvent::MouseMove : QEvent::MouseButtonPress;
+                             QWindowSystemInterface::handleMouseEvent(window(), window()->mapFromGlobal(localPoint.toPoint()), localPoint,
+                                                                      Qt::MouseButtons(uint(NSEvent.pressedMouseButtons & 0xFFFF)), button, eventType);
+                         }];


### PR DESCRIPTION
###### Motivation for this change

Qt 5.11.1 replaced one occurrence of NSMouseMoved with NSEventTypeMouseMoved:
https://github.com/qt/qtbase/commit/da32360ffc3c7b677355c37ae54c89637c18047f.

It is not available in AppKit from macOS 10.10, therefore this change restores
NSMouseMoved: https://developer.apple.com/documentation/appkit/nsmousemoved

Closes #43258

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).