### PR TITLE
xfce4-13.xfce4-screenshooter: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-screenshooter/default.nix
@@ -1,11 +1,12 @@
-{ mkXfceDerivation, exo, gtk3, libsoup, libxfce4ui, libxfce4util, xfce4-panel }:
+{ mkXfceDerivation, exo, gtk3, libsoup, libxfce4ui, libxfce4util, xfce4-panel, wrapGAppsHook, glib-networking }:
 
 mkXfceDerivation rec {
   category = "apps";
   pname = "xfce4-screenshooter";
-  version = "1.9.1";
+  version = "1.9.2";
 
-  sha256 = "1q13hvaz3ykrbgbbqb1186mhri8r9hkmpaayjwhnkvjm7jfyhbin";
+  sha256 = "1zl16xcmgrb1s6rsrn37mpl5w522i1i9s7x167xf2d092x333yx2";
 
-  buildInputs = [ exo gtk3 libsoup libxfce4ui libxfce4util xfce4-panel ];
+  nativeBuildInputs = [ wrapGAppsHook ]; # fix "No GSettings schemas are installed on the system"
+  buildInputs = [ exo gtk3 libsoup libxfce4ui libxfce4util xfce4-panel glib-networking ];
 }


### PR DESCRIPTION
###### Motivation for this change

 - [x] version update
 - [x] backport https://github.com/NixOS/nixpkgs/pull/25331

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

