### PR TITLE
Fix neovim PYTHONPATH handling

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -63,7 +63,6 @@ let
         --cmd \"${if withPython then "let g:python_host_prog='$out/bin/nvim-python'" else "let g:loaded_python_provider = 1"}\" \
         --cmd \"${if withPython3 then "let g:python3_host_prog='$out/bin/nvim-python3'" else "let g:loaded_python3_provider = 1"}\" \
         --cmd \"${if withRuby then "let g:ruby_host_prog='$out/bin/nvim-ruby'" else "let g:loaded_ruby_provider=1"}\" " \
-        --unset PYTHONPATH \
          ${optionalString withRuby '' --suffix PATH : ${rubyEnv}/bin --set GEM_HOME ${rubyEnv}/${rubyEnv.ruby.gemPath}'' }
 
       ''
@@ -75,9 +74,9 @@ let
           --replace 'Name=Neovim' 'Name=WrappedNeovim'
       ''
       + optionalString withPython ''
-      ln -s ${pythonEnv}/bin/python $out/bin/nvim-python
+        makeWrapper ${pythonEnv}/bin/python $out/bin/nvim-python --unset PYTHONPATH
     '' + optionalString withPython3 ''
-      ln -s ${python3Env}/bin/python3 $out/bin/nvim-python3
+        makeWrapper ${python3Env}/bin/python3 $out/bin/nvim-python3 --unset PYTHONPATH
     '' + optionalString withRuby ''
       ln -s ${rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
     ''

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1015,7 +1015,7 @@ let
       sha256 = "03sr53680kcwxaa5xbqzdfbsgday3bkzja33wym49w9gjmlaa320";
     };
     dependencies = ["vimproc" "vimshell" "self" "forms"];
-    pythonDependencies = with pythonPackages; [ sexpdata websocket_client ];
+    passthru.python3Dependencies = ps: with ps; [ sexpdata websocket_client ];
   };
 
   supertab = buildVimPluginFrom2Nix { # created by nix#NixDerivation

--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -280,6 +280,7 @@ let
             installPhase = lib.concatStringsSep
                              "\n"
                              (lib.flatten (lib.mapAttrsToList packageLinks packages));
+            preferLocalBuild = true;
           }
         );
       in
@@ -423,6 +424,7 @@ rec {
   } // a);
 
   requiredPlugins = {
+    packages ? {},
     givenKnownPlugins ? null,
     vam ? null,
     pathogen ? null, ...
@@ -437,8 +439,12 @@ rec {
       vamNames = findDependenciesRecursively { inherit knownPlugins; names = lib.concatMap toNames vam.pluginDictionaries; };
       names = (lib.optionals (pathogen != null) pathogenNames) ++
               (lib.optionals (vam != null) vamNames);
+      nonNativePlugins = map (name: knownPlugins.${name}) names;
+      nativePluginsConfigs = lib.attrsets.attrValues packages;
+      nativePlugins = lib.concatMap ({start?[], opt?[]}: start++opt) nativePluginsConfigs;
     in
-      map (name: knownPlugins.${name}) names;
+      nativePlugins ++ nonNativePlugins;
+
 
   # test cases:
   test_vim_with_vim_addon_nix_using_vam = vim_configurable.customize {

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/ensime-vim
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/ensime-vim
@@ -1,1 +1,1 @@
-    pythonDependencies = with pythonPackages; [ sexpdata websocket_client ];
+    passthru.python3Dependencies = ps: with ps; [ sexpdata websocket_client ];


### PR DESCRIPTION
###### Motivation for this change

These are two more or less independent improvements to the neovim wrapper.
1st commit:
```
nix-shell -p pythonPackages.numpy
nvim
:!python -c "import numpy"
```
this will fail to see numpy.
This is because the neovim wrapper unsets PYTHONPATH.

With this fix, I checked that `:checkhealth` is fine with and without extraPythonPackages and within and out of a nix-shell modifying the PYTHONPATH.

2nd commit:
During testing the above fix, I built my system config with an overlay using the neovim from my nixpkgs checkout. I override this wrapper with a few `extraPythonPackages`. But these packages **disappeared completely**. They were not even a dependency of neovim. Indeed, *a python module from stable will be **silently ignored** by unstable `python.buildEnv`*.

https://github.com/NixOS/nixpkgs/blob/f601ecfb215195c2491ce49d8f8a637960ca494e/pkgs/top-level/python-packages.nix#L89-L98
https://github.com/NixOS/nixpkgs/blob/f601ecfb215195c2491ce49d8f8a637960ca494e/pkgs/development/interpreters/python/wrapper.nix#L12

python.withPackages is just as powerful as python.buildEnv but not so treacherous, and I lost enough time with this, so I switched to python.withPackages.

This changes the type of `extraPython{,3}Packages` but in a backward compatible way.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

