### PR TITLE
orthorobot: 1.0 -> 1.1.1

### DIFF
--- a/pkgs/games/orthorobot/default.nix
+++ b/pkgs/games/orthorobot/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, unzip, love, lua, makeWrapper, makeDesktopItem }:
+{ stdenv, fetchurl, fetchFromGitHub, zip, love, lua, makeWrapper, makeDesktopItem }:
 
 let
   pname = "orthorobot";
-  version = "1.0";
+  version = "1.1.1";
 
   icon = fetchurl {
     url = "http://stabyourself.net/images/screenshots/orthorobot-5.png";
@@ -24,32 +24,26 @@ in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "http://stabyourself.net/dl.php?file=${pname}/${pname}-source.zip";
-    sha256 = "023nc3zwjkbmy4c8w6mfg39mg69zpqqr2gzlmp4fpydrjas70kbl";
+  src = fetchFromGitHub {
+    owner = "Stabyourself";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ca6hvd890kxmamsmsfiqzw15ngsvb4lkihjb6kabgmss61a6s5p";
   };
 
-  nativeBuildInputs = [ makeWrapper unzip ];
-  buildInputs = [ lua love ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ lua love zip ];
 
   phases = [ "unpackPhase" "installPhase" ];
 
-  unpackPhase = ''
-    unzip -j $src
-  '';  
-
   installPhase =
   ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/games/lovegames
-
-    cp -v ./*.love $out/share/games/lovegames/${pname}.love
-
+    mkdir -p $out/bin $out/share/games/lovegames $out/share/applications
+    zip -9 -r ${pname}.love ./*
+    mv ${pname}.love $out/share/games/lovegames/${pname}.love
     makeWrapper ${love}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
-
-    chmod +x $out/bin/${pname}
-    mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    chmod +x $out/bin/${pname}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19732,7 +19732,7 @@ with pkgs;
 
   openxcom = callPackage ../games/openxcom { };
 
-  orthorobot = callPackage ../games/orthorobot { love = love_0_7; };
+  orthorobot = callPackage ../games/orthorobot { };
 
   pacvim = callPackage ../games/pacvim { };
 


### PR DESCRIPTION
###### Motivation for this change

Updated version that no longer needs a very old LÖVE engine, but works with the current release.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

