### PR TITLE
linux-hardkernel: 4.14.47-139 -> 4.14.55-146. Additionally, use vendo…

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,10 +1,10 @@
 { stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.14.47-139";
+  version = "4.14.55-146";
 
   # modDirVersion needs to be x.y.z.
-  modDirVersion = "4.14.47";
+  modDirVersion = "4.14.55";
 
   # branchVersion needs to be x.y. 
   extraMeta.branch = "4.14";
@@ -13,7 +13,19 @@ buildLinux (args // rec {
     owner = "hardkernel";
     repo = "linux";
     rev = version;
-    sha256 = "0jjgrmvi1h8zs8snnvghnjd422yfmn7jv9y1n7xikmfv4nvwqrkv";
+    sha256 = "1bm1njng4rwfylgnqv06vabkvybm9rikqj1lsb7p9qcs3y1kw6mh";
   };
+
+  defconfig = "odroidxu4_defconfig";
+
+  # This extraConfig is (only) required because the gator module fails to build as-is.
+  extraConfig = ''
+
+    GATOR n
+
+    # This attempted fix applies correctly but does not fix the build.
+    #GATOR_MALI_MIDGARD_PATH ${src}/drivers/gpu/arm/midgard
+
+  '' + (args.extraConfig or "");
 
 } // (args.argsOverride or {}))


### PR DESCRIPTION
…r defconfig.

###### Motivation for this change
Update this vendor kernel to the latest release, and adopt the defconfig provided by them.

In order to make this build, I had to disable the `gator` module via `extraConfig`. The build error was of the form of not being able to find a header file related to the mali graphics driver. I've left in (commented out) my attempt to address the problem, but it doesn't work. I can provide more info if anyone is interested, and if anyone knows how to fix this properly, I'm all ears.

In any case, disabling the building of `gator` seems to work fine, and I've had this kernel running on my HC1 for the last few days without incident.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

