### PR TITLE
jmol: 14.29.12 -> 14.29.17

### DIFF
--- a/pkgs/applications/science/chemistry/jmol/default.nix
+++ b/pkgs/applications/science/chemistry/jmol/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, lib
 , fetchurl
 , unzip
 , makeDesktopItem
@@ -16,15 +17,15 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  version = "${baseVersion}.${patchVersion}";
-  baseVersion = "14.29";
-  patchVersion = "12";
+  version = "14.29.17";
   pname = "jmol";
   name = "${pname}-${version}";
 
-  src = fetchurl {
+  src = let 
+    baseVersion = "${lib.versions.major version}.${lib.versions.minor version}";
+  in fetchurl {
     url = "mirror://sourceforge/jmol/Jmol/Version%20${baseVersion}/Jmol%20${version}/Jmol-${version}-binary.tar.gz";
-    sha256 = "1ndq9am75janshrnk26334z1nmyh3k4bp20napvf2zv0lfp8k3bv";
+    sha256 = "1dnxbvi8ha9z2ldymkjpxydd216afv6k7fdp3j70sql10zgy0isk";
   };
 
   patchPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Simple version bump. Also simplifies the version attribute so that @r-ryantm hopefully can deal with that now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

