### PR TITLE
python: enable optimizations

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -124,6 +124,7 @@ let
     '';
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
     "--with-threads"
     "--enable-unicode=ucs${toString ucsEncoding}"

--- a/pkgs/development/interpreters/python/cpython/3.4/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.4/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, fetchpatch
 , bzip2
 , expat
+, llvm
 , libffi
 , gdbm
 , lzma
@@ -36,8 +37,9 @@ let
 
   buildInputs = filter (p: p != null) [
     zlib bzip2 expat lzma libffi gdbm sqlite readline ncurses openssl ]
-    ++ optionals x11Support [ tcl tk libX11 xproto ]
-    ++ optionals stdenv.isDarwin [ CF configd ];
+    ++ optional stdenv.cc.isClang llvm
+    ++ optionals stdenv.isDarwin [ CF configd ]
+    ++ optionals x11Support [ tcl tk libX11 xproto ];
 
   hasDistutilsCxxPatch = !(stdenv.cc.isGNU or false);
 
@@ -103,6 +105,7 @@ in stdenv.mkDerivation {
   LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
     "--with-threads"
     "--without-ensurepip"

--- a/pkgs/development/interpreters/python/cpython/3.5/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.5/default.nix
@@ -3,6 +3,7 @@
 , expat
 , libffi
 , gdbm
+, llvm
 , lzma
 , ncurses
 , openssl
@@ -36,8 +37,9 @@ let
 
   buildInputs = filter (p: p != null) [
     zlib bzip2 expat lzma libffi gdbm sqlite readline ncurses openssl ]
-    ++ optionals x11Support [ tcl tk libX11 xproto ]
-    ++ optionals stdenv.isDarwin [ CF configd ];
+    ++ optional stdenv.cc.isClang llvm
+    ++ optionals stdenv.isDarwin [ CF configd ]
+    ++ optionals x11Support [ tcl tk libX11 xproto ];
 
   hasDistutilsCxxPatch = !(stdenv.cc.isGNU or false);
 
@@ -103,6 +105,7 @@ in stdenv.mkDerivation {
   LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
     "--with-threads"
     "--without-ensurepip"

--- a/pkgs/development/interpreters/python/cpython/3.6/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.6/default.nix
@@ -4,6 +4,7 @@
 , expat
 , libffi
 , gdbm
+, llvm
 , lzma
 , ncurses
 , openssl
@@ -35,9 +36,11 @@ let
   sitePackages = "lib/${libPrefix}/site-packages";
 
   buildInputs = filter (p: p != null) [
-    zlib bzip2 expat lzma libffi gdbm sqlite readline ncurses openssl ]
-    ++ optionals x11Support [ tcl tk libX11 xproto ]
-    ++ optionals stdenv.isDarwin [ CF configd ];
+    zlib bzip2 expat lzma libffi gdbm sqlite readline ncurses openssl
+  ]
+    ++ optional stdenv.cc.isClang llvm
+    ++ optionals stdenv.isDarwin [ CF configd ]
+    ++ optionals x11Support [ tcl tk libX11 xproto ];
 
   nativeBuildInputs =
     optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.python3;
@@ -105,11 +108,12 @@ in stdenv.mkDerivation {
   LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
-    "--with-threads"
-    "--without-ensurepip"
     "--with-system-expat"
     "--with-system-ffi"
+    "--with-threads"
+    "--without-ensurepip"
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_buggy_getaddrinfo=no"
     # Assume little-endian IEEE 754 floating point when cross compiling

--- a/pkgs/development/interpreters/python/cpython/3.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/3.7/default.nix
@@ -4,6 +4,7 @@
 , expat
 , libffi
 , gdbm
+, llvm
 , lzma
 , ncurses
 , openssl
@@ -36,8 +37,9 @@ let
 
   buildInputs = filter (p: p != null) [
     zlib bzip2 expat lzma libffi gdbm sqlite readline ncurses openssl ]
-    ++ optionals x11Support [ tcl tk libX11 xproto ]
-    ++ optionals stdenv.isDarwin [ CF configd ];
+    ++ optional stdenv.cc.isClang llvm
+    ++ optionals stdenv.isDarwin [ CF configd ]
+    ++ optionals x11Support [ tcl tk libX11 xproto ];
 
 in stdenv.mkDerivation {
   name = "python3-${version}";
@@ -81,6 +83,7 @@ in stdenv.mkDerivation {
   LIBS="${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
 
   configureFlags = [
+    "--enable-optimizations"
     "--enable-shared"
     "--with-threads"
     "--without-ensurepip"


### PR DESCRIPTION
###### Motivation for this change

I didn't perform any tests yet, but I assume it's pretty safe and hopefully makes some stuff a bit faster.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
     - [x] python27
     - [ ] python34
     - [ ] python35
     - [x] python36
     - [ ] python37
   - [x] macOS
     - [ ] python27
     - [ ] python34
     - [ ] python35
     - [x] python36
     - [ ] python37
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
