### PR TITLE
xkbcomp: 1.4.0 -> 1.4.2

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2420,11 +2420,11 @@ let
   }) // {inherit inputproto libX11 libXext libXi libXinerama libXrandr ;};
 
   xkbcomp = (mkDerivation "xkbcomp" {
-    name = "xkbcomp-1.4.0";
+    name = "xkbcomp-1.4.2";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/xkbcomp-1.4.0.tar.bz2;
-      sha256 = "0syfc6zscvai824mzihlnrqxhkcr27dzkpy8zndavi83iischsdw";
+      url = mirror://xorg/individual/app/xkbcomp-1.4.2.tar.bz2;
+      sha256 = "0944rrkkf0dxp07vhh9yr4prslxhqyw63qmbjirbv1bypswvrn3d";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ libX11 libxkbfile xproto ];


### PR DESCRIPTION
###### Motivation for this change

5bdd9bddb564971b3e5b98aa27fe556e41d3fcb9 broke keyboard layout switch in XWayland sessions, which is caused by incompatibility betwen xkeyboardconfig 2.24 and xkbcomp 1.4.0. This issue is fixed in xkbcomp 1.4.2.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1587998

I've rebuilt my system on top of this change.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

