### PR TITLE
openblas: "backport" another patch, fix crash w/Go and Octave

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -125,6 +125,12 @@ stdenv.mkDerivation rec {
         url = "https://github.com/xianyi/OpenBLAS/commit/5f2a3c05cd0e3872be3c5686b9da6b627658eeb7.patch";
         sha256 = "1qvxhk92likrshw6z6hjqxvkblwzgsbzis2b2f71bsvx9174qfk1";
       })
+      # Double "MAX_ALLOCATING_THREADS", fix with Go and Octave
+      # https://github.com/xianyi/OpenBLAS/pull/1663 (see also linked issue)
+      (fetchpatch {
+        url = "https://github.com/xianyi/OpenBLAS/commit/a49203b48c4a3d6f86413fc8c4b1fbfaa1946463.patch";
+        sha256 = "0v6kjkbgbw7hli6xkism48wqpkypxmcqvxpx564snll049l2xzq2";
+      })
     ];
 
   doCheck = true;


### PR DESCRIPTION
Also fixes numpy crashing during tests w/musl.






<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---