### PR TITLE
circleci-cli: init at 2018-05-12

### DIFF
--- a/pkgs/development/tools/misc/circleci-cli/default.nix
+++ b/pkgs/development/tools/misc/circleci-cli/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, docker, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "circleci-cli";
+  version = "2018-05-12";
+
+  src = fetchFromGitHub {
+    owner = "circleci";
+    repo = "local-cli";
+    rev = "2c7c1a74e3c3ffb8eebc03fccd782b1bfe9e940a";
+    sha256 = "0fp0fz0xr7ynp32lqcmaigl9p45wk1hd2gv9i5q5bj9syj3g7qzm";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p "$out/bin/"
+    cp "$src/circleci.sh" "$out/bin/circleci"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/circleci \
+      --prefix "PATH" : "${docker}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    # Box blurb edited from the AUR package circleci-cli
+    description = ''
+      Command to enable you to reproduce the CircleCI environment locally and
+      run jobs as if they were running on the hosted CirleCI application.
+    '';
+    maintainers = with maintainers; [ synthetica ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+    homepage = https://circleci.com/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1680,6 +1680,8 @@ with pkgs;
 
   ciopfs = callPackage ../tools/filesystems/ciopfs { };
 
+  circleci-cli = callPackage ../development/tools/misc/circleci-cli { };
+
   citrix_receiver = callPackage ../applications/networking/remote/citrix-receiver { };
   citrix_receiver_13_10_0 = citrix_receiver.override { version = "13.10.0"; };
   citrix_receiver_13_9_1  = citrix_receiver.override { version = "13.9.1";  };


### PR DESCRIPTION
###### Motivation for this change

New package :tada: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

