### PR TITLE
rebar3: 3.4.3 -> 3.6.1

### DIFF
--- a/pkgs/development/beam-modules/hex-registry-snapshot.nix
+++ b/pkgs/development/beam-modules/hex-registry-snapshot.nix
@@ -2,15 +2,14 @@
 
 stdenv.mkDerivation rec {
     name = "hex-registry";
-    rev = "9f736e7";
-    version = "0.0.0+build.${rev}";
+    rev = "11d7a24e9f53f52490ce255a6248e71128e73aa1";
+    version = "20180712.${rev}";
 
-    # src = /home/gleber/code/erl/hex-pm-registry-snapshots;
     src = fetchFromGitHub {
-        owner = "erlang-nix";
-        repo = "hex-pm-registry-snapshots";
         inherit rev;
-        sha256 = "1xiw5yifyk3bbmr0cr82y1nc4c6zk11f6azdv07glb7yrgccrv79";
+        owner  = "erlang-nix";
+        repo   = "hex-pm-registry-snapshots";
+        sha256 = "0dbpcrdh6jqmvnm1ysmy7ixyc95vnbqmikyx5kk77qwgyd43fqgi";
     };
 
     installPhase = ''

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -3,19 +3,19 @@
   tree, fetchFromGitHub, hexRegistrySnapshot }:
 
 let
-  version = "3.4.3";
+  version = "3.6.1";
 
   bootstrapper = ./rebar3-nix-bootstrap;
 
   erlware_commons = fetchHex {
     pkg = "erlware_commons";
-    version = "1.0.0";
-    sha256 = "0wkphbrjk19lxdwndy92v058qwcaz13bcgdzp33h21aa7vminzx7";
+    version = "1.2.0";
+    sha256 = "149kkn9gc9cjgvlmakygq475r63q2rry31s29ax0s425dh37sfl7";
   };
   ssl_verify_fun = fetchHex {
     pkg = "ssl_verify_fun";
-    version = "1.1.2";
-    sha256 = "0qdyx70v09fydv4wzz1djnkixqj62ny40yjjhv2q6mh47lns2arj";
+    version = "1.1.3";
+    sha256 = "1zljxashfhqmiscmf298vhr880ppwbgi2rl3nbnyvsfn0mjhw4if";
   };
   certifi = fetchHex {
     pkg = "certifi";
@@ -24,23 +24,23 @@ let
   };
   providers = fetchHex {
     pkg = "providers";
-    version = "1.6.0";
-    sha256 = "0byfa1h57n46jilz4q132j0vk3iqc0v1vip89li38gb1k997cs0g";
+    version = "1.7.0";
+    sha256 = "19p4rbsdx9lm2ihgvlhxyld1q76kxpd7qwyqxxsgmhl5r8ln3rlb";
   };
   getopt = fetchHex {
     pkg = "getopt";
-    version = "0.8.2";
-    sha256 = "1xw30h59zbw957cyjd8n50hf9y09jnv9dyry6x3avfwzcyrnsvkk";
+    version = "1.0.1";
+    sha256 = "174mb46c2qd1f4a7507fng4vvscjh1ds7rykfab5rdnfp61spqak";
   };
   bbmustache = fetchHex {
     pkg = "bbmustache";
-    version = "1.3.0";
-    sha256 = "042pfgss8kscq6ssg8gix8ccmdsrx0anjczsbrn2a6c36ljrx2p6";
+    version = "1.5.0";
+    sha256 = "0xg3r4lxhqifrv32nm55b4zmkflacc1s964g15p6y6jfx6v4y1zd";
   };
   relx = fetchHex {
     pkg = "relx";
-    version = "3.23.1";
-    sha256 = "13j7wds2d7b8v3r9pwy3zhwhzywgwhn6l9gm3slqzyrs1jld0a9d";
+    version = "3.26.0";
+    sha256 = "1f810rb01kdidpa985s321ycg3y4hvqpzbk263n6i1bfnqykkvv9";
   };
   cf = fetchHex {
     pkg = "cf";
@@ -49,13 +49,13 @@ let
   };
   cth_readable = fetchHex {
     pkg = "cth_readable";
-    version = "1.3.0";
-    sha256 = "1s7bqj6f2zpbyjmbfq2mm6vcz1jrxjr2nd0531wshsx6fnshqhvs";
+    version = "1.4.2";
+    sha256 = "1pjid4f60pp81ds01rqa6ybksrnzqriw3aibilld1asn9iabxkav";
   };
   eunit_formatters = fetchHex {
     pkg = "eunit_formatters";
-    version = "0.3.1";
-    sha256 = "0cg9dasv60v09q3q4wja76pld0546mhmlpb0khagyylv890hg934";
+    version = "0.5.0";
+    sha256 = "1jb3hzb216r29x2h4pcjwfmx1k81431rgh5v0mp4x5146hhvmj6n";
   };
   rebar3_hex = fetchHex {
     pkg = "rebar3_hex";
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://github.com/rebar/rebar3/archive/${version}.tar.gz";
-    sha256 = "1a05gpxxc3mx5v33kzpb5xnq5vglmjl0q8hrcvpinjlazcwbg531";
+    sha256 = "0cqhqymzh10pfyxqiy4hcg3d2myz3chx0y4m2ixmq8zk81acics0";
   };
 
   inherit bootstrapper;
