### PR TITLE
fltk: get rid of composableDerivation

### DIFF
--- a/pkgs/applications/graphics/exrdisplay/default.nix
+++ b/pkgs/applications/graphics/exrdisplay/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchurl, pkgconfig, fltk, openexr, libGLU_combined, openexr_ctl }:
 
-assert fltk.glSupport;
-
 stdenv.mkDerivation {
   name ="openexr_viewers-2.2.1";
 
@@ -14,14 +12,14 @@ stdenv.mkDerivation {
     ./configure --prefix=$out --with-fltk-config=${fltk}/bin/fltk-config
   '';
 
-  buildPahse = ''
+  buildPhase = ''
     make LDFLAGS="`fltk-config --ldflags` -lGL -lfltk_gl"
   '';
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openexr fltk libGLU_combined openexr_ctl ];
 
-  meta = { 
+  meta = {
     description = "Application for viewing OpenEXR images on a display at various exposure settings";
     homepage = http://openexr.com;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/fltk/default.nix
+++ b/pkgs/development/libraries/fltk/default.nix
@@ -1,13 +1,11 @@
-{ stdenv, composableDerivation, fetchurl, pkgconfig, xlibsWrapper, inputproto, libXi
-, freeglut, libGLU_combined, libjpeg, zlib, libXinerama, libXft, libpng
-, cfg ? {}
+{ stdenv, fetchurl, pkgconfig, xlibsWrapper, inputproto, libXi
+, freeglut, libGLU_combined, libjpeg, zlib, libXft, libpng
 , darwin, libtiff, freetype
 }:
 
-let inherit (composableDerivation) edf; in
-
-let version = "1.3.4"; in
-composableDerivation.composableDerivation {} {
+let
+  version = "1.3.4";
+in stdenv.mkDerivation {
   name = "fltk-${version}";
 
   src = fetchurl {
@@ -18,39 +16,29 @@ composableDerivation.composableDerivation {} {
   patches = stdenv.lib.optionals stdenv.isDarwin [ ./nsosv.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [
+    libGLU_combined
+    libjpeg
+    zlib
+    libpng
+    libXft
+  ];
+
+  configureFlags = [
+    "--enable-gl"
+    "--enable-largefile"
+    "--enable-shared"
+    "--enable-threads"
+    "--enable-xft"
+  ];
+
   propagatedBuildInputs = [ inputproto ]
     ++ (if stdenv.isDarwin
         then (with darwin.apple_sdk.frameworks; [Cocoa AGL GLUT freetype libtiff])
         else [ xlibsWrapper libXi freeglut ]);
 
   enableParallelBuilding = true;
-
-  flags =
-    # this could be tidied up (?).. eg why does it require freeglut without glSupport?
-    edf { name = "cygwin"; }  #         use the CygWin libraries default=no
-    // edf { name = "debug"; }  #          turn on debugging default=no
-    // edf { name = "gl"; enable = { buildInputs = [ libGLU_combined ]; }; }  #             turn on OpenGL support default=yes
-    // edf { name = "shared"; }  #         turn on shared libraries default=no
-    // edf { name = "threads"; }  #        enable multi-threading support
-    // edf { name = "quartz"; enable = { buildInputs = "quartz"; }; }  # don't konw yet what quartz is #         use Quartz instead of Quickdraw (default=no)
-    // edf { name = "largefile"; } #     omit support for large files
-    // edf { name = "localjpeg"; disable = { buildInputs = [libjpeg]; }; } #       use local JPEG library, default=auto
-    // edf { name = "localzlib"; disable = { buildInputs = [zlib]; }; } #       use local ZLIB library, default=auto
-    // edf { name = "localpng"; disable = { buildInputs = [libpng]; }; } #       use local PNG library, default=auto
-    // edf { name = "xinerama"; enable = { buildInputs = [libXinerama]; }; } #       turn on Xinerama support default=no
-    // edf { name = "xft"; enable = { buildInputs=[libXft]; }; } #            turn on Xft support default=no
-    // edf { name = "xdbe"; };  #           turn on Xdbe support default=no
-
-  cfg = {
-    largefileSupport = true; # is default
-    glSupport = true; # doesn't build without it. Why?
-    localjpegSupport = false;
-    localzlibSupport = false;
-    localpngSupport = false;
-    sharedSupport = true;
-    threadsSupport = true;
-    xftSupport = true;
-  } // cfg;
 
   meta = {
     description = "A C++ cross-platform lightweight GUI library";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

