### PR TITLE
geojson: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/geojson/default.nix
+++ b/pkgs/development/python-modules/geojson/default.nix
@@ -2,11 +2,13 @@
 
 buildPythonPackage rec {
   pname = "geojson";
-  version = "2.3.0";
+  version = "2.4.0";
+
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "06ihcb8839zzgk5jcv18kc6nqld4hhj3nk4f3drzcr8n8893v1y8";
+    inherit pname version format;
+    sha256 = "0r9pc8hgnc5hf5rq98vinbrncn08v4kgzdfmfs14rfypvacsmfpj";
   };
 
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
###### Motivation for this change
Updated geojson to 2.4.0.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

