### PR TITLE
ghc861: use llvm6 so we're using supported LLVM version

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -75,8 +75,8 @@ in rec {
     ghc861 = callPackage ../development/compilers/ghc/8.6.1.nix rec {
       bootPkgs = packages.ghc822;
       inherit (bootPkgs) alex happy hscolour;
-      buildLlvmPackages = buildPackages.llvmPackages_5;
-      llvmPackages = pkgs.llvmPackages_5;
+      buildLlvmPackages = buildPackages.llvmPackages_6;
+      llvmPackages = pkgs.llvmPackages_6;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
       bootPkgs = packages.ghc821Binary;


### PR DESCRIPTION
Otherwise complains that LLVM version used is unsupported
and that LLVM 6.0 is the only supported version.

So, let's use it! :)

-----

This only impacts the cases where LLVM is used,
which currently means GHC's target'ing non-("x86"-glibc).

(`, useLLVM ? !targetPlatform.isx86 || targetPlatform.isMusl`)

Tested in various configurations,
probably biased towards those using  musl.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---