### PR TITLE
bloaty: 2018-05-22 -> 2018-06-15

### DIFF
--- a/pkgs/development/tools/bloaty/default.nix
+++ b/pkgs/development/tools/bloaty/default.nix
@@ -1,14 +1,14 @@
 { stdenv, binutils, cmake, zlib, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  version = "2018-05-22";
+  version = "2018-06-15";
   name = "bloaty-${version}";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "bloaty";
-    rev = "054788b091ccfd43b05b9817062139145096d440";
-    sha256 = "0pmv66137ipzsjjdz004n61pz3aipjhh3b0w0y1406clqpwkvpjm";
+    rev = "bdbb3ce196c86d2154f5fba99b5ff73ca43446a9";
+    sha256 = "1r7di2p8bi12jpgl6cm4ygi1s0chv767mdcavc7pb45874vl02fx";
     fetchSubmodules = true;
   };
 
@@ -19,8 +19,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
-
-  checkPhase = "ctest";
 
   installPhase = ''
     install -Dm755 {.,$out/bin}/bloaty


### PR DESCRIPTION
arm64 support, bump


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---