### PR TITLE
xscope: init at 1.4.1

### DIFF
--- a/pkgs/applications/misc/xscope/default.nix
+++ b/pkgs/applications/misc/xscope/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, libXt }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "xscope";
+  version = "1.4.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/app/${name}.tar.bz2";
+    sha256 = "08zl3zghvbcqy0r5dn54dim84lp52s0ygrr87jr3a942a6ypz01k";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libXt ];
+
+  meta = with stdenv.lib; {
+    description = "program to monitor X11/Client conversations";
+    homepage = https://cgit.freedesktop.org/xorg/app/xscope/;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ];
+    platforms = with platforms; unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19214,6 +19214,8 @@ with pkgs;
 
   xsd = callPackage ../development/libraries/xsd { };
 
+  xscope = callPackage ../applications/misc/xscope { };
+
   xscreensaver = callPackage ../misc/screensavers/xscreensaver {
     inherit (gnome2) libglade;
   };


### PR DESCRIPTION
See the xscope README for more information:

https://cgit.freedesktop.org/xorg/app/xscope/tree/README





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---