### PR TITLE
electron-cash: 3.1.6 -> 3.3.1

### DIFF
--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3Packages }:
+{ stdenv, fetchurl, python3Packages, qtbase, makeWrapper, lib }:
 
 let
 
@@ -36,6 +36,8 @@ python3Packages.buildPythonApplication rec {
     trezor
   ];
 
+  nativeBuildInputs = [ makeWrapper ];
+
   postPatch = ''
     # Remove pyqt5 check
     sed -i '/pyqt5/d' setup.py
@@ -56,11 +58,14 @@ python3Packages.buildPythonApplication rec {
 
     substituteInPlace $out/share/applications/electron-cash.desktop \
       --replace "Exec=electron-cash %u" "Exec=$out/bin/electron-cash %u"
+
+    wrapProgram $out/bin/electron-cash \
+      --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-5.${lib.versions.minor qtbase.version}/plugins
   '';
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/electrum help >/dev/null
+    $out/bin/electron-cash help >/dev/null
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -59,6 +59,7 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace $out/share/applications/electron-cash.desktop \
       --replace "Exec=electron-cash %u" "Exec=$out/bin/electron-cash %u"
 
+    # Please remove this when #44047 is fixed
     wrapProgram $out/bin/electron-cash \
       --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-5.${lib.versions.minor qtbase.version}/plugins
   '';

--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -7,14 +7,14 @@ let
 in
 
 python3Packages.buildPythonApplication rec {
-  version = "3.3";
+  version = "3.3.1";
   name = "electron-cash-${version}";
 
   src = fetchurl {
     url = "https://electroncash.org/downloads/${version}/win-linux/ElectronCash-${version}.tar.gz";
     # Verified using official SHA-1 and signature from
     # https://github.com/fyookball/keys-n-hashes
-    sha256 = "1x487hyacdm1qhik1mhfimr4jwcwz7sgsbkh11awrb6j19sxdxym";
+    sha256 = "1jdy89rfdwc2jadx3rqj5yvynpcn90cx6482ax9f1cj9gfxp9j2b";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/misc/electron-cash/default.nix
+++ b/pkgs/applications/misc/electron-cash/default.nix
@@ -7,14 +7,14 @@ let
 in
 
 python3Packages.buildPythonApplication rec {
-  version = "3.1.6";
+  version = "3.3";
   name = "electron-cash-${version}";
 
   src = fetchurl {
     url = "https://electroncash.org/downloads/${version}/win-linux/ElectronCash-${version}.tar.gz";
     # Verified using official SHA-1 and signature from
     # https://github.com/fyookball/keys-n-hashes
-    sha256 = "062k5iw0jcp10zxrffvgiyfg51c5xzs7gmm638icx01yy67d58dm";
+    sha256 = "1x487hyacdm1qhik1mhfimr4jwcwz7sgsbkh11awrb6j19sxdxym";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -42,7 +42,6 @@ python3Packages.buildPythonApplication rec {
   '';
 
   preBuild = ''
-    sed -i 's,usr_share = .*,usr_share = "'$out'/share",g' setup.py
     pyrcc5 icons.qrc -o gui/qt/icons_rc.py
     # Recording the creation timestamps introduces indeterminism to the build
     sed -i '/Created: .*/d' gui/qt/icons_rc.py
@@ -51,10 +50,9 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
 
   postInstall = ''
-    # Despite setting usr_share above, these files are installed under
-    # $out/nix ...
-    mv $out/${python.sitePackages}/nix/store"/"*/share $out
-    rm -rf $out/${python.sitePackages}/nix
+    # These files are installed under $out/homeless-shelter ...
+    mv $out/${python.sitePackages}/homeless-shelter/.local/share $out
+    rm -rf $out/${python.sitePackages}/homeless-shelter
 
     substituteInPlace $out/share/applications/electron-cash.desktop \
       --replace "Exec=electron-cash %u" "Exec=$out/bin/electron-cash %u"


### PR DESCRIPTION
###### Motivation for this change

Upgrade electron-cash to version 3.3

Unfortunately it's more complicated than expected.

Here is the error I get :
```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-org.kde.kwin.qpa, minimal, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, xcb.
```
If somebody could help me debug this, I would be very glad !

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

