### PR TITLE
parity: 1.10.8 -> 1.10.9

### DIFF
--- a/pkgs/applications/altcoins/parity/default.nix
+++ b/pkgs/applications/altcoins/parity/default.nix
@@ -1,6 +1,6 @@
 let
-  version     = "1.10.8";
-  sha256      = "0q6blsbxn48afqf3cmxvmdlyzvf0cpqcymsjbsk8nyx0zxzf1dpk";
+  version     = "1.10.9";
+  sha256      = "1irfksx887vvvdf97q26qacn22kmyj8fgb3ghh9wv5qnzrn3564g";
   cargoSha256 = "0rzhabyhprmcg0cdmibbb8zgqf6z4izsdq8m060mppkkv675x0lf";
   patches     = [ ./patches/vendored-sources-1.10.patch ];
 in


### PR DESCRIPTION
###### Motivation for this change

* https://github.com/paritytech/parity/releases/tag/v1.10.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

