### PR TITLE
nethack: add support for qt4 on linux

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19684,6 +19684,8 @@ with pkgs;
 
   nethack = callPackage ../games/nethack { };
 
+  nethack-qt4 = callPackage ../games/nethack { qt4Mode = true; };
+
   nethack-x11 = callPackage ../games/nethack { x11Mode = true; };
 
   neverball = callPackage ../games/neverball { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19684,7 +19684,7 @@ with pkgs;
 
   nethack = callPackage ../games/nethack { };
 
-  nethack-qt4 = callPackage ../games/nethack { qt4Mode = true; };
+  nethack-qt = callPackage ../games/nethack { qtMode = true; };
 
   nethack-x11 = callPackage ../games/nethack { x11Mode = true; };
 


### PR DESCRIPTION
###### Motivation for this change

Add a Qt4-based port of NetHack.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

