### PR TITLE
ghc{843,861}: add musl variants of "llvm-targets"

### DIFF
--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -124,6 +124,14 @@ stdenv.mkDerivation (rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
+  '' + stdenv.lib.optionalString targetPlatform.isMusl ''
+      echo "patching llvm-targets for musl targets...."
+      echo "Cloning these existing '*-linux-gnu*' targets:"
+      grep linux-gnu llvm-targets | sed 's/^/  /'
+      echo "go go gadget sed"
+      sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
+      echo "llvm-targets now contains these '*-linux-musl*' targets:"
+      grep linux-musl llvm-targets | sed 's/^/  /'
   '';
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -125,13 +125,21 @@ stdenv.mkDerivation (rec {
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
   '' + stdenv.lib.optionalString targetPlatform.isMusl ''
-      echo "patching llvm-targets for musl targets...."
+      echo "patching llvm-targets for musl targets..."
       echo "Cloning these existing '*-linux-gnu*' targets:"
       grep linux-gnu llvm-targets | sed 's/^/  /'
-      echo "go go gadget sed"
+      echo "(go go gadget sed)"
       sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
       echo "llvm-targets now contains these '*-linux-musl*' targets:"
       grep linux-musl llvm-targets | sed 's/^/  /'
+
+      echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
+      # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
+      for x in configure aclocal.m4; do
+        substituteInPlace $x \
+          --replace '*-android*|*-gnueabi*)' \
+                    '*-android*|*-gnueabi*|*-musleabi*)'
+      done
   '';
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -116,6 +116,14 @@ stdenv.mkDerivation (rec {
     export NIX_LDFLAGS+=" -no_dtrace_dof"
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
+  '' + stdenv.lib.optionalString targetPlatform.isMusl ''
+      echo "patching llvm-targets for musl targets...."
+      echo "Cloning these existing '*-linux-gnu*' targets:"
+      grep linux-gnu llvm-targets | sed 's/^/  /'
+      echo "go go gadget sed"
+      sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
+      echo "llvm-targets now contains these '*-linux-musl*' targets:"
+      grep linux-musl llvm-targets | sed 's/^/  /'
   '';
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -117,13 +117,21 @@ stdenv.mkDerivation (rec {
   '' + stdenv.lib.optionalString targetPlatform.useAndroidPrebuilt ''
     sed -i -e '5i ,("armv7a-unknown-linux-androideabi", ("e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64", "cortex-a8", ""))' llvm-targets
   '' + stdenv.lib.optionalString targetPlatform.isMusl ''
-      echo "patching llvm-targets for musl targets...."
+      echo "patching llvm-targets for musl targets..."
       echo "Cloning these existing '*-linux-gnu*' targets:"
       grep linux-gnu llvm-targets | sed 's/^/  /'
-      echo "go go gadget sed"
+      echo "(go go gadget sed)"
       sed -i 's,\(^.*linux-\)gnu\(.*\)$,\0\n\1musl\2,' llvm-targets
       echo "llvm-targets now contains these '*-linux-musl*' targets:"
       grep linux-musl llvm-targets | sed 's/^/  /'
+
+      echo "And now patching to preserve '-musleabi' as done with '-gnueabi'"
+      # (aclocal.m4 is actual source, but patch configure as well since we don't re-gen)
+      for x in configure aclocal.m4; do
+        substituteInPlace $x \
+          --replace '*-android*|*-gnueabi*)' \
+                    '*-android*|*-gnueabi*|*-musleabi*)'
+      done
   '';
 
   # TODO(@Ericson2314): Always pass "--target" and always prefix.


### PR DESCRIPTION
Currently only the 3-element targets are available w/musl,
which is especially unfortunate since this means when
target'ing raspberryPi w/musl ("muslpi" in our tree)
GHC sees "armv6l-unknown-linux-musleabihf" and drops
the last bit, which is bad for two reasons:
* GHC's llvm-targets file doesn't have an entry for `armv6l-unknown-linux`,
  preventing compilation/use in this configuration.
* Information about float mode to use (hard vs soft) is lost,
  at least in this style of target string.

I think the second reason is actually the explanation for the first,
and is why GHC special-cases "*-gnueabi*" which this PR extends
to similarly treat "*-musleabi*".

--------
This only impacts GHC builds using musl, to avoid the rebuild (and following what was done for Android).
If later this is expanded I think only makes sense/has impact when LLVM is used,
so same configurations as in #43303.

I was "on the fence" with preserving "-musl*" (not just "-musleabi*") to ensure in a mixed
environment there's less confusion about how to extend/interpret "x86_64-unknown-linux",
but in the end decided to just match the "-gnueabi*" behavior and revisit if there's
motivation from experiences "in the wild".


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested a number of configurations building basic packages (earlier today),
still rebuilding-all-the-haskell after a small rebase.

Inspected output of `${targetPrefix}ghc --info`, although I'm not a GHC expert
but things seem as they should be before/after.