### PR TITLE
libpoly: 0.1.5 -> 0.1.7 (noop), cleanup a bit to modern style

### DIFF
--- a/pkgs/applications/science/logic/poly/default.nix
+++ b/pkgs/applications/science/logic/poly/default.nix
@@ -1,17 +1,20 @@
-{stdenv, fetchurl, gmp, cmake, python}:
+{stdenv, fetchFromGitHub, gmp, cmake, python}:
 
-let version = "0.1.5";
-in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "libpoly";
+  version = "0.1.7";
 
-stdenv.mkDerivation {
-  name = "libpoly-${version}";
-
-  src = fetchurl {
-    url = "https://github.com/SRI-CSL/libpoly/archive/v${version}.tar.gz";
-    sha256 = "0yj3gd60lx8dcgw7hgld8wqvjkpixx3ww3v33sdf7p6lln7ksxyn";
+  src = fetchFromGitHub {
+    owner = "SRI-CSL";
+    repo = "libpoly";
+    rev = "v${version}";
+    sha256 = "0i5ar4lhs88glk0rvkmag656ii434i6i1q5dspx6d0kyg78fii64";
   };
 
-  buildInputs = [ cmake gmp python ];
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gmp python ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/SRI-CSL/libpoly;


### PR DESCRIPTION
Noticed update and started updating this before realized
the update is really a no-op.

Proposing we update anyway so I (or someone else) don't
make this mistake again :P and because there's no harm.

Only in-tree user is yices, so very small amount of rebuild :).



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---