### PR TITLE
[WIP]: lightdm-web-greeter (3.0.0rc2)

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/web.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/web.nix
@@ -1,0 +1,114 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dmcfg = config.services.xserver.displayManager;
+  ldmcfg = dmcfg.lightdm;
+  cfg = ldmcfg.greeters.web;
+
+  cfgFile = pkgs.writeText "web-greeter-yml" ''
+    #
+    # branding:
+    #     background_images_dir: Path to directory that contains background images for use by themes.
+    #     logo_image:            Path to logo image for use by greeter themes.
+    #     user_image:            Default user image/avatar. This is used by themes when user has no .face image.
+    #
+    # NOTE: Paths must be accessible to the lightdm system user account (so they cannot be anywhere in /home)
+    #
+    branding:
+        background_images_dir: '/run/current-system/sw/share/backgrounds'
+        logo_image: '/run/current-system/sw/share/web-greeter/themes/default/antergos-logo-user.png'
+        user_image: '/run/current-system/sw/share/web-greeter/themes/default/antergos.png'
+
+    #
+    # greeter:
+    #     debug_mode:          Enable debug mode for the greeter as well as greeter themes.
+    #     detect_theme_errors: Provide an option to load a fallback theme when theme errors are detected.
+    #     screensaver_timeout: Blank the screen after this many seconds of inactivity.
+    #     secure_mode:         Don't allow themes to make remote http requests.
+    #     theme:               Greeter theme to use.
+    #     time_format:         A moment.js format string so the greeter can generate localized time for display.
+    #     time_language:       Language to use when displaying the time or "auto" to use the system's language.
+    #
+    # NOTE: See moment.js documentation for format string options: http://momentjs.com/docs/#/displaying/format
+    #
+    greeter:
+        debug_mode: False
+        detect_theme_errors: True
+        screensaver_timeout: 300
+        secure_mode: True
+        theme: ${cfg.theme.name}
+        time_format: LT
+        time_language: auto
+  '';
+
+  inherit (pkgs) stdenv lightdm writeScript writeText;
+
+  theme = cfg.theme.package;
+
+  wrappedWebGreeter = pkgs.runCommand "lightdm-web-greeter"
+    { buildInputs = [ pkgs.makeWrapper ]; }
+    ''
+      # This wrapper ensures that we actually get themes
+      makeWrapper ${pkgs.lightdm-web-greeter}/bin/web-greeter \
+        $out/greeter \
+        --prefix PATH : "${pkgs.glibc.bin}/bin"
+
+      cat - > $out/lightdm-web-greeter.desktop << EOF
+      [Desktop Entry]
+      Name=LightDM Greeter
+      Comment=This runs the LightDM Greeter
+      Exec=$out/greeter
+      Type=Application
+      EOF
+    '';
+
+in
+{
+  options = {
+    services.xserver.displayManager.lightdm.greeters.web = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable lightdm-web-greeter as the lightdm greeter.
+        '';
+      };
+
+      theme = {
+        package = mkOption {
+          type = types.package;
+          default =      pkgs.lightdm-web-greeter.theme;
+          defaultText = "pkgs.lightdm-web-greeter.theme";
+          description = ''
+            The package path that contains the theme given in the name option.
+          '';
+        };
+
+        name = mkOption {
+          type = types.str;
+          default = "default";
+          description = ''
+            Name of the theme to use for the lightdm-web-greeter.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkIf (ldmcfg.enable && cfg.enable) {
+    services.xserver.displayManager.lightdm.greeter = mkDefault {
+      package = wrappedWebGreeter;
+      name = "lightdm-web-greeter";
+    };
+    environment.etc."lightdm/web-greeter.yml".source = cfgFile;
+    environment.systemPackages = [
+      cfg.theme.package
+    ];
+    environment.pathsToLink = [
+      "/share/web-greeter"
+    ];
+  };
+}

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -73,6 +73,7 @@ in
   imports = [
     ./lightdm-greeters/gtk.nix
     ./lightdm-greeters/mini.nix
+    ./lightdm-greeters/web.nix
   ];
 
   options = {

--- a/pkgs/applications/display-managers/lightdm-web-greeter/default.nix
+++ b/pkgs/applications/display-managers/lightdm-web-greeter/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, fetchFromGitHub
+, makeWrapper
+, buildPythonApplication
+, whither
+, zip
+, pygobject3
+, lightdm
+, gobjectIntrospection
+, qt5
+}:
+
+let
+  inherit (qt5) qtbase;
+in
+buildPythonApplication rec {
+  version = "3.0.0rc2";
+  name = "lightdm-web-greeter-${version}";
+
+  outputs = [ "out" "theme" ];
+
+  src = fetchFromGitHub {
+    owner = "Antergos";
+    repo = "web-greeter";
+    rev = "${version}";
+    sha256 = "1mhqnvc77m483sm4mj08qq1gzidkfkgn7xhaj3dgs65lndsxrwnn";
+  };
+
+  phases = [ "unpackPhase" "patchPhase" "installPhase" "fixupPhase" ];
+
+  postPatch = ''
+    patchShebangs build/utils.sh
+  '';
+
+  buildInputs = [
+    zip
+    whither
+    makeWrapper
+    pygobject3
+    lightdm
+    qtbase
+  ];
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+  ];
+
+  installPhase = ''
+    make -j1 \
+      PREFIX="/" \
+      DESTDIR="$out" \
+      themes_dir="/run/current-system/sw/share/web-greeter/themes" \
+      install
+
+    patchShebangs $out/bin/
+
+    wrapProgram $out/bin/web-greeter \
+      --set QT_PLUGIN_PATH ${qtbase.bin}/${qtbase.qtPluginPrefix} \
+      --set QTWEBENGINE_CHROMIUM_FLAGS "--enable-logging --log-level=0 --v=1" \
+      --prefix PYTHONPATH      : "$PYTHONPATH" \
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
+
+    # Move themes into `theme`
+    mkdir -p $theme/share/
+    # _vendor is needed :(
+    mv -v $out/share/web-greeter $theme/share/
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/Antergos/web-greeter;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -2,6 +2,7 @@
 , intltool, xlibsWrapper, libxklavier, libgcrypt, libaudit, coreutils
 , qt4 ? null
 , withQt5 ? false, qtbase
+, gobjectIntrospection
 }:
 
 with stdenv.lib;
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "18j33bm54i8k7ncxcs69zqi4105s62n58jrydqn3ikrb71s9nl6d";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
   buildInputs = [
     pam libxcb glib libXdmcp itstool libxml2 libxklavier libgcrypt
     qt4 libaudit

--- a/pkgs/development/python-modules/whither/5.11_hacky_fix.patch
+++ b/pkgs/development/python-modules/whither/5.11_hacky_fix.patch
@@ -1,0 +1,41 @@
+diff --git a/whither/toolkits/qt/web_container.py b/whither/toolkits/qt/web_container.py
+index d2c846e..74fa55b 100644
+--- a/whither/toolkits/qt/web_container.py
++++ b/whither/toolkits/qt/web_container.py
+@@ -50,7 +50,7 @@ from PyQt5.QtCore import (
+ # This Library
+ from whither.base.objects import WebContainer
+ from .devtools import DevTools
+-from .interceptor import QtUrlRequestInterceptor
++#from .interceptor import QtUrlRequestInterceptor
+ 
+ 
+ # Typing Helpers
+@@ -82,7 +82,7 @@ class QtWebContainer(WebContainer):
+             os.environ['QTWEBENGINE_REMOTE_DEBUGGING'] = '12345'
+ 
+         self.profile = QWebEngineProfile.defaultProfile()
+-        self.interceptor = QtUrlRequestInterceptor()
++        #self.interceptor = QtUrlRequestInterceptor()
+ 
+         self.view = QWebEngineView(parent=self._main_window.widget)
+         self.page = self.view.page()
+@@ -98,8 +98,8 @@ class QtWebContainer(WebContainer):
+         if not self._config.context_menu.enabled:
+             self.view.setContextMenuPolicy(Qt.PreventContextMenu)
+ 
+-        if not self._config.allow_remote_urls:
+-            self.profile.setRequestInterceptor(self.interceptor)
++        #if not self._config.allow_remote_urls:
++        #    self.profile.setRequestInterceptor(self.interceptor)
+ 
+         if self._config.entry_point.autoload:
+             self.initialize_bridge_objects()
+@@ -168,6 +168,7 @@ class QtWebContainer(WebContainer):
+         url = url if url else self._config.entry_point.url
+ 
+         if 'http' not in url and not os.path.exists(url):
++            self.logger.debug(f'Could not load url "{url}".')
+             self.page.setHtml(DEFAULT_ENTRY_POINT)
+             return
+ 

--- a/pkgs/development/python-modules/whither/default.nix
+++ b/pkgs/development/python-modules/whither/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ruamel_yaml
+, pyqt5
+}:
+
+buildPythonPackage rec {
+  pname = "whither";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "07ybxf5280dq6ismmm38r6xkd4s395l3yi3h0df5ff41da0ra93h";
+  };
+
+
+  propagatedBuildInputs = [
+    ruamel_yaml
+    pyqt5
+  ];
+
+  # I'm not sure why we don't find PyQt5 here but there's a similar
+  # sed on other packages.
+  postPatch = "sed -i /PyQt5/d setup.py";
+
+
+  meta = with lib; {
+    homepage = "https://github.com/Antergos/whither";
+    description = "Universal Linux Application SDK";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ samueldr ];
+  };
+}

