### PR TITLE
lib: Fix typo `fixed-points` to `fixedPoints`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -202,7 +202,7 @@ rec {
           callPackage = self.newScope {};
           overrideScope = g:
             makeScope newScope
-            (lib.fixed-points.extends f g);
+            (lib.fixedPoints.extends f g);
           packages = f;
         };
     in self;


### PR DESCRIPTION
###### Motivation for this change

CC @mdorman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

