### PR TITLE
mergerfs-tools: init at 20171221

### DIFF
--- a/pkgs/tools/filesystems/mergerfs/tools.nix
+++ b/pkgs/tools/filesystems/mergerfs/tools.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, coreutils, makeWrapper
+, rsync, python3, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name = "mergerfs-tools-${version}";
+  version = "20171221";
+
+  src = fetchFromGitHub {
+    owner = "trapexit";
+    repo = "mergerfs-tools";
+    rev = "9b4fe0097b5b51e1a7411a26eb344a24cc8ce1b4";
+    sha256 = "0qrixh3j58gzkmc8r2sgzgy56gm8bmhakwlc2gjb0yrpa1213na1";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ python3 ];
+
+  makeFlags = [
+    "INSTALL=${coreutils}/bin/install"
+    "PREFIX=$(out)"
+  ];
+
+  postInstall = with stdenv.lib; ''
+    wrapProgram $out/bin/mergerfs.balance --prefix PATH : ${makeBinPath [ rsync ]}
+    wrapProgram $out/bin/mergerfs.dup --prefix PATH : ${makeBinPath [ rsync ]}
+    wrapProgram $out/bin/mergerfs.mktrash --prefix PATH : ${makeBinPath [ pythonPackages.xattr ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Optional tools to help manage data in a mergerfs pool";
+    homepage = https://github.com/trapexit/mergerfs-tools;
+    license = licenses.isc;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10915,6 +10915,8 @@ with pkgs;
 
   mergerfs = callPackage ../tools/filesystems/mergerfs { };
 
+  mergerfs-tools = callPackage ../tools/filesystems/mergerfs/tools.nix { };
+
   ## libGL/libGLU/Mesa stuff
 
   # Default libGL implementation, should provide headers and libGL.so/libEGL.so/... to link agains them


### PR DESCRIPTION
###### Motivation for this change

Useful tools for mergerfs mounts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @makefu 
