### PR TITLE
kde-frameworks: 5.47 -> 5.48

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
@@ -1,21 +1,23 @@
-Index: extra-cmake-modules-5.18.0/kde-modules/KDEInstallDirs.cmake
-===================================================================
---- extra-cmake-modules-5.18.0.orig/kde-modules/KDEInstallDirs.cmake
-+++ extra-cmake-modules-5.18.0/kde-modules/KDEInstallDirs.cmake
-@@ -200,32 +200,6 @@
+diff --git a/kde-modules/KDEInstallDirs.cmake b/kde-modules/KDEInstallDirs.cmake
+index 52b2eb2..a04596c 100644
+--- a/kde-modules/KDEInstallDirs.cmake
++++ b/kde-modules/KDEInstallDirs.cmake
+@@ -232,34 +232,6 @@
  # GNUInstallDirs code deals with re-configuring, but that is dealt with
  # by the _define_* macros in this module).
  set(_LIBDIR_DEFAULT "lib")
 -# Override this default 'lib' with 'lib64' iff:
 -#  - we are on a Linux, kFreeBSD or Hurd system but NOT cross-compiling
 -#  - we are NOT on debian
+-#  - we are NOT on flatpak
 -#  - we are on a 64 bits system
 -# reason is: amd64 ABI: http://www.x86-64.org/documentation/abi.pdf
 -# For Debian with multiarch, use 'lib/${CMAKE_LIBRARY_ARCHITECTURE}' if
 -# CMAKE_LIBRARY_ARCHITECTURE is set (which contains e.g. "i386-linux-gnu"
 -# See http://wiki.debian.org/Multiarch
 -if((CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
--   AND NOT CMAKE_CROSSCOMPILING)
+-   AND NOT CMAKE_CROSSCOMPILING
+-   AND NOT DEFINED ENV{FLATPAK_ID})
 -  if (EXISTS "/etc/debian_version") # is this a debian system ?
 -    if(CMAKE_LIBRARY_ARCHITECTURE)
 -      set(_LIBDIR_DEFAULT "lib/${CMAKE_LIBRARY_ARCHITECTURE}")

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.47/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.48/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,627 +3,627 @@
 
 {
   attica = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/attica-5.47.0.tar.xz";
-      sha256 = "17i580hhi9rpd6d4nf408snlnf8xivwskkzbjja0snajx0nrd8bj";
-      name = "attica-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/attica-5.48.0.tar.xz";
+      sha256 = "1q2133gmhfi3wd9978556syzzqc1s6zgjc0p1353w6dmfwxfyzq8";
+      name = "attica-5.48.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/baloo-5.47.0.tar.xz";
-      sha256 = "15jpbl47pr86h5ji2x3079b6x38fchc2pf03rjqlf5mgkabdpafq";
-      name = "baloo-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/baloo-5.48.0.tar.xz";
+      sha256 = "0rgz2gx99c1k8vgfskx7w6q1sjf98wcvybv88djdlj2s6h2qn8lj";
+      name = "baloo-5.48.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/bluez-qt-5.47.0.tar.xz";
-      sha256 = "1pqgvpgr9xmgv8cxgvqx08jnabgmgzh2skkhwc9d9rdc2i4g7b1k";
-      name = "bluez-qt-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/bluez-qt-5.48.0.tar.xz";
+      sha256 = "149px5gnplk0y7cl3cz258qks3rq5p0kkk9rc48y59zvlxiyy949";
+      name = "bluez-qt-5.48.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/breeze-icons-5.47.0.tar.xz";
-      sha256 = "0fyzk196r8r0mzvijs9ws8ldh5vrw4yrgnvd1szb57vyy1agnnd7";
-      name = "breeze-icons-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/breeze-icons-5.48.0.tar.xz";
+      sha256 = "1p0krrxfz6p0qhy79lnjyi0xsrprw1q4z65xah89kj0wmfriiyqh";
+      name = "breeze-icons-5.48.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/extra-cmake-modules-5.47.0.tar.xz";
-      sha256 = "1591d27r6a2b7jn6zi2ik0i195pvl014dwxfpxv974hbbb8qnvcp";
-      name = "extra-cmake-modules-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/extra-cmake-modules-5.48.0.tar.xz";
+      sha256 = "1675xnc9hv8z8gp95ici2zqmbv7i6f65g0kln4fskxmlxnfplnzw";
+      name = "extra-cmake-modules-5.48.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/frameworkintegration-5.47.0.tar.xz";
-      sha256 = "0iwdfa7q8ryszsl2w3bgix8bxkn3jj2lfdlcicfz9qh6av76p4yf";
-      name = "frameworkintegration-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/frameworkintegration-5.48.0.tar.xz";
+      sha256 = "1na913ndc55nlmfc61122b1p29h4prxnpc5pqvh6drsgfyacnm8y";
+      name = "frameworkintegration-5.48.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kactivities-5.47.0.tar.xz";
-      sha256 = "01h5a4m0wkgz1gafhbqdidxdr2x6g5siwcx4csv9293pc5xf0qcd";
-      name = "kactivities-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kactivities-5.48.0.tar.xz";
+      sha256 = "1zxdzwz8j43hh8d7v1qfihf95kwxvsbqki0zgdhlnj7s0xds0yz8";
+      name = "kactivities-5.48.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kactivities-stats-5.47.0.tar.xz";
-      sha256 = "0linsga4d7lincnpj747wnbgidp2x7xk3jzh31lpfq8izkmqz1q5";
-      name = "kactivities-stats-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kactivities-stats-5.48.0.tar.xz";
+      sha256 = "11r61qnrjpc4ls18apb4a13j1lizjq48bxfw3f8p8hjxxxh8z0j6";
+      name = "kactivities-stats-5.48.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kapidox-5.47.0.tar.xz";
-      sha256 = "1z2ka5fnwqsmjhxdbahk7gkjmhgzndg3lq6196dmpws1zjqf14vq";
-      name = "kapidox-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kapidox-5.48.0.tar.xz";
+      sha256 = "1b22np0lygnm2r2q1anh0f4b7dh2h0lccx767g4r2w0fw5r1bbb4";
+      name = "kapidox-5.48.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/karchive-5.47.0.tar.xz";
-      sha256 = "0r8xxfg1wsnpzyfggpzhxap853gqfsnmbci1al6xyd0pslgcsb5r";
-      name = "karchive-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/karchive-5.48.0.tar.xz";
+      sha256 = "10qbx8k1yqqfp1pq5yj8ln3gpj2wnfnlln99gczf99f51fqd65p6";
+      name = "karchive-5.48.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kauth-5.47.0.tar.xz";
-      sha256 = "1s80grzkxvbkw39z5xida50ijb0k3aqy80k5h0025m9rqpbc7ir9";
-      name = "kauth-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kauth-5.48.0.tar.xz";
+      sha256 = "00mpbs24dm9ycabpcm2wwlv1vdq4dq5qr2zw6bbqpgj3jplakbs7";
+      name = "kauth-5.48.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kbookmarks-5.47.0.tar.xz";
-      sha256 = "0b4b2yp3pvlisf0g1gwnisn2rc94wn874aad3dlg0607kd11xmwk";
-      name = "kbookmarks-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kbookmarks-5.48.0.tar.xz";
+      sha256 = "11ics7gbdkx1f0pxryf2xwjq4fyqh6a3gzcizymm1m7gmygggqar";
+      name = "kbookmarks-5.48.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kcmutils-5.47.0.tar.xz";
-      sha256 = "0qpsjijd51cxmp3y8knr6k6bx8bg5hhngsh63nr8yskpms38kj5d";
-      name = "kcmutils-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kcmutils-5.48.0.tar.xz";
+      sha256 = "0nvlzvv2gmc2hz11w6bixz4mccnj09g69byrnvsrwh0psf1kqlmw";
+      name = "kcmutils-5.48.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kcodecs-5.47.0.tar.xz";
-      sha256 = "1qhdj54cx98dqdy8bqkxm8jgq8mm2i7l3h9vyd2bvvzc8nzhd1hv";
-      name = "kcodecs-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kcodecs-5.48.0.tar.xz";
+      sha256 = "1pz0s3krb4vv01hvpjdr5ngnw1ndxgsfln944fm9pfj0pmk7p92n";
+      name = "kcodecs-5.48.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kcompletion-5.47.0.tar.xz";
-      sha256 = "1wdw434bi90ldmdxw8wpkgszligqapy19klpnn528vh3gv5is00p";
-      name = "kcompletion-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kcompletion-5.48.0.tar.xz";
+      sha256 = "129mmh46y0r6dcnbxf5yswsr48qj5l25n930nlx7wzaav28y55lp";
+      name = "kcompletion-5.48.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kconfig-5.47.0.tar.xz";
-      sha256 = "0ifv7i6w7jz221rw07vb40sljx95kdjhxd7l9nfx95dbd5bjb0nq";
-      name = "kconfig-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kconfig-5.48.0.tar.xz";
+      sha256 = "1g640cnd9j2jp35bb5zgjfxskbg3fj9p03r0yf3dkm1d1681x9a3";
+      name = "kconfig-5.48.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kconfigwidgets-5.47.0.tar.xz";
-      sha256 = "05pxa7519f0730wrbh2bsqzfvc9dwvrh8l9vjh24rkaiaxnzhd6k";
-      name = "kconfigwidgets-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kconfigwidgets-5.48.0.tar.xz";
+      sha256 = "0xlnbw34zbmy7fwsi9iks4iv7shki4fqs7wd3yblmyxa2l18ldh9";
+      name = "kconfigwidgets-5.48.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kcoreaddons-5.47.0.tar.xz";
-      sha256 = "0ihbggv5ziazhv66cnc6d4h4m2bci0cgwh498k49phaagrsh9zs0";
-      name = "kcoreaddons-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kcoreaddons-5.48.0.tar.xz";
+      sha256 = "157k4l67iswny5krinfigfc6pabqfyfzya6hc5gcjrdplmnccy1f";
+      name = "kcoreaddons-5.48.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kcrash-5.47.0.tar.xz";
-      sha256 = "15wn4g7c26f3cpk7q2imci7p8pmcksw47h6csihyvlpi3b6ykqg9";
-      name = "kcrash-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kcrash-5.48.0.tar.xz";
+      sha256 = "0qqwdx7piz4wfm4lh41kknfcyw5saw17qh07ghhi7j80whpkazk8";
+      name = "kcrash-5.48.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdbusaddons-5.47.0.tar.xz";
-      sha256 = "04270rnfmasb9cq7kj40wny7vgkb7hksjnhr4sgyg4v2p8v5dmib";
-      name = "kdbusaddons-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdbusaddons-5.48.0.tar.xz";
+      sha256 = "0vpd4cij52v43fsifbk3nnmi5csik8h4avima6jw0b09s8xdz8rr";
+      name = "kdbusaddons-5.48.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdeclarative-5.47.0.tar.xz";
-      sha256 = "183l926yyhdw270rcwqh2lf1rjd4a9vbkcjlqyss2k7d79mj6m9s";
-      name = "kdeclarative-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdeclarative-5.48.0.tar.xz";
+      sha256 = "09nfp6vrj6dc3kfknicr8629ifz976wi4wxdh5bfx15z9296l8pd";
+      name = "kdeclarative-5.48.0.tar.xz";
     };
   };
   kded = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kded-5.47.0.tar.xz";
