### PR TITLE
hyperrogue: init at 10.4j

### DIFF
--- a/pkgs/games/hyperrogue/default.nix
+++ b/pkgs/games/hyperrogue/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, SDL, SDL_ttf, SDL_gfx, SDL_mixer, autoreconfHook,
+  libpng, glew }:
+
+stdenv.mkDerivation rec {
+  name = "hyperrogue-${version}";
+  version = "10.4j";
+
+  src = fetchFromGitHub {
+    owner = "zenorogue";
+    repo = "hyperrogue";
+    rev = "v${version}";
+    sha256 = "0p0aplfr5hs5dmkgbd4rhvrdk33gss1wdb7knd2vf27n4c2avjcl";
+  };
+
+  CPPFLAGS = "-I${SDL.dev}/include/SDL";
+
+  buildInputs = [ autoreconfHook SDL SDL_ttf SDL_gfx SDL_mixer libpng glew ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.roguetemple.com/z/hyper/;
+    description = "A roguelike game set in hyperbolic geometry";
+    maintainers = with maintainers; [ rardiol ];
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19345,6 +19345,8 @@ with pkgs;
 
   holdingnuts = callPackage ../games/holdingnuts { };
 
+  hyperrogue = callPackage ../games/hyperrogue { };
+
   icbm3d = callPackage ../games/icbm3d { };
 
   ingen = callPackage ../applications/audio/ingen {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I wish I was good enough at autoconf to understand why I need to set CPPFLAGS.

Does nixpkgs deal fine with this "10.4j" version naming scheme?
