### PR TITLE
chromium: do jumbo builds

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -210,6 +210,7 @@ let
       use_gold = true;
       gold_path = "${stdenv.cc}/bin";
       is_debug = false;
+      use_jumbo_build = true;
 
       proprietary_codecs = false;
       use_sysroot = false;


### PR DESCRIPTION
###### Motivation for this change

This should decrease compile times, see [1].

Unfortunately, couldn't test anything, as compiler is killed (presumably due to OOM, given my complete lack of buff/cache after the kill and the fact my computer froze for a few seconds) after ~1hr on my machine. If someone has a big enough machine to build chromium and run `tests/chromium.nix`, that'd likely be better than merging and letting hydra figure it out, but…

[1] https://chromium.googlesource.com/chromium/src/+/lkcr/docs/jumbo.md

cc @chaoflow @bendlas 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

