### PR TITLE
termite: Add support for macOS

### DIFF
--- a/pkgs/applications/misc/termite/add_errno_header.patch
+++ b/pkgs/applications/misc/termite/add_errno_header.patch
@@ -1,0 +1,24 @@
+From 95c90f302c384f410dc92e64468ac7061b57fe2d Mon Sep 17 00:00:00 2001
+From: Michael Hoang <enzime@users.noreply.github.com>
+Date: Fri, 13 Jul 2018 19:03:09 +1000
+Subject: [PATCH] Add errno.h header which isn't always included automatically.
+
+---
+ termite.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/termite.cc b/termite.cc
+index 160fe82..13e2572 100644
+--- a/termite.cc
++++ b/termite.cc
+@@ -21,6 +21,7 @@
+ #include <cstdlib>
+ #include <cstring>
+ #include <cmath>
++#include <errno.h>
+ #include <functional>
+ #include <limits>
+ #include <map>
+-- 
+2.17.1
+

--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, vte, gtk3, ncurses, makeWrapper, wrapGAppsHook, symlinkJoin
+{ stdenv, fetchFromGitHub, lib, pkgconfig, vte, gtk3, ncurses, makeWrapper, wrapGAppsHook, symlinkJoin
 , configFile ? null
 }:
 
@@ -7,16 +7,17 @@ let
   termite = stdenv.mkDerivation {
     name = "termite-${version}";
 
-    src = fetchgit {
-      url = "https://github.com/thestinger/termite";
-      rev = "refs/tags/v${version}";
+    src = fetchFromGitHub {
+      owner = "thestinger";
+      repo = "termite";
+      rev = "v${version}";
       sha256 = "02cn70ygl93ghhkhs3xdxn5b1yadc255v3yp8cmhhyzsv5027hvj";
+      fetchSubmodules = true;
     };
 
     # https://github.com/thestinger/termite/pull/516
-    patches = [ ./url_regexp_trailing.patch ];
-
-    postPatch = "sed '1i#include <math.h>' -i termite.cc";
+    patches = [ ./url_regexp_trailing.patch ./add_errno_header.patch
+                ] ++ lib.optional stdenv.isDarwin ./remove_ldflags_macos.patch;
 
     makeFlags = [ "VERSION=v${version}" "PREFIX=" "DESTDIR=$(out)" ];
 

--- a/pkgs/applications/misc/termite/remove_ldflags_macos.patch
+++ b/pkgs/applications/misc/termite/remove_ldflags_macos.patch
@@ -1,0 +1,25 @@
+From 1b5a6934635c55472eb7949bd87ab3f45fa1b2f3 Mon Sep 17 00:00:00 2001
+From: Michael Hoang <enzime@users.noreply.github.com>
+Date: Fri, 13 Jul 2018 19:01:51 +1000
+Subject: [PATCH] Remove --as-needed flag from ld to fix compilation on macOS.
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index b115f42..ab301ba 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,7 +29,7 @@ ifeq (${CXX}, clang++)
+ 	CXXFLAGS += -Wimplicit-fallthrough
+ endif
+ 
+-LDFLAGS := -s -Wl,--as-needed ${LDFLAGS}
++LDFLAGS := -s -Wl ${LDFLAGS}
+ LDLIBS := ${shell pkg-config --libs ${GTK} ${VTE}}
+ 
+ termite: termite.cc url_regex.hh util/clamp.hh util/maybe.hh util/memory.hh
+-- 
+2.17.1
+


### PR DESCRIPTION
Replace fetchgit with fetchFromGitHub now that it supports fetching
submodules. Remove unnecessary postPatch to add <math.h> as termite
already includes <cmath>. Add a patch to include <errno.h> and remove
the --as-needed flag from ld on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

