### PR TITLE
Package scuttlebot

### DIFF
--- a/pkgs/development/node-packages/default-v6.nix
+++ b/pkgs/development/node-packages/default-v6.nix
@@ -20,4 +20,8 @@ nodePackages // {
       done
     '';
   };
+
+  scuttlebot = nodePackages.scuttlebot.override (oldAttrs: {
+    buildInputs = oldAttrs.buildInputs ++ [ pkgs.automake pkgs.autoconf nodePackages.node-gyp-build ];
+  });
 }

--- a/pkgs/development/node-packages/node-packages-v10.nix
+++ b/pkgs/development/node-packages/node-packages-v10.nix
@@ -283,15 +283,6 @@ let
         sha1 = "4bc0373c164bc3291b4d368c829cf1a80a59dca0";
       };
     };
-    "combined-stream-1.0.6" = {
-      name = "combined-stream";
-      packageName = "combined-stream";
-      version = "1.0.6";
-      src = fetchurl {
-        url = "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz";
-        sha1 = "723e7df6e801ac5613113a7e445a9b69cb632818";
-      };
-    };
     "combined-stream-1.0.7" = {
       name = "combined-stream";
       packageName = "combined-stream";
@@ -522,7 +513,7 @@ let
       packageName = "fast-deep-equal";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
+        url = "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
         sha1 = "c053477817c86b51daa853c81e059b733d023614";
       };
     };
@@ -598,13 +589,13 @@ let
         sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
       };
     };
-    "form-data-2.3.2" = {
+    "form-data-2.3.3" = {
       name = "form-data";
       packageName = "form-data";
-      version = "2.3.2";
+      version = "2.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz";
-        sha1 = "4970498be604c20c005d4f5c23aecd21d6b49099";
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz";
+        sha512 = "1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==";
       };
     };
     "fragment-cache-0.2.1" = {
@@ -1192,22 +1183,22 @@ let
         sha512 = "MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==";
       };
     };
-    "mime-db-1.36.0" = {
+    "mime-db-1.37.0" = {
       name = "mime-db";
       packageName = "mime-db";
-      version = "1.36.0";
+      version = "1.37.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz";
-        sha512 = "L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==";
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz";
+        sha512 = "R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==";
       };
     };
-    "mime-types-2.1.20" = {
+    "mime-types-2.1.21" = {
       name = "mime-types";
       packageName = "mime-types";
-      version = "2.1.20";
+      version = "2.1.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz";
-        sha512 = "HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==";
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz";
+        sha512 = "3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==";
       };
     };
     "minimatch-3.0.4" = {
@@ -1237,13 +1228,13 @@ let
         sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
       };
     };
-    "minipass-2.3.4" = {
+    "minipass-2.3.5" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.3.4";
+      version = "2.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz";
-        sha512 = "mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz";
+        sha512 = "Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==";
       };
     };
     "minizlib-1.1.1" = {
@@ -1692,7 +1683,7 @@ let
       packageName = "safe-regex";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
+        url = "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
         sha1 = "40a3669f3b077d1e943d44629e157dd48023bf2e";
       };
     };
@@ -2420,11 +2411,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.11"
       sources."gauge-2.7.4"
@@ -2447,8 +2434,8 @@ in
       sources."json-schema-traverse-0.3.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -2554,7 +2541,7 @@ in
       sources."isarray-1.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.4"
+      sources."minipass-2.3.5"
       sources."minizlib-1.1.1"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
@@ -2606,10 +2593,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "2.16.3";
+    version = "2.17.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.16.3.tgz";
-      sha512 = "W63qZOC9YGr+33JYvZjvhzvYL4YKT2gAywDJQrHvKTL6vmnnSh+GdM3ZdGIIZ6A57YB3NgvQaq/BJ2uYjwn3ZQ==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.17.4.tgz";
+      sha512 = "yee6uJE9UZJAPF76JC7JqAPK1AKx8fr6ed862OPESYkw2GA0Rf3H/URlaTQSWYTAhP10DJNQ3t5ysbyrr6jzRw==";
     };
     buildInputs = globalBuildInputs;
     meta = {

--- a/pkgs/development/node-packages/node-packages-v6.json
+++ b/pkgs/development/node-packages/node-packages-v6.json
@@ -6,4 +6,5 @@
 , "node-gyp-build"
 , "node-pre-gyp"
 , "pnpm"
+, "scuttlebot"
 ]

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -5040,7 +5040,7 @@ let
       packageName = "to-vfile";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz";
+        url = "http://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz";
         sha1 = "88defecd43adb2ef598625f0e3d59f7f342941ba";
       };
     };
@@ -5319,7 +5319,7 @@ let
       packageName = "vfile";
       version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz";
+        url = "http://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz";
         sha1 = "c0fd6fa484f8debdb771f68c31ed75d88da97fe7";
       };
     };
@@ -5328,7 +5328,7 @@ let
       packageName = "vfile-find-down";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz";
+        url = "http://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz";
         sha1 = "84a4d66d03513f6140a84e0776ef0848d4f0ad95";
       };
     };
@@ -5337,7 +5337,7 @@ let
       packageName = "vfile-find-up";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz";
+        url = "http://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz";
         sha1 = "5604da6fe453b34350637984eb5fe4909e280390";
       };
     };
@@ -5346,7 +5346,7 @@ let
       packageName = "vfile-reporter";
       version = "1.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz";
+        url = "http://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz";
         sha1 = "21a7009bfe55e24df8ff432aa5bf6f6efa74e418";
       };
     };

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -13,6 +13,33 @@ let
         sha512 = "nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==";
       };
     };
+    "abstract-leveldown-0.12.4" = {
+      name = "abstract-leveldown";
+      packageName = "abstract-leveldown";
+      version = "0.12.4";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz";
+        sha1 = "29e18e632e60e4e221d5810247852a63d7b2e410";
+      };
+    };
+    "abstract-leveldown-4.0.3" = {
+      name = "abstract-leveldown";
+      packageName = "abstract-leveldown";
+      version = "4.0.3";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz";
+        sha512 = "qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==";
+      };
+    };
+    "abstract-leveldown-5.0.0" = {
+      name = "abstract-leveldown";
+      packageName = "abstract-leveldown";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz";
+        sha512 = "5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==";
+      };
+    };
     "ajv-5.5.2" = {
       name = "ajv";
       packageName = "ajv";
@@ -22,6 +49,24 @@ let
         sha1 = "73b5eeca3fab653e3d3f9422b341ad42205dc965";
       };
     };
+    "aligned-block-file-1.1.3" = {
+      name = "aligned-block-file";
+      packageName = "aligned-block-file";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.3.tgz";
+        sha512 = "ai/S+nZ9XMjC0ReZfq94OLGCICVBJyhNiKWmF1J+/GVZZaXtYV805plMi9obaWjfNl/QljB+VOsT+wQ7R858xA==";
+      };
+    };
+    "ansi-escapes-1.4.0" = {
+      name = "ansi-escapes";
+      packageName = "ansi-escapes";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz";
+        sha1 = "d3a8a83b319aa67793662b13e761c7911422306e";
+      };
+    };
     "ansi-regex-2.1.1" = {
       name = "ansi-regex";
       packageName = "ansi-regex";
@@ -29,6 +74,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz";
         sha1 = "c3b33ab5ee360d86e0e628f0468ae7ef27d654df";
+      };
+    };
+    "ansi-styles-2.2.1" = {
+      name = "ansi-styles";
+      packageName = "ansi-styles";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz";
+        sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
+      };
+    };
+    "anymatch-1.3.2" = {
+      name = "anymatch";
+      packageName = "anymatch";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz";
+        sha512 = "0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==";
+      };
+    };
+    "append-batch-0.0.1" = {
+      name = "append-batch";
+      packageName = "append-batch";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz";
+        sha1 = "9224858e556997ccc07f11f1ee9a128532aa0d25";
       };
     };
     "aproba-1.2.0" = {
@@ -47,6 +119,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz";
         sha512 = "5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==";
+      };
+    };
+    "arr-diff-2.0.0" = {
+      name = "arr-diff";
+      packageName = "arr-diff";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz";
+        sha1 = "8f3b827f955a8bd669697e4a4256ac3ceae356cf";
       };
     };
     "arr-diff-4.0.0" = {
@@ -94,6 +175,33 @@ let
         sha512 = "B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==";
       };
     };
+    "array-union-1.0.2" = {
+      name = "array-union";
+      packageName = "array-union";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz";
+        sha1 = "9a34410e4f4e3da23dea375be5be70f24778ec39";
+      };
+    };
+    "array-uniq-1.0.3" = {
+      name = "array-uniq";
+      packageName = "array-uniq";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz";
+        sha1 = "af6ac877a25cc7f74e058894753858dfdb24fdb6";
+      };
+    };
+    "array-unique-0.2.1" = {
+      name = "array-unique";
+      packageName = "array-unique";
+      version = "0.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz";
+        sha1 = "a1d97ccafcbc2625cc70fadceb36a50c58b01a53";
+      };
+    };
     "array-unique-0.3.2" = {
       name = "array-unique";
       packageName = "array-unique";
@@ -101,6 +209,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz";
         sha1 = "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428";
+      };
+    };
+    "arrify-1.0.1" = {
+      name = "arrify";
+      packageName = "arrify";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz";
+        sha1 = "898508da2226f380df904728456849c1501a4b0d";
       };
     };
     "asn1-0.2.4" = {
@@ -130,6 +247,33 @@ let
         sha1 = "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367";
       };
     };
+    "async-each-1.0.1" = {
+      name = "async-each";
+      packageName = "async-each";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz";
+        sha1 = "19d386a1d9edc6e7c1c85d388aedbcc56d33602d";
+      };
+    };
+    "async-single-1.0.5" = {
+      name = "async-single";
+      packageName = "async-single";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz";
+        sha1 = "125dd09de95d3ea30a378adbed021092179b03c9";
+      };
+    };
+    "async-write-2.1.0" = {
+      name = "async-write";
+      packageName = "async-write";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz";
+        sha1 = "1e762817d849ce44bfac07925a42036787061b15";
+      };
+    };
     "asynckit-0.4.0" = {
       name = "asynckit";
       packageName = "asynckit";
@@ -146,6 +290,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz";
         sha512 = "Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==";
+      };
+    };
+    "atomic-file-0.0.1" = {
+      name = "atomic-file";
+      packageName = "atomic-file";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/atomic-file/-/atomic-file-0.0.1.tgz";
+        sha1 = "6c36658f6c4ece33fba3877731e7c25fc82999bb";
+      };
+    };
+    "atomic-file-1.1.5" = {
+      name = "atomic-file";
+      packageName = "atomic-file";
+      version = "1.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz";
+        sha512 = "TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ==";
+      };
+    };
+    "attach-ware-1.1.1" = {
+      name = "attach-ware";
+      packageName = "attach-ware";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz";
+        sha1 = "28f51393dd8bb8bdaad972342519bf09621a35a3";
       };
     };
     "aws-sign2-0.7.0" = {
@@ -166,6 +337,15 @@ let
         sha512 = "ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==";
       };
     };
+    "bail-1.0.3" = {
+      name = "bail";
+      packageName = "bail";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz";
+        sha512 = "1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==";
+      };
+    };
     "balanced-match-1.0.0" = {
       name = "balanced-match";
       packageName = "balanced-match";
@@ -184,6 +364,24 @@ let
         sha512 = "5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==";
       };
     };
+    "base64-url-2.2.0" = {
+      name = "base64-url";
+      packageName = "base64-url";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/base64-url/-/base64-url-2.2.0.tgz";
+        sha512 = "Y4qHHAE+rWjmAFPQmHPiiD+hWwM/XvuFLlP6kVxlwZJK7rjiE2uIQR9tZ37iEr1E6iCj9799yxMAmiXzITb3lQ==";
+      };
+    };
+    "bash-color-0.0.4" = {
+      name = "bash-color";
+      packageName = "bash-color";
+      version = "0.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz";
+        sha1 = "e9be8ce33540cada4881768c59bd63865736e913";
+      };
+    };
     "bcrypt-pbkdf-1.0.2" = {
       name = "bcrypt-pbkdf";
       packageName = "bcrypt-pbkdf";
@@ -191,6 +389,60 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz";
         sha1 = "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e";
+      };
+    };
+    "binary-extensions-1.12.0" = {
+      name = "binary-extensions";
+      packageName = "binary-extensions";
+      version = "1.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz";
+        sha512 = "DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==";
+      };
+    };
+    "binary-search-1.3.4" = {
+      name = "binary-search";
+      packageName = "binary-search";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/binary-search/-/binary-search-1.3.4.tgz";
+        sha512 = "dPxU/vZLnH0tEVjVPgi015oSwqu6oLfCeHywuFRhBE0yM0mYocvleTl8qsdM1YFhRzTRhM1+VzS8XLDVrHPopg==";
+      };
+    };
+    "bindings-1.3.0" = {
+      name = "bindings";
+      packageName = "bindings";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz";
+        sha512 = "DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==";
+      };
+    };
+    "bl-0.8.2" = {
+      name = "bl";
+      packageName = "bl";
+      version = "0.8.2";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/bl/-/bl-0.8.2.tgz";
+        sha1 = "c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e";
+      };
+    };
+    "bl-1.2.2" = {
+      name = "bl";
+      packageName = "bl";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz";
+        sha512 = "e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==";
+      };
+    };
+    "blake2s-1.0.1" = {
+      name = "blake2s";
+      packageName = "blake2s";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/blake2s/-/blake2s-1.0.1.tgz";
+        sha1 = "1598822a320ece6aa401ba982954f82f61b0cd7b";
       };
     };
     "block-stream-0.0.9" = {
@@ -211,6 +463,15 @@ let
         sha512 = "iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==";
       };
     };
+    "braces-1.8.5" = {
+      name = "braces";
+      packageName = "braces";
+      version = "1.8.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz";
+        sha1 = "ba77962e12dff969d6b76711e914b737857bf6a7";
+      };
+    };
     "braces-2.3.2" = {
       name = "braces";
       packageName = "braces";
@@ -218,6 +479,69 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz";
         sha512 = "aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==";
+      };
+    };
+    "broadcast-stream-0.2.2" = {
+      name = "broadcast-stream";
+      packageName = "broadcast-stream";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.2.2.tgz";
+        sha1 = "79e7bb14a9abba77f72ac9258220242a8fd3919d";
+      };
+    };
+    "buffer-alloc-1.2.0" = {
+      name = "buffer-alloc";
+      packageName = "buffer-alloc";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz";
+        sha512 = "CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==";
+      };
+    };
+    "buffer-alloc-unsafe-1.1.0" = {
+      name = "buffer-alloc-unsafe";
+      packageName = "buffer-alloc-unsafe";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz";
+        sha512 = "TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==";
+      };
+    };
+    "buffer-fill-1.0.0" = {
+      name = "buffer-fill";
+      packageName = "buffer-fill";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz";
+        sha1 = "f8f78b76789888ef39f205cd637f68e702122b2c";
+      };
+    };
+    "buffer-from-1.1.1" = {
+      name = "buffer-from";
+      packageName = "buffer-from";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz";
+        sha512 = "MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==";
+      };
+    };
+    "bytewise-1.1.0" = {
+      name = "bytewise";
+      packageName = "bytewise";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz";
+        sha1 = "1d13cbff717ae7158094aa881b35d081b387253e";
+      };
+    };
+    "bytewise-core-1.2.3" = {
+      name = "bytewise-core";
+      packageName = "bytewise-core";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz";
+        sha1 = "3fb410c7e91558eb1ab22a82834577aa6bd61d42";
       };
     };
     "cache-base-1.0.1" = {
@@ -229,6 +553,24 @@ let
         sha512 = "AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==";
       };
     };
+    "camelcase-2.1.1" = {
+      name = "camelcase";
+      packageName = "camelcase";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz";
+        sha1 = "7c1d16d679a1bbe59ca02cacecfb011e201f5a1f";
+      };
+    };
+    "canonical-base64-1.1.0" = {
+      name = "canonical-base64";
+      packageName = "canonical-base64";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/canonical-base64/-/canonical-base64-1.1.0.tgz";
+        sha512 = "vHhtZX7TXMG0t8eEisjlOkNjDtaRkjqctDBVridYdqQNRYD8tbjw6GUSMqhSgkbnvIo6tCpDapzsDNitYcnH0Q==";
+      };
+    };
     "caseless-0.12.0" = {
       name = "caseless";
       packageName = "caseless";
@@ -236,6 +578,96 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz";
         sha1 = "1b681c21ff84033c826543090689420d187151dc";
+      };
+    };
+    "ccount-1.0.3" = {
+      name = "ccount";
+      packageName = "ccount";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz";
+        sha512 = "Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==";
+      };
+    };
+    "chalk-1.1.3" = {
+      name = "chalk";
+      packageName = "chalk";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz";
+        sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
+      };
+    };
+    "character-entities-1.2.2" = {
+      name = "character-entities";
+      packageName = "character-entities";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz";
+        sha512 = "sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==";
+      };
+    };
+    "character-entities-html4-1.1.2" = {
+      name = "character-entities-html4";
+      packageName = "character-entities-html4";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz";
+        sha512 = "sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==";
+      };
+    };
+    "character-entities-legacy-1.1.2" = {
+      name = "character-entities-legacy";
+      packageName = "character-entities-legacy";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz";
+        sha512 = "9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==";
+      };
+    };
+    "character-reference-invalid-1.1.2" = {
+      name = "character-reference-invalid";
+      packageName = "character-reference-invalid";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz";
+        sha512 = "7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==";
+      };
+    };
+    "charwise-3.0.1" = {
+      name = "charwise";
+      packageName = "charwise";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz";
+        sha512 = "RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==";
+      };
+    };
+    "chloride-2.2.10" = {
+      name = "chloride";
+      packageName = "chloride";
+      version = "2.2.10";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chloride/-/chloride-2.2.10.tgz";
+        sha512 = "CbU1ISGiB2JBV6PDXx7hkl8D94d2TPD1BANUMFbr8rZYKJi8De2d3Hu2XDIOLAhXf+8yhoFOdjtLG6fxz3QByQ==";
+      };
+    };
+    "chloride-test-1.2.2" = {
+      name = "chloride-test";
+      packageName = "chloride-test";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz";
+        sha1 = "178686a85e9278045112e96e8c791793f9a10aea";
+      };
+    };
+    "chokidar-1.7.0" = {
+      name = "chokidar";
+      packageName = "chokidar";
+      version = "1.7.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz";
+        sha1 = "798e689778151c8076b4b360e5edd28cda2bb468";
       };
     };
     "chownr-1.1.1" = {
@@ -256,6 +688,24 @@ let
         sha512 = "qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==";
       };
     };
+    "cli-cursor-1.0.2" = {
+      name = "cli-cursor";
+      packageName = "cli-cursor";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz";
+        sha1 = "64da3f7d56a54412e59794bd62dc35295e8f2987";
+      };
+    };
+    "co-3.1.0" = {
+      name = "co";
+      packageName = "co";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/co/-/co-3.1.0.tgz";
+        sha1 = "4ea54ea5a08938153185e15210c68d9092bc1b78";
+      };
+    };
     "co-4.6.0" = {
       name = "co";
       packageName = "co";
@@ -274,6 +724,15 @@ let
         sha1 = "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77";
       };
     };
+    "collapse-white-space-1.0.4" = {
+      name = "collapse-white-space";
+      packageName = "collapse-white-space";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz";
+        sha512 = "YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==";
+      };
+    };
     "collection-visit-1.0.0" = {
       name = "collection-visit";
       packageName = "collection-visit";
@@ -283,13 +742,13 @@ let
         sha1 = "4bc0373c164bc3291b4d368c829cf1a80a59dca0";
       };
     };
-    "combined-stream-1.0.6" = {
-      name = "combined-stream";
-      packageName = "combined-stream";
-      version = "1.0.6";
+    "colors-0.5.1" = {
+      name = "colors";
+      packageName = "colors";
+      version = "0.5.1";
       src = fetchurl {
-        url = "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz";
-        sha1 = "723e7df6e801ac5613113a7e445a9b69cb632818";
+        url = "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz";
+        sha1 = "7d0023eaeb154e8ee9fce75dcb923d0ed1667774";
       };
     };
     "combined-stream-1.0.7" = {
@@ -299,6 +758,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz";
         sha512 = "brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==";
+      };
+    };
+    "commander-2.19.0" = {
+      name = "commander";
+      packageName = "commander";
+      version = "2.19.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz";
+        sha512 = "6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==";
+      };
+    };
+    "compare-at-paths-1.0.0" = {
+      name = "compare-at-paths";
+      packageName = "compare-at-paths";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/compare-at-paths/-/compare-at-paths-1.0.0.tgz";
+        sha512 = "Ke1ejo/RZ+Hzku4gcW34uPMOR4Cpq87MAotELgV9mwiAzDN726cu+eWo0zWg1vRIfyf6yK5bW9uIW+c/SksQ5w==";
       };
     };
     "component-emitter-1.2.1" = {
@@ -319,6 +796,15 @@ let
         sha1 = "d8a96bd77fd68df7793a73036a3ba0d5405d477b";
       };
     };
+    "concat-stream-1.6.2" = {
+      name = "concat-stream";
+      packageName = "concat-stream";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz";
+        sha512 = "27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==";
+      };
+    };
     "console-control-strings-1.1.0" = {
       name = "console-control-strings";
       packageName = "console-control-strings";
@@ -326,6 +812,69 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz";
         sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
+      };
+    };
+    "cont-1.0.3" = {
+      name = "cont";
+      packageName = "cont";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz";
+        sha1 = "6874f1e935fca99d048caeaaad9a0aeb020bcce0";
+      };
+    };
+    "continuable-1.1.8" = {
+      name = "continuable";
+      packageName = "continuable";
+      version = "1.1.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz";
+        sha1 = "dc877b474160870ae3bcde87336268ebe50597d5";
+      };
+    };
+    "continuable-1.2.0" = {
+      name = "continuable";
+      packageName = "continuable";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz";
+        sha1 = "08277468d41136200074ccf87294308d169f25b6";
+      };
+    };
+    "continuable-hash-0.1.4" = {
+      name = "continuable-hash";
+      packageName = "continuable-hash";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz";
+        sha1 = "81c74d41771d8c92783e1e00e5f11b34d6dfc78c";
+      };
+    };
+    "continuable-list-0.1.6" = {
+      name = "continuable-list";
+      packageName = "continuable-list";
+      version = "0.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz";
+        sha1 = "87cf06ec580716e10dff95fb0b84c5f0e8acac5f";
+      };
+    };
+    "continuable-para-1.2.0" = {
+      name = "continuable-para";
+      packageName = "continuable-para";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz";
+        sha1 = "445510f649459dd0fc35c872015146122731c583";
+      };
+    };
+    "continuable-series-1.2.0" = {
+      name = "continuable-series";
+      packageName = "continuable-series";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz";
+        sha1 = "3243397ae93a71d655b3026834a51590b958b9e8";
       };
     };
     "copy-descriptor-0.1.1" = {
@@ -344,6 +893,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz";
         sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
+      };
+    };
+    "cross-spawn-5.1.0" = {
+      name = "cross-spawn";
+      packageName = "cross-spawn";
+      version = "5.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz";
+        sha1 = "e8bd0efee58fcff6f8f94510a0a554bbfa235449";
       };
     };
     "dashdash-1.14.1" = {
@@ -373,6 +931,33 @@ let
         sha1 = "eb3913333458775cb84cd1a1fae062106bb87545";
       };
     };
+    "decompress-response-3.3.0" = {
+      name = "decompress-response";
+      packageName = "decompress-response";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz";
+        sha1 = "80a4dd323748384bfa248083622aedec982adff3";
+      };
+    };
+    "deep-equal-0.2.2" = {
+      name = "deep-equal";
+      packageName = "deep-equal";
+      version = "0.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz";
+        sha1 = "84b745896f34c684e98f2ce0e42abaf43bba017d";
+      };
+    };
+    "deep-equal-1.0.1" = {
+      name = "deep-equal";
+      packageName = "deep-equal";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz";
+        sha1 = "f5d260292b660e084eff4cdbc9f08ad3247448b5";
+      };
+    };
     "deep-extend-0.6.0" = {
       name = "deep-extend";
       packageName = "deep-extend";
@@ -380,6 +965,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz";
         sha512 = "LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==";
+      };
+    };
+    "deferred-leveldown-0.2.0" = {
+      name = "deferred-leveldown";
+      packageName = "deferred-leveldown";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz";
+        sha1 = "2cef1f111e1c57870d8bbb8af2650e587cd2f5b4";
+      };
+    };
+    "deferred-leveldown-3.0.0" = {
+      name = "deferred-leveldown";
+      packageName = "deferred-leveldown";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz";
+        sha512 = "ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==";
+      };
+    };
+    "deferred-leveldown-4.0.2" = {
+      name = "deferred-leveldown";
+      packageName = "deferred-leveldown";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz";
+        sha512 = "5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==";
+      };
+    };
+    "define-properties-1.1.3" = {
+      name = "define-properties";
+      packageName = "define-properties";
+      version = "1.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz";
+        sha512 = "3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==";
       };
     };
     "define-property-0.2.5" = {
@@ -409,6 +1030,15 @@ let
         sha512 = "jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==";
       };
     };
+    "defined-1.0.0" = {
+      name = "defined";
+      packageName = "defined";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz";
+        sha1 = "c98d9bcef75674188e110969151199e39b1fa693";
+      };
+    };
     "delayed-stream-1.0.0" = {
       name = "delayed-stream";
       packageName = "delayed-stream";
@@ -425,6 +1055,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz";
         sha1 = "84c6e159b81904fdca59a0ef44cd870d31250f9a";
+      };
+    };
+    "detab-1.0.2" = {
+      name = "detab";
+      packageName = "detab";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz";
+        sha1 = "01bc2a4abe7bc7cc67c3039808edbae47049a0ee";
       };
     };
     "detect-file-1.0.0" = {
@@ -445,6 +1084,24 @@ let
         sha1 = "fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b";
       };
     };
+    "discontinuous-range-1.0.0" = {
+      name = "discontinuous-range";
+      packageName = "discontinuous-range";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz";
+        sha1 = "e38331f0844bba49b9a9cb71c771585aab1bc65a";
+      };
+    };
+    "dynamic-dijkstra-1.0.0" = {
+      name = "dynamic-dijkstra";
+      packageName = "dynamic-dijkstra";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/dynamic-dijkstra/-/dynamic-dijkstra-1.0.0.tgz";
+        sha512 = "AUbCFABXNoon689xft5ROX/fO9pdttZ6wZcMXZ4oH85Bn9rtiMdVHVBbAZ9kxAewdm5L1m+y+n97s8ofwya8WA==";
+      };
+    };
     "ecc-jsbn-0.1.2" = {
       name = "ecc-jsbn";
       packageName = "ecc-jsbn";
@@ -452,6 +1109,132 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz";
         sha1 = "3a83a904e54353287874c564b7549386849a98c9";
+      };
+    };
+    "ed2curve-0.1.4" = {
+      name = "ed2curve";
+      packageName = "ed2curve";
+      version = "0.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz";
+        sha1 = "94a44248bb87da35db0eff7af0aa576168117f59";
+      };
+    };
+    "elegant-spinner-1.0.1" = {
+      name = "elegant-spinner";
+      packageName = "elegant-spinner";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz";
+        sha1 = "db043521c95d7e303fd8f345bedc3349cfb0729e";
+      };
+    };
+    "emoji-named-characters-1.0.2" = {
+      name = "emoji-named-characters";
+      packageName = "emoji-named-characters";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz";
+        sha1 = "cdeb36d0e66002c4b9d7bf1dfbc3a199fb7d409b";
+      };
+    };
+    "emoji-server-1.0.0" = {
+      name = "emoji-server";
+      packageName = "emoji-server";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz";
+        sha1 = "d063cfee9af118cc5aeefbc2e9b3dd5085815c63";
+      };
+    };
+    "encoding-down-4.0.1" = {
+      name = "encoding-down";
+      packageName = "encoding-down";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.1.tgz";
+        sha512 = "AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==";
+      };
+    };
+    "encoding-down-5.0.4" = {
+      name = "encoding-down";
+      packageName = "encoding-down";
+      version = "5.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz";
+        sha512 = "8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==";
+      };
+    };
+    "end-of-stream-1.4.1" = {
+      name = "end-of-stream";
+      packageName = "end-of-stream";
+      version = "1.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz";
+        sha512 = "1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==";
+      };
+    };
+    "epidemic-broadcast-trees-6.3.4" = {
+      name = "epidemic-broadcast-trees";
+      packageName = "epidemic-broadcast-trees";
+      version = "6.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-6.3.4.tgz";
+        sha512 = "ucs3AI3ebPCDFGw8B0SUBwzcY2WqKrbJeqYeeX9KF+XvsO7GFEe0L+1hXPfJcEScfGPByXJNACkYwUFnNaOueQ==";
+      };
+    };
+    "errno-0.1.7" = {
+      name = "errno";
+      packageName = "errno";
+      version = "0.1.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz";
+        sha512 = "MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==";
+      };
+    };
+    "es-abstract-1.12.0" = {
+      name = "es-abstract";
+      packageName = "es-abstract";
+      version = "1.12.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz";
+        sha512 = "C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==";
+      };
+    };
+    "es-to-primitive-1.2.0" = {
+      name = "es-to-primitive";
+      packageName = "es-to-primitive";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz";
+        sha512 = "qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==";
+      };
+    };
+    "escape-string-regexp-1.0.5" = {
+      name = "escape-string-regexp";
+      packageName = "escape-string-regexp";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz";
+        sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
+      };
+    };
+    "exit-hook-1.1.1" = {
+      name = "exit-hook";
+      packageName = "exit-hook";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz";
+        sha1 = "f05ca233b48c05d54fff07765df8507e95c02ff8";
+      };
+    };
+    "expand-brackets-0.1.5" = {
+      name = "expand-brackets";
+      packageName = "expand-brackets";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz";
+        sha1 = "df07284e342a807cd733ac5af72411e581d1177b";
       };
     };
     "expand-brackets-2.1.4" = {
@@ -463,6 +1246,24 @@ let
         sha1 = "b77735e315ce30f6b6eff0f83b04151a22449622";
       };
     };
+    "expand-range-1.8.2" = {
+      name = "expand-range";
+      packageName = "expand-range";
+      version = "1.8.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz";
+        sha1 = "a299effd335fe2721ebae8e257ec79644fc85337";
+      };
+    };
+    "expand-template-1.1.1" = {
+      name = "expand-template";
+      packageName = "expand-template";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz";
+        sha512 = "cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==";
+      };
+    };
     "expand-tilde-2.0.2" = {
       name = "expand-tilde";
       packageName = "expand-tilde";
@@ -470,6 +1271,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz";
         sha1 = "97e801aa052df02454de46b02bf621642cdc8502";
+      };
+    };
+    "explain-error-1.0.4" = {
+      name = "explain-error";
+      packageName = "explain-error";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz";
+        sha1 = "a793d3ac0cad4c6ab571e9968fbbab6cb2532929";
       };
     };
     "extend-3.0.2" = {
@@ -499,6 +1309,24 @@ let
         sha1 = "26a71aaf073b39fb2127172746131c2704028db8";
       };
     };
+    "extend.js-0.0.2" = {
+      name = "extend.js";
+      packageName = "extend.js";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz";
+        sha1 = "0f9c7a81a1f208b703eb0c3131fe5716ac6ecd15";
+      };
+    };
+    "extglob-0.3.2" = {
+      name = "extglob";
+      packageName = "extglob";
+      version = "0.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz";
+        sha1 = "2e18ff3d2f49ab2765cec9023f011daa8d8349a1";
+      };
+    };
     "extglob-2.0.4" = {
       name = "extglob";
       packageName = "extglob";
@@ -522,8 +1350,17 @@ let
       packageName = "fast-deep-equal";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
+        url = "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
         sha1 = "c053477817c86b51daa853c81e059b733d023614";
+      };
+    };
+    "fast-future-1.0.2" = {
+      name = "fast-future";
+      packageName = "fast-future";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz";
+        sha1 = "8435a9aaa02d79248d17d704e76259301d99280a";
       };
     };
     "fast-json-stable-stringify-2.0.0" = {
@@ -533,6 +1370,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz";
         sha1 = "d5142c0caee6b1189f87d3a76111064f86c8bbf2";
+      };
+    };
+    "filename-regex-2.0.1" = {
+      name = "filename-regex";
+      packageName = "filename-regex";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz";
+        sha1 = "c1c4b9bee3e09725ddb106b75c1e301fe2f18b26";
+      };
+    };
+    "fill-range-2.2.4" = {
+      name = "fill-range";
+      packageName = "fill-range";
+      version = "2.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz";
+        sha512 = "cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==";
       };
     };
     "fill-range-4.0.0" = {
@@ -571,6 +1426,96 @@ let
         sha1 = "4e79ae9b2eb38bf86b3bb56bf3e0a56aa5fcabd7";
       };
     };
+    "flumecodec-0.0.0" = {
+      name = "flumecodec";
+      packageName = "flumecodec";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz";
+        sha1 = "36ce06abe2e0e01c44dd69f2a165305a2320649b";
+      };
+    };
+    "flumecodec-0.0.1" = {
+      name = "flumecodec";
+      packageName = "flumecodec";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz";
+        sha1 = "ae049a714386bb83e342657a82924b70364a90d6";
+      };
+    };
+    "flumedb-0.5.1" = {
+      name = "flumedb";
+      packageName = "flumedb";
+      version = "0.5.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumedb/-/flumedb-0.5.1.tgz";
+        sha512 = "WB/q5YYEvVB2ozp7xhp3ur5NfX03HZywx6EEV6AlKjd1PodZdHVspz3NpakV++mVB89CRoH2nq+WdY33ntbfQw==";
+      };
+    };
+    "flumelog-offset-3.3.2" = {
+      name = "flumelog-offset";
+      packageName = "flumelog-offset";
+      version = "3.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.3.2.tgz";
+        sha512 = "KG0TCb+cWuEvnL44xjBhVNu+jRmJ8Msh2b1krYb4FllLwSbjreaCU/hH3uzv+HmUrtU/EhJepcAu79WxLH3EZQ==";
+      };
+    };
+    "flumeview-hashtable-1.0.4" = {
+      name = "flumeview-hashtable";
+      packageName = "flumeview-hashtable";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.4.tgz";
+        sha512 = "4L52hBelX7dYVAQQ9uPjksqxOCxLwI4NsfEG/+sTM423axT2Poq5cnfdvGm3HzmNowzwDIKtdy429r6PbfKEIw==";
+      };
+    };
+    "flumeview-level-3.0.6" = {
+      name = "flumeview-level";
+      packageName = "flumeview-level";
+      version = "3.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.6.tgz";
+        sha512 = "omfYDMixWGL8Xx/mFl7xoALZvvOePiN/7jzY/kUJz3TR4px55QV4tZMba63QPyKj7NZVAPE61wq//P5sdiqvQw==";
+      };
+    };
+    "flumeview-query-6.3.0" = {
+      name = "flumeview-query";
+      packageName = "flumeview-query";
+      version = "6.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.3.0.tgz";
+        sha512 = "8QBannTFLICARmflhHpXNeR5hh6IzIyJz4XhKTofzmxq/hXEn1un7aF6P6dRQkOwthENDTbSB07eWKqwnYDKtw==";
+      };
+    };
+    "flumeview-query-7.1.0" = {
+      name = "flumeview-query";
+      packageName = "flumeview-query";
+      version = "7.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumeview-query/-/flumeview-query-7.1.0.tgz";
+        sha512 = "z/23qWuRW5dj7yNJ1i61R0RgnUWn4rdaf9Fr1Ckz3CzKpwJBWR1MqnABuGY3k1PZg1T11Busm2aRdb6oH1ZLsQ==";
+      };
+    };
+    "flumeview-reduce-1.3.14" = {
+      name = "flumeview-reduce";
+      packageName = "flumeview-reduce";
+      version = "1.3.14";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.14.tgz";
+        sha512 = "hMk9g42JrD92PCmNDiET6JGjur09wQrlAUQRPjmsk8LNqDz/tC5upvCfiynIgWUphe8dZMhUHIzOTh75xa1WKA==";
+      };
+    };
+    "for-each-0.3.3" = {
+      name = "for-each";
+      packageName = "for-each";
+      version = "0.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz";
+        sha512 = "jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==";
+      };
+    };
     "for-in-1.0.2" = {
       name = "for-in";
       packageName = "for-in";
@@ -578,6 +1523,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz";
         sha1 = "81068d295a8142ec0ac726c6e2200c30fb6d5e80";
+      };
+    };
+    "for-own-0.1.5" = {
+      name = "for-own";
+      packageName = "for-own";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz";
+        sha1 = "5265c681a4f294dabbf17c9509b6763aa84510ce";
       };
     };
     "for-own-1.0.0" = {
@@ -598,13 +1552,13 @@ let
         sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
       };
     };
-    "form-data-2.3.2" = {
+    "form-data-2.3.3" = {
       name = "form-data";
       packageName = "form-data";
-      version = "2.3.2";
+      version = "2.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz";
-        sha1 = "4970498be604c20c005d4f5c23aecd21d6b49099";
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz";
+        sha512 = "1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==";
       };
     };
     "fragment-cache-0.2.1" = {
@@ -614,6 +1568,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz";
         sha1 = "4290fad27f13e89be7f33799c6bc5a0abfff0d19";
+      };
+    };
+    "fs-constants-1.0.0" = {
+      name = "fs-constants";
+      packageName = "fs-constants";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz";
+        sha512 = "y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==";
       };
     };
     "fs-minipass-1.2.5" = {
@@ -634,6 +1597,15 @@ let
         sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
       };
     };
+    "fsevents-1.2.4" = {
+      name = "fsevents";
+      packageName = "fsevents";
+      version = "1.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz";
+        sha512 = "z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==";
+      };
+    };
     "fstream-1.0.11" = {
       name = "fstream";
       packageName = "fstream";
@@ -641,6 +1613,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz";
         sha1 = "5c1fb1f117477114f0632a0eb4b71b3cb0fd3171";
+      };
+    };
+    "function-bind-1.1.1" = {
+      name = "function-bind";
+      packageName = "function-bind";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz";
+        sha512 = "yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==";
       };
     };
     "gauge-2.7.4" = {
@@ -670,6 +1651,24 @@ let
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
+    "github-from-package-0.0.0" = {
+      name = "github-from-package";
+      packageName = "github-from-package";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz";
+        sha1 = "97fb5d96bfde8973313f20e8288ef9a167fa64ce";
+      };
+    };
+    "glob-6.0.4" = {
+      name = "glob";
+      packageName = "glob";
+      version = "6.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz";
+        sha1 = "0f08860f6a155127b2fadd4f9ce24b1aab6e4d22";
+      };
+    };
     "glob-7.1.3" = {
       name = "glob";
       packageName = "glob";
@@ -677,6 +1676,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz";
         sha512 = "vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==";
+      };
+    };
+    "glob-base-0.3.0" = {
+      name = "glob-base";
+      packageName = "glob-base";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz";
+        sha1 = "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4";
+      };
+    };
+    "glob-parent-2.0.0" = {
+      name = "glob-parent";
+      packageName = "glob-parent";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz";
+        sha1 = "81383d72db054fcccf5336daa902f182f6edbb28";
       };
     };
     "global-modules-1.0.0" = {
@@ -697,6 +1714,15 @@ let
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
       };
     };
+    "globby-4.1.0" = {
+      name = "globby";
+      packageName = "globby";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz";
+        sha1 = "080f54549ec1b82a6c60e631fc82e1211dbe95f8";
+      };
+    };
     "graceful-fs-4.1.11" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
@@ -704,6 +1730,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz";
         sha1 = "0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658";
+      };
+    };
+    "graphreduce-3.0.4" = {
+      name = "graphreduce";
+      packageName = "graphreduce";
+      version = "3.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/graphreduce/-/graphreduce-3.0.4.tgz";
+        sha1 = "bf442d0a878e83901e5ef3e652d23ffb5b831ed7";
       };
     };
     "grunt-known-options-1.1.1" = {
@@ -731,6 +1766,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz";
         sha512 = "+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==";
+      };
+    };
+    "has-1.0.3" = {
+      name = "has";
+      packageName = "has";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has/-/has-1.0.3.tgz";
+        sha512 = "f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==";
+      };
+    };
+    "has-ansi-2.0.0" = {
+      name = "has-ansi";
+      packageName = "has-ansi";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz";
+        sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
+      };
+    };
+    "has-network-0.0.1" = {
+      name = "has-network";
+      packageName = "has-network";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-network/-/has-network-0.0.1.tgz";
+        sha1 = "3eea7b44caa9601797124be8ba89d228c4101499";
+      };
+    };
+    "has-symbols-1.0.0" = {
+      name = "has-symbols";
+      packageName = "has-symbols";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz";
+        sha1 = "ba1a8f1af2a0fc39650f5c850367704122063b44";
       };
     };
     "has-unicode-2.0.1" = {
@@ -778,6 +1849,33 @@ let
         sha1 = "95b0b63fec2146619a6fe57fe75628d5a39efe4f";
       };
     };
+    "hashlru-2.2.1" = {
+      name = "hashlru";
+      packageName = "hashlru";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hashlru/-/hashlru-2.2.1.tgz";
+        sha1 = "10f2099a0d7c05a40f2beaf5c1d39cf2f7dabf36";
+      };
+    };
+    "he-0.5.0" = {
+      name = "he";
+      packageName = "he";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/he/-/he-0.5.0.tgz";
+        sha1 = "2c05ffaef90b68e860f3fd2b54ef580989277ee2";
+      };
+    };
+    "heap-0.2.6" = {
+      name = "heap";
+      packageName = "heap";
+      version = "0.2.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz";
+        sha1 = "087e1f10b046932fc8594dd9e6d378afc9d1e5ac";
+      };
+    };
     "homedir-polyfill-1.0.1" = {
       name = "homedir-polyfill";
       packageName = "homedir-polyfill";
@@ -785,6 +1883,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz";
         sha1 = "4c2bbc8a758998feebf5ed68580f76d46768b4bc";
+      };
+    };
+    "hoox-0.0.1" = {
+      name = "hoox";
+      packageName = "hoox";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz";
+        sha1 = "08a74d9272a9cc83ae8e6bbe0303f0ee76432094";
       };
     };
     "http-signature-1.2.0" = {
@@ -814,6 +1921,15 @@ let
         sha512 = "DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==";
       };
     };
+    "increment-buffer-1.0.1" = {
+      name = "increment-buffer";
+      packageName = "increment-buffer";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz";
+        sha1 = "65076d75189d808b39ad13ab5b958e05216f9e0d";
+      };
+    };
     "inflight-1.0.6" = {
       name = "inflight";
       packageName = "inflight";
@@ -841,6 +1957,15 @@ let
         sha512 = "RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==";
       };
     };
+    "int53-0.2.4" = {
+      name = "int53";
+      packageName = "int53";
+      version = "0.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz";
+        sha1 = "5ed8d7aad6c5c6567cae69aa7ffc4a109ee80f86";
+      };
+    };
     "interpret-1.1.0" = {
       name = "interpret";
       packageName = "interpret";
@@ -848,6 +1973,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz";
         sha1 = "7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614";
+      };
+    };
+    "ip-0.3.3" = {
+      name = "ip";
+      packageName = "ip";
+      version = "0.3.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz";
+        sha1 = "8ee8309e92f0b040d287f72efaca1a21702d3fb4";
+      };
+    };
+    "ip-1.1.5" = {
+      name = "ip";
+      packageName = "ip";
+      version = "1.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz";
+        sha1 = "bdded70114290828c0a039e72ef25f5aaec4354a";
+      };
+    };
+    "irregular-plurals-1.4.0" = {
+      name = "irregular-plurals";
+      packageName = "irregular-plurals";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz";
+        sha1 = "2ca9b033651111855412f16be5d77c62a458a766";
       };
     };
     "is-absolute-1.0.0" = {
@@ -877,6 +2029,33 @@ let
         sha512 = "m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==";
       };
     };
+    "is-alphabetical-1.0.2" = {
+      name = "is-alphabetical";
+      packageName = "is-alphabetical";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz";
+        sha512 = "V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==";
+      };
+    };
+    "is-alphanumerical-1.0.2" = {
+      name = "is-alphanumerical";
+      packageName = "is-alphanumerical";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz";
+        sha512 = "pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==";
+      };
+    };
+    "is-binary-path-1.0.1" = {
+      name = "is-binary-path";
+      packageName = "is-binary-path";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz";
+        sha1 = "75f16642b480f187a711c814161fd3a4a7655898";
+      };
+    };
     "is-buffer-1.1.6" = {
       name = "is-buffer";
       packageName = "is-buffer";
@@ -884,6 +2063,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz";
         sha512 = "NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==";
+      };
+    };
+    "is-callable-1.1.4" = {
+      name = "is-callable";
+      packageName = "is-callable";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz";
+        sha512 = "r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==";
       };
     };
     "is-data-descriptor-0.1.4" = {
@@ -904,6 +2092,24 @@ let
         sha512 = "jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==";
       };
     };
+    "is-date-object-1.0.1" = {
+      name = "is-date-object";
+      packageName = "is-date-object";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz";
+        sha1 = "9aa20eb6aeebbff77fbd33e74ca01b33581d3a16";
+      };
+    };
+    "is-decimal-1.0.2" = {
+      name = "is-decimal";
+      packageName = "is-decimal";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz";
+        sha512 = "TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==";
+      };
+    };
     "is-descriptor-0.1.6" = {
       name = "is-descriptor";
       packageName = "is-descriptor";
@@ -920,6 +2126,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz";
         sha512 = "2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==";
+      };
+    };
+    "is-dotfile-1.0.3" = {
+      name = "is-dotfile";
+      packageName = "is-dotfile";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz";
+        sha1 = "a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1";
+      };
+    };
+    "is-electron-2.1.0" = {
+      name = "is-electron";
+      packageName = "is-electron";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz";
+        sha512 = "dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw==";
+      };
+    };
+    "is-equal-shallow-0.1.3" = {
+      name = "is-equal-shallow";
+      packageName = "is-equal-shallow";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz";
+        sha1 = "2238098fc221de0bcfa5d9eac4c45d638aa1c534";
       };
     };
     "is-extendable-0.1.1" = {
@@ -940,6 +2173,15 @@ let
         sha512 = "arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==";
       };
     };
+    "is-extglob-1.0.0" = {
+      name = "is-extglob";
+      packageName = "is-extglob";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz";
+        sha1 = "ac468177c4943405a092fc8f29760c6ffc6206c0";
+      };
+    };
     "is-extglob-2.1.1" = {
       name = "is-extglob";
       packageName = "is-extglob";
@@ -958,6 +2200,15 @@ let
         sha1 = "ef9e31386f031a7f0d643af82fde50c457ef00cb";
       };
     };
+    "is-glob-2.0.1" = {
+      name = "is-glob";
+      packageName = "is-glob";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz";
+        sha1 = "d096f926a3ded5600f3fdfd91198cb0888c2d863";
+      };
+    };
     "is-glob-3.1.0" = {
       name = "is-glob";
       packageName = "is-glob";
@@ -965,6 +2216,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz";
         sha1 = "7ba5ae24217804ac70707b96922567486cc3e84a";
+      };
+    };
+    "is-hexadecimal-1.0.2" = {
+      name = "is-hexadecimal";
+      packageName = "is-hexadecimal";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz";
+        sha512 = "but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==";
+      };
+    };
+    "is-number-2.1.0" = {
+      name = "is-number";
+      packageName = "is-number";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz";
+        sha1 = "01fcbbb393463a548f2f466cce16dece49db908f";
       };
     };
     "is-number-3.0.0" = {
@@ -976,6 +2245,15 @@ let
         sha1 = "24fd6201a4782cf50561c810276afc7d12d71195";
       };
     };
+    "is-number-4.0.0" = {
+      name = "is-number";
+      packageName = "is-number";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz";
+        sha512 = "rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==";
+      };
+    };
     "is-plain-object-2.0.4" = {
       name = "is-plain-object";
       packageName = "is-plain-object";
@@ -985,6 +2263,33 @@ let
         sha512 = "h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==";
       };
     };
+    "is-posix-bracket-0.1.1" = {
+      name = "is-posix-bracket";
+      packageName = "is-posix-bracket";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz";
+        sha1 = "3334dc79774368e92f016e6fbc0a88f5cd6e6bc4";
+      };
+    };
+    "is-primitive-2.0.0" = {
+      name = "is-primitive";
+      packageName = "is-primitive";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz";
+        sha1 = "207bab91638499c07b2adf240a41a87210034575";
+      };
+    };
+    "is-regex-1.0.4" = {
+      name = "is-regex";
+      packageName = "is-regex";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz";
+        sha1 = "5517489b547091b0930e095654ced25ee97e9491";
+      };
+    };
     "is-relative-1.0.0" = {
       name = "is-relative";
       packageName = "is-relative";
@@ -992,6 +2297,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz";
         sha512 = "Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==";
+      };
+    };
+    "is-symbol-1.0.2" = {
+      name = "is-symbol";
+      packageName = "is-symbol";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz";
+        sha512 = "HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==";
       };
     };
     "is-typedarray-1.0.0" = {
@@ -1012,6 +2326,15 @@ let
         sha512 = "mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==";
       };
     };
+    "is-valid-domain-0.0.6" = {
+      name = "is-valid-domain";
+      packageName = "is-valid-domain";
+      version = "0.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.6.tgz";
+        sha512 = "XXiNRcLcNKeb0LB3PzB39gJa8QiA+6nnc4NX9zNvFQcaITWU+64hfVqaVppbSd3tSVlJttW6sINkX3xLKPax7A==";
+      };
+    };
     "is-windows-1.0.2" = {
       name = "is-windows";
       packageName = "is-windows";
@@ -1019,6 +2342,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz";
         sha512 = "eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==";
+      };
+    };
+    "isarray-0.0.1" = {
+      name = "isarray";
+      packageName = "isarray";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz";
+        sha1 = "8a18acfca9a8f4177e09abfc6038939b05d1eedf";
       };
     };
     "isarray-1.0.0" = {
@@ -1073,6 +2405,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz";
         sha1 = "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513";
+      };
+    };
+    "json-buffer-2.0.11" = {
+      name = "json-buffer";
+      packageName = "json-buffer";
+      version = "2.0.11";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz";
+        sha1 = "3e441fda3098be8d1e3171ad591bc62a33e2d55f";
       };
     };
     "json-schema-0.2.3" = {
@@ -1147,6 +2488,204 @@ let
         sha512 = "s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==";
       };
     };
+    "layered-graph-1.1.1" = {
+      name = "layered-graph";
+      packageName = "layered-graph";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/layered-graph/-/layered-graph-1.1.1.tgz";
+        sha512 = "YqnSwwiLxLdvJBi6ZrUEQEdjv+Z3S5fO1mT6ItWCfZu2tsBG22gr49Bj+hgtMeose/74apZeCx+/T9j4NgMDNA==";
+      };
+    };
+    "level-3.0.2" = {
+      name = "level";
+      packageName = "level";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level/-/level-3.0.2.tgz";
+        sha512 = "2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==";
+      };
+    };
+    "level-4.0.0" = {
+      name = "level";
+      packageName = "level";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level/-/level-4.0.0.tgz";
+        sha512 = "4epzCOlEcJ529NOdlAYiuiakS/kZTDdiKSBNJmE1B8bsmA+zEVwcpxyH86qJSQTpOu7SODrlaD9WgPRHLkGutA==";
+      };
+    };
+    "level-codec-6.2.0" = {
+      name = "level-codec";
+      packageName = "level-codec";
+      version = "6.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz";
+        sha1 = "a4b5244bb6a4c2f723d68a1d64e980c53627d9d4";
+      };
+    };
+    "level-codec-8.0.0" = {
+      name = "level-codec";
+      packageName = "level-codec";
+      version = "8.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz";
+        sha512 = "gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q==";
+      };
+    };
+    "level-codec-9.0.0" = {
+      name = "level-codec";
+      packageName = "level-codec";
+      version = "9.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz";
+        sha512 = "OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg==";
+      };
+    };
+    "level-errors-1.1.2" = {
+      name = "level-errors";
+      packageName = "level-errors";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz";
+        sha512 = "Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==";
+      };
+    };
+    "level-errors-2.0.0" = {
+      name = "level-errors";
+      packageName = "level-errors";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz";
+        sha512 = "AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==";
+      };
+    };
+    "level-iterator-stream-2.0.3" = {
+      name = "level-iterator-stream";
+      packageName = "level-iterator-stream";
+      version = "2.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz";
+        sha512 = "I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==";
+      };
+    };
+    "level-iterator-stream-3.0.1" = {
+      name = "level-iterator-stream";
+      packageName = "level-iterator-stream";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz";
+        sha512 = "nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==";
+      };
+    };
+    "level-packager-2.1.1" = {
+      name = "level-packager";
+      packageName = "level-packager";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz";
+        sha512 = "6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==";
+      };
+    };
+    "level-packager-3.1.0" = {
+      name = "level-packager";
+      packageName = "level-packager";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-packager/-/level-packager-3.1.0.tgz";
+        sha512 = "UxVEfK5WH0u0InR3WxTCSAroiorAGKzXWZT6i+nBjambmvINuXFUsFx2Ai3UIjUUtnyWhluv42jMlzUZCsAk9A==";
+      };
+    };
+    "level-post-1.0.7" = {
+      name = "level-post";
+      packageName = "level-post";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz";
+        sha512 = "PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==";
+      };
+    };
+    "level-sublevel-6.6.5" = {
+      name = "level-sublevel";
+      packageName = "level-sublevel";
+      version = "6.6.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz";
+        sha512 = "SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==";
+      };
+    };
+    "leveldown-3.0.2" = {
+      name = "leveldown";
+      packageName = "leveldown";
+      version = "3.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz";
+        sha512 = "+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==";
+      };
+    };
+    "leveldown-4.0.1" = {
+      name = "leveldown";
+      packageName = "leveldown";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/leveldown/-/leveldown-4.0.1.tgz";
+        sha512 = "ZlBKVSsglPIPJnz4ggB8o2R0bxDxbsMzuQohbfgoFMVApyTE118DK5LNRG0cRju6rt3OkGxe0V6UYACGlq/byg==";
+      };
+    };
+    "levelup-0.19.1" = {
+      name = "levelup";
+      packageName = "levelup";
+      version = "0.19.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz";
+        sha1 = "f3a6a7205272c4b5f35e412ff004a03a0aedf50b";
+      };
+    };
+    "levelup-2.0.2" = {
+      name = "levelup";
+      packageName = "levelup";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz";
+        sha512 = "us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==";
+      };
+    };
+    "levelup-3.1.1" = {
+      name = "levelup";
+      packageName = "levelup";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz";
+        sha512 = "9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==";
+      };
+    };
+    "libnested-1.3.2" = {
+      name = "libnested";
+      packageName = "libnested";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/libnested/-/libnested-1.3.2.tgz";
+        sha512 = "YvMQglpk/DyB8vFL5usJe6IZTqOU/fRopoUpoOt9TavYh5CaGdTp6zYqrA7DW8tHmZAr8fj+pDXbHBwlVrcVXQ==";
+      };
+    };
+    "libsodium-0.7.3" = {
+      name = "libsodium";
+      packageName = "libsodium";
+      version = "0.7.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/libsodium/-/libsodium-0.7.3.tgz";
+        sha512 = "ld+deUNqSsZYbAobUs63UyduPq8ICp/Ul/5lbvBIYpuSNWpPRU0PIxbW+xXipVZtuopR6fIz9e0tTnNuPMNeqw==";
+      };
+    };
+    "libsodium-wrappers-0.7.3" = {
+      name = "libsodium-wrappers";
+      packageName = "libsodium-wrappers";
+      version = "0.7.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.3.tgz";
+        sha512 = "dw5Jh6TZ5qc5rQVZe3JrSO/J05CE+DmAPnqD7Q2glBUE969xZ6o3fchnUxyPlp6ss3x0MFxmdJntveFN+XTg1g==";
+      };
+    };
     "liftoff-2.5.0" = {
       name = "liftoff";
       packageName = "liftoff";
@@ -1154,6 +2693,96 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz";
         sha1 = "2009291bb31cea861bbf10a7c15a28caf75c31ec";
+      };
+    };
+    "log-symbols-1.0.2" = {
+      name = "log-symbols";
+      packageName = "log-symbols";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz";
+        sha1 = "376ff7b58ea3086a0f09facc74617eca501e1a18";
+      };
+    };
+    "log-update-1.0.2" = {
+      name = "log-update";
+      packageName = "log-update";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz";
+        sha1 = "19929f64c4093d2d2e7075a1dad8af59c296b8d1";
+      };
+    };
+    "longest-streak-1.0.0" = {
+      name = "longest-streak";
+      packageName = "longest-streak";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz";
+        sha1 = "d06597c4d4c31b52ccb1f5d8f8fe7148eafd6965";
+      };
+    };
+    "looper-2.0.0" = {
+      name = "looper";
+      packageName = "looper";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz";
+        sha1 = "66cd0c774af3d4fedac53794f742db56da8f09ec";
+      };
+    };
+    "looper-3.0.0" = {
+      name = "looper";
+      packageName = "looper";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz";
+        sha1 = "2efa54c3b1cbaba9b94aee2e5914b0be57fbb749";
+      };
+    };
+    "looper-4.0.0" = {
+      name = "looper";
+      packageName = "looper";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz";
+        sha1 = "7706aded59a99edca06e6b54bb86c8ec19c95155";
+      };
+    };
+    "lossy-store-1.2.3" = {
+      name = "lossy-store";
+      packageName = "lossy-store";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.3.tgz";
+        sha1 = "562e2a9203d8661f60e8712de407fbdadf275dc9";
+      };
+    };
+    "lru-cache-4.1.3" = {
+      name = "lru-cache";
+      packageName = "lru-cache";
+      version = "4.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz";
+        sha512 = "fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==";
+      };
+    };
+    "ltgt-2.1.3" = {
+      name = "ltgt";
+      packageName = "ltgt";
+      version = "2.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz";
+        sha1 = "10851a06d9964b971178441c23c9e52698eece34";
+      };
+    };
+    "ltgt-2.2.1" = {
+      name = "ltgt";
+      packageName = "ltgt";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz";
+        sha1 = "f35ca91c493f7b73da0e07495304f17b31f87ee5";
       };
     };
     "make-iterator-1.0.1" = {
@@ -1174,6 +2803,33 @@ let
         sha1 = "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf";
       };
     };
+    "map-filter-reduce-2.2.1" = {
+      name = "map-filter-reduce";
+      packageName = "map-filter-reduce";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz";
+        sha1 = "632b127c3ae5d6ad9e21cfdd9691b63b8944fcd2";
+      };
+    };
+    "map-filter-reduce-3.2.2" = {
+      name = "map-filter-reduce";
+      packageName = "map-filter-reduce";
+      version = "3.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.2.tgz";
+        sha512 = "p+NIGQbEBxlw/qWwG+NME98G/9kjOQI70hmaH8QEZtIWfTmfMYLKQW4PJChP4izPHNAxlOfv/qefP0+2ZXn84A==";
+      };
+    };
+    "map-merge-1.1.0" = {
+      name = "map-merge";
+      packageName = "map-merge";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz";
+        sha1 = "6a6fc58c95d8aab46c2bdde44d515b6ee06fce34";
+      };
+    };
     "map-visit-1.0.0" = {
       name = "map-visit";
       packageName = "map-visit";
@@ -1181,6 +2837,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz";
         sha1 = "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f";
+      };
+    };
+    "markdown-table-0.4.0" = {
+      name = "markdown-table";
+      packageName = "markdown-table";
+      version = "0.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz";
+        sha1 = "890c2c1b3bfe83fb00e4129b8e4cfe645270f9d1";
+      };
+    };
+    "math-random-1.0.1" = {
+      name = "math-random";
+      packageName = "math-random";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz";
+        sha1 = "8b3aac588b8a66e4975e3cdea67f7bb329601fac";
+      };
+    };
+    "mdmanifest-1.0.8" = {
+      name = "mdmanifest";
+      packageName = "mdmanifest";
+      version = "1.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mdmanifest/-/mdmanifest-1.0.8.tgz";
+        sha1 = "c04891883c28c83602e1d06b05a11037e359b4c8";
+      };
+    };
+    "micromatch-2.3.11" = {
+      name = "micromatch";
+      packageName = "micromatch";
+      version = "2.3.11";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz";
+        sha1 = "86677c97d1720b363431d04d0d15293bd38c1565";
       };
     };
     "micromatch-3.1.10" = {
@@ -1192,22 +2884,31 @@ let
         sha512 = "MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==";
       };
     };
-    "mime-db-1.36.0" = {
+    "mime-db-1.37.0" = {
       name = "mime-db";
       packageName = "mime-db";
-      version = "1.36.0";
+      version = "1.37.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz";
-        sha512 = "L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==";
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz";
+        sha512 = "R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==";
       };
     };
-    "mime-types-2.1.20" = {
+    "mime-types-2.1.21" = {
       name = "mime-types";
       packageName = "mime-types";
-      version = "2.1.20";
+      version = "2.1.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz";
-        sha512 = "HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==";
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz";
+        sha512 = "3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==";
+      };
+    };
+    "mimic-response-1.0.1" = {
+      name = "mimic-response";
+      packageName = "mimic-response";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz";
+        sha512 = "j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==";
       };
     };
     "minimatch-3.0.4" = {
@@ -1237,13 +2938,13 @@ let
         sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
       };
     };
-    "minipass-2.3.4" = {
+    "minipass-2.3.5" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.3.4";
+      version = "2.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz";
-        sha512 = "mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz";
+        sha512 = "Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==";
       };
     };
     "minizlib-1.1.1" = {
@@ -1273,6 +2974,24 @@ let
         sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
       };
     };
+    "monotonic-timestamp-0.0.9" = {
+      name = "monotonic-timestamp";
+      packageName = "monotonic-timestamp";
+      version = "0.0.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz";
+        sha1 = "5ba5adc7aac85e1d7ce77be847161ed246b39603";
+      };
+    };
+    "moo-0.4.3" = {
+      name = "moo";
+      packageName = "moo";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz";
+        sha512 = "gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==";
+      };
+    };
     "ms-2.0.0" = {
       name = "ms";
       packageName = "ms";
@@ -1280,6 +2999,105 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz";
         sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
+      };
+    };
+    "multiblob-1.13.1" = {
+      name = "multiblob";
+      packageName = "multiblob";
+      version = "1.13.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multiblob/-/multiblob-1.13.1.tgz";
+        sha512 = "AvU9tbDqf3TxYgF1ldo3nVz4HoKI/ZDJBo/znLc6KCRiqr7dQv5vW3i3xh0JKZdLzgKG9JpUiKtwB8E92gn3ZQ==";
+      };
+    };
+    "multiblob-http-0.4.2" = {
+      name = "multiblob-http";
+      packageName = "multiblob-http";
+      version = "0.4.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.4.2.tgz";
+        sha512 = "hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==";
+      };
+    };
+    "multicb-1.2.2" = {
+      name = "multicb";
+      packageName = "multicb";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz";
+        sha512 = "PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ==";
+      };
+    };
+    "multiserver-1.13.7" = {
+      name = "multiserver";
+      packageName = "multiserver";
+      version = "1.13.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multiserver/-/multiserver-1.13.7.tgz";
+        sha512 = "nQKAe6+u7nWJY29pJjegltw0ROj2bDc2bCTm9Bnr4EQrp5H5Tav+ESUjgl3D4vuQgCeveb4h+CtLtjB8QnK1Dw==";
+      };
+    };
+    "multiserver-address-1.0.1" = {
+      name = "multiserver-address";
+      packageName = "multiserver-address";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multiserver-address/-/multiserver-address-1.0.1.tgz";
+        sha512 = "IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==";
+      };
+    };
+    "muxrpc-6.4.1" = {
+      name = "muxrpc";
+      packageName = "muxrpc";
+      version = "6.4.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.1.tgz";
+        sha512 = "r8+tucKMmQiYd8NWGQqAA5r+SlYuU30D/WbYo7E/PztG/jmizQJY5NfmLIJ+GWo+dEC6kIxkr0eY+U0uZexTNg==";
+      };
+    };
+    "muxrpc-validation-2.0.1" = {
+      name = "muxrpc-validation";
+      packageName = "muxrpc-validation";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-2.0.1.tgz";
+        sha1 = "cd650d172025fe9d064230aab38ca6328dd16f2f";
+      };
+    };
+    "muxrpcli-1.1.0" = {
+      name = "muxrpcli";
+      packageName = "muxrpcli";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/muxrpcli/-/muxrpcli-1.1.0.tgz";
+        sha1 = "4ae9ba986ab825c4a5c12fcb71c6daa81eab5158";
+      };
+    };
+    "mv-2.1.1" = {
+      name = "mv";
+      packageName = "mv";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz";
+        sha1 = "ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2";
+      };
+    };
+    "nan-2.10.0" = {
+      name = "nan";
+      packageName = "nan";
+      version = "2.10.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz";
+        sha512 = "bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==";
+      };
+    };
+    "nan-2.11.1" = {
+      name = "nan";
+      packageName = "nan";
+      version = "2.11.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz";
+        sha512 = "iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==";
       };
     };
     "nanomatch-1.2.13" = {
@@ -1291,6 +3109,24 @@ let
         sha512 = "fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==";
       };
     };
+    "ncp-2.0.0" = {
+      name = "ncp";
+      packageName = "ncp";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz";
+        sha1 = "195a21d6c46e361d2fb1281ba38b91e9df7bdbb3";
+      };
+    };
+    "nearley-2.15.1" = {
+      name = "nearley";
+      packageName = "nearley";
+      version = "2.15.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz";
+        sha512 = "8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==";
+      };
+    };
     "needle-2.2.4" = {
       name = "needle";
       packageName = "needle";
@@ -1298,6 +3134,51 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz";
         sha512 = "HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==";
+      };
+    };
+    "node-abi-2.4.5" = {
+      name = "node-abi";
+      packageName = "node-abi";
+      version = "2.4.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-abi/-/node-abi-2.4.5.tgz";
+        sha512 = "aa/UC6Nr3+tqhHGRsAuw/edz7/q9nnetBrKWxj6rpTtm+0X9T1qU7lIEHMS3yN9JwAbRiKUbRRFy1PLz/y3aaA==";
+      };
+    };
+    "node-gyp-build-3.5.0" = {
+      name = "node-gyp-build";
+      packageName = "node-gyp-build";
+      version = "3.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.5.0.tgz";
+        sha512 = "qjEE8eIWVyqZhkAFUzytGpOGvLHeX5kXBB6MYyTOCPZBrBlsLyXAAzTsp/hWMbVlg8kVpzDJCZZowIrnKpwmqQ==";
+      };
+    };
+    "nomnom-1.6.2" = {
+      name = "nomnom";
+      packageName = "nomnom";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz";
+        sha1 = "84a66a260174408fc5b77a18f888eccc44fb6971";
+      };
+    };
+    "non-private-ip-1.4.4" = {
+      name = "non-private-ip";
+      packageName = "non-private-ip";
+      version = "1.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz";
+        sha512 = "K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==";
+      };
+    };
+    "noop-logger-0.1.1" = {
+      name = "noop-logger";
+      packageName = "noop-logger";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz";
+        sha1 = "94a2b1633c4f1317553007d8966fd0e841b6a4c2";
       };
     };
     "nopt-3.0.6" = {
@@ -1318,6 +3199,24 @@ let
         sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
       };
     };
+    "normalize-path-2.1.1" = {
+      name = "normalize-path";
+      packageName = "normalize-path";
+      version = "2.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz";
+        sha1 = "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9";
+      };
+    };
+    "normalize-uri-1.1.1" = {
+      name = "normalize-uri";
+      packageName = "normalize-uri";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.1.tgz";
+        sha512 = "bui9/kzRGymbkxJsZEBZgDHK2WJWGOHzR0pCr404EpkpVFTkCOYaRwQTlehUE+7oI70mWNENncCWqUxT/icfHw==";
+      };
+    };
     "npm-bundled-1.0.5" = {
       name = "npm-bundled";
       packageName = "npm-bundled";
@@ -1334,6 +3233,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz";
         sha512 = "WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==";
+      };
+    };
+    "npm-prefix-1.2.0" = {
+      name = "npm-prefix";
+      packageName = "npm-prefix";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz";
+        sha1 = "e619455f7074ba54cc66d6d0d37dd9f1be6bcbc0";
       };
     };
     "npmlog-4.1.2" = {
@@ -1381,6 +3289,24 @@ let
         sha1 = "7e7d858b781bd7c991a41ba975ed3812754e998c";
       };
     };
+    "object-inspect-1.6.0" = {
+      name = "object-inspect";
+      packageName = "object-inspect";
+      version = "1.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz";
+        sha512 = "GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==";
+      };
+    };
+    "object-keys-1.0.12" = {
+      name = "object-keys";
+      packageName = "object-keys";
+      version = "1.0.12";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz";
+        sha512 = "FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==";
+      };
+    };
     "object-visit-1.0.1" = {
       name = "object-visit";
       packageName = "object-visit";
@@ -1408,6 +3334,15 @@ let
         sha1 = "cf83e59dc8fcc0ad5f4250e1f78b3b81bd801d37";
       };
     };
+    "object.omit-2.0.1" = {
+      name = "object.omit";
+      packageName = "object.omit";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz";
+        sha1 = "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa";
+      };
+    };
     "object.pick-1.3.0" = {
       name = "object.pick";
       packageName = "object.pick";
@@ -1417,6 +3352,60 @@ let
         sha1 = "87a10ac4c1694bd2e1cbf53591a66141fb5dd747";
       };
     };
+    "observ-0.2.0" = {
+      name = "observ";
+      packageName = "observ";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz";
+        sha1 = "0bc39b3e29faa5f9e6caa5906cb8392df400aa68";
+      };
+    };
+    "observ-debounce-1.1.1" = {
+      name = "observ-debounce";
+      packageName = "observ-debounce";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz";
+        sha1 = "304e97c85adda70ecd7f08da450678ef90f0b707";
+      };
+    };
+    "obv-0.0.0" = {
+      name = "obv";
+      packageName = "obv";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz";
+        sha1 = "edeab8468f91d4193362ed7f91d0b96dd39a79c1";
+      };
+    };
+    "obv-0.0.1" = {
+      name = "obv";
+      packageName = "obv";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz";
+        sha1 = "cb236106341536f0dac4815e06708221cad7fb5e";
+      };
+    };
+    "on-change-network-0.0.2" = {
+      name = "on-change-network";
+      packageName = "on-change-network";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/on-change-network/-/on-change-network-0.0.2.tgz";
+        sha1 = "d977249477f91726949d80e82346dab6ef45216b";
+      };
+    };
+    "on-wakeup-1.0.1" = {
+      name = "on-wakeup";
+      packageName = "on-wakeup";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz";
+        sha1 = "00d79d987dde7c8117bee74bb4903f6f6dafa52b";
+      };
+    };
     "once-1.4.0" = {
       name = "once";
       packageName = "once";
@@ -1424,6 +3413,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/once/-/once-1.4.0.tgz";
         sha1 = "583b1aa775961d4b113ac17d9c50baef9dd76bd1";
+      };
+    };
+    "onetime-1.1.0" = {
+      name = "onetime";
+      packageName = "onetime";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz";
+        sha1 = "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789";
+      };
+    };
+    "opencollective-postinstall-2.0.1" = {
+      name = "opencollective-postinstall";
+      packageName = "opencollective-postinstall";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.1.tgz";
+        sha512 = "saQQ9hjLwu/oS0492eyYotoh+bra1819cfAT5rjY/e4REWwuc8IgZ844Oo44SiftWcJuBiqp0SA0BFVbmLX0IQ==";
+      };
+    };
+    "options-0.0.6" = {
+      name = "options";
+      packageName = "options";
+      version = "0.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/options/-/options-0.0.6.tgz";
+        sha1 = "ec22d312806bb53e731773e7cdaefcf1c643128f";
       };
     };
     "os-homedir-1.0.2" = {
@@ -1453,6 +3469,33 @@ let
         sha512 = "0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==";
       };
     };
+    "packet-stream-2.0.4" = {
+      name = "packet-stream";
+      packageName = "packet-stream";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/packet-stream/-/packet-stream-2.0.4.tgz";
+        sha512 = "7+oxHdMMs6VhLvvbrDUc8QNuelE9fPKLDdToXBIKLPKOlnoBeMim+/35edp+AnFTLzk3xcogVvQ/jrZyyGsEiw==";
+      };
+    };
+    "packet-stream-codec-1.1.2" = {
+      name = "packet-stream-codec";
+      packageName = "packet-stream-codec";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz";
+        sha1 = "79b302fc144cdfbb4ab6feba7040e6a5d99c79c7";
+      };
+    };
+    "parse-entities-1.2.0" = {
+      name = "parse-entities";
+      packageName = "parse-entities";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz";
+        sha512 = "XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==";
+      };
+    };
     "parse-filepath-1.0.2" = {
       name = "parse-filepath";
       packageName = "parse-filepath";
@@ -1460,6 +3503,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz";
         sha1 = "a632127f53aaf3d15876f5872f3ffac763d6c891";
+      };
+    };
+    "parse-glob-3.0.4" = {
+      name = "parse-glob";
+      packageName = "parse-glob";
+      version = "3.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz";
+        sha1 = "b2c376cfb11f35513badd173ef0bb6e3a388391c";
       };
     };
     "parse-passwd-1.0.0" = {
@@ -1525,6 +3577,42 @@ let
         sha1 = "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b";
       };
     };
+    "pify-2.3.0" = {
+      name = "pify";
+      packageName = "pify";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz";
+        sha1 = "ed141a6ac043a849ea588498e7dca8b15330e90c";
+      };
+    };
+    "pinkie-2.0.4" = {
+      name = "pinkie";
+      packageName = "pinkie";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz";
+        sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
+      };
+    };
+    "pinkie-promise-2.0.1" = {
+      name = "pinkie-promise";
+      packageName = "pinkie-promise";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz";
+        sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
+      };
+    };
+    "plur-2.1.2" = {
+      name = "plur";
+      packageName = "plur";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz";
+        sha1 = "7482452c1a0f508e3e344eaec312c91c29dc655a";
+      };
+    };
     "posix-character-classes-0.1.1" = {
       name = "posix-character-classes";
       packageName = "posix-character-classes";
@@ -1532,6 +3620,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz";
         sha1 = "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab";
+      };
+    };
+    "prebuild-install-4.0.0" = {
+      name = "prebuild-install";
+      packageName = "prebuild-install";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz";
+        sha512 = "7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==";
+      };
+    };
+    "preserve-0.2.0" = {
+      name = "preserve";
+      packageName = "preserve";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz";
+        sha1 = "815ed1f6ebc65926f865b310c0713bcb3315ce4b";
+      };
+    };
+    "private-box-0.3.0" = {
+      name = "private-box";
+      packageName = "private-box";
+      version = "0.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/private-box/-/private-box-0.3.0.tgz";
+        sha512 = "zsK6DDEC+cnNiunYamcVbx4ZCLbKnzTOZa09K4Pj3/tH3nQFPUO9K2QoYy4kfxLqmoyw6RPDtACN9OYviMQZ2Q==";
       };
     };
     "process-nextick-args-2.0.0" = {
@@ -1543,6 +3658,33 @@ let
         sha512 = "MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==";
       };
     };
+    "prr-0.0.0" = {
+      name = "prr";
+      packageName = "prr";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz";
+        sha1 = "1a84b85908325501411853d0081ee3fa86e2926a";
+      };
+    };
+    "prr-1.0.1" = {
+      name = "prr";
+      packageName = "prr";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz";
+        sha1 = "d3fc114ba06995a45ec6893f484ceb1d78f5f476";
+      };
+    };
+    "pseudomap-1.0.2" = {
+      name = "pseudomap";
+      packageName = "pseudomap";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz";
+        sha1 = "f052a28da70e618917ef0a8ac34c1ae5a68286b3";
+      };
+    };
     "psl-1.1.29" = {
       name = "psl";
       packageName = "psl";
@@ -1550,6 +3692,420 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz";
         sha512 = "AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==";
+      };
+    };
+    "pull-abortable-4.0.0" = {
+      name = "pull-abortable";
+      packageName = "pull-abortable";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz";
+        sha1 = "7017a984c3b834de77bac38c10b776f22dfc1843";
+      };
+    };
+    "pull-abortable-4.1.1" = {
+      name = "pull-abortable";
+      packageName = "pull-abortable";
+      version = "4.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz";
+        sha1 = "b3ad5aefb4116b25916d26db89393ac98d0dcea1";
+      };
+    };
+    "pull-box-stream-1.0.13" = {
+      name = "pull-box-stream";
+      packageName = "pull-box-stream";
+      version = "1.0.13";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz";
+        sha1 = "c3e240398eab3f5951b2ed1078c5988bf7a0a2b9";
+      };
+    };
+    "pull-cat-1.1.11" = {
+      name = "pull-cat";
+      packageName = "pull-cat";
+      version = "1.1.11";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz";
+        sha1 = "b642dd1255da376a706b6db4fa962f5fdb74c31b";
+      };
+    };
+    "pull-cont-0.0.0" = {
+      name = "pull-cont";
+      packageName = "pull-cont";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz";
+        sha1 = "3fac48b81ac97b75ba01332088b0ce7af8c1be0e";
+      };
+    };
+    "pull-cont-0.1.1" = {
+      name = "pull-cont";
+      packageName = "pull-cont";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz";
+        sha1 = "df1d580e271757ba9acbaeba20de2421d660d618";
+      };
+    };
+    "pull-core-1.1.0" = {
+      name = "pull-core";
+      packageName = "pull-core";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz";
+        sha1 = "3d8127d6dac1475705c9800961f59d66c8046c8a";
+      };
+    };
+    "pull-cursor-3.0.0" = {
+      name = "pull-cursor";
+      packageName = "pull-cursor";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz";
+        sha512 = "95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==";
+      };
+    };
+    "pull-defer-0.2.3" = {
+      name = "pull-defer";
+      packageName = "pull-defer";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz";
+        sha512 = "/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==";
+      };
+    };
+    "pull-file-0.5.0" = {
+      name = "pull-file";
+      packageName = "pull-file";
+      version = "0.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz";
+        sha1 = "b3ca405306e082f9d4528288933badb2b656365b";
+      };
+    };
+    "pull-file-1.1.0" = {
+      name = "pull-file";
+      packageName = "pull-file";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz";
+        sha1 = "1dd987605d6357a0d23c1e4b826f7915a215129c";
+      };
+    };
+    "pull-flatmap-0.0.1" = {
+      name = "pull-flatmap";
+      packageName = "pull-flatmap";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz";
+        sha1 = "13d494453e8f6d478e7bbfade6f8fe0197fa6bb7";
+      };
+    };
+    "pull-fs-1.1.6" = {
+      name = "pull-fs";
+      packageName = "pull-fs";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz";
+        sha1 = "f184f6a7728bb4d95641376bead69f6f66df47cd";
+      };
+    };
+    "pull-glob-1.0.7" = {
+      name = "pull-glob";
+      packageName = "pull-glob";
+      version = "1.0.7";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.7.tgz";
+        sha1 = "eef915dde644bddbea8dd2e0106d544aacbcd5c2";
+      };
+    };
+    "pull-goodbye-0.0.2" = {
+      name = "pull-goodbye";
+      packageName = "pull-goodbye";
+      version = "0.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz";
+        sha1 = "8d8357db55e22a710dfff0f16a8c90b45efe4171";
+      };
+    };
+    "pull-handshake-1.1.4" = {
+      name = "pull-handshake";
+      packageName = "pull-handshake";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz";
+        sha1 = "6000a0fd018884cdfd737254f8cc60ab2a637791";
+      };
+    };
+    "pull-hash-1.0.0" = {
+      name = "pull-hash";
+      packageName = "pull-hash";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-hash/-/pull-hash-1.0.0.tgz";
+        sha1 = "fcad4d2507bf2c2b3231f653dc9bfb2db4f0d88c";
+      };
+    };
+    "pull-inactivity-2.1.3" = {
+      name = "pull-inactivity";
+      packageName = "pull-inactivity";
+      version = "2.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.3.tgz";
+        sha512 = "swJ/jwkIN/O1bQCE3iY7Xy9r3gYuJ50MXaxZilw/HIduAy4tJu+vcz2/If0L+xNK7Ku/FfjtVbTpRTe7sf3hmA==";
+      };
+    };
+    "pull-level-2.0.4" = {
+      name = "pull-level";
+      packageName = "pull-level";
+      version = "2.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz";
+        sha512 = "fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==";
+      };
+    };
+    "pull-live-1.0.1" = {
+      name = "pull-live";
+      packageName = "pull-live";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz";
+        sha1 = "a4ecee01e330155e9124bbbcf4761f21b38f51f5";
+      };
+    };
+    "pull-looper-1.0.0" = {
+      name = "pull-looper";
+      packageName = "pull-looper";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz";
+        sha512 = "djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==";
+      };
+    };
+    "pull-many-1.0.8" = {
+      name = "pull-many";
+      packageName = "pull-many";
+      version = "1.0.8";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz";
+        sha1 = "3dadd9b6d156c545721bda8d0003dd8eaa06293e";
+      };
+    };
+    "pull-next-1.0.1" = {
+      name = "pull-next";
+      packageName = "pull-next";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-next/-/pull-next-1.0.1.tgz";
+        sha1 = "03f4d7d19872fc1114161e88db6ecf4c65e61e56";
+      };
+    };
+    "pull-notify-0.1.1" = {
+      name = "pull-notify";
+      packageName = "pull-notify";
+      version = "0.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz";
+        sha1 = "6f86ff95d270b89c3ebf255b6031b7032dc99cca";
+      };
+    };
+    "pull-pair-1.1.0" = {
+      name = "pull-pair";
+      packageName = "pull-pair";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz";
+        sha1 = "7ee427263fdf4da825397ac0a05e1ab4b74bd76d";
+      };
+    };
+    "pull-paramap-1.2.2" = {
+      name = "pull-paramap";
+      packageName = "pull-paramap";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz";
+        sha1 = "51a4193ce9c8d7215d95adad45e2bcdb8493b23a";
+      };
+    };
+    "pull-ping-2.0.2" = {
+      name = "pull-ping";
+      packageName = "pull-ping";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz";
+        sha1 = "7bc4a340167dad88f682a196c63485735c7a0894";
+      };
+    };
+    "pull-pushable-2.2.0" = {
+      name = "pull-pushable";
+      packageName = "pull-pushable";
+      version = "2.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz";
+        sha1 = "5f2f3aed47ad86919f01b12a2e99d6f1bd776581";
+      };
+    };
+    "pull-rate-1.0.2" = {
+      name = "pull-rate";
+      packageName = "pull-rate";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz";
+        sha1 = "17b231ad5f359f675826670172b0e590c8964e8d";
+      };
+    };
+    "pull-reader-1.3.1" = {
+      name = "pull-reader";
+      packageName = "pull-reader";
+      version = "1.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz";
+        sha512 = "CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw==";
+      };
+    };
+    "pull-sink-through-0.0.0" = {
+      name = "pull-sink-through";
+      packageName = "pull-sink-through";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz";
+        sha1 = "d3c0492f3a80b4ed204af67c4b4f935680fc5b1f";
+      };
+    };
+    "pull-sort-1.0.1" = {
+      name = "pull-sort";
+      packageName = "pull-sort";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.1.tgz";
+        sha1 = "a8ab0c70c86f45343c9accc939fc42769ad3dc6d";
+      };
+    };
+    "pull-stream-2.28.4" = {
+      name = "pull-stream";
+      packageName = "pull-stream";
+      version = "2.28.4";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz";
+        sha1 = "7ea97413c1619c20bc3bdf9e10e91347b03253e4";
+      };
+    };
+    "pull-stream-3.5.0" = {
+      name = "pull-stream";
+      packageName = "pull-stream";
+      version = "3.5.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz";
+        sha1 = "1ee5b6f76fd3b3a49a5afb6ded5c0320acb3cfc7";
+      };
+    };
+    "pull-stream-3.6.9" = {
+      name = "pull-stream";
+      packageName = "pull-stream";
+      version = "3.6.9";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz";
+        sha512 = "hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw==";
+      };
+    };
+    "pull-stream-to-stream-1.3.4" = {
+      name = "pull-stream-to-stream";
+      packageName = "pull-stream-to-stream";
+      version = "1.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz";
+        sha1 = "3f81d8216bd18d2bfd1a198190471180e2738399";
+      };
+    };
+    "pull-stringify-1.2.2" = {
+      name = "pull-stringify";
+      packageName = "pull-stringify";
+      version = "1.2.2";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/pull-stringify/-/pull-stringify-1.2.2.tgz";
+        sha1 = "5a1c34e0075faf2f2f6d46004e36dccd33bd7c7c";
+      };
+    };
+    "pull-through-1.0.18" = {
+      name = "pull-through";
+      packageName = "pull-through";
+      version = "1.0.18";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz";
+        sha1 = "8dd62314263e59cf5096eafbb127a2b6ef310735";
+      };
+    };
+    "pull-traverse-1.0.3" = {
+      name = "pull-traverse";
+      packageName = "pull-traverse";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz";
+        sha1 = "74fb5d7be7fa6bd7a78e97933e199b7945866938";
+      };
+    };
+    "pull-utf8-decoder-1.0.2" = {
+      name = "pull-utf8-decoder";
+      packageName = "pull-utf8-decoder";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz";
+        sha1 = "a7afa2384d1e6415a5d602054126cc8de3bcbce7";
+      };
+    };
+    "pull-window-2.1.4" = {
+      name = "pull-window";
+      packageName = "pull-window";
+      version = "2.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz";
+        sha1 = "fc3b86feebd1920c7ae297691e23f705f88552f0";
+      };
+    };
+    "pull-write-1.1.4" = {
+      name = "pull-write";
+      packageName = "pull-write";
+      version = "1.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz";
+        sha1 = "dddea31493b48f6768b84a281d01eb3b531fe0b8";
+      };
+    };
+    "pull-write-file-0.2.4" = {
+      name = "pull-write-file";
+      packageName = "pull-write-file";
+      version = "0.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz";
+        sha1 = "437344aeb2189f65e678ed1af37f0f760a5453ef";
+      };
+    };
+    "pull-ws-3.3.1" = {
+      name = "pull-ws";
+      packageName = "pull-ws";
+      version = "3.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz";
+        sha512 = "kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==";
+      };
+    };
+    "pump-1.0.3" = {
+      name = "pump";
+      packageName = "pump";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz";
+        sha512 = "8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==";
+      };
+    };
+    "pump-2.0.1" = {
+      name = "pump";
+      packageName = "pump";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz";
+        sha512 = "ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==";
       };
     };
     "punycode-1.4.1" = {
@@ -1561,6 +4117,24 @@ let
         sha1 = "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e";
       };
     };
+    "push-stream-10.0.4" = {
+      name = "push-stream";
+      packageName = "push-stream";
+      version = "10.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/push-stream/-/push-stream-10.0.4.tgz";
+        sha512 = "IrP96RziNzT4UR7ZffM26o2NQ/Dq0dlRi1p8S/HE4+pHF6OaKWS1DyaJevsxJ6Q8bHafLqin6/pwI36FCmiV0w==";
+      };
+    };
+    "push-stream-to-pull-stream-1.0.3" = {
+      name = "push-stream-to-pull-stream";
+      packageName = "push-stream-to-pull-stream";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/push-stream-to-pull-stream/-/push-stream-to-pull-stream-1.0.3.tgz";
+        sha512 = "pdE/OKi/jnp9DqGgNRzLY0oVHffn/8TXJmBPzv+ikdvpkeA0J//l5d7TZk1yWwZj9P0JcOIEVDOuHzhXaeBlmw==";
+      };
+    };
     "qs-6.5.2" = {
       name = "qs";
       packageName = "qs";
@@ -1568,6 +4142,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz";
         sha512 = "N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==";
+      };
+    };
+    "railroad-diagrams-1.0.0" = {
+      name = "railroad-diagrams";
+      packageName = "railroad-diagrams";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz";
+        sha1 = "eb7e6267548ddedfb899c1b90e57374559cddb7e";
+      };
+    };
+    "randexp-0.4.6" = {
+      name = "randexp";
+      packageName = "randexp";
+      version = "0.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz";
+        sha512 = "80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==";
+      };
+    };
+    "randomatic-3.1.1" = {
+      name = "randomatic";
+      packageName = "randomatic";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz";
+        sha512 = "TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==";
       };
     };
     "rc-1.2.8" = {
@@ -1579,6 +4180,15 @@ let
         sha512 = "y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==";
       };
     };
+    "readable-stream-1.0.34" = {
+      name = "readable-stream";
+      packageName = "readable-stream";
+      version = "1.0.34";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz";
+        sha1 = "125820e34bc842d2f2aaafafe4c2916ee32c157c";
+      };
+    };
     "readable-stream-2.3.6" = {
       name = "readable-stream";
       packageName = "readable-stream";
@@ -1586,6 +4196,15 @@ let
       src = fetchurl {
         url = "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz";
         sha512 = "tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==";
+      };
+    };
+    "readdirp-2.2.1" = {
+      name = "readdirp";
+      packageName = "readdirp";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz";
+        sha512 = "1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==";
       };
     };
     "rechoir-0.6.2" = {
@@ -1597,6 +4216,15 @@ let
         sha1 = "85204b54dba82d5742e28c96756ef43af50e3384";
       };
     };
+    "regex-cache-0.4.4" = {
+      name = "regex-cache";
+      packageName = "regex-cache";
+      version = "0.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz";
+        sha512 = "nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==";
+      };
+    };
     "regex-not-1.0.2" = {
       name = "regex-not";
       packageName = "regex-not";
@@ -1604,6 +4232,42 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz";
         sha512 = "J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==";
+      };
+    };
+    "relative-url-1.0.2" = {
+      name = "relative-url";
+      packageName = "relative-url";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz";
+        sha1 = "d21c52a72d6061018bcee9f9c9fc106bf7d65287";
+      };
+    };
+    "remark-3.2.3" = {
+      name = "remark";
+      packageName = "remark";
+      version = "3.2.3";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/remark/-/remark-3.2.3.tgz";
+        sha1 = "802a38c3aa98c9e1e3ea015eeba211d27cb65e1f";
+      };
+    };
+    "remark-html-2.0.2" = {
+      name = "remark-html";
+      packageName = "remark-html";
+      version = "2.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz";
+        sha1 = "592a347bdd3d5881f4f080c98b5b152fb1407a92";
+      };
+    };
+    "remove-trailing-separator-1.1.0" = {
+      name = "remove-trailing-separator";
+      packageName = "remove-trailing-separator";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz";
+        sha1 = "c24bce2a283adad5bc3f58e0d48249b92379d8ef";
       };
     };
     "repeat-element-1.1.3" = {
@@ -1633,6 +4297,15 @@ let
         sha512 = "NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==";
       };
     };
+    "resolve-1.7.1" = {
+      name = "resolve";
+      packageName = "resolve";
+      version = "1.7.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz";
+        sha512 = "c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==";
+      };
+    };
     "resolve-1.8.1" = {
       name = "resolve";
       packageName = "resolve";
@@ -1660,6 +4333,24 @@ let
         sha1 = "2c637fe77c893afd2a663fe21aa9080068e2052a";
       };
     };
+    "restore-cursor-1.0.1" = {
+      name = "restore-cursor";
+      packageName = "restore-cursor";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz";
+        sha1 = "34661f46886327fed2991479152252df92daa541";
+      };
+    };
+    "resumer-0.0.0" = {
+      name = "resumer";
+      packageName = "resumer";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz";
+        sha1 = "f1e8f461e4064ba39e82af3cdc2a8c893d076759";
+      };
+    };
     "ret-0.1.15" = {
       name = "ret";
       packageName = "ret";
@@ -1667,6 +4358,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz";
         sha512 = "TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==";
+      };
+    };
+    "rimraf-2.2.8" = {
+      name = "rimraf";
+      packageName = "rimraf";
+      version = "2.2.8";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz";
+        sha1 = "e439be2aaee327321952730f99a8929e4fc50582";
+      };
+    };
+    "rimraf-2.4.5" = {
+      name = "rimraf";
+      packageName = "rimraf";
+      version = "2.4.5";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz";
+        sha1 = "ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da";
       };
     };
     "rimraf-2.6.2" = {
@@ -1692,7 +4401,7 @@ let
       packageName = "safe-regex";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
+        url = "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
         sha1 = "40a3669f3b077d1e943d44629e157dd48023bf2e";
       };
     };
@@ -1714,6 +4423,42 @@ let
         sha512 = "NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==";
       };
     };
+    "secret-handshake-1.1.14" = {
+      name = "secret-handshake";
+      packageName = "secret-handshake";
+      version = "1.1.14";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.14.tgz";
+        sha512 = "e4hiMTahaLiN5XKap1YrifoyT8yRu9yQEZrMTglTBgq8Lv8iChFKLpbmXYeNxy2rCnutuWaQDFbp3sBgl4NQ4g==";
+      };
+    };
+    "secret-stack-4.2.4" = {
+      name = "secret-stack";
+      packageName = "secret-stack";
+      version = "4.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/secret-stack/-/secret-stack-4.2.4.tgz";
+        sha512 = "HUG0YujOk20t7CeQz75dz79XmQQl1qsxEVngF+3l5ZNEHNEO6TJHNKo0OAxAWGKzSWiJDkzKLSnHqqZFNKcrPA==";
+      };
+    };
+    "secure-scuttlebutt-18.5.0" = {
+      name = "secure-scuttlebutt";
+      packageName = "secure-scuttlebutt";
+      version = "18.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.5.0.tgz";
+        sha512 = "b50xp0XAWtd6y4ygw2RRgDxaFNgGqC7XahRt/mC4XhiCe6HoTjpt6j07HVnTDcRtLzNiCPKlFJnYySFTFay2lQ==";
+      };
+    };
+    "semver-5.1.1" = {
+      name = "semver";
+      packageName = "semver";
+      version = "5.1.1";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/semver/-/semver-5.1.1.tgz";
+        sha1 = "a3292a373e6f3e0798da0b20641b9a9c5bc47e19";
+      };
+    };
     "semver-5.3.0" = {
       name = "semver";
       packageName = "semver";
@@ -1730,6 +4475,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz";
         sha512 = "RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==";
+      };
+    };
+    "separator-escape-0.0.0" = {
+      name = "separator-escape";
+      packageName = "separator-escape";
+      version = "0.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz";
+        sha1 = "e433676932020454e3c14870c517ea1de56c2fa4";
       };
     };
     "set-blocking-2.0.0" = {
@@ -1759,6 +4513,51 @@ let
         sha512 = "hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==";
       };
     };
+    "sha.js-2.4.11" = {
+      name = "sha.js";
+      packageName = "sha.js";
+      version = "2.4.11";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz";
+        sha512 = "QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==";
+      };
+    };
+    "sha.js-2.4.5" = {
+      name = "sha.js";
+      packageName = "sha.js";
+      version = "2.4.5";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz";
+        sha1 = "27d171efcc82a118b99639ff581660242b506e7c";
+      };
+    };
+    "shebang-command-1.2.0" = {
+      name = "shebang-command";
+      packageName = "shebang-command";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz";
+        sha1 = "44aac65b695b03398968c39f363fee5deafdf1ea";
+      };
+    };
+    "shebang-regex-1.0.0" = {
+      name = "shebang-regex";
+      packageName = "shebang-regex";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz";
+        sha1 = "da42f49740c0b42db2ca9728571cb190c98efea3";
+      };
+    };
+    "shellsubstitute-1.2.0" = {
+      name = "shellsubstitute";
+      packageName = "shellsubstitute";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz";
+        sha1 = "e4f702a50c518b0f6fe98451890d705af29b6b70";
+      };
+    };
     "signal-exit-3.0.2" = {
       name = "signal-exit";
       packageName = "signal-exit";
@@ -1766,6 +4565,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz";
         sha1 = "b5fdc08f1287ea1178628e415e25132b73646c6d";
+      };
+    };
+    "simple-concat-1.0.0" = {
+      name = "simple-concat";
+      packageName = "simple-concat";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz";
+        sha1 = "7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6";
+      };
+    };
+    "simple-get-2.8.1" = {
+      name = "simple-get";
+      packageName = "simple-get";
+      version = "2.8.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz";
+        sha512 = "lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==";
+      };
+    };
+    "smart-buffer-4.0.1" = {
+      name = "smart-buffer";
+      packageName = "smart-buffer";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz";
+        sha512 = "RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==";
       };
     };
     "snapdragon-0.8.2" = {
@@ -1795,6 +4621,51 @@ let
         sha512 = "mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==";
       };
     };
+    "socks-2.2.1" = {
+      name = "socks";
+      packageName = "socks";
+      version = "2.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/socks/-/socks-2.2.1.tgz";
+        sha512 = "0GabKw7n9mI46vcNrVfs0o6XzWzjVa3h6GaSo2UPxtWAROXUWavfJWh1M4PR5tnE0dcnQXZIDFP4yrAysLze/w==";
+      };
+    };
+    "sodium-browserify-1.2.4" = {
+      name = "sodium-browserify";
+      packageName = "sodium-browserify";
+      version = "1.2.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.4.tgz";
+        sha512 = "IYcxKje/uf/c3a7VhZYJLlUxWMcktfbD4AjqHjUD1/VWKjj0Oq5wNbX8wjJOWVO9UhUMqJQiOn2xFbzKWBmy5w==";
+      };
+    };
+    "sodium-browserify-tweetnacl-0.2.3" = {
+      name = "sodium-browserify-tweetnacl";
+      packageName = "sodium-browserify-tweetnacl";
+      version = "0.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz";
+        sha1 = "b5537ffcbb9f74ebc443b8b6a211b291e8fcbc8e";
+      };
+    };
+    "sodium-chloride-1.1.2" = {
+      name = "sodium-chloride";
+      packageName = "sodium-chloride";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.2.tgz";
+        sha512 = "8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g==";
+      };
+    };
+    "sodium-native-2.2.2" = {
+      name = "sodium-native";
+      packageName = "sodium-native";
+      version = "2.2.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.2.tgz";
+        sha512 = "TdAa+PlmWki2Spx3TJyGFVkj6gLsxs5HV/i/j2COZ5INEaCmLz15NIHgUAT/GQ0KrG8Ddy6tkvuP7B5YJpmW6g==";
+      };
+    };
     "source-map-0.5.7" = {
       name = "source-map";
       packageName = "source-map";
@@ -1822,6 +4693,15 @@ let
         sha1 = "3e935d7ddd73631b97659956d55128e87b5084a3";
       };
     };
+    "split-buffer-1.0.0" = {
+      name = "split-buffer";
+      packageName = "split-buffer";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz";
+        sha1 = "b7e8e0ab51345158b72c1f6dbef2406d51f1d027";
+      };
+    };
     "split-string-3.1.0" = {
       name = "split-string";
       packageName = "split-string";
@@ -1829,6 +4709,114 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz";
         sha512 = "NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==";
+      };
+    };
+    "ssb-blobs-1.1.6" = {
+      name = "ssb-blobs";
+      packageName = "ssb-blobs";
+      version = "1.1.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.6.tgz";
+        sha512 = "/dQIhg19Sk/cnRg25yUFFKhY67eB+Mlx00rK138dCVz3JhKLdmgDbK8kF5Ik/C/DdxDVya3xJZRW0fexwGOAkw==";
+      };
+    };
+    "ssb-client-4.6.0" = {
+      name = "ssb-client";
+      packageName = "ssb-client";
+      version = "4.6.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-client/-/ssb-client-4.6.0.tgz";
+        sha512 = "LyH5Y/U7xvafmAuG1puyhNv4G3Ew9xC67dYgRX0wwbUf5iT422WB1Cvat9qGFAu3/BQbdctXtdEQPxaAn0+hYA==";
+      };
+    };
+    "ssb-config-2.3.6" = {
+      name = "ssb-config";
+      packageName = "ssb-config";
+      version = "2.3.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.6.tgz";
+        sha512 = "gR6og13QBkHxoeGcqVtD4MDPi+4UM2SRadglTIgHRs24lzRhk7YyI9oCESOMYtVmR09i4X24+LruBZbVkyXLBw==";
+      };
+    };
+    "ssb-ebt-5.2.3" = {
+      name = "ssb-ebt";
+      packageName = "ssb-ebt";
+      version = "5.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.2.3.tgz";
+        sha512 = "LTIry3qRZRLqv3l97tcd22dNiLjZHz7Ynot0OQFG10zL4jsECSkSxMUqSwrFUTfZEySUxhAx92TDcafDy+/J3A==";
+      };
+    };
+    "ssb-friends-3.1.4" = {
+      name = "ssb-friends";
+      packageName = "ssb-friends";
+      version = "3.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-3.1.4.tgz";
+        sha512 = "/+1qQ4exI/MpAAZzt7jQW8tI0rKGZh+AEMAm4pNk+FnH/jjxSVwC6zjNRX8sZy8EWpJEb5czYC6j8SCUXtAHSA==";
+      };
+    };
+    "ssb-keys-7.1.3" = {
+      name = "ssb-keys";
+      packageName = "ssb-keys";
+      version = "7.1.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.3.tgz";
+        sha512 = "f66vIZ3LkeMx73enLTkPC9ecTUcUrjtVHvRt45nDmubGMom21Z82JQLWYbQ++09v3JG3B4XEir8inhv6AAISSQ==";
+      };
+    };
+    "ssb-links-3.0.3" = {
+      name = "ssb-links";
+      packageName = "ssb-links";
+      version = "3.0.3";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/ssb-links/-/ssb-links-3.0.3.tgz";
+        sha512 = "x09ShIMjwvdZI7aDZm8kc1v5YCGZa9ulCOoxrf/RYJ98s5gbTfO9CBCzeMBAeQ5kRwSuKjiOxJHdeEBkj4Y6hw==";
+      };
+    };
+    "ssb-msgs-5.2.0" = {
+      name = "ssb-msgs";
+      packageName = "ssb-msgs";
+      version = "5.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz";
+        sha1 = "c681da5cd70c574c922dca4f03c521538135c243";
+      };
+    };
+    "ssb-query-2.3.0" = {
+      name = "ssb-query";
+      packageName = "ssb-query";
+      version = "2.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-query/-/ssb-query-2.3.0.tgz";
+        sha512 = "y4OA2MvGl1jU7bUTYsTmMNSqlPt4eh9401THUW1DO4aFyBFEWvpa3eKJHc8aTmaph2hutPPbdKgEFsWDzw26uw==";
+      };
+    };
+    "ssb-ref-2.13.1" = {
+      name = "ssb-ref";
+      packageName = "ssb-ref";
+      version = "2.13.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.1.tgz";
+        sha512 = "ncxWWvCHwRw7jP6EwY9/GZJRC3WhmEb+2KhPFuvVl0GvJWN46xhSxQniGZ1+nLqc8ixwtn94hlJ7ni9+1pqtpw==";
+      };
+    };
+    "ssb-validate-3.0.11" = {
+      name = "ssb-validate";
+      packageName = "ssb-validate";
+      version = "3.0.11";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-validate/-/ssb-validate-3.0.11.tgz";
+        sha512 = "mZPI9HKZtqPP7Qi26B0GR7HqYmmcELEaoj5zr8TlUcULg9BOZy7f4VSzcKZ36LIkvpuK2sfA6znxIlBLq78fjg==";
+      };
+    };
+    "ssb-ws-3.0.0" = {
+      name = "ssb-ws";
+      packageName = "ssb-ws";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ssb-ws/-/ssb-ws-3.0.0.tgz";
+        sha512 = "Qna9Oa9+MYhv+Xtqmidb6xww2JZAdO6ZzidJleWbOLJTSV2QkkB7aAFpWdYst/N78ZhThPqT/mdgEmWpaCqTbw==";
       };
     };
     "sshpk-1.15.1" = {
@@ -1840,6 +4828,15 @@ let
         sha512 = "mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==";
       };
     };
+    "stack-0.1.0" = {
+      name = "stack";
+      packageName = "stack";
+      version = "0.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stack/-/stack-0.1.0.tgz";
+        sha1 = "e923598a9be51e617682cb21cf1b2818a449ada2";
+      };
+    };
     "static-extend-0.1.2" = {
       name = "static-extend";
       packageName = "static-extend";
@@ -1847,6 +4844,24 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz";
         sha1 = "60809c39cbff55337226fd5e0b520f341f1fb5c6";
+      };
+    };
+    "statistics-3.3.0" = {
+      name = "statistics";
+      packageName = "statistics";
+      version = "3.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz";
+        sha1 = "ec7b4750ff03ab24a64dd9b357a78316bead78aa";
+      };
+    };
+    "stream-to-pull-stream-1.7.2" = {
+      name = "stream-to-pull-stream";
+      packageName = "stream-to-pull-stream";
+      version = "1.7.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz";
+        sha1 = "757609ae1cebd33c7432d4afbe31ff78650b9dde";
       };
     };
     "string-width-1.0.2" = {
@@ -1858,6 +4873,24 @@ let
         sha1 = "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3";
       };
     };
+    "string.prototype.trim-1.1.2" = {
+      name = "string.prototype.trim";
+      packageName = "string.prototype.trim";
+      version = "1.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz";
+        sha1 = "d04de2c89e137f4d7d206f086b5ed2fae6be8cea";
+      };
+    };
+    "string_decoder-0.10.31" = {
+      name = "string_decoder";
+      packageName = "string_decoder";
+      version = "0.10.31";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz";
+        sha1 = "62e203bc41766c6c28c9fc84301dab1c5310fa94";
+      };
+    };
     "string_decoder-1.1.1" = {
       name = "string_decoder";
       packageName = "string_decoder";
@@ -1865,6 +4898,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz";
         sha512 = "n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==";
+      };
+    };
+    "stringify-entities-1.3.2" = {
+      name = "stringify-entities";
+      packageName = "stringify-entities";
+      version = "1.3.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz";
+        sha512 = "nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==";
       };
     };
     "strip-ansi-3.0.1" = {
@@ -1885,6 +4927,24 @@ let
         sha1 = "3c531942e908c2697c0ec344858c286c7ca0a60a";
       };
     };
+    "supports-color-2.0.0" = {
+      name = "supports-color";
+      packageName = "supports-color";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz";
+        sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
+      };
+    };
+    "tape-4.9.1" = {
+      name = "tape";
+      packageName = "tape";
+      version = "4.9.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz";
+        sha512 = "6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==";
+      };
+    };
     "tar-2.2.1" = {
       name = "tar";
       packageName = "tar";
@@ -1901,6 +4961,51 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz";
         sha512 = "tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==";
+      };
+    };
+    "tar-fs-1.16.3" = {
+      name = "tar-fs";
+      packageName = "tar-fs";
+      version = "1.16.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz";
+        sha512 = "NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==";
+      };
+    };
+    "tar-stream-1.6.2" = {
+      name = "tar-stream";
+      packageName = "tar-stream";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz";
+        sha512 = "rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==";
+      };
+    };
+    "text-table-0.2.0" = {
+      name = "text-table";
+      packageName = "text-table";
+      version = "0.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz";
+        sha1 = "7f5ee823ae805207c00af2df4a84ec3fcfa570b4";
+      };
+    };
+    "through-2.3.8" = {
+      name = "through";
+      packageName = "through";
+      version = "2.3.8";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/through/-/through-2.3.8.tgz";
+        sha1 = "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5";
+      };
+    };
+    "to-buffer-1.1.1" = {
+      name = "to-buffer";
+      packageName = "to-buffer";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz";
+        sha512 = "lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==";
       };
     };
     "to-object-path-0.3.0" = {
@@ -1930,6 +5035,15 @@ let
         sha1 = "7c80c17b9dfebe599e27367e0d4dd5590141db38";
       };
     };
+    "to-vfile-1.0.0" = {
+      name = "to-vfile";
+      packageName = "to-vfile";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz";
+        sha1 = "88defecd43adb2ef598625f0e3d59f7f342941ba";
+      };
+    };
     "tough-cookie-2.4.3" = {
       name = "tough-cookie";
       packageName = "tough-cookie";
@@ -1937,6 +5051,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz";
         sha512 = "Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==";
+      };
+    };
+    "trim-0.0.1" = {
+      name = "trim";
+      packageName = "trim";
+      version = "0.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz";
+        sha1 = "5858547f6b290757ee95cccc666fb50084c460dd";
+      };
+    };
+    "trim-lines-1.1.1" = {
+      name = "trim-lines";
+      packageName = "trim-lines";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz";
+        sha512 = "X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg==";
+      };
+    };
+    "trim-trailing-lines-1.1.1" = {
+      name = "trim-trailing-lines";
+      packageName = "trim-trailing-lines";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz";
+        sha512 = "bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==";
       };
     };
     "tunnel-agent-0.6.0" = {
@@ -1957,6 +5098,69 @@ let
         sha1 = "5ae68177f192d4456269d108afa93ff8743f4f64";
       };
     };
+    "tweetnacl-auth-0.3.1" = {
+      name = "tweetnacl-auth";
+      packageName = "tweetnacl-auth";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz";
+        sha1 = "b75bc2df15649bb84e8b9aa3c0669c6c4bce0d25";
+      };
+    };
+    "typedarray-0.0.6" = {
+      name = "typedarray";
+      packageName = "typedarray";
+      version = "0.0.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz";
+        sha1 = "867ac74e3864187b1d3d47d996a78ec5c8830777";
+      };
+    };
+    "typewise-1.0.3" = {
+      name = "typewise";
+      packageName = "typewise";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz";
+        sha1 = "1067936540af97937cc5dcf9922486e9fa284651";
+      };
+    };
+    "typewise-core-1.2.0" = {
+      name = "typewise-core";
+      packageName = "typewise-core";
+      version = "1.2.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz";
+        sha1 = "97eb91805c7f55d2f941748fa50d315d991ef195";
+      };
+    };
+    "typewiselite-1.0.0" = {
+      name = "typewiselite";
+      packageName = "typewiselite";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz";
+        sha1 = "c8882fa1bb1092c06005a97f34ef5c8508e3664e";
+      };
+    };
+    "uint48be-1.0.2" = {
+      name = "uint48be";
+      packageName = "uint48be";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/uint48be/-/uint48be-1.0.2.tgz";
+        sha512 = "jNn1eEi81BLiZfJkjbiAKPDMj7iFrturKazqpBu0aJYLr6evgkn+9rgkX/gUwPBj5j2Ri5oUelsqC/S1zmpWBA==";
+      };
+    };
+    "ultron-1.0.2" = {
+      name = "ultron";
+      packageName = "ultron";
+      version = "1.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz";
+        sha1 = "ace116ab557cd197386a4e88f4685378c8b2e4fa";
+      };
+    };
     "unc-path-regex-0.1.2" = {
       name = "unc-path-regex";
       packageName = "unc-path-regex";
@@ -1964,6 +5168,33 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz";
         sha1 = "e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa";
+      };
+    };
+    "underscore-1.4.4" = {
+      name = "underscore";
+      packageName = "underscore";
+      version = "1.4.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz";
+        sha1 = "61a6a32010622afa07963bf325203cf12239d604";
+      };
+    };
+    "unherit-1.1.1" = {
+      name = "unherit";
+      packageName = "unherit";
+      version = "1.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz";
+        sha512 = "+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==";
+      };
+    };
+    "unified-2.1.4" = {
+      name = "unified";
+      packageName = "unified";
+      version = "2.1.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz";
+        sha1 = "14bc6cd40d98ffff75b405506bad873ecbbac3ba";
       };
     };
     "union-value-1.0.0" = {
@@ -1975,6 +5206,33 @@ let
         sha1 = "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4";
       };
     };
+    "unist-util-is-2.1.2" = {
+      name = "unist-util-is";
+      packageName = "unist-util-is";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz";
+        sha512 = "YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==";
+      };
+    };
+    "unist-util-visit-1.4.0" = {
+      name = "unist-util-visit";
+      packageName = "unist-util-visit";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz";
+        sha512 = "FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==";
+      };
+    };
+    "unist-util-visit-parents-2.0.1" = {
+      name = "unist-util-visit-parents";
+      packageName = "unist-util-visit-parents";
+      version = "2.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz";
+        sha512 = "6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==";
+      };
+    };
     "unset-value-1.0.0" = {
       name = "unset-value";
       packageName = "unset-value";
@@ -1982,6 +5240,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz";
         sha1 = "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559";
+      };
+    };
+    "untildify-2.1.0" = {
+      name = "untildify";
+      packageName = "untildify";
+      version = "2.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz";
+        sha1 = "17eb2807987f76952e9c0485fc311d06a826a2e0";
       };
     };
     "urix-0.1.0" = {
@@ -2000,6 +5267,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/use/-/use-3.1.1.tgz";
         sha512 = "cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==";
+      };
+    };
+    "user-home-2.0.0" = {
+      name = "user-home";
+      packageName = "user-home";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz";
+        sha1 = "9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f";
       };
     };
     "util-deprecate-1.0.2" = {
@@ -2038,6 +5314,60 @@ let
         sha1 = "3a105ca17053af55d6e270c1f8288682e18da400";
       };
     };
+    "vfile-1.4.0" = {
+      name = "vfile";
+      packageName = "vfile";
+      version = "1.4.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz";
+        sha1 = "c0fd6fa484f8debdb771f68c31ed75d88da97fe7";
+      };
+    };
+    "vfile-find-down-1.0.0" = {
+      name = "vfile-find-down";
+      packageName = "vfile-find-down";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz";
+        sha1 = "84a4d66d03513f6140a84e0776ef0848d4f0ad95";
+      };
+    };
+    "vfile-find-up-1.0.0" = {
+      name = "vfile-find-up";
+      packageName = "vfile-find-up";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz";
+        sha1 = "5604da6fe453b34350637984eb5fe4909e280390";
+      };
+    };
+    "vfile-reporter-1.5.0" = {
+      name = "vfile-reporter";
+      packageName = "vfile-reporter";
+      version = "1.5.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz";
+        sha1 = "21a7009bfe55e24df8ff432aa5bf6f6efa74e418";
+      };
+    };
+    "vfile-sort-1.0.0" = {
+      name = "vfile-sort";
+      packageName = "vfile-sort";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "http://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz";
+        sha1 = "17ee491ba43e8951bb22913fcff32a7dc4d234d4";
+      };
+    };
+    "ware-1.3.0" = {
+      name = "ware";
+      packageName = "ware";
+      version = "1.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz";
+        sha1 = "d1b14f39d2e2cb4ab8c4098f756fe4b164e473d4";
+      };
+    };
     "which-1.3.1" = {
       name = "which";
       packageName = "which";
@@ -2045,6 +5375,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/which/-/which-1.3.1.tgz";
         sha512 = "HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==";
+      };
+    };
+    "which-pm-runs-1.0.0" = {
+      name = "which-pm-runs";
+      packageName = "which-pm-runs";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz";
+        sha1 = "670b3afbc552e0b55df6b7780ca74615f23ad1cb";
       };
     };
     "wide-align-1.1.3" = {
@@ -2056,6 +5395,24 @@ let
         sha512 = "QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==";
       };
     };
+    "word-wrap-1.2.3" = {
+      name = "word-wrap";
+      packageName = "word-wrap";
+      version = "1.2.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz";
+        sha512 = "Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==";
+      };
+    };
+    "wrap-fn-0.1.5" = {
+      name = "wrap-fn";
+      packageName = "wrap-fn";
+      version = "0.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz";
+        sha1 = "f21b6e41016ff4a7e31720dbc63a09016bdf9845";
+      };
+    };
     "wrappy-1.0.2" = {
       name = "wrappy";
       packageName = "wrappy";
@@ -2065,6 +5422,42 @@ let
         sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
       };
     };
+    "ws-1.1.5" = {
+      name = "ws";
+      packageName = "ws";
+      version = "1.1.5";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz";
+        sha512 = "o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==";
+      };
+    };
+    "xtend-3.0.0" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "3.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz";
+        sha1 = "5cce7407baf642cba7becda568111c493f59665a";
+      };
+    };
+    "xtend-4.0.1" = {
+      name = "xtend";
+      packageName = "xtend";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz";
+        sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
+      };
+    };
+    "yallist-2.1.2" = {
+      name = "yallist";
+      packageName = "yallist";
+      version = "2.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz";
+        sha1 = "1c11f9218f076089a47dd512f93c6699a6a81d52";
+      };
+    };
     "yallist-3.0.2" = {
       name = "yallist";
       packageName = "yallist";
@@ -2072,6 +5465,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz";
         sha1 = "8452b4bb7e83c7c188d8041c1a837c773d6d8bb9";
+      };
+    };
+    "zerr-1.0.4" = {
+      name = "zerr";
+      packageName = "zerr";
+      version = "1.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz";
+        sha1 = "62814dd799eff8361f2a228f41f705c5e19de4c9";
       };
     };
   };
@@ -2420,11 +5822,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.11"
       sources."gauge-2.7.4"
@@ -2447,8 +5845,8 @@ in
       sources."json-schema-traverse-0.3.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -2554,7 +5952,7 @@ in
       sources."isarray-1.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.4"
+      sources."minipass-2.3.5"
       sources."minizlib-1.1.1"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
@@ -2606,15 +6004,871 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "2.16.3";
+    version = "2.17.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.16.3.tgz";
-      sha512 = "W63qZOC9YGr+33JYvZjvhzvYL4YKT2gAywDJQrHvKTL6vmnnSh+GdM3ZdGIIZ6A57YB3NgvQaq/BJ2uYjwn3ZQ==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.17.4.tgz";
+      sha512 = "yee6uJE9UZJAPF76JC7JqAPK1AKx8fr6ed862OPESYkw2GA0Rf3H/URlaTQSWYTAhP10DJNQ3t5ysbyrr6jzRw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
       description = "Fast, disk space efficient package manager";
       homepage = https://pnpm.js.org/;
+      license = "MIT";
+    };
+    production = true;
+    bypassCache = false;
+  };
+  scuttlebot = nodeEnv.buildNodePackage {
+    name = "scuttlebot";
+    packageName = "scuttlebot";
+    version = "13.0.1";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/scuttlebot/-/scuttlebot-13.0.1.tgz";
+      sha512 = "HLp9h19g8s5XOZfJ/Bq92RFXFMmJhpjNhdZa/JaBfiyLw+k6QQHDPi8xtpTwg91jPx+Gw5Vlfqtv6CECQCzypA==";
+    };
+    dependencies = [
+      sources."abstract-leveldown-4.0.3"
+      (sources."aligned-block-file-1.1.3" // {
+        dependencies = [
+          sources."obv-0.0.0"
+        ];
+      })
+      sources."ansi-escapes-1.4.0"
+      sources."ansi-regex-2.1.1"
+      sources."ansi-styles-2.2.1"
+      sources."anymatch-1.3.2"
+      sources."append-batch-0.0.1"
+      sources."aproba-1.2.0"
+      sources."are-we-there-yet-1.1.5"
+      sources."arr-diff-2.0.0"
+      sources."arr-flatten-1.1.0"
+      sources."arr-union-3.1.0"
+      sources."array-union-1.0.2"
+      sources."array-uniq-1.0.3"
+      sources."array-unique-0.2.1"
+      sources."arrify-1.0.1"
+      sources."assign-symbols-1.0.0"
+      sources."async-each-1.0.1"
+      sources."async-single-1.0.5"
+      sources."async-write-2.1.0"
+      sources."atob-2.1.2"
+      sources."atomic-file-0.0.1"
+      sources."attach-ware-1.1.1"
+      sources."bail-1.0.3"
+      sources."balanced-match-1.0.0"
+      (sources."base-0.11.2" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."base64-url-2.2.0"
+      sources."bash-color-0.0.4"
+      sources."binary-extensions-1.12.0"
+      sources."binary-search-1.3.4"
+      sources."bindings-1.3.0"
+      sources."bl-1.2.2"
+      sources."blake2s-1.0.1"
+      sources."brace-expansion-1.1.11"
+      sources."braces-1.8.5"
+      sources."broadcast-stream-0.2.2"
+      sources."buffer-alloc-1.2.0"
+      sources."buffer-alloc-unsafe-1.1.0"
+      sources."buffer-fill-1.0.0"
+      sources."buffer-from-1.1.1"
+      sources."bytewise-1.1.0"
+      sources."bytewise-core-1.2.3"
+      (sources."cache-base-1.0.1" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."camelcase-2.1.1"
+      sources."canonical-base64-1.1.0"
+      sources."ccount-1.0.3"
+      sources."chalk-1.1.3"
+      sources."character-entities-1.2.2"
+      sources."character-entities-html4-1.1.2"
+      sources."character-entities-legacy-1.1.2"
+      sources."character-reference-invalid-1.1.2"
+      sources."charwise-3.0.1"
+      sources."chloride-2.2.10"
+      sources."chloride-test-1.2.2"
+      sources."chokidar-1.7.0"
+      sources."chownr-1.1.1"
+      (sources."class-utils-0.3.6" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."isobject-3.0.1"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."cli-cursor-1.0.2"
+      sources."co-3.1.0"
+      sources."code-point-at-1.1.0"
+      sources."collapse-white-space-1.0.4"
+      sources."collection-visit-1.0.0"
+      sources."colors-0.5.1"
+      sources."commander-2.19.0"
+      sources."compare-at-paths-1.0.0"
+      sources."component-emitter-1.2.1"
+      sources."concat-map-0.0.1"
+      sources."concat-stream-1.6.2"
+      sources."console-control-strings-1.1.0"
+      sources."cont-1.0.3"
+      sources."continuable-1.2.0"
+      (sources."continuable-hash-0.1.4" // {
+        dependencies = [
+          sources."continuable-1.1.8"
+        ];
+      })
+      (sources."continuable-list-0.1.6" // {
+        dependencies = [
+          sources."continuable-1.1.8"
+        ];
+      })
+      sources."continuable-para-1.2.0"
+      sources."continuable-series-1.2.0"
+      sources."copy-descriptor-0.1.1"
+      sources."core-util-is-1.0.2"
+      sources."cross-spawn-5.1.0"
+      sources."debug-2.6.9"
+      sources."decode-uri-component-0.2.0"
+      sources."decompress-response-3.3.0"
+      sources."deep-equal-1.0.1"
+      sources."deep-extend-0.6.0"
+      sources."deferred-leveldown-3.0.0"
+      sources."define-properties-1.1.3"
+      (sources."define-property-2.0.2" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."defined-1.0.0"
+      sources."delegates-1.0.0"
+      sources."detab-1.0.2"
+      sources."detect-libc-1.0.3"
+      sources."discontinuous-range-1.0.0"
+      sources."dynamic-dijkstra-1.0.0"
+      sources."ed2curve-0.1.4"
+      sources."elegant-spinner-1.0.1"
+      sources."emoji-named-characters-1.0.2"
+      sources."emoji-server-1.0.0"
+      (sources."encoding-down-4.0.1" // {
+        dependencies = [
+          sources."level-codec-8.0.0"
+        ];
+      })
+      sources."end-of-stream-1.4.1"
+      sources."epidemic-broadcast-trees-6.3.4"
+      sources."errno-0.1.7"
+      sources."es-abstract-1.12.0"
+      sources."es-to-primitive-1.2.0"
+      sources."escape-string-regexp-1.0.5"
+      sources."exit-hook-1.1.1"
+      sources."expand-brackets-0.1.5"
+      sources."expand-range-1.8.2"
+      sources."expand-template-1.1.1"
+      sources."explain-error-1.0.4"
+      sources."extend-3.0.2"
+      (sources."extend-shallow-3.0.2" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."extend.js-0.0.2"
+      sources."extglob-0.3.2"
+      sources."fast-future-1.0.2"
+      sources."filename-regex-2.0.1"
+      sources."fill-range-2.2.4"
+      sources."flumecodec-0.0.1"
+      sources."flumedb-0.5.1"
+      (sources."flumelog-offset-3.3.2" // {
+        dependencies = [
+          sources."looper-4.0.0"
+        ];
+      })
+      (sources."flumeview-hashtable-1.0.4" // {
+        dependencies = [
+          sources."atomic-file-1.1.5"
+        ];
+      })
+      (sources."flumeview-level-3.0.6" // {
+        dependencies = [
+          sources."obv-0.0.0"
+        ];
+      })
+      (sources."flumeview-query-6.3.0" // {
+        dependencies = [
+          sources."map-filter-reduce-3.2.2"
+        ];
+      })
+      (sources."flumeview-reduce-1.3.14" // {
+        dependencies = [
+          sources."atomic-file-1.1.5"
+          sources."flumecodec-0.0.0"
+          sources."obv-0.0.0"
+        ];
+      })
+      sources."for-each-0.3.3"
+      sources."for-in-1.0.2"
+      sources."for-own-0.1.5"
+      sources."fragment-cache-0.2.1"
+      sources."fs-constants-1.0.0"
+      sources."fs.realpath-1.0.0"
+      sources."fsevents-1.2.4"
+      sources."function-bind-1.1.1"
+      sources."gauge-2.7.4"
+      sources."get-value-2.0.6"
+      sources."github-from-package-0.0.0"
+      sources."glob-6.0.4"
+      sources."glob-base-0.3.0"
+      sources."glob-parent-2.0.0"
+      sources."globby-4.1.0"
+      sources."graceful-fs-4.1.11"
+      sources."graphreduce-3.0.4"
+      sources."has-1.0.3"
+      sources."has-ansi-2.0.0"
+      sources."has-network-0.0.1"
+      sources."has-symbols-1.0.0"
+      sources."has-unicode-2.0.1"
+      (sources."has-value-1.0.0" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      (sources."has-values-1.0.0" // {
+        dependencies = [
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."kind-of-4.0.0"
+        ];
+      })
+      sources."hashlru-2.2.1"
+      sources."he-0.5.0"
+      sources."heap-0.2.6"
+      sources."hoox-0.0.1"
+      sources."increment-buffer-1.0.1"
+      sources."inflight-1.0.6"
+      sources."inherits-2.0.3"
+      sources."ini-1.3.5"
+      sources."int53-0.2.4"
+      sources."ip-0.3.3"
+      sources."irregular-plurals-1.4.0"
+      (sources."is-accessor-descriptor-1.0.0" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-alphabetical-1.0.2"
+      sources."is-alphanumerical-1.0.2"
+      sources."is-binary-path-1.0.1"
+      sources."is-buffer-1.1.6"
+      sources."is-callable-1.1.4"
+      (sources."is-data-descriptor-1.0.0" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-date-object-1.0.1"
+      sources."is-decimal-1.0.2"
+      (sources."is-descriptor-1.0.2" // {
+        dependencies = [
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."is-dotfile-1.0.3"
+      sources."is-electron-2.1.0"
+      sources."is-equal-shallow-0.1.3"
+      sources."is-extendable-0.1.1"
+      sources."is-extglob-1.0.0"
+      sources."is-fullwidth-code-point-1.0.0"
+      sources."is-glob-2.0.1"
+      sources."is-hexadecimal-1.0.2"
+      sources."is-number-2.1.0"
+      (sources."is-plain-object-2.0.4" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."is-posix-bracket-0.1.1"
+      sources."is-primitive-2.0.0"
+      sources."is-regex-1.0.4"
+      sources."is-symbol-1.0.2"
+      sources."is-valid-domain-0.0.6"
+      sources."is-windows-1.0.2"
+      sources."isarray-1.0.0"
+      sources."isexe-2.0.0"
+      sources."isobject-2.1.0"
+      sources."json-buffer-2.0.11"
+      sources."kind-of-3.2.2"
+      (sources."layered-graph-1.1.1" // {
+        dependencies = [
+          sources."pull-cont-0.1.1"
+        ];
+      })
+      sources."level-3.0.2"
+      sources."level-codec-6.2.0"
+      sources."level-errors-1.1.2"
+      sources."level-iterator-stream-2.0.3"
+      sources."level-packager-2.1.1"
+      sources."level-post-1.0.7"
+      (sources."level-sublevel-6.6.5" // {
+        dependencies = [
+          (sources."abstract-leveldown-0.12.4" // {
+            dependencies = [
+              sources."xtend-3.0.0"
+            ];
+          })
+          sources."bl-0.8.2"
+          sources."deferred-leveldown-0.2.0"
+          sources."isarray-0.0.1"
+          (sources."levelup-0.19.1" // {
+            dependencies = [
+              sources."xtend-3.0.0"
+            ];
+          })
+          sources."ltgt-2.1.3"
+          sources."prr-0.0.0"
+          sources."readable-stream-1.0.34"
+          sources."semver-5.1.1"
+          sources."string_decoder-0.10.31"
+        ];
+      })
+      (sources."leveldown-3.0.2" // {
+        dependencies = [
+          sources."nan-2.10.0"
+        ];
+      })
+      sources."levelup-2.0.2"
+      sources."libnested-1.3.2"
+      sources."libsodium-0.7.3"
+      sources."libsodium-wrappers-0.7.3"
+      sources."log-symbols-1.0.2"
+      sources."log-update-1.0.2"
+      sources."longest-streak-1.0.0"
+      sources."looper-3.0.0"
+      sources."lossy-store-1.2.3"
+      sources."lru-cache-4.1.3"
+      sources."ltgt-2.2.1"
+      sources."map-cache-0.2.2"
+      sources."map-filter-reduce-2.2.1"
+      sources."map-merge-1.1.0"
+      sources."map-visit-1.0.0"
+      sources."markdown-table-0.4.0"
+      sources."math-random-1.0.1"
+      sources."mdmanifest-1.0.8"
+      sources."micromatch-2.3.11"
+      sources."mimic-response-1.0.1"
+      sources."minimatch-3.0.4"
+      sources."minimist-1.2.0"
+      (sources."mixin-deep-1.3.1" // {
+        dependencies = [
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      (sources."mkdirp-0.5.1" // {
+        dependencies = [
+          sources."minimist-0.0.8"
+        ];
+      })
+      sources."monotonic-timestamp-0.0.9"
+      sources."moo-0.4.3"
+      sources."ms-2.0.0"
+      (sources."multiblob-1.13.1" // {
+        dependencies = [
+          sources."pull-file-0.5.0"
+          sources."rimraf-2.2.8"
+        ];
+      })
+      sources."multiblob-http-0.4.2"
+      sources."multicb-1.2.2"
+      sources."multiserver-1.13.7"
+      sources."multiserver-address-1.0.1"
+      sources."muxrpc-6.4.1"
+      (sources."muxrpc-validation-2.0.1" // {
+        dependencies = [
+          sources."pull-stream-2.28.4"
+        ];
+      })
+      (sources."muxrpcli-1.1.0" // {
+        dependencies = [
+          sources."pull-stream-2.28.4"
+        ];
+      })
+      (sources."mv-2.1.1" // {
+        dependencies = [
+          sources."rimraf-2.4.5"
+        ];
+      })
+      sources."nan-2.11.1"
+      (sources."nanomatch-1.2.13" // {
+        dependencies = [
+          sources."arr-diff-4.0.0"
+          sources."array-unique-0.3.2"
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."ncp-2.0.0"
+      sources."nearley-2.15.1"
+      sources."node-abi-2.4.5"
+      sources."node-gyp-build-3.5.0"
+      sources."nomnom-1.6.2"
+      (sources."non-private-ip-1.4.4" // {
+        dependencies = [
+          sources."ip-1.1.5"
+        ];
+      })
+      sources."noop-logger-0.1.1"
+      sources."normalize-path-2.1.1"
+      sources."normalize-uri-1.1.1"
+      sources."npm-prefix-1.2.0"
+      sources."npmlog-4.1.2"
+      sources."number-is-nan-1.0.1"
+      sources."object-assign-4.1.1"
+      (sources."object-copy-0.1.0" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."is-accessor-descriptor-0.1.6"
+          sources."is-data-descriptor-0.1.4"
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+        ];
+      })
+      sources."object-inspect-1.6.0"
+      sources."object-keys-1.0.12"
+      (sources."object-visit-1.0.1" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."object.omit-2.0.1"
+      (sources."object.pick-1.3.0" // {
+        dependencies = [
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."observ-0.2.0"
+      sources."observ-debounce-1.1.1"
+      sources."obv-0.0.1"
+      sources."on-change-network-0.0.2"
+      sources."on-wakeup-1.0.1"
+      sources."once-1.4.0"
+      sources."onetime-1.1.0"
+      sources."opencollective-postinstall-2.0.1"
+      sources."options-0.0.6"
+      sources."os-homedir-1.0.2"
+      sources."os-tmpdir-1.0.2"
+      sources."osenv-0.1.5"
+      sources."packet-stream-2.0.4"
+      sources."packet-stream-codec-1.1.2"
+      sources."parse-entities-1.2.0"
+      sources."parse-glob-3.0.4"
+      sources."pascalcase-0.1.1"
+      sources."path-is-absolute-1.0.1"
+      sources."path-parse-1.0.6"
+      sources."pify-2.3.0"
+      sources."pinkie-2.0.4"
+      sources."pinkie-promise-2.0.1"
+      sources."plur-2.1.2"
+      sources."posix-character-classes-0.1.1"
+      sources."prebuild-install-4.0.0"
+      sources."preserve-0.2.0"
+      sources."private-box-0.3.0"
+      sources."process-nextick-args-2.0.0"
+      sources."prr-1.0.1"
+      sources."pseudomap-1.0.2"
+      sources."pull-abortable-4.1.1"
+      sources."pull-box-stream-1.0.13"
+      sources."pull-cat-1.1.11"
+      sources."pull-cont-0.0.0"
+      sources."pull-core-1.1.0"
+      (sources."pull-cursor-3.0.0" // {
+        dependencies = [
+          sources."looper-4.0.0"
+        ];
+      })
+      sources."pull-defer-0.2.3"
+      sources."pull-file-1.1.0"
+      sources."pull-flatmap-0.0.1"
+      (sources."pull-fs-1.1.6" // {
+        dependencies = [
+          sources."pull-file-0.5.0"
+        ];
+      })
+      sources."pull-glob-1.0.7"
+      (sources."pull-goodbye-0.0.2" // {
+        dependencies = [
+          sources."pull-stream-3.5.0"
+        ];
+      })
+      sources."pull-handshake-1.1.4"
+      sources."pull-hash-1.0.0"
+      (sources."pull-inactivity-2.1.3" // {
+        dependencies = [
+          sources."pull-abortable-4.0.0"
+        ];
+      })
+      sources."pull-level-2.0.4"
+      sources."pull-live-1.0.1"
+      (sources."pull-looper-1.0.0" // {
+        dependencies = [
+          sources."looper-4.0.0"
+        ];
+      })
+      sources."pull-many-1.0.8"
+      sources."pull-next-1.0.1"
+      sources."pull-notify-0.1.1"
+      sources."pull-pair-1.1.0"
+      (sources."pull-paramap-1.2.2" // {
+        dependencies = [
+          sources."looper-4.0.0"
+        ];
+      })
+      sources."pull-ping-2.0.2"
+      sources."pull-pushable-2.2.0"
+      sources."pull-rate-1.0.2"
+      sources."pull-reader-1.3.1"
+      sources."pull-sink-through-0.0.0"
+      sources."pull-sort-1.0.1"
+      sources."pull-stream-3.6.9"
+      sources."pull-stream-to-stream-1.3.4"
+      sources."pull-stringify-1.2.2"
+      sources."pull-through-1.0.18"
+      sources."pull-traverse-1.0.3"
+      sources."pull-utf8-decoder-1.0.2"
+      (sources."pull-window-2.1.4" // {
+        dependencies = [
+          sources."looper-2.0.0"
+        ];
+      })
+      (sources."pull-write-1.1.4" // {
+        dependencies = [
+          sources."looper-4.0.0"
+        ];
+      })
+      sources."pull-write-file-0.2.4"
+      sources."pull-ws-3.3.1"
+      sources."pump-2.0.1"
+      sources."push-stream-10.0.4"
+      sources."push-stream-to-pull-stream-1.0.3"
+      sources."railroad-diagrams-1.0.0"
+      sources."randexp-0.4.6"
+      (sources."randomatic-3.1.1" // {
+        dependencies = [
+          sources."is-number-4.0.0"
+          sources."kind-of-6.0.2"
+        ];
+      })
+      sources."rc-1.2.8"
+      sources."readable-stream-2.3.6"
+      (sources."readdirp-2.2.1" // {
+        dependencies = [
+          sources."arr-diff-4.0.0"
+          sources."array-unique-0.3.2"
+          (sources."braces-2.3.2" // {
+            dependencies = [
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."expand-brackets-2.1.4" // {
+            dependencies = [
+              sources."define-property-0.2.5"
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."extglob-2.0.4" // {
+            dependencies = [
+              sources."define-property-1.0.0"
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."fill-range-4.0.0" // {
+            dependencies = [
+              sources."extend-shallow-2.0.1"
+            ];
+          })
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-5.1.0"
+            ];
+          })
+          (sources."is-number-3.0.0" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."isobject-3.0.1"
+          sources."kind-of-6.0.2"
+          sources."micromatch-3.1.10"
+        ];
+      })
+      sources."regex-cache-0.4.4"
+      sources."regex-not-1.0.2"
+      sources."relative-url-1.0.2"
+      sources."remark-3.2.3"
+      sources."remark-html-2.0.2"
+      sources."remove-trailing-separator-1.1.0"
+      sources."repeat-element-1.1.3"
+      sources."repeat-string-1.6.1"
+      sources."resolve-1.7.1"
+      sources."resolve-url-0.2.1"
+      sources."restore-cursor-1.0.1"
+      sources."resumer-0.0.0"
+      sources."ret-0.1.15"
+      (sources."rimraf-2.6.2" // {
+        dependencies = [
+          sources."glob-7.1.3"
+        ];
+      })
+      sources."safe-buffer-5.1.2"
+      sources."safe-regex-1.1.0"
+      sources."secret-handshake-1.1.14"
+      (sources."secret-stack-4.2.4" // {
+        dependencies = [
+          sources."ip-1.1.5"
+        ];
+      })
+      (sources."secure-scuttlebutt-18.5.0" // {
+        dependencies = [
+          sources."deep-equal-0.2.2"
+        ];
+      })
+      sources."semver-5.6.0"
+      sources."separator-escape-0.0.0"
+      sources."set-blocking-2.0.0"
+      (sources."set-value-2.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
+      sources."sha.js-2.4.5"
+      sources."shebang-command-1.2.0"
+      sources."shebang-regex-1.0.0"
+      sources."shellsubstitute-1.2.0"
+      sources."signal-exit-3.0.2"
+      sources."simple-concat-1.0.0"
+      sources."simple-get-2.8.1"
+      sources."smart-buffer-4.0.1"
+      (sources."snapdragon-0.8.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      (sources."snapdragon-node-2.1.1" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."snapdragon-util-3.0.1"
+      (sources."socks-2.2.1" // {
+        dependencies = [
+          sources."ip-1.1.5"
+        ];
+      })
+      sources."sodium-browserify-1.2.4"
+      (sources."sodium-browserify-tweetnacl-0.2.3" // {
+        dependencies = [
+          sources."sha.js-2.4.11"
+        ];
+      })
+      sources."sodium-chloride-1.1.2"
+      sources."sodium-native-2.2.2"
+      sources."source-map-0.5.7"
+      sources."source-map-resolve-0.5.2"
+      sources."source-map-url-0.4.0"
+      sources."split-buffer-1.0.0"
+      sources."split-string-3.1.0"
+      (sources."ssb-blobs-1.1.6" // {
+        dependencies = [
+          sources."abstract-leveldown-5.0.0"
+          sources."deferred-leveldown-4.0.2"
+          sources."encoding-down-5.0.4"
+          sources."level-4.0.0"
+          sources."level-codec-9.0.0"
+          sources."level-errors-2.0.0"
+          sources."level-iterator-stream-3.0.1"
+          sources."level-packager-3.1.0"
+          sources."leveldown-4.0.1"
+          sources."levelup-3.1.1"
+          sources."nan-2.10.0"
+        ];
+      })
+      sources."ssb-client-4.6.0"
+      sources."ssb-config-2.3.6"
+      sources."ssb-ebt-5.2.3"
+      (sources."ssb-friends-3.1.4" // {
+        dependencies = [
+          sources."pull-cont-0.1.1"
+        ];
+      })
+      sources."ssb-keys-7.1.3"
+      sources."ssb-links-3.0.3"
+      sources."ssb-msgs-5.2.0"
+      (sources."ssb-query-2.3.0" // {
+        dependencies = [
+          sources."flumeview-query-7.1.0"
+          sources."map-filter-reduce-3.2.2"
+        ];
+      })
+      (sources."ssb-ref-2.13.1" // {
+        dependencies = [
+          sources."ip-1.1.5"
+        ];
+      })
+      sources."ssb-validate-3.0.11"
+      sources."ssb-ws-3.0.0"
+      sources."stack-0.1.0"
+      (sources."static-extend-0.1.2" // {
+        dependencies = [
+          sources."define-property-0.2.5"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+        ];
+      })
+      sources."statistics-3.3.0"
+      sources."stream-to-pull-stream-1.7.2"
+      sources."string-width-1.0.2"
+      sources."string.prototype.trim-1.1.2"
+      sources."string_decoder-1.1.1"
+      sources."stringify-entities-1.3.2"
+      sources."strip-ansi-3.0.1"
+      sources."strip-json-comments-2.0.1"
+      sources."supports-color-2.0.0"
+      (sources."tape-4.9.1" // {
+        dependencies = [
+          sources."glob-7.1.3"
+        ];
+      })
+      (sources."tar-fs-1.16.3" // {
+        dependencies = [
+          sources."pump-1.0.3"
+        ];
+      })
+      sources."tar-stream-1.6.2"
+      sources."text-table-0.2.0"
+      sources."through-2.3.8"
+      sources."to-buffer-1.1.1"
+      sources."to-object-path-0.3.0"
+      sources."to-regex-3.0.2"
+      (sources."to-regex-range-2.1.1" // {
+        dependencies = [
+          sources."is-number-3.0.0"
+        ];
+      })
+      sources."to-vfile-1.0.0"
+      sources."trim-0.0.1"
+      sources."trim-lines-1.1.1"
+      sources."trim-trailing-lines-1.1.1"
+      sources."tunnel-agent-0.6.0"
+      sources."tweetnacl-0.14.5"
+      sources."tweetnacl-auth-0.3.1"
+      sources."typedarray-0.0.6"
+      sources."typewise-1.0.3"
+      sources."typewise-core-1.2.0"
+      sources."typewiselite-1.0.0"
+      sources."uint48be-1.0.2"
+      sources."ultron-1.0.2"
+      sources."underscore-1.4.4"
+      sources."unherit-1.1.1"
+      sources."unified-2.1.4"
+      (sources."union-value-1.0.0" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+          sources."set-value-0.4.3"
+        ];
+      })
+      sources."unist-util-is-2.1.2"
+      sources."unist-util-visit-1.4.0"
+      sources."unist-util-visit-parents-2.0.1"
+      (sources."unset-value-1.0.0" // {
+        dependencies = [
+          (sources."has-value-0.3.1" // {
+            dependencies = [
+              sources."isobject-2.1.0"
+            ];
+          })
+          sources."has-values-0.1.4"
+          sources."isobject-3.0.1"
+        ];
+      })
+      sources."untildify-2.1.0"
+      sources."urix-0.1.0"
+      sources."use-3.1.1"
+      sources."user-home-2.0.0"
+      sources."util-deprecate-1.0.2"
+      sources."vfile-1.4.0"
+      sources."vfile-find-down-1.0.0"
+      sources."vfile-find-up-1.0.0"
+      sources."vfile-reporter-1.5.0"
+      sources."vfile-sort-1.0.0"
+      sources."ware-1.3.0"
+      sources."which-1.3.1"
+      sources."which-pm-runs-1.0.0"
+      sources."wide-align-1.1.3"
+      sources."word-wrap-1.2.3"
+      sources."wrap-fn-0.1.5"
+      sources."wrappy-1.0.2"
+      sources."ws-1.1.5"
+      sources."xtend-4.0.1"
+      sources."yallist-2.1.2"
+      sources."zerr-1.0.4"
+    ];
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "network protocol layer for secure-scuttlebutt";
+      homepage = https://github.com/ssbc/scuttlebot;
       license = "MIT";
     };
     production = true;

--- a/pkgs/development/node-packages/node-packages-v8.nix
+++ b/pkgs/development/node-packages/node-packages-v8.nix
@@ -22058,13 +22058,13 @@ let
         sha1 = "4f3152e09540fde28c76f44b19bbcd1d5a42478d";
       };
     };
-    "nanobus-4.3.4" = {
+    "nanobus-4.3.5" = {
       name = "nanobus";
       packageName = "nanobus";
-      version = "4.3.4";
+      version = "4.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nanobus/-/nanobus-4.3.4.tgz";
-        sha512 = "N1IBreECNaxmsaOLMqqm01K7XIp+sMvoVX8mvmT/p1VjM2FLcBU0lj0FalKooi2/2i+ph9WsEoEogOJevqQ6LQ==";
+        url = "https://registry.npmjs.org/nanobus/-/nanobus-4.3.5.tgz";
+        sha512 = "6UlqagLV9/ADqcTU60mipAPEd16WDbO+a9WeeGVn9RucHKNDTcPt9MOf8ZmAvbA3V2CV+EJS28eupNalg4YF8Q==";
       };
     };
     "nanoid-1.3.1" = {
@@ -32673,7 +32673,7 @@ let
       packageName = "to-vfile";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz";
+        url = "http://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz";
         sha1 = "88defecd43adb2ef598625f0e3d59f7f342941ba";
       };
     };
@@ -34545,7 +34545,7 @@ let
       packageName = "vfile";
       version = "1.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz";
+        url = "http://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz";
         sha1 = "c0fd6fa484f8debdb771f68c31ed75d88da97fe7";
       };
     };
@@ -34554,7 +34554,7 @@ let
       packageName = "vfile-find-down";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz";
+        url = "http://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz";
         sha1 = "84a4d66d03513f6140a84e0776ef0848d4f0ad95";
       };
     };
@@ -34563,7 +34563,7 @@ let
       packageName = "vfile-find-up";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz";
+        url = "http://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz";
         sha1 = "5604da6fe453b34350637984eb5fe4909e280390";
       };
     };
@@ -34572,7 +34572,7 @@ let
       packageName = "vfile-reporter";
       version = "1.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz";
+        url = "http://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz";
         sha1 = "21a7009bfe55e24df8ff432aa5bf6f6efa74e418";
       };
     };
@@ -38854,7 +38854,7 @@ in
       sources."mutexify-1.2.0"
       sources."nan-2.11.1"
       sources."nanoassert-1.1.0"
-      sources."nanobus-4.3.4"
+      sources."nanobus-4.3.5"
       sources."nanoscheduler-1.0.3"
       sources."nanotiming-7.3.1"
       sources."ncp-1.0.1"

--- a/pkgs/development/node-packages/node-packages-v8.nix
+++ b/pkgs/development/node-packages/node-packages-v8.nix
@@ -22,13 +22,13 @@ let
         sha512 = "tGAp3ULNyoA8b5o9LsU2Lq6SwgVPUOKAqKywu2liEtTvrFSGPrObwanhYwArq3GPeOqp2bi+JknSJCIU3oQN1Q==";
       };
     };
-    "@apollographql/graphql-playground-html-1.6.0" = {
+    "@apollographql/graphql-playground-html-1.6.4" = {
       name = "_at_apollographql_slash_graphql-playground-html";
       packageName = "@apollographql/graphql-playground-html";
-      version = "1.6.0";
+      version = "1.6.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.0.tgz";
-        sha512 = "QAZIFrfVRkjvMkUHIQKZXZ3La0V5t12w5PWrhihYEabHwzIZV/txQd/kSYHgYPXC4s5OURxsXZop9f0BzI2QIQ==";
+        url = "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.4.tgz";
+        sha512 = "gwvaQO6/Hv4DEwhDLmmu2tzCU9oPjC5Xl9Kk8Yd0IxyKhYLlLalmkMMjsZLzU5H3fGaalLD96OYfxHL0ClVUDQ==";
       };
     };
     "@babel/code-frame-7.0.0" = {
@@ -958,13 +958,13 @@ let
         sha512 = "jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==";
       };
     };
-    "@types/async-2.0.49" = {
+    "@types/async-2.0.50" = {
       name = "_at_types_slash_async";
       packageName = "@types/async";
-      version = "2.0.49";
+      version = "2.0.50";
       src = fetchurl {
-        url = "http://registry.npmjs.org/@types/async/-/async-2.0.49.tgz";
-        sha512 = "Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==";
+        url = "https://registry.npmjs.org/@types/async/-/async-2.0.50.tgz";
+        sha512 = "VMhZMMQgV1zsR+lX/0IBfAk+8Eb7dPVMWiQGFAt3qjo5x7Ml6b77jUo0e1C3ToD+XRDXqtrfw+6AB0uUsPEr3Q==";
       };
     };
     "@types/babel-types-7.0.4" = {
@@ -1066,13 +1066,13 @@ let
         sha512 = "A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==";
       };
     };
-    "@types/node-10.11.7" = {
+    "@types/node-10.12.0" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "10.11.7";
+      version = "10.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz";
-        sha512 = "yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==";
+        url = "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz";
+        sha512 = "3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==";
       };
     };
     "@types/node-8.10.36" = {
@@ -1165,184 +1165,184 @@ let
         sha512 = "DhZ+wIaJnLzcVmkZMWxy0If9Rh68YWhsxeXuxIbcL4tpGBbIdd+44A5CqHWFkTkVma5zWlqckhVuTXUYdstEZw==";
       };
     };
-    "@webassemblyjs/ast-1.7.8" = {
+    "@webassemblyjs/ast-1.7.10" = {
       name = "_at_webassemblyjs_slash_ast";
       packageName = "@webassemblyjs/ast";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.8.tgz";
-        sha512 = "dOrtdtEyB8sInpl75yLPNksY4sRl0j/+t6aHyB/YA+ab9hV3Fo7FmG12FHzP+2MvWVAJtDb+6eXR5EZbZJ+uVg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.10.tgz";
+        sha512 = "wTUeaByYN2EA6qVqhbgavtGc7fLTOx0glG2IBsFlrFG51uXIGlYBTyIZMf4SPLo3v1bgV/7lBN3l7Z0R6Hswew==";
       };
     };
-    "@webassemblyjs/floating-point-hex-parser-1.7.8" = {
+    "@webassemblyjs/floating-point-hex-parser-1.7.10" = {
       name = "_at_webassemblyjs_slash_floating-point-hex-parser";
       packageName = "@webassemblyjs/floating-point-hex-parser";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.8.tgz";
-        sha512 = "kn2zNKGsbql5i56VAgRYkpG+VazqHhQQZQycT2uXAazrAEDs23gy+Odkh5VblybjnwX2/BITkDtNmSO76hdIvQ==";
+        url = "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.10.tgz";
+        sha512 = "gMsGbI6I3p/P1xL2UxqhNh1ga2HCsx5VBB2i5VvJFAaqAjd2PBTRULc3BpTydabUQEGlaZCzEUQhLoLG7TvEYQ==";
       };
     };
-    "@webassemblyjs/helper-api-error-1.7.8" = {
+    "@webassemblyjs/helper-api-error-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-api-error";
       packageName = "@webassemblyjs/helper-api-error";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.8.tgz";
-        sha512 = "xUwxDXsd1dUKArJEP5wWM5zxgCSwZApSOJyP1XO7M8rNUChUDblcLQ4FpzTpWG2YeylMwMl1MlP5Ztryiz1x4g==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.10.tgz";
+        sha512 = "DoYRlPWtuw3yd5BOr9XhtrmB6X1enYF0/54yNvQWGXZEPDF5PJVNI7zQ7gkcKfTESzp8bIBWailaFXEK/jjCsw==";
       };
     };
-    "@webassemblyjs/helper-buffer-1.7.8" = {
+    "@webassemblyjs/helper-buffer-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-buffer";
       packageName = "@webassemblyjs/helper-buffer";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.8.tgz";
-        sha512 = "WXiIMnuvuwlhWvVOm8xEXU9DnHaa3AgAU0ZPfvY8vO1cSsmYb2WbGbHnMLgs43vXnA7XAob9b56zuZaMkxpCBg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.10.tgz";
+        sha512 = "+RMU3dt/dPh4EpVX4u5jxsOlw22tp3zjqE0m3ftU2tsYxnPULb4cyHlgaNd2KoWuwasCQqn8Mhr+TTdbtj3LlA==";
       };
     };
-    "@webassemblyjs/helper-code-frame-1.7.8" = {
+    "@webassemblyjs/helper-code-frame-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-code-frame";
       packageName = "@webassemblyjs/helper-code-frame";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.8.tgz";
-        sha512 = "TLQxyD9qGOIdX5LPQOPo0Ernd88U5rHkFb8WAjeMIeA0sPjCHeVPaGqUGGIXjUcblUkjuDAc07bruCcNHUrHDA==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.10.tgz";
+        sha512 = "UiytbpKAULOEab2hUZK2ywXen4gWJVrgxtwY3Kn+eZaaSWaRM8z/7dAXRSoamhKFiBh1uaqxzE/XD9BLlug3gw==";
       };
     };
-    "@webassemblyjs/helper-flaten-ast-1.7.8" = {
+    "@webassemblyjs/helper-flaten-ast-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-flaten-ast";
       packageName = "@webassemblyjs/helper-flaten-ast";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-flaten-ast/-/helper-flaten-ast-1.7.8.tgz";
-        sha512 = "Z6U67Havfc1LsCysc2Wb7FKjSxBXgaEp39wfzjPA86mcctxYv6T+6udzmgD872/s24TZoV4cC65eC78JT0kaeg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-flaten-ast/-/helper-flaten-ast-1.7.10.tgz";
+        sha512 = "8wcgxObd2Z5IQFLSpXHwoLATl6fypw7Ir9AK1tkpBjoBsmaSCLIowEfycsWnglgPtdJXMqPzKM41d63u7Q7xZA==";
       };
     };
-    "@webassemblyjs/helper-fsm-1.7.8" = {
+    "@webassemblyjs/helper-fsm-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-fsm";
       packageName = "@webassemblyjs/helper-fsm";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.8.tgz";
-        sha512 = "TjK0CnD8hAPkV5mbSp5aWl6SO1+H3WFcjWtixWoy8EMA99YnNzYhpc/WSYWhf7yrhpzkq5tZB0tvLK3Svr3IXA==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.10.tgz";
+        sha512 = "w2vDtUK9xeSRtt5+RnnlRCI7wHEvLjF0XdnxJpgx+LJOvklTZPqWkuy/NhwHSLP19sm9H8dWxKeReMR7sCkGZA==";
       };
     };
-    "@webassemblyjs/helper-module-context-1.7.8" = {
+    "@webassemblyjs/helper-module-context-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-module-context";
       packageName = "@webassemblyjs/helper-module-context";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.8.tgz";
-        sha512 = "uCutAKR7Nm0VsFixcvnB4HhAyHouNbj0Dx1p7eRjFjXGGZ+N7ftTaG1ZbWCasAEbtwGj54LP8+lkBZdTCPmLGg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.10.tgz";
+        sha512 = "yE5x/LzZ3XdPdREmJijxzfrf+BDRewvO0zl8kvORgSWmxpRrkqY39KZSq6TSgIWBxkK4SrzlS3BsMCv2s1FpsQ==";
       };
     };
-    "@webassemblyjs/helper-wasm-bytecode-1.7.8" = {
+    "@webassemblyjs/helper-wasm-bytecode-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-wasm-bytecode";
       packageName = "@webassemblyjs/helper-wasm-bytecode";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.8.tgz";
-        sha512 = "AdCCE3BMW6V34WYaKUmPgVHa88t2Z14P4/0LjLwuGkI0X6pf7nzp0CehzVVk51cKm2ymVXjl9dCG+gR1yhITIQ==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.10.tgz";
+        sha512 = "u5qy4SJ/OrxKxZqJ9N3qH4ZQgHaAzsopsYwLvoWJY6Q33r8PhT3VPyNMaJ7ZFoqzBnZlCcS/0f4Sp8WBxylXfg==";
       };
     };
-    "@webassemblyjs/helper-wasm-section-1.7.8" = {
+    "@webassemblyjs/helper-wasm-section-1.7.10" = {
       name = "_at_webassemblyjs_slash_helper-wasm-section";
       packageName = "@webassemblyjs/helper-wasm-section";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.8.tgz";
-        sha512 = "BkBhYQuzyl4hgTGOKo87Vdw6f9nj8HhI7WYpI0MCC5qFa5ahrAPOGgyETVdnRbv+Rjukl9MxxfDmVcVC435lDg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.10.tgz";
+        sha512 = "Ecvww6sCkcjatcyctUrn22neSJHLN/TTzolMGG/N7S9rpbsTZ8c6Bl98GpSpV77EvzNijiNRHBG0+JO99qKz6g==";
       };
     };
-    "@webassemblyjs/ieee754-1.7.8" = {
+    "@webassemblyjs/ieee754-1.7.10" = {
       name = "_at_webassemblyjs_slash_ieee754";
       packageName = "@webassemblyjs/ieee754";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.8.tgz";
-        sha512 = "tOarWChdG1a3y1yqCX0JMDKzrat5tQe4pV6K/TX19BcXsBLYxFQOL1DEDa5KG9syeyvCrvZ+i1+Mv1ExngvktQ==";
+        url = "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.10.tgz";
+        sha512 = "HRcWcY+YWt4+s/CvQn+vnSPfRaD4KkuzQFt5MNaELXXHSjelHlSEA8ZcqT69q0GTIuLWZ6JaoKar4yWHVpZHsQ==";
       };
     };
-    "@webassemblyjs/leb128-1.7.8" = {
+    "@webassemblyjs/leb128-1.7.10" = {
       name = "_at_webassemblyjs_slash_leb128";
       packageName = "@webassemblyjs/leb128";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.8.tgz";
-        sha512 = "GCYeGPgUFWJiZuP4NICbcyUQNxNLJIf476Ei+K+jVuuebtLpfvwkvYT6iTUE7oZYehhkor4Zz2g7SJ/iZaPudQ==";
+        url = "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.10.tgz";
+        sha512 = "og8MciYlA8hvzCLR71hCuZKPbVBfLQeHv7ImKZ4nlyxrYbG7uJHYtHiHu6OV9SqrGuD03H/HtXC4Bgdjfm9FHw==";
       };
     };
-    "@webassemblyjs/utf8-1.7.8" = {
+    "@webassemblyjs/utf8-1.7.10" = {
       name = "_at_webassemblyjs_slash_utf8";
       packageName = "@webassemblyjs/utf8";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.8.tgz";
-        sha512 = "9X+f0VV+xNXW2ujfIRSXBJENGE6Qh7bNVKqu3yDjTFB3ar3nsThsGBBKdTG58aXOm2iUH6v28VIf88ymPXODHA==";
+        url = "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.10.tgz";
+        sha512 = "Ng6Pxv6siyZp635xCSnH3mKmIFgqWPCcGdoo0GBYgyGdxu7cUj4agV7Uu1a8REP66UYUFXJLudeGgd4RvuJAnQ==";
       };
     };
-    "@webassemblyjs/validation-1.7.8" = {
+    "@webassemblyjs/validation-1.7.10" = {
       name = "_at_webassemblyjs_slash_validation";
       packageName = "@webassemblyjs/validation";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.7.8.tgz";
-        sha512 = "UmEQX0TMA+uCbaQYA+Z8YwwIr+Y5W5UMaROEh4V+7Ef6HpkFZBn8sHRo5xNQORy2rxkkOSR25tjUK62n6iQlDA==";
+        url = "https://registry.npmjs.org/@webassemblyjs/validation/-/validation-1.7.10.tgz";
+        sha512 = "7Hjg56EaijlI70WGvdT1xpE9gB07AKtU2qbfQoYjC76JWAF8+2ZKzda4Gz3e8QoDr3DRl16KV1jg0yfzdxRT3A==";
       };
     };
-    "@webassemblyjs/wasm-edit-1.7.8" = {
+    "@webassemblyjs/wasm-edit-1.7.10" = {
       name = "_at_webassemblyjs_slash_wasm-edit";
       packageName = "@webassemblyjs/wasm-edit";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.8.tgz";
-        sha512 = "6D3Hm2gFixrfyx9XjSON4ml1FZTugqpkIz5Awvrou8fnpyprVzcm4X8pyGRtA2Piixjl3DqmX/HB1xdWyE097A==";
+        url = "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.10.tgz";
+        sha512 = "e9RZFQlb+ZuYcKRcW9yl+mqX/Ycj9+3/+ppDI8nEE/NCY6FoK8f3dKBcfubYV/HZn44b+ND4hjh+4BYBt+sDnA==";
       };
     };
-    "@webassemblyjs/wasm-gen-1.7.8" = {
+    "@webassemblyjs/wasm-gen-1.7.10" = {
       name = "_at_webassemblyjs_slash_wasm-gen";
       packageName = "@webassemblyjs/wasm-gen";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.8.tgz";
-        sha512 = "a7O/wE6eBeVKKUYgpMK7NOHmMADD85rSXLe3CqrWRDwWff5y3cSVbzpN6Qv3z6C4hdkpq9qyij1Ga1kemOZGvQ==";
+        url = "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.10.tgz";
+        sha512 = "M0lb6cO2Y0PzDye/L39PqwV+jvO+2YxEG5ax+7dgq7EwXdAlpOMx1jxyXJTScQoeTpzOPIb+fLgX/IkLF8h2yw==";
       };
     };
-    "@webassemblyjs/wasm-opt-1.7.8" = {
+    "@webassemblyjs/wasm-opt-1.7.10" = {
       name = "_at_webassemblyjs_slash_wasm-opt";
       packageName = "@webassemblyjs/wasm-opt";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.8.tgz";
-        sha512 = "3lbQ0PT81NHCdi1sR/7+SNpZadM4qYcTSr62nFFAA7e5lFwJr14M1Gi+A/Y3PgcDWOHYjsaNGPpPU0H03N6Blg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.10.tgz";
+        sha512 = "R66IHGCdicgF5ZliN10yn5HaC7vwYAqrSVJGjtJJQp5+QNPBye6heWdVH/at40uh0uoaDN/UVUfXK0gvuUqtVg==";
       };
     };
-    "@webassemblyjs/wasm-parser-1.7.8" = {
+    "@webassemblyjs/wasm-parser-1.7.10" = {
       name = "_at_webassemblyjs_slash_wasm-parser";
       packageName = "@webassemblyjs/wasm-parser";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.8.tgz";
-        sha512 = "rZ/zlhp9DHR/05zh1MbAjT2t624sjrPP/OkJCjXqzm7ynH+nIdNcn9Ixc+qzPMFXhIrk0rBoQ3to6sEIvHh9jQ==";
+        url = "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.10.tgz";
+        sha512 = "AEv8mkXVK63n/iDR3T693EzoGPnNAwKwT3iHmKJNBrrALAhhEjuPzo/lTE4U7LquEwyvg5nneSNdTdgrBaGJcA==";
       };
     };
-    "@webassemblyjs/wast-parser-1.7.8" = {
+    "@webassemblyjs/wast-parser-1.7.10" = {
       name = "_at_webassemblyjs_slash_wast-parser";
       packageName = "@webassemblyjs/wast-parser";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.8.tgz";
-        sha512 = "Q/zrvtUvzWuSiJMcSp90fi6gp2nraiHXjTV2VgAluVdVapM4gy1MQn7akja2p6eSBDQpKJPJ6P4TxRkghRS5dg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.10.tgz";
+        sha512 = "YTPEtOBljkCL0VjDp4sHe22dAYSm3ZwdJ9+2NTGdtC7ayNvuip1wAhaAS8Zt9Q6SW9E5Jf5PX7YE3XWlrzR9cw==";
       };
     };
-    "@webassemblyjs/wast-printer-1.7.8" = {
+    "@webassemblyjs/wast-printer-1.7.10" = {
       name = "_at_webassemblyjs_slash_wast-printer";
       packageName = "@webassemblyjs/wast-printer";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.8.tgz";
-        sha512 = "GllIthRtwTxRDAURRNXscu7Napzmdf1jt1gpiZiK/QN4fH0lSGs3OTmvdfsMNP7tqI4B3ZtfaaWRlNIQug6Xyg==";
+        url = "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.10.tgz";
+        sha512 = "mJ3QKWtCchL1vhU/kZlJnLPuQZnlDOdZsyP0bbLWPGdYsQDnSBvyTLhzwBA3QAMlzEL9V4JHygEmK6/OTEyytA==";
       };
     };
     "@xtuc/ieee754-1.2.0" = {
@@ -1494,7 +1494,7 @@ let
       packageName = "abstract-leveldown";
       version = "0.12.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz";
+        url = "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz";
         sha1 = "29e18e632e60e4e221d5810247852a63d7b2e410";
       };
     };
@@ -1503,8 +1503,17 @@ let
       packageName = "abstract-leveldown";
       version = "4.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz";
+        url = "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz";
         sha512 = "qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==";
+      };
+    };
+    "abstract-leveldown-5.0.0" = {
+      name = "abstract-leveldown";
+      packageName = "abstract-leveldown";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz";
+        sha512 = "5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==";
       };
     };
     "abstract-random-access-1.1.2" = {
@@ -1615,6 +1624,15 @@ let
         sha512 = "zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==";
       };
     };
+    "acorn-dynamic-import-4.0.0" = {
+      name = "acorn-dynamic-import";
+      packageName = "acorn-dynamic-import";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz";
+        sha512 = "d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==";
+      };
+    };
     "acorn-globals-1.0.9" = {
       name = "acorn-globals";
       packageName = "acorn-globals";
@@ -1651,13 +1669,22 @@ let
         sha512 = "JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==";
       };
     };
-    "acorn-node-1.6.0" = {
+    "acorn-jsx-5.0.0" = {
+      name = "acorn-jsx";
+      packageName = "acorn-jsx";
+      version = "5.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz";
+        sha512 = "XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==";
+      };
+    };
+    "acorn-node-1.6.2" = {
       name = "acorn-node";
       packageName = "acorn-node";
-      version = "1.6.0";
+      version = "1.6.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/acorn-node/-/acorn-node-1.6.0.tgz";
-        sha512 = "ZsysjEh+Y3i14f7YXCAKJy99RXbd56wHKYBzN4FlFtICIZyFpYwK6OwNJhcz8A/FMtxoUZkJofH1v9KIfNgWmw==";
+        url = "https://registry.npmjs.org/acorn-node/-/acorn-node-1.6.2.tgz";
+        sha512 = "rIhNEZuNI8ibQcL7ANm/mGyPukIaZsRNX9psFNQURyJW0nu6k8wjSDld20z6v2mDBWqX13pIEnk9gGZJHIlEXg==";
       };
     };
     "acorn-walk-6.1.0" = {
@@ -1804,13 +1831,13 @@ let
         sha512 = "JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==";
       };
     };
-    "agentkeepalive-3.5.1" = {
+    "agentkeepalive-3.5.2" = {
       name = "agentkeepalive";
       packageName = "agentkeepalive";
-      version = "3.5.1";
+      version = "3.5.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.1.tgz";
-        sha512 = "Cte/sTY9/XcygXjJ0q58v//SnEQ7ViWExKyJpLJlLqomDbQyMLh6Is4KuWJ/wmxzhiwkGRple7Gqv1zf6Syz5w==";
+        url = "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz";
+        sha512 = "e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==";
       };
     };
     "aggregate-error-1.0.0" = {
@@ -1935,7 +1962,7 @@ let
       packageName = "aliasify";
       version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aliasify/-/aliasify-2.1.0.tgz";
+        url = "http://registry.npmjs.org/aliasify/-/aliasify-2.1.0.tgz";
         sha1 = "7c30825b9450b9e6185ba27533eaf6e2067d4b42";
       };
     };
@@ -2245,13 +2272,13 @@ let
         sha1 = "ee49736b639b4f108b6e9e626c6da99306b41692";
       };
     };
-    "apollo-cache-1.1.17" = {
+    "apollo-cache-1.1.19" = {
       name = "apollo-cache";
       packageName = "apollo-cache";
-      version = "1.1.17";
+      version = "1.1.19";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.17.tgz";
-        sha512 = "7sp24n2HZO4vXgTaKNomLyIfGxG4gDdDkBB0jkRzRi7HhnKmfwhiF/RCiKNbgLdrPX151INdls0KwIVliD0dHQ==";
+        url = "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.19.tgz";
+        sha512 = "p163+GVne1Gyw2v9L5kHEQhUhih7btWvyUFOl4uKf7brieqd4tHZt8ZA3vT1SaXbCeQZNSp/tFI3yFyi8RPKzw==";
       };
     };
     "apollo-cache-control-0.2.5" = {
@@ -2263,22 +2290,22 @@ let
         sha512 = "xEDrUvo3U2mQKSzA8NzQmgeqK4ytwFnTGl2YKGKPfG0+r8fZdswKp6CDBue29KLO8KkSuqW/hntveWrAdK51FQ==";
       };
     };
-    "apollo-cache-inmemory-1.3.5" = {
+    "apollo-cache-inmemory-1.3.7" = {
       name = "apollo-cache-inmemory";
       packageName = "apollo-cache-inmemory";
-      version = "1.3.5";
+      version = "1.3.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.5.tgz";
-        sha512 = "CD4Dl9vcCp7N05KUqR3rNDj2WJ1DQNNfeyBUIo5T6XTiUhfBQp5x+CL7S+ezy5mPp+xo4TnwFzLFh/vy2LdDog==";
+        url = "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.7.tgz";
+        sha512 = "7AKGBuVRfgsjtq1yxcTWgpzi0WDVpjX2HJU9GFoYd+j7I253bSRn7YbwCNwkxyrH6ilSDU6JKm8DQ3QMA/z7rQ==";
       };
     };
-    "apollo-client-2.4.2" = {
+    "apollo-client-2.4.4" = {
       name = "apollo-client";
       packageName = "apollo-client";
-      version = "2.4.2";
+      version = "2.4.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.2.tgz";
-        sha512 = "g1z23umaVSoKLj9xNl0aAnk2KBF4JeBi7MeKFc9CGTixH7TkqeQUQtxcjrC7j2h4KmDbuhOAHOFUGf8YshN+ag==";
+        url = "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.4.tgz";
+        sha512 = "i29w/+aa9O4fe8NxzJNOViHdsjpN2723Q2mNl0HiOJFwG+VjA4RXdTpyZHPZqcO8FwgK1k43l8nULD4Cdlx/Ww==";
       };
     };
     "apollo-codegen-0.19.1" = {
@@ -2443,13 +2470,13 @@ let
         sha512 = "JEgStzhnwybj1ifE2nViLEl7NTM5+zS++fKbDL95PIpodg2AdYeeN7eEa7RXpYD14iC3FVcsfqgGMREv2+cSxw==";
       };
     };
-    "apollo-utilities-1.0.21" = {
+    "apollo-utilities-1.0.24" = {
       name = "apollo-utilities";
       packageName = "apollo-utilities";
-      version = "1.0.21";
+      version = "1.0.24";
       src = fetchurl {
-        url = "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.21.tgz";
-        sha512 = "ZcxELlEl+sDCYBgEMdNXJAsZtRVm8wk4HIA58bMsqYfd1DSAJQEtZ93F0GZgYNAGy3QyaoBeZtbb0/01++G8JQ==";
+        url = "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.24.tgz";
+        sha512 = "cOXtrkio3wKfggp/zKCzQYxSZZRND/njNVmUksM1cckoJF3g/2o3bhh6z0HPhNhee8qzJzVXtl+3vmwXYGh0Gg==";
       };
     };
     "append-0.1.1" = {
@@ -3316,13 +3343,13 @@ let
         sha1 = "00f35b2d27ac91b1f0d3ef2084c98cf1d1f0adc3";
       };
     };
-    "aws-sdk-2.334.0" = {
+    "aws-sdk-2.344.0" = {
       name = "aws-sdk";
       packageName = "aws-sdk";
-      version = "2.334.0";
+      version = "2.344.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.334.0.tgz";
-        sha512 = "JiqtB2t/PklHCfo86HA6g6a8CXu5SDNa8XiaQ0rYyVBlzDR41p/s/yNlva3D1/QGiBTojl2fd9ZxBUxKa2Q9cg==";
+        url = "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.344.0.tgz";
+        sha512 = "VGiVgX4+qk/67o8GL3qeHK1KC4r73jlsJoE6ZSPsujX6UjP0PgrfUL1J9cdW/sgXc0lzmK3ksdKqZordFZ4/xw==";
       };
     };
     "aws-sign-0.2.1" = {
@@ -3523,13 +3550,13 @@ let
         sha1 = "aa9a49fb9081a210f2f4cc6596ca4653b68306e6";
       };
     };
-    "azure-arm-resource-7.0.0" = {
+    "azure-arm-resource-7.0.1" = {
       name = "azure-arm-resource";
       packageName = "azure-arm-resource";
-      version = "7.0.0";
+      version = "7.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-7.0.0.tgz";
-        sha512 = "LW1OmW49d5xQo/KDBK2BNfoFVOlP8Gq9yKqP2kz0e6RURl5UXhIfN65Y4GeJramuyGIOXeGPV+NrXrzl1k4d4g==";
+        url = "https://registry.npmjs.org/azure-arm-resource/-/azure-arm-resource-7.0.1.tgz";
+        sha512 = "vimPiR/xf6TFWNooIXZM6gRQV7Gdqs0y2wzNF+SNSMxPj3h8XEuSL/SyRZHNULY7sJseAx+0aGjWXbZxQo+kVw==";
       };
     };
     "azure-arm-servermanagement-1.1.0" = {
@@ -3559,13 +3586,13 @@ let
         sha1 = "b46cfcf7f1690e4739864dcdb5c8de322e82ec50";
       };
     };
-    "azure-arm-website-5.3.0" = {
+    "azure-arm-website-5.4.0" = {
       name = "azure-arm-website";
       packageName = "azure-arm-website";
-      version = "5.3.0";
+      version = "5.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-arm-website/-/azure-arm-website-5.3.0.tgz";
-        sha512 = "R2x44/SIGCuTBkRvnZuEjagIMAqcec38HnCl1AEO9NwpEh0HiD9eIa1XEM7j6wa7vHqyQdL7hNwYnCS0QRDkNQ==";
+        url = "https://registry.npmjs.org/azure-arm-website/-/azure-arm-website-5.4.0.tgz";
+        sha512 = "VTJIAXQVy0oFYmJxfzMqcX5ausau4pdLr/yaf1haKDl+RfJMIWfynPXUq4VsvX/Y9nh7xyAbvaOx658Bagl9EQ==";
       };
     };
     "azure-asm-compute-0.18.0" = {
@@ -3721,13 +3748,13 @@ let
         sha512 = "SkMg4vVrQ7Vd7/h8h3qZzURQysV4KJqUIy4pjs/XRjVbCduSePlJ3EOgAl9ed739RWkT906xIAU3tu2Pf5RKFQ==";
       };
     };
-    "azure-storage-2.10.1" = {
+    "azure-storage-2.10.2" = {
       name = "azure-storage";
       packageName = "azure-storage";
-      version = "2.10.1";
+      version = "2.10.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.1.tgz";
-        sha512 = "rnFo1uMIPtilusRCpK91tfY3P4Q7qRsDNwriXdp+OeTIGkGt0cTxL4mhqYfNPYPK+WBQmBdGWhOk+iROM05dcw==";
+        url = "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.2.tgz";
+        sha512 = "pOyGPya9+NDpAfm5YcFfklo57HfjDbYLXxs4lomPwvRxmb0Di/A+a+RkUmEFzaQ8S13CqxK40bRRB0sjj2ZQxA==";
       };
     };
     "babel-code-frame-6.26.0" = {
@@ -4527,7 +4554,7 @@ let
       packageName = "blob";
       version = "0.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz";
+        url = "http://registry.npmjs.org/blob/-/blob-0.0.2.tgz";
         sha1 = "b89562bd6994af95ba1e812155536333aa23cf24";
       };
     };
@@ -4536,7 +4563,7 @@ let
       packageName = "blob";
       version = "0.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz";
+        url = "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz";
         sha1 = "bcf13052ca54463f30f9fc7e95b9a47630a94921";
       };
     };
@@ -5013,7 +5040,7 @@ let
       packageName = "browserify-transform-tools";
       version = "1.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz";
+        url = "http://registry.npmjs.org/browserify-transform-tools/-/browserify-transform-tools-1.7.0.tgz";
         sha1 = "83e277221f63259bed2e7eb2a283a970a501f4c4";
       };
     };
@@ -5350,13 +5377,13 @@ let
         sha1 = "741c5216468eadc457b03410118ad77de8c1ddb1";
       };
     };
-    "byte-size-4.0.3" = {
+    "byte-size-4.0.4" = {
       name = "byte-size";
       packageName = "byte-size";
-      version = "4.0.3";
+      version = "4.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/byte-size/-/byte-size-4.0.3.tgz";
-        sha512 = "JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg==";
+        url = "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz";
+        sha512 = "82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==";
       };
     };
     "bytebuffer-3.5.5" = {
@@ -5634,7 +5661,7 @@ let
       packageName = "camelcase-keys";
       version = "2.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz";
+        url = "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz";
         sha1 = "308beeaffdf28119051efa1d932213c91b8f92e7";
       };
     };
@@ -5645,6 +5672,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz";
         sha1 = "a2aa5fb1af688758259c32c141426d78923b9b77";
+      };
+    };
+    "canonical-base64-1.1.0" = {
+      name = "canonical-base64";
+      packageName = "canonical-base64";
+      version = "1.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/canonical-base64/-/canonical-base64-1.1.0.tgz";
+        sha512 = "vHhtZX7TXMG0t8eEisjlOkNjDtaRkjqctDBVridYdqQNRYD8tbjw6GUSMqhSgkbnvIo6tCpDapzsDNitYcnH0Q==";
       };
     };
     "capture-stack-trace-1.0.1" = {
@@ -5940,7 +5976,7 @@ let
       packageName = "cheerio";
       version = "0.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cheerio/-/cheerio-0.17.0.tgz";
+        url = "http://registry.npmjs.org/cheerio/-/cheerio-0.17.0.tgz";
         sha1 = "fa5ae42cc60121133d296d0b46d983215f7268ea";
       };
     };
@@ -5949,7 +5985,7 @@ let
       packageName = "cheerio";
       version = "0.20.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz";
+        url = "http://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz";
         sha1 = "5c710f2bab95653272842ba01c6ea61b3545ec35";
       };
     };
@@ -5958,7 +5994,7 @@ let
       packageName = "cheerio";
       version = "0.22.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz";
+        url = "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz";
         sha1 = "a9baa860a3f9b595a6b81b1a86873121ed3a269e";
       };
     };
@@ -6133,13 +6169,13 @@ let
         sha512 = "UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==";
       };
     };
-    "circular-json-0.5.7" = {
+    "circular-json-0.5.9" = {
       name = "circular-json";
       packageName = "circular-json";
-      version = "0.5.7";
+      version = "0.5.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/circular-json/-/circular-json-0.5.7.tgz";
-        sha512 = "/pXoV1JA847qRKPrHbBK6YIBGFF8GOP4wzSgUOA7q0ew0vAv0iJswP+2/nZQ9uzA3Azi7eTrg9L2yzXc/7ZMIA==";
+        url = "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz";
+        sha512 = "4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==";
       };
     };
     "clarinet-0.11.0" = {
@@ -6210,7 +6246,7 @@ let
       packageName = "cli-color";
       version = "0.1.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz";
+        url = "http://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz";
         sha1 = "adc3200fa471cc211b0da7f566b71e98b9d67347";
       };
     };
@@ -6824,15 +6860,6 @@ let
       src = fetchurl {
         url = "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz";
         sha1 = "0137e657baa5a7541c57ac37ac5fc07d73b4dc1f";
-      };
-    };
-    "combined-stream-1.0.6" = {
-      name = "combined-stream";
-      packageName = "combined-stream";
-      version = "1.0.6";
-      src = fetchurl {
-        url = "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz";
-        sha1 = "723e7df6e801ac5613113a7e445a9b69cb632818";
       };
     };
     "combined-stream-1.0.7" = {
@@ -7912,7 +7939,7 @@ let
       packageName = "core-js";
       version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz";
+        url = "http://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz";
         sha1 = "fab83fbb0b2d8dc85fa636c4b9d34c75420c6d65";
       };
     };
@@ -8308,26 +8335,26 @@ let
       packageName = "css-select";
       version = "1.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz";
+        url = "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz";
         sha1 = "2b3a110539c5355f1cd8d314623e870b121ec858";
       };
     };
-    "css-select-2.0.0" = {
+    "css-select-2.0.2" = {
       name = "css-select";
       packageName = "css-select";
-      version = "2.0.0";
+      version = "2.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-select/-/css-select-2.0.0.tgz";
-        sha512 = "MGhoq1S9EyPgZIGnts8Yz5WwUOyHmPMdlqeifsYs/xFX7AAm3hY0RJe1dqVlXtYPI66Nsk39R/sa5/ree6L2qg==";
+        url = "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz";
+        sha512 = "dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==";
       };
     };
-    "css-select-base-adapter-0.1.0" = {
+    "css-select-base-adapter-0.1.1" = {
       name = "css-select-base-adapter";
       packageName = "css-select-base-adapter";
-      version = "0.1.0";
+      version = "0.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.0.tgz";
-        sha1 = "0102b3d14630df86c3eb9fa9f5456270106cf990";
+        url = "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz";
+        sha512 = "jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==";
       };
     };
     "css-stringify-1.0.5" = {
@@ -8366,13 +8393,13 @@ let
         sha1 = "83834230cc9f74c457de59eebd1543feeb83b7ec";
       };
     };
-    "css-what-2.1.0" = {
+    "css-what-2.1.2" = {
       name = "css-what";
       packageName = "css-what";
-      version = "2.1.0";
+      version = "2.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz";
-        sha1 = "9467d032c38cfaefb9f2d79501253062f87fa1bd";
+        url = "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz";
+        sha512 = "wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==";
       };
     };
     "cssauron-1.4.0" = {
@@ -9221,6 +9248,15 @@ let
         sha512 = "ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==";
       };
     };
+    "deferred-leveldown-4.0.2" = {
+      name = "deferred-leveldown";
+      packageName = "deferred-leveldown";
+      version = "4.0.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz";
+        sha512 = "5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==";
+      };
+    };
     "define-properties-1.1.3" = {
       name = "define-properties";
       packageName = "define-properties";
@@ -9352,7 +9388,7 @@ let
       packageName = "depd";
       version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz";
+        url = "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz";
         sha1 = "80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa";
       };
     };
@@ -9635,6 +9671,15 @@ let
         sha1 = "4d5afc5187edba67ec6ab0e55f6422a0e2cb7338";
       };
     };
+    "discontinuous-range-1.0.0" = {
+      name = "discontinuous-range";
+      packageName = "discontinuous-range";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz";
+        sha1 = "e38331f0844bba49b9a9cb71c771585aab1bc65a";
+      };
+    };
     "discovery-channel-5.5.1" = {
       name = "discovery-channel";
       packageName = "discovery-channel";
@@ -9874,7 +9919,7 @@ let
       packageName = "domelementtype";
       version = "1.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz";
+        url = "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz";
         sha1 = "bd28773e2642881aec51544924299c5cd822185b";
       };
     };
@@ -9883,7 +9928,7 @@ let
       packageName = "domelementtype";
       version = "1.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz";
+        url = "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz";
         sha1 = "b17aed82e8ab59e52dd9c19b1756e0fc187204c2";
       };
     };
@@ -10410,6 +10455,15 @@ let
         sha512 = "AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==";
       };
     };
+    "encoding-down-5.0.4" = {
+      name = "encoding-down";
+      packageName = "encoding-down";
+      version = "5.0.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz";
+        sha512 = "8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==";
+      };
+    };
     "end-of-stream-0.1.5" = {
       name = "end-of-stream";
       packageName = "end-of-stream";
@@ -10577,17 +10631,17 @@ let
       packageName = "entities";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz";
+        url = "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz";
         sha1 = "b2987aa3821347fcde642b24fdfc9e4fb712bf26";
       };
     };
-    "entities-1.1.1" = {
+    "entities-1.1.2" = {
       name = "entities";
       packageName = "entities";
-      version = "1.1.1";
+      version = "1.1.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz";
-        sha1 = "6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0";
+        url = "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz";
+        sha512 = "f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==";
       };
     };
     "env-paths-1.0.0" = {
@@ -10820,7 +10874,7 @@ let
       packageName = "es6-promisify";
       version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz";
+        url = "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz";
         sha1 = "5109d62f3e56ea967c4b63505aef08291c8a5203";
       };
     };
@@ -10959,13 +11013,13 @@ let
         sha512 = "D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==";
       };
     };
-    "eslint-5.7.0" = {
+    "eslint-5.8.0" = {
       name = "eslint";
       packageName = "eslint";
-      version = "5.7.0";
+      version = "5.8.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz";
-        sha512 = "zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==";
+        url = "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz";
+        sha512 = "Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==";
       };
     };
     "eslint-plugin-no-unsafe-innerhtml-1.0.16" = {
@@ -11018,7 +11072,7 @@ let
       packageName = "espree";
       version = "3.5.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz";
+        url = "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz";
         sha512 = "yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==";
       };
     };
@@ -11029,6 +11083,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz";
         sha512 = "kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==";
+      };
+    };
+    "espree-4.1.0" = {
+      name = "espree";
+      packageName = "espree";
+      version = "4.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz";
+        sha512 = "I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==";
       };
     };
     "esprima-1.0.4" = {
@@ -11562,13 +11625,13 @@ let
         sha512 = "j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==";
       };
     };
-    "express-5.0.0-alpha.6" = {
+    "express-5.0.0-alpha.7" = {
       name = "express";
       packageName = "express";
-      version = "5.0.0-alpha.6";
+      version = "5.0.0-alpha.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/express/-/express-5.0.0-alpha.6.tgz";
-        sha1 = "85dc44d7e90d4809041407f388f239b5bd2f681e";
+        url = "https://registry.npmjs.org/express/-/express-5.0.0-alpha.7.tgz";
+        sha512 = "3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==";
       };
     };
     "express-handlebars-3.0.0" = {
@@ -11891,7 +11954,7 @@ let
       packageName = "fast-deep-equal";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
+        url = "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz";
         sha1 = "c053477817c86b51daa853c81e059b733d023614";
       };
     };
@@ -12019,15 +12082,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz";
         sha1 = "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38";
-      };
-    };
-    "fclone-1.0.11" = {
-      name = "fclone";
-      packageName = "fclone";
-      version = "1.0.11";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz";
-        sha1 = "10e85da38bfea7fc599341c296ee1d77266ee640";
       };
     };
     "fd-read-stream-1.1.0" = {
@@ -12271,15 +12325,6 @@ let
       src = fetchurl {
         url = "http://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz";
         sha1 = "2c400d8d4530935bc232549c5fa385ec07de6fcd";
-      };
-    };
-    "finalhandler-1.0.6" = {
-      name = "finalhandler";
-      packageName = "finalhandler";
-      version = "1.0.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz";
-        sha1 = "007aea33d1a4d3e42017f624848ad58d212f814f";
       };
     };
     "finalhandler-1.1.0" = {
@@ -12755,7 +12800,7 @@ let
       packageName = "form-data";
       version = "0.0.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz";
+        url = "http://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz";
         sha1 = "db345a5378d86aeeb1ed5d553b869ac192d2f5ed";
       };
     };
@@ -12764,7 +12809,7 @@ let
       packageName = "form-data";
       version = "0.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz";
+        url = "http://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz";
         sha1 = "4ee4346e6eb5362e8344a02075bd8dbd8c7373ea";
       };
     };
@@ -12773,7 +12818,7 @@ let
       packageName = "form-data";
       version = "1.0.0-rc3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz";
+        url = "http://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz";
         sha1 = "d35bc62e7fbc2937ae78f948aaa0d38d90607577";
       };
     };
@@ -12782,7 +12827,7 @@ let
       packageName = "form-data";
       version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz";
+        url = "http://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz";
         sha1 = "ae315db9a4907fa065502304a66d7733475ee37c";
       };
     };
@@ -12795,13 +12840,13 @@ let
         sha1 = "33c183acf193276ecaa98143a69e94bfee1750d1";
       };
     };
-    "form-data-2.3.2" = {
+    "form-data-2.3.3" = {
       name = "form-data";
       packageName = "form-data";
-      version = "2.3.2";
+      version = "2.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz";
-        sha1 = "4970498be604c20c005d4f5c23aecd21d6b49099";
+        url = "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz";
+        sha512 = "1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==";
       };
     };
     "format-util-1.0.3" = {
@@ -13317,13 +13362,13 @@ let
         sha1 = "8b465c1a7588ea9dd2bb133bda0bb66bfef8a63e";
       };
     };
-    "genfun-4.0.1" = {
+    "genfun-5.0.0" = {
       name = "genfun";
       packageName = "genfun";
-      version = "4.0.1";
+      version = "5.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz";
-        sha1 = "ed10041f2e4a7f1b0a38466d17a5c3e27df1dfc1";
+        url = "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz";
+        sha512 = "KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==";
       };
     };
     "get-assigned-identifiers-1.2.0" = {
@@ -14056,13 +14101,13 @@ let
         sha512 = "QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==";
       };
     };
-    "graphql-anywhere-4.1.19" = {
+    "graphql-anywhere-4.1.21" = {
       name = "graphql-anywhere";
       packageName = "graphql-anywhere";
-      version = "4.1.19";
+      version = "4.1.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.19.tgz";
-        sha512 = "mQlvbECzYPBcgBC9JsdM4v+DSvNmcIP+8Vwr+ij3gktbaLSE0Iza30mztuz40Jlf7ooMs+0emBZucNjLzqz7tA==";
+        url = "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.21.tgz";
+        sha512 = "1Grw/WGoQUV52VxMFvMu97brfSDKpnHGmSH9U7IbKOJVUcvD0QSO+Exyv/8mjZf/urflmTmneDvCOo8LK4CkvQ==";
       };
     };
     "graphql-cli-prepare-1.4.19" = {
@@ -14151,7 +14196,7 @@ let
       packageName = "graphql-playground-html";
       version = "1.5.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.5.5.tgz";
+        url = "http://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.5.5.tgz";
         sha512 = "PzSywpEKcjbDUkV6e3ivEixvAuUJGyYmBUvuittzySe/RgwHRo0xKLD7HouUCTbpFfWMw8kRKhAUVtt7Ys97uw==";
       };
     };
@@ -14848,13 +14893,13 @@ let
         sha1 = "b8a9c5493212a9392f0222b649c9611497ebfb88";
       };
     };
-    "highlight.js-9.13.0" = {
+    "highlight.js-9.13.1" = {
       name = "highlight.js";
       packageName = "highlight.js";
-      version = "9.13.0";
+      version = "9.13.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.0.tgz";
-        sha512 = "2B90kcNnErqRTmzdZw6IPLEC9CdsiIMhj+r8L3LJKRCgtEJ+LY5yzWuQCVnADTI0wwocQinFzaaL/JjTQNqI/g==";
+        url = "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz";
+        sha512 = "Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==";
       };
     };
     "hiredis-0.4.1" = {
@@ -14992,12 +15037,21 @@ let
         sha1 = "3a03edc2214bca3b66424a3e7959349509cb0351";
       };
     };
+    "htmlparser2-3.10.0" = {
+      name = "htmlparser2";
+      packageName = "htmlparser2";
+      version = "3.10.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz";
+        sha512 = "J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==";
+      };
+    };
     "htmlparser2-3.7.3" = {
       name = "htmlparser2";
       packageName = "htmlparser2";
       version = "3.7.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz";
+        url = "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz";
         sha1 = "6a64c77637c08c6f30ec2a8157a53333be7cb05e";
       };
     };
@@ -15006,17 +15060,8 @@ let
       packageName = "htmlparser2";
       version = "3.8.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz";
+        url = "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz";
         sha1 = "996c28b191516a8be86501a7d79757e5c70c1068";
-      };
-    };
-    "htmlparser2-3.9.2" = {
-      name = "htmlparser2";
-      packageName = "htmlparser2";
-      version = "3.9.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz";
-        sha1 = "1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338";
       };
     };
     "http-auth-2.0.7" = {
@@ -15109,13 +15154,13 @@ let
         sha1 = "29691b6fc58f4f7e81a3605dca82682b068e4430";
       };
     };
-    "http-parser-js-0.4.13" = {
+    "http-parser-js-0.5.0" = {
       name = "http-parser-js";
       packageName = "http-parser-js";
-      version = "0.4.13";
+      version = "0.5.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz";
-        sha1 = "3bd6d6fde6e3172c9334c3b33b6c193d80fe1137";
+        url = "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz";
+        sha512 = "cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==";
       };
     };
     "http-proxy-1.0.2" = {
@@ -15123,7 +15168,7 @@ let
       packageName = "http-proxy";
       version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.2.tgz";
+        url = "http://registry.npmjs.org/http-proxy/-/http-proxy-1.0.2.tgz";
         sha1 = "08060ff2edb2189e57aa3a152d3ac63ed1af7254";
       };
     };
@@ -15258,7 +15303,7 @@ let
       packageName = "humanize-plus";
       version = "1.8.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz";
+        url = "http://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz";
         sha1 = "a65b34459ad6367adbb3707a82a3c9f916167030";
       };
     };
@@ -15532,13 +15577,13 @@ let
         sha512 = "5s6NiCGbtWc+OQA60jrre54w12U7tynIyUNjO5LJjNA5lWwvCv6640roq8Wk/wIuaqnd4Pgtp453OyJ7hbONkQ==";
       };
     };
-    "immutable-tuple-0.4.8" = {
+    "immutable-tuple-0.4.9" = {
       name = "immutable-tuple";
       packageName = "immutable-tuple";
-      version = "0.4.8";
+      version = "0.4.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/immutable-tuple/-/immutable-tuple-0.4.8.tgz";
-        sha512 = "1m29EVSrF+LJJAyVo1v12NsIalVKjyi4HNQVQDBx+LNCIuRXnfeMCHuLao5CyN1m3Sn0T63U5JEkmPArPCipQA==";
+        url = "https://registry.npmjs.org/immutable-tuple/-/immutable-tuple-0.4.9.tgz";
+        sha512 = "LWbJPZnidF8eczu7XmcnLBsumuyRBkpwIRPCZxlojouhBo5jEBO4toj6n7hMy6IxHU/c+MqDSWkvaTpPlMQcyA==";
       };
     };
     "import-global-0.1.0" = {
@@ -15971,15 +16016,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz";
         sha1 = "5fa78cf301b825c78abc3042d812723049ea23c7";
-      };
-    };
-    "ipaddr.js-1.4.0" = {
-      name = "ipaddr.js";
-      packageName = "ipaddr.js";
-      version = "1.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz";
-        sha1 = "296aca878a821816e5b85d0a285a99bcff4582f0";
       };
     };
     "ipaddr.js-1.8.0" = {
@@ -16945,13 +16981,13 @@ let
         sha512 = "8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==";
       };
     };
-    "isemail-3.1.3" = {
+    "isemail-3.2.0" = {
       name = "isemail";
       packageName = "isemail";
-      version = "3.1.3";
+      version = "3.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz";
-        sha512 = "5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==";
+        url = "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz";
+        sha512 = "zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==";
       };
     };
     "isexe-1.1.2" = {
@@ -18287,6 +18323,15 @@ let
         sha512 = "2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==";
       };
     };
+    "level-4.0.0" = {
+      name = "level";
+      packageName = "level";
+      version = "4.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level/-/level-4.0.0.tgz";
+        sha512 = "4epzCOlEcJ529NOdlAYiuiakS/kZTDdiKSBNJmE1B8bsmA+zEVwcpxyH86qJSQTpOu7SODrlaD9WgPRHLkGutA==";
+      };
+    };
     "level-codec-6.2.0" = {
       name = "level-codec";
       packageName = "level-codec";
@@ -18305,6 +18350,15 @@ let
         sha512 = "gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q==";
       };
     };
+    "level-codec-9.0.0" = {
+      name = "level-codec";
+      packageName = "level-codec";
+      version = "9.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz";
+        sha512 = "OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg==";
+      };
+    };
     "level-errors-1.1.2" = {
       name = "level-errors";
       packageName = "level-errors";
@@ -18314,6 +18368,15 @@ let
         sha512 = "Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==";
       };
     };
+    "level-errors-2.0.0" = {
+      name = "level-errors";
+      packageName = "level-errors";
+      version = "2.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz";
+        sha512 = "AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==";
+      };
+    };
     "level-iterator-stream-2.0.3" = {
       name = "level-iterator-stream";
       packageName = "level-iterator-stream";
@@ -18321,6 +18384,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz";
         sha512 = "I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==";
+      };
+    };
+    "level-iterator-stream-3.0.1" = {
+      name = "level-iterator-stream";
+      packageName = "level-iterator-stream";
+      version = "3.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz";
+        sha512 = "nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==";
       };
     };
     "level-packager-0.18.0" = {
@@ -18339,6 +18411,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz";
         sha512 = "6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==";
+      };
+    };
+    "level-packager-3.1.0" = {
+      name = "level-packager";
+      packageName = "level-packager";
+      version = "3.1.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/level-packager/-/level-packager-3.1.0.tgz";
+        sha512 = "UxVEfK5WH0u0InR3WxTCSAroiorAGKzXWZT6i+nBjambmvINuXFUsFx2Ai3UIjUUtnyWhluv42jMlzUZCsAk9A==";
       };
     };
     "level-post-1.0.7" = {
@@ -18377,6 +18458,15 @@ let
         sha512 = "+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==";
       };
     };
+    "leveldown-4.0.1" = {
+      name = "leveldown";
+      packageName = "leveldown";
+      version = "4.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/leveldown/-/leveldown-4.0.1.tgz";
+        sha512 = "ZlBKVSsglPIPJnz4ggB8o2R0bxDxbsMzuQohbfgoFMVApyTE118DK5LNRG0cRju6rt3OkGxe0V6UYACGlq/byg==";
+      };
+    };
     "levelup-0.18.6" = {
       name = "levelup";
       packageName = "levelup";
@@ -18402,6 +18492,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz";
         sha512 = "us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==";
+      };
+    };
+    "levelup-3.1.1" = {
+      name = "levelup";
+      packageName = "levelup";
+      version = "3.1.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz";
+        sha512 = "9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==";
       };
     };
     "leven-1.0.2" = {
@@ -20258,13 +20357,13 @@ let
         sha1 = "632b127c3ae5d6ad9e21cfdd9691b63b8944fcd2";
       };
     };
-    "map-filter-reduce-3.2.1" = {
+    "map-filter-reduce-3.2.2" = {
       name = "map-filter-reduce";
       packageName = "map-filter-reduce";
-      version = "3.2.1";
+      version = "3.2.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.1.tgz";
-        sha512 = "0+0C/3IVCX8PLXRyBL0umF/YMy3/ch7Zgxu91ZUIXS6YHyv4UVMZlkclUk9rQI63FQ+uvBdHYzo8VPJbIxKTVw==";
+        url = "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.2.tgz";
+        sha512 = "p+NIGQbEBxlw/qWwG+NME98G/9kjOQI70hmaH8QEZtIWfTmfMYLKQW4PJChP4izPHNAxlOfv/qefP0+2ZXn84A==";
       };
     };
     "map-merge-1.1.0" = {
@@ -20497,7 +20596,7 @@ let
       packageName = "media-typer";
       version = "0.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
+        url = "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz";
         sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
       };
     };
@@ -20641,7 +20740,7 @@ let
       packageName = "meow";
       version = "3.7.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz";
+        url = "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz";
         sha1 = "72cb668b425228290abbfa856892587308a801fb";
       };
     };
@@ -20663,13 +20762,13 @@ let
         sha512 = "CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==";
       };
     };
-    "merge-1.2.0" = {
+    "merge-1.2.1" = {
       name = "merge";
       packageName = "merge";
-      version = "1.2.0";
+      version = "1.2.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz";
-        sha1 = "7531e39d4949c281a66b8c5a6e0265e8b05894da";
+        url = "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz";
+        sha512 = "VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==";
       };
     };
     "merge-descriptors-0.0.2" = {
@@ -20884,7 +20983,7 @@ let
       packageName = "mime-db";
       version = "1.12.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz";
+        url = "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz";
         sha1 = "3d0c63180f458eb10d325aaa37d7c58ae312e9d7";
       };
     };
@@ -20893,17 +20992,17 @@ let
       packageName = "mime-db";
       version = "1.33.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz";
+        url = "http://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz";
         sha512 = "BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==";
       };
     };
-    "mime-db-1.36.0" = {
+    "mime-db-1.37.0" = {
       name = "mime-db";
       packageName = "mime-db";
-      version = "1.36.0";
+      version = "1.37.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz";
-        sha512 = "L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==";
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz";
+        sha512 = "R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==";
       };
     };
     "mime-types-2.0.14" = {
@@ -20911,7 +21010,7 @@ let
       packageName = "mime-types";
       version = "2.0.14";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz";
+        url = "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz";
         sha1 = "310e159db23e077f8bb22b748dabfa4957140aa6";
       };
     };
@@ -20920,17 +21019,17 @@ let
       packageName = "mime-types";
       version = "2.1.18";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz";
+        url = "http://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz";
         sha512 = "lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==";
       };
     };
-    "mime-types-2.1.20" = {
+    "mime-types-2.1.21" = {
       name = "mime-types";
       packageName = "mime-types";
-      version = "2.1.20";
+      version = "2.1.21";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz";
-        sha512 = "HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==";
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz";
+        sha512 = "3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==";
       };
     };
     "mimelib-0.3.1" = {
@@ -21086,13 +21185,13 @@ let
         sha512 = "FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==";
       };
     };
-    "minipass-2.3.4" = {
+    "minipass-2.3.5" = {
       name = "minipass";
       packageName = "minipass";
-      version = "2.3.4";
+      version = "2.3.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz";
-        sha512 = "mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==";
+        url = "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz";
+        sha512 = "Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==";
       };
     };
     "minizlib-1.1.1" = {
@@ -21345,6 +21444,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz";
         sha1 = "5ba5adc7aac85e1d7ce77be847161ed246b39603";
+      };
+    };
+    "moo-0.4.3" = {
+      name = "moo";
+      packageName = "moo";
+      version = "0.4.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz";
+        sha512 = "gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==";
       };
     };
     "mooremachine-2.2.1" = {
@@ -21707,13 +21815,22 @@ let
         sha1 = "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b";
       };
     };
-    "multiserver-1.13.5" = {
+    "multiserver-1.13.7" = {
       name = "multiserver";
       packageName = "multiserver";
-      version = "1.13.5";
+      version = "1.13.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/multiserver/-/multiserver-1.13.5.tgz";
-        sha512 = "1bxts3gFkHKJsGAaWR9D4nFLVH995eiEt38n/jPf1dni/FI0o6PH3hlar3ge/bMs58FX/T+DzrGNXZhEkMVFqA==";
+        url = "https://registry.npmjs.org/multiserver/-/multiserver-1.13.7.tgz";
+        sha512 = "nQKAe6+u7nWJY29pJjegltw0ROj2bDc2bCTm9Bnr4EQrp5H5Tav+ESUjgl3D4vuQgCeveb4h+CtLtjB8QnK1Dw==";
+      };
+    };
+    "multiserver-address-1.0.1" = {
+      name = "multiserver-address";
+      packageName = "multiserver-address";
+      version = "1.0.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/multiserver-address/-/multiserver-address-1.0.1.tgz";
+        sha512 = "IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==";
       };
     };
     "multistream-2.1.1" = {
@@ -21950,13 +22067,13 @@ let
         sha512 = "N1IBreECNaxmsaOLMqqm01K7XIp+sMvoVX8mvmT/p1VjM2FLcBU0lj0FalKooi2/2i+ph9WsEoEogOJevqQ6LQ==";
       };
     };
-    "nanoid-1.3.0" = {
+    "nanoid-1.3.1" = {
       name = "nanoid";
       packageName = "nanoid";
-      version = "1.3.0";
+      version = "1.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nanoid/-/nanoid-1.3.0.tgz";
-        sha512 = "OP8SoC91Kyjl1sdSTEnM1xYh4gUEOSkUl6wRBUklWOPyfPRbeJbhvdhQYXEjVtZ1LI9amVMkIWQI2nO8O7DL9A==";
+        url = "https://registry.npmjs.org/nanoid/-/nanoid-1.3.1.tgz";
+        sha512 = "wSBw7t+JVjQAY8q89BhrTaBTMdoPGbZP8qQqidQHL76oeaFJ9i+c6SKKHP2l/DmzLP43eeV6JkM3f5Mb6saH8Q==";
       };
     };
     "nanolru-1.0.0" = {
@@ -22141,6 +22258,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz";
         sha1 = "ae603b36b134bcec347b452422b0bf98d5832ec8";
+      };
+    };
+    "nearley-2.15.1" = {
+      name = "nearley";
+      packageName = "nearley";
+      version = "2.15.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz";
+        sha512 = "8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==";
       };
     };
     "neat-input-1.8.0" = {
@@ -22387,13 +22513,13 @@ let
         sha1 = "1f1b916b56b9ea241c0135f97ced6940f556f292";
       };
     };
-    "node-appc-0.2.48" = {
+    "node-appc-0.2.49" = {
       name = "node-appc";
       packageName = "node-appc";
-      version = "0.2.48";
+      version = "0.2.49";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-appc/-/node-appc-0.2.48.tgz";
-        sha512 = "fKPynW61a+PmqssitvJXxN2FZAN/w4eBvmE5zqJXl+eDfOip/b26y7SIGGJOn23KjAYX2uyl2Oy/+qTaRz/gHQ==";
+        url = "https://registry.npmjs.org/node-appc/-/node-appc-0.2.49.tgz";
+        sha512 = "PldEN7CgEy7ekSZyomgpajLX7STCZPDJI6rGy7FCbWi7ZJgTt9/C3omCxPkIKVjtwcXzXoSA31zUWUnBzTkEUg==";
       };
     };
     "node-cache-4.2.0" = {
@@ -22531,6 +22657,15 @@ let
         sha512 = "MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==";
       };
     };
+    "node-notifier-5.3.0" = {
+      name = "node-notifier";
+      packageName = "node-notifier";
+      version = "5.3.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz";
+        sha512 = "AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==";
+      };
+    };
     "node-phantom-simple-2.2.4" = {
       name = "node-phantom-simple";
       packageName = "node-phantom-simple";
@@ -22576,22 +22711,22 @@ let
         sha512 = "Bb9M5bFrOqoFxBVxfstBM/g+VPaV4EPQptXQBMrlsCd3P40CXcGL0mDylXU+3cekWNd5hLHfqTHvXJdkowHGDw==";
       };
     };
-    "node-red-node-rbe-0.2.3" = {
+    "node-red-node-rbe-0.2.4" = {
       name = "node-red-node-rbe";
       packageName = "node-red-node-rbe";
-      version = "0.2.3";
+      version = "0.2.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-rbe/-/node-red-node-rbe-0.2.3.tgz";
-        sha512 = "5+MtH9t8tX6Aw6M+SeoyGR23XplNTOln3aTQ7El9tj/606bxea4GxYyvV4ymTmuoODz3GXQlLLQVdGkFLyIdDQ==";
+        url = "https://registry.npmjs.org/node-red-node-rbe/-/node-red-node-rbe-0.2.4.tgz";
+        sha512 = "ft/8/dTRGzGQ9vCnAzuBxzR+aDv4Yun/vuSKi/eI5Qj2/ZBal28L9HpWziSTWlLrMhZns8CRz7s2p84P2ee/vA==";
       };
     };
-    "node-red-node-twitter-1.1.3" = {
+    "node-red-node-twitter-1.1.4" = {
       name = "node-red-node-twitter";
       packageName = "node-red-node-twitter";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/node-red-node-twitter/-/node-red-node-twitter-1.1.3.tgz";
-        sha512 = "H4q6wfIeDkDp7ykFh4nK7vrnJa9NI3FmC2rASabup/9LEJ5XD5KXH07eqo+B3Cf3jAzJDmL7RFEFucA8C1oqCw==";
+        url = "https://registry.npmjs.org/node-red-node-twitter/-/node-red-node-twitter-1.1.4.tgz";
+        sha512 = "mkw8HOosXHMBRdyJkio77vPx4Ls5IY26P5ZyoMWmKMkimXKTnX00DdpmNlkW+dHwMDYq1H66WzFtQhNOdEAbgA==";
       };
     };
     "node-request-by-swagger-1.1.3" = {
@@ -22747,13 +22882,13 @@ let
         sha1 = "586db8101db30cb4438eb546737a41aad0cf13d5";
       };
     };
-    "nodemon-1.18.4" = {
+    "nodemon-1.18.5" = {
       name = "nodemon";
       packageName = "nodemon";
-      version = "1.18.4";
+      version = "1.18.5";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nodemon/-/nodemon-1.18.4.tgz";
-        sha512 = "hyK6vl65IPnky/ee+D3IWvVGgJa/m3No2/Xc/3wanS6Ce1MWjCzH6NnhPJ/vZM+6JFym16jtHx51lmCMB9HDtg==";
+        url = "https://registry.npmjs.org/nodemon/-/nodemon-1.18.5.tgz";
+        sha512 = "8806dC8dfBlbxQmqNOSEeay/qlbddKvFzxIGNxnPtxUlTtH77xsrC66RnA3M47HCSgMgE5bj+U586o50RowXBg==";
       };
     };
     "nodesecurity-npm-utils-6.0.0" = {
@@ -22763,6 +22898,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-6.0.0.tgz";
         sha512 = "NLRle1woNaT2orR6fue2jNqkhxDTktgJj3sZxvR/8kp21pvOY7Gwlx5wvo0H8ZVPqdgd2nE2ADB9wDu5Cl8zNg==";
+      };
+    };
+    "nomnom-1.6.2" = {
+      name = "nomnom";
+      packageName = "nomnom";
+      version = "1.6.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz";
+        sha1 = "84a66a260174408fc5b77a18f888eccc44fb6971";
       };
     };
     "nomnom-1.8.1" = {
@@ -23112,7 +23256,7 @@ let
       packageName = "npmlog";
       version = "2.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz";
+        url = "http://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz";
         sha1 = "98b52530f2514ca90d09ec5b22c8846722375692";
       };
     };
@@ -23130,7 +23274,7 @@ let
       packageName = "nprogress";
       version = "0.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz";
+        url = "http://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz";
         sha1 = "cb8f34c53213d895723fcbab907e9422adbcafb1";
       };
     };
@@ -23143,13 +23287,13 @@ let
         sha1 = "883ca2ec605f5ed64a4d5190b2625401928f8f8d";
       };
     };
-    "nth-check-1.0.1" = {
+    "nth-check-1.0.2" = {
       name = "nth-check";
       packageName = "nth-check";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz";
-        sha1 = "9929acdf628fc2c41098deab82ac580cf149aae4";
+        url = "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz";
+        sha512 = "WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==";
       };
     };
     "number-is-nan-1.0.1" = {
@@ -23621,13 +23765,13 @@ let
         sha1 = "42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc";
       };
     };
-    "opencollective-postinstall-2.0.0" = {
+    "opencollective-postinstall-2.0.1" = {
       name = "opencollective-postinstall";
       packageName = "opencollective-postinstall";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.0.tgz";
-        sha512 = "XAe80GycLe2yRGnJsUtt+EO5lk06XYRQt4kJJe53O2kJHPZJOZ+XMF/b47HW96e6LhfKVpwnXVr/s56jhV98jg==";
+        url = "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.1.tgz";
+        sha512 = "saQQ9hjLwu/oS0492eyYotoh+bra1819cfAT5rjY/e4REWwuc8IgZ844Oo44SiftWcJuBiqp0SA0BFVbmLX0IQ==";
       };
     };
     "opener-1.4.3" = {
@@ -23702,13 +23846,13 @@ let
         sha512 = "YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==";
       };
     };
-    "optimism-0.6.6" = {
+    "optimism-0.6.7" = {
       name = "optimism";
       packageName = "optimism";
-      version = "0.6.6";
+      version = "0.6.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/optimism/-/optimism-0.6.6.tgz";
-        sha512 = "1Y6LY7pYbXP5y6yeXYfXhxJi9hsxYAZWpt7bBp4seAwfcYtaN7tq9wot/pdrhyI809/K4gDm3BcZcEkmwGevjg==";
+        url = "https://registry.npmjs.org/optimism/-/optimism-0.6.7.tgz";
+        sha512 = "gSRISmAZXmTOedipfzP14ZR7/XnnqnQjl9ubgkHWx6WJjtBlEtk2mvzE5GGM2OMcsX5Z5qN55AhX6LWuonXfow==";
       };
     };
     "optimist-0.2.8" = {
@@ -24206,13 +24350,13 @@ let
         sha1 = "79b302fc144cdfbb4ab6feba7040e6a5d99c79c7";
       };
     };
-    "pacote-9.1.0" = {
+    "pacote-9.1.1" = {
       name = "pacote";
       packageName = "pacote";
-      version = "9.1.0";
+      version = "9.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pacote/-/pacote-9.1.0.tgz";
-        sha512 = "AFXaSWhOtQf3jHqEvg+ZYH/dfT8TKq6TKspJ4qEFwVVuh5aGvMIk6SNF8vqfzz+cBceDIs9drOcpBbrPai7i+g==";
+        url = "https://registry.npmjs.org/pacote/-/pacote-9.1.1.tgz";
+        sha512 = "f28Rq5ozzKAA9YwIKw61/ipwAatUZseYmVssDbHHaexF0wRIVotapVEZPAjOT7Eu3LYVqEp0NVpNizoAnYBUaA==";
       };
     };
     "pad-0.0.5" = {
@@ -25013,7 +25157,7 @@ let
       packageName = "pify";
       version = "2.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz";
+        url = "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz";
         sha1 = "ed141a6ac043a849ea588498e7dca8b15330e90c";
       };
     };
@@ -25296,13 +25440,13 @@ let
         sha1 = "8dd70c4fe7c694109add784ffe80eacac1e7b28d";
       };
     };
-    "portfinder-1.0.17" = {
+    "portfinder-1.0.19" = {
       name = "portfinder";
       packageName = "portfinder";
-      version = "1.0.17";
+      version = "1.0.19";
       src = fetchurl {
-        url = "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz";
-        sha512 = "syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==";
+        url = "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz";
+        sha512 = "23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==";
       };
     };
     "posix-character-classes-0.1.1" = {
@@ -25535,17 +25679,17 @@ let
       packageName = "progress";
       version = "1.1.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz";
+        url = "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz";
         sha1 = "e260c78f6161cdd9b0e56cc3e0a85de17c7a57be";
       };
     };
-    "progress-2.0.0" = {
+    "progress-2.0.1" = {
       name = "progress";
       packageName = "progress";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz";
-        sha1 = "8a1be366bf8fc23db2bd23f10c6fe920b4389d1f";
+        url = "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz";
+        sha512 = "OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==";
       };
     };
     "progress-string-1.2.2" = {
@@ -25746,13 +25890,13 @@ let
         sha512 = "SmjEuAf3hc3h3rWZ6V1YaaQw2MNJWK848gLJgzx/sefOJdNLujKinJVXIS0q2cBQpQn2Q32TinawZyDZPzm4kQ==";
       };
     };
-    "protoduck-5.0.0" = {
+    "protoduck-5.0.1" = {
       name = "protoduck";
       packageName = "protoduck";
-      version = "5.0.0";
+      version = "5.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/protoduck/-/protoduck-5.0.0.tgz";
-        sha512 = "agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==";
+        url = "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz";
+        sha512 = "WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==";
       };
     };
     "proxy-addr-1.0.10" = {
@@ -25762,15 +25906,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz";
         sha1 = "0d40a82f801fc355567d2ecb65efe3f077f121c5";
-      };
-    };
-    "proxy-addr-1.1.5" = {
-      name = "proxy-addr";
-      packageName = "proxy-addr";
-      version = "1.1.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz";
-        sha1 = "71c0ee3b102de3f202f3b64f608d173fcba1a918";
       };
     };
     "proxy-addr-2.0.4" = {
@@ -26241,13 +26376,13 @@ let
         sha1 = "5f99af15e8846d48ecf625edc248ec2cf57f6b0d";
       };
     };
-    "pull-inactivity-2.1.2" = {
+    "pull-inactivity-2.1.3" = {
       name = "pull-inactivity";
       packageName = "pull-inactivity";
-      version = "2.1.2";
+      version = "2.1.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.2.tgz";
-        sha1 = "37a3d6ebbfac292cd435f5e481e5074c8c1fad75";
+        url = "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.3.tgz";
+        sha512 = "swJ/jwkIN/O1bQCE3iY7Xy9r3gYuJ50MXaxZilw/HIduAy4tJu+vcz2/If0L+xNK7Ku/FfjtVbTpRTe7sf3hmA==";
       };
     };
     "pull-kvdiff-0.0.0" = {
@@ -26772,15 +26907,6 @@ let
         sha1 = "13e26d28ad6b0ffaa91312cd3bf708ed351e7233";
       };
     };
-    "qs-6.5.0" = {
-      name = "qs";
-      packageName = "qs";
-      version = "6.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz";
-        sha512 = "fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==";
-      };
-    };
     "qs-6.5.1" = {
       name = "qs";
       packageName = "qs";
@@ -26889,6 +27015,24 @@ let
         sha1 = "8ccfd014d0f9608630dd73c19b8e4b057754a6a6";
       };
     };
+    "railroad-diagrams-1.0.0" = {
+      name = "railroad-diagrams";
+      packageName = "railroad-diagrams";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz";
+        sha1 = "eb7e6267548ddedfb899c1b90e57374559cddb7e";
+      };
+    };
+    "randexp-0.4.6" = {
+      name = "randexp";
+      packageName = "randexp";
+      version = "0.4.6";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz";
+        sha512 = "80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==";
+      };
+    };
     "random-access-file-2.0.1" = {
       name = "random-access-file";
       packageName = "random-access-file";
@@ -26934,13 +27078,13 @@ let
         sha1 = "f7d97d92dee6665ec5f6da08c7f963cad4b2ac99";
       };
     };
-    "randomatic-3.1.0" = {
+    "randomatic-3.1.1" = {
       name = "randomatic";
       packageName = "randomatic";
-      version = "3.1.0";
+      version = "3.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz";
-        sha512 = "KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==";
+        url = "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz";
+        sha512 = "TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==";
       };
     };
     "randombytes-2.0.6" = {
@@ -27587,7 +27731,7 @@ let
       packageName = "remark";
       version = "3.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz";
+        url = "http://registry.npmjs.org/remark/-/remark-3.2.3.tgz";
         sha1 = "802a38c3aa98c9e1e3ea015eeba211d27cb65e1f";
       };
     };
@@ -27843,13 +27987,13 @@ let
         sha1 = "5281770f68e0c9719e5163fd3fab482215f4fda5";
       };
     };
-    "requestretry-3.0.1" = {
+    "requestretry-3.0.2" = {
       name = "requestretry";
       packageName = "requestretry";
-      version = "3.0.1";
+      version = "3.0.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/requestretry/-/requestretry-3.0.1.tgz";
-        sha512 = "vJUdB4xucpx+Hc5N1hV44/fHmT4ovhrwGWfG9MtZR6AeO1G350IqPUXJL4gfZND6RtqoSqB+Zs9EeCsMizYf9A==";
+        url = "https://registry.npmjs.org/requestretry/-/requestretry-3.0.2.tgz";
+        sha512 = "3UXO4EOBwRFXm2AeAElyhM3bmMb57jZi5QC2httyXXSyT49O6o+AdzUZRA/vj5O2tE6xbdpDygRZb5Q19Q7lCA==";
       };
     };
     "require-directory-2.1.1" = {
@@ -28284,13 +28428,13 @@ let
         sha1 = "6f04063a2d04eba3303a1bbc6765eef63037cf3d";
       };
     };
-    "router-1.3.3" = {
+    "router-2.0.0-alpha.1" = {
       name = "router";
       packageName = "router";
-      version = "1.3.3";
+      version = "2.0.0-alpha.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/router/-/router-1.3.3.tgz";
-        sha1 = "c142f6b5ea4d6b3359022ca95b6580bd217f89cf";
+        url = "https://registry.npmjs.org/router/-/router-2.0.0-alpha.1.tgz";
+        sha512 = "fz/T/qLkJM6RTtbqGqA1+uZ88ejqJoPyKeJAeXPYjebA7HzV/UyflH4gXWqW/Y6SERnp4kDwNARjqy6se3PcOw==";
       };
     };
     "rsvp-3.6.2" = {
@@ -28469,7 +28613,7 @@ let
       packageName = "safe-regex";
       version = "1.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
+        url = "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz";
         sha1 = "40a3669f3b077d1e943d44629e157dd48023bf2e";
       };
     };
@@ -28860,15 +29004,6 @@ let
         sha1 = "765e7607c8055452bba6f0b052595350986036de";
       };
     };
-    "send-0.15.6" = {
-      name = "send";
-      packageName = "send";
-      version = "0.15.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/send/-/send-0.15.6.tgz";
-        sha1 = "20f23a9c925b762ab82705fe2f9db252ace47e34";
-      };
-    };
     "send-0.16.2" = {
       name = "send";
       packageName = "send";
@@ -28993,15 +29128,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz";
         sha1 = "ce5a6ecd3101fed5ec09827dac22a9c29bfb0535";
-      };
-    };
-    "serve-static-1.12.6" = {
-      name = "serve-static";
-      packageName = "serve-static";
-      version = "1.12.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz";
-        sha1 = "b973773f63449934da54e5beba5e31d9f4211577";
       };
     };
     "serve-static-1.13.2" = {
@@ -29337,13 +29463,13 @@ let
         sha512 = "Wvre/Jq5vgoz31Z9stYWPLn0PqRqmBDpFSdypAnHu5AvRVCYPRYGnvryNLiXu8GOBNDH82J2FRHUGMjjHUpXFw==";
       };
     };
-    "simple-git-1.105.0" = {
+    "simple-git-1.106.0" = {
       name = "simple-git";
       packageName = "simple-git";
-      version = "1.105.0";
+      version = "1.106.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.105.0.tgz";
-        sha512 = "ZrGcCPRIKCm6Q8gNJ+gx+leHqaokKpXae6K9lZpVD4sfeA2/rVvxcIR4KVVujNOmA6wHE2xaQ0GQWuIY88o6pA==";
+        url = "https://registry.npmjs.org/simple-git/-/simple-git-1.106.0.tgz";
+        sha512 = "LaxKq4X9Om7bb16Cpinc36hT1YLHMM9KDQMSWJVv4Y1TGDEUuZbs+0lAk2JSKkCEO3xFjcMSx5OjvZo+i4eJvQ==";
       };
     };
     "simple-lru-cache-0.0.2" = {
@@ -29531,7 +29657,7 @@ let
       packageName = "slice-ansi";
       version = "0.0.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz";
+        url = "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz";
         sha1 = "edbf8903f66f7ce2f8eafd6ceed65e264c831b35";
       };
     };
@@ -29706,13 +29832,13 @@ let
         sha512 = "FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==";
       };
     };
-    "snyk-1.103.4" = {
+    "snyk-1.105.0" = {
       name = "snyk";
       packageName = "snyk";
-      version = "1.103.4";
+      version = "1.105.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk/-/snyk-1.103.4.tgz";
-        sha512 = "ynLlsLDjAkzymd0qi1il6f34S4oNTfIgvFCFvkYxvqfBkedfOoDQT4TLU8gi+55MGM6iornf2iefC2FW92BwnQ==";
+        url = "https://registry.npmjs.org/snyk/-/snyk-1.105.0.tgz";
+        sha512 = "j4qNnZ+i9fwuS6t2xM+QSOYedbr9f10s4EC2m4fHWb22uyQYqDdRBISwY8nUAeYbJTMJvJTJzRcEEdXboSkNhA==";
       };
     };
     "snyk-config-2.2.0" = {
@@ -29733,13 +29859,13 @@ let
         sha512 = "QqKq2bGdnf1L2PNGQrHoqcoaV/PIlJv1qjKIzwA93gfhToKGkgJ31oPXwfef/l9N+ui0Y44c4POBHFbFf8PlJw==";
       };
     };
-    "snyk-go-plugin-1.5.2" = {
+    "snyk-go-plugin-1.6.0" = {
       name = "snyk-go-plugin";
       packageName = "snyk-go-plugin";
-      version = "1.5.2";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.5.2.tgz";
-        sha512 = "XWajcSh6Ld+I+WdcyU3DGDuE2ydThQd8ORkESy0nQ2LwekygLYVYN66OBy0uxpqYfd4qoqeg+J8lb4oGzCmyGA==";
+        url = "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.6.0.tgz";
+        sha512 = "E6aYw7XAXSs2wJR3fU+vGQ1lVyjAw8PHIQYQwBwMkTHByhJIWPcu6Hy/jT5LcjJHlhYXlpOuk53HeLVK+kcXrQ==";
       };
     };
     "snyk-gradle-plugin-2.1.0" = {
@@ -29805,13 +29931,13 @@ let
         sha512 = "CEioNnDzccHyid7UIVl3bJ1dnG4co4ofI+KxuC1mo0IUXy64gxnBTeVoZF5gVLWbAyxGxSeW8f0+8GmWMHVb7w==";
       };
     };
-    "snyk-python-plugin-1.8.2" = {
+    "snyk-python-plugin-1.9.0" = {
       name = "snyk-python-plugin";
       packageName = "snyk-python-plugin";
-      version = "1.8.2";
+      version = "1.9.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.8.2.tgz";
-        sha512 = "LBvjztnXarSHKyhivzM567icOOLOB98I7S9EEnjepuG+EZ0jiZzqOEMVRmzuYi+hRq3Cwh0hhjkwgJAQpKDz+g==";
+        url = "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.9.0.tgz";
+        sha512 = "zlyOHoCpmyVym9AwkboeepzEGrY3gHsM7eWP/nJ85TgCnQO5H5orKm3RL57PNbWRY+BnDmoQQ+udQgjym2+3sg==";
       };
     };
     "snyk-resolve-1.0.1" = {
@@ -30543,13 +30669,13 @@ let
         sha1 = "06cd70795ee58d1462d100a45c660df3179d3b39";
       };
     };
-    "ssb-blobs-1.1.5" = {
+    "ssb-blobs-1.1.6" = {
       name = "ssb-blobs";
       packageName = "ssb-blobs";
-      version = "1.1.5";
+      version = "1.1.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.5.tgz";
-        sha512 = "DeeInkFU8oN1mYlPVrqrm9tupf6wze4HuowK7N2vv/O+UeSLuYPU1p4HrxSqdAPvUabr0OtvbFA6z1T4nw+9fw==";
+        url = "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.6.tgz";
+        sha512 = "/dQIhg19Sk/cnRg25yUFFKhY67eB+Mlx00rK138dCVz3JhKLdmgDbK8kF5Ik/C/DdxDVya3xJZRW0fexwGOAkw==";
       };
     };
     "ssb-client-4.6.0" = {
@@ -30561,13 +30687,13 @@ let
         sha512 = "LyH5Y/U7xvafmAuG1puyhNv4G3Ew9xC67dYgRX0wwbUf5iT422WB1Cvat9qGFAu3/BQbdctXtdEQPxaAn0+hYA==";
       };
     };
-    "ssb-config-2.3.5" = {
+    "ssb-config-2.3.6" = {
       name = "ssb-config";
       packageName = "ssb-config";
-      version = "2.3.5";
+      version = "2.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.5.tgz";
-        sha512 = "lT30POSTXX6nsACYwMkNto0M74YMoEzLqpSpZqK+AwaRWlNvFqGmjEMwLb5G5jz7deCrXJFo87O3IubiQrwdGg==";
+        url = "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.6.tgz";
+        sha512 = "gR6og13QBkHxoeGcqVtD4MDPi+4UM2SRadglTIgHRs24lzRhk7YyI9oCESOMYtVmR09i4X24+LruBZbVkyXLBw==";
       };
     };
     "ssb-ebt-5.2.3" = {
@@ -30579,13 +30705,13 @@ let
         sha512 = "LTIry3qRZRLqv3l97tcd22dNiLjZHz7Ynot0OQFG10zL4jsECSkSxMUqSwrFUTfZEySUxhAx92TDcafDy+/J3A==";
       };
     };
-    "ssb-friends-3.1.3" = {
+    "ssb-friends-3.1.4" = {
       name = "ssb-friends";
       packageName = "ssb-friends";
-      version = "3.1.3";
+      version = "3.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-3.1.3.tgz";
-        sha512 = "bufgvAcqjAyjKfmh788dr3fV9YYrIgdkIhfETPHidbgIKgx15clNUzjP/s7FZk2PwwrjHyQ54kE0BR2em6u/nQ==";
+        url = "https://registry.npmjs.org/ssb-friends/-/ssb-friends-3.1.4.tgz";
+        sha512 = "/+1qQ4exI/MpAAZzt7jQW8tI0rKGZh+AEMAm4pNk+FnH/jjxSVwC6zjNRX8sZy8EWpJEb5czYC6j8SCUXtAHSA==";
       };
     };
     "ssb-git-0.5.0" = {
@@ -30696,13 +30822,13 @@ let
         sha512 = "y4OA2MvGl1jU7bUTYsTmMNSqlPt4eh9401THUW1DO4aFyBFEWvpa3eKJHc8aTmaph2hutPPbdKgEFsWDzw26uw==";
       };
     };
-    "ssb-ref-2.12.0" = {
+    "ssb-ref-2.13.1" = {
       name = "ssb-ref";
       packageName = "ssb-ref";
-      version = "2.12.0";
+      version = "2.13.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.12.0.tgz";
-        sha512 = "xcVFLYgvWkxZoNDCOQHLqgHYsjmfunVkdby9OPEygjufXbiW6zpnFTBqlqEBojBetxxtVdwCgZreD9kYXED/ZA==";
+        url = "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.1.tgz";
+        sha512 = "ncxWWvCHwRw7jP6EwY9/GZJRC3WhmEb+2KhPFuvVl0GvJWN46xhSxQniGZ1+nLqc8ixwtn94hlJ7ni9+1pqtpw==";
       };
     };
     "ssb-validate-3.0.11" = {
@@ -31484,7 +31610,7 @@ let
       packageName = "strip-eof";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz";
+        url = "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz";
         sha1 = "bb43ff5598a6eb05d89b59fcd129c983313606bf";
       };
     };
@@ -32277,17 +32403,17 @@ let
       packageName = "thunky";
       version = "0.1.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz";
+        url = "http://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz";
         sha1 = "bf30146824e2b6e67b0f2d7a4ac8beb26908684e";
       };
     };
-    "thunky-1.0.2" = {
+    "thunky-1.0.3" = {
       name = "thunky";
       packageName = "thunky";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz";
-        sha1 = "a862e018e3fb1ea2ec3fce5d55605cf57f247371";
+        url = "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz";
+        sha512 = "YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==";
       };
     };
     "tildify-1.2.0" = {
@@ -34455,7 +34581,7 @@ let
       packageName = "vfile-sort";
       version = "1.0.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz";
+        url = "http://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz";
         sha1 = "17ee491ba43e8951bb22913fcff32a7dc4d234d4";
       };
     };
@@ -34801,13 +34927,13 @@ let
         sha1 = "79691584d98607f5070bd3b70a40e6bb22e401eb";
       };
     };
-    "webassemblyjs-1.7.8" = {
+    "webassemblyjs-1.7.10" = {
       name = "webassemblyjs";
       packageName = "webassemblyjs";
-      version = "1.7.8";
+      version = "1.7.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.7.8.tgz";
-        sha512 = "7J64n2yTf2apgtRJypiHUFNRc2twQrMAFIWsm8u4qih7nG+sry2Bna1zq3qFI35fazIF1m42VGHHvdp9bBXmBA==";
+        url = "https://registry.npmjs.org/webassemblyjs/-/webassemblyjs-1.7.10.tgz";
+        sha512 = "VobGQmJDq1sZQe8Qhc3nnpPlTpqaMnNRPcbK86+JE2beomgkk/m3FGXDz20szy3maIkLPGqbPHWrin2oroDgGA==";
       };
     };
     "webidl-conversions-2.0.1" = {
@@ -34999,13 +35125,13 @@ let
         sha512 = "QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==";
       };
     };
-    "widest-line-2.0.0" = {
+    "widest-line-2.0.1" = {
       name = "widest-line";
       packageName = "widest-line";
-      version = "2.0.0";
+      version = "2.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz";
-        sha1 = "0142a4e8a243f8882c0233aa0e0281aa76152273";
+        url = "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz";
+        sha512 = "Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==";
       };
     };
     "win-detect-browsers-1.0.2" = {
@@ -36035,13 +36161,13 @@ let
         sha512 = "Dhp/R0pqSHj3vPs5O1gVd9kZx5Iew2lqVcfJQOBHx3llM/dLea8vl9wSa9FK8wLdSBQJ6mmgKi9+Rk2DRH3i9Q==";
       };
     };
-    "zen-observable-0.8.9" = {
+    "zen-observable-0.8.10" = {
       name = "zen-observable";
       packageName = "zen-observable";
-      version = "0.8.9";
+      version = "0.8.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.9.tgz";
-        sha512 = "Y9kPzjGvIZ5jchSlqlCpBW3I82zBBL4z+ulXDRVA1NwsKzjt5kwAi+gOYIy0htNkfuehGZZtP5mRXHRV6TjDWw==";
+        url = "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.10.tgz";
+        sha512 = "UXEh0ekA/QWYI2NkLHc5IH0V1FstIN4qGVlVvq0DQAS3oR72mofYHkjJ2f4ysMKRAziwnACzg3c0ZuG+SMDu8w==";
       };
     };
     "zen-observable-ts-0.8.10" = {
@@ -36283,11 +36409,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs-extra-0.26.7"
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
@@ -36308,8 +36430,8 @@ in
       sources."jsonfile-2.4.0"
       sources."jsprim-1.4.1"
       sources."klaw-1.3.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -36431,11 +36553,11 @@ in
           sources."request-2.74.0"
         ];
       })
-      sources."azure-arm-resource-7.0.0"
+      sources."azure-arm-resource-7.0.1"
       sources."azure-arm-servermanagement-1.1.0"
       sources."azure-arm-storage-5.2.0"
       sources."azure-arm-trafficmanager-1.1.0-preview"
-      sources."azure-arm-website-5.3.0"
+      sources."azure-arm-website-5.4.0"
       sources."azure-asm-compute-0.18.0"
       sources."azure-asm-hdinsight-0.10.2"
       sources."azure-asm-mgmt-0.10.1"
@@ -36470,13 +36592,13 @@ in
         ];
       })
       sources."azure-servicefabric-2.0.0"
-      (sources."azure-storage-2.10.1" // {
+      (sources."azure-storage-2.10.2" // {
         dependencies = [
-          sources."extend-1.2.1"
           sources."readable-stream-2.0.6"
           sources."underscore-1.8.3"
           sources."validator-9.4.1"
           sources."xml2js-0.2.8"
+          sources."xmlbuilder-9.0.7"
         ];
       })
       sources."balanced-match-1.0.0"
@@ -36607,8 +36729,8 @@ in
       sources."lodash-4.17.11"
       sources."map-stream-0.1.0"
       sources."md5.js-1.3.4"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -36675,11 +36797,7 @@ in
           sources."assert-plus-1.0.0"
           sources."aws-sign2-0.7.0"
           sources."caseless-0.12.0"
-          (sources."form-data-2.3.2" // {
-            dependencies = [
-              sources."combined-stream-1.0.6"
-            ];
-          })
+          sources."form-data-2.3.3"
           sources."har-validator-5.1.0"
           sources."http-signature-1.2.0"
           sources."oauth-sign-0.9.0"
@@ -36847,7 +36965,7 @@ in
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
-      sources."mime-db-1.36.0"
+      sources."mime-db-1.37.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
@@ -36924,7 +37042,8 @@ in
     dependencies = [
       sources."JSONStream-1.3.5"
       sources."acorn-6.0.2"
-      sources."acorn-node-1.6.0"
+      sources."acorn-dynamic-import-4.0.0"
+      sources."acorn-node-1.6.2"
       sources."acorn-walk-6.1.0"
       sources."array-filter-0.0.1"
       sources."array-map-0.0.0"
@@ -37197,7 +37316,7 @@ in
         dependencies = [
           sources."minimist-0.0.8"
           sources."mkdirp-0.5.1"
-          sources."thunky-1.0.2"
+          sources."thunky-1.0.3"
         ];
       })
       sources."fs.realpath-1.0.0"
@@ -37626,7 +37745,8 @@ in
       sources."abbrev-1.1.1"
       sources."accepts-1.3.5"
       sources."acorn-5.7.3"
-      (sources."acorn-node-1.6.0" // {
+      sources."acorn-dynamic-import-4.0.0"
+      (sources."acorn-node-1.6.2" // {
         dependencies = [
           sources."acorn-6.0.2"
         ];
@@ -37820,11 +37940,7 @@ in
       sources."finalhandler-1.1.1"
       sources."foreach-2.0.5"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."fs.realpath-1.0.0"
@@ -37930,8 +38046,8 @@ in
       sources."methods-1.1.2"
       sources."miller-rabin-4.0.1"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimalistic-assert-1.0.1"
       sources."minimalistic-crypto-utils-1.0.1"
       sources."minimatch-3.0.4"
@@ -38131,7 +38247,7 @@ in
       sources."verror-1.10.0"
       sources."vm-browserify-0.0.4"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."win-release-1.1.1"
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.3.0"
@@ -38174,7 +38290,7 @@ in
       sources."@cycle/run-3.4.0"
       sources."@cycle/time-0.10.1"
       sources."@types/cookiejar-2.1.0"
-      sources."@types/node-10.11.7"
+      sources."@types/node-10.12.0"
       sources."@types/superagent-3.8.2"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
@@ -38192,7 +38308,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."combine-errors-3.0.3"
-      sources."combined-stream-1.0.6"
+      sources."combined-stream-1.0.7"
       sources."component-emitter-1.2.1"
       sources."cookiejar-2.1.2"
       sources."core-util-is-1.0.2"
@@ -38213,7 +38329,7 @@ in
       sources."extend-3.0.2"
       sources."external-editor-2.2.0"
       sources."figures-2.0.0"
-      sources."form-data-2.3.2"
+      sources."form-data-2.3.3"
       sources."formidable-1.2.1"
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
@@ -38240,8 +38356,8 @@ in
       sources."lru-cache-4.1.3"
       sources."methods-1.1.2"
       sources."mime-1.6.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimist-1.2.0"
       sources."ms-2.1.1"
@@ -38618,11 +38734,7 @@ in
       sources."for-in-1.0.2"
       sources."for-own-0.1.5"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."from2-2.3.0"
       sources."fs.realpath-1.0.0"
       sources."get-stream-3.0.0"
@@ -38722,8 +38834,8 @@ in
       sources."merkle-tree-stream-3.0.3"
       sources."micromatch-2.3.11"
       sources."mime-2.3.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."min-document-2.19.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
@@ -38790,7 +38902,7 @@ in
       sources."random-access-file-2.0.1"
       sources."random-access-memory-3.0.0"
       sources."random-access-storage-1.3.0"
-      (sources."randomatic-3.1.0" // {
+      (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
           sources."kind-of-6.0.2"
@@ -38858,7 +38970,7 @@ in
       sources."supports-color-5.5.0"
       sources."term-size-1.2.0"
       sources."throttle-1.0.3"
-      sources."thunky-1.0.2"
+      sources."thunky-1.0.3"
       sources."timed-out-4.0.1"
       sources."to-buffer-1.1.1"
       (sources."toiletdb-1.4.1" // {
@@ -38889,7 +39001,7 @@ in
       sources."varint-3.0.1"
       sources."verror-1.10.0"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       (sources."winston-2.1.1" // {
         dependencies = [
           sources."async-1.0.0"
@@ -38985,7 +39097,7 @@ in
       sources."fresh-0.2.4"
       sources."from-0.1.7"
       sources."hiredis-0.4.1"
-      sources."http-parser-js-0.4.13"
+      sources."http-parser-js-0.5.0"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
       sources."ipaddr.js-1.0.5"
@@ -39004,8 +39116,8 @@ in
       sources."merge-descriptors-0.0.2"
       sources."methods-1.1.2"
       sources."mime-1.2.11"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.10"
       sources."ms-0.7.0"
       sources."nan-2.11.1"
@@ -39258,7 +39370,7 @@ in
       sources."assert-plus-1.0.0"
       sources."async-2.6.1"
       sources."asynckit-0.4.0"
-      sources."aws-sdk-2.334.0"
+      sources."aws-sdk-2.344.0"
       sources."aws-sign2-0.7.0"
       sources."aws4-1.8.0"
       sources."base64-js-1.3.0"
@@ -39279,11 +39391,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."getpass-0.1.7"
       sources."har-schema-2.0.0"
       sources."har-validator-5.1.0"
@@ -39302,8 +39410,8 @@ in
       sources."jsprim-1.4.1"
       sources."lodash-4.17.11"
       sources."lossless-json-1.0.3"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.10"
       sources."oauth-sign-0.9.0"
       sources."optimist-0.6.1"
@@ -39317,7 +39425,7 @@ in
           sources."uuid-3.3.2"
         ];
       })
-      sources."requestretry-3.0.1"
+      sources."requestretry-3.0.2"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.1"
@@ -39494,11 +39602,7 @@ in
       sources."firstline-1.2.1"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."fs-extra-0.30.0"
       sources."fs.realpath-1.0.0"
@@ -39559,8 +39663,8 @@ in
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       sources."micromatch-3.1.10"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."mixin-deep-1.3.1"
@@ -39973,16 +40077,16 @@ in
   eslint = nodeEnv.buildNodePackage {
     name = "eslint";
     packageName = "eslint";
-    version = "5.7.0";
+    version = "5.8.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/eslint/-/eslint-5.7.0.tgz";
-      sha512 = "zYCeFQahsxffGl87U2aJ7DPyH8CbWgxBC213Y8+TCanhUTf2gEvfq3EKpHmEcozTLyPmGe9LZdMAwC/CpJBM5A==";
+      url = "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz";
+      sha512 = "Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==";
     };
     dependencies = [
       sources."@babel/code-frame-7.0.0"
       sources."@babel/highlight-7.0.0"
-      sources."acorn-5.7.3"
-      sources."acorn-jsx-4.1.1"
+      sources."acorn-6.0.2"
+      sources."acorn-jsx-5.0.0"
       sources."ajv-6.5.4"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-3.0.0"
@@ -40012,7 +40116,7 @@ in
       sources."eslint-scope-4.0.0"
       sources."eslint-utils-1.3.1"
       sources."eslint-visitor-keys-1.0.0"
-      sources."espree-4.0.0"
+      sources."espree-4.1.0"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
@@ -40072,7 +40176,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pluralize-7.0.0"
       sources."prelude-ls-1.1.2"
-      sources."progress-2.0.0"
+      sources."progress-2.0.1"
       sources."punycode-2.1.1"
       sources."regexpp-2.0.1"
       sources."require-uncached-1.0.3"
@@ -40124,8 +40228,8 @@ in
     dependencies = [
       sources."@babel/code-frame-7.0.0"
       sources."@babel/highlight-7.0.0"
-      sources."acorn-5.7.3"
-      sources."acorn-jsx-4.1.1"
+      sources."acorn-6.0.2"
+      sources."acorn-jsx-5.0.0"
       sources."ajv-6.5.4"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-3.0.0"
@@ -40152,11 +40256,11 @@ in
       sources."del-2.2.2"
       sources."doctrine-2.1.0"
       sources."escape-string-regexp-1.0.5"
-      sources."eslint-5.7.0"
+      sources."eslint-5.8.0"
       sources."eslint-scope-4.0.0"
       sources."eslint-utils-1.3.1"
       sources."eslint-visitor-keys-1.0.0"
-      sources."espree-4.0.0"
+      sources."espree-4.1.0"
       sources."esprima-4.0.1"
       sources."esquery-1.0.1"
       sources."esrecurse-4.2.1"
@@ -40218,7 +40322,7 @@ in
       sources."pinkie-promise-2.0.1"
       sources."pluralize-7.0.0"
       sources."prelude-ls-1.1.2"
-      sources."progress-2.0.0"
+      sources."progress-2.0.1"
       sources."punycode-2.1.1"
       sources."regexpp-2.0.1"
       sources."require-uncached-1.0.3"
@@ -40328,11 +40432,7 @@ in
       sources."fd-slicer-1.0.1"
       sources."find-up-1.1.2"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs-extra-1.0.0"
       sources."get-stdin-4.0.1"
       sources."getpass-0.1.7"
@@ -40375,8 +40475,8 @@ in
       sources."loud-rejection-1.6.0"
       sources."map-obj-1.0.1"
       sources."meow-3.7.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
@@ -40737,7 +40837,7 @@ in
       sources."process-nextick-args-2.0.0"
       sources."prompt-0.2.14"
       sources."ps-tree-0.0.3"
-      (sources."randomatic-3.1.0" // {
+      (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
           sources."kind-of-6.0.2"
@@ -40923,7 +41023,7 @@ in
       sources."microee-0.0.6"
       sources."minilog-3.1.0"
       sources."ms-2.1.1"
-      sources."simple-git-1.105.0"
+      sources."simple-git-1.106.0"
       sources."tabtab-git+https://github.com/mixu/node-tabtab.git"
     ];
     buildInputs = globalBuildInputs;
@@ -40945,11 +41045,14 @@ in
     };
     dependencies = [
       sources."asyncmemo-1.0.0"
+      sources."canonical-base64-1.1.0"
       sources."chloride-2.2.10"
       sources."chloride-test-1.2.2"
+      sources."colors-0.5.1"
       sources."deep-equal-1.0.1"
       sources."deep-extend-0.6.0"
       sources."diff-3.5.0"
+      sources."discontinuous-range-1.0.0"
       sources."ed2curve-0.1.4"
       sources."emoji-named-characters-1.0.2"
       sources."explain-error-1.0.4"
@@ -40959,7 +41062,7 @@ in
       sources."git-remote-ssb-2.0.4"
       sources."git-ssb-web-2.8.0"
       sources."hashlru-2.2.1"
-      sources."highlight.js-9.13.0"
+      sources."highlight.js-9.13.1"
       sources."increment-buffer-1.0.1"
       sources."inherits-2.0.3"
       sources."ini-1.3.5"
@@ -40977,8 +41080,8 @@ in
       sources."libsodium-wrappers-0.7.3"
       sources."looper-4.0.0"
       sources."lrucache-1.0.3"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
         dependencies = [
@@ -40986,12 +41089,16 @@ in
         ];
       })
       sources."moment-2.22.2"
+      sources."moo-0.4.3"
       sources."multicb-1.2.2"
-      sources."multiserver-1.13.5"
+      sources."multiserver-1.13.7"
+      sources."multiserver-address-1.0.1"
       sources."muxrpc-6.4.1"
       sources."nan-2.11.1"
+      sources."nearley-2.15.1"
       sources."node-gyp-build-3.5.0"
       sources."node-polyglot-1.0.0"
+      sources."nomnom-1.6.2"
       sources."non-private-ip-1.4.4"
       sources."options-0.0.6"
       sources."os-homedir-1.0.2"
@@ -41044,9 +41151,12 @@ in
         ];
       })
       sources."pull-ws-3.3.1"
+      sources."railroad-diagrams-1.0.0"
+      sources."randexp-0.4.6"
       sources."rc-1.2.8"
       sources."relative-url-1.0.2"
       sources."remove-markdown-0.1.0"
+      sources."ret-0.1.15"
       sources."safe-buffer-5.1.2"
       sources."secret-handshake-1.1.14"
       sources."semver-5.6.0"
@@ -41065,7 +41175,7 @@ in
       sources."split-buffer-1.0.0"
       sources."ssb-avatar-0.2.0"
       sources."ssb-client-4.6.0"
-      sources."ssb-config-2.3.5"
+      sources."ssb-config-2.3.6"
       sources."ssb-git-0.5.0"
       sources."ssb-git-repo-2.8.3"
       sources."ssb-issues-1.0.0"
@@ -41083,7 +41193,7 @@ in
       })
       sources."ssb-msgs-5.2.0"
       sources."ssb-pull-requests-1.0.0"
-      sources."ssb-ref-2.12.0"
+      sources."ssb-ref-2.13.1"
       (sources."stream-to-pull-stream-1.7.2" // {
         dependencies = [
           sources."looper-3.0.0"
@@ -41094,6 +41204,7 @@ in
       sources."tweetnacl-0.14.5"
       sources."tweetnacl-auth-0.3.1"
       sources."ultron-1.0.2"
+      sources."underscore-1.4.4"
       sources."ws-1.1.5"
       sources."xtend-4.0.1"
     ];
@@ -41299,11 +41410,7 @@ in
       sources."find-0.2.9"
       sources."find-up-2.1.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."format-util-1.0.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
@@ -41463,8 +41570,8 @@ in
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
@@ -41646,7 +41753,7 @@ in
       sources."whatwg-fetch-2.0.4"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       (sources."wrap-ansi-2.1.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -42868,7 +42975,7 @@ in
       (sources."dom-serializer-0.1.0" // {
         dependencies = [
           sources."domelementtype-1.1.3"
-          sources."entities-1.1.1"
+          sources."entities-1.1.2"
         ];
       })
       sources."domelementtype-1.3.0"
@@ -42905,11 +43012,7 @@ in
       sources."for-in-1.0.2"
       sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs-extra-1.0.0"
       sources."fs.realpath-1.0.0"
       (sources."ftp-0.3.10" // {
@@ -43020,8 +43123,8 @@ in
       sources."lru-cache-4.1.3"
       sources."macos-release-1.1.0"
       sources."make-dir-1.3.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
@@ -43112,10 +43215,10 @@ in
       sources."shelljs-0.3.0"
       sources."signal-exit-3.0.2"
       sources."smart-buffer-1.1.15"
-      sources."snyk-1.103.4"
+      sources."snyk-1.105.0"
       sources."snyk-config-2.2.0"
       sources."snyk-docker-plugin-1.12.0"
-      sources."snyk-go-plugin-1.5.2"
+      sources."snyk-go-plugin-1.6.0"
       sources."snyk-gradle-plugin-2.1.0"
       sources."snyk-module-1.8.2"
       sources."snyk-mvn-plugin-2.0.0"
@@ -43127,7 +43230,7 @@ in
       sources."snyk-nuget-plugin-1.6.5"
       sources."snyk-php-plugin-1.5.1"
       sources."snyk-policy-1.12.0"
-      sources."snyk-python-plugin-1.8.2"
+      sources."snyk-python-plugin-1.9.0"
       sources."snyk-resolve-1.0.1"
       sources."snyk-resolve-deps-4.0.2"
       sources."snyk-sbt-plugin-2.0.0"
@@ -43223,16 +43326,16 @@ in
   html-minifier = nodeEnv.buildNodePackage {
     name = "html-minifier";
     packageName = "html-minifier";
-    version = "3.5.20";
+    version = "3.5.21";
     src = fetchurl {
-      url = "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz";
-      sha512 = "ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==";
+      url = "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz";
+      sha512 = "LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==";
     };
     dependencies = [
       sources."camel-case-3.0.0"
       sources."clean-css-4.2.1"
       sources."commander-2.17.1"
-      sources."he-1.1.1"
+      sources."he-1.2.0"
       sources."lower-case-1.1.4"
       sources."no-case-2.3.2"
       sources."param-case-2.1.1"
@@ -43282,7 +43385,7 @@ in
           sources."minimist-0.0.10"
         ];
       })
-      (sources."portfinder-1.0.17" // {
+      (sources."portfinder-1.0.19" // {
         dependencies = [
           sources."debug-2.6.9"
         ];
@@ -43339,7 +43442,7 @@ in
       sources."co-4.6.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."combined-stream-1.0.6"
+      sources."combined-stream-1.0.7"
       sources."component-emitter-1.2.1"
       sources."concat-map-0.0.1"
       sources."configstore-3.1.2"
@@ -43373,7 +43476,7 @@ in
       sources."fast-levenshtein-2.0.6"
       sources."figures-2.0.0"
       sources."file-uri-to-path-1.0.0"
-      sources."form-data-2.3.2"
+      sources."form-data-2.3.3"
       sources."formidable-1.2.1"
       sources."fs-minipass-1.2.5"
       sources."fs.realpath-1.0.0"
@@ -43459,12 +43562,12 @@ in
       sources."make-dir-1.3.0"
       sources."methods-1.1.2"
       sources."mime-1.6.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
-      (sources."minipass-2.3.4" // {
+      (sources."minipass-2.3.5" // {
         dependencies = [
           sources."yallist-3.0.2"
         ];
@@ -43588,7 +43691,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."uuid-3.3.2"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."win-release-1.1.1"
       sources."wordwrap-1.0.0"
       (sources."wrap-ansi-4.0.0" // {
@@ -43616,10 +43719,10 @@ in
   ios-deploy = nodeEnv.buildNodePackage {
     name = "ios-deploy";
     packageName = "ios-deploy";
-    version = "1.9.3";
+    version = "1.9.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ios-deploy/-/ios-deploy-1.9.3.tgz";
-      sha512 = "i/8DxXzcL2feqqL6DjUfjqUHyWVmHYNkzZFTyf6yoC4glrI3jQ+8Hhg63vzw/5OoFXN7OyXqjkshAj9c1EsVSw==";
+      url = "https://registry.npmjs.org/ios-deploy/-/ios-deploy-1.9.4.tgz";
+      sha512 = "pgyc19zgtwGrfx3GL8yV0c0dAPucTpJ0VZkuS3DcqxIZYC48+UW+tBTxI43u1ZDk17mop0ABLs1SkAy5SUQ6pQ==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -44154,7 +44257,7 @@ in
       (sources."dom-serializer-0.1.0" // {
         dependencies = [
           sources."domelementtype-1.1.3"
-          sources."entities-1.1.1"
+          sources."entities-1.1.2"
         ];
       })
       sources."domelementtype-1.3.0"
@@ -44172,11 +44275,7 @@ in
       sources."fast-json-stable-stringify-2.0.0"
       sources."fd-slicer-1.0.1"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs-extra-1.0.0"
       sources."fs.realpath-1.0.0"
       sources."getpass-0.1.7"
@@ -44203,8 +44302,8 @@ in
       sources."kew-0.7.0"
       sources."klaw-1.3.1"
       sources."lodash-4.17.11"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -44277,13 +44376,13 @@ in
   js-beautify = nodeEnv.buildNodePackage {
     name = "js-beautify";
     packageName = "js-beautify";
-    version = "1.8.7";
+    version = "1.8.8";
     src = fetchurl {
-      url = "https://registry.npmjs.org/js-beautify/-/js-beautify-1.8.7.tgz";
-      sha512 = "yhAMCTv0L9GNg6Gql7i+g4C1z9rQhfHXy4J0TGYFoBzzHR4reWYS573gkRrPuE58dYOH451LmBeAb8L1pLEfdA==";
+      url = "https://registry.npmjs.org/js-beautify/-/js-beautify-1.8.8.tgz";
+      sha512 = "qVNq7ZZ7ZbLdzorvSlRDadS0Rh5oyItaE95v6I4wbbuSiijxn7SnnsV6dvKlcXuO2jX7lK8tn9fBulx34K/Ejg==";
     };
     dependencies = [
-      sources."@types/node-10.11.7"
+      sources."@types/node-10.12.0"
       sources."@types/semver-5.5.0"
       sources."abbrev-1.1.1"
       sources."commander-2.19.0"
@@ -44388,7 +44487,7 @@ in
     dependencies = [
       sources."argparse-1.0.10"
       sources."asynckit-0.4.0"
-      sources."combined-stream-1.0.6"
+      sources."combined-stream-1.0.7"
       sources."commander-2.11.0"
       sources."component-emitter-1.2.1"
       sources."cookiejar-2.1.2"
@@ -44397,7 +44496,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
-      sources."form-data-2.3.2"
+      sources."form-data-2.3.3"
       sources."formidable-1.2.1"
       sources."graphlib-2.1.5"
       sources."inherits-2.0.3"
@@ -44406,8 +44505,8 @@ in
       sources."lodash-4.17.11"
       sources."methods-1.1.2"
       sources."mime-1.6.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."ms-2.1.1"
       sources."native-promise-only-0.8.1"
       sources."path-loader-1.0.9"
@@ -44520,11 +44619,7 @@ in
       })
       sources."find-up-2.1.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."get-caller-file-1.0.3"
@@ -44581,13 +44676,13 @@ in
       sources."method-override-2.3.10"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimist-1.2.0"
       sources."morgan-1.9.1"
       sources."ms-2.0.0"
-      sources."nanoid-1.3.0"
+      sources."nanoid-1.3.1"
       sources."negotiator-0.6.1"
       sources."npm-run-path-2.0.2"
       sources."number-is-nan-1.0.1"
@@ -44666,7 +44761,7 @@ in
       sources."verror-1.10.0"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       (sources."wrap-ansi-2.1.0" // {
         dependencies = [
           sources."ansi-regex-2.1.1"
@@ -44716,10 +44811,10 @@ in
   karma = nodeEnv.buildNodePackage {
     name = "karma";
     packageName = "karma";
-    version = "3.0.0";
+    version = "3.1.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/karma/-/karma-3.0.0.tgz";
-      sha512 = "ZTjyuDXVXhXsvJ1E4CnZzbCjSxD6sEdzEsFYogLuZM0yqvg/mgz+O+R1jb0J7uAQeuzdY8kJgx6hSNXLwFuHIQ==";
+      url = "https://registry.npmjs.org/karma/-/karma-3.1.1.tgz";
+      sha512 = "NetT3wPCQMNB36uiL9LLyhrOt8SQwrEKt0xD3+KpTCfm0VxVyUJdPL5oTq2Ic5ouemgL/Iz4wqXEbF3zea9kQQ==";
     };
     dependencies = [
       sources."accepts-1.3.5"
@@ -44763,7 +44858,7 @@ in
       sources."cache-base-1.0.1"
       sources."callsite-1.0.0"
       sources."chokidar-2.0.4"
-      sources."circular-json-0.5.7"
+      sources."circular-json-0.5.9"
       (sources."class-utils-0.3.6" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -44937,8 +45032,8 @@ in
       sources."media-typer-0.3.0"
       sources."micromatch-3.1.10"
       sources."mime-2.3.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mixin-deep-1.3.1"
@@ -45198,8 +45293,8 @@ in
       })
       sources."methods-1.1.2"
       sources."mime-1.3.4"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."morgan-1.6.1"
@@ -45383,10 +45478,10 @@ in
   leetcode-cli = nodeEnv.buildNodePackage {
     name = "leetcode-cli";
     packageName = "leetcode-cli";
-    version = "2.5.2";
+    version = "2.5.3";
     src = fetchurl {
-      url = "https://registry.npmjs.org/leetcode-cli/-/leetcode-cli-2.5.2.tgz";
-      sha512 = "KneaqL2/SAfJQpxR1yheLrnB10f8vwJJbVBA4vxtRl6aENbO+JKsJSgE1cZvO/4isD+MPI7C5HPjJbL5+MOmnw==";
+      url = "https://registry.npmjs.org/leetcode-cli/-/leetcode-cli-2.5.3.tgz";
+      sha512 = "FlV2bYtdELx6NPSyd+ZfiQ9LKpjNr/UZ3orAhwx2Llg361QvS03XIxFFAi/RuvMKDi01zvHfRzsONPJt4hRXlQ==";
     };
     dependencies = [
       sources."abab-1.0.4"
@@ -45433,7 +45528,7 @@ in
         ];
       })
       sources."css-select-1.2.0"
-      sources."css-what-2.1.0"
+      sources."css-what-2.1.2"
       sources."cssom-0.3.4"
       sources."cssstyle-0.2.37"
       sources."cycle-1.0.3"
@@ -45451,7 +45546,7 @@ in
       sources."domhandler-2.3.0"
       sources."domutils-1.5.1"
       sources."ecc-jsbn-0.1.2"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."escape-string-regexp-1.0.5"
       sources."escodegen-1.11.0"
       sources."esprima-3.1.3"
@@ -45466,11 +45561,7 @@ in
       sources."fast-levenshtein-2.0.6"
       sources."find-up-2.1.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs.realpath-1.0.0"
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
@@ -45512,8 +45603,8 @@ in
       sources."log-symbols-2.2.0"
       sources."lru-cache-4.1.3"
       sources."mem-1.1.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
@@ -45527,7 +45618,7 @@ in
       })
       sources."ncp-1.0.1"
       sources."npm-run-path-2.0.2"
-      sources."nth-check-1.0.1"
+      sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
       sources."nwmatcher-1.4.4"
       sources."oauth-sign-0.8.2"
@@ -45705,7 +45796,7 @@ in
       sources."JSONStream-1.3.5"
       sources."abbrev-1.1.1"
       sources."agent-base-4.2.1"
-      sources."agentkeepalive-3.5.1"
+      sources."agentkeepalive-3.5.2"
       sources."ajv-5.5.2"
       sources."ansi-escapes-3.1.0"
       sources."ansi-regex-2.1.1"
@@ -45751,7 +45842,7 @@ in
       sources."builtin-modules-1.1.1"
       sources."builtins-1.0.3"
       sources."byline-5.0.0"
-      sources."byte-size-4.0.3"
+      sources."byte-size-4.0.4"
       sources."cacache-11.2.0"
       sources."cache-base-1.0.1"
       sources."call-me-maybe-1.0.1"
@@ -45914,11 +46005,7 @@ in
       sources."flush-write-stream-1.0.3"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."from2-2.3.0"
       sources."fs-extra-7.0.0"
@@ -45932,7 +46019,7 @@ in
           sources."string-width-1.0.2"
         ];
       })
-      sources."genfun-4.0.1"
+      sources."genfun-5.0.0"
       sources."get-caller-file-1.0.3"
       (sources."get-pkg-repo-1.4.0" // {
         dependencies = [
@@ -46090,13 +46177,13 @@ in
       })
       sources."merge2-1.2.3"
       sources."micromatch-3.1.10"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       sources."minimist-options-3.0.2"
-      (sources."minipass-2.3.4" // {
+      (sources."minipass-2.3.5" // {
         dependencies = [
           sources."yallist-3.0.2"
         ];
@@ -46182,11 +46269,7 @@ in
       sources."p-reduce-1.0.0"
       sources."p-try-2.0.0"
       sources."p-waterfall-1.0.0"
-      (sources."pacote-9.1.0" // {
-        dependencies = [
-          sources."get-stream-3.0.0"
-        ];
-      })
+      sources."pacote-9.1.1"
       sources."parallel-transform-1.1.0"
       sources."parse-github-repo-url-1.4.1"
       sources."parse-json-4.0.0"
@@ -46215,7 +46298,7 @@ in
       sources."promise-retry-1.1.1"
       sources."promzard-0.3.0"
       sources."proto-list-1.2.4"
-      sources."protoduck-5.0.0"
+      sources."protoduck-5.0.1"
       sources."pseudomap-1.0.2"
       sources."psl-1.1.29"
       sources."pump-3.0.0"
@@ -46488,11 +46571,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."getpass-0.1.7"
       sources."graceful-fs-4.1.11"
       sources."har-schema-2.0.0"
@@ -46507,8 +46586,8 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
       sources."mime-1.6.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."oauth-sign-0.9.0"
@@ -46691,7 +46770,7 @@ in
           sources."statuses-1.5.0"
         ];
       })
-      sources."http-parser-js-0.4.13"
+      sources."http-parser-js-0.5.0"
       sources."inherits-2.0.3"
       (sources."is-accessor-descriptor-1.0.0" // {
         dependencies = [
@@ -46734,8 +46813,8 @@ in
       sources."math-random-1.0.1"
       sources."micromatch-2.3.11"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       (sources."mixin-deep-1.3.1" // {
         dependencies = [
           sources."is-extendable-1.0.1"
@@ -46789,7 +46868,7 @@ in
       sources."preserve-0.2.0"
       sources."process-nextick-args-2.0.0"
       sources."proxy-middleware-0.15.0"
-      (sources."randomatic-3.1.0" // {
+      (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
           sources."kind-of-6.0.2"
@@ -47073,7 +47152,7 @@ in
         ];
       })
       sources."engine.io-parser-2.1.2"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."escape-html-1.0.3"
       sources."etag-1.8.1"
       sources."expand-brackets-0.1.5"
@@ -47103,11 +47182,7 @@ in
       sources."for-in-1.0.2"
       sources."for-own-0.1.5"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
@@ -47205,8 +47280,8 @@ in
       sources."methods-1.1.2"
       sources."micromatch-2.3.11"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-1.2.0"
       (sources."mixin-deep-1.3.1" // {
         dependencies = [
@@ -47266,7 +47341,7 @@ in
       sources."psl-1.1.29"
       sources."punycode-1.4.1"
       sources."qs-6.5.2"
-      (sources."randomatic-3.1.0" // {
+      (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
           sources."kind-of-6.0.2"
@@ -47773,11 +47848,7 @@ in
       sources."for-in-1.0.2"
       sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       (sources."fs-mkdirp-stream-1.0.0" // {
         dependencies = [
@@ -47981,8 +48052,8 @@ in
       sources."memoizee-0.4.14"
       sources."micromatch-3.1.10"
       sources."mime-1.6.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-2.0.10"
       sources."minimist-1.2.0"
       (sources."mixin-deep-1.3.1" // {
@@ -48297,7 +48368,7 @@ in
     dependencies = [
       sources."argparse-1.0.10"
       sources."asynckit-0.4.0"
-      sources."combined-stream-1.0.6"
+      sources."combined-stream-1.0.7"
       sources."commander-2.19.0"
       sources."component-emitter-1.2.1"
       sources."cookiejar-2.1.2"
@@ -48306,7 +48377,7 @@ in
       sources."delayed-stream-1.0.0"
       sources."esprima-4.0.1"
       sources."extend-3.0.2"
-      sources."form-data-2.3.2"
+      sources."form-data-2.3.3"
       sources."formidable-1.2.1"
       sources."graphlib-2.1.5"
       sources."inherits-2.0.3"
@@ -48316,8 +48387,8 @@ in
       sources."lodash-4.17.11"
       sources."methods-1.1.2"
       sources."mime-1.6.0"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."ms-2.1.1"
       sources."native-promise-only-0.8.1"
       sources."path-loader-1.0.9"
@@ -48405,11 +48476,7 @@ in
       sources."findit-2.0.0"
       sources."foreachasync-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       (sources."fs-extra-0.6.4" // {
         dependencies = [
           sources."mkdirp-0.3.5"
@@ -48441,10 +48508,10 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.4"
+      sources."minipass-2.3.5"
       sources."minizlib-1.1.1"
       sources."mkdirp-0.5.1"
       sources."ncp-0.4.2"
@@ -48559,11 +48626,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs.realpath-1.0.0"
       sources."fstream-1.0.11"
       sources."gauge-2.7.4"
@@ -48586,8 +48649,8 @@ in
       sources."json-schema-traverse-0.3.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsprim-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -48794,8 +48857,8 @@ in
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
@@ -48986,7 +49049,7 @@ in
       sources."isarray-1.0.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
-      sources."minipass-2.3.4"
+      sources."minipass-2.3.5"
       sources."minizlib-1.1.1"
       sources."mkdirp-0.5.1"
       sources."ms-2.0.0"
@@ -49038,10 +49101,10 @@ in
   nodemon = nodeEnv.buildNodePackage {
     name = "nodemon";
     packageName = "nodemon";
-    version = "1.18.4";
+    version = "1.18.5";
     src = fetchurl {
-      url = "https://registry.npmjs.org/nodemon/-/nodemon-1.18.4.tgz";
-      sha512 = "hyK6vl65IPnky/ee+D3IWvVGgJa/m3No2/Xc/3wanS6Ce1MWjCzH6NnhPJ/vZM+6JFym16jtHx51lmCMB9HDtg==";
+      url = "https://registry.npmjs.org/nodemon/-/nodemon-1.18.5.tgz";
+      sha512 = "8806dC8dfBlbxQmqNOSEeay/qlbddKvFzxIGNxnPtxUlTtH77xsrC66RnA3M47HCSgMgE5bj+U586o50RowXBg==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -49382,7 +49445,7 @@ in
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."write-file-atomic-2.3.0"
       sources."xdg-basedir-3.0.0"
       sources."yallist-2.1.2"
@@ -49426,7 +49489,11 @@ in
       sources."bcrypt-2.0.1"
       sources."bcrypt-pbkdf-1.0.2"
       sources."bcryptjs-2.4.3"
-      sources."bl-1.2.2"
+      (sources."bl-1.2.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."body-parser-1.18.3"
       sources."boolbase-1.0.0"
       sources."brace-expansion-1.1.11"
@@ -49444,7 +49511,11 @@ in
         ];
       })
       sources."bytes-3.0.0"
-      sources."callback-stream-1.1.0"
+      (sources."callback-stream-1.1.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."caseless-0.12.0"
       sources."cheerio-0.22.0"
       sources."clone-2.1.2"
@@ -49453,7 +49524,11 @@ in
       sources."commander-2.17.1"
       sources."commist-1.0.0"
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.2"
+      (sources."concat-stream-1.6.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."content-disposition-0.5.2"
       sources."content-type-1.0.4"
       sources."cookie-0.3.1"
@@ -49464,7 +49539,7 @@ in
       sources."crc-3.4.4"
       sources."cron-1.4.1"
       sources."css-select-1.2.0"
-      sources."css-what-2.1.0"
+      sources."css-what-2.1.2"
       sources."d-1.0.0"
       sources."dashdash-1.14.1"
       sources."debug-2.6.9"
@@ -49487,13 +49562,17 @@ in
       sources."domelementtype-1.3.0"
       sources."domhandler-2.4.2"
       sources."domutils-1.5.1"
-      sources."duplexify-3.6.1"
+      (sources."duplexify-3.6.1" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."es5-ext-0.10.46"
       sources."es6-iterator-2.0.3"
       sources."es6-map-0.1.5"
@@ -49529,6 +49608,7 @@ in
       (sources."feedparser-2.2.9" // {
         dependencies = [
           sources."addressparser-1.0.1"
+          sources."readable-stream-2.3.6"
         ];
       })
       (sources."finalhandler-1.1.1" // {
@@ -49537,11 +49617,7 @@ in
         ];
       })
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."fs-extra-5.0.0"
@@ -49550,7 +49626,11 @@ in
       sources."getpass-0.1.7"
       sources."glob-7.1.3"
       sources."glob-parent-3.1.0"
-      sources."glob-stream-6.1.0"
+      (sources."glob-stream-6.1.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."graceful-fs-4.1.11"
       sources."har-schema-2.0.0"
       (sources."har-validator-5.1.0" // {
@@ -49562,7 +49642,7 @@ in
       })
       sources."hash-sum-1.0.2"
       sources."help-me-1.1.0"
-      sources."htmlparser2-3.9.2"
+      sources."htmlparser2-3.10.0"
       sources."http-errors-1.6.3"
       sources."http-signature-1.2.0"
       (sources."https-proxy-agent-2.2.1" // {
@@ -49636,8 +49716,8 @@ in
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       (sources."mimelib-0.3.1" // {
         dependencies = [
           sources."addressparser-1.0.1"
@@ -49652,7 +49732,11 @@ in
       })
       sources."moment-2.22.2"
       sources."moment-timezone-0.5.21"
-      sources."mqtt-2.18.8"
+      (sources."mqtt-2.18.8" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."mqtt-packet-5.6.0"
       sources."mri-1.1.1"
       sources."ms-2.0.0"
@@ -49668,8 +49752,8 @@ in
       sources."next-tick-1.0.0"
       sources."node-red-node-email-0.1.29"
       sources."node-red-node-feedparser-0.1.14"
-      sources."node-red-node-rbe-0.2.3"
-      sources."node-red-node-twitter-1.1.3"
+      sources."node-red-node-rbe-0.2.4"
+      sources."node-red-node-twitter-1.1.4"
       sources."nodemailer-1.11.0"
       sources."nodemailer-direct-transport-1.1.0"
       (sources."nodemailer-smtp-transport-1.1.0" // {
@@ -49679,7 +49763,7 @@ in
       })
       sources."nodemailer-wellknown-0.1.10"
       sources."nopt-4.0.1"
-      sources."nth-check-1.0.1"
+      sources."nth-check-1.0.2"
       sources."oauth-0.9.15"
       sources."oauth-sign-0.9.0"
       sources."oauth2orize-1.11.0"
@@ -49693,7 +49777,11 @@ in
         ];
       })
       sources."options-0.0.6"
-      sources."ordered-read-streams-1.0.1"
+      (sources."ordered-read-streams-1.0.1" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
       sources."osenv-0.1.5"
@@ -49723,7 +49811,7 @@ in
       sources."random-bytes-1.0.0"
       sources."range-parser-1.2.0"
       sources."raw-body-2.3.3"
-      sources."readable-stream-2.3.6"
+      sources."readable-stream-3.0.6"
       sources."reinterval-1.1.0"
       sources."remove-trailing-separator-1.1.0"
       (sources."request-2.88.0" // {
@@ -49753,7 +49841,11 @@ in
       sources."stream-shift-1.0.0"
       sources."streamsearch-0.1.2"
       sources."string_decoder-1.1.1"
-      sources."through2-2.0.3"
+      (sources."through2-2.0.3" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."through2-filter-2.0.0"
       sources."to-absolute-glob-2.0.2"
       (sources."tough-cookie-2.4.3" // {
@@ -49788,6 +49880,7 @@ in
       sources."verror-1.10.0"
       (sources."websocket-stream-5.1.2" // {
         dependencies = [
+          sources."readable-stream-2.3.6"
           sources."ws-3.3.3"
         ];
       })
@@ -50010,11 +50103,7 @@ in
       sources."findit-1.2.0"
       sources."foreachasync-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       (sources."fs-extra-0.6.4" // {
         dependencies = [
           sources."rimraf-2.2.8"
@@ -50049,8 +50138,8 @@ in
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-1.0.1"
       sources."jsprim-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.3.5"
@@ -50264,7 +50353,7 @@ in
       })
       sources."url-parse-lax-1.0.0"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."write-file-atomic-2.3.0"
       sources."xdg-basedir-3.0.0"
       sources."yallist-2.1.2"
@@ -50537,7 +50626,7 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."error-ex-1.3.2"
       sources."escape-html-1.0.3"
       sources."esprima-4.0.1"
@@ -50560,11 +50649,7 @@ in
       })
       sources."find-up-1.1.2"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."function-bind-1.1.1"
@@ -50641,12 +50726,12 @@ in
       sources."lodash.clone-4.3.2"
       sources."media-typer-0.3.0"
       sources."mediawiki-title-0.6.5"
-      sources."merge-1.2.0"
+      sources."merge-1.2.1"
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.10"
       (sources."mkdirp-0.5.1" // {
@@ -51024,7 +51109,7 @@ in
       sources."symbol-observable-1.0.1"
       sources."thirty-two-1.0.2"
       sources."through-2.3.8"
-      sources."thunky-1.0.2"
+      sources."thunky-1.0.3"
       sources."tmp-0.0.33"
       sources."torrent-discovery-5.4.0"
       sources."torrent-piece-1.1.2"
@@ -51297,8 +51382,8 @@ in
       })
       sources."methods-1.1.2"
       sources."mime-1.3.4"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
@@ -51454,7 +51539,7 @@ in
       sources."string_decoder-1.1.1"
       sources."tar-stream-1.6.2"
       sources."thirty-two-0.0.2"
-      sources."thunky-1.0.2"
+      sources."thunky-1.0.3"
       sources."to-array-0.1.4"
       sources."to-buffer-1.1.1"
       sources."toidentifier-1.0.0"
@@ -51580,8 +51665,8 @@ in
       sources."kew-0.7.0"
       sources."klaw-1.3.1"
       sources."lodash-4.17.11"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.0"
@@ -51638,10 +51723,10 @@ in
   pnpm = nodeEnv.buildNodePackage {
     name = "pnpm";
     packageName = "pnpm";
-    version = "2.16.3";
+    version = "2.17.4";
     src = fetchurl {
-      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.16.3.tgz";
-      sha512 = "W63qZOC9YGr+33JYvZjvhzvYL4YKT2gAywDJQrHvKTL6vmnnSh+GdM3ZdGIIZ6A57YB3NgvQaq/BJ2uYjwn3ZQ==";
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-2.17.4.tgz";
+      sha512 = "yee6uJE9UZJAPF76JC7JqAPK1AKx8fr6ed862OPESYkw2GA0Rf3H/URlaTQSWYTAhP10DJNQ3t5ysbyrr6jzRw==";
     };
     buildInputs = globalBuildInputs;
     meta = {
@@ -51680,7 +51765,8 @@ in
     dependencies = [
       sources."JSONStream-1.3.5"
       sources."acorn-6.0.2"
-      sources."acorn-node-1.6.0"
+      sources."acorn-dynamic-import-4.0.0"
+      sources."acorn-node-1.6.2"
       sources."acorn-walk-6.1.0"
       sources."anymatch-2.0.0"
       sources."arr-diff-4.0.0"
@@ -52304,8 +52390,8 @@ in
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."morgan-1.9.1"
@@ -52629,11 +52715,7 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."formidable-1.0.11"
       sources."fresh-0.2.0"
       sources."getpass-0.1.7"
@@ -52653,8 +52735,8 @@ in
       sources."keypress-0.1.0"
       sources."methods-0.1.0"
       sources."mime-1.2.11"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mkdirp-0.3.5"
       sources."ms-2.1.1"
       sources."multiparty-2.2.0"
@@ -52706,10 +52788,10 @@ in
   scuttlebot = nodeEnv.buildNodePackage {
     name = "scuttlebot";
     packageName = "scuttlebot";
-    version = "13.0.0";
+    version = "13.0.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/scuttlebot/-/scuttlebot-13.0.0.tgz";
-      sha512 = "niRO3ySzMcXXIrx88zBMdLZ53zvC3DALiFZL42hELL0nE3ohGlhSYQNYefgPB1KiVyMomuNvlhusw9yQsYs/dQ==";
+      url = "https://registry.npmjs.org/scuttlebot/-/scuttlebot-13.0.1.tgz";
+      sha512 = "HLp9h19g8s5XOZfJ/Bq92RFXFMmJhpjNhdZa/JaBfiyLw+k6QQHDPi8xtpTwg91jPx+Gw5Vlfqtv6CECQCzypA==";
     };
     dependencies = [
       sources."abstract-leveldown-4.0.3"
@@ -52769,6 +52851,7 @@ in
         ];
       })
       sources."camelcase-2.1.1"
+      sources."canonical-base64-1.1.0"
       sources."ccount-1.0.3"
       sources."chalk-1.1.3"
       sources."character-entities-1.2.2"
@@ -52803,6 +52886,7 @@ in
       sources."code-point-at-1.1.0"
       sources."collapse-white-space-1.0.4"
       sources."collection-visit-1.0.0"
+      sources."colors-0.5.1"
       sources."commander-2.19.0"
       sources."compare-at-paths-1.0.0"
       sources."component-emitter-1.2.1"
@@ -52842,6 +52926,7 @@ in
       sources."delegates-1.0.0"
       sources."detab-1.0.2"
       sources."detect-libc-1.0.3"
+      sources."discontinuous-range-1.0.0"
       sources."dynamic-dijkstra-1.0.0"
       sources."ed2curve-0.1.4"
       sources."elegant-spinner-1.0.1"
@@ -52893,7 +52978,7 @@ in
       })
       (sources."flumeview-query-6.3.0" // {
         dependencies = [
-          sources."map-filter-reduce-3.2.1"
+          sources."map-filter-reduce-3.2.2"
         ];
       })
       (sources."flumeview-reduce-1.3.14" // {
@@ -53069,6 +53154,7 @@ in
         ];
       })
       sources."monotonic-timestamp-0.0.9"
+      sources."moo-0.4.3"
       sources."ms-2.0.0"
       (sources."multiblob-1.13.1" // {
         dependencies = [
@@ -53078,7 +53164,8 @@ in
       })
       sources."multiblob-http-0.4.2"
       sources."multicb-1.2.2"
-      sources."multiserver-1.13.5"
+      sources."multiserver-1.13.7"
+      sources."multiserver-address-1.0.1"
       sources."muxrpc-6.4.1"
       (sources."muxrpc-validation-2.0.1" // {
         dependencies = [
@@ -53104,8 +53191,10 @@ in
         ];
       })
       sources."ncp-2.0.0"
+      sources."nearley-2.15.1"
       sources."node-abi-2.4.5"
       sources."node-gyp-build-3.5.0"
+      sources."nomnom-1.6.2"
       (sources."non-private-ip-1.4.4" // {
         dependencies = [
           sources."ip-1.1.5"
@@ -53150,7 +53239,7 @@ in
       sources."on-wakeup-1.0.1"
       sources."once-1.4.0"
       sources."onetime-1.1.0"
-      sources."opencollective-postinstall-2.0.0"
+      sources."opencollective-postinstall-2.0.1"
       sources."options-0.0.6"
       sources."os-homedir-1.0.2"
       sources."os-tmpdir-1.0.2"
@@ -53199,7 +53288,7 @@ in
       })
       sources."pull-handshake-1.1.4"
       sources."pull-hash-1.0.0"
-      (sources."pull-inactivity-2.1.2" // {
+      (sources."pull-inactivity-2.1.3" // {
         dependencies = [
           sources."pull-abortable-4.0.0"
         ];
@@ -53247,7 +53336,9 @@ in
       sources."pump-2.0.1"
       sources."push-stream-10.0.4"
       sources."push-stream-to-pull-stream-1.0.3"
-      (sources."randomatic-3.1.0" // {
+      sources."railroad-diagrams-1.0.0"
+      sources."randexp-0.4.6"
+      (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
           sources."kind-of-6.0.2"
@@ -53396,11 +53487,25 @@ in
       sources."source-map-url-0.4.0"
       sources."split-buffer-1.0.0"
       sources."split-string-3.1.0"
-      sources."ssb-blobs-1.1.5"
+      (sources."ssb-blobs-1.1.6" // {
+        dependencies = [
+          sources."abstract-leveldown-5.0.0"
+          sources."deferred-leveldown-4.0.2"
+          sources."encoding-down-5.0.4"
+          sources."level-4.0.0"
+          sources."level-codec-9.0.0"
+          sources."level-errors-2.0.0"
+          sources."level-iterator-stream-3.0.1"
+          sources."level-packager-3.1.0"
+          sources."leveldown-4.0.1"
+          sources."levelup-3.1.1"
+          sources."nan-2.10.0"
+        ];
+      })
       sources."ssb-client-4.6.0"
-      sources."ssb-config-2.3.5"
+      sources."ssb-config-2.3.6"
       sources."ssb-ebt-5.2.3"
-      (sources."ssb-friends-3.1.3" // {
+      (sources."ssb-friends-3.1.4" // {
         dependencies = [
           sources."pull-cont-0.1.1"
         ];
@@ -53411,10 +53516,10 @@ in
       (sources."ssb-query-2.3.0" // {
         dependencies = [
           sources."flumeview-query-7.1.0"
-          sources."map-filter-reduce-3.2.1"
+          sources."map-filter-reduce-3.2.2"
         ];
       })
-      (sources."ssb-ref-2.12.0" // {
+      (sources."ssb-ref-2.13.1" // {
         dependencies = [
           sources."ip-1.1.5"
         ];
@@ -53482,6 +53587,7 @@ in
       sources."typewiselite-1.0.0"
       sources."uint48be-1.0.2"
       sources."ultron-1.0.2"
+      sources."underscore-1.4.4"
       sources."unherit-1.1.1"
       sources."unified-2.1.4"
       (sources."union-value-1.0.0" // {
@@ -53633,7 +53739,7 @@ in
       sources."update-check-1.5.2"
       sources."uri-js-4.2.2"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."yallist-2.1.2"
     ];
     buildInputs = globalBuildInputs;
@@ -53717,7 +53823,7 @@ in
         ];
       })
       sources."engine.io-parser-1.0.6"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."escape-html-1.0.3"
       sources."etag-1.8.1"
       sources."event-stream-3.3.6"
@@ -53729,11 +53835,7 @@ in
       sources."finalhandler-1.1.1"
       sources."flatmap-stream-0.1.1"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."from-0.1.7"
@@ -53772,8 +53874,8 @@ in
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
       sources."moment-2.7.0"
@@ -53896,12 +53998,10 @@ in
       (sources."body-parser-1.18.3" // {
         dependencies = [
           sources."bytes-3.0.0"
+          sources."debug-2.6.9"
           sources."http-errors-1.6.3"
           sources."iconv-lite-0.4.23"
-          sources."qs-6.5.2"
           sources."raw-body-2.3.3"
-          sources."setprototypeof-1.1.0"
-          sources."statuses-1.5.0"
         ];
       })
       sources."brace-expansion-1.1.11"
@@ -53918,6 +54018,7 @@ in
       (sources."compression-1.7.3" // {
         dependencies = [
           sources."bytes-3.0.0"
+          sources."debug-2.6.9"
         ];
       })
       sources."concat-map-0.0.1"
@@ -53929,7 +54030,7 @@ in
       sources."core-util-is-1.0.2"
       sources."crypt3-0.2.0"
       sources."dashdash-1.14.1"
-      sources."debug-2.6.9"
+      sources."debug-3.1.0"
       sources."delayed-stream-1.0.0"
       sources."depd-1.1.2"
       sources."destroy-1.0.4"
@@ -53945,25 +54046,25 @@ in
       sources."ecc-jsbn-0.1.2"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."es6-shim-0.21.1"
       sources."escape-html-1.0.3"
       sources."escape-string-regexp-1.0.5"
       sources."esprima-4.0.1"
       sources."etag-1.8.1"
-      sources."express-5.0.0-alpha.6"
+      sources."express-5.0.0-alpha.7"
       sources."express-json5-0.1.0"
       sources."extend-3.0.2"
       sources."extsprintf-1.3.0"
       sources."fast-deep-equal-1.1.0"
       sources."fast-json-stable-stringify-2.0.0"
-      sources."finalhandler-1.0.6"
-      sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
+      (sources."finalhandler-1.1.1" // {
         dependencies = [
-          sources."combined-stream-1.0.6"
+          sources."debug-2.6.9"
         ];
       })
+      sources."forever-agent-0.6.1"
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fresh-0.5.2"
       sources."fs-ext-0.6.0"
@@ -53978,14 +54079,13 @@ in
       sources."har-validator-5.1.0"
       sources."has-flag-3.0.0"
       sources."highlight.js-8.9.1"
-      (sources."htmlparser2-3.9.2" // {
+      (sources."htmlparser2-3.10.0" // {
         dependencies = [
-          sources."readable-stream-2.3.6"
+          sources."readable-stream-3.0.6"
         ];
       })
       (sources."http-errors-1.7.1" // {
         dependencies = [
-          sources."setprototypeof-1.1.0"
           sources."statuses-1.5.0"
         ];
       })
@@ -53993,9 +54093,9 @@ in
       sources."iconv-lite-0.4.8"
       sources."inflight-1.0.6"
       sources."inherits-2.0.3"
-      sources."ipaddr.js-1.4.0"
+      sources."ipaddr.js-1.8.0"
       sources."is-typedarray-1.0.0"
-      sources."isarray-1.0.0"
+      sources."isarray-0.0.1"
       sources."isstream-0.1.2"
       sources."jju-1.4.0"
       sources."js-yaml-3.12.0"
@@ -54019,9 +54119,9 @@ in
       sources."media-typer-0.3.0"
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
-      sources."mime-1.3.4"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-1.4.1"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-1.0.0"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
@@ -54046,56 +54146,41 @@ in
           sources."source-map-0.6.1"
         ];
       })
-      sources."process-nextick-args-2.0.0"
-      sources."proxy-addr-1.1.5"
+      sources."proxy-addr-2.0.4"
       sources."psl-1.1.29"
       sources."punycode-1.4.1"
-      sources."qs-6.5.0"
+      sources."qs-6.5.2"
       sources."range-parser-1.2.0"
       sources."raw-body-1.3.4"
       (sources."readable-stream-1.1.14" // {
         dependencies = [
-          sources."isarray-0.0.1"
           sources."string_decoder-0.10.31"
         ];
       })
       sources."render-readme-1.3.1"
-      (sources."request-2.88.0" // {
-        dependencies = [
-          sources."qs-6.5.2"
-        ];
-      })
+      sources."request-2.88.0"
       sources."rimraf-2.4.5"
-      (sources."router-1.3.3" // {
-        dependencies = [
-          sources."setprototypeof-1.1.0"
-          sources."utils-merge-1.0.1"
-        ];
-      })
+      sources."router-2.0.0-alpha.1"
       sources."safe-buffer-5.1.2"
       sources."safe-json-stringify-1.2.0"
       sources."safer-buffer-2.1.2"
       sources."sanitize-html-1.19.1"
       sources."semver-4.3.6"
-      (sources."send-0.15.6" // {
+      (sources."send-0.16.2" // {
         dependencies = [
-          (sources."http-errors-1.6.3" // {
-            dependencies = [
-              sources."statuses-1.5.0"
-            ];
-          })
-          sources."setprototypeof-1.1.0"
+          sources."debug-2.6.9"
+          sources."http-errors-1.6.3"
         ];
       })
-      sources."serve-static-1.12.6"
-      sources."setprototypeof-1.0.3"
+      sources."serve-static-1.13.2"
+      sources."setprototypeof-1.1.0"
       sources."sigmund-1.0.1"
       sources."sinopia-htpasswd-0.4.5"
       sources."source-map-0.1.43"
       sources."sprintf-js-1.0.3"
       sources."srcset-1.0.0"
       sources."sshpk-1.15.1"
-      sources."statuses-1.3.1"
+      sources."statuses-1.4.0"
       sources."string_decoder-1.1.1"
       sources."supports-color-5.5.0"
       sources."through-2.3.8"
@@ -54112,7 +54197,7 @@ in
       })
       sources."unpipe-1.0.0"
       sources."util-deprecate-1.0.2"
-      sources."utils-merge-1.0.0"
+      sources."utils-merge-1.0.1"
       sources."uuid-3.3.2"
       sources."vary-1.1.2"
       sources."verror-1.10.0"
@@ -54521,10 +54606,10 @@ in
   snyk = nodeEnv.buildNodePackage {
     name = "snyk";
     packageName = "snyk";
-    version = "1.103.4";
+    version = "1.105.0";
     src = fetchurl {
-      url = "https://registry.npmjs.org/snyk/-/snyk-1.103.4.tgz";
-      sha512 = "ynLlsLDjAkzymd0qi1il6f34S4oNTfIgvFCFvkYxvqfBkedfOoDQT4TLU8gi+55MGM6iornf2iefC2FW92BwnQ==";
+      url = "https://registry.npmjs.org/snyk/-/snyk-1.105.0.tgz";
+      sha512 = "j4qNnZ+i9fwuS6t2xM+QSOYedbr9f10s4EC2m4fHWb22uyQYqDdRBISwY8nUAeYbJTMJvJTJzRcEEdXboSkNhA==";
     };
     dependencies = [
       sources."@yarnpkg/lockfile-1.1.0"
@@ -54725,7 +54810,7 @@ in
       sources."smart-buffer-1.1.15"
       sources."snyk-config-2.2.0"
       sources."snyk-docker-plugin-1.12.0"
-      sources."snyk-go-plugin-1.5.2"
+      sources."snyk-go-plugin-1.6.0"
       sources."snyk-gradle-plugin-2.1.0"
       sources."snyk-module-1.8.2"
       sources."snyk-mvn-plugin-2.0.0"
@@ -54737,7 +54822,7 @@ in
       sources."snyk-nuget-plugin-1.6.5"
       sources."snyk-php-plugin-1.5.1"
       sources."snyk-policy-1.12.0"
-      sources."snyk-python-plugin-1.8.2"
+      sources."snyk-python-plugin-1.9.0"
       sources."snyk-resolve-1.0.1"
       sources."snyk-resolve-deps-4.0.2"
       sources."snyk-sbt-plugin-2.0.0"
@@ -54840,8 +54925,8 @@ in
       sources."has-cors-1.1.0"
       sources."indexof-0.0.1"
       sources."isarray-2.0.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."ms-2.0.0"
       sources."negotiator-0.6.1"
       sources."object-component-0.0.3"
@@ -55000,11 +55085,11 @@ in
       sources."boolbase-1.0.0"
       sources."coa-2.0.1"
       sources."colors-1.1.2"
-      sources."css-select-2.0.0"
-      sources."css-select-base-adapter-0.1.0"
+      sources."css-select-2.0.2"
+      sources."css-select-base-adapter-0.1.1"
       sources."css-tree-1.0.0-alpha.28"
       sources."css-url-regex-1.1.0"
-      sources."css-what-2.1.0"
+      sources."css-what-2.1.2"
       (sources."csso-3.5.1" // {
         dependencies = [
           sources."css-tree-1.0.0-alpha.29"
@@ -55018,7 +55103,7 @@ in
       })
       sources."domelementtype-1.3.0"
       sources."domutils-1.7.0"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."es-abstract-1.12.0"
       sources."es-to-primitive-1.2.0"
       sources."esprima-4.0.1"
@@ -55033,7 +55118,7 @@ in
       sources."mdn-data-1.1.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.5.1"
-      sources."nth-check-1.0.1"
+      sources."nth-check-1.0.2"
       sources."object-keys-1.0.12"
       sources."object.getownpropertydescriptors-2.0.3"
       sources."object.values-1.0.4"
@@ -55153,7 +55238,7 @@ in
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
-      sources."combined-stream-1.0.6"
+      sources."combined-stream-1.0.7"
       sources."commander-2.19.0"
       sources."component-emitter-1.2.1"
       sources."concat-map-0.0.1"
@@ -55239,7 +55324,7 @@ in
       sources."finalhandler-1.1.0"
       sources."flatmap-stream-0.1.1"
       sources."for-in-1.0.2"
-      sources."form-data-2.3.2"
+      sources."form-data-2.3.3"
       sources."formidable-1.2.1"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
@@ -55386,8 +55471,8 @@ in
       sources."methods-1.1.2"
       sources."micromatch-3.1.10"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mixin-deep-1.3.1"
@@ -55410,7 +55495,7 @@ in
       sources."nan-2.11.1"
       sources."nanomatch-1.2.13"
       sources."native-promise-only-0.8.1"
-      (sources."nodemon-1.18.4" // {
+      (sources."nodemon-1.18.5" // {
         dependencies = [
           sources."debug-3.2.6"
           sources."ms-2.1.1"
@@ -55673,7 +55758,7 @@ in
       sources."valid-url-1.0.9"
       sources."validator-10.8.0"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."wordwrap-0.0.3"
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.3.0"
@@ -55812,16 +55897,12 @@ in
         ];
       })
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs-extra-7.0.0"
       sources."getpass-0.1.7"
       sources."graceful-fs-4.1.11"
       sources."har-schema-2.0.0"
-      sources."har-validator-5.0.3"
+      sources."har-validator-5.1.0"
       sources."http-signature-1.2.0"
       sources."humanize-0.0.9"
       sources."is-typedarray-1.0.0"
@@ -55835,23 +55916,30 @@ in
       sources."keypress-0.2.1"
       sources."lodash-4.17.11"
       sources."longjohn-0.2.12"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimist-0.0.10"
       sources."moment-2.22.2"
-      (sources."node-appc-0.2.48" // {
+      (sources."node-appc-0.2.49" // {
         dependencies = [
-          sources."fs-extra-6.0.1"
+          sources."request-2.88.0"
         ];
       })
-      sources."oauth-sign-0.8.2"
+      sources."oauth-sign-0.9.0"
       sources."optimist-0.6.1"
       sources."os-tmpdir-1.0.2"
       sources."performance-now-2.1.0"
       sources."pkginfo-0.3.1"
+      sources."psl-1.1.29"
       sources."punycode-1.4.1"
       sources."qs-6.5.2"
-      sources."request-2.87.0"
+      (sources."request-2.87.0" // {
+        dependencies = [
+          sources."har-validator-5.0.3"
+          sources."oauth-sign-0.8.2"
+          sources."tough-cookie-2.3.4"
+        ];
+      })
       sources."rimraf-2.2.8"
       sources."safe-buffer-5.1.2"
       sources."safer-buffer-2.1.2"
@@ -55862,7 +55950,7 @@ in
       sources."sshpk-1.15.1"
       sources."stack-trace-0.0.10"
       sources."temp-0.8.3"
-      sources."tough-cookie-2.3.4"
+      sources."tough-cookie-2.4.3"
       sources."tunnel-agent-0.6.0"
       sources."tweetnacl-0.14.5"
       sources."uglify-js-3.4.9"
@@ -56128,7 +56216,7 @@ in
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
       sources."columnify-1.5.4"
-      sources."combined-stream-1.0.6"
+      sources."combined-stream-1.0.7"
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
       sources."configstore-3.1.2"
@@ -56149,7 +56237,7 @@ in
       sources."execa-0.7.0"
       sources."exit-hook-1.1.1"
       sources."extend-3.0.2"
-      sources."form-data-2.3.2"
+      sources."form-data-2.3.3"
       sources."fs.realpath-1.0.0"
       sources."function-bind-1.1.1"
       sources."get-stream-3.0.0"
@@ -56199,8 +56287,8 @@ in
       sources."make-dir-1.3.0"
       sources."make-error-1.3.5"
       sources."make-error-cause-1.2.2"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
       (sources."mkdirp-0.5.1" // {
@@ -56286,7 +56374,7 @@ in
       sources."util-deprecate-1.0.2"
       sources."wcwidth-1.0.1"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."wordwrap-1.0.0"
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.3.0"
@@ -56328,10 +56416,10 @@ in
   ungit = nodeEnv.buildNodePackage {
     name = "ungit";
     packageName = "ungit";
-    version = "1.4.34";
+    version = "1.4.35";
     src = fetchurl {
-      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.34.tgz";
-      sha512 = "7sgDDNaWakL7tzp5NwENWHV0SekB6LzcW99nVv0CLthggQnw7wWDnSFAz9iHbBINNj14Sh3gscO7nd73qBtlgA==";
+      url = "https://registry.npmjs.org/ungit/-/ungit-1.4.35.tgz";
+      sha512 = "K1Un15sypkCp57VPCaDFCfXkUs0UlJ2EBh3PyafA2juqX1V1UkOWQabkMV7OYZudqJz2UVOkkKVFDBd+/x/52g==";
     };
     dependencies = [
       sources."abbrev-1.1.1"
@@ -56562,8 +56650,8 @@ in
       sources."merge-descriptors-1.0.1"
       sources."methods-1.1.2"
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
@@ -56634,11 +56722,7 @@ in
           sources."combined-stream-1.0.7"
           sources."delayed-stream-1.0.0"
           sources."extend-3.0.2"
-          (sources."form-data-2.3.2" // {
-            dependencies = [
-              sources."combined-stream-1.0.6"
-            ];
-          })
+          sources."form-data-2.3.3"
         ];
       })
       sources."require-directory-2.1.1"
@@ -56697,12 +56781,12 @@ in
       sources."strip-json-comments-2.0.1"
       (sources."superagent-4.0.0-beta.5" // {
         dependencies = [
-          sources."combined-stream-1.0.6"
+          sources."combined-stream-1.0.7"
           sources."component-emitter-1.2.1"
           sources."cookiejar-2.1.2"
           sources."debug-4.1.0"
           sources."delayed-stream-1.0.0"
-          sources."form-data-2.3.2"
+          sources."form-data-2.3.3"
           sources."formidable-1.2.1"
           sources."mime-2.3.1"
           sources."ms-2.1.1"
@@ -56871,11 +56955,7 @@ in
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-2.1.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fs-constants-1.0.0"
       sources."fs-extra-0.26.7"
       sources."fs.realpath-1.0.0"
@@ -56946,8 +57026,8 @@ in
           sources."supports-color-2.0.0"
         ];
       })
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
@@ -57065,7 +57145,7 @@ in
     dependencies = [
       sources."@akryum/winattr-3.0.0"
       sources."@apollographql/apollo-upload-server-5.0.3"
-      sources."@apollographql/graphql-playground-html-1.6.0"
+      sources."@apollographql/graphql-playground-html-1.6.4"
       sources."@babel/runtime-7.1.2"
       sources."@babel/runtime-corejs2-7.1.2"
       sources."@mrmlnc/readdir-enhanced-2.2.1"
@@ -57081,7 +57161,7 @@ in
       sources."@protobufjs/pool-1.1.0"
       sources."@protobufjs/utf8-1.1.0"
       sources."@types/accepts-1.3.5"
-      sources."@types/async-2.0.49"
+      sources."@types/async-2.0.50"
       sources."@types/body-parser-1.17.0"
       sources."@types/connect-3.4.32"
       sources."@types/cors-2.8.4"
@@ -57090,7 +57170,7 @@ in
       sources."@types/express-serve-static-core-4.16.0"
       sources."@types/long-4.0.0"
       sources."@types/mime-2.0.0"
-      sources."@types/node-10.11.7"
+      sources."@types/node-10.12.0"
       sources."@types/range-parser-1.2.2"
       sources."@types/serve-static-1.13.2"
       sources."@types/ws-5.1.2"
@@ -57110,10 +57190,10 @@ in
       sources."ansi-regex-3.0.0"
       sources."ansi-styles-3.2.1"
       sources."anymatch-2.0.0"
-      sources."apollo-cache-1.1.17"
+      sources."apollo-cache-1.1.19"
       sources."apollo-cache-control-0.2.5"
-      sources."apollo-cache-inmemory-1.3.5"
-      sources."apollo-client-2.4.2"
+      sources."apollo-cache-inmemory-1.3.7"
+      sources."apollo-client-2.4.4"
       sources."apollo-datasource-0.1.3"
       sources."apollo-engine-reporting-0.0.6"
       sources."apollo-engine-reporting-protobuf-0.0.1"
@@ -57139,7 +57219,7 @@ in
       })
       sources."apollo-tracing-0.2.5"
       sources."apollo-upload-client-8.1.0"
-      sources."apollo-utilities-1.0.21"
+      sources."apollo-utilities-1.0.24"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
       sources."arr-flatten-1.1.0"
@@ -57370,7 +57450,6 @@ in
       sources."fast-deep-equal-1.1.0"
       sources."fast-glob-2.2.3"
       sources."fast-json-stable-stringify-2.0.0"
-      sources."fclone-1.0.11"
       sources."fd-slicer-1.1.0"
       sources."figures-2.0.0"
       sources."file-type-5.2.0"
@@ -57386,11 +57465,7 @@ in
       sources."flatmap-stream-0.1.1"
       sources."for-in-1.0.2"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."forwarded-0.1.2"
       sources."fragment-cache-0.2.1"
       sources."fresh-0.5.2"
@@ -57426,7 +57501,7 @@ in
       sources."graceful-fs-4.1.11"
       sources."graceful-readlink-1.0.1"
       sources."graphql-0.13.2"
-      sources."graphql-anywhere-4.1.19"
+      sources."graphql-anywhere-4.1.21"
       sources."graphql-extensions-0.2.1"
       sources."graphql-subscriptions-1.0.0"
       sources."graphql-tag-2.10.0"
@@ -57455,7 +57530,7 @@ in
       sources."ieee754-1.1.12"
       sources."ignore-3.3.10"
       sources."ignore-by-default-1.0.1"
-      sources."immutable-tuple-0.4.8"
+      sources."immutable-tuple-0.4.9"
       sources."import-global-0.1.0"
       sources."import-lazy-2.1.0"
       sources."imurmurhash-0.1.4"
@@ -57499,7 +57574,7 @@ in
       sources."is-wsl-1.1.0"
       sources."isarray-0.0.1"
       sources."isbinaryfile-3.0.3"
-      sources."isemail-3.1.3"
+      sources."isemail-3.2.0"
       sources."isexe-2.0.0"
       sources."isobject-3.0.1"
       sources."isstream-0.1.2"
@@ -57536,7 +57611,7 @@ in
       sources."map-stream-0.0.7"
       sources."map-visit-1.0.0"
       sources."media-typer-0.3.0"
-      sources."merge-1.2.0"
+      sources."merge-1.2.1"
       sources."merge-descriptors-1.0.1"
       sources."merge2-1.2.3"
       sources."methods-1.1.2"
@@ -57547,8 +57622,8 @@ in
         ];
       })
       sources."mime-1.4.1"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimalistic-assert-1.0.1"
       sources."minimatch-3.0.4"
@@ -57566,7 +57641,7 @@ in
       sources."ms-2.0.0"
       sources."mute-stream-0.0.7"
       sources."nan-2.11.1"
-      sources."nanoid-1.3.0"
+      sources."nanoid-1.3.1"
       (sources."nanomatch-1.2.13" // {
         dependencies = [
           sources."extend-shallow-3.0.2"
@@ -57577,8 +57652,8 @@ in
       sources."nice-try-1.0.5"
       sources."node-fetch-2.2.0"
       sources."node-ipc-9.1.1"
-      sources."node-notifier-5.2.1"
-      sources."nodemon-1.18.4"
+      sources."node-notifier-5.3.0"
+      sources."nodemon-1.18.5"
       sources."nopt-1.0.10"
       sources."normalize-path-2.1.1"
       sources."npm-conf-1.1.3"
@@ -57607,7 +57682,7 @@ in
       sources."once-1.4.0"
       sources."onetime-2.0.1"
       sources."opn-5.4.0"
-      sources."optimism-0.6.6"
+      sources."optimism-0.6.7"
       sources."ora-2.1.0"
       sources."os-tmpdir-1.0.2"
       sources."p-finally-1.0.0"
@@ -57629,7 +57704,7 @@ in
       sources."pify-3.0.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
-      (sources."portfinder-1.0.17" // {
+      (sources."portfinder-1.0.19" // {
         dependencies = [
           sources."debug-2.6.9"
         ];
@@ -57878,7 +57953,7 @@ in
       sources."watch-1.0.2"
       sources."wcwidth-1.0.1"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."wrappy-1.0.2"
       sources."write-file-atomic-2.3.0"
       sources."ws-5.2.2"
@@ -57892,7 +57967,7 @@ in
       })
       sources."yauzl-2.10.0"
       sources."yn-2.0.0"
-      sources."zen-observable-0.8.9"
+      sources."zen-observable-0.8.10"
       sources."zen-observable-ts-0.8.10"
     ];
     buildInputs = globalBuildInputs;
@@ -57907,34 +57982,35 @@ in
   "@webassemblyjs/cli" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_cli";
     packageName = "@webassemblyjs/cli";
-    version = "1.7.8";
+    version = "1.7.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/cli/-/cli-1.7.8.tgz";
-      sha512 = "/zEE5vL2lVlZVv3XYLo6+yeEU5pqi8AByBWBVYSuPSRBu0bY9cTCRU4exS/Jd7bdbF9I3s1Moa1FRG1wCQErfA==";
+      url = "https://registry.npmjs.org/@webassemblyjs/cli/-/cli-1.7.10.tgz";
+      sha512 = "+4NHGgHrJm/huSZSTH8i+v9PadhRQkv9J8ZS7+zqwqZOpReiXVa3Zs59x2yviW80qMwIsKx5qdYY+CVJOfVupA==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.7.8"
-      sources."@webassemblyjs/floating-point-hex-parser-1.7.8"
-      sources."@webassemblyjs/helper-api-error-1.7.8"
-      sources."@webassemblyjs/helper-code-frame-1.7.8"
-      sources."@webassemblyjs/helper-flaten-ast-1.7.8"
-      sources."@webassemblyjs/helper-fsm-1.7.8"
-      sources."@webassemblyjs/helper-module-context-1.7.8"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.7.8"
-      sources."@webassemblyjs/ieee754-1.7.8"
-      sources."@webassemblyjs/leb128-1.7.8"
-      sources."@webassemblyjs/utf8-1.7.8"
-      sources."@webassemblyjs/validation-1.7.8"
-      sources."@webassemblyjs/wasm-parser-1.7.8"
-      sources."@webassemblyjs/wast-parser-1.7.8"
-      sources."@webassemblyjs/wast-printer-1.7.8"
+      sources."@webassemblyjs/ast-1.7.10"
+      sources."@webassemblyjs/floating-point-hex-parser-1.7.10"
+      sources."@webassemblyjs/helper-api-error-1.7.10"
+      sources."@webassemblyjs/helper-code-frame-1.7.10"
+      sources."@webassemblyjs/helper-flaten-ast-1.7.10"
+      sources."@webassemblyjs/helper-fsm-1.7.10"
+      sources."@webassemblyjs/helper-module-context-1.7.10"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.7.10"
+      sources."@webassemblyjs/ieee754-1.7.10"
+      sources."@webassemblyjs/leb128-1.7.10"
+      sources."@webassemblyjs/utf8-1.7.10"
+      sources."@webassemblyjs/validation-1.7.10"
+      sources."@webassemblyjs/wasm-parser-1.7.10"
+      sources."@webassemblyjs/wast-parser-1.7.10"
+      sources."@webassemblyjs/wast-printer-1.7.10"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.1"
-      sources."webassemblyjs-1.7.8"
+      sources."webassemblyjs-1.7.10"
     ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "Toolbox for WebAssembly";
+      homepage = "https://github.com/xtuc/webassemblyjs#readme";
       license = "MIT";
     };
     production = true;
@@ -57943,34 +58019,35 @@ in
   "@webassemblyjs/repl" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_repl";
     packageName = "@webassemblyjs/repl";
-    version = "1.7.8";
+    version = "1.7.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/repl/-/repl-1.7.8.tgz";
-      sha512 = "IClmDKT+XgTiJ3lNaaXbHBAt2LqabugJmsabtF8TIlulG5Y5NEOOeJGjm56/rmwuW3/ul/zvaLQ1pFpU3WEIXg==";
+      url = "https://registry.npmjs.org/@webassemblyjs/repl/-/repl-1.7.10.tgz";
+      sha512 = "XhF/4drgVJSRry+Mp47McnAxgS/jBPwhDrml1CfwzvZ5MiAimHbCkKdc7i22H6ZM38QgwpJvL1RrXHwkGLsg+A==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.7.8"
-      sources."@webassemblyjs/floating-point-hex-parser-1.7.8"
-      sources."@webassemblyjs/helper-api-error-1.7.8"
-      sources."@webassemblyjs/helper-code-frame-1.7.8"
-      sources."@webassemblyjs/helper-flaten-ast-1.7.8"
-      sources."@webassemblyjs/helper-fsm-1.7.8"
-      sources."@webassemblyjs/helper-module-context-1.7.8"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.7.8"
-      sources."@webassemblyjs/ieee754-1.7.8"
-      sources."@webassemblyjs/leb128-1.7.8"
-      sources."@webassemblyjs/utf8-1.7.8"
-      sources."@webassemblyjs/validation-1.7.8"
-      sources."@webassemblyjs/wasm-parser-1.7.8"
-      sources."@webassemblyjs/wast-parser-1.7.8"
-      sources."@webassemblyjs/wast-printer-1.7.8"
+      sources."@webassemblyjs/ast-1.7.10"
+      sources."@webassemblyjs/floating-point-hex-parser-1.7.10"
+      sources."@webassemblyjs/helper-api-error-1.7.10"
+      sources."@webassemblyjs/helper-code-frame-1.7.10"
+      sources."@webassemblyjs/helper-flaten-ast-1.7.10"
+      sources."@webassemblyjs/helper-fsm-1.7.10"
+      sources."@webassemblyjs/helper-module-context-1.7.10"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.7.10"
+      sources."@webassemblyjs/ieee754-1.7.10"
+      sources."@webassemblyjs/leb128-1.7.10"
+      sources."@webassemblyjs/utf8-1.7.10"
+      sources."@webassemblyjs/validation-1.7.10"
+      sources."@webassemblyjs/wasm-parser-1.7.10"
+      sources."@webassemblyjs/wast-parser-1.7.10"
+      sources."@webassemblyjs/wast-printer-1.7.10"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.1"
-      sources."webassemblyjs-1.7.8"
+      sources."webassemblyjs-1.7.10"
     ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "WebAssembly REPL";
+      homepage = "https://github.com/xtuc/webassemblyjs#readme";
       license = "MIT";
     };
     production = true;
@@ -57979,28 +58056,28 @@ in
   "@webassemblyjs/wasm-strip" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_wasm-strip";
     packageName = "@webassemblyjs/wasm-strip";
-    version = "1.7.8";
+    version = "1.7.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/wasm-strip/-/wasm-strip-1.7.8.tgz";
-      sha512 = "ZhPzbEX3UKaLjJ7hjPVjNG3tNjiD7B8eriTR11yrctdyD5vAOVoyrUEsBPX0WadxDOzOsGZmSbFD1SHBjJT8jQ==";
+      url = "https://registry.npmjs.org/@webassemblyjs/wasm-strip/-/wasm-strip-1.7.10.tgz";
+      sha512 = "qGFju5p6oL0p/B/3/YKyt+X1LSbQa0XvacCgPQL+DhJTI0Cgjp5+5qSdyoP8euKEQfp/t3fyVcaarkET/DviCA==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.7.8"
-      sources."@webassemblyjs/floating-point-hex-parser-1.7.8"
-      sources."@webassemblyjs/helper-api-error-1.7.8"
-      sources."@webassemblyjs/helper-buffer-1.7.8"
-      sources."@webassemblyjs/helper-code-frame-1.7.8"
-      sources."@webassemblyjs/helper-fsm-1.7.8"
-      sources."@webassemblyjs/helper-module-context-1.7.8"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.7.8"
-      sources."@webassemblyjs/helper-wasm-section-1.7.8"
-      sources."@webassemblyjs/ieee754-1.7.8"
-      sources."@webassemblyjs/leb128-1.7.8"
-      sources."@webassemblyjs/utf8-1.7.8"
-      sources."@webassemblyjs/wasm-gen-1.7.8"
-      sources."@webassemblyjs/wasm-parser-1.7.8"
-      sources."@webassemblyjs/wast-parser-1.7.8"
-      sources."@webassemblyjs/wast-printer-1.7.8"
+      sources."@webassemblyjs/ast-1.7.10"
+      sources."@webassemblyjs/floating-point-hex-parser-1.7.10"
+      sources."@webassemblyjs/helper-api-error-1.7.10"
+      sources."@webassemblyjs/helper-buffer-1.7.10"
+      sources."@webassemblyjs/helper-code-frame-1.7.10"
+      sources."@webassemblyjs/helper-fsm-1.7.10"
+      sources."@webassemblyjs/helper-module-context-1.7.10"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.7.10"
+      sources."@webassemblyjs/helper-wasm-section-1.7.10"
+      sources."@webassemblyjs/ieee754-1.7.10"
+      sources."@webassemblyjs/leb128-1.7.10"
+      sources."@webassemblyjs/utf8-1.7.10"
+      sources."@webassemblyjs/wasm-gen-1.7.10"
+      sources."@webassemblyjs/wasm-parser-1.7.10"
+      sources."@webassemblyjs/wast-parser-1.7.10"
+      sources."@webassemblyjs/wast-printer-1.7.10"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.1"
     ];
@@ -58015,10 +58092,10 @@ in
   "@webassemblyjs/wasm-text-gen" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_wasm-text-gen";
     packageName = "@webassemblyjs/wasm-text-gen";
-    version = "1.7.8";
+    version = "1.7.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/wasm-text-gen/-/wasm-text-gen-1.7.8.tgz";
-      sha512 = "cDzQh/rniwchQfzGQriAg7Io2xqEu5s1Po29jMkRfJse4OFbh54aWcbKk2DO0ph+9lbNQZ0VYTPBP5NGIKqNmw==";
+      url = "https://registry.npmjs.org/@webassemblyjs/wasm-text-gen/-/wasm-text-gen-1.7.10.tgz";
+      sha512 = "yc851UCD6YQDVcKTpNf7v4EdWGhK6KmWl44VsreWOFKGFaz52sj/mQXuGg4Ach2iBnq0csNMGiucBvu/KlZRIA==";
     };
     dependencies = [
       sources."@babel/code-frame-7.0.0"
@@ -58027,19 +58104,19 @@ in
       sources."@babel/parser-7.1.3"
       sources."@babel/template-7.1.2"
       sources."@babel/types-7.1.3"
-      sources."@webassemblyjs/ast-1.7.8"
-      sources."@webassemblyjs/floating-point-hex-parser-1.7.8"
-      sources."@webassemblyjs/helper-api-error-1.7.8"
-      sources."@webassemblyjs/helper-code-frame-1.7.8"
-      sources."@webassemblyjs/helper-fsm-1.7.8"
-      sources."@webassemblyjs/helper-module-context-1.7.8"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.7.8"
-      sources."@webassemblyjs/ieee754-1.7.8"
-      sources."@webassemblyjs/leb128-1.7.8"
-      sources."@webassemblyjs/utf8-1.7.8"
-      sources."@webassemblyjs/wasm-parser-1.7.8"
-      sources."@webassemblyjs/wast-parser-1.7.8"
-      sources."@webassemblyjs/wast-printer-1.7.8"
+      sources."@webassemblyjs/ast-1.7.10"
+      sources."@webassemblyjs/floating-point-hex-parser-1.7.10"
+      sources."@webassemblyjs/helper-api-error-1.7.10"
+      sources."@webassemblyjs/helper-code-frame-1.7.10"
+      sources."@webassemblyjs/helper-fsm-1.7.10"
+      sources."@webassemblyjs/helper-module-context-1.7.10"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.7.10"
+      sources."@webassemblyjs/ieee754-1.7.10"
+      sources."@webassemblyjs/leb128-1.7.10"
+      sources."@webassemblyjs/utf8-1.7.10"
+      sources."@webassemblyjs/wasm-parser-1.7.10"
+      sources."@webassemblyjs/wast-parser-1.7.10"
+      sources."@webassemblyjs/wast-printer-1.7.10"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.1"
       sources."ansi-styles-3.2.1"
@@ -58069,26 +58146,27 @@ in
   "@webassemblyjs/wast-refmt" = nodeEnv.buildNodePackage {
     name = "_at_webassemblyjs_slash_wast-refmt";
     packageName = "@webassemblyjs/wast-refmt";
-    version = "1.7.8";
+    version = "1.7.10";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@webassemblyjs/wast-refmt/-/wast-refmt-1.7.8.tgz";
-      sha512 = "eSkc1/NnfbMYQP/DQaC2W0/DEY/TO4reAS/F/v2cnafFMBrwJ8xQCQwr9IAMiez1aKKYZmL4kyRRbU/0Q9Qbtg==";
+      url = "https://registry.npmjs.org/@webassemblyjs/wast-refmt/-/wast-refmt-1.7.10.tgz";
+      sha512 = "akbf+hDXgPU8UCrNO70KEo/H3FFOemKMDs655RtSCYQu8/kG+wPxyzHdcLSrM9EtD978Ba7Efq9mKNVVmgz4lw==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.7.8"
-      sources."@webassemblyjs/floating-point-hex-parser-1.7.8"
-      sources."@webassemblyjs/helper-api-error-1.7.8"
-      sources."@webassemblyjs/helper-code-frame-1.7.8"
-      sources."@webassemblyjs/helper-fsm-1.7.8"
-      sources."@webassemblyjs/helper-module-context-1.7.8"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.7.8"
-      sources."@webassemblyjs/wast-parser-1.7.8"
-      sources."@webassemblyjs/wast-printer-1.7.8"
+      sources."@webassemblyjs/ast-1.7.10"
+      sources."@webassemblyjs/floating-point-hex-parser-1.7.10"
+      sources."@webassemblyjs/helper-api-error-1.7.10"
+      sources."@webassemblyjs/helper-code-frame-1.7.10"
+      sources."@webassemblyjs/helper-fsm-1.7.10"
+      sources."@webassemblyjs/helper-module-context-1.7.10"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.7.10"
+      sources."@webassemblyjs/wast-parser-1.7.10"
+      sources."@webassemblyjs/wast-printer-1.7.10"
       sources."@xtuc/long-4.2.1"
     ];
     buildInputs = globalBuildInputs;
     meta = {
       description = "WAST refmt";
+      homepage = "https://github.com/xtuc/webassemblyjs#readme";
       license = "MIT";
     };
     production = true;
@@ -58190,8 +58268,8 @@ in
       sources."kew-0.1.7"
       sources."klaw-1.3.1"
       sources."lodash-4.17.11"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."minimatch-3.0.4"
       sources."minimist-0.0.8"
       sources."mkdirp-0.3.5"
@@ -58261,30 +58339,30 @@ in
   webpack = nodeEnv.buildNodePackage {
     name = "webpack";
     packageName = "webpack";
-    version = "4.20.2";
+    version = "4.23.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/webpack/-/webpack-4.20.2.tgz";
-      sha512 = "75WFUMblcWYcocjSLlXCb71QuGyH7egdBZu50FtBGl2Nso8CK3Ej+J7bTZz2FPFq5l6fzCisD9modB7t30ikuA==";
+      url = "https://registry.npmjs.org/webpack/-/webpack-4.23.1.tgz";
+      sha512 = "iE5Cu4rGEDk7ONRjisTOjVHv3dDtcFfwitSxT7evtYj/rANJpt1OuC/Kozh1pBa99AUBr1L/LsaNB+D9Xz3CEg==";
     };
     dependencies = [
-      sources."@webassemblyjs/ast-1.7.8"
-      sources."@webassemblyjs/floating-point-hex-parser-1.7.8"
-      sources."@webassemblyjs/helper-api-error-1.7.8"
-      sources."@webassemblyjs/helper-buffer-1.7.8"
-      sources."@webassemblyjs/helper-code-frame-1.7.8"
-      sources."@webassemblyjs/helper-fsm-1.7.8"
-      sources."@webassemblyjs/helper-module-context-1.7.8"
-      sources."@webassemblyjs/helper-wasm-bytecode-1.7.8"
-      sources."@webassemblyjs/helper-wasm-section-1.7.8"
-      sources."@webassemblyjs/ieee754-1.7.8"
-      sources."@webassemblyjs/leb128-1.7.8"
-      sources."@webassemblyjs/utf8-1.7.8"
-      sources."@webassemblyjs/wasm-edit-1.7.8"
-      sources."@webassemblyjs/wasm-gen-1.7.8"
-      sources."@webassemblyjs/wasm-opt-1.7.8"
-      sources."@webassemblyjs/wasm-parser-1.7.8"
-      sources."@webassemblyjs/wast-parser-1.7.8"
-      sources."@webassemblyjs/wast-printer-1.7.8"
+      sources."@webassemblyjs/ast-1.7.10"
+      sources."@webassemblyjs/floating-point-hex-parser-1.7.10"
+      sources."@webassemblyjs/helper-api-error-1.7.10"
+      sources."@webassemblyjs/helper-buffer-1.7.10"
+      sources."@webassemblyjs/helper-code-frame-1.7.10"
+      sources."@webassemblyjs/helper-fsm-1.7.10"
+      sources."@webassemblyjs/helper-module-context-1.7.10"
+      sources."@webassemblyjs/helper-wasm-bytecode-1.7.10"
+      sources."@webassemblyjs/helper-wasm-section-1.7.10"
+      sources."@webassemblyjs/ieee754-1.7.10"
+      sources."@webassemblyjs/leb128-1.7.10"
+      sources."@webassemblyjs/utf8-1.7.10"
+      sources."@webassemblyjs/wasm-edit-1.7.10"
+      sources."@webassemblyjs/wasm-gen-1.7.10"
+      sources."@webassemblyjs/wasm-opt-1.7.10"
+      sources."@webassemblyjs/wasm-parser-1.7.10"
+      sources."@webassemblyjs/wast-parser-1.7.10"
+      sources."@webassemblyjs/wast-printer-1.7.10"
       sources."@xtuc/ieee754-1.2.0"
       sources."@xtuc/long-4.2.1"
       sources."acorn-5.7.3"
@@ -58820,7 +58898,7 @@ in
       sources."flatten-1.0.2"
       (sources."fs-chunk-store-1.7.0" // {
         dependencies = [
-          sources."thunky-1.0.2"
+          sources."thunky-1.0.3"
         ];
       })
       sources."fs.realpath-1.0.0"
@@ -58882,7 +58960,7 @@ in
       sources."ms-2.0.0"
       (sources."multicast-dns-6.2.3" // {
         dependencies = [
-          sources."thunky-1.0.2"
+          sources."thunky-1.0.3"
         ];
       })
       (sources."multistream-2.1.1" // {
@@ -59030,7 +59108,7 @@ in
     dependencies = [
       sources."@cliqz-oss/firefox-client-0.3.1"
       sources."@cliqz-oss/node-firefox-connect-1.2.1"
-      sources."@types/node-10.11.7"
+      sources."@types/node-10.12.0"
       sources."@yarnpkg/lockfile-1.1.0"
       sources."JSONSelect-0.2.1"
       sources."abbrev-1.1.1"
@@ -59074,9 +59152,14 @@ in
       (sources."archiver-2.1.1" // {
         dependencies = [
           sources."async-2.6.1"
+          sources."readable-stream-2.3.6"
         ];
       })
-      sources."archiver-utils-1.3.0"
+      (sources."archiver-utils-1.3.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."archy-1.0.0"
       sources."argparse-1.0.10"
       sources."arr-diff-4.0.0"
@@ -59135,7 +59218,11 @@ in
       sources."base64-js-1.3.0"
       sources."bcrypt-pbkdf-1.0.2"
       sources."binary-extensions-1.12.0"
-      sources."bl-1.2.2"
+      (sources."bl-1.2.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."bluebird-2.9.34"
       sources."boolbase-1.0.0"
       sources."boxen-1.3.0"
@@ -59210,22 +59297,34 @@ in
       sources."commander-2.19.0"
       sources."common-tags-1.8.0"
       sources."component-emitter-1.2.1"
-      sources."compress-commons-1.2.2"
+      (sources."compress-commons-1.2.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."concat-map-0.0.1"
-      sources."concat-stream-1.6.2"
+      (sources."concat-stream-1.6.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."configstore-3.1.2"
       sources."convert-source-map-1.6.0"
       sources."copy-descriptor-0.1.1"
       sources."core-js-2.5.7"
       sources."core-util-is-1.0.2"
       sources."crc-3.8.0"
-      sources."crc32-stream-2.0.0"
+      (sources."crc32-stream-2.0.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
       sources."crx-parser-0.1.2"
       sources."crypto-random-string-1.0.0"
       sources."css-select-1.2.0"
-      sources."css-what-2.1.0"
+      sources."css-what-2.1.2"
       sources."d-1.0.0"
       sources."dashdash-1.14.1"
       sources."data-uri-to-buffer-1.2.0"
@@ -59275,7 +59374,7 @@ in
       sources."email-validator-2.0.4"
       sources."encoding-0.1.12"
       sources."end-of-stream-1.4.1"
-      sources."entities-1.1.1"
+      sources."entities-1.1.2"
       sources."error-ex-1.3.2"
       sources."es-abstract-1.12.0"
       sources."es-to-primitive-1.2.0"
@@ -59407,18 +59506,18 @@ in
           sources."async-2.5.0"
         ];
       })
-      sources."first-chunk-stream-2.0.0"
+      (sources."first-chunk-stream-2.0.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."flat-cache-1.3.0"
       sources."flatstr-1.0.8"
       sources."fluent-syntax-0.7.0"
       sources."for-in-1.0.2"
       sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."fs-constants-1.0.0"
       sources."fs-extra-4.0.3"
@@ -59445,7 +59544,11 @@ in
       sources."generate-object-property-1.2.0"
       sources."get-caller-file-1.0.3"
       sources."get-stream-3.0.0"
-      sources."get-uri-2.0.2"
+      (sources."get-uri-2.0.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
       sources."gettext-parser-1.1.0"
@@ -59494,7 +59597,7 @@ in
       })
       sources."home-or-tmp-2.0.0"
       sources."hosted-git-info-2.7.1"
-      sources."htmlparser2-3.9.2"
+      sources."htmlparser2-3.10.0"
       sources."http-errors-1.6.3"
       (sources."http-proxy-agent-2.1.0" // {
         dependencies = [
@@ -59624,7 +59727,11 @@ in
       sources."kind-of-3.2.2"
       sources."latest-version-3.1.0"
       sources."lazy-cache-0.2.7"
-      sources."lazystream-1.0.0"
+      (sources."lazystream-1.0.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."lcid-2.0.0"
       sources."levn-0.3.0"
       sources."lie-3.1.1"
@@ -59669,8 +59776,8 @@ in
           sources."kind-of-6.0.2"
         ];
       })
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."minimatch-3.0.4"
       sources."minimist-1.2.0"
@@ -59740,7 +59847,7 @@ in
       sources."normalize-package-data-2.4.0"
       sources."normalize-path-2.1.1"
       sources."npm-run-path-2.0.2"
-      sources."nth-check-1.0.1"
+      sources."nth-check-1.0.2"
       sources."number-is-nan-1.0.1"
       sources."oauth-sign-0.9.0"
       sources."object-assign-4.1.1"
@@ -59817,7 +59924,7 @@ in
       sources."probe-image-size-4.0.0"
       sources."process-0.11.10"
       sources."process-nextick-args-2.0.0"
-      sources."progress-2.0.0"
+      sources."progress-2.0.1"
       sources."promise-7.3.1"
       (sources."proxy-agent-2.3.1" // {
         dependencies = [
@@ -59845,8 +59952,12 @@ in
           sources."path-exists-2.1.0"
         ];
       })
-      sources."readable-stream-2.3.6"
-      sources."readdirp-2.2.1"
+      sources."readable-stream-3.0.6"
+      (sources."readdirp-2.2.1" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       (sources."readline2-1.0.1" // {
         dependencies = [
           sources."mute-stream-0.0.5"
@@ -59958,7 +60069,7 @@ in
         ];
       })
       sources."snapdragon-util-3.0.1"
-      (sources."snyk-1.103.4" // {
+      (sources."snyk-1.105.0" // {
         dependencies = [
           sources."ansi-regex-3.0.0"
           sources."ansi-styles-3.2.1"
@@ -59985,7 +60096,7 @@ in
           sources."ms-2.1.1"
         ];
       })
-      sources."snyk-go-plugin-1.5.2"
+      sources."snyk-go-plugin-1.6.0"
       sources."snyk-gradle-plugin-2.1.0"
       (sources."snyk-module-1.8.2" // {
         dependencies = [
@@ -60019,7 +60130,7 @@ in
           sources."ms-2.1.1"
         ];
       })
-      sources."snyk-python-plugin-1.8.2"
+      sources."snyk-python-plugin-1.9.0"
       (sources."snyk-resolve-1.0.1" // {
         dependencies = [
           sources."debug-3.2.6"
@@ -60105,7 +60216,11 @@ in
       sources."supports-color-2.0.0"
       sources."symbol-observable-1.0.1"
       sources."table-4.0.3"
-      sources."tar-stream-1.6.2"
+      (sources."tar-stream-1.6.2" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
       sources."temp-dir-1.0.0"
       sources."tempfile-2.0.0"
       (sources."term-size-1.2.0" // {
@@ -60183,7 +60298,7 @@ in
       sources."when-3.7.7"
       sources."which-1.3.1"
       sources."which-module-2.0.0"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."win-release-1.1.1"
       sources."window-size-0.1.4"
       sources."winreg-0.0.12"
@@ -60226,7 +60341,11 @@ in
           sources."jszip-2.6.1"
         ];
       })
-      sources."zip-stream-1.2.0"
+      (sources."zip-stream-1.2.0" // {
+        dependencies = [
+          sources."readable-stream-2.3.6"
+        ];
+      })
     ];
     buildInputs = globalBuildInputs;
     meta = {
@@ -60477,11 +60596,7 @@ in
       sources."for-in-1.0.2"
       sources."foreachasync-3.0.0"
       sources."forever-agent-0.6.1"
-      (sources."form-data-2.3.2" // {
-        dependencies = [
-          sources."combined-stream-1.0.6"
-        ];
-      })
+      sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."from2-2.3.0"
       sources."fs.realpath-1.0.0"
@@ -60634,8 +60749,8 @@ in
       })
       sources."merge2-1.2.3"
       sources."micromatch-3.1.10"
-      sources."mime-db-1.36.0"
-      sources."mime-types-2.1.20"
+      sources."mime-db-1.37.0"
+      sources."mime-types-2.1.21"
       sources."mimic-fn-1.2.0"
       sources."mimic-response-1.0.1"
       sources."minimatch-3.0.4"
@@ -60959,7 +61074,7 @@ in
       })
       sources."walk-2.3.14"
       sources."which-1.3.1"
-      sources."widest-line-2.0.0"
+      sources."widest-line-2.0.1"
       sources."win-release-1.1.1"
       (sources."wrap-ansi-2.1.0" // {
         dependencies = [


### PR DESCRIPTION
###### Motivation for this change

Scuttlebot provides a command-line utility, and therefore warrants packaging under the `nodePackages` attribute.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

