### PR TITLE
hetzner-kube: init at version 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1144,6 +1144,11 @@
     github = "proteansec";
     name = "Dejan Lukan";
   };
+  eliasp = {
+    email = "mail@eliasprobst.eu";
+    github = "eliasp";
+    name = "Elias Probst";
+  };
   elijahcaine = {
     email = "elijahcainemv@gmail.com";
     github = "pop";

--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoPackage, fetchFromGitHub, ... }:
+
+let version = "0.3.1"; in
+
+buildGoPackage {
+  name = "hetzner-kube-${version}";
+
+  src = fetchFromGitHub {
+    owner = "xetys";
+    repo = "hetzner-kube";
+    rev = "${version}";
+    sha256 = "1xldh1ca8ym8cg3w5cxizmhqxwi5kmiin28f320mxdr28fzljc2w";
+  };
+
+  goPackagePath = "github.com/xetys/hetzner-kube";
+
+  meta = {
+    description = "A CLI tool for provisioning Kubernetes clusters on Hetzner Cloud";
+    homepage = https://github.com/xetys/hetzner-kube;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -18,7 +18,7 @@ buildGoPackage {
     description = "A CLI tool for provisioning Kubernetes clusters on Hetzner Cloud";
     homepage = https://github.com/xetys/hetzner-kube;
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ eliasp ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14711,6 +14711,8 @@ with pkgs;
 
   helvetica-neue-lt-std = callPackage ../data/fonts/helvetica-neue-lt-std { };
 
+  hetzner-kube = callPackage ../applications/networking/cluster/hetzner-kube { };
+
   hicolor-icon-theme = callPackage ../data/icons/hicolor-icon-theme { };
 
   hanazono = callPackage ../data/fonts/hanazono { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to use [`hetzner-kube`](https://github.com/xetys/hetzner-kube) and didn't want to work with locally maintained/manually built binaries

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