@@ -121,6 +121,6 @@ stdenv.mkDerivation {
       '';
 
     platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.gleber ];
+    maintainers = with stdenv.lib.maintainers; [ gleber tazjin ];
   };
 }

--- a/pkgs/development/tools/build-managers/rebar3/hermetic-rebar3.patch
+++ b/pkgs/development/tools/build-managers/rebar3/hermetic-rebar3.patch
@@ -1,5 +1,5 @@
 diff --git a/bootstrap b/bootstrap
-index 7c56bab..16c1be5 100755
+index 5dedd713..864056c4 100755
 --- a/bootstrap
 +++ b/bootstrap
 @@ -101,7 +101,7 @@ extract(Binary) ->
@@ -12,9 +12,8 @@ index 7c56bab..16c1be5 100755
                         [{body_format, binary}],
                         rebar) of
 diff --git a/src/rebar_hermeticity.erl b/src/rebar_hermeticity.erl
-new file mode 100644
-index 0000000..8f6cc7d
---- /dev/null
+index e69de29b..8f6cc7d0 100644
+--- a/src/rebar_hermeticity.erl
 +++ b/src/rebar_hermeticity.erl
 @@ -0,0 +1,42 @@
 +%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
@@ -60,20 +59,20 @@ index 0000000..8f6cc7d
 +    ?ERROR("Request: ~p ~s", [Method, Url]),
 +    erlang:halt(1).
 diff --git a/src/rebar_pkg_resource.erl b/src/rebar_pkg_resource.erl
-index d588f24..9ac8ad4 100644
+index 2cf167ee..6080aaca 100644
 --- a/src/rebar_pkg_resource.erl
 +++ b/src/rebar_pkg_resource.erl
-@@ -109,7 +109,7 @@ make_vsn(_) ->
+@@ -127,7 +127,7 @@ make_vsn(_) ->
  request(Url, ETag) ->
