### PR TITLE
nethack: add qt support on linux

### DIFF
--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, writeScript, coreutils, ncurses, gzip, flex, bison, less
-, x11Mode ? false, libXaw, libXext, mkfontdir
+, x11Mode ? false, qtMode ? false, libXaw, libXext, mkfontdir, pkgconfig, qt5
 }:
 
 let
@@ -8,6 +8,7 @@ let
     else throw "Unknown platform for NetHack: ${stdenv.system}";
   unixHint =
     if x11Mode then "linux-x11"
+    else if qtMode then "linux-qt4"
     else if stdenv.hostPlatform.isLinux  then "linux"
     else if stdenv.hostPlatform.isDarwin then "macosx10.10"
     # We probably want something different for Darwin
@@ -15,17 +16,27 @@ let
   userDir = "~/.config/nethack";
   binPath = lib.makeBinPath [ coreutils less ];
 
-in stdenv.mkDerivation {
-  name = "nethack${lib.optionalString x11Mode "-x11"}-3.6.1";
+in stdenv.mkDerivation rec {
+  version = "3.6.1";
+  name = if x11Mode then "nethack-x11-${version}"
+         else if qtMode then "nethack-qt-${version}"
+         else "nethack-${version}";
 
   src = fetchurl {
     url = "https://nethack.org/download/3.6.1/nethack-361-src.tgz";
     sha256 = "1dha0ijvxhx7c9hr0452h93x81iiqsll8bc9msdnp7xdqcfbz32b";
   };
 
-  buildInputs = [ ncurses ] ++ lib.optionals x11Mode [ libXaw libXext ];
+  buildInputs = [ ncurses ]
+                ++ lib.optionals x11Mode [ libXaw libXext ]
+                ++ lib.optionals qtMode [ gzip qt5.qtbase.bin qt5.qtmultimedia.bin ];
 
-  nativeBuildInputs = [ flex bison ] ++ lib.optionals x11Mode [ mkfontdir ];
+  nativeBuildInputs = [ flex bison ]
+                      ++ lib.optionals x11Mode [ mkfontdir ]
+                      ++ lib.optionals qtMode [
+                           pkgconfig mkfontdir qt5.qtbase.dev
+                           qt5.qtmultimedia.dev
+                         ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
@@ -36,6 +47,11 @@ in stdenv.mkDerivation {
       -e 's/^LEX *=.*/LEX = flex/' \
       -i sys/unix/Makefile.utl
     sed \
+      -e 's,^WINQT4LIB =.*,WINQT4LIB = `pkg-config Qt5Gui --libs` \\\
+            `pkg-config Qt5Widgets --libs` \\\
+            `pkg-config Qt5Multimedia --libs`,' \
+      -i sys/unix/Makefile.src
+    sed \
       -e 's,/bin/gzip,${gzip}/bin/gzip,g' \
       -e 's,^WINTTYLIB=.*,WINTTYLIB=-lncurses,' \
       -i sys/unix/hints/linux
@@ -45,6 +61,12 @@ in stdenv.mkDerivation {
       -e 's,^SHELLDIR=.*$,SHELLDIR=\$(PREFIX)/games,' \
       -i sys/unix/hints/macosx10.10
     sed -e '/define CHDIR/d' -i include/config.h
+    sed \
+      -e 's,^QTDIR *=.*,QTDIR=${qt5.qtbase.dev},' \
+      -e 's,CFLAGS.*QtGui.*,CFLAGS += `pkg-config Qt5Gui --cflags`,' \
+      -e 's,CFLAGS+=-DCOMPRESS.*,CFLAGS+=-DCOMPRESS=\\"${gzip}/bin/gzip\\" \\\
+        -DCOMPRESS_EXTENSION=\\".gz\\",' \
+      -i sys/unix/hints/linux-qt4
   '';
 
   configurePhase = ''
@@ -90,6 +112,7 @@ in stdenv.mkDerivation {
     EOF
     chmod +x $out/bin/nethack
     ${lib.optionalString x11Mode "mv $out/bin/nethack $out/bin/nethack-x11"}
+    ${lib.optionalString qtMode "mv $out/bin/nethack $out/bin/nethack-qt"}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchurl, writeScript, coreutils, ncurses, gzip, flex, bison, less
+{ stdenv, lib, fetchurl, writeScript, coreutils, ncurses, gzip, flex, bison
+, less, makeWrapper
 , x11Mode ? false, qtMode ? false, libXaw, libXext, mkfontdir, pkgconfig, qt5
 }:
 
@@ -35,7 +36,7 @@ in stdenv.mkDerivation rec {
                       ++ lib.optionals x11Mode [ mkfontdir ]
                       ++ lib.optionals qtMode [
                            pkgconfig mkfontdir qt5.qtbase.dev
-                           qt5.qtmultimedia.dev
+                           qt5.qtmultimedia.dev makeWrapper
                          ];
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -113,6 +114,11 @@ in stdenv.mkDerivation rec {
     chmod +x $out/bin/nethack
     ${lib.optionalString x11Mode "mv $out/bin/nethack $out/bin/nethack-x11"}
     ${lib.optionalString qtMode "mv $out/bin/nethack $out/bin/nethack-qt"}
+  '';
+
+  postFixup = lib.optionalString qtMode ''
+    wrapProgram $out/bin/nethack-qt \
+      --prefix QT_PLUGIN_PATH : "${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19684,6 +19684,8 @@ with pkgs;
 
   nethack = callPackage ../games/nethack { };
 
+  nethack-qt = callPackage ../games/nethack { qtMode = true; };
+
   nethack-x11 = callPackage ../games/nethack { x11Mode = true; };
 
   neverball = callPackage ../games/neverball { };


### PR DESCRIPTION
###### Motivation for this change

Add Qt 5 support on Linux. Note that Qt 5 support is not available on Mac OS since upstream does not support this yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