-      sha256 = "0z5xsxalxasnyhhkvy247a08l37012fiaahwyy0477p7p5x3c845";
-      name = "kded-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kded-5.48.0.tar.xz";
+      sha256 = "13527iv6cf44wgxpqfhmkhryihjfi02fi78lf2bnvgwmhd2nl954";
+      name = "kded-5.48.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/portingAids/kdelibs4support-5.47.0.tar.xz";
-      sha256 = "1rij23ns9axlwi2fvbiz2wv3y3vh1p9cm3nxkkrj3axc0hs39n20";
-      name = "kdelibs4support-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/portingAids/kdelibs4support-5.48.0.tar.xz";
+      sha256 = "058s5h6sfhi1i3pa59hwpyxzd01jgpb8r68nnbphmryimi5nazqf";
+      name = "kdelibs4support-5.48.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdesignerplugin-5.47.0.tar.xz";
-      sha256 = "0ijdjjfqj2wpl0jrr2n90i74d378986lkqwdicig2rwkylsivr1g";
-      name = "kdesignerplugin-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdesignerplugin-5.48.0.tar.xz";
+      sha256 = "1kswvxgjpyi1p1kg4z5x5df8yqhrwhcpavzx4a83dg6hp5xk0l2l";
+      name = "kdesignerplugin-5.48.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdesu-5.47.0.tar.xz";
-      sha256 = "1rc2v13d4i0wwzmgrbwf6i6khcd4wfa79flq764cvx62flingfvr";
-      name = "kdesu-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdesu-5.48.0.tar.xz";
+      sha256 = "14ka3h06xbfv357z29zgbwnjcfwspi42f0fm3m7lszqhz9skj4v5";
+      name = "kdesu-5.48.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdewebkit-5.47.0.tar.xz";
-      sha256 = "1yg4lydz03y6cc1f44larfd4xnvnbnzpkfa97qxjzvvrk06hdxx3";
-      name = "kdewebkit-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdewebkit-5.48.0.tar.xz";
+      sha256 = "0wf2prv85sayz1mqq0ymrqw3p0f3ikakhgzy01pixrp7qgwqkkrv";
+      name = "kdewebkit-5.48.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdnssd-5.47.0.tar.xz";
-      sha256 = "0xgv4fvhyr3gk99vaicq45zqf5mnbc4xpyz66jfhsk1w655bqijp";
-      name = "kdnssd-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdnssd-5.48.0.tar.xz";
+      sha256 = "01hra59b0sm82j7ry78f3clrypc80q59vx9h0ahacbab4pzq41p5";
+      name = "kdnssd-5.48.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kdoctools-5.47.0.tar.xz";
-      sha256 = "06zlk04ldi9cq3ricni74s3737gmvs73g2k9mgfkdjq5grcsw177";
-      name = "kdoctools-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kdoctools-5.48.0.tar.xz";
+      sha256 = "0v8x198kfgz2p56nyy9cb6lks5yazdbdg55c4ps5bw36dbmpd3v8";
+      name = "kdoctools-5.48.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kemoticons-5.47.0.tar.xz";
-      sha256 = "1hg72mf629g67wll5b80rw9k85qia1jdfhabg64vy7n7i9fm912y";
-      name = "kemoticons-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kemoticons-5.48.0.tar.xz";
+      sha256 = "166sjwrn9dm4km8sypdwcfsylcamhl1gfl28h8hrv498zhnyrfb9";
+      name = "kemoticons-5.48.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kfilemetadata-5.47.0.tar.xz";
-      sha256 = "0ywp45akvn0cky757azkf6p4ql2l02xy7fplbhv7j6qz39s0p2vm";
-      name = "kfilemetadata-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kfilemetadata-5.48.0.tar.xz";
+      sha256 = "0krn53a2s950fb980gdap5hwf994kxfd4h8zk7a4s9cick957z5f";
+      name = "kfilemetadata-5.48.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kglobalaccel-5.47.0.tar.xz";
-      sha256 = "1lcac55kanddpn6nphmyixp33mk8zmhfih7p9vzhnxvrc5k9r6hb";
-      name = "kglobalaccel-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kglobalaccel-5.48.0.tar.xz";
+      sha256 = "15dlpm69d38bsgl6hc7f1mjjq8qyxac010whx4rcsk4vsrwdfnm7";
+      name = "kglobalaccel-5.48.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kguiaddons-5.47.0.tar.xz";
-      sha256 = "14pivzmpsmmqrhvmvlc10fc7mc6gdq214qy27r4dsxmjdvgljhhj";
-      name = "kguiaddons-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kguiaddons-5.48.0.tar.xz";
+      sha256 = "0viqq9qg448fh12isc1kkmzcnnsjqw5fx4wlshyza19gfr4ym0dz";
+      name = "kguiaddons-5.48.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kholidays-5.47.0.tar.xz";
-      sha256 = "001misp4bdd4q05ns4bch7gx1j8h2wpa2is7zdazqy0bp1blsfwb";
-      name = "kholidays-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kholidays-5.48.0.tar.xz";
+      sha256 = "04vjp2jm2c6qgj50jbqkkgqh8b759pd4dpsczfkyq30p03vybxr4";
+      name = "kholidays-5.48.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/portingAids/khtml-5.47.0.tar.xz";
-      sha256 = "1c9fja1mb2jrlrial2mz2bvw004s14kn7jnakawqg0d19fhlqg1h";
-      name = "khtml-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/portingAids/khtml-5.48.0.tar.xz";
+      sha256 = "1zrilnvvvvjq82hm6gbh5pvzfygy8w7a0140d3l74jjgy01394m1";
+      name = "khtml-5.48.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.47.0";
+    version = "5.48.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/ki18n-5.47.0.tar.xz";
-      sha256 = "1a190wf2ms09cwzpk1ylx7kjfz8yvzv2p14fjwyld6vf32hgl9r6";
-      name = "ki18n-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/ki18n-5.48.1.tar.xz";
+      sha256 = "0m9x6bagviqrnm0hx7ykggqiykxv3qi11bmi0xz2f02y78q89f3h";
+      name = "ki18n-5.48.1.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kiconthemes-5.47.0.tar.xz";
-      sha256 = "14j8d1glrcd6a9xn86jxa7wx80bpf5wax5vkv09swcbbshp7vqdp";
-      name = "kiconthemes-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kiconthemes-5.48.0.tar.xz";
+      sha256 = "1xqbg10qlk1zdha4kfyya1471r35gnz63iyj0ks3gzyfjvbivpy4";
+      name = "kiconthemes-5.48.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kidletime-5.47.0.tar.xz";
-      sha256 = "0dirflwwnq83nxml66kk4bf70nl04dhrg8pvh9md3hip5cn6mq2f";
-      name = "kidletime-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kidletime-5.48.0.tar.xz";
+      sha256 = "184b1qdh4bwsdg9lyl4d8rcs833fqcmfvbb5qmdd3mqvvg8xv9mm";
+      name = "kidletime-5.48.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kimageformats-5.47.0.tar.xz";
-      sha256 = "19j6wdfv9yncdgcm5ij0rz5rv0a3jlgdnwmyrw1gjyz5isv2qp4f";
-      name = "kimageformats-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kimageformats-5.48.0.tar.xz";
+      sha256 = "1myxp583gw5d50ddkkv6ipbdzf6k3sdk9gambklay1dzmy4b91sc";
+      name = "kimageformats-5.48.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kinit-5.47.0.tar.xz";
-      sha256 = "1rc0ig4gw7lkvkpwcik6krn5w1zqj6y710c58i9kr9vxxpffj170";
-      name = "kinit-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kinit-5.48.0.tar.xz";
+      sha256 = "08sf3j1bpxzqjim777d6znn8f7rzs5vpm4wz21s1ng3f32z2km9a";
+      name = "kinit-5.48.0.tar.xz";
     };
   };
   kio = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kio-5.47.0.tar.xz";
