### PR TITLE
freecad: fix by using python-enabled boost

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -7,6 +7,11 @@ assert mpi != null;
 
 let
   pythonPackages = python27Packages;
+  boost_py = boost.override {
+    inherit (pythonPackages) python;
+    enablePython = true;
+  };
+
 in stdenv.mkDerivation rec {
   name = "freecad-${version}";
   version = "0.17";
@@ -19,7 +24,7 @@ in stdenv.mkDerivation rec {
   buildInputs = with pythonPackages; [ cmake coin3d xercesc ode eigen qt4 opencascade gts
     zlib  swig gfortran soqt libf2c makeWrapper  mpi vtk hdf5 medfile
   ] ++ (with pythonPackages; [
-    matplotlib pycollada pyside pysideShiboken pysideTools pivy python boost
+    matplotlib pycollada pyside pysideShiboken pysideTools pivy python boost_py
   ]);
 
   patches = [


### PR DESCRIPTION
Fixes #43305


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---