### PR TITLE
vagrant: update deps for 2.1.2

### DIFF
--- a/pkgs/development/tools/vagrant/Gemfile.lock
+++ b/pkgs/development/tools/vagrant/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    vagrant (2.1.1)
+    vagrant (2.1.2)
       childprocess (~> 0.6.0)
       erubis (~> 2.7.0)
       hashicorp-checkpoint (~> 0.1.5)
@@ -25,8 +25,6 @@ PATH
       rest-client (>= 1.6.0, < 3.0)
       ruby_dep (<= 1.3.1)
       wdm (~> 0.1.0)
-      win32-file (~> 0.8.1)
-      win32-file-security (~> 1.0.10)
       winrm (~> 2.1)
       winrm-elevated (~> 1.1)
       winrm-fs (~> 1.0)
@@ -47,8 +45,6 @@ GEM
     erubis (2.7.0)
     fake_ftp (0.1.1)
     ffi (1.9.23)
-    ffi-win32-extensions (1.0.3)
-      ffi
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
@@ -119,16 +115,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    win32-file (0.8.1)
-      ffi
-      ffi-win32-extensions
-      win32-file-stat (>= 1.4.0)
-    win32-file-security (1.0.10)
-      ffi
-      ffi-win32-extensions
-    win32-file-stat (1.5.5)
-      ffi
-      ffi-win32-extensions
     winrm (2.2.3)
       builder (>= 2.1.2)
       erubis (~> 2.7)
@@ -160,4 +146,4 @@ DEPENDENCIES
   webmock (~> 2.3.1)
 
 BUNDLED WITH
-   1.14.6
+   1.16.2

--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -1,6 +1,10 @@
 { lib, fetchurl, buildRubyGem, bundlerEnv, ruby, libarchive }:
 
 let
+  # NOTE: bumping the version and updating the hash is insufficient;
+  # you must copy a fresh Gemfile.lock from the vagrant source,
+  # and use bundix to generate a new gemset.nix.
+  # Do not change the existing Gemfile.
   version = "2.1.2";
   url = "https://github.com/hashicorp/vagrant/archive/v${version}.tar.gz";
   sha256 = "0fb90v43d30whhyjlgb9mmy93ccbpr01pz97kp5hrg3wfd7703b1";

--- a/pkgs/development/tools/vagrant/gemset.nix
+++ b/pkgs/development/tools/vagrant/gemset.nix
@@ -75,15 +75,6 @@
     };
     version = "1.9.23";
   };
-  ffi-win32-extensions = {
-    dependencies = ["ffi"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1ywkkbr3bpi2ais2jr8yrsqwwrm48jg262anmdkcb9if95vajx7l";
-      type = "gem";
-    };
-    version = "1.0.3";
-  };
   gssapi = {
     dependencies = ["ffi"];
     source = {
@@ -406,7 +397,7 @@
     version = "0.0.7.5";
   };
   vagrant = {
-    dependencies = ["childprocess" "erubis" "hashicorp-checkpoint" "i18n" "listen" "log4r" "net-scp" "net-sftp" "net-ssh" "rb-kqueue" "rest-client" "ruby_dep" "wdm" "win32-file" "win32-file-security" "winrm" "winrm-elevated" "winrm-fs"];
+    dependencies = ["childprocess" "erubis" "hashicorp-checkpoint" "i18n" "listen" "log4r" "net-scp" "net-sftp" "net-ssh" "rb-kqueue" "rest-client" "ruby_dep" "wdm" "winrm" "winrm-elevated" "winrm-fs"];
   };
   vagrant-spec = {
     dependencies = ["childprocess" "log4r" "rspec" "thor"];
@@ -435,33 +426,6 @@
       type = "gem";
     };
     version = "2.3.2";
-  };
-  win32-file = {
-    dependencies = ["ffi" "ffi-win32-extensions" "win32-file-stat"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0mjylzv4bbnxyjqf7hnd9ghcs5xr2sv8chnmkqdi2cc6pya2xax0";
-      type = "gem";
-    };
-    version = "0.8.1";
-  };
-  win32-file-security = {
-    dependencies = ["ffi" "ffi-win32-extensions"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0lpq821a1hrxmm0ki5c34wijzhn77g4ny76v698ixwg853y2ir9r";
-      type = "gem";
-    };
-    version = "1.0.10";
-  };
-  win32-file-stat = {
-    dependencies = ["ffi" "ffi-win32-extensions"];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0lc3yajcb8xxabvj9qian938k60ixydvs3ixl5fldi0nlvnvk468";
-      type = "gem";
-    };
-    version = "1.5.5";
   };
   winrm = {
     dependencies = ["builder" "erubis" "gssapi" "gyoku" "httpclient" "logging" "nori" "rubyntlm"];


### PR DESCRIPTION
The version was bumped but the dependencies were not updated.
Do so and add some instructions for future package updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): decrease of -371624 (bytes?)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).