-      sha256 = "0847dxrhdywrx2v6knf6l70slm8dfz4n4j1c1si13jrj1fp2w4ji";
-      name = "kio-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kio-5.48.0.tar.xz";
+      sha256 = "0am03nwbfidb5dxs8j8qaan4mcs7xv75sk135rslwfp5q56v1fa0";
+      name = "kio-5.48.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kirigami2-5.47.0.tar.xz";
-      sha256 = "1mdahdb5z0i9bf63480b2j6xm7cgsh1anx0cljn2hivglpixjbgd";
-      name = "kirigami2-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kirigami2-5.48.0.tar.xz";
+      sha256 = "0f01rnzzv2w7mmb0war8kph46c3wbdbz7s9i6rwh6g7kg6zvzn52";
+      name = "kirigami2-5.48.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kitemmodels-5.47.0.tar.xz";
-      sha256 = "0151arf7s5ns2qadn86z385i9v9z8rga0jcj8pnw329k4pjpc2ks";
-      name = "kitemmodels-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kitemmodels-5.48.0.tar.xz";
+      sha256 = "13b0fqy4yg4zahqq8376gnna36mfg94yb5d1fz0cgw7fk9d920gf";
+      name = "kitemmodels-5.48.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kitemviews-5.47.0.tar.xz";
-      sha256 = "0dnk7y50d5wxpl4fppb0hdzy5w6xa04a178y49zggpjm5x048mp5";
-      name = "kitemviews-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kitemviews-5.48.0.tar.xz";
+      sha256 = "0cdyw0gy67yhhxv44j1bhhd4qnj7rwi0fjzf275532bf3js1j12w";
+      name = "kitemviews-5.48.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kjobwidgets-5.47.0.tar.xz";
-      sha256 = "05vgqm3nfpbwbnv46ajb8hc5wzs1444513ahay1qn8vpah4kqbpp";
-      name = "kjobwidgets-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kjobwidgets-5.48.0.tar.xz";
+      sha256 = "0a5awpbka6mk4r4m5if7s9i5ybysykpcmlj69liabzcv0k1x5y6w";
+      name = "kjobwidgets-5.48.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/portingAids/kjs-5.47.0.tar.xz";
-      sha256 = "1rhvmdwmsr48ih0qrpwphiwcl25af8shwj8nrkq619krc549gf8q";
-      name = "kjs-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/portingAids/kjs-5.48.0.tar.xz";
+      sha256 = "0ysbf6m63cw2iywwr7p5ngsh7s7ml9sc1sqkhnbh7racn0pzc1l4";
+      name = "kjs-5.48.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/portingAids/kjsembed-5.47.0.tar.xz";
-      sha256 = "104nv33zpqh78zxqj1z9sj6cyliv0l9gzgmsc4n9nq9fcr1f2hdd";
-      name = "kjsembed-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/portingAids/kjsembed-5.48.0.tar.xz";
+      sha256 = "0j74g3xb23k55pixk76z2ib6yyc7f2iwvwqvvw1f907rn43g6qqx";
+      name = "kjsembed-5.48.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/portingAids/kmediaplayer-5.47.0.tar.xz";
-      sha256 = "0cz0m2sa48893p6vq4pm92xmvq2aqqgfmijlskzdpd3gp3x9l1qw";
-      name = "kmediaplayer-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/portingAids/kmediaplayer-5.48.0.tar.xz";
+      sha256 = "1kw35c5dmwsrkinfgmylzgvw3zcg0yimlfcl52bhdg0x7sgdbjkq";
+      name = "kmediaplayer-5.48.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/knewstuff-5.47.0.tar.xz";
-      sha256 = "04zn4iy0gy00d835qjfmb0prm802ggphj4aw328v29474nqs14nf";
-      name = "knewstuff-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/knewstuff-5.48.0.tar.xz";
+      sha256 = "0g2sxk6wqqgynmqgz6jxknlrsmpj4y94cn7vpw84isd9brsr5hfv";
+      name = "knewstuff-5.48.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/knotifications-5.47.0.tar.xz";
-      sha256 = "08cm2aks35lzspchyb6p25bfk4mrljb6wf7yi29674k4kg7gr6sv";
-      name = "knotifications-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/knotifications-5.48.0.tar.xz";
+      sha256 = "11p03jgkw8zvfsal6q3yxz5shkpxiknnryw2a120sjmsab87imzb";
+      name = "knotifications-5.48.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/knotifyconfig-5.47.0.tar.xz";
-      sha256 = "0zava15sabmxc38ngmw9yylwnm27h8ah8df0jadxbqjpaaf0jssl";
-      name = "knotifyconfig-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/knotifyconfig-5.48.0.tar.xz";
+      sha256 = "1rlzmp1lzrniav2d5sjzh43mdm47i5dpa2rlsqppqq5887wjphcm";
+      name = "knotifyconfig-5.48.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kpackage-5.47.0.tar.xz";
-      sha256 = "1pwlvcmn9crjgqf1ccwb86zq962jnwavx6h6dcx7vb982z772j98";
-      name = "kpackage-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kpackage-5.48.0.tar.xz";
+      sha256 = "18q6gp1gmzjyid803j7mcm9dbqg4bcd059qlp6sb6rkllygv4pcr";
+      name = "kpackage-5.48.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kparts-5.47.0.tar.xz";
-      sha256 = "1b21kmn8bjq69qhldacqpby9pa56c4y8j84kkwailylk3nngilsf";
-      name = "kparts-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kparts-5.48.0.tar.xz";
+      sha256 = "1p4xdrxfvq5xj17zf8gfxc0c9lryp8n9ahinardlb3rnb1wcw4hv";
+      name = "kparts-5.48.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kpeople-5.47.0.tar.xz";
-      sha256 = "13x1f5jwxhmdq5qq43qzfmxm20j95dwa0fck1ns1rg8k7gazmdqb";
-      name = "kpeople-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kpeople-5.48.0.tar.xz";
+      sha256 = "1gddld3phsqknm3x0k0wnhgqid5dqsqbw06v91vbl8746np04zf7";
+      name = "kpeople-5.48.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kplotting-5.47.0.tar.xz";
-      sha256 = "0sw448g5wa2gz6krzp7d8q1ryh6qs51hgxv432fjpblijnwzb6xx";
-      name = "kplotting-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kplotting-5.48.0.tar.xz";
+      sha256 = "17f78wppaj433x6fm108z5zw849qvnjsxisa92rxmkm9c64wzijg";
+      name = "kplotting-5.48.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kpty-5.47.0.tar.xz";
-      sha256 = "1q4hkm701ridf07a4m93zvifi1sk6vn8z1h0b1rz5srxasaxnxlh";
-      name = "kpty-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kpty-5.48.0.tar.xz";
+      sha256 = "0ywkiw7gpqx7zrj6wrvfsn2sjkyxzsmqn8p91z0kz1s3id2s04fk";
+      name = "kpty-5.48.0.tar.xz";
     };
   };
   kross = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/portingAids/kross-5.47.0.tar.xz";
