### PR TITLE
xfce4-13.xfce4-power-manager: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-power-manager/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-power-manager/default.nix
@@ -4,9 +4,9 @@
 mkXfceDerivation rec {
   category = "xfce";
   pname = "xfce4-power-manager";
-  version = "1.6.0";
+  version = "1.6.1";
 
-  sha256 = "1sh6ydn44j1yki8f020ljayp1fjcigkywcvjp38fsk7j25ni2wrp";
+  sha256 = "0b32m46v3dv1ln3xwlpqbnpflknm4gyfk2w6gn7xjx1k7igcjym3";
 
   nativeBuildInputs = [ automakeAddFlags exo ];
   buildInputs = [ gtk3 libnotify libxfce4ui libxfce4util upower xfconf ];
@@ -14,6 +14,6 @@ mkXfceDerivation rec {
   postPatch = ''
     substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
     automakeAddFlags src/Makefile.am xfce4_power_manager_CFLAGS GIO_CFLAGS
-    automakeAddFlags src/Makefile.am xfce4_power_manager_settings_CFLAGS GIO_CFLAGS
+    automakeAddFlags settings/Makefile.am xfce4_power_manager_settings_CFLAGS GIO_CFLAGS
   '';
 }


### PR DESCRIPTION
###### Motivation for this change

minor version upgrade

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

