### PR TITLE
xfce.gtk-xfce-engine: fix build when withGtk3=true

### DIFF
--- a/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
+++ b/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk, withGtk3 ? false, gtk3 }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk2, withGtk3 ? false, gtk3 ? null }:
+
+assert withGtk3 -> (gtk3 != null);
 
 stdenv.mkDerivation rec {
   p_name  = "gtk-xfce-engine";
@@ -12,8 +14,11 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool gtk ] ++ stdenv.lib.optional withGtk3 gtk3;
-  
+  buildInputs = [ intltool gtk2 ] ++ stdenv.lib.optional withGtk3 gtk3;
+
+  # `glib-mkenums' is unhappy that some source files are not valid UTF-8
+  postPatch = ''find . -type f -name '*.[ch]' -exec sed -r -i 's/\xD6/O/g' {} +'';
+
   configureFlags = stdenv.lib.optional withGtk3 "--enable-gtk3";
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

fix build when withGtk3=true