### PR TITLE
arc-theme: 2017-05-12 -> 2018-07-13

### DIFF
--- a/pkgs/misc/themes/arc/default.nix
+++ b/pkgs/misc/themes/arc/default.nix
@@ -1,43 +1,53 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gnome3, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, sassc, autoreconfHook, pkgconfig, gtk3
+, gnome-themes-standard, gtk-engine-murrine, optipng, inkscape}:
 
 let
-  # treat versions newer than 3.22 as 3.22
-  gnomeVersion = if stdenv.lib.versionOlder "3.22" gnome3.version then "3.22" else gnome3.version;
   pname = "arc-theme";
 in
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "2017-05-12";
+  version = "20180715";
 
   src = fetchFromGitHub {
-    owner  = "horst3180";
+    owner  = "NicoHood";
     repo   = pname;
-    rev    = "8290cb813f157a22e64ae58ac3dfb5983b0416e6";
-    sha256 = "1lxiw5iq9n62xzs0fks572c5vkz202jigndxaankxb44wcgn9zyf";
+    rev    = version;
+    sha256 = "1kkfnkiih0i3pds5mgd1v9lrdrp4nh4hk42mw7sa4fpbjff4jh6j";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ gnome3.gtk ];
+  preBuild = ''
+    # Shut up inkscape's warnings
+    export HOME="$NIX_BUILD_ROOT"
+  '';
 
-  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig sassc optipng inkscape ];
+  buildInputs = [ gtk3 ];
 
-  preferLocalBuild = true;
+  propagatedUserEnvPkgs = [ gnome-themes-standard gtk-engine-murrine ];
 
-  configureFlags = [ "--disable-unity" "--with-gnome=${gnomeVersion}" ];
+  postPatch = ''
+    find . -name render-assets.sh |
+    while read filename
+    do
+      substituteInPlace "$filename" \
+        --replace "/usr/bin/inkscape" "${inkscape.out}/bin/inkscape" \
+        --replace "/usr/bin/optipng" "${optipng.out}/bin/optipng"
+    done
+    patchShebangs .
+  '';
+
+  configureFlags = [ "--disable-unity" ];
 
   postInstall = ''
-    mkdir -p $out/share/plank/themes
-    cp -r extra/*-Plank $out/share/plank/themes
-    install -Dm644 -t $out/share/doc/${pname}/Chrome extra/Chrome/*.crx
     install -Dm644 -t $out/share/doc/${pname}        AUTHORS *.md
   '';
 
   meta = with stdenv.lib; {
     description = "A flat theme with transparent elements for GTK 3, GTK 2 and Gnome-Shell";
-    homepage    = https://github.com/horst3180/arc-theme;
+    homepage    = https://github.com/NicoHood/arc-theme;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ simonvandel romildo ];
-    platforms   = platforms.unix;
+    platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The horst3180 repo was unmaintained - this is the updated version as per [this comment](https://github.com/horst3180/arc-theme/issues/882).

Updated build dependencies. Plank theme is installed automatically now, and there is no chrome theme

Still learning nix so criticism is welcome!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

