### PR TITLE
pythonPackages.cvxopt: temporarily disable tests

### DIFF
--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -46,6 +46,11 @@ buildPythonPackage rec {
     export CVXOPT_FFTW_INC_DIR=${fftw.dev}/include
   '';
 
+  # https://github.com/cvxopt/cvxopt/issues/122
+  # This is fixed on staging (by #43234, status 2018-07-15), but until that
+  # lands we should disable the tests. Otherwise the 99% of use cases that
+  # should be unaffected by that failure are affected.
+  doCheck = false;
   checkPhase = ''
     ${python.interpreter} -m unittest discover -s tests
   '';


### PR DESCRIPTION
###### Motivation for this change

The tests have transient failures that will be fixed once staging is merged. Since #43234 didn't make the cut for staging-next, that'll probably take some while. So here is a band-aid.

I'll immediately open a patch against staging that reverts it once this is merged.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

