### PR TITLE
glava: adjust syntax in patchelf command

### DIFF
--- a/pkgs/applications/misc/glava/default.nix
+++ b/pkgs/applications/misc/glava/default.nix
@@ -84,8 +84,9 @@ in
       mv $out/usr/bin/glava $out/bin/.glava-unwrapped
       rm -rf $out/usr
 
-      patchelf $out/bin/.glava-unwrapped \
+      patchelf \
         --set-rpath "$(patchelf --print-rpath $out/bin/.glava-unwrapped):${makeLibraryPath [ libGL ]}" \
+        $out/bin/.glava-unwrapped
 
       substitute ${wrapperScript} $out/bin/glava --subst-var out
       chmod +x $out/bin/glava


### PR DESCRIPTION
###### Motivation for this change
Properly adds missing libs (once again?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

