### PR TITLE
tor-browser-bundle: update license to free

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
@@ -340,7 +340,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An unofficial version of the tor browser bundle, built from source";
     homepage = https://torproject.org/;
-    license = licenses.unfreeRedistributable; # TODO: check this
+    license = licenses.free;
     platforms = [ "x86_64-linux" ];
     hydraPlatforms = [ ];
     maintainers = with maintainers; [ joachifm ];


### PR DESCRIPTION
###### Motivation for this change

The Tor Browser Bundle [is free software under various licenses](https://www.torproject.org/docs/faq.html.en#DistributingTor):

<blockquote> 
    <h3><a class="anchor" href="#DistributingTor">Can I distribute
Tor?</a></h3>
    <p>
    Yes.
    </p>
    <p>
    The Tor software is <a href="https://www.fsf.org/">free software</a>. This
    means we give you the rights to redistribute the Tor software, either
    modified or unmodified, either for a fee or gratis. You don't have to
    ask us for specific permission.
    </p>
    <p>
    However, if you want to redistribute the Tor software you must follow our
    <a href="https://gitweb.torproject.org/tor.git/plain/LICENSE">LICENSE</a>.
    Essentially this means that you need to include our LICENSE file along
    with whatever part of the Tor software you're distributing.
    </p>
    <p>
    Most people who ask us this question don't want to distribute just the
    Tor software, though. They want to distribute the <a href="../projects/torbrowser.html.en">Tor Browser</a>. This includes <a href="https://www.mozilla.org/en-US/firefox/organizations/">Firefox
    Extended Support Release</a>, and the NoScript and HTTPS-Everywhere
    extensions. You will need to follow the license for those programs as
    well. Both of those Firefox extensions are distributed under
    the <a href="https://www.fsf.org/licensing/licenses/gpl.html">GNU General
    Public License</a>, while Firefox ESR is released under the Mozilla Public
    License. The simplest way to obey their licenses is to include the source
    code for these programs everywhere you include the bundles themselves.
    </p>
    <p>
    Also, you should make sure not to confuse your readers about what Tor is,
    who makes it, and what properties it provides (and doesn't provide). See
    our <a href="../docs/trademark-faq.html.en">trademark FAQ</a> for details.
    </p>  
</blockquote>

tor-browser-bundle-bin is [already](https://github.com/NixOS/nixpkgs/blob/ee9eeea63a7764c0ded898982d4cfb091fb0d342/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix#L408)  marked as licenses.free, so it doesn't really make sense that this one is marked as unfree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).