### PR TITLE
youtube-dl: 2018.05.18 -> 2018.07.10

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, targetPlatform, fetchurl, buildPythonPackage
+{ stdenv, lib, targetPlatform, fetchurl, buildPythonPackage
 , zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
 # Pandoc is required to build the package's man page. Release tarballs contain a
 # formatted man page already, though, it will still be installed. We keep the
@@ -12,20 +12,19 @@
 , hlsEncryptedSupport ? true
 , makeWrapper }:
 
-with stdenv.lib;
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.05.18";
+  version = "2018.07.10";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "11r0hv6885w8k4m307kvf9545vr5a3ym9bf7szghvbcgmgc8lm5w";
+    sha256 = "1rigah941k2drzx5qz937lk68gw9jrizj5lgd9f9znp0bgi2d0xd";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ zip ] ++ optional generateManPage pandoc;
-  propagatedBuildInputs = optional hlsEncryptedSupport pycryptodome;
+  buildInputs = [ zip ] ++ lib.optional generateManPage pandoc;
+  propagatedBuildInputs = lib.optional hlsEncryptedSupport pycryptodome;
 
   # Ensure ffmpeg is available in $PATH for post-processing & transcoding support.
   # rtmpdump is required to download files over RTMP
@@ -33,10 +32,10 @@ buildPythonPackage rec {
   makeWrapperArgs = let
       packagesToBinPath =
         [ atomicparsley ]
-        ++ optional ffmpegSupport ffmpeg
-        ++ optional rtmpSupport rtmpdump
-        ++ optional phantomjsSupport phantomjs2;
-    in [ ''--prefix PATH : "${makeBinPath packagesToBinPath}"'' ];
+        ++ lib.optional ffmpegSupport ffmpeg
+        ++ lib.optional rtmpSupport rtmpdump
+        ++ lib.optional phantomjsSupport phantomjs2;
+    in [ ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"'' ];
 
   postInstall = ''
     mkdir -p $out/share/zsh/site-functions
@@ -46,7 +45,7 @@ buildPythonPackage rec {
   # Requires network
   doCheck = false;
 
-  meta = {
+  meta = with lib; {
     homepage = https://rg3.github.io/youtube-dl/;
     repositories.git = https://github.com/rg3/youtube-dl.git;
     description = "Command-line tool to download videos from YouTube.com and other sites";
@@ -58,6 +57,6 @@ buildPythonPackage rec {
     '';
     license = licenses.publicDomain;
     platforms = with platforms; linux ++ darwin;
-    maintainers = with maintainers; [ bluescreen303 phreedom AndersonTorres fuuzetsu fpletz ];
+    maintainers = with maintainers; [ bluescreen303 phreedom AndersonTorres fuuzetsu fpletz enzime ];
   };
 }


### PR DESCRIPTION
Also remove `with stdenv.lib` from Nix derivation to make it clearer
where variables are coming from.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested without sandboxing on macOS
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

