### PR TITLE
release-staging: a release set for the staging branch

### DIFF
--- a/pkgs/top-level/release-staging.nix
+++ b/pkgs/top-level/release-staging.nix
@@ -1,0 +1,71 @@
+/*
+A release file that builds few packages.
+
+The aim is to test the `staging` branch before it is merged into `staging-next` at which points more builds are run.
+
+*/
+
+
+{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; }
+, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
+}:
+
+with import ./release-lib.nix { inherit supportedSystems; };
+
+
+(import ./release-small.nix {inherit nixpkgs; inherit supportedSystems;}) // (mapTestOn (rec {
+
+  # Some tools
+  diffoscope = all;
+  emacs = all;
+  git = all;
+  nox = all;
+  vim = all;
+
+  llvm = all;
+
+  linuxPackages.kernel = linux;
+
+  ## Package sets - Here a certain package is chosen simply to test the package set logic
+
+  # Erlang
+  erlang = all;
+
+  # Gnome 3
+  gnome3.gnome-system-monitor = linux;
+
+  # Go
+  go = all;
+
+  # Haskell
+  ghc = all;
+  pandoc = all;
+
+  # KDE
+  systemsettings = linux;
+
+  # Perl
+  exiftool = all;
+
+  # Python
+  python2Packages.pytest = all;
+  python3Packages.pytest = all;
+
+  # Node
+  npm2nix = all;
+
+  # Rust
+  cargo = all;
+
+  # Ocaml
+  unison = all;
+
+  # Ruby
+  bundix = all;
+  bundler = all;
+  ruby = all;
+
+  # Qt5
+  calibre = all;
+
+}))


### PR DESCRIPTION
The new `staging-next` branch tests all the packages that were tested on
the previous `staging` branch. The `staging` branch will be reduced in
size, and for that the following release set is created.

###### Motivation for this change

Please suggest improvements on the package set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

