### PR TITLE
lib.debug: fix traceValSeqFn

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -77,7 +77,7 @@ rec {
                (modify depth snip x)) y;
 
   /* A combination of `traceVal` and `traceSeq` */
-  traceValSeqFn = f: v: traceVal f (builtins.deepSeq v v);
+  traceValSeqFn = f: v: traceValFn f (builtins.deepSeq v v);
   traceValSeq = traceValSeqFn id;
 
   /* A combination of `traceVal` and `traceSeqN`. */


### PR DESCRIPTION
was calling the wrong parent version.

###### Motivation for this change
was printing LAMBDA instead of the expected nested set. Because it was printing the `id` function.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

