### PR TITLE
circleci: init at 0.0.4705-deba4df

### DIFF
--- a/pkgs/applications/misc/circleci/default.nix
+++ b/pkgs/applications/misc/circleci/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, bash }:
+
+stdenv.mkDerivation rec {
+  name = "circleci-${version}";
+  version = "0.0.4705-deba4df";
+
+  src = fetchurl {
+    url = "https://github.com/circleci/local-cli/archive/v${version}.tar.gz";
+    sha256 = "0an0d4n87zv379lbapk4aa5x83nmfwgqf1w5vgvnlkmza49xij2q";
+  };
+
+  buildInputs = [ bash ];
+
+  phases = ["unpackPhase" "installPhase"];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp circleci.sh $out/bin/circleci
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://circleci.com/docs/2.0/local-cli/;
+    description = "Reproduce the CircleCI environment locally and validate config";
+    license = licenses.mit;
+    maintainers = with maintainers; [ davidak ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15518,6 +15518,8 @@ with pkgs;
     cmake = cmake_2_8;
   };
 
+  circleci = callPackage ../applications/misc/circleci { };
+
   codeblocks = callPackage ../applications/editors/codeblocks { };
   codeblocksFull = codeblocks.override { contribPlugins = true; };
 


### PR DESCRIPTION
###### Motivation for this change

use it for CircleCI

needs docker to be useful

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

