### PR TITLE
octopus: 7.2 -> 8.1 (libxc 3.0.1 -> 4.2.3)

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, symlinkJoin, gfortran, perl, procps
-, libyaml, libxc, fftw, openblas, gsl
+, libyaml, libxc, fftw, openblas, gsl, netcdf, arpack
 }:
 
 let
-  version = "7.3";
+  version = "8.1";
   fftwAll = symlinkJoin { name ="ftw-dev-out"; paths = [ fftw.dev fftw.out ]; };
 
 in stdenv.mkDerivation {
@@ -11,11 +11,11 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.tddft.org/programs/octopus/down.php?file=${version}/octopus-${version}.tar.gz";
-    sha256 = "0hnpqjjxdxh2ggf6ckrsy4hs9iglnazscb4siczddvmysi4kv15d";
+    sha256 = "0rxwvcp22364nnhwhqlr38w4rwv1yl60snxi2f8nqdflx1143n10";
   };
 
   nativeBuildInputs = [ perl procps fftw.dev ];
-  buildInputs = [ libyaml gfortran libxc openblas gsl fftw.out ];
+  buildInputs = [ libyaml gfortran libxc openblas gsl fftw.out netcdf arpack ];
 
   configureFlags = ''
     --with-yaml-prefix=${libyaml}
@@ -36,6 +36,8 @@ in stdenv.mkDerivation {
   postConfigure = ''
     patchShebangs testsuite/oct-run_testsuite.sh
   '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Real-space time dependent density-functional theory code";

--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, gfortran, perl }:
 
 let
-  version = "3.0.1";
+  version = "4.2.3";
 
 in stdenv.mkDerivation {
   name = "libxc-${version}";
   src = fetchurl {
     url = "http://www.tddft.org/programs/octopus/down.php?file=libxc/${version}/libxc-${version}.tar.gz";
-    sha256 = "1xyac89yx03vm86rvk07ps1d39xss3amw46a1k53mv30mgr94rl3";
+    sha256 = "0mj26jga0nj76blf2rp9cmgf0v0yhsp7xrg92zgih7fjlydrxr02";
   };
 
   buildInputs = [ gfortran ];


### PR DESCRIPTION
###### Motivation for this change
Update `octopus` and `libxc`. Version is 8.1 is now compatible with the latest version of `libxc`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

