### PR TITLE
Move note from COPYING into new file COPYING-NOTICE

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -18,12 +18,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-======================================================================
-
-Note: the license above does not apply to the packages built by the
-Nix Packages collection, merely to the package descriptions (i.e., Nix
-expressions, build scripts, etc.).  It also might not apply to patches
-included in Nixpkgs, which may be derivative works of the packages to
-which they apply.  The aforementioned artifacts are all covered by the
-licenses of the respective packages.

--- a/COPYING-NOTICE
+++ b/COPYING-NOTICE
@@ -1,0 +1,6 @@
+Note: The license in file COPYING does not apply to the packages built
+by the  Nix Packages  collection, merely  to the  package descriptions
+(i.e., Nix expressions, build scripts,  etc.). It also might not apply
+to patches included  in Nixpkgs, which may be derivative  works of the
+packages to  which they apply.   The aforementioned artifacts  are all
+covered by the licenses of the respective packages.


### PR DESCRIPTION
This moves the note - which says that the license in
COPYING does not apply to packages built by the Nix
Packages Collection and some other files - into a
seperate file COPYING-NOTICE.

###### Motivation for this change
This has the advantage that the licence containt in
COPYING can be detected by programs automatically with
high accuracy. GitHub uses such programs to show the
license of projects on their start pages.

This was discussed in issue #25705.

cc @copumpkin, @c0bw3b