-      sha256 = "13nav8fihj1pammiwz8na482qpsmcxmyxd47rqhwldvxz1z0kbq1";
-      name = "kross-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/portingAids/kross-5.48.0.tar.xz";
+      sha256 = "0zxhn8wai71ll1113k47xmcspbp16iz1rybm6m2qs6f4j5ghif8q";
+      name = "kross-5.48.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/krunner-5.47.0.tar.xz";
-      sha256 = "0j3j6831y5j96cl19jdwcnd9h4rl95ymj3gy5sxilazgafzfihbd";
-      name = "krunner-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/krunner-5.48.0.tar.xz";
+      sha256 = "0mdwyvx656ba8pwvg4qw8jr268iffqrp9ipr28m71hkx0sh7k6hn";
+      name = "krunner-5.48.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kservice-5.47.0.tar.xz";
-      sha256 = "0ryipmvydh924zjpfzmwivwagaad9dicnfcfa4drrygbwnm60bd9";
-      name = "kservice-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kservice-5.48.0.tar.xz";
+      sha256 = "1r5d3cdvmbyqn8hm2hjalgg1ncnpdh1w7fd5rr0k97j5qj29ypis";
+      name = "kservice-5.48.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/ktexteditor-5.47.0.tar.xz";
-      sha256 = "1k089k9ssk06734wnjyfmvlgxy2hqxh7fgy5qiyjvp807kmf4jkb";
-      name = "ktexteditor-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/ktexteditor-5.48.0.tar.xz";
+      sha256 = "1fnq6d3ky277rbg3ngq55gdswrgfxsn19c43s23xcbfaymmhapj7";
+      name = "ktexteditor-5.48.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/ktextwidgets-5.47.0.tar.xz";
-      sha256 = "19w84d6v8yrci4fb6c7m91q2ykc9p24cf85cnm6lsb8ggis4dsyr";
-      name = "ktextwidgets-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/ktextwidgets-5.48.0.tar.xz";
+      sha256 = "0hf4rpnkc9qfpnpfm6bsrrjrvvkr6785pnakqyfbjcgbyavp58hg";
+      name = "ktextwidgets-5.48.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kunitconversion-5.47.0.tar.xz";
-      sha256 = "0avm3g78zfzrh4h6ampf54n9j715ii5cra8praq0waiy94idn7cq";
-      name = "kunitconversion-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kunitconversion-5.48.0.tar.xz";
+      sha256 = "0hipqjj82zkq8ysvg304m5jblxxrvjh8vfc3wgl93zvj0mwx06db";
+      name = "kunitconversion-5.48.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kwallet-5.47.0.tar.xz";
-      sha256 = "0hy3kzkcqbzkjkvnaaanfdcnwcidnbw6j14ifvhlh2padql7kyix";
-      name = "kwallet-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kwallet-5.48.0.tar.xz";
+      sha256 = "047jp26igla05isq6hg5bq9l3xd3dfa3v8dq3rz4im7dwa10hshr";
+      name = "kwallet-5.48.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kwayland-5.47.0.tar.xz";
-      sha256 = "0j15xzlzxqi0g8lj5k9w0lbnvx26h6bblgz8rhqlkl80ml2wzgfv";
-      name = "kwayland-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kwayland-5.48.0.tar.xz";
+      sha256 = "1qcb2kg1a23fvl6i0xky6mzmn3f6pqkvpv0dy245bd01x7q4csg4";
+      name = "kwayland-5.48.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kwidgetsaddons-5.47.0.tar.xz";
-      sha256 = "0d2sxh6g7igjdsgj9agknx8zvymyvq9rb0xkfbr044vg5q0g99js";
-      name = "kwidgetsaddons-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kwidgetsaddons-5.48.0.tar.xz";
+      sha256 = "079f28ifadxhvk4miwlnhw3dvg7bmb6gjiqcg2w65bmp21rsywb7";
+      name = "kwidgetsaddons-5.48.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kwindowsystem-5.47.0.tar.xz";
-      sha256 = "1hfbjy17b6iw6443a3zw304syi4j0vid7nmm5hqdv8685lnp4wx6";
-      name = "kwindowsystem-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kwindowsystem-5.48.0.tar.xz";
+      sha256 = "1b6cvx3yqkqmvji2y7ys421hmj98xhww1rlgphfdvrdaqzl4579n";
+      name = "kwindowsystem-5.48.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kxmlgui-5.47.0.tar.xz";
-      sha256 = "194linh0px5mk404hbgrzcfx9zblk4q835nvj4lrbl62nffzwnlp";
-      name = "kxmlgui-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kxmlgui-5.48.0.tar.xz";
+      sha256 = "0n38bxxip1c4fgj00jvph98qhb11ifx40z4m0pjafm52bg0kaa2h";
+      name = "kxmlgui-5.48.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/kxmlrpcclient-5.47.0.tar.xz";
-      sha256 = "1wmsycpg5yljdpa0slv47baqpag6jzg75g0l2jddl3knznp7br8i";
-      name = "kxmlrpcclient-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/kxmlrpcclient-5.48.0.tar.xz";
+      sha256 = "0s0xrx2p0jngk83zb8zjn4vkwnj46wzbxzj904g71ca428nmfx40";
+      name = "kxmlrpcclient-5.48.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/modemmanager-qt-5.47.0.tar.xz";
-      sha256 = "00wxsc4wz5fflld4h1w77726w1c06g1ql5qld2r30yibx1fb2slb";
-      name = "modemmanager-qt-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/modemmanager-qt-5.48.0.tar.xz";
+      sha256 = "17pnzpv3g3g25vnh9jjjk3fk6i3lhk6icl56ifcsmpj09nlw41im";
+      name = "modemmanager-qt-5.48.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/networkmanager-qt-5.47.0.tar.xz";
-      sha256 = "02c2d1jm3azzbwd52awq6ikjsgfg9f2dc12dkw14zkz41r87gcyh";
-      name = "networkmanager-qt-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/networkmanager-qt-5.48.0.tar.xz";
+      sha256 = "15qikndykampl63bnp6rik1vkmwpivqf1krbsb0r29fmwyzhy38v";
+      name = "networkmanager-qt-5.48.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/oxygen-icons5-5.47.0.tar.xz";
-      sha256 = "19w7ab5b7qdhj3j0pg8378k918kwjd1m5lm13jdg2kkn1f4j0j4m";
-      name = "oxygen-icons5-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/oxygen-icons5-5.48.0.tar.xz";
+      sha256 = "08y1gy2xgzby9wxbh90cfzly1aym9nym5r8m7z848a4v7chp0wpw";
+      name = "oxygen-icons5-5.48.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/plasma-framework-5.47.0.tar.xz";
-      sha256 = "1d3f2k5y966jnwrjps1x5lx9scpakq3ri3111m5h0vidkrlvnhsa";
-      name = "plasma-framework-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/plasma-framework-5.48.0.tar.xz";
+      sha256 = "1hl1q1v8kmq20bzm2bfrpjx1f1rljg2akib0sc65nw6vclrcgh82";
+      name = "plasma-framework-5.48.0.tar.xz";
     };
   };
   prison = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/prison-5.47.0.tar.xz";