--- a/pkgs/development/python-modules/whither/default.nix
+++ b/pkgs/development/python-modules/whither/default.nix
@@ -14,6 +14,13 @@ buildPythonPackage rec {
     sha256 = "07ybxf5280dq6ismmm38r6xkd4s395l3yi3h0df5ff41da0ra93h";
   };
 
+  patches = [
+    # Qt 5.11 "broke file:// url access".
+    #  → https://github.com/Antergos/whither/commit/bf4000dbd8c0963528c17419d0ccb6395fd8bb47
+    # Disables the interceptor meanwhile.
+    # (This will need to be fixed by upstream before this gets in nixpkgs imho)
+    ./5.11_hacky_fix.patch
+  ];
 
   propagatedBuildInputs = [
     ruamel_yaml

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18246,6 +18246,8 @@ with pkgs;
     inherit (xfce) exo;
   };
 
+  lightdm-web-greeter = python3Packages.callPackage ../applications/display-managers/lightdm-web-greeter { };
+
   lightdm-mini-greeter = callPackage ../applications/display-managers/lightdm-mini-greeter { };
 
   slic3r = callPackage ../applications/misc/slic3r { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18111,6 +18111,8 @@ EOF
   qiskit = callPackage ../development/python-modules/qiskit { };
 
   qasm2image = callPackage ../development/python-modules/qasm2image { };
+
+  whither = callPackage ../development/python-modules/whither { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
## Motivation for this change

This is PRed for visibility. I have seen a couple of times people ask about lightdm-web-greeter. This is not ready to merge, though it works. This will give a hand to anyone trying to use or contribute lightdm-web-greeter, as they are bound to find this PR.

#### Why 3.0.0rc2 and not stable 2.2.5?

[I did an initial try in the past, for the 2.x branch](https://github.com/samueldr/nixpkgs/tree/feature/lightdm-web-greeter). **It will not work with nixos.** It seems that there is a bug with the way webkitgtk is packaged for NixOS, and local files are not rendered as html, but as plain text. This [seems to also affect gnucash](https://github.com/NixOS/nixpkgs/issues/14105) and the same bug did affect midori's DOM inspector during at least 17.09's lifetime.

#### Why isn't this PR for 3.0.0rc2 finished?

Well, first thing first, the code quality for the module hasn't been reviewed; this is a port from a module I wrote about a year ago, which was basically a copy of the ligthdm-gtk-greeter module. I would also need to take a couple minutes to review the derivations, but I think they're in mostly good standing.

Then, there's the issue of "rc2" It has been tagged 6 months ago, on the 8th of January. I would much prefer if they tagged a stable release. Though, there is some activity in the repo, so they eventually will.

Finally, the main reason I'm not continuing: I'm not sure about the quality of the implementation of that greeter. Maybe it's lightdm's configuration at fault, and not the web greeter, but it seems a bit buggy. The shutdown/reboot buttons do nothing (inside a nixos-rebuild build-vm). There are also some layout issue in the default theme, but that's probably not as much an issue.

I'm more concerned with the current state of their *whither* library, which I had to patch to work around (their quote) "*broke[n] file::// url access in qt 5.11*". I had to basically remove a bit of security from the library for it to work. That's not good. Until that is resolved, I may continue on and off (mostly off) to polish this, but this isn't worthy yet for inclusion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ❌ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ⬜ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
