### PR TITLE
git: optionally build gnome-keyring and libsecret credential helpers

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -39,6 +39,7 @@ let
     svnSupport = true;
     guiSupport = true;
     sendEmailSupport = !stdenv.isDarwin;
+    withLibsecret = !stdenv.isDarwin;
   };
 
   # Git with SVN support, but without GUI.

--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -12,6 +12,8 @@
 , withpcre2 ? true
 , sendEmailSupport
 , darwin
+, withLibsecret ? false
+, pkgconfig, glib, libsecret
 }:
 
 assert sendEmailSupport -> perlSupport;
@@ -64,7 +66,8 @@ stdenv.mkDerivation {
     ++ stdenv.lib.optionals perlSupport [ perl ]
     ++ stdenv.lib.optionals guiSupport [tcl tk]
     ++ stdenv.lib.optionals withpcre2 [ pcre2 ]
-    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.Security ];
+    ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.Security ]
+    ++ stdenv.lib.optionals withLibsecret [ pkgconfig glib libsecret ];
 
   # required to support pthread_cancel()
   NIX_LDFLAGS = stdenv.lib.optionalString (!stdenv.cc.isClang) "-lgcc_s"
@@ -90,12 +93,14 @@ stdenv.mkDerivation {
   ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl ["NO_SYS_POLL_H=1" "NO_GETTEXT=YesPlease"]
   ++ stdenv.lib.optional withpcre2 "USE_LIBPCRE2=1";
 
-  # build git-credential-osxkeychain if darwin
-  postBuild = stdenv.lib.optionalString stdenv.isDarwin ''
-    pushd $PWD/contrib/credential/osxkeychain/
-    make
-    popd
-  '';
+
+  postBuild = ''
+    make -C contrib/subtree
+  '' + (stdenv.lib.optionalString stdenv.isDarwin ''
+    make -C contrib/credential/osxkeychain
+  '') + (stdenv.lib.optionalString withLibsecret ''
+    make -C contrib/credential/libsecret
+  '');
 
 
   ## Install
@@ -105,11 +110,15 @@ stdenv.mkDerivation {
 
   installFlags = "NO_INSTALL_HARDLINKS=1";
 
-  preInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+  preInstall = (stdenv.lib.optionalString stdenv.isDarwin ''
     mkdir -p $out/bin
-    cp -a $PWD/contrib/credential/osxkeychain/git-credential-osxkeychain $out/bin
+    ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/bin/
     rm -f $PWD/contrib/credential/osxkeychain/git-credential-osxkeychain.o
-  '';
+  '') + (stdenv.lib.optionalString withLibsecret ''
+    mkdir -p $out/bin
+    ln -s $out/share/git/contrib/credential/libsecret/git-credential-libsecret $out/bin/
+    rm -f $PWD/contrib/credential/libsecret/git-credential-libsecret.o
+  '');
 
   postInstall =
     ''
@@ -118,10 +127,7 @@ stdenv.mkDerivation {
       }
 
       # Install git-subtree.
-      pushd contrib/subtree
-      make
-      make install ${stdenv.lib.optionalString withManual "install-doc"}
-      popd
+      make -C contrib/subtree install ${stdenv.lib.optionalString withManual "install-doc"}
       rm -rf contrib/subtree
 
       # Install contrib stuff.


### PR DESCRIPTION
Some very minor cleanup of the build/install phase too.

###### Motivation for this change
Encrypted storage for git secret credentials.

There is no change to the default `git` derivation.

This adds ~200mb to the transitive closure of `gitFull` because of the new dependencies on libgnome-keyring and libsecret.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

