### PR TITLE
lmms: 1.2.0-rc4 -> 1.2.0-rc6

### DIFF
--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, alsaLib ? null, fftwFloat, fltk13
 , fluidsynth ? null, lame ? null, libgig ? null, libjack2 ? null, libpulseaudio ? null
 , libsamplerate, libsoundio ? null, libsndfile, libvorbis ? null, portaudio ? null
-, qtbase, qttools, SDL ? null }:
+, qtbase, qtx11extras, qttools, SDL ? null }:
 
 stdenv.mkDerivation rec {
   name = "lmms-${version}";
-  version = "1.2.0-rc4";
+  version = "1.2.0-rc6";
 
   src = fetchFromGitHub {
     owner = "LMMS";
     repo = "lmms";
     rev = "v${version}";
-    sha256 = "1n3py18zqbvfnkdiz4wc6z60xaajpkd3kn1wxmby5dmc4vccvjj5";
+    sha256 = "1pqir5srfrknfd8nmbz565ymq18ffw8d8k9pbmzggaxvlcr12b25";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake qttools pkgconfig ];
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
     libvorbis
     portaudio
     qtbase
+    qtx11extras
     SDL # TODO: switch to SDL2 in the next version
   ];
 


### PR DESCRIPTION
This fixes compilation. I can start it, but I have not test further then that.

cc @nek0 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

