### PR TITLE
clipmenu: init at 5.4.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -320,6 +320,7 @@
   ./services/misc/canto-daemon.nix
   ./services/misc/calibre-server.nix
   ./services/misc/cfdyndns.nix
+  ./services/misc/clipmenu.nix
   ./services/misc/cpuminer-cryptonight.nix
   ./services/misc/cgminer.nix
   ./services/misc/confd.nix

--- a/nixos/modules/services/misc/clipmenu.nix
+++ b/nixos/modules/services/misc/clipmenu.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.clipmenu;
+in {
+
+  options.services.clipmenu = {
+    enable = mkEnableOption "clipmenu, the clipboard management daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.clipmenu;
+      defaultText = "pkgs.clipmenu";
+      description = "clipmenu derivation to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.clipmenu = {
+      enable      = true;
+      description = "Clipboard management daemon";
+      wantedBy = [ "graphical-session.target" ];
+      after    = [ "graphical-session.target" ];
+      serviceConfig.ExecStart = "${cfg.package}/bin/clipmenud";
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/pkgs/applications/misc/clipmenu/default.nix
+++ b/pkgs/applications/misc/clipmenu/default.nix
@@ -1,0 +1,33 @@
+{ clipnotify, makeWrapper, xsel, dmenu2, utillinux, gawk, stdenv, fetchFromGitHub, lib }:
+let
+  runtimePath = lib.makeBinPath [ clipnotify xsel dmenu2 utillinux gawk ];
+in
+stdenv.mkDerivation rec {
+  name = "clipmenu-${version}";
+  version = "5.4.0";
+
+  src = fetchFromGitHub {
+    owner  = "cdown";
+    repo   = "clipmenu";
+    rev    = version;
+    sha256 = "1qbpca0wny6i222vbikfl2znn3fynhbl4100qs8v4wn27ra5p0mi";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp clipdel clipmenu clipmenud $out/bin
+
+    for bin in $out/bin/*; do
+      wrapProgram "$bin" --prefix PATH : "${runtimePath}"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Clipboard management using dmenu";
+    inherit (src.meta) homepage;
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.publicDomain;
+  };
+}

--- a/pkgs/tools/misc/clipnotify/default.nix
+++ b/pkgs/tools/misc/clipnotify/default.nix
@@ -1,0 +1,26 @@
+{ libX11, libXfixes, stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "clipnotify-${version}";
+  version = "git-2018-02-20";
+
+  src = fetchFromGitHub {
+    owner = "cdown";
+    repo  = "clipnotify";
+    rev   = "9cb223fbe494c5b71678a9eae704c21a97e3bddd";
+    sha256 = "1x9avjq0fgw0svcbw6b6873qnsqxbacls9sipmcv86xia4bxh8dn";
+  };
+
+  buildInputs = [ libX11 libXfixes ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp clipnotify $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Notify on new X clipboard events";
+    inherit (src.meta) homepage;
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.publicDomain;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5905,6 +5905,8 @@ with pkgs;
     gccCross = pkgsCross.ben-nanonote.buildPackages.gccCrossStageStatic;
   };
 
+  clipnotify = callPackage ../tools/misc/clipnotify { };
+
   xclip = callPackage ../tools/misc/xclip { };
 
   xcwd = callPackage ../tools/X11/xcwd { };
@@ -15468,6 +15470,8 @@ with pkgs;
   cligh = python3Packages.callPackage ../development/tools/github/cligh {};
 
   clipgrab = callPackage ../applications/video/clipgrab { };
+
+  clipmenu = callPackage ../applications/misc/clipmenu { };
 
   clipit = callPackage ../applications/misc/clipit { };
 


### PR DESCRIPTION
###### Motivation for this change

clipmenu is a tool for managing your clipboard with dmenu. see https://github.com/cdown/clipmenu

also add a nixos systemd user module for running clipmenud

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [xd] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

