### PR TITLE
stdenv: introduce isBootstrap for conditionals

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -132,7 +132,8 @@ in rec {
 
         extraAttrs = {
           inherit platform;
-          parent = last;
+          isBootstrap = true;
+          parent      = last;
 
           # This is used all over the place so I figured I'd just leave it here for now
           secure-format-patch = ./darwin-secure-format.patch;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -125,6 +125,9 @@ let
         isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian;
       isArm = builtins.trace "stdenv.isArm is deprecated after 18.03" hostPlatform.isArm;
 
+      # Whether this is an stdenv from one of the bootstrap stages.
+      isBootstrap = false;
+
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -107,6 +107,7 @@ let
           # Having the proper 'platform' in all the stdenvs allows getting proper
           # linuxHeaders for example.
           inherit platform;
+          isBootstrap = true;
         };
         overrides = self: super: (overrides self super) // { fetchurl = thisStdenv.fetchurlBoot; };
       };


### PR DESCRIPTION
###### Motivation for this change

This is useful for conditionals like optional dependencies that we don't
need when bootstrapping the stdenv, reducing the set of build time
dependencies that are required for a full rebuild.

On darwin it's even easier to pollute the stdenv build closure with extra dependencies because of cmake, python, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

