### PR TITLE
darwin.trash: f68ad25a -> 0.9.1

### DIFF
--- a/pkgs/os-specific/darwin/trash/default.nix
+++ b/pkgs/os-specific/darwin/trash/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, frameworks, perl } :
 stdenv.mkDerivation rec {
-  version = "0.9.0";
+  version = "0.9.1";
   name = "trash-${version}";
 
   src = fetchFromGitHub {
     owner = "ali-rantakari";
     repo = "trash";
-    rev = "f68ad25a02e24cc58eb8ef9a493d6dc0122bcd8f";
+    rev = "v${version}";
     sha256 = "0ylkf7jxfy1pj7i1s48w28kzqjdfd57m2pw0jycsgcj5bkzwll41";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Update `darwin.trash` to `0.9.1.`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

