### PR TITLE
IPMIView: 2.13.0 -> 2.14.0

### DIFF
--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
    name = "IPMIView-${version}";
-   version = "2.13.0";
-   buildVersion = "170504";
+   version = "2.14.0";
+   buildVersion = "180213";
 
    src = fetchurl {
     url = "ftp://ftp.supermicro.com/utility/IPMIView/Linux/IPMIView_${version}_build.${buildVersion}_bundleJRE_Linux_x64.tar.gz";
-    sha256 = "1hfw5g6lxg3vqg0nc3g2sv2h6bn8za35bxxms0ri0sgb9v3xg1y6";
+    sha256 = "1wp22wm7smlsb25x0cck4p660cycfczxj381930crd1qrf68mw4h";
   };
 
    buildInputs = [ patchelf makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Installing old version got stuck on downloading, so I had to bump it to install it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

