### PR TITLE
openrct2: 0.1.2 -> 0.2.0

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -1,17 +1,24 @@
 { stdenv, fetchurl, fetchFromGitHub,
-  SDL2, cmake, curl, fontconfig, freetype, jansson, libiconv, libpng,
+  SDL2, cmake, curl, fontconfig, freetype, icu, jansson, libiconv, libpng,
   libpthreadstubs, libzip, libGLU, openssl, pkgconfig, speexdsp, zlib
 }:
 
 let
   name = "openrct2-${version}";
-  version = "0.1.2";
+  version = "0.2.0";
 
   openrct2-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
     rev = "v${version}";
-    sha256 = "1zqrdxr79c9yx4bdxz1r5866hhwq0lcs9qpv3vhisr56ar5n5wk3";
+    sha256 = "1nmz8war8b49iicpc70gk7zlqizrvvwpidqm70lfpa0p68m7m3px";
+  };
+
+  objects-src = fetchFromGitHub {
+    owner = "OpenRCT2";
+    repo = "objects";
+    rev = "v1.0.2";
+    sha256 = "1gl37fmhhrfgd6gilw0n7hfdq80a9b31bi5r0xhxg7d579jccb04";
   };
 
   title-sequences-src = fetchFromGitHub {
@@ -32,6 +39,7 @@ stdenv.mkDerivation rec {
     curl
     fontconfig
     freetype
+    icu
     jansson
     libiconv
     libpng
@@ -45,11 +53,15 @@ stdenv.mkDerivation rec {
   ];
 
   postUnpack = ''
-    cp -r ${title-sequences-src} $sourceRoot/title
+    cp -r ${objects-src}         $sourceRoot/data/object
+    cp -r ${title-sequences-src} $sourceRoot/data/title
   '';
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=RELWITHDEBINFO" "-DDOWNLOAD_TITLE_SEQUENCES=OFF"];
+    "-DCMAKE_BUILD_TYPE=RELWITHDEBINFO"
+    "-DDOWNLOAD_OBJECTS=OFF"
+    "-DDOWNLOAD_TITLE_SEQUENCES=OFF"
+  ];
 
   makeFlags = ["all" "g2"];
 


### PR DESCRIPTION
###### Motivation for this change
Updated to current release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

