### PR TITLE
libxklavier: 5.3 -> 5.4

### DIFF
--- a/pkgs/development/libraries/libxklavier/default.nix
+++ b/pkgs/development/libraries/libxklavier/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchurl, pkgconfig, xkeyboard_config, libxml2, xorg
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, gtk-doc, xkeyboard_config, libxml2, xorg, docbook_xsl
 , glib, isocodes, gobjectIntrospection }:
 
 let
-  version = "5.3";
+  version = "5.4";
 in
 stdenv.mkDerivation rec {
   name = "libxklavier-${version}";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/libxklavier/${version}/${name}.tar.xz";
-    sha256 = "016lpdv35z0qsw1cprdc2k5qzkdi5waj6qmr0a2q6ljn9g2kpv7b";
+  src = fetchgit {
+    url = "git://anongit.freedesktop.org/git/libxklavier";
+    rev = name;
+    sha256 = "1w1x5mrgly2ldiw3q2r6y620zgd89gk7n90ja46775lhaswxzv7a";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
@@ -17,14 +18,20 @@ stdenv.mkDerivation rec {
   # TODO: enable xmodmap support, needs xmodmap DB
   propagatedBuildInputs = with xorg; [ libX11 libXi xkeyboard_config libxml2 libICE glib libxkbfile isocodes ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig gtk-doc docbook_xsl ];
 
   buildInputs = [ gobjectIntrospection ];
+
+  preAutoreconf = ''
+    export NOCONFIGURE=1
+    gtkdocize
+  '';
 
   configureFlags = [
     "--with-xkb-base=${xkeyboard_config}/etc/X11/xkb"
     "--with-xkb-bin-base=${xorg.xkbcomp}/bin"
     "--disable-xmodmap-support"
+    "--enable-gtk-doc"
   ];
 
   meta = with stdenv.lib; {
@@ -34,4 +41,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

xfce 4.13 needs it

unfortunately, upstream has no source tarball, only git

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

