### PR TITLE
gtkperf: init at 0.40.0

### DIFF
--- a/pkgs/development/tools/misc/gtkperf/bench.patch
+++ b/pkgs/development/tools/misc/gtkperf/bench.patch
@@ -1,0 +1,60 @@
+--- gtkperf/src/callbacks.c	2005-10-30 11:33:42.000000000 +0000
++++ gtkperf-patched/src/callbacks.c	2008-05-23 23:41:17.000000000 +0100
+@@ -219,6 +219,13 @@
+ }
+
+
++void
++on_cmdline_test(char *optarg)
++{
++	appdata->test_type = atoi(optarg);
++}
++
++
+ /* Initialize appdata */
+ void
+ setup_appdata(AppData * appdata_in)
+@@ -398,7 +405,7 @@
+ 	appdata->pixbuf_drawing = gdk_pixbuf_new_from_file (filename, NULL);
+
+ 	gtk_combo_box_set_active (GTK_COMBO_BOX (appdata->combobox_testtype),
+-				  0);
++				  appdata->test_type);
+
+ 	/* create end mark to info textview */
+ 	GtkTextIter iter;
+--- gtkperf/src/callbacks.h	2005-10-30 10:21:23.000000000 +0000
++++ gtkperf-patched/src/callbacks.h	2008-05-23 23:22:30.000000000 +0100
+@@ -13,6 +13,7 @@
+ void on_cmdline_run_all ();
+ void on_cmdline_help () ;
+ void on_cmdline_count (char *optarg) ;
++void on_cmdline_test (char *optarg) ;
+ void on_window_main_show (AppData * data);
+
+ gboolean
+--- gtkperf/src/main.c	2005-10-30 11:26:42.000000000 +0000
++++ gtkperf-patched/src/main.c	2008-05-23 23:44:02.000000000 +0100
+@@ -65,9 +65,10 @@
+ 			{"help", 0, 0, 0},
+ 			{"automatic", 0, 0, 0},
+ 			{"count", 1, 0, 0},
++			{"test", 1, 0, 0},
+ 			{0, 0, 0, 0}
+ 		};
+-		c = getopt_long (argc, argv, "hac:",
++		c = getopt_long (argc, argv, "hac:t:",
+ 			long_options, &option_index);
+ 		if (c == -1)
+ 			break;
+@@ -104,6 +105,10 @@
+ 				on_cmdline_count(optarg);
+ 				break;
+
++			case 't':
++				on_cmdline_test(optarg);
++				break;
++
+ 			default:
+ 			case 'h':
+ 				on_cmdline_help ();

--- a/pkgs/development/tools/misc/gtkperf/default.nix
+++ b/pkgs/development/tools/misc/gtkperf/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, gtk2, pkgconfig, libintl }:
+
+stdenv.mkDerivation {
+  name = "gtkperf-0.40.0";
+  src = fetchurl {
+    url = "mirror://sourceforge//gtkperf/gtkperf_0.40.tar.gz";
+    sha256 = "0yxj3ap3yfi76vqg6xjvgc16nfi9arm9kp87s35ywf10fd73814p";
+  };
+
+  hardeningDisable = [ "format" ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ gtk2 libintl ];
+
+  meta = with stdenv.lib; {
+    description = "Application designed to test GTK+ performance";
+    homepage = http://gtkperf.sourceforge.net/;
+    license = with licenses; [ gpl2 ];
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/development/tools/misc/gtkperf/default.nix
+++ b/pkgs/development/tools/misc/gtkperf/default.nix
@@ -12,6 +12,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtk2 libintl ];
 
+  # https://openbenchmarking.org/innhold/7e9780c11550d09aa67bdba71248facbe2d781db
+  patches = [ ./bench.patch ];
+
   meta = with stdenv.lib; {
     description = "Application designed to test GTK+ performance";
     homepage = http://gtkperf.sourceforge.net/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2867,6 +2867,8 @@ with pkgs;
 
   gtkgnutella = callPackage ../tools/networking/p2p/gtk-gnutella { };
 
+  gtkperf = callPackage ../development/tools/misc/gtkperf { };
+
   gtkvnc = callPackage ../tools/admin/gtk-vnc {};
 
   gtmess = callPackage ../applications/networking/instant-messengers/gtmess { };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---