-      sha256 = "17j12mg11fnjnlj04fzxd5x95cs2f34xc2lk09hjlm7ihkw932xh";
-      name = "prison-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/prison-5.48.0.tar.xz";
+      sha256 = "04asjh9k6qhz6mzqvcw5famjh8fdfrjj5gwhar9lpzvl53k9236q";
+      name = "prison-5.48.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/purpose-5.47.0.tar.xz";
-      sha256 = "1symzvzk50d3szz2rh7c9jd60hzpvlv6d8n7r6j9rzrplvshk879";
-      name = "purpose-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/purpose-5.48.0.tar.xz";
+      sha256 = "015dcsz2pybfl13dq0fhja7j05bvchjd6bcwmniq8cwc2dg2qxyp";
+      name = "purpose-5.48.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/qqc2-desktop-style-5.47.0.tar.xz";
-      sha256 = "1w897ixs0bfhzrzq8v4yg3rsrd8zmb08j5xh52ysb4mp7zs8jcyk";
-      name = "qqc2-desktop-style-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/qqc2-desktop-style-5.48.0.tar.xz";
+      sha256 = "1wc4vxjipdw3zq1lqwz3s7f0gzrcvs8svy9ip5r40qcz2w55s4an";
+      name = "qqc2-desktop-style-5.48.0.tar.xz";
     };
   };
   solid = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/solid-5.47.0.tar.xz";
