### PR TITLE
gurobi: init at 8.0.1

### DIFF
--- a/pkgs/applications/science/math/gurobi/default.nix
+++ b/pkgs/applications/science/math/gurobi/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, autoPatchelfHook, python }:
+
+stdenv.mkDerivation rec {
+  name = "gurobi-${version}";
+  version = "8.0.1";
+
+  src = with stdenv.lib; fetchurl {
+    url = "http://packages.gurobi.com/${versions.majorMinor version}/gurobi${version}_linux64.tar.gz";
+    sha256 = "0y3lb0mngnyn7ql4s2n8qxnr1d2xcjdpdhpdjdxc4sc8f2w2ih18";
+  };
+
+  sourceRoot = "gurobi${builtins.replaceStrings ["."] [""] version}/linux64";
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ (python.withPackages (ps: [ ps.gurobipy ])) ];
+
+  buildPhase = ''
+    cd src/build
+    make
+    cd ../..
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/* $out/bin/
+    rm $out/bin/gurobi.env
+    rm $out/bin/gurobi.sh
+    rm $out/bin/python2.7
+
+    cp lib/gurobi.py $out/bin/gurobi.sh
+
+    mkdir -p $out/include
+    cp include/gurobi*.h $out/include/
+
+    mkdir -p $out/lib
+    cp lib/libgurobi*.so* $out/lib/
+    cp lib/libgurobi*.a $out/lib/
+    cp src/build/*.a $out/lib/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Optimization solver for mathematical programming";
+    homepage = https://www.gurobi.com;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20187,6 +20187,8 @@ with pkgs;
 
   flintqs = callPackage ../development/libraries/science/math/flintqs { };
 
+  gurobi = callPackage ../applications/science/math/gurobi { };
+
   jags = callPackage ../applications/science/math/jags { };
 
 


### PR DESCRIPTION
###### Motivation for this change

See #32513

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @bbarker @shlevy 