### PR TITLE
logmein-hamachi 2.1.0.174 -> 2.1.0.198

### DIFF
--- a/pkgs/tools/networking/logmein-hamachi/default.nix
+++ b/pkgs/tools/networking/logmein-hamachi/default.nix
@@ -9,14 +9,14 @@ let
     else throwSystem;
   throwSystem = throw "Unsupported system: ${stdenv.system}";
   sha256 =
-    if stdenv.system == "x86_64-linux" then "011xg1frhjavv6zj1y3da0yh7rl6v1ax6xy2g8fk3sry9bi2p4j3"
+    if stdenv.system == "x86_64-linux" then "11mxa4kls5xjj3462ycrfvfxb1xkk23p5m9iirvwsi0zdmhpnwm8"
     else if stdenv.system == "i686-linux" then "03ml9xv19km99f0z7fpr21b1zkxvw7q39kjzd8wpb2pds51wnc62"
     else throwSystem;
   libraries = stdenv.lib.makeLibraryPath [ stdenv.cc.cc ];
 
 in stdenv.mkDerivation rec {
   name = "logmein-hamachi-${version}";
-  version = "2.1.0.174";
+  version = "2.1.0.198";
 
   src = fetchurl {
     url = "https://www.vpn.net/installers/${name}-${arch}.tgz";


### PR DESCRIPTION
###### Motivation for this change
Hamachi service dies on login due to incompatible Linux version, as per Hamachi forums, I downloaded a newer version.

###### Things done
Just incremented version number to newest version and installed on my machine (with updating the hash)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

