### PR TITLE
rofi-systemd: init at 0.1.0

### DIFF
--- a/pkgs/tools/system/rofi-systemd/default.nix
+++ b/pkgs/tools/system/rofi-systemd/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, rofi, systemd, coreutils, utillinux, gawk, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  name = "rofi-systemd-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "IvanMalison";
+    repo = "rofi-systemd";
+    rev = "v${version}";
+    sha256 = "1dbygq3qaj1f73hh3njdnmibq7vi6zbyzdc6c0j989c0r1ksv0zi";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a rofi-systemd $out/bin/rofi-systemd
+  '';
+
+  wrapperPath = with stdenv.lib; makeBinPath [
+    rofi
+    coreutils
+    utillinux
+    gawk
+    systemd
+  ];
+
+  fixupPhase = ''
+    patchShebangs $out/bin
+
+    wrapProgram $out/bin/rofi-systemd --prefix PATH : "${wrapperPath}"
+  '';
+
+  meta = {
+    description = "Control your systemd units using rofi";
+    homepage = https://github.com/IvanMalison/rofi-systemd;
+    maintainers = with stdenv.lib.maintainers; [ imalison ];
+    license = stdenv.lib.licenses.gpl3;
+    platforms = with stdenv.lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18051,6 +18051,8 @@ with pkgs;
 
   rofi-menugen = callPackage ../applications/misc/rofi-menugen { };
 
+  rofi-systemd = callPackage ../tools/system/rofi-systemd { };
+
   rpcs3 = libsForQt5.callPackage ../misc/emulators/rpcs3 { };
 
   rstudio = libsForQt5.callPackage ../applications/editors/rstudio {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

