### PR TITLE
pythonPackages.cypari2: 1.1.4 -> 1.2.1

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -84,6 +84,12 @@ stdenv.mkDerivation rec {
   ];
 
   packageUpgradePatches = [
+    (fetchpatch {
+      name = "cypari2-1.2.1.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?h=62fe6eb15111327d930336d4252d5b23cbb22ab9";
+      sha256 = "1xax7vvs8h4xip16xcsp47xdb6lig6f2r3pl8cksvlz8lhgbyxh2";
+    })
+
     # matplotlib 2.2.2 deprecated `normed` (replaced by `density`).
     # This patch only ignores the warning. It would be equally easy to fix it
     # (by replacing all mentions of `normed` by `density`), but its better to

--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -7,16 +7,15 @@
 , gmp
 , cython
 , cysignals
-, six
 }:
 
 buildPythonPackage rec {
   pname = "cypari2";
-  version = "1.1.4"; # remove six dependency on upgrade to >1.1.4
+  version = "1.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0n0mp8qmvvzmfaawg39d3mkyzf65q2zkz7bnqyk4sfjbz4xwc6mb";
+    sha256 = "0v2kikwf0advq8j76nwzhlacwj1yys9cvajm4fqgmasjdsnf1q4k";
   };
 
   # This differs slightly from the default python installPhase in that it pip-installs
@@ -39,7 +38,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     cysignals
     cython
-    six # after 1.1.4: will not be needed
   ];
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

This update also contains the compatibility patch to sage, so it should be applied outside of the regular auto-update. Since nobody except sage uses cypari anyways, there is no risk of breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

