### PR TITLE
lollypop-portal: init at 0.9.7

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec  {
   ];
 
   buildInputs = [ glib ] ++ (with gnome3; [
-    easytag gsettings_desktop_schemas gtk3 libsecret libsoup totem-pl-parser
+    gsettings_desktop_schemas gtk3 libsecret libsoup totem-pl-parser
   ]) ++ (with gst_all_1; [
     gst-libav gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly
     gstreamer

--- a/pkgs/misc/lollypop-portal/default.nix
+++ b/pkgs/misc/lollypop-portal/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, fetchFromGitLab, meson, ninja, pkgconfig
+, python36Packages, gnome3, gst_all_1, gtk3, libnotify
+, kid3, easytag, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  name = "lollypop-portal";
+  version = "0.9.7";
+
+  src = fetchFromGitLab {
+     domain = "gitlab.gnome.org";
+     owner = "gnumdk";
+     repo = name;
+     rev = version;
+     sha256 = "0rn5xmh6391i9l69y613pjad3pzdilskr2xjfcir4vpk8wprvph3";
+  };
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python36Packages.wrapPython
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.totem-pl-parser
+    gnome3.libsecret
+    gnome3.gnome-settings-daemon
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+
+    gtk3
+    libnotify
+  ];
+
+  pythonPath = with python36Packages; [
+    pygobject3
+    pydbus
+    pycairo
+  ];
+
+  preFixup = ''
+    buildPythonPath "$out/libexec/lollypop-portal $pythonPath"
+
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$program_PYTHONPATH"
+      --prefix PATH : "${stdenv.lib.makeBinPath [ easytag kid3 ]}"
+    )
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DBus Service for Lollypop";
+    homepage = https://gitlab.gnome.org/gnumdk/lollypop-portal;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21204,6 +21204,9 @@ with pkgs;
   lilypond-with-fonts = callPackage ../misc/lilypond/with-fonts.nix {
     lilypond = lilypond-unstable;
   };
+
+  lollypop-portal = callPackages ../misc/lollypop-portal { };
+
   openlilylib-fonts = callPackage ../misc/lilypond/fonts.nix { };
 
   mailcore2 = callPackage ../development/libraries/mailcore2 {


### PR DESCRIPTION
###### Motivation for this change
This #43292 

###### Notes
I didn't exactly know where this belonged in nixpkgs so feel free to suggest a better place.
There will also need to be a stupid simple nixos module for this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

