### PR TITLE
pythonPackages.cython: run tests in parallel

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -44,7 +44,7 @@ in buildPythonPackage rec {
 
   checkPhase = ''
     export HOME="$NIX_BUILD_TOP"
-    ${python.interpreter} runtests.py \
+    ${python.interpreter} runtests.py -j$NIX_BUILD_CORES \
       ${stdenv.lib.optionalString (builtins.length excludedTests != 0)
         ''--exclude="(${builtins.concatStringsSep "|" excludedTests})"''}
   '';


### PR DESCRIPTION
###### Motivation for this change

Attempt to fix the timeout (https://github.com/NixOS/nixpkgs/issues/41673#issuecomment-399775390)
There are too many tests and they run sequentially

@dotlambda 
