### PR TITLE
keeperrl: init at alpha24

### DIFF
--- a/pkgs/games/keeperrl/default.nix
+++ b/pkgs/games/keeperrl/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, SDL2, SDL2_image, openal, libvorbis, zlib, curl,
+  libGL, makeWrapper, boost }:
+
+stdenv.mkDerivation rec {
+  name = "keeperrl-${version}";
+  version = "alpha24";
+
+  src = fetchFromGitHub {
+    owner = "miki151";
+    repo = "keeperrl";
+    rev = "${version}";
+    sha256 = "00vpq4njdl8hqndjvx2r0w0azz9lfil4qg1rlhj3y9qvc1i0xwwn";
+  };
+
+  patches = [ ./makefile_cflags.patch ];
+
+  buildInputs = [
+    SDL2 SDL2_image openal libvorbis zlib curl libGL makeWrapper
+  ] ++ stdenv.lib.optional stdenv.isDarwin boost ;
+
+  makeFlags = [ "OPT=true" "RELEASE=true" ];
+
+  CFLAGS = "-I${SDL2.dev}/include/SDL2";
+
+  installPhase = ''
+    mkdir -p $out/keeperrl
+    mkdir -p $out/bin
+    cp ./keeper $out/bin/
+    cp -r data_contrib data_free  $out/keeperrl
+    wrapProgram $out/bin/keeper \
+      --run 'mkdir -p $HOME/.keeperrl' \
+      --run 'cd $HOME/.keeperrl' \
+      --run "rm data_free || true" \
+      --run "rm data_contrib || true" \
+      --run "ln -s $out/keeperrl/data_free ." \
+      --run "ln -s $out/keeperrl/data_contrib ."
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://keeperrl.com/;
+    description = "Ambitious dungeon builder with roguelike elements";
+    maintainers = with maintainers; [ rardiol ];
+    license = licenses.gpl2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/games/keeperrl/makefile_cflags.patch
+++ b/pkgs/games/keeperrl/makefile_cflags.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
+--- b/Makefile
+@@ -4,7 +4,7 @@
+ RPATH = .
+ endif
+ 
+-CFLAGS = -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags -ftemplate-depth=512
++CFLAGS += -Wall -std=c++1y -Wno-sign-compare -Wno-unused-variable -Wno-shift-count-overflow -Wno-tautological-constant-out-of-range-compare -Wno-mismatched-tags -ftemplate-depth=512
+ 
+ ifndef GCC
+ GCC = g++

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19359,6 +19359,8 @@ with pkgs;
 
   ja2-stracciatella = callPackage ../games/ja2-stracciatella { };
 
+  keeperrl = callPackage ../games/keeperrl { };
+
   klavaro = callPackage ../games/klavaro {};
 
   kobodeluxe = callPackage ../games/kobodeluxe { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Is the version name ok?

Does someone have a cleaner way to deal with a program that thinks it always runs with write permission on the compilation dir? https://github.com/miki151/keeperrl/issues/376

I think that you can just put the data folder for the paid version on ~/.keeperrl, in case someone can test this.