-      sha256 = "041fvxxlazbpdl5ncdpxzj8jq48rk31kd1nqsm8p5wqglzrz6dsl";
-      name = "solid-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/solid-5.48.0.tar.xz";
+      sha256 = "0fy070kbqs9hvi1ngmqzfz8a9vnry0mrin51z1yfdc44806bk2ns";
+      name = "solid-5.48.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/sonnet-5.47.0.tar.xz";
-      sha256 = "14nfrv1z1lpjhxsxhjx8bi88yp1qx4dzwf6v22w0mk71qc6z2rgr";
-      name = "sonnet-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/sonnet-5.48.0.tar.xz";
+      sha256 = "1mzl2a61jrqflnlkkrp079z428sf2bc811qwfx0rdh0jp7bc7sq4";
+      name = "sonnet-5.48.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/syntax-highlighting-5.47.0.tar.xz";
-      sha256 = "0bv25cv3xvhl9v23dn3yxhdcv5ag2i1zhvna6gnng6k30n316v0c";
-      name = "syntax-highlighting-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/syntax-highlighting-5.48.0.tar.xz";
+      sha256 = "03cfljg90iszpxmx6f0dv1w1r451yqzi9bk27x56s5xzsghj8bv5";
+      name = "syntax-highlighting-5.48.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.47.0";
+    version = "5.48.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.47/threadweaver-5.47.0.tar.xz";
-      sha256 = "0h48b6mvgq3igbs6jzngj1iad7m5kgkird17shk86ma79k6igriz";
-      name = "threadweaver-5.47.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.48/threadweaver-5.48.0.tar.xz";
+      sha256 = "0pks8sddqdhlcrqgb106b6jy0gh3gfcss2rdavqfck6d9780v125";
+      name = "threadweaver-5.48.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

@adisbladis @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

