### PR TITLE
scantailor-advanced: 1.0.15 -> 1.0.16

### DIFF
--- a/pkgs/applications/graphics/scantailor/advanced.nix
+++ b/pkgs/applications/graphics/scantailor/advanced.nix
@@ -4,46 +4,23 @@
 
 stdenv.mkDerivation rec {
   name = "scantailor-advanced-${version}";
-  version = "1.0.15";
+  version = "1.0.16";
 
   src = fetchFromGitHub {
     owner = "4lex4";
     repo = "scantailor-advanced";
     rev = "v${version}";
-    sha256 = "031jqk64ig6lmscl5yg5lp116zwn0jl7xs9rlniqf6a8g4wfbjk9";
+    sha256 = "0lc9lzbpiy5hgimyhl4s4q67pb9gacpy985gl6iy8pl79zxhmcyp";
   };
 
   nativeBuildInputs = [ cmake qttools ];
   buildInputs = [ libjpeg libpng libtiff boost qtbase ];
-
-  postInstall = ''
-    mkdir -p $out/share/icons/hicolor/scalable/apps
-    cp $src/resources/appicon.svg $out/share/icons/hicolor/scalable/apps/scantailor.svg
-
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications/
-    for entry in $out/share/applications/*.desktop; do
-      substituteAllInPlace $entry
-    done
-  '';
-
-  desktopItem = makeDesktopItem {
-    name = "scantailor-advanced";
-    exec = "scantailor %f";
-    icon = "scantailor";
-    comment = meta.description;
-    desktopName = "Scan Tailor Advanced";
-    genericName = "Scan Processing Software";
-    mimeType = "image/png;image/tif;image/jpeg;";
-    categories = "Graphics;";
-    startupNotify = "true";
-  };
 
   meta = with stdenv.lib; {
     homepage = https://github.com/4lex4/scantailor-advanced;
     description = "Interactive post-processing tool for scanned pages";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jfrankenau ];
-    platforms = platforms.gnu ++ platforms.linux;
+    platforms = with platforms; gnu ++ linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update and enable build for macOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

