### PR TITLE
pulseeffects, lightdm-gtk-greeter, gxmessage, viking: depend on hicolor-icon-theme

### DIFF
--- a/pkgs/applications/audio/pulseeffects/default.nix
+++ b/pkgs/applications/audio/pulseeffects/default.nix
@@ -27,6 +27,7 @@
 , zam-plugins
 , rubberband
 , mda_lv2
+, hicolor-icon-theme
 }:
 
 let
@@ -75,6 +76,7 @@ in stdenv.mkDerivation rec {
     boost
     fftwFloat
     zita-convolver
+    hicolor-icon-theme
   ];
 
   postPatch = ''

--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ lightdm exo intltool makeWrapper ]
+  buildInputs = [ lightdm exo intltool makeWrapper hicolor-icon-theme ]
     ++ (if useGTK2 then [ gtk2 ] else [ gtk3 ]);
 
   configureFlags = [

--- a/pkgs/applications/misc/gxmessage/default.nix
+++ b/pkgs/applications/misc/gxmessage/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, gnome3, intltool, pkgconfig, texinfo}:
+{ stdenv, fetchurl, gnome3, intltool, pkgconfig, texinfo, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "gxmessage-${version}";
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool gnome3.gtk texinfo ];
+  buildInputs = [ intltool gnome3.gtk texinfo hicolor-icon-theme ];
+
   meta = {
     description = "A GTK enabled dropin replacement for xmessage";
     homepage = "http://homepages.ihug.co.nz/~trmusson/programs.html#gxmessage";

--- a/pkgs/applications/misc/viking/default.nix
+++ b/pkgs/applications/misc/viking/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, makeWrapper, pkgconfig, intltool, gettext, gtk2, expat, curl
 , gpsd, bc, file, gnome-doc-utils, libexif, libxml2, libxslt, scrollkeeper
-, docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect }:
+, docbook_xml_dtd_412, gexiv2, sqlite, gpsbabel, expect, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "viking-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ makeWrapper intltool gettext gtk2 expat curl gpsd bc file gnome-doc-utils
-    libexif libxml2 libxslt scrollkeeper docbook_xml_dtd_412 gexiv2 sqlite
+    libexif libxml2 libxslt scrollkeeper docbook_xml_dtd_412 gexiv2 sqlite hicolor-icon-theme
   ];
 
   configureFlags = [ "--disable-scrollkeeper --disable-mapnik" ];


### PR DESCRIPTION
###### Motivation for this change

Avoid conflicts on `share/icons/hicolor/icon-theme.cache`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

