### PR TITLE
bazel: Set a sensible strict action environment.

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -96,6 +96,15 @@ stdenv.mkDerivation rec {
     sed -i -e "361 a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
     sed -i -e "361 a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
     sed -i -e "361 a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
+
+    # --experimental_strict_action_env (which will soon become the
+    # default, see bazelbuild/bazel#2574) hardcodes the default
+    # action environment to a value that on NixOS at least is bogus.
+    # So we hardcode it to something useful.
+    substituteInPlace \
+		  src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java \
+      --replace /bin:/usr/bin ${defaultShellPath}
+
     patchShebangs .
   '';
 

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchurl, runCommand, jdk, zip, unzip, bash, writeCBin, coreutils, makeWrapper, which, python, gnused
+{ stdenv, lib, fetchurl, runCommand, makeWrapper
+, jdk, zip, unzip, bash, writeCBin, coreutils
+, which, python, gnused, gnugrep, findutils
 # Always assume all markers valid (don't redownload dependencies).
 # Also, don't clean up environment variables.
 , enableNixHacks ? false
@@ -6,16 +8,21 @@
 , libcxx, CoreFoundation, CoreServices, Foundation
 }:
 
-let srcDeps = stdenv.lib.singleton (
-      fetchurl {
-        url = "https://github.com/google/desugar_jdk_libs/archive/f5e6d80c6b4ec6b0a46603f72b015d45cf3c11cd.zip";
-        sha256 = "c80f3f3d442d8a6ca7adc83f90ecd638c3864087fdd6787ffac070b6f1cc8f9b";
-      }
-    );
-    distDir = runCommand "bazel-deps" {} ''
-      mkdir -p $out
-      for i in ${builtins.toString srcDeps}; do cp $i $out/$(stripHash $i); done
-    '';
+let
+  srcDeps = stdenv.lib.singleton (
+    fetchurl {
+      url = "https://github.com/google/desugar_jdk_libs/archive/f5e6d80c6b4ec6b0a46603f72b015d45cf3c11cd.zip";
+      sha256 = "c80f3f3d442d8a6ca7adc83f90ecd638c3864087fdd6787ffac070b6f1cc8f9b";
+    }
+  );
+
+  distDir = runCommand "bazel-deps" {} ''
+    mkdir -p $out
+    for i in ${builtins.toString srcDeps}; do cp $i $out/$(stripHash $i); done
+  '';
+
+  defaultShellPath = lib.makeBinPath [ bash coreutils findutils gnugrep gnused which ];
+
 in
 stdenv.mkDerivation rec {
 
@@ -52,7 +59,7 @@ stdenv.mkDerivation rec {
 
     int main(int argc, char *argv[]) {
       char *path = getenv("PATH");
-      char *pathToAppend = "${lib.makeBinPath [ coreutils gnused ]}";
+      char *pathToAppend = "${defaultShellPath}";
       char *newPath;
       if (path != NULL) {
         int length = strlen(path) + 1 + strlen(pathToAppend) + 1;
@@ -140,7 +147,7 @@ stdenv.mkDerivation rec {
   # Save paths to hardcoded dependencies so Nix can detect them.
   postFixup = ''
     mkdir -p $out/nix-support
-    echo "${customBash} ${gnused} ${coreutils}" > $out/nix-support/depends
+    echo "${customBash} ${defaultShellPath}" > $out/nix-support/depends
   '';
 
   dontStrip = true;


### PR DESCRIPTION
Bazel either reuses the `PATH` from the client, or sets a hardcoded
one. The former mode in problematic for build hermeticity. But the
latter is crippled on NixOS, because the hardcoded value is
`/bin:/usr/bin`. So we set the hardcoded value to match what
`customBash` provides. This has the effect of aligning the
environments for `ctx.actions.run` and `ctx.actions.run_shell`, which
were previously distinct (bug).

cc @uri-canva