### PR TITLE
sage: replace flask-babel version pin by patch

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -14,16 +14,6 @@ let
 
       cvxopt = super.cvxopt.override { inherit glpk; };
 
-      # https://github.com/sagemath/sagenb/issues/437
-      flask-babel = super.flask-babel.overridePythonAttrs (attrs: rec {
-        version = "0.9";
-        src = attrs.src.override {
-          inherit version;
-          sha256 = "0k7vk4k54y55ma0nx2k5s0phfqbriwslhy5shh3b0d046q7ibzaa";
-        };
-        doCheck = false;
-      });
-
       # python packages that appear unmaintained and were not accepted into the nixpkgs
       # tree because of that. These packages are only dependencies of the more-or-less
       # deprecated sagenb. However sagenb is still a default dependency and the doctests

--- a/pkgs/applications/science/math/sage/sagenb.nix
+++ b/pkgs/applications/science/math/sage/sagenb.nix
@@ -36,6 +36,14 @@ buildPythonPackage rec {
   # tests depend on sage
   doCheck = false;
 
+  patches = [
+    # work with latest flask-babel
+    (fetchpatch {
+      url = "https://github.com/sagemath/sagenb/commit/ba065eca63dd34a383e4c7ba7561430a90fcd087.patch";
+      sha256 = "1lamzsrgymdd618imrasjp6ivhw2aynh83gkybsd7pm1rzjcq4x8";
+    })
+  ];
+
   meta = with stdenv.lib; {
     description = "Sage Notebook";
     license = licenses.gpl3Plus;


### PR DESCRIPTION
###### Motivation for this change

Upstream fixed the problem with flask-babel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

