### PR TITLE
gnomecast: init at 1.4.0

### DIFF
--- a/pkgs/applications/video/gnomecast/default.nix
+++ b/pkgs/applications/video/gnomecast/default.nix
@@ -1,0 +1,28 @@
+{ lib, python3Packages, gtk3, gobjectIntrospection, ffmpeg, wrapGAppsHook }:
+
+with python3Packages;
+buildPythonApplication rec {
+  pname = "gnomecast";
+  version = "1.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "17hxqpisw6j6caw6bzp0wd0p3idqy6a78wwwk8kms6hpxasirwyk";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  propagatedBuildInputs = [
+    PyChromecast bottle pycaption paste html5lib pygobject3 dbus-python
+    gtk3 gobjectIntrospection
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ffmpeg ]})
+  '';
+
+  meta = with lib; {
+    description = "A native Linux GUI for Chromecasting local files";
+    homepage = https://github.com/keredson/gnomecast;
+    license = with licenses; [ gpl3 ];
+  };
+}

--- a/pkgs/development/python-modules/pycaption/default.nix
+++ b/pkgs/development/python-modules/pycaption/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchpatch
+, buildPythonPackage, fetchPypi, isPy3k, pythonOlder
+, beautifulsoup4, lxml, cssutils, future, enum34, six
+}:
+
+buildPythonPackage rec {
+  pname = "pycaption";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0f2hx9ky65c4niws3x5yx59yi8mqqrw9b2cghd220g4hj9yl800h";
+  };
+
+  disabled = !isPy3k;
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace 'beautifulsoup4>=4.2.1,<4.5.0' \
+                'beautifulsoup4>=4.2.1,<=4.6.0'
+  '';
+
+  # don't require enum34 on python >= 3.4
+  patches = [
+    (fetchpatch {
+        url = "https://github.com/pbs/pycaption/pull/161.patch";
+        sha256 = "0p58awpsqx1qc3x9zfl1gd85h1nk7204lzn4kglsgh1bka0j237j";
+    })
+  ];
+
+  propagatedBuildInputs = [ beautifulsoup4 lxml cssutils future enum34 six ];
+
+  # Tests not included in pypi (?)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Closed caption converter";
+    homepage = https://github.com/pbs/pycaption;
+    license = with licenses; [ asl20 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16490,6 +16490,8 @@ with pkgs;
 
   gmtp = callPackage ../applications/misc/gmtp {};
 
+  gnomecast = callPackage ../applications/video/gnomecast { };
+
   gnome-mpv = callPackage ../applications/video/gnome-mpv { };
 
   gollum = callPackage ../applications/misc/gollum { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10376,6 +10376,7 @@ in {
     };
   };
 
+  pycaption = callPackage ../development/python-modules/pycaption { };
 
   pycdio = buildPythonPackage rec {
     name = "pycdio-2.0.0";


### PR DESCRIPTION
also pycaption, required dep.



new package \o/.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---