### PR TITLE
ksonnet: init at 0.11.0

### DIFF
--- a/pkgs/applications/networking/cluster/ksonnet/default.nix
+++ b/pkgs/applications/networking/cluster/ksonnet/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoPackage, fetchFromGitHub, ... }:
+
+buildGoPackage rec {
+  version = "0.11.0";
+  name = "ksonnet-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ksonnet";
+    repo = "ksonnet";
+    rev = "v${version}";
+    sha256 = "0z7gkgcsiclm72bznmzv5jcgx5rblndcsiqc0r2mwhxhmv19bs04";
+  };
+
+  goPackagePath = "github.com/ksonnet/ksonnet";
+
+  meta = {
+    description = "A CLI-supported framework that streamlines writing and deployment of Kubernetes configurations to multiple clusters";
+    homepage = https://github.com/ksonnet/ksonnet;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ flokli ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16948,6 +16948,8 @@ with pkgs;
 
   ktorrent = libsForQt5.callPackage ../applications/networking/p2p/ktorrent { };
 
+  ksonnet = callPackage ../applications/networking/cluster/ksonnet { };
+
   kubecfg = callPackage ../applications/networking/cluster/kubecfg { };
 
   kubernetes = callPackage ../applications/networking/cluster/kubernetes {  };


### PR DESCRIPTION
###### Motivation for this change
This adds ksonnet like #42596, addressing the changes suggested there.

/cc @nlewo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

