### PR TITLE
stdenv: cleanup darwin bootstrapping

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/boot.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/boot.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, CF, configd, coreutils }:
+{ stdenv, fetchurl, configd, CF, coreutils }:
 
 with stdenv.lib;
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -188,7 +188,18 @@ in rec {
   };
 
   stage1 = prevStage: let
-    persistent = _: super: { python = super.python.override { configd = null; }; };
+    persistent = self: super: with prevStage; {
+      cmake = super.cmake.override {
+        majorVersion = "3.9";  # FIXME: update ApplicationServices patch
+        isBootstrap = true;
+        useSharedLibraries = false;
+      };
+
+      python = super.callPackage ../../development/interpreters/python/cpython/2.7/boot.nix {
+        CF = null;  # use CoreFoundation from bootstrap-tools
+        configd = null;
+      };
+    };
   in with prevStage; stageFun 1 prevStage {
     extraPreHook = "export NIX_CFLAGS_COMPILE+=\" -F${bootstrapTools}/Library/Frameworks\"";
     extraNativeBuildInputs = [];
@@ -239,6 +250,9 @@ in rec {
         openssh sqlite sed serf openldap db cyrus-sasl expat apr-util
         findfreetype libssh curl cmake autoconf automake libtool cpio;
 
+      # Avoid pulling in a full python and it's extra dependencies for the llvm/clang builds.
+      libxml2 = super.libxml2.override { pythonSupport = false; };
+
       llvmPackages_5 = super.llvmPackages_5 // (let
         libraries = super.llvmPackages_5.libraries.extend (_: _: {
           inherit (llvmPackages_5) libcxx libcxxabi;
@@ -281,6 +295,15 @@ in rec {
         ncurses libffi zlib gmp pcre gnugrep
         coreutils findutils diffutils patchutils;
 
+      # Hack to make sure we don't link ncurses in bootstrap tools. The proper
+      # solution is to avoid passing -L/nix-store/...-bootstrap-tools/lib,
+      # quite a sledgehammer just to get the C runtime.
+      gettext = super.gettext.overrideAttrs (drv: {
+        configureFlags = drv.configureFlags ++ [
+          "--disable-curses"
+        ];
+      });
+
       llvmPackages_5 = super.llvmPackages_5 // (let
         tools = super.llvmPackages_5.tools.extend (llvmSelf: _: {
           inherit (llvmPackages_5) llvm clang-unwrapped;
@@ -303,16 +326,7 @@ in rec {
     extraPreHook = ''
       export PATH_LOCALE=${pkgs.darwin.locale}/share/locale
     '';
-    overrides = lib.composeExtensions persistent (self: super: {
-      # Hack to make sure we don't link ncurses in bootstrap tools. The proper
-      # solution is to avoid passing -L/nix-store/...-bootstrap-tools/lib,
-      # quite a sledgehammer just to get the C runtime.
-      gettext = super.gettext.overrideAttrs (old: {
-         configureFlags = old.configureFlags ++ [
-           "--disable-curses"
-         ];
-      });
-    });
+    overrides = persistent;
   };
 
   stdenvDarwin = prevStage: let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6873,13 +6873,6 @@ with pkgs;
     inherit (stdenvAdapters) overrideCC;
     buildLlvmTools = buildPackages.llvmPackages_5.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_5.libraries;
-  } // stdenv.lib.optionalAttrs (stdenv.isDarwin && hostPlatform == buildPlatform) {
-    cmake = buildPackages.cmake.override {
-      isBootstrap = true;
-      majorVersion = "3.9"; # 3.10.2: 'ApplicationServices/ApplicationServices.h' file not found
-    };
-    libxml2 = libxml2.override { pythonSupport = false; };
-    python2 = callPackage ../development/interpreters/python/cpython/2.7/boot.nix { inherit (darwin) CF configd; };
   } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
     stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });


### PR DESCRIPTION
###### Motivation for this change

I finally spent some time to clean this up. 😄
Also gets rid of the full python and some of it's dependencies in the stdenv build closure.

db, gdbm, openssl, readline, sqlite and python2 no longer cause an stdenv rebuild.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

