### PR TITLE
buildGoPackage: Dont copy sources to $out

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -12,17 +12,6 @@ buildGoPackage rec {
   # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
   hardeningDisable = [ "fortify" ];
 
-  # Only install binaries in $out, source is not interesting and takes ~50M
-  outputs = [ "out" ];
-  preFixup = ''
-    export bin="''${out}"
-  '';
-  installPhase = ''
-    mkdir -p $out/bin $out
-    dir="$NIX_BUILD_TOP/go/bin"
-    [ -e "$dir" ] && cp -r $dir $out
-  '';
-
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = "go-ethereum";

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -176,15 +176,6 @@ go.stdenv.mkDerivation (
   installPhase = args.installPhase or ''
     runHook preInstall
 
-    mkdir -p $out
-    pushd "$NIX_BUILD_TOP/go"
-    while read f; do
-      echo "$f" | grep -q '^./\(src\|pkg/[^/]*\)/${goPackagePath}' || continue
-      mkdir -p "$(dirname "$out/share/go/$f")"
-      cp "$NIX_BUILD_TOP/go/$f" "$out/share/go/$f"
-    done < <(find . -type f)
-    popd
-
     mkdir -p $bin
     dir="$NIX_BUILD_TOP/go/bin"
     [ -e "$dir" ] && cp -r $dir $bin


### PR DESCRIPTION
###### Motivation for this change
I don't see the reason to copy sources that are potentially quite large, especially with the go community practices of vendoring dependencies.
Do these sources serve any purpose?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CCing maintainers & others who have touched this recently @pbogdan @Mic92 @yegortimoshenko @kamilchm @lethalman @cstrahan @orivej @velovix 