### PR TITLE
tig: add zsh completion

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/tig/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/tig/default.nix
@@ -33,6 +33,9 @@ stdenv.mkDerivation rec {
     make install-doc
     mkdir -p $out/etc/bash_completion.d/
     cp contrib/tig-completion.bash $out/etc/bash_completion.d/
+    mkdir -p $out/share/zsh/site-functions
+    cp contrib/tig-completion.zsh $out/share/zsh/site-functions/
+    cp contrib/vim.tigrc $out/etc/
 
     wrapProgram $out/bin/tig \
       --prefix PATH ':' "${git}/bin"

--- a/pkgs/applications/version-management/git-and-tools/tig/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/tig/default.nix
@@ -31,10 +31,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     make install
     make install-doc
-    mkdir -p $out/etc/bash_completion.d/
-    cp contrib/tig-completion.bash $out/etc/bash_completion.d/
-    mkdir -p $out/share/zsh/site-functions
-    cp contrib/tig-completion.zsh $out/share/zsh/site-functions/
+    install -D contrib/tig-completion.bash $out/etc/bash_completion.d/tig-completion.bash
+    install -D contrib/tig-completion.zsh $out/share/zsh/site-functions/_tig
     cp contrib/vim.tigrc $out/etc/
 
     wrapProgram $out/bin/tig \


### PR DESCRIPTION
along with contrib/vim.tigrc config in case users want to use it.

###### Motivation for this change
I wanted to configure tig with vim bindings, through the contrib/vim.tigrc upstream file so that I can do in home-manager:
`  home.file."${config.xdg.configHome}/tig/tigrc".text = "${pkgs.tig}/etc/vim.tigrc";`
I added zsh completion while at it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

