### PR TITLE
runelite: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1997,6 +1997,13 @@
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";
   };
+
+  kmeakin = {
+    email = "karlwfmeakin@gmail.com";
+    name = "Karl Meakin";
+    github = "Kmeakin";
+  };
+
   knedlsepp = {
     email = "josef.kemetmueller@gmail.com";
     github = "knedlsepp";

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, makeWrapper, jre, makeDesktopItem, lib }:
+
+  stdenv.mkDerivation rec {
+  name = "runelite-${version}";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "https://github.com/runelite/launcher/releases/download/${version}/RuneLite.jar";
+    sha256 = "0q2xx0wrnlg5mrv8nnmnh300r8mqfm8k2p028m7mr09kn18xvkzx";
+  };
+
+  icon = fetchurl {
+    url = "https://github.com/runelite/runelite/raw/master/runelite-client/src/main/resources/runelite.png";
+    sha256 = "0fxzkpsin09giqp7h8z0plxznk5d5j60sv34v1lw61p7d5y2izvr";
+  };
+
+  desktop = makeDesktopItem {
+    name = "RuneLite";
+    type = "Application";
+    exec = "runelite";
+    icon = "${icon}";
+    comment = "Open source Old School RuneScape client";
+    terminal = "false";
+    desktopName = "RuneLite";
+    genericName = "Oldschool Runescape";
+    categories = "Application;Game";
+    startupNotify = null;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  # colon is bash form of no-op (do nothing)
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/share/runelite
+    mkdir -p $out/share/applications
+
+    ln -s ${src} $out/share/runelite/RuneLite.jar
+    ln -s ${desktop}/share/applications/* $out/share/applications
+
+    makeWrapper ${jre}/bin/java $out/bin/runelite \
+    --add-flags "-jar $out/share/runelite/RuneLite.jar"
+  '';
+
+  meta = {
+    description = "Open source Old School RuneScape client";
+    homepage = "https://runelite.net/";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.kmeakin ];
+    platforms = lib.platforms.all;
+  };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4898,6 +4898,8 @@ with pkgs;
 
   rubocop = callPackage ../development/tools/rubocop { };
 
+  runelite = callPackages ../games/runelite { };
+
   runningx = callPackage ../tools/X11/runningx { };
 
   runzip = callPackage ../tools/archivers/runzip { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

