### PR TITLE
sdcc, gputils: add gputils

### DIFF
--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       PIC18 targets. It can be retargeted for other microprocessors.
     '';
     homepage = http://sdcc.sourceforge.net/;
-    license = with licenses; if (gputils == null) then unfreeRedistributable else gpl2;
+    license = with licenses; if (gputils == null) then gpl2 else unfreeRedistributable;
     maintainers = with maintainers; [ bjornfor yorickvp ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -1,5 +1,9 @@
-{ stdenv, fetchurl, bison, flex, boost, texinfo, gputils ? null }:
-
+{ stdenv, fetchurl, bison, flex, boost, texinfo, autoconf, gputils ? null, disabled ? [] }:
+let
+  allDisabled = (if gputils == null then [ "pic14" "pic16" ] else []) ++ disabled;
+  # choices: mcs51 z80 z180 r2k r3ka gbz80 tlcs90 ds390 ds400 pic14 pic16 hc08 s08 stm8
+  inherit (stdenv) lib;
+in
 stdenv.mkDerivation rec {
   version = "3.7.0";
   name = "sdcc-${version}";
@@ -9,14 +13,13 @@ stdenv.mkDerivation rec {
     sha256 = "13llvx0j3v5qa7qd4fh7nix4j3alpd3ccprxvx163c4q8q4lfkc5";
   };
 
-  # TODO: remove this comment when gputils != null is tested
-  buildInputs = [ bison flex boost texinfo gputils ];
+  buildInputs = [ bison flex boost texinfo gputils autoconf ];
 
   configureFlags = ''
-    ${if gputils == null then "--disable-pic14-port --disable-pic16-port" else ""}
+    ${lib.concatMapStringsSep " " (f: "--disable-${f}-port") allDisabled}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Small Device C Compiler";
     longDescription = ''
       SDCC is a retargettable, optimizing ANSI - C compiler suite that targets
@@ -29,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = http://sdcc.sourceforge.net/;
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = [ maintainers.bjornfor maintainers.yorickvp ];
   };
 }

--- a/pkgs/development/compilers/sdcc/default.nix
+++ b/pkgs/development/compilers/sdcc/default.nix
@@ -1,25 +1,27 @@
-{ stdenv, fetchurl, bison, flex, boost, texinfo, autoconf, gputils ? null, disabled ? [] }:
+{ stdenv, fetchurl, autoconf, bison, boost, flex, texinfo, gputils ? null
+, excludePorts ? [] }:
+
+with stdenv.lib;
+
 let
-  allDisabled = (if gputils == null then [ "pic14" "pic16" ] else []) ++ disabled;
   # choices: mcs51 z80 z180 r2k r3ka gbz80 tlcs90 ds390 ds400 pic14 pic16 hc08 s08 stm8
-  inherit (stdenv) lib;
+  excludedPorts = excludePorts ++ (optionals (gputils == null) [ "pic14" "pic16" ]);
 in
+
 stdenv.mkDerivation rec {
-  version = "3.7.0";
   name = "sdcc-${version}";
+  version = "3.7.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/sdcc/sdcc-src-${version}.tar.bz2";
     sha256 = "13llvx0j3v5qa7qd4fh7nix4j3alpd3ccprxvx163c4q8q4lfkc5";
   };
 
-  buildInputs = [ bison flex boost texinfo gputils autoconf ];
+  buildInputs = [ autoconf bison boost flex gputils texinfo ];
 
-  configureFlags = ''
-    ${lib.concatMapStringsSep " " (f: "--disable-${f}-port") allDisabled}
-  '';
+  configureFlags = map (f: "--disable-${f}-port") excludedPorts;
 
-  meta = with lib; {
+  meta = {
     description = "Small Device C Compiler";
     longDescription = ''
       SDCC is a retargettable, optimizing ANSI - C compiler suite that targets
@@ -30,8 +32,8 @@ stdenv.mkDerivation rec {
       PIC18 targets. It can be retargeted for other microprocessors.
     '';
     homepage = http://sdcc.sourceforge.net/;
-    license = licenses.gpl2;
+    license = with licenses; if (gputils == null) then unfreeRedistributable else gpl2;
+    maintainers = with maintainers; [ bjornfor yorickvp ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.bjornfor maintainers.yorickvp ];
   };
 }

--- a/pkgs/development/tools/misc/gputils/default.nix
+++ b/pkgs/development/tools/misc/gputils/default.nix
@@ -1,16 +1,18 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  version = "1.5.0-1";
   name = "gputils-${version}";
+  version = "1.5.0-1";
+
   src = fetchurl {
     url = "mirror://sourceforge/gputils/${name}.tar.bz2";
     sha256 = "055v83fdgqljprapf7rmh8x66mr13fj0qypj49xba5spx0ca123g";
   };
+
   meta = with stdenv.lib; {
-    homepage = http://sdcc.sourceforge.net/;
+    homepage = https://gputils.sourceforge.io/;
     license = licenses.gpl2;
+    maintainers = with maintainers; [ yorickvp ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.yorickvp ];
   };
 }

--- a/pkgs/development/tools/misc/gputils/default.nix
+++ b/pkgs/development/tools/misc/gputils/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "1.5.0-1";
+  name = "gputils-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/gputils/${name}.tar.bz2";
+    sha256 = "055v83fdgqljprapf7rmh8x66mr13fj0qypj49xba5spx0ca123g";
+  };
+  meta = with stdenv.lib; {
+    homepage = http://sdcc.sourceforge.net/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.yorickvp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7074,7 +7074,9 @@ with pkgs;
 
   scalafmt = callPackage ../development/tools/scalafmt { };
 
-  sdcc = callPackage ../development/compilers/sdcc { };
+  sdcc = callPackage ../development/compilers/sdcc {
+    gputils = null;
+  };
 
   serpent = callPackage ../development/compilers/serpent { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8163,6 +8163,8 @@ with pkgs;
 
   gotty = callPackage ../servers/gotty { };
 
+  gputils = callPackage ../development/tools/misc/gputils { };
+
   gradleGen = callPackage ../development/tools/build-managers/gradle { };
   gradle = self.gradleGen.gradle_latest;
   gradle_2_14 = self.gradleGen.gradle_2_14;


### PR DESCRIPTION
###### Motivation for this change

Currently, sdcc is built without gputils. This means it can't build for pic14 and pic16.
I added gputils, and added the dependencies needed for sdcc not to crash at runtime.
Also added a `disabled` argument for faster builds if you only need one architecture.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

