### PR TITLE
go_1_10: remove cache artificates (closure size reduction)

### DIFF
--- a/pkgs/data/misc/iana-etc/default.nix
+++ b/pkgs/data/misc/iana-etc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "iana-etc-${version}";
-  version = "20180405";
+  version = "20180711";
 
   src = fetchurl {
     url = "https://github.com/Mic92/iana-etc/releases/download/${version}/iana-etc-${version}.tar.gz";
-    sha256 = "0x6i95arrc4lcq2il3r05hbnd9vsi87z4yc8s3agkvbj74d6hfhj";
+    sha256 = "0xigkz6pcqx55px7fap7j6p3hz27agv056crbl5pgfcdix7y8z26";
   };
 
   installPhase = ''

--- a/pkgs/development/compilers/go/1.10.nix
+++ b/pkgs/development/compilers/go/1.10.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     sha256 = "0i89298dgnmpmam3ifkm0ax266vvbq1yz7wfw8wwrcma0szrbrnb";
   };
 
+  GOCACHE = "off";
+
   # perl is used for testing go vet
   nativeBuildInputs = [ perl which pkgconfig patch makeWrapper procps ];
   buildInputs = [ cacert pcre ]


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

