### PR TITLE
[wip] haskell: add core libraries logic to remove need for global package db

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -228,40 +228,6 @@ stdenv.mkDerivation rec {
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.2.2";
-
-    # Libraries included in this Haskell compiler
-    libraries = [
-      "rts"
-
-      "Cabal-2.0.1.0"
-      "array-0.5.2.0"
-      "base-4.10.1.0"
-      "binary-0.8.5.1"
-      "bytestring-0.10.8.2"
-      "containers-0.5.10.2"
-      "deepseq-1.4.3.0"
-      "directory-1.3.0.2"
-      "filepath-1.4.1.2"
-      "ghc-8.2.2"
-      "ghc-boot-8.2.2"
-      "ghc-boot-th-8.2.2"
-      "ghc-compact-0.1.0.0"
-      "ghc-prim-0.5.1.1"
-      "ghci-8.2.2"
-      "haskeline-0.7.4.0"
-      "hoopl-3.10.2.2"
-      "hpc-0.6.0.3"
-      "integer-gmp-1.0.1.0"
-      "pretty-1.1.3.3"
-      "process-1.6.1.0"
-      "template-haskell-2.12.0.0"
-      "terminfo-0.4.1.0"
-      "time-1.8.0.2"
-      "transformers-0.5.2.0"
-      "unix-2.7.2.2"
-      "xhtml-3000.2.2"
-    ];
-
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -228,6 +228,40 @@ stdenv.mkDerivation rec {
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.2.2";
+
+    # Libraries included in this Haskell compiler
+    libraries = [
+      "rts"
+
+      "Cabal-2.0.1.0"
+      "array-0.5.2.0"
+      "base-4.10.1.0"
+      "binary-0.8.5.1"
+      "bytestring-0.10.8.2"
+      "containers-0.5.10.2"
+      "deepseq-1.4.3.0"
+      "directory-1.3.0.2"
+      "filepath-1.4.1.2"
+      "ghc-8.2.2"
+      "ghc-boot-8.2.2"
+      "ghc-boot-th-8.2.2"
+      "ghc-compact-0.1.0.0"
+      "ghc-prim-0.5.1.1"
+      "ghci-8.2.2"
+      "haskeline-0.7.4.0"
+      "hoopl-3.10.2.2"
+      "hpc-0.6.0.3"
+      "integer-gmp-1.0.1.0"
+      "pretty-1.1.3.3"
+      "process-1.6.1.0"
+      "template-haskell-2.12.0.0"
+      "terminfo-0.4.1.0"
+      "time-1.8.0.2"
+      "transformers-0.5.2.0"
+      "unix-2.7.2.2"
+      "xhtml-3000.2.2"
+    ];
+
   };
 
   meta = {

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -222,7 +222,7 @@ stdenv.mkDerivation (rec {
       "deepseq-1.4.4.0"
       "directory-1.3.2.3"
       "filepath-1.4.2"
-      "ghc-8.6.0.20180627"
+      # "ghc-8.6.0.20180627"
       "ghc-boot-8.6.0.20180627"
       "ghc-boot-th-8.6.0.20180627"
       "ghc-compact-0.1.0.0"

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -208,6 +208,45 @@ stdenv.mkDerivation (rec {
 
     # Our Cabal compiler name
     haskellCompilerName = "ghc-8.4.3";
+
+    # Libraries included in this Haskell compiler
+    libraries = [
+      "rts"
+
+      "Cabal-2.3.0.0"
+      "array-0.5.2.0"
+      "base-4.12.0.0"
+      "binary-0.8.5.1"
+      "bytestring-0.10.8.2"
+      "containers-0.6.0.1"
+      "deepseq-1.4.4.0"
+      "directory-1.3.2.3"
+      "filepath-1.4.2"
+      "ghc-8.6.0.20180627"
+      "ghc-boot-8.6.0.20180627"
+      "ghc-boot-th-8.6.0.20180627"
+      "ghc-compact-0.1.0.0"
+      "ghc-heap-8.6.0.20180627"
+      "ghc-prim-0.5.3"
+      "ghci-8.6.0.20180627"
+      "haskeline-0.7.4.2"
+      "hpc-0.6.0.3"
+      "integer-gmp-1.0.2.0"
+      "libiserv-8.6.1"
+      "mtl-2.2.2"
+      "parsec-3.1.13.0.0.0.0.0"
+      "pretty-1.1.3.6"
+      "process-1.6.3.0"
+      "stm-2.5.0.0"
+      "template-haskell-2.14.0.0"
+      "terminfo-0.4.1.1"
+      "text-1.2.3.0"
+      "time-1.8.0.2"
+      "transformers-0.5.5.0"
+      "unix-2.8.0.0"
+      "xhtml-3000.2.2"
+    ];
+
   };
 
   meta = {

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -7,40 +7,6 @@ self: super: {
   # This compiler version needs llvm 5.x.
   llvmPackages = pkgs.llvmPackages_5;
 
-  # Disable GHC 8.6.x core libraries.
-  array = null;
-  base = null;
-  binary = null;
-  bytestring = null;
-  Cabal = null;
-  containers = null;
-  deepseq = null;
-  directory = null;
-  filepath = null;
-  ghc-boot = null;
-  ghc-boot-th = null;
-  ghc-compact = null;
-  ghc-heap = null;
-  ghc-prim = null;
-  ghci = null;
-  haskeline = null;
-  hpc = null;
-  integer-gmp = null;
-  libiserv = null;
-  mtl = null;
-  parsec = null;
-  pretty = null;
-  process = null;
-  rts = null;
-  stm = null;
-  template-haskell = null;
-  terminfo = null;
-  text = null;
-  time = null;
-  transformers = null;
-  unix = null;
-  xhtml = null;
-
   # Use to be a core-library, but no longer is since GHC 8.4.x.
   hoopl = self.hoopl_3_10_2_2;
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -186,13 +186,14 @@ let
 
   depsBuildBuild = [ nativeGhc ];
   nativeBuildInputs = [ ghc removeReferencesTo ]
-                   ++ map (mkCoreLib ghc) (ghc.libraries or [])
                    ++ optional (allPkgconfigDepends != []) pkgconfig ++
                       setupHaskellDepends ++
                       buildTools ++ libraryToolDepends ++ executableToolDepends ++
                       optionals doCheck testToolDepends ++
                       optionals doBenchmark benchmarkToolDepends;
-  propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends ++ libraryFrameworkDepends;
+  propagatedBuildInputs = buildDepends ++ libraryHaskellDepends
+                      ++ executableHaskellDepends ++ libraryFrameworkDepends
+                      ++ map (mkCoreLib ghc) (ghc.libraries or []);
   otherBuildInputs = extraLibraries ++ librarySystemDepends ++ executableSystemDepends ++ executableFrameworkDepends ++
                      allPkgconfigDepends ++
                      optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testFrameworkDepends) ++

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -1,6 +1,6 @@
 { stdenv, buildPackages, buildHaskellPackages, ghc
 , jailbreak-cabal, hscolour, cpphs, nodejs
-, buildPlatform, hostPlatform, runCommand
+, buildPlatform, hostPlatform
 }:
 
 let
@@ -185,15 +185,12 @@ let
                         optionals doCheck testPkgconfigDepends ++ optionals doBenchmark benchmarkPkgconfigDepends;
 
   depsBuildBuild = [ nativeGhc ];
-  nativeBuildInputs = [ ghc removeReferencesTo ]
-                   ++ optional (allPkgconfigDepends != []) pkgconfig ++
+  nativeBuildInputs = [ ghc removeReferencesTo ] ++ optional (allPkgconfigDepends != []) pkgconfig ++
                       setupHaskellDepends ++
                       buildTools ++ libraryToolDepends ++ executableToolDepends ++
                       optionals doCheck testToolDepends ++
                       optionals doBenchmark benchmarkToolDepends;
-  propagatedBuildInputs = buildDepends ++ libraryHaskellDepends
-                      ++ executableHaskellDepends ++ libraryFrameworkDepends
-                      ++ map (mkCoreLib ghc) (ghc.libraries or []);
+  propagatedBuildInputs = buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends ++ libraryFrameworkDepends;
   otherBuildInputs = extraLibraries ++ librarySystemDepends ++ executableSystemDepends ++ executableFrameworkDepends ++
                      allPkgconfigDepends ++
                      optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testFrameworkDepends) ++
@@ -216,32 +213,11 @@ let
 
   nativeGhcCommand = "${nativeGhc.targetPrefix}ghc";
 
-  buildPkgDb = ghcName: packageConfDir: optionalString (ghc ? libraries) ''
-    # Skip the ghc compiler. We want to avoid referencing it directly
-    # in the output. We don't care about nativeGhc currently because
-    # it doesn't end up in the output (but it might not hurt to do the
-    # same thing there)
-    if [ "$p" = "${ghc}" ]; then
-      continue
-    fi
-  '' + ''
+  buildPkgDb = ghcName: packageConfDir: ''
     if [ -d "$p/lib/${ghcName}/package.conf.d" ]; then
       cp -f "$p/lib/${ghcName}/package.conf.d/"*.conf ${packageConfDir}/
       continue
     fi
-  '';
-
-  # Make a derivation that is just a copy of one of GHC’s core
-  # libraries. This is done to prevent stuff built by GHC from
-  # referencing GHC itself.
-  mkCoreLib = ghc: pkg: runCommand pkg {} ''
-    install -D ${ghc}/lib/${ghc.name}/package.conf.d/${pkg}.conf \
-               $out/lib/${ghc.name}/package.conf.d/${pkg}.conf
-    cp -r ${ghc}/lib/${ghc.name}/${pkg} $out/lib/${ghc.name}/${pkg}
-    substituteInPlace $out/lib/${ghc.name}/package.conf.d/${pkg}.conf \
-      --replace ${ghc} $out
-    ${optionalString (pkg == "rts")
-        "cp -r ${ghc}/lib/${ghc.name}/include $out/lib/${ghc.name}/include"}
   '';
 
 in


### PR DESCRIPTION
This moves core libraries in Haskell to its own derivations. This is
needed to avoid references to the GHC compiler ending up in binaries
built by GHC. Instead of referencing GHC directly, these binaries will
now link to the copies.

Unfortunately, for this to work, we need to know which GHC libraries
exist at evaluation time. This requires maintaining a list of the
builtin library names & their versions in the GHC compiler’s “libs”
attribute. A better way of handling this is needed.

This is still a work in progress.

/cc @kirelagin @bgamari @ElvishJerricco 