### PR TITLE
s4cmd: init at 2.0.1

### DIFF
--- a/pkgs/tools/networking/s4cmd/default.nix
+++ b/pkgs/tools/networking/s4cmd/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "s4cmd";
+  version = "2.0.1";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "14gfpnj4xa1sq3x3zd29drpzsygn998y32szwm069ma0w9jwjjz6";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ boto3 pytz ];
+
+  # The upstream package tries to install some bash shell completion scripts in /etc.
+  # Setuptools is bugged and doesn't handle --prefix properly: https://github.com/pypa/setuptools/issues/130
+  patchPhase = ''
+    sed -i '/ data_files=/d' setup.py
+    sed -i 's|os.chmod("/etc.*|pass|' setup.py
+  '';
+
+  # Replace upstream's s4cmd wrapper script with the built-in Nix wrapper
+  postInstall = ''
+    ln -fs $out/bin/s4cmd.py $out/bin/s4cmd
+  '';
+
+  # Test suite requires an S3 bucket
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/bloomreach/s4cmd;
+    description = "Super S3 command line tool";
+    license = licenses.asl20;
+    maintainers = [ maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4912,6 +4912,8 @@ with pkgs;
 
   s3cmd = callPackage ../tools/networking/s3cmd { };
 
+  s4cmd = callPackage ../tools/networking/s4cmd { };
+
   s3gof3r = callPackage ../tools/networking/s3gof3r { };
 
   s6Dns = callPackage ../tools/networking/s6-dns { };


### PR DESCRIPTION
Tool for interacting with S3 buckets, with some performance optimizations over s3cmd.

Skips installing the bash shell completion scripts in /etc, to work around:
https://github.com/NixOS/nixpkgs/issues/4968
https://github.com/pypa/setuptools/issues/130

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

