### PR TITLE
ocamlPackages.lwt_log: init at 1.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchzip, pkgconfig, ncurses, libev, jbuilder
-, ocaml, findlib, camlp4, cppo
+, ocaml, findlib, cppo
 , ocaml-migrate-parsetree, ppx_tools_versioned, result
+, withP4 ? !stdenv.lib.versionAtLeast ocaml.version "4.07"
+, camlp4 ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -13,12 +15,13 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    ocaml src/util/configure.ml -use-libev true -use-camlp4 true
+    ocaml src/util/configure.ml -use-libev true -use-camlp4 ${if withP4 then "true" else "false"}
   '';
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ncurses ocaml findlib jbuilder camlp4 cppo
-    ocaml-migrate-parsetree ppx_tools_versioned ];
+  buildInputs = [ ncurses ocaml findlib jbuilder cppo
+    ocaml-migrate-parsetree ppx_tools_versioned ]
+  ++ stdenv.lib.optional withP4 camlp4;
   propagatedBuildInputs = [ libev result ];
 
   installPhase = ''

--- a/pkgs/development/ocaml-modules/lwt_log/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_log/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, ocaml, findlib, jbuilder, lwt }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.0";
+  name = "ocaml${ocaml.version}-lwt_log-${version}";
+
+  inherit (lwt) src;
+
+  buildInputs = [ ocaml findlib jbuilder ];
+
+  propagatedBuildInputs = [ lwt ];
+
+  buildPhase = "jbuilder build -p lwt_log";
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    description = "Lwt logging library (deprecated)";
+    homepage = "https://github.com/aantron/lwt_log";
+    license = stdenv.lib.licenses.lgpl21;
+    inherit (ocaml.meta) platforms;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/tools/analysis/flow/default.nix
+++ b/pkgs/development/tools/analysis/flow/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchFromGitHub, lib, ocaml, libelf, cf-private, CoreServices,
-  findlib, camlp4, sedlex, ocamlbuild, lwt_ppx, wtf8, dtoa }:
+{ stdenv, fetchFromGitHub, lib, ocamlPackages, libelf, cf-private, CoreServices }:
 
 with lib;
 
@@ -14,21 +13,15 @@ stdenv.mkDerivation rec {
     sha256 = "0xrcjjk16w6anpy58qa4la1jyfjs0xg5xkp58slhai996wqif24k";
   };
 
-  # lwt.log is being split out into a separate package, so this can be
-  # removed once nixpkgs is updated.
-  # See https://github.com/ocsigen/lwt/issues/453#issuecomment-352897664
-  postPatch = ''
-    substituteInPlace Makefile --replace lwt_log lwt.log
-  '';
-
   installPhase = ''
     mkdir -p $out/bin
     cp bin/flow $out/bin/
   '';
 
-  buildInputs = [
-    ocaml libelf findlib camlp4 sedlex ocamlbuild lwt_ppx wtf8 dtoa
-  ] ++ optionals stdenv.isDarwin [ cf-private CoreServices ];
+  buildInputs = [ libelf
+  ] ++ (with ocamlPackages; [
+    ocaml findlib camlp4 sedlex ocamlbuild lwt_ppx lwt_log wtf8 dtoa
+  ]) ++ optionals stdenv.isDarwin [ cf-private CoreServices ];
 
   meta = with stdenv.lib; {
     description = "A static type checker for JavaScript";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8098,8 +8098,6 @@ with pkgs;
   flow = callPackage ../development/tools/analysis/flow {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     inherit (darwin) cf-private;
-    inherit (ocamlPackages) ocaml findlib camlp4 sedlex ocamlbuild lwt_ppx
-      wtf8 dtoa;
   };
 
   foreman = callPackage ../tools/system/foreman { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -394,6 +394,10 @@ let
 
     ocaml_lwt = if lib.versionOlder "4.02" ocaml.version then lwt3 else lwt2;
 
+    lwt_log = callPackage ../development/ocaml-modules/lwt_log {
+      lwt = lwt3;
+    };
+
     lwt_ppx = callPackage ../development/ocaml-modules/lwt/ppx.nix {
       lwt = lwt3;
     };


### PR DESCRIPTION
###### Motivation for this change

Needed by `flow` and other recent libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

