### PR TITLE
dar: 2.5.14 -> 2.5.15

### DIFF
--- a/pkgs/tools/backup/dar/default.nix
+++ b/pkgs/tools/backup/dar/default.nix
@@ -3,27 +3,37 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  version = "2.5.14";
+  version = "2.5.15";
   name = "dar-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/dar/${name}-bis.tar.gz";
-    sha256 = "1sbd7n5mfqkwxy5rz2v8575y21j94ypwrpinizr3l2yy9pq49rx5";
+    url = "mirror://sourceforge/dar/${name}.tar.gz";
+    sha256 = "1h700i2k524w5rf5gr9yxl50ca5jwzqlkifay4ffcbhbkqln1n2q";
   };
 
   buildInputs = [ zlib bzip2 openssl lzo libgcrypt gpgme xz ]
     ++ optionals stdenv.isLinux [ attr e2fsprogs ];
 
-  configureFlags = [ "--disable-dar-static" ];
+  configureFlags = [
+    "--disable-birthtime"
+    "--disable-upx"
+    "--disable-dar-static"
+    "--disable-build-html"
+    "--enable-threadar"
+  ];
+
+  postInstall = ''
+    rm -r "$out"/share/dar # Disable html help
+  '';
 
   enableParallelBuilding = true;
 
   hardeningDisable = [ "format" ];
 
   meta = {
-    homepage = http://dar.linux.free.fr/;
+    homepage = http://dar.linux.free.fr;
     description = "Disk ARchiver, allows backing up files into indexed archives";
-    maintainers = [ maintainers.viric ];
+    maintainers = with maintainers; [ viric ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1946,7 +1946,7 @@ with pkgs;
 
   daq = callPackage ../applications/networking/ids/daq { };
 
-  dar = callPackage ../tools/archivers/dar { };
+  dar = callPackage ../tools/backup/dar { };
 
   darkhttpd = callPackage ../servers/http/darkhttpd { };
 


### PR DESCRIPTION
###### Motivation for this change
Update version.
Moved to backup category.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

