### PR TITLE
haskell generic-builder: Use strictDeps always, take II

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -5,7 +5,7 @@
 # stripLen acts as the -p parameter when applying a patch.
 
 { lib, fetchurl, patchutils }:
-{ stripLen ? 0, extraPrefix ? null, excludes ? [], ... }@args:
+{ stripLen ? 0, extraPrefix ? null, excludes ? [], includes ? [], ... }@args:
 
 fetchurl ({
   postFetch = ''
@@ -24,7 +24,9 @@ fetchurl ({
     ${patchutils}/bin/filterdiff \
       -p1 \
       ${builtins.toString (builtins.map (x: "-x ${x}") excludes)} \
+      ${builtins.toString (builtins.map (x: "-i ${x}") includes)} \
       "$tmpfile" > "$out"
     ${args.postFetch or ""}
   '';
-} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "postFetch"])
+  meta.broken = excludes != [] && includes != [];
+} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "includes" "postFetch"])

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1126,4 +1126,5 @@ self: super: {
   http-types = addTestToolDepend super.http-types self.hspec-discover;
   invariant = addTestToolDepend super.invariant self.hspec-discover;
   hpack = addTestToolDepend super.hpack self.hspec-discover;
+  conduit-extra = addTestToolDepend super.conduit-extra self.hspec-discover;
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1117,4 +1117,7 @@ self: super: {
   hspec-contrib = addTestToolDepend super.hspec-contrib self.hspec-meta;
   hspec-wai = addTestToolDepend super.hspec-wai self.hspec-meta;
   hspec-checkers = addTestToolDepend super.hspec-checkers self.hspec-meta;
+
+  unliftio = addTestToolDepend super.unliftio self.hspec-discover;
+  word8 = addTestToolDepend super.word8 self.hspec-discover;
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1033,7 +1033,7 @@ self: super: {
 
   # The test suite does not know how to find the 'alex' binary.
   alex = overrideCabal super.alex (drv: {
-    testSystemDepends = (drv.testSystemDepends or []) ++ [pkgs.which];
+    testToolDepends = (drv.testToolDepends or []) ++ [ pkgs.buildPackages.which ];
     preCheck = ''export PATH="$PWD/dist/build/alex:$PATH"'';
   });
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1121,7 +1121,6 @@ self: super: {
   unliftio = addTestToolDepend super.unliftio self.hspec-discover;
   word8 = addTestToolDepend super.word8 self.hspec-discover;
   distributive = addTestToolDepend super.distributive self.hspec-discover;
-  facade = addTestToolDepend super.facade self.hspec-discover;
   logging-facade = addTestToolDepend super.logging-facade self.hspec-discover;
   interpolate = addTestToolDepend super.interpolate self.hspec-discover;
   http-types = addTestToolDepend super.http-types self.hspec-discover;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -333,7 +333,7 @@ self: super: {
   hsbencher = dontCheck super.hsbencher;
   hsexif = dontCheck super.hsexif;
   hspec-server = dontCheck super.hspec-server;
-  HTF = dontCheck super.HTF;
+  HTF = addBuildTool (dontCheck super.HTF) self.cpphs;
   htsn = dontCheck super.htsn;
   htsn-import = dontCheck super.htsn-import;
   http-link-header = dontCheck super.http-link-header; # non deterministic failure https://hydra.nixos.org/build/75041105

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -558,7 +558,7 @@ self: super: {
   vimus = overrideCabal super.vimus (drv: { broken = pkgs.stdenv.isLinux && pkgs.stdenv.isi686; });
 
   # https://github.com/hspec/mockery/issues/6
-  mockery = overrideCabal super.mockery (drv: { preCheck = "export TRAVIS=true"; });
+  mockery = addTestToolDepend (overrideCabal super.mockery (drv: { preCheck = "export TRAVIS=true"; })) self.hspec-discover;
 
   # https://github.com/alphaHeavy/lzma-conduit/issues/5
   lzma-conduit = dontCheck super.lzma-conduit;
@@ -815,7 +815,7 @@ self: super: {
   http-api-data = dontCheck super.http-api-data;
 
   # https://github.com/snoyberg/yaml/issues/106
-  yaml = disableCabalFlag super.yaml "system-libyaml";
+  yaml = addTestToolDepend (disableCabalFlag super.yaml "system-libyaml") self.hspec-discover;
 
   # https://github.com/diagrams/diagrams-lib/issues/288
   diagrams-lib = overrideCabal super.diagrams-lib (drv: { doCheck = !pkgs.stdenv.isi686; });
@@ -1120,4 +1120,11 @@ self: super: {
 
   unliftio = addTestToolDepend super.unliftio self.hspec-discover;
   word8 = addTestToolDepend super.word8 self.hspec-discover;
+  distributive = addTestToolDepend super.distributive self.hspec-discover;
+  facade = addTestToolDepend super.facade self.hspec-discover;
+  logging-facade = addTestToolDepend super.logging-facade self.hspec-discover;
+  interpolate = addTestToolDepend super.interpolate self.hspec-discover;
+  http-types = addTestToolDepend super.http-types self.hspec-discover;
+  invariant = addTestToolDepend super.invariant self.hspec-discover;
+  hpack = addTestToolDepend super.hpack self.hspec-discover;
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -51,8 +51,6 @@ self: super: {
   clock = dontCheck super.clock;
   Dust-crypto = dontCheck super.Dust-crypto;
   hasql-postgres = dontCheck super.hasql-postgres;
-  hspec = super.hspec.override { stringbuilder = dontCheck self.stringbuilder; };
-  hspec-core = super.hspec-core.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
   hspec-expectations = dontCheck super.hspec-expectations;
   HTTP = dontCheck super.HTTP;
   http-streams = dontCheck super.http-streams;
@@ -1100,4 +1098,23 @@ self: super: {
   unix-time = if pkgs.stdenv.hostPlatform.isMusl then dontCheck super.unix-time else super.unix-time;
   # dontCheck: printf double rounding behavior
   prettyprinter = if pkgs.stdenv.hostPlatform.isMusl then dontCheck super.prettyprinter else super.prettyprinter;
+
+  # A few things for hspec*:
+  #
+  #   1. Break cycles for test
+  #
+  #   2. https://github.com/hspec/hspec/pull/355 The buildTool will be properly
+  #      cabal2nixed when run on the patched cabal file.
+  hspec = let
+    breakCycles = super.hspec.override { stringbuilder = dontCheck self.stringbuilder; };
+  in addTestToolDepend breakCycles self.hspec-meta;
+  hspec-core = let
+    breakCycles = super.hspec-core.override { silently = dontCheck self.silently; temporary = dontCheck self.temporary; };
+  in addTestToolDepend breakCycles self.hspec-meta;
+  hspec-discover = addTestToolDepend super.hspec-discover self.hspec-meta;
+  hspec-smallcheck = addTestToolDepend super.hspec-smallcheck self.hspec-meta;
+  hspec-attoparsec = addTestToolDepend super.hspec-attoparsec self.hspec-meta;
+  hspec-contrib = addTestToolDepend super.hspec-contrib self.hspec-meta;
+  hspec-wai = addTestToolDepend super.hspec-wai self.hspec-meta;
+  hspec-checkers = addTestToolDepend super.hspec-checkers self.hspec-meta;
 }

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -53,7 +53,7 @@ self: super: builtins.intersectAttrs super {
 
   # Use the default version of mysql to build this package (which is actually mariadb).
   # test phase requires networking
-  mysql = dontCheck (super.mysql.override { mysql = pkgs.mysql.connector-c; });
+  mysql = dontCheck (addBuildTool (super.mysql.override { mysql = pkgs.mysql.connector-c; }) pkgs.mysql);
 
   # CUDA needs help finding the SDK headers and libraries.
   cuda = overrideCabal super.cuda (drv: {
@@ -513,5 +513,13 @@ self: super: builtins.intersectAttrs super {
   # Tests require a browser: https://github.com/ku-fpg/blank-canvas/issues/73
   blank-canvas = dontCheck super.blank-canvas;
   blank-canvas_0_6_2 = dontCheck super.blank-canvas_0_6_2;
+
+  # Custom setup needs pg_config
+  HDBC-postgresql = addBuildTool super.HDBC-postgresql pkgs.postgresql;
+
+  # Custom setup needs sdl-config
+  SDL = addBuildTool super.SDL pkgs.SDL;
+  neat-interpolation = addBuildTool super.neat-interpolation self.HTF;
+  hnix = addBuildTool super.hnix pkgs.nix;
 
 }

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -233,6 +233,7 @@ stdenv.mkDerivation ({
 
   inherit src;
 
+  strictDeps = true;
   inherit depsBuildBuild nativeBuildInputs;
   buildInputs = otherBuildInputs ++ optionals (!hasActiveLibrary) propagatedBuildInputs;
   propagatedBuildInputs = optionals hasActiveLibrary propagatedBuildInputs;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -143,6 +143,12 @@ rec {
   addBuildTool = drv: x: addBuildTools drv [x];
   addBuildTools = drv: xs: overrideCabal drv (drv: { buildTools = (drv.buildTools or []) ++ xs; });
 
+  addTestToolDepend = drv: x: addTestToolDepends drv [x];
+  addTestToolDepends = drv: xs: overrideCabal drv (drv: { testToolDepends = (drv.testToolDepends or []) ++ xs; });
+
+  addBenchmarkToolDepend = drv: x: addBenchmarkToolDepends drv [x];
+  addBenchmarkToolDepends = drv: xs: overrideCabal drv (drv: { benchmarkToolDepends = (drv.benchmarkToolDepends or []) ++ xs; });
+
   addExtraLibrary = drv: x: addExtraLibraries drv [x];
   addExtraLibraries = drv: xs: overrideCabal drv (drv: { extraLibraries = (drv.extraLibraries or []) ++ xs; });
 


### PR DESCRIPTION
###### Motivation for this change

The regenerated code + I think the subset of the overrides we still need

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @matthewbauer 

