### PR TITLE
cryptominisat: 5.0.1 -> 5.6.3, enable "full", run tests

### DIFF
--- a/pkgs/applications/science/logic/cryptominisat/darwin-rpath.patch
+++ b/pkgs/applications/science/logic/cryptominisat/darwin-rpath.patch
@@ -1,0 +1,31 @@
+From fd3b19d39f064fb5ef5410c75981160d60812c23 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Mon, 16 Jul 2018 07:55:09 -0500
+Subject: [PATCH] CMakeLists.txt: darwin rpath touchup
+
+From minisat.
+---
+ CMakeLists.txt | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6712e87f..968a194b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,6 +46,13 @@ if(POLICY CMP0026)
+     cmake_policy(SET CMP0026 NEW)
+ endif()
+ 
++# Reference specific library paths used during linking for install
++if (POLICY CMP0042)
++  # Enable `MACOSX_RPATH` by default.
++  cmake_policy(SET CMP0042 NEW)
++endif()
++SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++
+ # -----------------------------------------------------------------------------
+ # Provide scripts dir for included cmakes to use
+ # -----------------------------------------------------------------------------
+-- 
+2.18.0
+

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ boost libzip sqlite python ncurses];
   nativeBuildInputs = [ cmake lit ];
 
-  cmakeFlags = [ "-DENABLE_TESTING=ON" ];
+  cmakeFlags = [ "-DENABLE_TESTING=ON" "-DLIT_ARGS=-vv" ];
 
   hardeningDisable = [ "fortify" ];
 

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -2,23 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "cryptominisat-${version}";
-  version = "5.0.1";
+  version = "5.6.3";
 
   src = fetchFromGitHub {
     owner  = "msoos";
     repo   = "cryptominisat";
     rev    = version;
-    sha256 = "0cpw5d9vplxvv3aaplhnga55gz1hy29p7s4pkw1306knkbhlzvkb";
+    sha256 = "0902dy2k5qkvav9qc4b4nvz7bynsahb46llms46bnpamb0rqnzc8";
+    fetchSubmodules = true;
   };
 
   buildInputs = [ python xxd ];
   nativeBuildInputs = [ cmake ];
-
-  patches = [(fetchpatch rec {
-    name = "fix-exported-library-name.patch";
-    url = "https://github.com/msoos/cryptominisat/commit/7a47795cbe5ad5a899731102d297f234bcade077.patch";
-    sha256 = "11hf3cfqs4cykn7rlgjglq29lzqfxvlm0f20qasi0kdrz01cr30f";
-  })];
 
   meta = with stdenv.lib; {
     description = "An advanced SAT Solver";

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH \
     DYLD_LIBRARY_PATH=$PWD/lib:$DYLD_LIBRARY_PATH \
-      make test
+      make test ARGS=-VV
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, lit, python, boost, libzip, sqlite }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, lit, python, boost, libzip, sqlite, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "cryptominisat-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ boost libzip sqlite python ];
+  buildInputs = [ boost libzip sqlite python ncurses];
   nativeBuildInputs = [ cmake lit ];
 
   cmakeFlags = [ "-DENABLE_TESTING=ON" ];

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DENABLE_TESTING=ON" ];
 
+  hardeningDisable = [ "fortify" ];
+
   doCheck = true;
 
   checkPhase = ''

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "fortify" ];
 
+  patches = [ ./darwin-rpath.patch ];
+
   doCheck = true;
 
   checkPhase = ''

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, python, boost, libzip, sqlite, xxd }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, lit, python, boost, libzip, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "cryptominisat-${version}";
@@ -12,8 +12,16 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ boost libzip sqlite python xxd ];
-  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost libzip sqlite python ];
+  nativeBuildInputs = [ cmake lit ];
+
+  cmakeFlags = [ "-DENABLE_TESTING=ON" ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH make test
+  '';
 
   meta = with stdenv.lib; {
     description = "An advanced SAT Solver";

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   checkPhase = ''
-    LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH make test
+    LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH \
+    DYLD_LIBRARY_PATH=$PWD/lib:$DYLD_LIBRARY_PATH \
+      make test
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/science/logic/cryptominisat/default.nix
+++ b/pkgs/applications/science/logic/cryptominisat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, python, xxd }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, python, boost, libzip, sqlite, xxd }:
 
 stdenv.mkDerivation rec {
   name = "cryptominisat-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  buildInputs = [ python xxd ];
+  buildInputs = [ boost libzip sqlite python xxd ];
   nativeBuildInputs = [ cmake ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/lit/default.nix
+++ b/pkgs/development/tools/misc/lit/default.nix
@@ -1,10 +1,10 @@
-{ lib, python2 }:
+{ lib, python }:
 
-python2.pkgs.buildPythonApplication rec {
+python.pkgs.buildPythonApplication rec {
   pname = "lit";
   version = "0.6.0";
 
-  src = python2.pkgs.fetchPypi {
+  src = python.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "1png3jgbhrw8a602gy6rnzvjcrj8w2p2kk6szdg9lz42zr090lgb";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8951,7 +8951,10 @@ with pkgs;
 
   cryptopp = callPackage ../development/libraries/crypto++ { };
 
-  cryptominisat = callPackage ../applications/science/logic/cryptominisat { };
+  cryptominisat = callPackage ../applications/science/logic/cryptominisat {
+    python = python3;
+    lit = lit.override { python = python3; };
+  };
 
   curlcpp = callPackage ../development/libraries/curlcpp { };
 


### PR DESCRIPTION
Significant update \o/


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---