### PR TITLE
somatic-sniper: init 1.0.5.0

### DIFF
--- a/pkgs/applications/science/biology/somatic-sniper/default.nix
+++ b/pkgs/applications/science/biology/somatic-sniper/default.nix
@@ -1,0 +1,26 @@
+{stdenv, fetchFromGitHub, cmake, zlib, ncurses}:
+
+stdenv.mkDerivation rec {
+  name = "somatic-sniper-${version}";
+  version = "1.0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "genome";
+    repo = "somatic-sniper";
+    rev = "v${version}";
+    sha256 = "0lk7p9sp6mp50f6w1nppqhr40fcwy1asw06ivw8w8jvvnwaqf987";
+  };
+
+  patches = [ ./somatic-sniper.patch ];
+
+  buildInputs = [ cmake zlib ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "Identify single nucleotide positions that are different between tumor and normal";
+    license = licenses.mit;
+    homepage = https://github.com/genome/somatic-sniper;
+    maintainers = with maintainers; [ jbedo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/applications/science/biology/somatic-sniper/somatic-sniper.patch
+++ b/pkgs/applications/science/biology/somatic-sniper/somatic-sniper.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d5a180..7254292 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,7 +11,7 @@ set(CMAKE_MODULE_PATH
+     )
+ 
+ include(TestHelper)
+-include(VersionHelper)
++#include(VersionHelper)
+ include(ProjectHelper)
+ 
+ # NOTE: for sniper we want the exe suffix to be like 0.7.4, not just 0.7
+diff --git a/vendor/samtools.patch b/vendor/samtools.patch
+index f173017..654f878 100644
+--- a/vendor/samtools.patch
++++ b/vendor/samtools.patch
+@@ -6,7 +6,7 @@ diff -Nuar a/Makefile b/Makefile
+  
+  samtools:lib $(AOBJS)
+ -		$(CC) $(CFLAGS) -o $@ $(AOBJS) -lm $(LIBPATH) $(LIBCURSES) -lz -L. -lbam
+-+		$(CC) $(CFLAGS) -o $@ $(AOBJS) -lm $(LIBPATH) $(LIBCURSES) -L. -lbam -lz
+++		$(CC) $(CFLAGS) -o $@ $(AOBJS) -lm $(LIBPATH) -lncurses -L. -lbam -lz
+  
+  razip:razip.o razf.o
+  		$(CC) $(CFLAGS) -o $@ razf.o razip.o -lz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20352,6 +20352,8 @@ with pkgs;
 
   snpeff = callPackage ../applications/science/biology/snpeff { };
 
+  somatic-sniper = callPackage ../applications/science/biology/somatic-sniper { };
+
   star = callPackage ../applications/science/biology/star { };
 
   varscan = callPackage ../applications/science/biology/varscan { };


### PR DESCRIPTION
###### Motivation for this change

somatic-sniper: init 1.0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

