### PR TITLE
charles: init at 4.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1929,6 +1929,11 @@
     github = "kaiha";
     name = "Kai Harries";
   };
+  kalbasit = {
+    email = "wael.nasreddine@gmail.com";
+    github = "kalbasit";
+    name = "Wael Nasreddine";
+  };
   kamilchm = {
     email = "kamil.chm@gmail.com";
     github = "kamilchm";

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     makeWrapper ${jre}/bin/java $out/bin/charles \
-      --add-flags "-Xmx1024M -Dcharles.config="~/.charles.config" -Djava.library.path="$out/lib" -jar $out/share/java/charles.jar"
+      --add-flags "-Xmx1024M -Dcharles.config="~/.charles.config" -Djava.library.path="$out/share/java" -jar $out/share/java/charles.jar"
 
     for fn in lib/*.jar; do
       install -D -m644 $fn $out/share/java/$(basename $fn)

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -6,7 +6,7 @@ let
     desktopName = "Charles";
     exec = "charles %F";
     genericName  = "Web Debugging Proxy";
-    icon = "charles";
+    icon = "charles-proxy";
     mimeType = "application/x-charles-savedsession;application/x-charles-savedsession+xml;application/x-charles-savedsession+json;application/har+json;application/vnd.tcpdump.pcap;application/x-charles-trace";
     name = "Charles";
     startupNotify = "true";
@@ -22,13 +22,7 @@ in stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    set -e
-
     mkdir -pv $out/bin
-
-    for fn in lib/*.jar; do
-      install -D -m644 $fn $out/$fn
-    done
 
     cat > $out/bin/charles << EOF
     #!${stdenv.shell}
@@ -38,20 +32,15 @@ in stdenv.mkDerivation rec {
 
     chmod +x $out/bin/charles
 
+    for fn in lib/*.jar; do
+      install -D -m644 $fn $out/$fn
+    done
+
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
 
-    for dim in 16x16 32x32 64x64 128x128 256x256 512x512; do
-      install -D -m644 icon/$dim/apps/charles-proxy.png \
-        $out/share/icons/hicolor/$dim/apps/charles.png
-      for mimetype in application-har+json.png application-vnd.tcpdump.pcap.png application-x-charles-savedsession.png application-x-charles-trace.png; do
-        install -D -m644 icon/$dim/mimetypes/$mimetype \
-          $out/share/icons/hicolor/$dim/mimetypes/$mimetype
-      done
-    done
-
-    install -D -m644 doc/licenses/bounce-license.txt \
-      $out/share/licenses/bounce-license.txt
+    mkdir -p $out/share/icons
+    cp -r icon $out/share/icons/hicolor
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeDesktopItem, jre, hicolor-icon-theme }:
+{ stdenv, fetchurl, makeDesktopItem, jre, makeWrapper }:
 
 let
   desktopItem = makeDesktopItem {
@@ -21,19 +21,14 @@ in stdenv.mkDerivation rec {
     sha256 = "1hjfimyr9nnbbxadwni02d2xl64ybarh42l1g6hlslq5qwl8ywzb";
   };
 
+  buildInputs = [ makeWrapper ];
+
   installPhase = ''
-    mkdir -pv $out/bin
-
-    cat > $out/bin/charles << EOF
-    #!${stdenv.shell}
-
-    ${jre}/bin/java -Xmx1024M -Dcharles.config="~/.charles.config" -Djava.library.path="$out/lib" -jar $out/lib/charles.jar $*
-    EOF
-
-    chmod +x $out/bin/charles
+    makeWrapper ${jre}/bin/java $out/bin/charles \
+      --add-flags "-Xmx1024M -Dcharles.config="~/.charles.config" -Djava.library.path="$out/lib" -jar $out/share/java/charles.jar"
 
     for fn in lib/*.jar; do
-      install -D -m644 $fn $out/$fn
+      install -D -m644 $fn $out/share/java/$(basename $fn)
     done
 
     mkdir -p $out/share/applications

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchurl, makeDesktopItem, jre, hicolor-icon-theme }:
+
+let
+  desktopItem = makeDesktopItem {
+    categories = "Network;Development;WebDevelopment;Java;";
+    desktopName = "Charles";
+    exec = "charles %F";
+    genericName  = "Web Debugging Proxy";
+    icon = "charles";
+    mimeType = "application/x-charles-savedsession;application/x-charles-savedsession+xml;application/x-charles-savedsession+json;application/har+json;application/vnd.tcpdump.pcap;application/x-charles-trace";
+    name = "Charles";
+    startupNotify = "true";
+  };
+
+in stdenv.mkDerivation rec {
+  name = "charles-${version}";
+  version = "4.2.6";
+
+  src = fetchurl {
+    url = "https://www.charlesproxy.com/assets/release/${version}/charles-proxy-${version}.tar.gz";
+    sha256 = "1hjfimyr9nnbbxadwni02d2xl64ybarh42l1g6hlslq5qwl8ywzb";
+  };
+
+  installPhase = ''
+    set -e
+
+    mkdir -pv $out/bin
+
+    for fn in lib/*.jar; do
+      install -D -m644 $fn $out/$fn
+    done
+
+    cat > $out/bin/charles << EOF
+    #!${stdenv.shell}
+
+    ${jre}/bin/java -Xmx1024M -Dcharles.config="~/.charles.config" -Djava.library.path="$out/lib" -jar $out/lib/charles.jar $*
+    EOF
+
+    chmod +x $out/bin/charles
+
+    mkdir -p $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+
+    for dim in 16x16 32x32 64x64 128x128 256x256 512x512; do
+      install -D -m644 icon/$dim/apps/charles-proxy.png \
+        $out/share/icons/hicolor/$dim/apps/charles.png
+      for mimetype in application-har+json.png application-vnd.tcpdump.pcap.png application-x-charles-savedsession.png application-x-charles-trace.png; do
+        install -D -m644 icon/$dim/mimetypes/$mimetype \
+          $out/share/icons/hicolor/$dim/mimetypes/$mimetype
+      done
+    done
+
+    install -D -m644 doc/licenses/bounce-license.txt \
+      $out/share/licenses/bounce-license.txt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Web Debugging Proxy";
+    homepage = https://www.charlesproxy.com/;
+    maintainers = [ maintainers.kalbasit ];
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     makeWrapper ${jre}/bin/java $out/bin/charles \
-      --add-flags "-Xmx1024M -Dcharles.config="~/.charles.config" -Djava.library.path="$out/share/java" -jar $out/share/java/charles.jar"
+      --add-flags "-Xmx1024M -Dcharles.config='~/.charles.config' -jar $out/share/java/charles.jar"
 
     for fn in lib/*.jar; do
       install -D -m644 $fn $out/share/java/$(basename $fn)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3720,7 +3720,7 @@ with pkgs;
   lzip = callPackage ../tools/compression/lzip { };
 
   luxcorerender = callPackage ../tools/graphics/luxcorerender { };
-
+  
   xz = callPackage ../tools/compression/xz { };
 
   lz4 = callPackage ../tools/compression/lz4 { };
@@ -4989,7 +4989,7 @@ with pkgs;
   securefs = callPackage ../tools/filesystems/securefs { };
 
   seexpr = callPackage ../development/compilers/seexpr { };
-
+ 
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -848,6 +848,8 @@ with pkgs;
 
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
 
+  charles = callPackage ../applications/networking/charles { };
+
   libqmatrixclient = libsForQt5.callPackage ../development/libraries/libqmatrixclient { };
 
   quaternion = libsForQt5.callPackage ../applications/networking/instant-messengers/quaternion { };
@@ -3718,7 +3720,7 @@ with pkgs;
   lzip = callPackage ../tools/compression/lzip { };
 
   luxcorerender = callPackage ../tools/graphics/luxcorerender { };
-  
+
   xz = callPackage ../tools/compression/xz { };
 
   lz4 = callPackage ../tools/compression/lz4 { };
@@ -4987,7 +4989,7 @@ with pkgs;
   securefs = callPackage ../tools/filesystems/securefs { };
 
   seexpr = callPackage ../development/compilers/seexpr { };
- 
+
   setroot = callPackage  ../tools/X11/setroot { };
 
   setserial = callPackage ../tools/system/setserial { };


### PR DESCRIPTION
###### Motivation for this change

Charles is an HTTP proxy / HTTP monitor / Reverse Proxy that enables a developer to view all of the HTTP and SSL / HTTPS traffic between their machine and the Internet. This includes requests, responses and the HTTP headers (which contain the cookies and caching information).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

