### PR TITLE
libebml: 1.3.5 -> 1.3.6 and libmatroska: 1.4.8 -> 1.4.9

### DIFF
--- a/pkgs/development/libraries/libebml/default.nix
+++ b/pkgs/development/libraries/libebml/default.nix
@@ -1,19 +1,27 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig }:
 
 stdenv.mkDerivation rec {
-  name = "libebml-1.3.5";
+  name = "libebml-${version}";
+  version = "1.3.6";
 
-  src = fetchurl {
-    url = "https://dl.matroska.org/downloads/libebml/${name}.tar.xz";
-    sha256 = "005a0ipqnfbsq47zrc61zszi439jw32q5xd6dc1jyb3lc0zl266q";
+  src = fetchFromGitHub {
+    owner  = "Matroska-Org";
+    repo   = "libebml";
+    rev    = "release-${version}";
+    sha256 = "0fl8d35ywj9id93yp78qlxy7j81kjri957agq40r420kmwac3dzs";
   };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=YES"
+  ];
 
   meta = with stdenv.lib; {
     description = "Extensible Binary Meta Language library";
-    license = licenses.lgpl21;
     homepage = https://dl.matroska.org/downloads/libebml/;
-    maintainers = [ maintainers.spwhitt ];
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ spwhitt ];
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -1,23 +1,30 @@
-{ stdenv, fetchurl, pkgconfig, libebml }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
+, libebml }:
 
 stdenv.mkDerivation rec {
-  name = "libmatroska-1.4.8";
+  name = "libmatroska-${version}";
+  version = "1.4.9";
 
-  src = fetchurl {
-    url = "https://dl.matroska.org/downloads/libmatroska/${name}.tar.xz";
-    sha256 = "14n9sw974prr3yp4yjb7aadi6x2yz5a0hjw8fs3qigy5shh2piyq";
+  src = fetchFromGitHub {
+    owner  = "Matroska-Org";
+    repo   = "libmatroska";
+    rev    = "release-${version}";
+    sha256 = "1hfrcpvmyqnvdkw8rz1z20zw7fpnjyl5h0g9ky7k6y1a44b1fz86";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [ libebml ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=YES"
+  ];
 
   meta = with stdenv.lib; {
     description = "A library to parse Matroska files";
     homepage = https://matroska.org/;
     license = licenses.lgpl21;
-    maintainers = [ maintainers.spwhitt ];
+    maintainers = with maintainers; [ spwhitt ];
     platforms = platforms.unix;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

Upstream update. Both projects have been converted to use cmake so they need to be updated at the same time.

~~~Waiting for nox-review to finish.~~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

