### PR TITLE
xfce.xfce4-hardware-monitor-plugin: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix
@@ -5,11 +5,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname  = "xfce4-hardware-monitor-plugin";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchurl {
     url = "https://git.xfce.org/panel-plugins/${pname}/snapshot/${name}.tar.bz2";
-    sha256 = "0sqvisr8gagpywq9sfyzqw37hxmj54ii89j5s2g8hx8bng5a98z1";
+    sha256 = "0xg5har11fk1wmdymydxlbk1z8aa39j8k0p4gzw2iqslv3n0zf7b";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

update within XFCE 4.12 (stable)
it does not bring GTK3 or any new dependencies

[CHANGELOG and sources diff](https://git.xfce.org/panel-plugins/xfce4-hardware-monitor-plugin/diff/?id=e68cd4972155057a5c575c7cc8a2b0f21bd94a62&id2=5ef872f4fb3d725fa45f8b60f869ad6f9336978f)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

