### PR TITLE
xfce4-13: update components

### DIFF
--- a/pkgs/desktops/xfce/art/xfce4-icon-theme.nix
+++ b/pkgs/desktops/xfce/art/xfce4-icon-theme.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk2 }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-icon-theme";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool gtk ];
+  buildInputs = [ intltool gtk2 ];
 
   meta = {
     homepage = http://www.xfce.org/;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, xfconf, gtk2}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -19,9 +19,7 @@ makeScope newScope (self: with self; {
 
   libxfce4ui = callPackage ./libxfce4ui { };
 
-  mousepad = callPackage ./mousepad {
-    inherit (gnome3) gtksourceview;
-  };
+  mousepad = callPackage ./mousepad { };
 
   orage = callPackage ./orage { };
 

--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -44,6 +44,12 @@ makeScope newScope (self: with self; {
 
   xfce4-appfinder = callPackage ./xfce4-appfinder { };
 
+  xfce4-battery-plugin = callPackage ./xfce4-battery-plugin { };
+
+  xfce4-clipman-plugin = callPackage ./xfce4-clipman-plugin { };
+
+  xfce4-cpufreq-plugin = callPackage ./xfce4-cpufreq-plugin { };
+
   xfce4-dev-tools = callPackage ./xfce4-dev-tools {
     mkXfceDerivation = mkXfceDerivation.override {
       xfce4-dev-tools = null;
@@ -54,19 +60,26 @@ makeScope newScope (self: with self; {
 
   xfce4-mixer = callPackage ./xfce4-mixer { };
 
+  xfce4-netload-plugin = callPackage ./xfce4-netload-plugin { };
+
   xfce4-notifyd = callPackage ./xfce4-notifyd { };
 
   xfce4-panel = callPackage ./xfce4-panel { };
 
   xfce4-power-manager = callPackage ./xfce4-power-manager { };
 
+  xfce4-pulseaudio-plugin = callPackage ./xfce4-pulseaudio-plugin { };
+
   xfce4-screenshooter = callPackage ./xfce4-screenshooter {
     inherit (gnome3) libsoup;
   };
 
-  xfce4-taskmanager = callPackage ./xfce4-taskmanager { };
+  xfce4-session = callPackage ./xfce4-session { };
+  xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
 
   xfce4-settings = callPackage ./xfce4-settings { };
+
+  xfce4-taskmanager = callPackage ./xfce4-taskmanager { };
 
   xfce4-terminal = callPackage ./xfce4-terminal {
     inherit (gnome3) vte;
@@ -74,5 +87,29 @@ makeScope newScope (self: with self; {
 
   xfce4-volumed-pulse = callPackage ./xfce4-volumed-pulse { };
 
+  xfce4-whiskermenu-plugin = callPackage ./xfce4-whiskermenu-plugin { };
+
+  xfce4-xkb-plugin = callPackage ./xfce4-xkb-plugin { };
+
   xfwm4 = callPackage ./xfwm4 { };
+
+  ## COMMON PARTS WITH XFCE 4.12
+
+  gtk-xfce-engine = callPackage ../xfce/core/gtk-xfce-engine.nix { withGtk3 = false; };
+
+  xfce4-icon-theme = callPackage ../xfce/art/xfce4-icon-theme.nix { };
+
+  xfwm4-themes = callPackage ../xfce/art/xfwm4-themes.nix { };
+
+  xfce4-embed-plugin = callPackage ../xfce/panel-plugins/xfce4-embed-plugin.nix { };
+
+  xfce4-hardware-monitor-plugin = callPackage ../xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix { };
+
+  ## THIRD PARTY PLIGINS
+
+  xfce4-dockbarx-plugin = callPackage ../xfce/panel-plugins/xfce4-dockbarx-plugin.nix { };
+
+  xfce4-namebar-plugin = callPackage ../xfce/panel-plugins/xfce4-namebar-plugin.nix { };
+
+  xfce4-windowck-plugin = callPackage ../xfce/panel-plugins/xfce4-windowck-plugin.nix { };
 })

--- a/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools ? null }:
+{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools }:
 
-{ category, pname, sha256 ? null, version, ... } @ args:
+{ category, pname, version, rev ? "${pname}-${version}", sha256, ... } @ args:
 
 let
   inherit (builtins) filter getAttr head isList;
@@ -20,12 +20,13 @@ let
 
     src = fetchgit {
       url = "git://git.xfce.org/${category}/${pname}";
-      rev = name;
-      inherit sha256;
+      inherit rev sha256;
     };
 
     enableParallelBuilding = true;
     outputs = [ "out" "dev" ];
+
+    preFixup = ''rm $out/share/icons/hicolor/icon-theme.cache || true'';
 
     meta = with stdenv.lib; {
       homepage = "https://git.xfce.org/${category}/${pname}/about";

--- a/pkgs/desktops/xfce4-13/mousepad/default.nix
+++ b/pkgs/desktops/xfce4-13/mousepad/default.nix
@@ -1,12 +1,12 @@
-{ mkXfceDerivation, exo, wrapGAppsHook, dbus_glib ? null, gtk3, gtksourceview }:
+{ mkXfceDerivation, exo, wrapGAppsHook, dbus-glib, gtk3, gtksourceview3 }:
 
 mkXfceDerivation rec {
   category = "apps";
   pname = "mousepad";
-  version = "0.4.0";
+  version = "0.4.1";
 
-  sha256 = "0mm90iq2yd3d0qbgsjyk3yj25k0gm3p34jazl640vixk84v20lyw";
+  sha256 = "0pr1w9n0qq2raxhy78982i9g17x0ya02q7vdrn0wb2bpk74hlki5";
 
   nativeBuildInputs = [ exo wrapGAppsHook ];
-  buildInputs = [ dbus_glib gtk3 gtksourceview ];
+  buildInputs = [ dbus-glib gtk3 gtksourceview3 ];
 }

--- a/pkgs/desktops/xfce4-13/orage/default.nix
+++ b/pkgs/desktops/xfce4-13/orage/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchpatch, mkXfceDerivation, dbus_glib ? null, gtk2, libical, libnotify ? null
+{ lib, fetchpatch, mkXfceDerivation, dbus-glib, gtk2, libical, libnotify
 , popt ? null, libxfce4ui ? null, xfce4-panel ? null, withPanelPlugin ? true }:
 
 assert withPanelPlugin -> libxfce4ui != null && xfce4-panel != null;
@@ -13,7 +13,7 @@ mkXfceDerivation rec {
   version = "4.12.1";
 
   sha256 = "04z6y1vfaz1im1zq1zr7cf8pjibjhj9zkyanbp7vn30q520yxa0m";
-  buildInputs = [ dbus_glib gtk2 libical libnotify popt ]
+  buildInputs = [ dbus-glib gtk2 libical libnotify popt ]
     ++ optionals withPanelPlugin [ libxfce4ui xfce4-panel ];
 
   patches = [

--- a/pkgs/desktops/xfce4-13/xfburn/default.nix
+++ b/pkgs/desktops/xfce4-13/xfburn/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, docbook_xml_xslt, exo, gtk2, libburn, libICE, libisofs, libSM, libxfce4ui, libxslt }:
+{ mkXfceDerivation, docbook_xml_xslt, exo, gtk2, libburn, libisofs, libxfce4ui, libxslt }:
 
 mkXfceDerivation rec {
   category = "apps";
@@ -14,5 +14,5 @@ mkXfceDerivation rec {
   sha256 = "1lmv48vqrlap1a2ha72g16vqly18zvcwj8y3f3f00l10pmn52bkp";
 
   nativeBuildInputs = [ libxslt ];
-  buildInputs = [ exo gtk2 libburn libICE libisofs libSM libxfce4ui ];
+  buildInputs = [ exo gtk2 libburn libisofs libxfce4ui ];
 }

--- a/pkgs/desktops/xfce4-13/xfce4-battery-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-battery-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-battery-plugin";
+  version = "1.1.0";
+  rev = version;
+  sha256 = "0mz0lj3wjrsj9n4wcqrvv08430g38nkjbdimxdy8316n6bqgngfn";
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-clipman-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-clipman-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, libXtst, libxfce4ui, libxfce4util, xfce4-panel, xfconf, exo }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-clipman-plugin";
+  version = "1.4.2";
+  rev = version;
+  sha256 = "1c2h1cs7pycf1rhpirmvb0l0dfvlacb7xgm31q9rxmhihnycd2na";
+
+  buildInputs = [ exo gtk3 libXtst libxfce4ui libxfce4util xfce4-panel xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-cpufreq-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-cpufreq-plugin/default.nix
@@ -1,0 +1,10 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-cpufreq-plugin";
+  version = "1.2.0";
+  sha256 = "0zhs7b7py1njczmpnib4532fwpnd3vnpqfhss2r136cfgy72kp6g";
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-mixer/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-mixer/default.nix
@@ -1,5 +1,4 @@
-{ mkXfceDerivation, automakeAddFlags, dbus_glib, gst-plugins-base, gtk2
-, libICE, libSM, libunique, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+{ mkXfceDerivation, automakeAddFlags, dbus-glib, gtk2, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
 
 mkXfceDerivation rec {
   category = "apps";
@@ -16,12 +15,8 @@ mkXfceDerivation rec {
   '';
 
   buildInputs = [
-    dbus_glib
-    gst-plugins-base
+    dbus-glib
     gtk2
-    libICE
-    libSM
-    libunique
     libxfce4ui
     libxfce4util
     xfce4-panel

--- a/pkgs/desktops/xfce4-13/xfce4-netload-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-netload-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-netload-plugin";
+  version = "1.3.1";
+  rev = "version-${version}";
+  sha256 = "0nm8advafw4jpc9p1qszyfqa56194sz51z216rdh4c6ilcrrpy1h";
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-pulseaudio-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-pulseaudio-plugin/default.nix
@@ -1,0 +1,19 @@
+{ mkXfceDerivation, automakeAddFlags, dbus-glib, dbus, gtk3, libpulseaudio
+, libnotify, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-pulseaudio-plugin";
+  version = "0.4.1";
+  sha256 = "1c8krpg3l6ki00ldd9hifc4bddysdm0w3x5w43fkr31j0zrscvfp";
+
+  nativeBuildInputs = [ automakeAddFlags ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${dbus-glib.dev}/include/dbus-1.0" "-I${dbus.dev}/include/dbus-1.0" ];
+
+  postPatch = ''
+    substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
+  '';
+
+  buildInputs = [ gtk3 libnotify libpulseaudio libxfce4ui libxfce4util xfce4-panel xfconf ];
+}

--- a/pkgs/desktops/xfce4-13/xfce4-session/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-session/default.nix
@@ -1,0 +1,27 @@
+{ mkXfceDerivation, polkit, exo, libxfce4util, libxfce4ui, xfconf, dbus-glib, dbus, iceauth, gtk3, libwnck3, xorg }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-session";
+  version = "4.13.0";
+
+  sha256 = "0d6h1kgqq6g084jrxx4jxw98h5g0vwsxqrvk0bmapyxh2sbrg07y";
+
+  buildInputs = [ exo dbus-glib dbus gtk3 libxfce4ui libxfce4util libwnck3 xfconf polkit iceauth ];
+
+  configureFlags = [ "--with-xsession-prefix=$(out)" ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${dbus-glib.dev}/include/dbus-1.0"
+                         "-I${dbus.dev}/include/dbus-1.0"
+                         "-I${dbus.lib}/lib/dbus-1.0/include"
+                       ];
+
+  postPatch = ''
+    substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
+    substituteInPlace scripts/xflock4 --replace PATH=/bin:/usr/bin "PATH=/run/current-system/sw/bin:$out/bin:${xorg.xset}/bin"
+  '';
+
+  meta =  {
+    description = "Session manager for Xfce";
+  };
+}

--- a/pkgs/desktops/xfce4-13/xfce4-whiskermenu-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-whiskermenu-plugin/default.nix
@@ -1,0 +1,18 @@
+{ mkXfceDerivation, dbus-glib, gtk3, cmake, exo, garcon, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-whiskermenu-plugin";
+  version = "2.2.0";
+  rev = "v${version}";
+  sha256 = "1d35xxkdzw8pl3d5ps226mmrrjk0hqczsbvl5smh7l7jbwfambjm";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ dbus-glib exo garcon gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/xfce4-popup-whiskermenu \
+      --replace $out/bin/xfce4-panel ${xfce4-panel.out}/bin/xfce4-panel
+  '';
+}

--- a/pkgs/desktops/xfce4-13/xfce4-xkb-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-xkb-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, librsvg, libwnck3, libxklavier, garcon, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-xkb-plugin";
+  version = "0.8.1";
+  rev = version;
+  sha256 = "1gyky4raynp2ggdnq0g96c6646fjm679fzipcsmf1q0aymr8d5ky";
+
+  buildInputs = [ garcon gtk3 librsvg libxfce4ui libxfce4util libxklavier libwnck3 xfce4-panel xfconf ];
+}


### PR DESCRIPTION
###### Motivation for this change

 - [x] update minor versions of XFCE components
 - [x] libxklavier: 5.3 -> 5.4 (updated dependency)
 - [x] fix ```xfce4-panel``` so it is able to find the plugins (the patch is copied from ```xfce4-12```)
 - [x] backported #16227 from ```xfce4-12```
 - [x] added few plugins from ```xfce4-12```

@yegortimoshenko @vcunat 

EDIT: the PR seems to be too big to be accepted, so I extracted some pieces into own PRs. As they are  accepted, this PR will shrink down with each rebase until become small and understandable.