### PR TITLE
aws-rotate-key: init at 1.0.0

### DIFF
--- a/pkgs/tools/admin/aws-rotate-key/default.nix
+++ b/pkgs/tools/admin/aws-rotate-key/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "aws-rotate-key-${version}";
+  version = "1.0.0";
+
+  goPackagePath = "github.com/Fullscreen/aws-rotate-key";
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "Fullscreen";
+    repo = "aws-rotate-key";
+    sha256 = "13q7rns65cj8b4i0s75dbswijpra9z74b462zribwfjdm29by5k1";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Easily rotate your AWS key";
+    homepage = https://github.com/Fullscreen/aws-rotate-key;
+    license = licenses.mit;
+    maintainers = [maintainers.mbode];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/admin/aws-rotate-key/deps.nix
+++ b/pkgs/tools/admin/aws-rotate-key/deps.nix
@@ -1,0 +1,29 @@
+[
+  {
+    goPackagePath = "github.com/go-ini/ini";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-ini/ini";
+      rev = "af26abd521cd7697481572fdbc4a53cbea3dde1b";
+      sha256 = "1yribbqy9i4i70dfg3yrjhkn3n0fywpr3kismn2mvi882mm01pxz";
+    };
+  }
+  {
+    goPackagePath = "github.com/jmespath/go-jmespath";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmespath/go-jmespath";
+      rev = "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5";
+      sha256 = "1r6w7ydx8ydryxk3sfhzsk8m6f1nsik9jg3i1zhi69v4kfl4d5cz";
+    };
+  }
+  {
+    goPackagePath = "github.com/aws/aws-sdk-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aws/aws-sdk-go";
+      rev = "f844700ba2a387dfee7ab3679e7544b5dbd6d394";
+      sha256 = "0s9100bzqj58nnax3dxfgi5qr4rbaa53cb0cj3s58k9jc9z6270m";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -553,6 +553,8 @@ with pkgs;
 
   awslogs = callPackage ../tools/admin/awslogs { };
 
+  aws-rotate-key = callPackage ../tools/admin/aws-rotate-key { };
+
   aws_shell = pythonPackages.callPackage ../tools/admin/aws_shell { };
 
   aws-sam-cli = callPackage ../development/tools/aws-sam-cli { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

