### PR TITLE
goBuildPackage: Add -x to the go build command if NIX_DEBUG >= 1

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -151,6 +151,10 @@ go.stdenv.mkDerivation (
       fi
     }
 
+    if (( "''${NIX_DEBUG:-0}" >= 1 )); then
+      buildFlagsArray+=(-x)
+    fi
+
     if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
       declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
     else


### PR DESCRIPTION
The -x go option prints all intermediate commands used by the Go
compiler. For instance, this is pretty useful to debug Go LD_FLAGS
because the used linker command is printed.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

