### PR TITLE
pythonPackages.parsy: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -93,6 +93,11 @@
     github = "adolfogc";
     name = "Adolfo E. García Castro";
   };
+  aepsil0n = {
+    email = "eduard.bopp@aepsil0n.de";
+    github = "aepsil0n";
+    name = "Eduard Bopp";
+  };
   aespinosa = {
     email = "allan.espinosa@outlook.com";
     github = "aespinosa";

--- a/pkgs/development/python-modules/parsy/default.nix
+++ b/pkgs/development/python-modules/parsy/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, pytest }:
+
+buildPythonPackage rec {
+  pname = "parsy";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mdqg07x5ybmbmj55x75gyhfcjrn7ml0cf3z0jwbskx845j31m6x";
+  };
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test test/
+  '';
+
+  disabled = pythonOlder "3.4";
+
+  meta = with lib; {
+    homepage = https://github.com/python-parsy/parsy;
+    description = "Easy-to-use parser combinators, for parsing in pure Python";
+    license = [ licenses.mit ];
+    maintainers = with maintainers; [ aepsil0n ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1882,6 +1882,8 @@ in {
     '';
   };
 
+  parsy = callPackage ../development/python-modules/parsy { };
+
   portpicker = callPackage ../development/python-modules/portpicker { };
 
   pkginfo = callPackage ../development/python-modules/pkginfo { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---