### PR TITLE
release-18.03: Update VLC to version 3.0.3

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -1,88 +1,93 @@
-{ stdenv, fetchurl, xz, bzip2, perl, xorg, libdvdnav, libbluray
+{ stdenv, fetchurl, autoreconfHook
+, libarchive, perl, xorg, libdvdnav, libbluray
 , zlib, a52dec, libmad, faad2, ffmpeg, alsaLib
 , pkgconfig, dbus, fribidi, freefont_ttf, libebml, libmatroska
-, libvorbis, libtheora, speex, lua5, libgcrypt, libupnp
+, libvorbis, libtheora, speex, lua5, libgcrypt, libgpgerror, libupnp
 , libcaca, libpulseaudio, flac, schroedinger, libxml2, librsvg
-, mpeg2dec, udev, gnutls, avahi, libcddb, libjack2, SDL, SDL_image
+, mpeg2dec, systemd, gnutls, avahi, libcddb, libjack2, SDL, SDL_image
 , libmtp, unzip, taglib, libkate, libtiger, libv4l, samba, liboggz
-, libass, libva, libdvbpsi, libdc1394, libraw1394, libopus
-, libvdpau, libsamplerate, live555, fluidsynth
+, libass, libva-full, libdvbpsi, libdc1394, libraw1394, libopus
+, libvdpau, libsamplerate, live555, fluidsynth, wayland, wayland-protocols
 , onlyLibVLC ? false
-, qt4 ? null
-, withQt5 ? false, qtbase ? null, qtx11extras ? null
+, withQt5 ? true, qtbase ? null, qtsvg ? null, qtx11extras ? null
 , jackSupport ? false
 , fetchpatch
 }:
 
 with stdenv.lib;
 
-assert (withQt5 -> qtbase != null && qtx11extras != null);
-assert (!withQt5 -> qt4 != null);
+assert (withQt5 -> qtbase != null && qtsvg != null && qtx11extras != null);
 
 stdenv.mkDerivation rec {
   name = "vlc-${version}";
-  version = "2.2.8";
+  version = "3.0.3";
 
   src = fetchurl {
     url = "http://get.videolan.org/vlc/${version}/${name}.tar.xz";
-    sha256 = "1v32snw46rkgbdqdy3dssl2y13i8p2cr1cw1i18r6vdmiy24dw4v";
+    sha256 = "0lavzly8l0ll1d9iris9cnirgcs77g48lxj14058dxqkvd5v1a4v";
   };
 
-  # Comment-out the Qt 5.5 version check, as we do apply the relevant patch.
-  # https://trac.videolan.org/vlc/ticket/16497
-  postPatch = if (!withQt5) then null else
-    "sed '/I78ef29975181ee22429c9bd4b11d96d9e68b7a9c/s/^/: #/' -i configure";
-
-  buildInputs =
-    [ xz bzip2 perl zlib a52dec libmad faad2 ffmpeg alsaLib libdvdnav libdvdnav.libdvdread
-      libbluray dbus fribidi libvorbis libtheora speex lua5 libgcrypt
-      libupnp libcaca libpulseaudio flac schroedinger libxml2 librsvg mpeg2dec
-      udev gnutls avahi libcddb SDL SDL_image libmtp unzip taglib
-      libkate libtiger libv4l samba liboggz libass libdvbpsi libva
-      xorg.xlibsWrapper xorg.libXv xorg.libXvMC xorg.libXpm xorg.xcbutilkeysyms
-      libdc1394 libraw1394 libopus libebml libmatroska libvdpau libsamplerate live555
-      fluidsynth
-    ]
-    ++ [(if withQt5 then qtbase else qt4)]
-    ++ optional withQt5 qtx11extras
+  # VLC uses a *ton* of libraries for various pieces of functionality, many of
+  # which are not included here for no other reason that nobody has mentioned
+  # needing them
+  buildInputs = [
+    zlib a52dec libmad faad2 ffmpeg alsaLib libdvdnav libdvdnav.libdvdread
+    libbluray dbus fribidi libvorbis libtheora speex lua5 libgcrypt libgpgerror
+    libupnp libcaca libpulseaudio flac schroedinger libxml2 librsvg mpeg2dec
+    systemd gnutls avahi libcddb SDL SDL_image libmtp unzip taglib libarchive
+    libkate libtiger libv4l samba liboggz libass libdvbpsi libva-full
+    xorg.xlibsWrapper xorg.libXv xorg.libXvMC xorg.libXpm xorg.xcbutilkeysyms
+    libdc1394 libraw1394 libopus libebml libmatroska libvdpau libsamplerate live555
+    fluidsynth wayland wayland-protocols
+  ] ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
     ++ optional jackSupport libjack2;
 
-  nativeBuildInputs = [ pkgconfig ];
-
-  LIVE555_PREFIX = live555;
-
-  preConfigure = ''
-    sed -e "s@/bin/echo@echo@g" -i configure
-  '' + optionalString withQt5 ''
-    # Make sure we only *add* "-std=c++11" to CXXFLAGS instead of overriding the
-    # values figured out by configure (for example "-g -O2").
-    sed -i -re '/^ *CXXFLAGS=("[^$"]+")? *$/s/CXXFLAGS="?/&-std=c++11 /' \
-      configure
-  '';
-
-  configureFlags =
-    [ "--enable-alsa"
-      "--with-kde-solid=$out/share/apps/solid/actions"
-      "--enable-dc1394"
-      "--enable-ncurses"
-      "--enable-vdpau"
-      "--enable-dvdnav"
-      "--enable-samplerate"
-    ]
-    ++ optional onlyLibVLC  "--disable-vlc";
+  nativeBuildInputs = [ autoreconfHook perl pkgconfig ];
 
   enableParallelBuilding = true;
 
-  preBuild = ''
-    substituteInPlace modules/text_renderer/freetype.c --replace \
-      /usr/share/fonts/truetype/freefont/FreeSerifBold.ttf \
-      ${freefont_ttf}/share/fonts/truetype/FreeSerifBold.ttf
+  LIVE555_PREFIX = live555;
+
+  # vlc depends on a c11-gcc wrapper script which we don't have so we need to
+  # set the path to the compiler
+  BUILDCC = "${stdenv.cc}/bin/gcc";
+
+  patches = [
+    (fetchpatch {
+      name = "vlc-qt5.11.patch";
+      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/vlc-qt5.11.patch?h=packages/vlc";
+      sha256 = "0yh65bhhaz876cazhagnafs1dr61184lpj3y0m3y7k37bswykj8p";
+    })
+    (fetchpatch {
+      url = "https://github.com/videolan/vlc/commit/26e2d3906658c30f2f88f4b1bc9630ec43bf5525.patch";
+      sha256 = "0sm73cbzxva8sww526bh5yin1k2pdkvj826wdlmqnj7xf0f3mki4";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace configure \
+      --replace /bin/echo echo
+
+    substituteInPlace modules/text_renderer/freetype/platform_fonts.h --replace \
+      /usr/share/fonts/truetype/freefont ${freefont_ttf}/share/fonts/truetype
   '';
+
+  # https://github.com/NixOS/nixpkgs/pull/35124#issuecomment-370552830
+  postFixup = ''
+    find $out/lib/vlc/plugins -exec touch -d @1 '{}' ';'
+    $out/lib/vlc/vlc-cache-gen $out/vlc/plugins
+  '';
+
+  # Most of the libraries are auto-detected so we don't need to set a bunch of
+  # "--enable-foo" flags here
+  configureFlags = [
+    "--with-kde-solid=$out/share/apps/solid/actions"
+  ] ++ optional onlyLibVLC "--disable-vlc";
 
   meta = with stdenv.lib; {
     description = "Cross-platform media player and streaming server";
     homepage = http://www.videolan.org/vlc/;
-    platforms = platforms.linux;
     license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/vlc/plugin.nix
+++ b/pkgs/applications/video/vlc/plugin.nix
@@ -5,7 +5,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "vlc-plugin-${version}";
-  version = "2.2.2"; # This 2.2.2 builds fine with vlc 2.2.4
+  version = "2.2.2"; # This 2.2.2 builds fine with vlc 3.0.3
 
   src = fetchgit {
     url = "https://code.videolan.org/videolan/npapi-vlc.git";

--- a/pkgs/development/libraries/phonon/backends/vlc.nix
+++ b/pkgs/development/libraries/phonon/backends/vlc.nix
@@ -1,21 +1,22 @@
 { stdenv, lib, fetchurl, cmake, phonon, pkgconfig, vlc
 , extra-cmake-modules, qtbase ? null, qtx11extras ? null, qt4 ? null
-, withQt5 ? false
+, withQt4 ? false
 , debug ? false
 }:
 
 with lib;
 
 let
-  v = "0.9.0";
+  v = "0.10.1";
   pname = "phonon-backend-vlc";
 in
 
-assert withQt5 -> qtbase != null;
-assert withQt5 -> qtx11extras != null;
+assert withQt4 -> qt4 != null;
+assert !withQt4 -> qtbase != null;
+assert !withQt4 -> qtx11extras != null;
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${if withQt5 then "qt5" else "qt4"}-${v}";
+  name = "${pname}-${if withQt4 then "qt4" else "qt5"}-${v}";
 
   meta = with stdenv.lib; {
     homepage = https://phonon.kde.org/;
@@ -25,16 +26,16 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://kde/stable/phonon/${pname}/${v}/${pname}-${v}.tar.xz";
-    sha256 = "1gnd1j305mqajw5gxm42vg6ajkvi8611bxgc3qhj5k0saz5dgkn0";
+    sha256 = "0b87mzkw9fdkrwgnh1kw5i5wnrd05rl42hynlykb7cfymsk6v5h9";
   };
 
   buildInputs =
     [ phonon vlc ]
-    ++ (if withQt5 then [ qtbase qtx11extras ] else [ qt4 ]);
+    ++ (if withQt4 then [ qt4 ] else [ qtbase qtx11extras ]);
 
-  nativeBuildInputs = [ cmake pkgconfig ] ++ optional withQt5 extra-cmake-modules;
+  nativeBuildInputs = [ cmake pkgconfig ] ++ optional (!withQt4) extra-cmake-modules;
 
   cmakeFlags =
     [ "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}" ]
-    ++ optional withQt5 "-DPHONON_BUILD_PHONON4QT5=ON";
+    ++ optional (!withQt4) "-DPHONON_BUILD_PHONON4QT5=ON";
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11177,9 +11177,7 @@ with pkgs;
       withQt5 = true;
     };
 
-    phonon-backend-vlc = callPackage ../development/libraries/phonon/backends/vlc.nix {
-      withQt5 = true;
-    };
+    phonon-backend-vlc = callPackage ../development/libraries/phonon/backends/vlc.nix { };
 
     polkit-qt = callPackage ../development/libraries/polkit-qt-1/qt-5.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11213,11 +11213,7 @@ with pkgs;
 
     telepathy = callPackage ../development/libraries/telepathy/qt { };
 
-    vlc = lowPrio (callPackage ../applications/video/vlc {
-      qt4 = null;
-      withQt5 = true;
-      ffmpeg = ffmpeg_2;
-    });
+    vlc = callPackage ../applications/video/vlc { };
 
     qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };
 
@@ -18173,16 +18169,13 @@ with pkgs;
 
   vkeybd = callPackage ../applications/audio/vkeybd {};
 
-  vlc = callPackage ../applications/video/vlc {
-    ffmpeg = ffmpeg_2;
-    libva = libva-full; # also wants libva-x11
-  };
+  vlc =  libsForQt5.vlc;
 
   vlc_npapi = callPackage ../applications/video/vlc/plugin.nix {
     gtk = gtk2;
   };
 
-  vlc_qt5 = libsForQt5.vlc;
+  vlc_qt5 = vlc;
 
   vmpk = callPackage ../applications/audio/vmpk { };
 


### PR DESCRIPTION
###### Motivation for this change

Update VLC (and phonon-backend-vlc) to include fixes to security vulnerabilities.

See https://github.com/NixOS/nixpkgs/issues/43307

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

All executables run, with except of `tribler` that fails with 2 Python `ImportError`s (`sip` and `_tkinter`), however, the same errors happen when running `tribler` from the stable channel.

Built packages:
- vlc
- vlc_npapi 
- libsForQt5.vlc
- tribler
- obs-studio 
- megaglest
- libsForQt5.phonon-backend-vlc 
- cantata
