### PR TITLE
pythonPackages.aws-adfs: init at 0.12.0

### DIFF
--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, pythonPackages, isPy3k
-, pytest, pytestrunner, pytestcov, mock, lxml, boto3, requests, click, configparser }:
+{ lib, buildPythonPackage, fetchPypi
+, pytest, pytestrunner, pytestcov, mock, glibcLocales, lxml, boto3, requests, click, configparser }:
 
 buildPythonPackage rec {
   version = "0.12.0";
@@ -18,11 +18,11 @@ buildPythonPackage rec {
   # Test suite writes files to $HOME/.aws/, or /homeless-shelter if unset
   HOME = ".";
 
-  checkInputs = [ pytest pytestrunner pytestcov mock ];
-  propagatedBuildInputs = [ lxml boto3 requests click configparser ];
+  # Required for python3 tests, along with glibcLocales
+  LC_ALL = "en_US.UTF-8";
 
-  # Python3 tests fail with UTF-8 issues due to click
-  doCheck = !isPy3k;
+  checkInputs = [ glibcLocales pytest pytestrunner pytestcov mock ];
+  propagatedBuildInputs = [ lxml boto3 requests click configparser ];
 
   meta = {
     description = "Command line tool to ease aws cli authentication against ADFS";

--- a/pkgs/development/python-modules/aws-adfs/default.nix
+++ b/pkgs/development/python-modules/aws-adfs/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi, pythonPackages, isPy3k
+, pytest, pytestrunner, pytestcov, mock, lxml, boto3, requests, click, configparser }:
+
+buildPythonPackage rec {
+  version = "0.12.0";
+  pname = "aws-adfs";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cjrm61k6905dmhgrqyc5caxx5hbhj3sr6cx4r6sbdyz453i7pc6";
+  };
+
+  # Relax version constraint
+  patchPhase = ''
+    sed -i 's/coverage < 4/coverage/' setup.py
+  '';
+
+  # Test suite writes files to $HOME/.aws/, or /homeless-shelter if unset
+  HOME = ".";
+
+  checkInputs = [ pytest pytestrunner pytestcov mock ];
+  propagatedBuildInputs = [ lxml boto3 requests click configparser ];
+
+  # Python3 tests fail with UTF-8 issues due to click
+  doCheck = !isPy3k;
+
+  meta = {
+    description = "Command line tool to ease aws cli authentication against ADFS";
+    homepage = https://github.com/venth/aws-adfs;
+    license = lib.licenses.psfl;
+    maintainers = [ lib.maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -205,6 +205,8 @@ in {
 
   aws-xray-sdk = callPackage ../development/python-modules/aws-xray-sdk { };
 
+  aws-adfs = callPackage ../development/python-modules/aws-adfs { };
+
   # packages defined elsewhere
 
   amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