-     HttpOptions = [{ssl, ssl_opts(Url)}, {relaxed, true} | rebar_utils:get_proxy_auth()],
- 
--    case httpc:request(get, {Url, [{"if-none-match", ETag} || ETag =/= false]++[{"User-Agent", rebar_utils:user_agent()}]},
-+    case rebar_hermeticity:request(get, {Url, [{"if-none-match", ETag} || ETag =/= false]++[{"User-Agent", rebar_utils:user_agent()}]},
-                        HttpOptions,
-                        [{body_format, binary}],
-                        rebar) of
+     HttpOptions = [{ssl, ssl_opts(Url)},
+                    {relaxed, true} | rebar_utils:get_proxy_auth()],
+-    case httpc:request(get, {Url, [{"if-none-match", "\"" ++ ETag ++ "\""}
++    case rebar_hermeticity:request(get, {Url, [{"if-none-match", "\"" ++ ETag ++ "\""}
+                                    || ETag =/= false] ++
+                              [{"User-Agent", rebar_utils:user_agent()}]},
+                        HttpOptions, [{body_format, binary}], rebar) of
 diff --git a/src/rebar_prv_update.erl b/src/rebar_prv_update.erl
-index a019c5a..697cbab 100644
+index 17446311..4d44d794 100644
 --- a/src/rebar_prv_update.erl
 +++ b/src/rebar_prv_update.erl
 @@ -38,6 +38,8 @@ init(State) ->
@@ -85,17 +84,17 @@ index a019c5a..697cbab 100644
  do(State) ->
      try
          case rebar_packages:registry_dir(State) of
-@@ -52,7 +54,7 @@ do(State) ->
-                 case rebar_utils:url_append_path(CDN, ?REMOTE_REGISTRY_FILE) of
+@@ -53,7 +55,7 @@ do(State) ->
                      {ok, Url} ->
+                         HttpOptions = [{relaxed, true} | rebar_utils:get_proxy_auth()],
                          ?DEBUG("Fetching registry from ~p", [Url]),
 -                        case httpc:request(get, {Url, [{"User-Agent", rebar_utils:user_agent()}]},
 +                        case rebar_hermeticity:request(get, {Url, [{"User-Agent", rebar_utils:user_agent()}]},
-                                            [], [{stream, TmpFile}, {sync, true}],
+                                            HttpOptions, [{stream, TmpFile}, {sync, true}],
                                             rebar) of
                              {ok, saved_to_file} ->
-@@ -76,6 +78,7 @@ do(State) ->
-             ?DEBUG("Error creating package index: ~p ~p", [C, erlang:get_stacktrace()]),
+@@ -77,6 +79,7 @@ do(State) ->
+             ?DEBUG("Error creating package index: ~p ~p", [C, S]),
              throw(?PRV_ERROR(package_index_write))
      end.
 +-endif.

--- a/pkgs/development/tools/erlang/hex2nix/default.nix
+++ b/pkgs/development/tools/erlang/hex2nix/default.nix
@@ -1,32 +1,23 @@
-{ stdenv, fetchFromGitHub, buildRebar3, buildHex
+{ stdenv, fetchFromGitHub, buildRebar3, buildHex,
 
-, getopt_0_8_2, erlware_commons_1_0_0 }:
+  # Erlang dependencies:
+  ibrowse_4_2_2,
+  getopt_0_8_2,
+  erlware_commons_1_0_0,
+  jsx_2_8_0 }:
 
-let
-  ibrowse_4_4_0 = buildHex {
-    name = "ibrowse";
-    version = "4.4.0";
-    sha256 = "1hpic1xgksfm00mbl1kwmszca6jmjca32s7gdd8g11i0hy45k3ka";
-  };
-  jsx_2_8_2 = buildHex {
-    name = "jsx";
-    version = "2.8.2";
-    sha256 = "0k7lnmwqbgpmh90wy30kc0qlddkbh9r3sjlyayaqsz1r1cix7idl";
-  };
-
-in
 buildRebar3 rec {
     name = "hex2nix";
-    version = "0.0.6";
+    version = "0.0.6-a31eadd7";
 
     src = fetchFromGitHub {
-      owner = "erlang-nix";
-      repo = "hex2nix";
-      rev = "${version}";
-      sha256 = "17rkzg836v7z2xf0i5m8zqfvr23dbmw1bi3c83km92f9glwa1dbf";
+      owner  = "erlang-nix";
+      repo   = "hex2nix";
+      rev    = "a31eadd7af2cbdac1b87991b378e98ea4fb40ae0";
+      sha256 = "1hnkrksyrbpq2gq25rfsrnm86n0g3biab88gswm3zj88ddrz6dyk";
     };
 
-    beamDeps = [ ibrowse_4_4_0 jsx_2_8_2 erlware_commons_1_0_0 getopt_0_8_2 ];
+    beamDeps = [ ibrowse_4_2_2 jsx_2_8_0 erlware_commons_1_0_0 getopt_0_8_2 ];
 
     enableDebugInfo = true;
 


### PR DESCRIPTION
Left to do:

* [x] get erlang-nix/hex-pm-registry-snapshots/#4 merged or host the registry snapshot elsewhere
* [ ] ~update `hex-packages.nix` (currently running on my machine)~ (will be a followup PR)
* [x] ensure that existing rebar-based packages still build correctly
----------------------

Updates rebar3 to version 3.6.1, which amongst other things introduces
support for rebar3 on Erlang/OTP 21.

Changes made:

* rebar3 and dependencies updated to new versions
* rebar3 hermeticity patch updated to apply against new version
* hex package registry snapshot updated

###### Motivation for this change

Nixpkgs already includes Erlang/OTP 21. The current included version of rebar3 is incompatible with the Erlang release, so an update is required.

This fixes #38966.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
