### PR TITLE
creduce: 2.7.0 -> 2.8.0

### DIFF
--- a/pkgs/development/tools/misc/creduce/default.nix
+++ b/pkgs/development/tools/misc/creduce/default.nix
@@ -8,18 +8,18 @@
 
 stdenv.mkDerivation rec {
   name = "creduce-${version}";
-  version = "2.7.0";
+  version = "2.8.0";
 
   src = fetchurl {
     url = "https://embed.cs.utah.edu/creduce/${name}.tar.gz";
-    sha256 = "0h8s4d54q6cl6i45x3143l2xmr29b2yhr3m0n5qqx63sr5csip1n";
+    sha256 = "1vqx73ymfscvlyig03972a5m7ar3gx2yv6m8c6h2mibz792j5xkp";
   };
 
+  nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [
     # Ensure stdenv's CC is on PATH before clang-unwrapped
     stdenv.cc
     # Actual deps:
-    cmake makeWrapper
     llvm clang-unwrapped
     flex zlib
     perl ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7985,7 +7985,7 @@ with pkgs;
   creduce = callPackage ../development/tools/misc/creduce {
     inherit (perlPackages) perl
       ExporterLite FileWhich GetoptTabular RegexpCommon TermReadKey;
-    inherit (llvmPackages_4) llvm clang-unwrapped;
+    inherit (llvmPackages_6) llvm clang-unwrapped;
   };
 
   cscope = callPackage ../development/tools/misc/cscope { };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---