### PR TITLE
radare2-cutter: don't wrap, shouldn't be needed (and might be wrong)

### DIFF
--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 # nativeBuildInputs
-, qmake, pkgconfig, makeWrapper
+, qmake, pkgconfig
 # Qt
 , qtbase, qtsvg, qtwebengine
 # buildInputs
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       --replace "include(lib_radare2.pri)" ""
   '';
 
-  nativeBuildInputs = [ qmake pkgconfig makeWrapper ];
+  nativeBuildInputs = [ qmake pkgconfig ];
   buildInputs = [ qtbase qtsvg qtwebengine radare2 python3 ];
 
   qmakeFlags = [
@@ -41,13 +41,6 @@ stdenv.mkDerivation rec {
     # Disable until can be looked at.
     "CUTTER_ENABLE_JUPYTER=false"
   ];
-
-  # Fix crash on startup in some situations
-  postInstall = ''
-    wrapProgram $out/bin/Cutter \
-      --prefix QT_PLUGIN_PATH : ${qtbase.bin}/${qtbase.qtPluginPrefix} \
-      --prefix LD_LIBRARY_PATH : ${qtbase.out}/lib
-  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
This was working around mixed qt versions apparently,
which I've fixed and it is no longer needed.

Sorry about that.





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---