### PR TITLE
rPackages.haven: fix installation

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -264,7 +264,7 @@ let
     graphscan = [ pkgs.gsl_1 ];
     gsl = [ pkgs.gsl_1 ];
     h5 = [ pkgs.hdf5-cpp pkgs.which ];
-    haven = [ pkgs.libiconv ];
+    haven = [ pkgs.libiconv pkgs.zlib.dev ];
     h5vc = [ pkgs.zlib.dev ];
     HiCseg = [ pkgs.gsl_1 ];
     imager = [ pkgs.x11 ];


### PR DESCRIPTION
###### Motivation for this change

Installation of `rPackages.haven` fails using the current master branch of NixOS/nixpkgs (18.03-beta-14880-ge65bdb91997). This causes installation of `rPackages.tidyverse` to fail as well.
The cause of the error is the missing buildInput `pkgs.zlib.dev`.

###### Steps to reproduce

```bash
nix-build -E 'with import <nixpkgs> {}; rWrapper.override { packages = [rPackages.haven]; }'
```

Resulting in (partial output):
```
...

readstat/spss/readstat_zsav_write.c:3:10: fatal error: zlib.h: No such file or directory
 #include <zlib.h>
          ^~~~~~~~
compilation terminated.
make: *** [/nix/store/38s6jybgbpxprys4pbgyc83f1zkfl8sj-R-3.5.1/lib/R/etc/Makeconf:159: readstat/spss/readstat_zsav_write.o] Error 1
ERROR: compilation failed for package 'haven'
* removing '/nix/store/8gb8wdk33jsjj78xlcyw6cj1yp7dhj51-r-haven-1.1.2/library/haven'
builder for '/nix/store/4zhk033hcfyih4kk1hiv9fr96f5a0ahy-r-haven-1.1.2.drv' failed with exit code 1
cannot build derivation '/nix/store/viz2ikwnqc4p3vj59f1pjgadiwmal0ql-R-3.5.1-wrapper.drv': 1 dependencies couldn't be built
error: build of '/nix/store/viz2ikwnqc4p3vj59f1pjgadiwmal0ql-R-3.5.1-wrapper.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

