### PR TITLE
xpra.xf86videodummy: init at 0.3.8

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, python2Packages, pkgconfig
+{ stdenv, lib, fetchurl, callPackage, python2Packages, pkgconfig
 , xorg, gtk2, glib, pango, cairo, gdk_pixbuf, atk
 , makeWrapper, xorgserver, getopt, xauth, utillinux, which
 , ffmpeg, x264, libvpx, libwebp
@@ -10,12 +10,14 @@ with lib;
 
 let
   inherit (python2Packages) cython buildPythonApplication;
+
+  xf86videodummy = callPackage ./xf86videodummy { };
 in buildPythonApplication rec {
-  name = "xpra-${version}";
+  pname = "xpra";
   version = "2.3.3";
 
   src = fetchurl {
-    url = "https://xpra.org/src/${name}.tar.xz";
+    url = "https://xpra.org/src/${pname}-${version}.tar.xz";
     sha256 = "1azvvddjfq7lb5kmbn0ilgq2nf7pmymsc3b9lhbjld6w156qdv01";
   };
 
@@ -73,6 +75,7 @@ in buildPythonApplication rec {
   #  sed -i '4iexport PATH=${stdenv.lib.makeBinPath [ getopt xorgserver xauth which utillinux ]}\${PATH:+:}\$PATH' $out/bin/xpra
   #'';
 
+  passthru = { inherit xf86videodummy; };
 
   meta = {
     homepage = http://xpra.org/;
@@ -80,7 +83,7 @@ in buildPythonApplication rec {
     downloadURLRegexp = "xpra-.*[.]tar[.]xz$";
     description = "Persistent remote applications for X";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ tstrobel offline ];
     license = licenses.gpl2;
+    maintainers = with maintainers; [ tstrobel offline numinit ];
   };
 }

--- a/pkgs/tools/X11/xpra/xf86videodummy/0002-Constant-DPI.patch
+++ b/pkgs/tools/X11/xpra/xf86videodummy/0002-Constant-DPI.patch
@@ -1,0 +1,96 @@
+--- a/src/dummy.h	2016-12-17 23:02:53.396287041 +0100
++++ b/src/dummy.h	2016-12-17 23:03:30.319616550 +0100
+@@ -51,6 +51,7 @@
+     /* options */
+     OptionInfoPtr Options;
+     Bool swCursor;
++    Bool constantDPI;
+     /* proc pointer */
+     CloseScreenProcPtr CloseScreen;
+     xf86CursorInfoPtr CursorInfo;
+--- a/src/dummy_driver.c	2016-12-14 21:54:20.000000000 +0100
++++ b/src/dummy_driver.c	2016-12-17 23:04:59.916416126 +0100
+@@ -17,6 +17,12 @@
+ /* All drivers using the mi colormap manipulation need this */
+ #include "micmap.h"
+ 
++#ifdef RANDR
++#include "randrstr.h"
++#endif
++
++#include "windowstr.h"
++
+ /* identifying atom needed by magnifiers */
+ #include <X11/Xatom.h>
+ #include "property.h"
+@@ -115,11 +121,15 @@
+ };
+ 
+ typedef enum {
+-    OPTION_SW_CURSOR
++    OPTION_SW_CURSOR,
++    OPTION_CONSTANT_DPI
+ } DUMMYOpts;
+ 
+ static const OptionInfoRec DUMMYOptions[] = {
+     { OPTION_SW_CURSOR,	"SWcursor",	OPTV_BOOLEAN,	{0}, FALSE },
++#ifdef RANDR
++    { OPTION_CONSTANT_DPI,	"ConstantDPI",	OPTV_BOOLEAN,	{0}, FALSE },
++#endif
+     { -1,                  NULL,           OPTV_NONE,	{0}, FALSE }
+ };
+ 
+@@ -359,6 +369,7 @@
+     xf86ProcessOptions(pScrn->scrnIndex, pScrn->options, dPtr->Options);
+ 
+     xf86GetOptValBool(dPtr->Options, OPTION_SW_CURSOR,&dPtr->swCursor);
++    xf86GetOptValBool(dPtr->Options, OPTION_CONSTANT_DPI, &dPtr->constantDPI);
+ 
+     if (device->videoRam != 0) {
+ 	pScrn->videoRam = device->videoRam;
+@@ -639,10 +650,45 @@
+     return TRUE;
+ }
+ 
++const char *XDPY_PROPERTY = "dummy-constant-xdpi";
++const char *YDPY_PROPERTY = "dummy-constant-ydpi";
++static int get_dpi_value(WindowPtr root, const char *property_name, int default_dpi)
++{
++    PropertyPtr prop;
++    Atom type_atom = MakeAtom("CARDINAL", 8, TRUE);
++    Atom prop_atom = MakeAtom(property_name, strlen(property_name), FALSE);
++
++    for (prop = wUserProps(root); prop; prop = prop->next) {
++       if (prop->propertyName == prop_atom && prop->type == type_atom && prop->data) {
++           int v = (int) (*((CARD32 *) prop->data));
++           if ((v>0) && (v<4096)) {
++               xf86DrvMsg(0, X_INFO, "get_constant_dpi_value() found property \"%s\" with value=%i\n", property_name, (int) v);
++               return (int) v;
++           }
++           break;
++       }
++    }
++    return default_dpi;
++}
++
+ /* Mandatory */
+ Bool
+ DUMMYSwitchMode(SWITCH_MODE_ARGS_DECL)
+ {
++    SCRN_INFO_PTR(arg);
++#ifdef RANDR
++    DUMMYPtr dPtr = DUMMYPTR(pScrn);
++    if (dPtr->constantDPI) {
++        int xDpi = get_dpi_value(pScrn->pScreen->root, XDPY_PROPERTY, pScrn->xDpi);
++        int yDpi = get_dpi_value(pScrn->pScreen->root, YDPY_PROPERTY, pScrn->yDpi);
++        //25.4 mm per inch: (254/10)
++        pScrn->pScreen->mmWidth = mode->HDisplay * 254 / xDpi / 10;
++        pScrn->pScreen->mmHeight = mode->VDisplay * 254 / yDpi / 10;
++        xf86DrvMsg(pScrn->scrnIndex, X_INFO, "mm(dpi %ix%i)=%ix%i\n", xDpi, yDpi, pScrn->pScreen->mmWidth, pScrn->pScreen->mmHeight);
++        RRScreenSizeNotify(pScrn->pScreen);
++        RRTellChanged(pScrn->pScreen);
++    }
++#endif
+     return TRUE;
+ }
+ 

--- a/pkgs/tools/X11/xpra/xf86videodummy/0003-fix-pointer-limits.patch
+++ b/pkgs/tools/X11/xpra/xf86videodummy/0003-fix-pointer-limits.patch
@@ -1,0 +1,39 @@
+--- xf86-video-dummy-0.3.6/src/dummy_driver.c	2014-11-05 19:24:02.668656601 +0700
++++ xf86-video-dummy-0.3.6.new/src/dummy_driver.c	2014-11-05 19:37:53.076061853 +0700
+@@ -55,6 +55,9 @@
+ #include <X11/extensions/xf86dgaproto.h>
+ #endif
+ 
++/* Needed for fixing pointer limits on resize */
++#include "inputstr.h"
++
+ /* Mandatory functions */
+ static const OptionInfoRec *	DUMMYAvailableOptions(int chipid, int busid);
+ static void     DUMMYIdentify(int flags);
+@@ -713,6 +716,26 @@
+         RRTellChanged(pScrn->pScreen);
+     }
+ #endif
++    //ensure the screen dimensions are also updated:
++    pScrn->pScreen->width = mode->HDisplay;
++    pScrn->pScreen->height = mode->VDisplay;
++    pScrn->virtualX = mode->HDisplay;
++    pScrn->virtualY = mode->VDisplay;
++    pScrn->frameX1 = mode->HDisplay;
++    pScrn->frameY1 = mode->VDisplay;
++
++    //ensure the pointer uses the new limits too:
++    DeviceIntPtr pDev;
++    SpritePtr pSprite;
++    for (pDev = inputInfo.devices; pDev; pDev = pDev->next) {
++        if (pDev->spriteInfo!=NULL && pDev->spriteInfo->sprite!=NULL) {
++            pSprite = pDev->spriteInfo->sprite;
++            pSprite->hotLimits.x2 = mode->HDisplay;
++            pSprite->hotLimits.y2 = mode->VDisplay;
++            pSprite->physLimits.x2 = mode->HDisplay;
++            pSprite->physLimits.y2 = mode->VDisplay;
++        }
++    }
+     return TRUE;
+ }
+ 

