### PR TITLE
st: add derivation flags to enable some official patches

### DIFF
--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -1,18 +1,41 @@
-{ stdenv, fetchurl, pkgconfig, writeText, makeWrapper, libX11, ncurses, libXext
-, libXft, fontconfig, dmenu, conf ? null, patches ? [], extraLibs ? []}:
+{ stdenv, fetchpatch, fetchurl, pkgconfig, writeText, makeWrapper, libX11, ncurses, libXext
+, libXft, fontconfig, dmenu, conf ? null, patches ? [], extraLibs ? []
+, withAlpha ? false, withClipboard ? false, withHidecursor ? false,  }:
 
 with stdenv.lib;
 
 let patches' = if patches == null then [] else patches;
 in stdenv.mkDerivation rec {
-  name = "st-0.8.1";
+  name = "st-${version}";
+  version = "0.8.1";
 
   src = fetchurl {
     url = "https://dl.suckless.org/st/${name}.tar.gz";
     sha256 = "09k94v3n20gg32xy7y68p96x9dq5msl80gknf9gbvlyjp3i0zyy4";
   };
 
-  patches = patches';
+  alphaPatch = fetchpatch {
+    name = "st-alpha.patch";
+    url = "https://st.suckless.org/patches/alpha/st-alpha-${version}.diff";
+    sha256 = "18iw0bzmagcchlf5m5dfvdryn47kpdbcs1j1waq8vl1w2wvcg5al";
+  };
+
+  clipboardPatch = fetchpatch {
+    name = "clipboard.patch";
+    url = "https://st.suckless.org/patches/clipboard/st-clipboard-${version}.diff";
+    sha256 = "0gdjgzg2a98fph4sn4w210p39401mm4imkrllfyhc836bjyhi5pc";
+  };
+
+  hidecursorPatch = fetchpatch {
+    name = "hidecursor.patch";
+    url = "https://st.suckless.org/patches/hidecursor/st-hidecursor-${version}.diff";
+    sha256 = "02b4h375c2vd79f7cagki5fnx1ipygywlxn25c62kg529d7zfck0";
+  };
+
+  patches = optional withAlpha alphaPatch
+    ++ optional withClipboard clipboardPatch
+    ++ optional withHidecursor hidecursorPatch
+    ++ patches';
 
   configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
@@ -29,7 +52,7 @@ in stdenv.mkDerivation rec {
     homepage = https://st.suckless.org/;
     description = "Simple Terminal for X from Suckless.org Community";
     license = licenses.mit;
-    maintainers = with maintainers; [viric andsild];
+    maintainers = with maintainers; [viric andsild koral];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Make it easier to enable official patches available here: https://st.suckless.org/patches/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

