### PR TITLE
boost167: Add lockfree next_prior patch

### DIFF
--- a/pkgs/development/libraries/boost/1.67.nix
+++ b/pkgs/development/libraries/boost/1.67.nix
@@ -1,7 +1,13 @@
-{ stdenv, callPackage, fetchurl, hostPlatform, buildPlatform, ... } @ args:
+{ stdenv, callPackage, fetchurl, fetchpatch, hostPlatform, buildPlatform, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
   version = "1.67_0";
+
+  patches = [ (fetchpatch {
+    url = "https://github.com/boostorg/lockfree/commit/12726cda009a855073b9bedbdce57b6ce7763da2.patch";
+    sha256 = "0x65nkwzv8fdacj8sw5njl3v63jj19dirrpklbwy6qpsncw7fc7h";
+    stripLen = 1;
+  })];
 
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_67_0.tar.bz2";


### PR DESCRIPTION
###### Motivation for this change

Fix spsc_queue.hpp missing include of next_prior.hpp

cc: @anttih

Closes https://github.com/NixOS/nixpkgs/issues/43118

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

