### PR TITLE
split2flac: init at 122

### DIFF
--- a/pkgs/applications/audio/split2flac/default.nix
+++ b/pkgs/applications/audio/split2flac/default.nix
@@ -1,0 +1,62 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, shntool, cuetools
+, flac, faac, mp4v2, wavpack, mac
+, imagemagick, libiconv, enca, lame, pythonPackages, vorbis-tools
+, aacgain, mp3gain, vorbisgain
+}:
+
+let
+  wrapSplit2flac =  format: ''
+    makeWrapper $out/bin/.split2flac-wrapped $out/bin/split2${format} \
+      --set SPLIT2FLAC_FORMAT ${format} \
+      --prefix PATH : ${stdenv.lib.makeBinPath [
+        shntool cuetools
+        flac faac mp4v2 wavpack mac
+        imagemagick libiconv enca lame pythonPackages.mutagen vorbis-tools
+        aacgain mp3gain vorbisgain
+      ]}
+  '';
+
+in stdenv.mkDerivation rec {
+  name = "split2flac-${version}";
+  version = "122";
+
+  src = fetchFromGitHub {
+    owner = "ftrvxmtrx";
+    repo = "split2flac";
+    rev = version;
+    sha256 = "1a71amamip25hhqx7wwzfcl3d5snry9xsiha0kw73iq2m83r2k63";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patchPhase = ''
+    substituteInPlace split2flac \
+      --replace 'FORMAT="''${0##*split2}"' 'FORMAT=''${SPLIT2FLAC_FORMAT:-flac}'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/bash-completion/completions
+    cp split2flac-bash-completion.sh \
+      $out/share/bash-completion/completions/split2flac-bash-completion.sh
+
+    mkdir -p $out/bin
+    cp split2flac $out/bin/.split2flac-wrapped
+
+    ${wrapSplit2flac "flac"}
+    ${wrapSplit2flac "mp3"}
+    ${wrapSplit2flac "ogg"}
+    ${wrapSplit2flac "m4a"}
+    ${wrapSplit2flac "wav"}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Split flac/ape/wv/wav + cue sheet into separate tracks";
+    homepage = https://github.com/ftrvxmtrx/split2flac;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/libraries/mac/default.nix
+++ b/pkgs/development/libraries/mac/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, fetchpatch, yasm }:
+
+stdenv.mkDerivation rec {
+  name = "mac-${version}";
+  version = "4.11-u4-b5-s7";
+
+  src = fetchurl {
+    url = "https://www.deb-multimedia.org/pool/main/m/monkeys-audio/monkeys-audio_${version}.orig.tar.gz";
+    sha256 = "16i96cw5r3xbsivjigqp15vv32wa38k86mxq11qx1pzmpryqpqkk";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "mac-4.11.4.5.7-gcc6.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/mac/files/mac-4.11.4.5.7-gcc6.patch?id=1bd4e0e30e4d8a8862217d7067323851b34c7fe4";
+      sha256 = "093b8m8p8s6dmc62fc8vb4hlmjc2ncb4rdgc82g0a8gg6w5kcj8x";
+    })
+    (fetchpatch {
+      name = "mac-4.11.4.5.7-output.patch";
+      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-sound/mac/files/mac-4.11.4.5.7-output.patch?id=1bd4e0e30e4d8a8862217d7067323851b34c7fe4";
+      sha256 = "0njmwj6d9jqi4pz4fax02w37gk22vda0grszrs2nn97zzmjl36zk";
+    })
+  ];
+
+  CXXFLAGS = "-DSHNTOOL";
+
+  nativeBuildInputs = [ yasm ];
+
+  meta = with stdenv.lib; {
+    description = "APE codec and decompressor";
+    homepage = http://www.deb-multimedia.org/dists/testing/main/binary-amd64/package/monkeys-audio.php;
+    license = licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17119,6 +17119,8 @@ with pkgs;
 
   lyx = libsForQt5.callPackage ../applications/misc/lyx { };
 
+  mac = callPackage ../development/libraries/mac { };
+
   magic-wormhole = with python3Packages; toPythonApplication magic-wormhole;
 
   mail-notification = callPackage ../desktops/gnome-2/desktop/mail-notification {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18201,6 +18201,8 @@ with pkgs;
 
   spideroak = callPackage ../applications/networking/spideroak { };
 
+  split2flac = callPackage ../applications/audio/split2flac { };
+
   squishyball = callPackage ../applications/audio/squishyball {
     ncurses = ncurses5;
   };


### PR DESCRIPTION
###### Motivation for this change

Useful tool for splitting FLAC files according to CUE sheets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

