### PR TITLE
libphonenumber: init at 8.9.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1679,6 +1679,11 @@
     github = "ikervagyok";
     name = "Balázs Lengyel";
   };
+  illegalprime = {
+    email = "themichaeleden@gmail.com";
+    github = "illegalprime";
+    name = "Michael Eden";
+  };
   ilya-kolpakov = {
     email = "ilya.kolpakov@gmail.com";
     github = "ilya-kolpakov";

--- a/pkgs/development/libraries/libphonenumber/default.nix
+++ b/pkgs/development/libraries/libphonenumber/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, cmake, gmock, boost, pkgconfig, protobuf, icu }:
+
+let
+  version = "8.9.9";
+in
+stdenv.mkDerivation {
+  name = "phonenumber-${version}";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "googlei18n";
+    repo = "libphonenumber";
+    rev = "v${version}";
+    sha256 = "005visnfnr84blgdi0yp4hrzskwbsnawrzv6lqfi9f073l6w5j6w";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gmock
+    pkgconfig
+  ];
+
+  buildInputs = [
+    boost
+    protobuf
+    icu
+  ];
+
+  cmakeDir = "../cpp";
+
+  checkPhase = "./libphonenumber_test";
+
+  meta = with stdenv.lib; {
+    description = "Google's i18n library for parsing and using phone numbers";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ illegalprime ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10672,6 +10672,8 @@ with pkgs;
 
   libpgf = callPackage ../development/libraries/libpgf { };
 
+  libphonenumber = callPackage ../development/libraries/libphonenumber { };
+
   libpng = callPackage ../development/libraries/libpng { };
   libpng_apng = libpng.override { apngSupport = true; };
   libpng12 = callPackage ../development/libraries/libpng/12.nix { };


### PR DESCRIPTION
###### Motivation for this change

Adds `libphonenumber` a handy library to parse and work with phone number of different formats.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This is my first package contribution here, so I'm sorry in advance if I don't have everything formatted.