### PR TITLE
ponyc: 0.23.0 -> 0.24.0

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.23.0";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "1m0zvl30926652akyzpvy5m7jn35697d5mkg3xbn3yqwbsfk4yhk";
+    sha256 = "1yq82jj0c9nxrx4vxcb3s6yr154kaj2a3wrk12m6fm3dscsqsqq1";
   };
 
   buildInputs = [ llvm makeWrapper which ];

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -12,16 +12,3 @@ index baf29e7..b63f368 100644
      test(_TestTCPWritev)
      test(_TestTCPExpect)
      test(_TestTCPMute)
-diff --git a/packages/net/http/_test.pony b/packages/net/http/_test.pony
-index e55d5a7..40a4cb6 100644
---- a/packages/net/http/_test.pony
-+++ b/packages/net/http/_test.pony
-@@ -29,8 +29,6 @@ actor Main is TestList
-     test(_Valid)
-     test(_ToStringFun)
- 
--    test(_HTTPConnTest)
--
- class iso _Encode is UnitTest
-   fun name(): String => "net/http/URLEncode.encode"
- 


### PR DESCRIPTION
###### Motivation for this change
Version bump, adjust patch for net/http package removal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

