### PR TITLE
openvpn: document how to import an external config

### DIFF
--- a/nixos/modules/services/networking/openvpn.nix
+++ b/nixos/modules/services/networking/openvpn.nix
@@ -131,6 +131,9 @@ in
               Configuration of this OpenVPN instance.  See
               <citerefentry><refentrytitle>openvpn</refentrytitle><manvolnum>8</manvolnum></citerefentry>
               for details.
+
+              To import an external config file, use the following definition:
+              <literal>config = "config /path/to/config.ovpn"</literal>
             '';
           };
 


### PR DESCRIPTION
###### Rationale
1. Increases ease of use when the config is already present as a file, which is a common case:
     `configFile = ./foo.ovpn`
     versus
     `config = builtins.readFile ./foo.ovpn`

2. Practical for building mutable services that allow changing the config without rebuilding NixOS:
   `configFile = "/etc/my-mutable.ovpn"`


###### Things done

- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

