### PR TITLE
markdown-pp: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4415,6 +4415,11 @@
     email = "zef@zef.me";
     name = "Zef Hemel";
   };
+  zgrannan = {
+    email = "zgrannan@gmail.com";
+    github = "zgrannan";
+    name = "Zack Grannan";
+  };
   zimbatm = {
     email = "zimbatm@zimbatm.com";
     github = "zimbatm";

--- a/pkgs/tools/text/markdown-pp/default.nix
+++ b/pkgs/tools/text/markdown-pp/default.nix
@@ -3,14 +3,17 @@
 with pythonPackages;
 buildPythonApplication rec {
   pname = "MarkdownPP";
-  version = "1.3";
-  doCheck = false;
-  propagatedBuildInputs = [ watchdog ];
+  version = "1.4";
+  propagatedBuildInputs = [ pillow watchdog ];
+  checkPhase = ''
+    cd test
+    PATH=$out/bin:$PATH ${python}/bin/${python.executable} test.py
+  '';
   src = fetchFromGitHub {
     owner = "jreese";
     repo = "markdown-pp";
-    rev = "8c1e3fb659ece44a2992b0e341dd5a0f2322a871";
-    sha256 = "1f9pbmjwnn04z6fl872rryzcssqsxcq5yzkpaqcmxgjj11hxbjlx";
+    rev = "v${version}";
+    sha256 = "1xmc0cxvvf6jzr7p4f0hm8icysrd44sy2kgff9b99lr1agwkmysq";
   };
   meta = with stdenv.lib; {
     description = "Preprocessor for Markdown files to generate a table of contents and other documentation needs";

--- a/pkgs/tools/text/markdown-pp/default.nix
+++ b/pkgs/tools/text/markdown-pp/default.nix
@@ -1,0 +1,21 @@
+{ fetchFromGitHub, pythonPackages, stdenv }:
+
+with pythonPackages;
+buildPythonApplication rec {
+  pname = "MarkdownPP";
+  version = "1.3";
+  doCheck = false;
+  propagatedBuildInputs = [ watchdog ];
+  src = fetchFromGitHub {
+    owner = "jreese";
+    repo = "markdown-pp";
+    rev = "8c1e3fb659ece44a2992b0e341dd5a0f2322a871";
+    sha256 = "1f9pbmjwnn04z6fl872rryzcssqsxcq5yzkpaqcmxgjj11hxbjlx";
+  };
+  meta = with stdenv.lib; {
+    description = "Preprocessor for Markdown files to generate a table of contents and other documentation needs";
+    license = licenses.mit;
+    homepage = "https://github.com/jreese/markdown-pp";
+    maintainers = with maintainers; [ zgrannan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17127,6 +17127,8 @@ with pkgs;
   marathon = callPackage ../applications/networking/cluster/marathon { };
   marathonctl = callPackage ../tools/virtualization/marathonctl { } ;
 
+  markdown-pp = callPackage ../tools/text/markdown-pp { };
+
   marp = callPackage ../applications/office/marp { };
 
   matchbox = callPackage ../applications/window-managers/matchbox { };


### PR DESCRIPTION
###### Motivation for this change

Add the `markdown-pp` executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

