### PR TITLE
mpv: use wrapper for scripts and add mpris script

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -38,9 +38,6 @@
 , vapoursynthSupport ? false, vapoursynth   ? null
 , archiveSupport     ? false, libarchive    ? null
 , jackaudioSupport   ? false, libjack2      ? null
-
-# scripts you want to be loaded by default
-, scripts ? []
 }:
 
 with stdenv.lib;
@@ -180,7 +177,6 @@ in stdenv.mkDerivation rec {
     ln -s ${freefont_ttf}/share/fonts/truetype/FreeSans.ttf $out/share/mpv/subfont.ttf
     # Ensure youtube-dl is available in $PATH for MPV
     wrapProgram $out/bin/mpv \
-      --add-flags "--scripts=${concatStringsSep "," scripts}" \
       --prefix LUA_PATH : "${luaPath}" \
       --prefix LUA_CPATH : "${luaCPath}" \
   '' + optionalString youtubeSupport ''

--- a/pkgs/applications/video/mpv/scripts/mpris.nix
+++ b/pkgs/applications/video/mpv/scripts/mpris.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkgconfig, gobjectIntrospection, mpv }:
+
+stdenv.mkDerivation rec {
+  name = "mpv-mpris-${version}.so";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "hoyon";
+    repo = "mpv-mpris";
+    rev = "v${version}";
+    sha256 = "0rsbrbv5q7vki59wdlx4cdkd0vvd79qgbjvdb3fn3li7aznvjwiy";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ gobjectIntrospection mpv ];
+
+  installPhase = ''
+    cp mpris.so $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "MPRIS plugin for mpv";
+    homepage = https://github.com/hoyon/mpv-mpris;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/applications/video/mpv/wrapper.nix
+++ b/pkgs/applications/video/mpv/wrapper.nix
@@ -1,0 +1,14 @@
+{ stdenv, symlinkJoin, makeWrapper, mpv, scripts ? [] }:
+
+symlinkJoin {
+  name = "mpv-with-scripts-${mpv.version}";
+
+  paths = [ mpv ];
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/mpv \
+      --add-flags "${stdenv.lib.concatMapStringsSep " " (x: "--script=" + x) scripts}"
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17356,8 +17356,11 @@ with pkgs;
     xvSupport          = !stdenv.isDarwin;
   };
 
+  mpv-with-scripts = callPackage ../applications/video/mpv/wrapper.nix { };
+
   mpvScripts = {
     convert = callPackage ../applications/video/mpv/scripts/convert.nix {};
+    mpris = callPackage ../applications/video/mpv/scripts/mpris.nix {};
   };
 
   mrpeach = callPackage ../applications/audio/pd-plugins/mrpeach { };


### PR DESCRIPTION
###### Motivation for this change

#14040 added the ability to use Lua scripts with mpv. mpv also supports C scripts/plugins which need to be compiled with libmpv. Thus loading C plugins is not possible by simply modifiying mpv's derivation. I've add a wrapper called `mpv-with-scripts` to solve this problem.

@Profpatsch, could you have a look as the author of #14040?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

