### PR TITLE
bazel: use per-user tmp directory to avoid conflict with other builders

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/0.4.nix
+++ b/pkgs/development/tools/build-managers/bazel/0.4.nix
@@ -65,8 +65,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildPhase = ''
+    export TMPDIR=/tmp/.bazel-$UID
     ./compile.sh
-    ./output/bazel --output_user_root=/tmp/.bazel build //scripts:bash_completion \
+    ./output/bazel --output_user_root=$TMPDIR/.bazel build //scripts:bash_completion \
       --spawn_strategy=standalone \
       --genrule_strategy=standalone
     cp bazel-bin/scripts/bazel-complete.bash output/

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -483,9 +483,9 @@ stdenv.mkDerivation rec {
   # Change this to $(mktemp -d) as soon as we figure out why.
 
   buildPhase = ''
-    export TMPDIR=/tmp
+    export TMPDIR=/tmp/.bazel-$UID
     ./compile.sh
-    ./output/bazel --output_user_root=/tmp/.bazel build //scripts:bash_completion \
+    ./output/bazel --output_user_root=$TMPDIR/.bazel build //scripts:bash_completion \
       --spawn_strategy=standalone \
       --genrule_strategy=standalone \
       --crosstool_top=//nix:nix --host_crosstool_top=//nix:nix


### PR DESCRIPTION
###### Motivation for this change

```bazel``` cannot be built twice on the same machine because a build left ```/tmp/.bazel``` owned by one of ```nixbld*``` users and inaccessible for any other build user.

```TMPDIR=$(mktemp -d)``` and ```TMPDIR=$NIX_BUILD_TOP/tmp``` still hit "infinite symlink detector", 


Fixes https://github.com/NixOS/nixpkgs/issues/43500
Related: https://github.com/NixOS/nixpkgs/pull/23074
cc @izuk