### PR TITLE
[18.03] home-assistant: mark as insecure

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -85,6 +85,8 @@ in with py.pkgs; buildPythonApplication rec {
   makeWrapperArgs = lib.optional skipPip "--add-flags --skip-pip";
 
   meta = with lib; {
+    # home-assistant should be installed from unstable channel anyway
+    knownVulnerabilities = [ "https://www.home-assistant.io/blog/2018/07/16/release-73-2/" ];
     homepage = https://home-assistant.io/;
     description = "Open-source home automation platform running on Python 3";
     license = licenses.asl20;


### PR DESCRIPTION
###### Motivation for this change
The packaged version is susceptible to man-in-the-middle attacks.
See https://www.home-assistant.io/blog/2018/07/16/release-73-2/.
I also checked whether applying https://github.com/home-assistant/home-assistant/commit/335c643009d38b231efd815e17d96027b84623bd would work, but that patch doesn't apply cleanly.

The issue was fixed on master by 7682a1f0ec0a6e0c63f6456b9e956255af62ca58.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg @FRidh 