### PR TITLE
odpic: 2.4.0 -> 2.4.2

### DIFF
--- a/pkgs/development/libraries/odpic/default.nix
+++ b/pkgs/development/libraries/odpic/default.nix
@@ -2,17 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "odpic-${version}";
-  version = "2.4.0";
+  version = "2.4.2";
 
   src = fetchurl {
     url = "https://github.com/oracle/odpi/archive/v${version}.tar.gz";
-    sha256 = "1z793mg8hmy067xhllip7ca84xy07ca1cqilnr35mbvhmydp03zz";
+    sha256 = "0hw6b38vnh0cgm1iwpgkqa2am86baal6irp9bglacblwh8sshqdi";
   };
-
-  patches = [ (fetchpatch {
-    url = https://github.com/oracle/odpi/commit/31fdd70c06be711840a2668f572c7ee7c4434d18.patch;
-    sha256 = "1f00zp4w7l4vnkg0fmvnkga20ih8kjd5bxvr1nryziibjh1xp41j";
-  }) ];
 
   nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin [ fixDarwinDylibNames ];
 


### PR DESCRIPTION
###### Motivation for this change

Bump.

Changelog: https://oracle.github.io/odpi/doc/releasenotes.html#version-2-4-2-july-9-2018

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

