### PR TITLE
Fix Synergy building on macOS

### DIFF
--- a/pkgs/applications/misc/synergy/default.nix
+++ b/pkgs/applications/misc/synergy/default.nix
@@ -1,7 +1,6 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, xlibsWrapper, libX11, libXi, libXtst, libXrandr
-, xinput, curl, openssl, unzip }:
-
-with stdenv.lib;
+{ stdenv, lib, fetchFromGitHub, fetchpatch, fetchurl, cmake, xlibsWrapper
+, ApplicationServices, Carbon, Cocoa, CoreServices, ScreenSaver
+, libX11, libXi, libXtst, libXrandr, xinput, curl, openssl, unzip }:
 
 stdenv.mkDerivation rec {
   name = "synergy-${version}";
@@ -14,17 +13,33 @@ stdenv.mkDerivation rec {
     sha256 = "0ksgr9hkf09h54572p7k7b9zkfhcdb2g2d5x7ixxn028y8i3jyp3";
   };
 
-  patches = [ ./openssl-1.1.patch ];
+  patches = [./openssl-1.1.patch ./update_gtest_gmock.patch
+  ] ++ lib.optional stdenv.isDarwin ./respect_macos_arch.patch;
 
   patch_gcc6 = fetchpatch {
     url = https://raw.githubusercontent.com/gentoo/gentoo/20e2bff3697ebf5f291e9907b34aae3074a36b53/dev-cpp/gmock/files/gmock-1.7.0-gcc6.patch;
     sha256 = "0j3f381x1lf8qci9pfv6mliggl8qs2w05v5lw3rs3gn7aibg174d";
   };
 
+  # Due to the included gtest and gmock not supporting clang
+  # we replace it with 1.7.0 for synergy-1.8.8. This should
+  # become unnecessary when we update to a newer version of Synergy.
+  gmock_zip = fetchurl {
+    url = https://github.com/google/googlemock/archive/release-1.7.0.zip;
+    sha256 = "11bd04098rzamv7f9y01zaf9c8zrmzdk6g1qrlwq780pxzlr4ya0";
+  };
+
+  gtest_zip = fetchurl {
+    url = https://github.com/google/googletest/archive/release-1.7.0.zip;
+    sha256 = "1l5n6kzdypjzjrz2jh14ylzrx735lccfx2p3s4ccgci8g9abg35m";
+  };
+
   postPatch = ''
-    ${unzip}/bin/unzip -d ext/gmock-1.6.0 ext/gmock-1.6.0.zip
-    ${unzip}/bin/unzip -d ext/gtest-1.6.0 ext/gtest-1.6.0.zip
-    patch -d ext/gmock-1.6.0 -p1 -i ${patch_gcc6}
+    ${unzip}/bin/unzip -d ext/ ${gmock_zip}
+    ${unzip}/bin/unzip -d ext/ ${gtest_zip}
+    mv ext/googlemock-release-1.7.0 ext/gmock-1.7.0
+    mv ext/googletest-release-1.7.0 ext/gtest-1.7.0
+    patch -d ext/gmock-1.7.0 -p1 -i ${patch_gcc6}
   ''
     # We have XRRNotifyEvent (libXrandr), but with the upstream CMakeLists.txt
     # it's not able to find it (it's trying to search the store path of libX11
@@ -38,15 +53,19 @@ stdenv.mkDerivation rec {
     #   Looking for XRRNotifyEvent - not found
     #
     # So let's force it:
-  + optionalString stdenv.isLinux ''
+  + lib.optionalString stdenv.isLinux ''
     sed -i -e '/HAVE_X11_EXTENSIONS_XRANDR_H/c \
       set(HAVE_X11_EXTENSIONS_XRANDR_H true)
     ' CMakeLists.txt
   '';
 
+  cmakeFlags = lib.optionals stdenv.isDarwin [ "-DOSX_TARGET_MAJOR=10" "-DOSX_TARGET_MINOR=7" ];
+
   buildInputs = [
-    cmake xlibsWrapper libX11 libXi libXtst libXrandr xinput curl openssl
-  ];
+    cmake curl openssl
+  ] ++ lib.optionals stdenv.isDarwin [
+    ApplicationServices Carbon Cocoa CoreServices ScreenSaver
+  ] ++ lib.optionals stdenv.isLinux [ xlibsWrapper libX11 libXi libXtst libXrandr xinput ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -58,12 +77,11 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = "../bin/unittests";
 
-  meta = {
+  meta = with lib; {
     description = "Share one mouse and keyboard between multiple computers";
     homepage = http://synergy-project.org/;
     license = licenses.gpl2;
-    maintainers = [ maintainers.aszlig ];
+    maintainers = with maintainers; [ aszlig enzime ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/applications/misc/synergy/respect_macos_arch.patch
+++ b/pkgs/applications/misc/synergy/respect_macos_arch.patch
@@ -1,0 +1,61 @@
+From 944177c76d4c7ff5ef3460eab28286a45344a0e7 Mon Sep 17 00:00:00 2001
+From: Michael Hoang <enzime@users.noreply.github.com>
+Date: Sat, 14 Jul 2018 21:56:59 +1000
+Subject: [PATCH 2/2] Make sure CMake respects the current arch on macOS
+
+Only set the macOS architecture if not defined by the user. Use the
+OpenSSL libraries and headers from Nix on macOS to prevent architecture
+mismatches.
+---
+ CMakeLists.txt     |  2 +-
+ src/CMakeLists.txt | 14 +-------------
+ 2 files changed, 2 insertions(+), 14 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2f37424d..c7217e28 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -172,7 +172,7 @@ if (UNIX)
+ 			# <= 10.5: 32-bit Intel and PowerPC
+ 			set(CMAKE_OSX_ARCHITECTURES "ppc;i386"
+ 				CACHE STRING "" FORCE)
+-		else()
++		elseif (NOT CMAKE_OSX_ARCHITECTURES)
+ 			# >= 10.6: Intel only
+ 			set(CMAKE_OSX_ARCHITECTURES "i386"
+ 				CACHE STRING "" FORCE)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 237ba484..04428636 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -23,11 +23,6 @@ if (WIN32)
+ 	set(OPENSSL_INCLUDE ${CMAKE_SOURCE_DIR}/ext/${OPENSSL_PLAT_DIR}/inc32)
+ endif()
+ 
+-if (APPLE)
+-	set(OPENSSL_PLAT_DIR openssl-osx)
+-	set(OPENSSL_INCLUDE ${CMAKE_SOURCE_DIR}/ext/${OPENSSL_PLAT_DIR}/include)
+-endif()
+-
+ if (WIN32)
+ 	set(OPENSSL_LIBS
+ 		${CMAKE_SOURCE_DIR}/ext/${OPENSSL_PLAT_DIR}/out32dll/libeay32.lib
+@@ -36,14 +31,7 @@ if (WIN32)
+ endif()
+ 
+ if (UNIX)
+-	if (APPLE)
+-		set(OPENSSL_LIBS
+-		${CMAKE_SOURCE_DIR}/ext/${OPENSSL_PLAT_DIR}/libssl.a
+-		${CMAKE_SOURCE_DIR}/ext/${OPENSSL_PLAT_DIR}/libcrypto.a
+-		)
+-	else()
+-		set(OPENSSL_LIBS ssl crypto)
+-	endif()
++	set(OPENSSL_LIBS ssl crypto)
+ endif()
+ 
+ add_subdirectory(lib)
+-- 
+2.17.1
+

--- a/pkgs/applications/misc/synergy/update_gtest_gmock.patch
+++ b/pkgs/applications/misc/synergy/update_gtest_gmock.patch
@@ -1,0 +1,158 @@
+From eea85dbf4bbde545d8cb07d7ee9fbdca3dcf48fd Mon Sep 17 00:00:00 2001
+From: Michael Hoang <enzime@users.noreply.github.com>
+Date: Sat, 14 Jul 2018 22:07:39 +1000
+Subject: [PATCH 1/2] Update gtest and gmock to version 1.7.0
+
+Fixes compilation under clang on macOS as <tr1/tuple> is now found under
+<tuple>.
+---
+ CMakeLists.txt                     |  2 +-
+ ext/toolchain/commands1.py         |  4 ++--
+ src/lib/platform/CMakeLists.txt    |  2 +-
+ src/lib/server/CMakeLists.txt      |  2 +-
+ src/lib/shared/CMakeLists.txt      |  2 +-
+ src/lib/synergy/CMakeLists.txt     |  2 +-
+ src/test/CMakeLists.txt            | 12 ++++++------
+ src/test/integtests/CMakeLists.txt |  4 ++--
+ src/test/unittests/CMakeLists.txt  |  4 ++--
+ 9 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 94c474e8..2f37424d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -178,7 +178,7 @@ if (UNIX)
+ 				CACHE STRING "" FORCE)
+ 		endif()
+ 		
+-		set(CMAKE_CXX_FLAGS "--sysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
++		set(CMAKE_CXX_FLAGS "--sysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CXX_FLAGS}")
+ 
+ 		find_library(lib_ScreenSaver ScreenSaver)
+ 		find_library(lib_IOKit IOKit)
+diff --git a/ext/toolchain/commands1.py b/ext/toolchain/commands1.py
+index f32ec483..bf997cf6 100644
+--- a/ext/toolchain/commands1.py
++++ b/ext/toolchain/commands1.py
+@@ -251,10 +251,10 @@ class InternalCommands:
+ 	macIdentity = None
+ 	
+ 	# gtest dir with version number
+-	gtestDir = 'gtest-1.6.0'
++	gtestDir = 'gtest-1.7.0'
+ 	
+ 	# gmock dir with version number
+-	gmockDir = 'gmock-1.6.0'
++	gmockDir = 'gmock-1.7.0'
+ 
+ 	win32_generators = {
+ 		1 : VisualStudioGenerator('10'),
+diff --git a/src/lib/platform/CMakeLists.txt b/src/lib/platform/CMakeLists.txt
+index 481d8ef9..1ce67eca 100644
+--- a/src/lib/platform/CMakeLists.txt
++++ b/src/lib/platform/CMakeLists.txt
+@@ -31,7 +31,7 @@ endif()
+ 
+ include_directories(
+ 	../
+-	../../../ext/gtest-1.6.0/include
++	../../../ext/gtest-1.7.0/include
+ )
+ 
+ if (UNIX)
+diff --git a/src/lib/server/CMakeLists.txt b/src/lib/server/CMakeLists.txt
+index 3cb582ec..0525d627 100644
+--- a/src/lib/server/CMakeLists.txt
++++ b/src/lib/server/CMakeLists.txt
+@@ -24,7 +24,7 @@ endif()
+ include_directories(
+ 	../
+ 	../../../ext
+-	../../../ext/gtest-1.6.0/include
++	../../../ext/gtest-1.7.0/include
+ )
+ 
+ if (UNIX)
+diff --git a/src/lib/shared/CMakeLists.txt b/src/lib/shared/CMakeLists.txt
+index 891f4aa7..16c8b04a 100644
+--- a/src/lib/shared/CMakeLists.txt
++++ b/src/lib/shared/CMakeLists.txt
+@@ -25,7 +25,7 @@ add_library(shared STATIC ${sources})
+ include_directories(
+ 	../
+ 	../../../ext
+-	../../../ext/gtest-1.6.0/include
++	../../../ext/gtest-1.7.0/include
+ )
+ 
+ target_link_libraries(shared arch base)
+diff --git a/src/lib/synergy/CMakeLists.txt b/src/lib/synergy/CMakeLists.txt
+index 0972be8c..e19fcce5 100644
+--- a/src/lib/synergy/CMakeLists.txt
++++ b/src/lib/synergy/CMakeLists.txt
+@@ -36,7 +36,7 @@ endif()
+ include_directories(
+ 	../
+ 	../../../ext
+-	../../../ext/gtest-1.6.0/include
++	../../../ext/gtest-1.7.0/include
+ )
+ 
+ if (UNIX)
+diff --git a/src/test/CMakeLists.txt b/src/test/CMakeLists.txt
+index 8812150a..04cdfc50 100644
+--- a/src/test/CMakeLists.txt
++++ b/src/test/CMakeLists.txt
+@@ -15,13 +15,13 @@
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ include_directories(
+-	../../ext/gtest-1.6.0
+-	../../ext/gtest-1.6.0/include
+-	../../ext/gmock-1.6.0
+-	../../ext/gmock-1.6.0/include)
++	../../ext/gtest-1.7.0
++	../../ext/gtest-1.7.0/include
++	../../ext/gmock-1.7.0
++	../../ext/gmock-1.7.0/include)
+ 	
+-add_library(gtest STATIC ../../ext/gtest-1.6.0/src/gtest-all.cc)
+-add_library(gmock STATIC ../../ext/gmock-1.6.0/src/gmock-all.cc)
++add_library(gtest STATIC ../../ext/gtest-1.7.0/src/gtest-all.cc)
++add_library(gmock STATIC ../../ext/gmock-1.7.0/src/gmock-all.cc)
+ 
+ if (UNIX)
+ 	# ignore warnings in gtest and gmock
+diff --git a/src/test/integtests/CMakeLists.txt b/src/test/integtests/CMakeLists.txt
+index 2f1ca7f3..6ddbd29a 100644
+--- a/src/test/integtests/CMakeLists.txt
++++ b/src/test/integtests/CMakeLists.txt
+@@ -56,8 +56,8 @@ endif()
+ include_directories(
+ 	../../
+ 	../../lib/
+-	../../../ext/gtest-1.6.0/include
+-	../../../ext/gmock-1.6.0/include
++	../../../ext/gtest-1.7.0/include
++	../../../ext/gmock-1.7.0/include
+ )
+ 
+ if (UNIX)
+diff --git a/src/test/unittests/CMakeLists.txt b/src/test/unittests/CMakeLists.txt
+index 3e49dc3c..5f6c4fac 100644
+--- a/src/test/unittests/CMakeLists.txt
++++ b/src/test/unittests/CMakeLists.txt
+@@ -51,8 +51,8 @@ list(APPEND headers ${platform_sources})
+ include_directories(
+ 	../../
+ 	../../lib/
+-	../../../ext/gtest-1.6.0/include
+-	../../../ext/gmock-1.6.0/include
++	../../../ext/gtest-1.7.0/include
++	../../../ext/gmock-1.7.0/include
+ 	../../../ext
+ )
+ 
+-- 
+2.17.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18416,8 +18416,9 @@ with pkgs;
 
   syncthing-tray = callPackage ../applications/misc/syncthing-tray { };
 
-  # linux only by now
-  synergy = callPackage ../applications/misc/synergy { };
+  synergy = callPackage ../applications/misc/synergy {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa CoreServices ScreenSaver;
+  };
 
   tabbed = callPackage ../applications/window-managers/tabbed {
     # if you prefer a custom config, write the config.h in tabbed.config.h


### PR DESCRIPTION
Update gtest and gmock to fix clang compiler issues, as well as patch CMakeLists.txt in multiple places to fix other issues on macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested without sandboxing on macOS
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

