### PR TITLE
ghc: support musl-native!

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -113,7 +113,8 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
     "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}";
+  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
 
   # Stripping combined with patchelf breaks the executables (they die
   # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -16,7 +16,8 @@ let
 
   glibcDynLinker = assert stdenv.isLinux;
     if stdenv.hostPlatform.libc == "glibc" then
-       stdenv.cc.bintools.dynamicLinker
+       # Could be stdenv.cc.bintools.dynamicLinker, keeping as-is to avoid rebuild.
+       ''"$(cat $NIX_CC/nix-support/dynamic-linker)"''
     else
       "${stdenv.lib.getLib glibc}/lib/ld-linux*";
 


### PR DESCRIPTION
\o/

Examples: `pkgsMusl.bench` (=`pkgsMusl.haskellPackages.bench`),
`pkgsMusl.shellcheck`, ...

This makes it possible to:

* use haskell when using musl as (system) libc
* easily build haskell packages against musl,
  and avoids the need for cross-compilation and
  potential issues that entails.

Many packages now build and seem to work,
although a few do not and have not been investigated.
The failures I did look at appear to be the sort that
are rather plausibly caused by using musl vs glibc.

(details in date/timezone, string formatting, locale usage, etc.)

-----

For anyone interested in testing this, consider using the 'allvm' cachix to save time,
it has a number of GHC variants and ghc843 packages available.

Oh and any needed dependencies not available on cachix.nixos.org,
not sure how signiicant this is (but I believe includes LLVM at least).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---