### PR TITLE
gutenberg: 0.3.1 -> 0.3.4

### DIFF
--- a/pkgs/applications/misc/gutenberg/default.nix
+++ b/pkgs/applications/misc/gutenberg/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   name = "gutenberg-${version}";
-  version = "0.3.1";
+  version = "0.3.4";
 
   src = fetchFromGitHub {
     owner = "Keats";
     repo = "gutenberg";
     rev = "v${version}";
-    sha256 = "03zhbwxp4dbqydiydx0hpp3vpg769zzn5i95h2sl868mpfia8gyd";
+    sha256 = "1v26q1m3bx7mdmmwgd6p601ncf13rr4rrx9s06fiy8vnd0ar1vlf";
   };
 
-  cargoSha256 = "0441lbmxx16aar6fn651ihk3psrx0lk3qdbbyih05xjlkkbk1qxs";
+  cargoSha256 = "0cdy0wvibkpnmlqwxvn02a2k2vqy6zdqzflj2dh6g1cjbz1j8qh5";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices cf-private ];
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     description = "An opinionated static site generator with everything built-in";
     homepage = https://www.getgutenberg.io;
     license = licenses.mit;
-    maintainers = [];
+    maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
[0.3.4 (2018-06-22)](https://github.com/Keats/gutenberg/blob/master/CHANGELOG.md#034-2018-06-22)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

