### PR TITLE
firejail: add nixos module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -19,6 +19,27 @@
 
   <itemizedlist>
    <listitem>
+     <para>
+       Support for wrapping binaries using <literal>firejail</literal> has been
+       added through <varname>programs.firejail.wrappedBinaries</varname>.
+     </para>
+     <para>
+       For example
+     </para>
+<programlisting>
+programs.firejail = {
+  enable = true;
+  wrappedBinaries = {
+    firefox = "${lib.getBin pkgs.firefox}/bin/firefox";
+    mpv = "${lib.getBin pkgs.mpv}/bin/mpv";
+  };
+};
+</programlisting>
+      <para>
+        This will place <literal>firefox</literal> and <literal>mpv</literal> binaries in the global path wrapped by firejail.
+      </para>
+   </listitem>
+   <listitem>
     <para>
      User channels are now in the default <literal>NIX_PATH</literal>, allowing
      users to use their personal <command>nix-channel</command> defined

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -86,6 +86,7 @@
   ./programs/dconf.nix
   ./programs/digitalbitbox/default.nix
   ./programs/environment.nix
+  ./programs/firejail.nix
   ./programs/fish.nix
   ./programs/freetds.nix
   ./programs/gnupg.nix

--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.firejail;
+
+  wrappedBins = pkgs.stdenv.mkDerivation rec {
+    name = "firejail-wrapped-binaries";
+    nativeBuildInputs = with pkgs; [ makeWrapper ];
+    buildCommand = ''
+      mkdir -p $out/bin
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (command: binary: ''
+      cat <<_EOF >$out/bin/${command}
+      #!${pkgs.stdenv.shell} -e
+      /run/wrappers/bin/firejail ${binary} "\$@"
+      _EOF
+      chmod 0755 $out/bin/${command}
+      '') cfg.wrappedBinaries)}
+    '';
+  };
+
+in {
+  options.programs.firejail = {
+    enable = mkEnableOption "firejail";
+
+    wrappedBinaries = mkOption {
+      type = types.attrs;
+      default = {};
+      description = ''
+        Wrap the binaries in firejail and place them in the global path.
+        </para>
+        <para>
+        You will get file collisions if you put the actual application binary in
+        the global environment and applications started via .desktop files are
+        not wrapped if they specify the absolute path to the binary.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.wrappers.firejail.source = "${lib.getBin pkgs.firejail}/bin/firejail";
+
+    environment.systemPackages = [ wrappedBins ];
+  };
+
+  meta.maintainers = with maintainers; [ peterhoeg ];
+}


### PR DESCRIPTION
###### Motivation for this change

We need to set up a wrapper for it to work.

Cc: @coretemp 

Fixes #43488

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