--- a/pkgs/tools/X11/xpra/xf86videodummy/0005-support-for-30-bit-depth-in-dummy-driver.patch
+++ b/pkgs/tools/X11/xpra/xf86videodummy/0005-support-for-30-bit-depth-in-dummy-driver.patch
@@ -1,0 +1,41 @@
+--- a/src/dummy.h	2016-12-17 23:33:33.279533389 +0100
++++ b/src/dummy.h	2016-12-17 23:33:56.695739166 +0100
+@@ -69,7 +69,7 @@
+     int overlay_offset;
+     int videoKey;
+     int interlace;
+-    dummy_colors colors[256];
++    dummy_colors colors[1024];
+     pointer* FBBase;
+     Bool        (*CreateWindow)() ;     /* wrapped CreateWindow */
+     Bool prop;
+--- a/src/dummy_driver.c	2016-12-17 23:33:47.446657886 +0100
++++ b/src/dummy_driver.c	2016-12-17 23:33:56.696739175 +0100
+@@ -317,6 +317,7 @@
+ 	case 15:
+ 	case 16:
+ 	case 24:
++        case 30:
+ 	    break;
+ 	default:
+ 	    xf86DrvMsg(pScrn->scrnIndex, X_ERROR,
+@@ -331,8 +332,8 @@
+ 	pScrn->rgbBits = 8;
+ 
+     /* Get the depth24 pixmap format */
+-    if (pScrn->depth == 24 && pix24bpp == 0)
+-	pix24bpp = xf86GetBppFromDepth(pScrn, 24);
++    if (pScrn->depth >= 24 && pix24bpp == 0)
++	pix24bpp = xf86GetBppFromDepth(pScrn, pScrn->depth);
+ 
+     /*
+      * This must happen after pScrn->display has been set because
+@@ -623,7 +624,7 @@
+     if(!miCreateDefColormap(pScreen))
+ 	return FALSE;
+ 
+-    if (!xf86HandleColormaps(pScreen, 256, pScrn->rgbBits,
++    if (!xf86HandleColormaps(pScreen, 1024, pScrn->rgbBits,
+                          DUMMYLoadPalette, NULL, 
+                          CMAP_PALETTED_TRUECOLOR 
+ 			     | CMAP_RELOAD_ON_MODE_SWITCH))

--- a/pkgs/tools/X11/xpra/xf86videodummy/default.nix
+++ b/pkgs/tools/X11/xpra/xf86videodummy/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchurl
+, fontsproto, randrproto, renderproto, videoproto, xf86dgaproto, xorgserver, xproto
+, pkgconfig
+, xpra }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  version = "0.3.8";
+  suffix = "1";
+  name = "xpra-xf86videodummy-${version}-${suffix}";
+  builder = ../../../../servers/x11/xorg/builder.sh;
+  src = fetchurl {
+    url = "mirror://xorg/individual/driver/xf86-video-dummy-${version}.tar.bz2";
+    sha256 = "1fcm9vwgv8wnffbvkzddk4yxrh3kc0np6w65wj8k88q7jf3bn4ip";
+  };
+  patches = [
+    ./0002-Constant-DPI.patch
+    ./0003-fix-pointer-limits.patch
+    ./0005-support-for-30-bit-depth-in-dummy-driver.patch
+  ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ fontsproto randrproto renderproto videoproto xf86dgaproto xorgserver xproto ];
+
+  meta = {
+    description = "Dummy driver for Xorg with xpra patches";
+    homepage = https://xpra.org/trac/wiki/Xdummy;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ numinit ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

If you want correct DPI scaling in xpra, you need a patched xf86videodummy driver (see: https://xpra.org/trac/wiki/Xdummy for the patches).

Create one as `xpra.xf86videodummy`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

