### PR TITLE
idris: Recurse into attrs, fix build and remove unneeded overrides

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -421,16 +421,6 @@ self: super: builtins.intersectAttrs super {
   # so disable this on Darwin only
   ${if pkgs.stdenv.isDarwin then null else "GLUT"} = addPkgconfigDepend (appendPatch super.GLUT ./patches/GLUT.patch) pkgs.freeglut;
 
-  idris = overrideCabal super.idris (drv: {
-    # https://github.com/idris-lang/Idris-dev/issues/2499
-    librarySystemDepends = (drv.librarySystemDepends or []) ++ [pkgs.gmp];
-
-    # tests and build run executable, so need to set LD_LIBRARY_PATH
-    preBuild = ''
-      export LD_LIBRARY_PATH="$PWD/dist/build:$LD_LIBRARY_PATH"
-    '';
-  });
-
   libsystemd-journal = overrideCabal super.libsystemd-journal (old: {
     librarySystemDepends = old.librarySystemDepends or [] ++ [ pkgs.systemd ];
   });

--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -20,7 +20,7 @@ let
   };
 in
 stdenv.mkDerivation ({
-  name = "${name}-${version}";
+  name = "idris-${name}-${version}";
 
   buildInputs = [ idris-with-packages gmp ] ++ extraBuildInputs;
   propagatedBuildInputs = allIdrisDeps;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6633,20 +6633,7 @@ with pkgs;
   icedtea_web = icedtea8_web;
 
   idrisPackages = callPackage ../development/idris-modules {
-
-    idris-no-deps =
-      let
-        inherit (self.haskell) lib;
-        haskellPackages = self.haskellPackages.override {
-          overrides = self: super: {
-            binary = lib.dontCheck self.binary_0_8_5_1;
-            parsers = lib.dontCheck super.parsers;
-            semigroupoids = lib.dontCheck super.semigroupoids;
-            trifecta = lib.dontCheck super.trifecta;
-          };
-        };
-      in
-        haskellPackages.idris;
+    idris-no-deps = haskellPackages.idris;
   };
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -166,6 +166,7 @@ let
     } // (mapTestOn ((packagePlatforms pkgs) // rec {
       haskell.compiler = packagePlatforms pkgs.haskell.compiler;
       haskellPackages = packagePlatforms pkgs.haskellPackages;
+      idrisPackages = packagePlatforms pkgs.idrisPackages;
 
       # Language packages disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66
 


### PR DESCRIPTION
- The gmp issue has long been fixed and closed
- The preBuild thing was never used afaik, it works no problem without
it, especially since checks don't run (To get checks to work we'd have
to compile the libraries into idris, which are currently nicely
separated)
- The dependencies overrides aren't needed anymore

###### Motivation for this change
Originally just removing the hacks, but after rebasing on master I discovered that since 69cd09f8fb2427233319883dfdc0c702b87e2bf1 it wouldn't build at all. This cleanup surprisingly (or not) just happens to fix it :).

In the second commit I also made idris packages to be included in the packages hydra builds and nix-env finds. I hope that's okay, the ~80 idris packages don't change very often and it would be very nice to have them cached because Idris can take a while to build them (and you currently don't even have any progress reporting!  Will be fixed with my https://github.com/idris-lang/Idris-dev/pull/4498 in the next Idris version though).

Ping @brainrape @mpickering @peti 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

