### PR TITLE
vimPlugis.gist-vim: depend on vimPlugins.WebAPI

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1863,7 +1863,7 @@ rec {
       rev = "f0d63579eab7548cf12f979dc52ef5a370ecbe63";
       sha256 = "06nix49j4inxy3rkcv32f4ka89g4crqwfqnrm3b76iwwky8m2p17";
     };
-    dependencies = [];
+    dependencies = ["WebAPI"];
 
   };
 


### PR DESCRIPTION
###### Motivation for this change

I'm trying to use `:Gist` from NeoVim, but I get the following error:

```vimL
Gist: require 'webapi', install https://github.com/mattn/webapi-vim
Gist: require 'webapi', install https://github.com/mattn/webapi-vim
E117: Unknown function: gist#Gist
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

When I try to generate with `nix-shell -p vimPlugins.pluginnames2nix --command "vim-plugin-names-to-nix"`, I do not see the dependency I've just added. Can someone help to get this fixed? Thanks!