### PR TITLE
xlog: init at 2.0.15

### DIFF
--- a/pkgs/applications/misc/xlog/default.nix
+++ b/pkgs/applications/misc/xlog/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, glib, gtk2, pkgconfig, hamlib }:
+stdenv.mkDerivation rec {
+  name = "xlog-${version}";
+  version = "2.0.15";
+  
+  src = fetchurl {
+    url = "http://download.savannah.gnu.org/releases/xlog/${name}.tar.gz";
+    sha256 = "0an883wqw3zwpw8nqinm9cb17hp2xw9vf603k4l2345p61jqdw2j";
+  };
+
+  buildInputs = [ glib pkgconfig gtk2 hamlib ];
+
+  meta = with stdenv.lib; {
+    description = "An amateur radio logging program";
+    longDescription =
+      '' Xlog is an amateur radio logging program.
+         It supports cabrillo, ADIF, trlog (format also used by tlf),
+         and EDI (ARRL VHF/UHF contest format) and can import twlog, editest and OH1AA logbook files.
+         Xlog is able to do DXCC lookups and will display country information, CQ and ITU zone,
+         location in latitude and longitude and distance and heading in kilometers or miles,
+         both for short and long path. 
+      '';
+    homepage = http://www.nongnu.org/xlog;
+    maintainers = [ maintainers.mafo ];
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21758,6 +21758,8 @@ with pkgs;
 
   xinput_calibrator = callPackage ../tools/X11/xinput_calibrator { };
 
+  xlog = callPackage ../applications/misc/xlog { };
+
   xmagnify = callPackage ../tools/X11/xmagnify { };
 
   xosd = callPackage ../misc/xosd { };


### PR DESCRIPTION
###### Motivation for this change
I would like to add xlog to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

