### PR TITLE
libqmatrixclient: 0.2.1 -> 0.3.0.2; quaternion: 0.0.9 -> 0.0.9.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "quaternion-${version}";
-  version = "0.0.9";
+  version = "0.0.9.2";
 
   src = fetchFromGitHub {
     owner  = "QMatrixClient";
     repo   = "Quaternion";
     rev    = "v${version}";
-    sha256 = "0zdpll953a7biwnklhgmgg3k2vz7j58lc1nmfkmvsfcj1fmdf408";
+    sha256 = "0zrr4khbbdf5ziq65gi0cb1yb1d0y5rv18wld22w1x96f7fkmrib";
   };
 
   buildInputs = [ qtbase qtquickcontrols libqmatrixclient ];

--- a/pkgs/development/libraries/libqmatrixclient/default.nix
+++ b/pkgs/development/libraries/libqmatrixclient/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "libqmatrixclient-${version}";
-  version = "0.2.1";
+  version = "0.3.0.2";
 
   src = fetchFromGitHub {
     owner  = "QMatrixClient";
     repo   = "libqmatrixclient";
     rev    = "v${version}";
-    sha256 = "0sv5hhdsffq7092n6hggfz9a78qn3jfmbvw2flmc4ippzz563akv";
+    sha256 = "03pxmr4wa818fgqddkr2fkwz6pda538x3ic9yq7c40x98zqf55w5";
   };
 
   buildInputs = [ qtbase ];


### PR DESCRIPTION
Big bump to libqmatrixclient.

See also:

https://github.com/QMatrixClient/Quaternion/releases/tag/v0.0.9.2



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---