### PR TITLE
percona-xtrabackup: 2.4.9 -> 2.4.12

### DIFF
--- a/pkgs/tools/backup/percona-xtrabackup/default.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     "-DWITH_SSL=system"
     "-DWITH_ZLIB=system"
     "-DWITH_MAN_PAGES=OFF"
+    "-DCMAKE_CXX_FLAGS=-std=gnu++03"
   ];
 
   postInstall = ''

--- a/pkgs/tools/backup/percona-xtrabackup/default.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/default.nix
@@ -1,40 +1,38 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig
-, boost, bison, curl, ncurses, openssl, readline, xxd
+, boost, bison, curl, ncurses, openssl, xxd
 , libaio, libev, libgcrypt, libgpgerror, libtool, zlib
 }:
 
 stdenv.mkDerivation rec {
   name = "percona-xtrabackup-${version}";
-  version = "2.4.9";
+  version = "2.4.12";
 
   src = fetchFromGitHub {
     owner = "percona";
     repo = "percona-xtrabackup";
     rev = name;
-    sha256 = "11w87wj2jasrnygzjg3b59q9x0m6lhyg1wzdvclmgbmqsk9bvqv4";
+    sha256 = "1w17v2c677b3vfnm81bs63kjbfiin7f12wl9fbgp83hfpyx5msan";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    boost bison curl ncurses openssl readline xxd
+    boost bison curl ncurses openssl xxd
     libaio libev libgcrypt libgpgerror libtool zlib
   ];
 
   cmakeFlags = [
     "-DBUILD_CONFIG=xtrabackup_release"
     "-DINSTALL_MYSQLTESTDIR=OFF"
-    "-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock"
+    "-DWITH_BOOST=system"
     "-DWITH_SSL=system"
     "-DWITH_ZLIB=system"
-    "-DWITH_MECAB=system"
-    "-DWITH_EXTRA_CHARSETS=all"
-    "-DWITH_INNODB_MEMCACHED=1"
     "-DWITH_MAN_PAGES=OFF"
-    "-DWITH_HTML_DOCS=OFF"
-    "-DWITH_LATEX_DOCS=OFF"
-    "-DWITH_PDF_DOCS=OFF"
   ];
+
+  postInstall = ''
+    rm -r "$out"/lib/plugin/debug
+  '';
 
   meta = with stdenv.lib; {
     description = "Non-blocking backup tool for MySQL";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4364,6 +4364,7 @@ with pkgs;
   pepper = callPackage ../tools/admin/salt/pepper { };
 
   percona-xtrabackup = callPackage ../tools/backup/percona-xtrabackup {
+    stdenv = overrideCC stdenv gcc5;
     boost = boost159;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4364,7 +4364,6 @@ with pkgs;
   pepper = callPackage ../tools/admin/salt/pepper { };
 
   percona-xtrabackup = callPackage ../tools/backup/percona-xtrabackup {
-    stdenv = overrideCC stdenv gcc5;
     boost = boost159;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

