### PR TITLE
radare2-cutter: 1.5 -> 1.6

### DIFF
--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   name = "radare2-cutter-${version}";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "radareorg";
     repo = "cutter";
     rev = "v${version}";
-    sha256 = "0xwls8jhhigdkwyq3nf9xwcz4inm5smwinkyliwmfzvfflbbci5c";
+    sha256 = "1ps52yf94yfnws3nn1iiwch2jy33dyvi7j47xkmh0m5fpdqi5xk7";
   };
 
   postUnpack = "export sourceRoot=$sourceRoot/src";

--- a/pkgs/development/tools/analysis/radare2-cutter/default.nix
+++ b/pkgs/development/tools/analysis/radare2-cutter/default.nix
@@ -7,10 +7,20 @@
 , radare2
 , python3 }:
 
-
+let
+  r2 = radare2.overrideDerivation (o: {
+    name = "radare2-for-cutter-${version}";
+    src = fetchFromGitHub {
+      owner = "radare";
+      repo = "radare2";
+      rev = "a98557bfbfa96e9f677a8c779ee78085ee5a23bb";
+      sha256 = "04jl1lq3dqljb6vagzlym4wc867ayhx1v52f75rkfz0iybsh249r";
+    };
+  });
+  version = "1.6";
+in
 stdenv.mkDerivation rec {
   name = "radare2-cutter-${version}";
-  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "radareorg";
@@ -31,7 +41,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ qmake pkgconfig ];
-  buildInputs = [ qtbase qtsvg qtwebengine radare2 python3 ];
+  buildInputs = [ qtbase qtsvg qtwebengine r2 python3 ];
 
   qmakeFlags = [
     "CONFIG+=link_pkgconfig"


### PR DESCRIPTION
Small bump for misc fixes.

Move to using pinned r2, let's see how this goes.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---