### PR TITLE
undervolt: init at 0.2.5

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -275,6 +275,7 @@
   ./services/hardware/u2f.nix
   ./services/hardware/udev.nix
   ./services/hardware/udisks2.nix
+  ./services/hardware/undervolt.nix
   ./services/hardware/upower.nix
   ./services/hardware/usbmuxd.nix
   ./services/hardware/thermald.nix

--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -1,0 +1,93 @@
+{ lib, pkgs, config, ... }:
+
+with lib;
+let
+  cfg = config.powerManagement.undervolt;
+in {
+  options = {
+    powerManagement = {
+      undervolt = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable the undervolt daemon.
+          '';
+        };
+
+        core = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            Core offset (mV)
+          '';
+        };
+
+        cache = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            Cache offset (mV)
+          '';
+        };
+
+        analogio = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            Analogio offset (mV)
+          '';
+        };
+
+        uncore = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            Uncore offset (mV)
+          '';
+        };
+
+        gpu = mkOption {
+          type = types.int;
+          default = 0;
+          description = ''
+            Gpu offset (mV)
+          '';
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      systemPackages = with pkgs; [
+        undervolt
+      ];
+    };
+
+    systemd = {
+      services = {
+        undervolt = {
+          after = [
+            "suspend.target"
+            "hibernate.target"
+            "hybrid-sleep.target"
+          ];
+          description = "Intel undervolting";
+          enable = true;
+          serviceConfig = {
+            ExecStart = ''
+              ${pkgs.undervolt}/bin/undervolt --core ${toString cfg.core} --cache ${toString cfg.cache} --analogio ${toString cfg.analogio} --uncore ${toString cfg.uncore} --gpu ${toString cfg.gpu}
+            '';
+          };
+          wantedBy = [
+            "suspend.target"
+            "hibernate.target"
+            "hybrid-sleep.target"
+            "multi-user.target"
+          ];
+        };
+      };
+    };
+  };
+}

--- a/pkgs/tools/misc/undervolt/default.nix
+++ b/pkgs/tools/misc/undervolt/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, buildPythonApplication }:
+
+buildPythonApplication rec {
+  pname = "undervolt";
+  version = "0.2.5";
+
+  src = fetchFromGitHub rec {
+    owner = "georgewhewell";
+    repo = pname;
+    rev = version;
+    sha256 = "0saqd8qs3c39bsjnm6yw1l90ns9jrvnbrgygw17bnylz2vcw1ml7";
+  };
+
+  meta = with stdenv.lib; {
+    description = ''
+      Undervolt Intel CPUs under Linux
+    '';
+    homepage = https://github.com/georgewhewell/undervolt;
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [
+      eadwu
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18620,6 +18620,8 @@ with pkgs;
 
   udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };
 
+  undervolt = pythonPackages.callPackage ../tools/misc/undervolt { };
+
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
   inherit (ocamlPackages) unison;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

