### PR TITLE
libmysofa: init at 0.6 and enable in ffmpeg-full

### DIFF
--- a/pkgs/development/libraries/audio/libmysofa/default.nix
+++ b/pkgs/development/libraries/audio/libmysofa/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "libmysofa-${version}";
+  version = "0.6";
+
+  src = fetchFromGitHub {
+    owner = "hoene";
+    repo = "libmysofa";
+    rev = "v${version}";
+    sha256 = "160gcmsn6dwaca29bs95nsgjdalwc299lip0h37k3jcbxxkchgsh";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib ];
+
+  cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
+
+  meta = with stdenv.lib; {
+    description = "Reader for AES SOFA files to get better HRTFs";
+    homepage = https://github.com/hoene/libmysofa;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -78,6 +78,7 @@
 #, libiec61883 ? null, libavc1394 ? null # iec61883 (also uses libraw1394)
 #, libmfx ? null # Hardware acceleration vis libmfx
 , libmodplug ? null # ModPlug support
+, libmysofa ? null # HRTF support via SOFAlizer
 #, libnut ? null # NUT (de)muxer, native (de)muser exists
 , libogg ? null # Ogg container used by vorbis & theora
 , libopus ? null # Opus de/encoder
@@ -342,6 +343,7 @@ stdenv.mkDerivation rec {
     #(enableFeature (if isLinux then libiec61883 != null && libavc1394 != null && libraw1394 != null else false) "libiec61883")
     #(enableFeature (libmfx != null) "libmfx")
     (enableFeature (libmodplug != null) "libmodplug")
+    (enableFeature (libmysofa != null) "libmysofa")
     #(enableFeature (libnut != null) "libnut")
     (enableFeature (libopus != null) "libopus")
     (enableFeature (libssh != null) "libssh")
@@ -402,7 +404,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     bzip2 celt fontconfig freetype frei0r fribidi game-music-emu gnutls gsm
-    libjack2 ladspaH lame libass libbluray libbs2b libcaca libdc1394 libmodplug
+    libjack2 ladspaH lame libass libbluray libbs2b libcaca libdc1394 libmodplug libmysofa
     libogg libopus libssh libtheora libvdpau libvorbis libvpx libwebp libX11
     libxcb libXv lzma openal openjpeg_1 libpulseaudio rtmpdump opencore-amr
     samba SDL2 soxr speex vid-stab wavpack x264 x265 xavs xvidcore zeromq4 zlib

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9702,6 +9702,8 @@ with pkgs;
 
   libmypaint = callPackage ../development/libraries/libmypaint { };
 
+  libmysofa = callPackage ../development/libraries/audio/libmysofa { };
+
   libmysqlconnectorcpp = callPackage ../development/libraries/libmysqlconnectorcpp {
     mysql = mysql57;
   };


### PR DESCRIPTION
###### Motivation for this change

Using [HRTF](https://en.wikipedia.org/wiki/Head-related_transfer_function)s with mpv.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

