### PR TITLE
Backport signal-desktop to stable (18.03)

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/beta.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/beta.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
-fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
 }:
@@ -33,7 +33,7 @@ let
     nss
     stdenv.cc.cc
     udev
-    xlibs.libxcb
+    xorg.libxcb
   ];
 
 in

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, gnome3, atk, cairo, pango, gdk_pixbuf, glib, freetype,
+{ stdenv, lib, fetchurl, dpkg, gnome3, gtk2, atk, cairo, pango, gdk_pixbuf, glib, freetype,
 fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
@@ -16,7 +16,7 @@ let
     gdk_pixbuf
     glib
     gnome3.gconf
-    gnome3.gtk2
+    gtk2
     pango
     libX11
     libXScrnSaver

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
+{ stdenv, lib, fetchurl, dpkg, gnome3, atk, cairo, pango, gdk_pixbuf, glib, freetype,
 fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
@@ -15,9 +15,9 @@ let
     freetype
     gdk_pixbuf
     glib
-    gnome2.GConf
-    gnome2.gtk
-    gnome2.pango
+    gnome3.gconf
+    gnome3.gtk2
+    pango
     libX11
     libXScrnSaver
     libXcomposite

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, dpkg, gnome2, atk, cairo, gdk_pixbuf, glib, freetype,
-fontconfig, dbus, libX11, xlibs, libXi, libXcursor, libXdamage, libXrandr,
+fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
 }:
@@ -33,7 +33,7 @@ let
     nss
     stdenv.cc.cc
     udev
-    xlibs.libxcb
+    xorg.libxcb
   ];
 
 in

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.13.0";
+  version = "1.14.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1iapkkfqssbjcksgic7i8x0cwp6gwcbbrfxlw7vp6k1cfvjwv9pf";
+    sha256 = "1f76dzm9qq12i4s95c51d9s923n69y8cbg8yz79qjpd6k30j8vkq";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.14.0";
+  version = "1.14.1";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1f76dzm9qq12i4s95c51d9s923n69y8cbg8yz79qjpd6k30j8vkq";
+    sha256 = "1f54azqdfqa2yrzlp9b7pz7nswl5n3pgln38yxcvb3y5k6x0ljqp";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, gnome3, gtk3, atk, cairo, pango, gdk_pixbuf, glib, freetype,
+{ stdenv, lib, fetchurl, dpkg, wrapGAppsHook, gnome3, gtk3, atk, cairo, pango, gdk_pixbuf, glib, freetype,
 fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
@@ -52,7 +52,7 @@ in
         throw "Signal for Desktop is not currently supported on ${stdenv.system}";
 
     phases = [ "unpackPhase" "installPhase" ];
-    nativeBuildInputs = [ dpkg ];
+    nativeBuildInputs = [ dpkg wrapGAppsHook ];
     unpackPhase = "dpkg-deb -x $src .";
     installPhase = ''
       mkdir -p $out
@@ -67,6 +67,9 @@ in
       # Patch signal
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
                --set-rpath ${rpath}:$out/libexec $out/libexec/signal-desktop
+      wrapProgram $out/libexec/signal-desktop \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        "''${gappsWrapperArgs[@]}"
 
       # Symlink to bin
       mkdir -p $out/bin

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.12.0";
+  version = "1.12.1";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "19c9pilx2qkpyqw3p167bfcizrpd4np5jxdcwqmpbcfibmrpmcsk";
+    sha256 = "1p85hpk8kzzgncfm033bzpwm7hk6rrq8zdpwqlk5z2biarwjdqfx";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -40,11 +40,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "signal-desktop-${version}";
-  version = "1.12.1";
+  version = "1.13.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-    sha256 = "1p85hpk8kzzgncfm033bzpwm7hk6rrq8zdpwqlk5z2biarwjdqfx";
+    sha256 = "1iapkkfqssbjcksgic7i8x0cwp6gwcbbrfxlw7vp6k1cfvjwv9pf";
   };
 
   phases = [ "unpackPhase" "installPhase" ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, dpkg, gnome3, gtk2, atk, cairo, pango, gdk_pixbuf, glib, freetype,
+{ stdenv, lib, fetchurl, dpkg, gnome3, gtk3, atk, cairo, pango, gdk_pixbuf, glib, freetype,
 fontconfig, dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr,
 libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss,
 nspr, alsaLib, cups, expat, udev
@@ -16,7 +16,7 @@ let
     gdk_pixbuf
     glib
     gnome3.gconf
-    gtk2
+    gtk3
     pango
     libX11
     libXScrnSaver
@@ -40,13 +40,13 @@ in
   stdenv.mkDerivation rec {
     name = "signal-desktop-${version}";
 
-    version = "1.11.0";
+    version = "1.12.0";
 
     src =
       if stdenv.system == "x86_64-linux" then
         fetchurl {
           url = "https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-          sha256 = "0s3qlzm7iy9qxca2hlh1hq0dnjr7y5wxad1ssqgmyhxsif0nqm96";
+          sha256 = "19c9pilx2qkpyqw3p167bfcizrpd4np5jxdcwqmpbcfibmrpmcsk";
         }
       else
         throw "Signal for Desktop is not currently supported on ${stdenv.system}";


### PR DESCRIPTION
###### Motivation for this change

According to an IRC discussion the Signal team might regularly break older clients.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

