### PR TITLE
ffmpeg: build fixes

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -170,9 +170,15 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails
 
+  # ffmpeg 3+ generates pkg-config (.pc) files that don't have the
+  # form automatically handled by the multiple-outputs hooks.
   postFixup = ''
     moveToOutput bin "$bin"
     moveToOutput share/ffmpeg/examples "$doc"
+    for pc in ''${!outputDev}/lib/pkgconfig/*.pc; do
+      substituteInPlace $pc \
+        --replace "includedir=$out" "includedir=''${!outputInclude}"
+    done
   '';
 
   installFlags = [ "install-man" ];

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -148,7 +148,7 @@ stdenv.mkDerivation rec {
       "--disable-stripping"
     # Disable mmx support for 0.6.90
       (verFix null "0.6.90" "--disable-mmx")
-  ] ++ optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+  ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "--cross-prefix=${stdenv.cc.targetPrefix}"
       "--enable-cross-compile"
   ] ++ optional stdenv.cc.isClang "--cc=clang";


### PR DESCRIPTION
###### Motivation for this change

The pkg-config files for `ffmpeg_3` and `ffmpeg_4` use an incorrect `includedir`, which prevents them being used through pkg-config.

While I'm here: fix a typo in the cross compilation flags.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

