### PR TITLE
bluemix-cli: 0.6.6 -> 0.8.0

### DIFF
--- a/pkgs/tools/admin/bluemix-cli/default.nix
+++ b/pkgs/tools/admin/bluemix-cli/default.nix
@@ -2,16 +2,30 @@
 
 stdenv.mkDerivation rec {
   name = "bluemix-cli-${version}";
-  version = "0.6.6";
+  version = "0.8.0";
 
-  src = fetchurl {
-    name = "linux64.tar.gz";
-    url = "https://clis.ng.bluemix.net/download/bluemix-cli/${version}/linux64";
-    sha256 = "1swjawc4szqrl0wgjcb4na1hbxylaqp2mp53lxsbfbk1db0c3y85";
-  };
+  src =
+    if stdenv.system == "i686-linux" then
+      fetchurl {
+        name = "linux32-${version}.tar.gz";
+        url = "https://clis.ng.bluemix.net/download/bluemix-cli/${version}/linux32";
+        sha256 = "1ryngbjlw59x33rfd32bcz49r93a1q1g92jh7xmi9vydgqnzsifh";
+      }
+    else
+      fetchurl {
+        name = "linux64-${version}.tar.gz";
+        url = "https://clis.ng.bluemix.net/download/bluemix-cli/${version}/linux64";
+        sha256 = "056zbaca430ldcn0s86vy40m5abvwpfrmvqybbr6fjwfv9zngywx";
+      }
+    ;
 
   installPhase = ''
-    install -m755 -D --target $out/bin bin/bluemix bin/bluemix-analytics bin/cfcli/cf
+    install -m755 -D -t $out/bin bin/ibmcloud bin/ibmcloud-analytics
+    install -m755 -D -t $out/bin/cfcli bin/cfcli/cf
+    ln -sv $out/bin/ibmcloud $out/bin/bx
+    ln -sv $out/bin/ibmcloud $out/bin/bluemix
+    install -D -t "$out/etc/bash_completion.d" bx/bash_autocomplete
+    install -D -t "$out/share/zsh/site-functions" bx/zsh_autocomplete
   '';
 
   meta = with lib; {
@@ -19,7 +33,7 @@ stdenv.mkDerivation rec {
     homepage     = "https://console.bluemix.net/docs/cli/index.html";
     downloadPage = "https://console.bluemix.net/docs/cli/reference/bluemix_cli/download_cli.html#download_install";
     license      = licenses.unfree;
-    maintainers  = [ maintainers.tazjin ];
-    platforms    = [ "x86_64-linux" ];
+    maintainers  = [ maintainers.tazjin maintainers.jensbin ];
+    platforms    = [ "x86_64-linux" "i686-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
* Upstream version update
* Added platform Linux32

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

