### PR TITLE
esptool: 2.4.1 -> 2.5.0

### DIFF
--- a/pkgs/tools/misc/esptool/default.nix
+++ b/pkgs/tools/misc/esptool/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python3, openssl }:
 
 python3.pkgs.buildPythonApplication rec {
-  name = "esptool-${version}";
-  version = "2.4.1";
+  pname = "esptool";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    sha256 = "1djlmqdvcyqjqbj225xkn4ix9qr01b8pmsdija2h4nizx77xjyng";
+    sha256 = "0cvxapcln1xcz8hy0hidw6g8q61s5j3q03j3wrviagbh0zip8jdx";
   };
 
   checkInputs = with python3.pkgs; [ flake8 flake8-future-import flake8-import-order ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

