### PR TITLE
ntl: 9.11.0 -> 11.2.1

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -26,7 +26,7 @@ let
       pybrial = self.callPackage ./pybrial.nix {};
 
       sagelib = self.callPackage ./sagelib.nix {
-        inherit flint ecl pari glpk eclib;
+        inherit flint ecl pari glpk eclib ntl arb;
         inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
         linbox = nixpkgs.linbox.override { withSage = true; };
       };
@@ -47,13 +47,13 @@ let
       };
 
       sage-env = self.callPackage ./sage-env.nix {
-        inherit sage-src python rWrapper openblas-cblas-pc glpk ecl singular eclib pari palp flint pynac pythonEnv;
+        inherit sage-src python rWrapper openblas-cblas-pc glpk ecl singular eclib pari palp flint pynac pythonEnv giac ntl;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
       };
 
       sage-with-env = self.callPackage ./sage-with-env.nix {
-        inherit pari eclib pythonEnv;
-        inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
+        inherit pari eclib pythonEnv ntl;
+        inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular giac;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
         three = nodePackages_8_x.three;
       };
@@ -108,10 +108,23 @@ let
     });
   };
 
+  # https://trac.sagemath.org/ticket/25532
+  ntl = nixpkgs.ntl.overrideAttrs (oldAttrs: rec {
+    name = "ntl-10.5.0";
+    sourceRoot = "${name}/src";
+    src = fetchurl {
+      url = "http://www.shoup.net/ntl/${name}.tar.gz";
+      sha256 = "1lmldaldgfr2b2a6585m3np5ds8bq1bis2s1ajycjm49vp4kc2xr";
+    };
+  });
+
+  giac = nixpkgs.giac.override { inherit ntl; };
+  arb = nixpkgs.arb.override { inherit flint; };
+
   # update causes issues
   # https://groups.google.com/forum/#!topic/sage-packaging/cS3v05Q0zso
   # https://trac.sagemath.org/ticket/24735
-  singular = nixpkgs.singular.overrideAttrs (oldAttrs: {
+  singular = (nixpkgs.singular.override { inherit ntl flint; }).overrideAttrs (oldAttrs: {
     name = "singular-4.1.0p3";
     src = fetchurl {
       url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/4-1-0/singular-4.1.0p3.tar.gz";
@@ -121,15 +134,15 @@ let
 
   # *not* to confuse with the python package "pynac"
   # https://trac.sagemath.org/ticket/24838 (depends on arb update)
-  pynac = nixpkgs.pynac.override { inherit singular; };
+  pynac = nixpkgs.pynac.override { inherit singular flint; };
 
-  eclib = nixpkgs.eclib.override { inherit pari; };
+  eclib = nixpkgs.eclib.override { inherit pari ntl; };
 
   # With openblas (64 bit), the tests fail the same way as when sage is build with
   # openblas instead of openblasCompat. Apparently other packages somehow use flints
   # blas when it is available. Alternative would be to override flint to use
   # openblasCompat.
-  flint = nixpkgs.flint.override { withBlas = false; };
+  flint = nixpkgs.flint.override { withBlas = false; inherit ntl; };
 
   # Multiple palp dimensions need to be available and sage expects them all to be
   # in the same folder.

--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -37,6 +37,10 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals withBlas [
     "--with-blas=${openblas}"
   ];
+
+  # issues with ntl -- https://github.com/wbhart/flint2/issues/487
+  NIX_CFLAGS_COMPILE = [ "-std=c++11" ];
+
   patches = [
     (fetchpatch {
       # Always produce libflint.so.MAJOR; will be included in the next flint version

--- a/pkgs/development/libraries/ntl/default.nix
+++ b/pkgs/development/libraries/ntl/default.nix
@@ -1,27 +1,60 @@
-{ stdenv, fetchurl, perl, gmp, libtool
+{ stdenv
+, lib
+, fetchurl
+, perl
+, gmp
+, gf2x ? null
+# I asked the ntl maintainer weather or not to include gf2x by default:
+# > If I remember correctly, gf2x is now thread safe, so there's no reason not to use it.
+, withGf2x ? true
+, tune ? false # tune for current system; non reproducible and time consuming
 }:
+
+assert withGf2x -> gf2x != null;
 
 stdenv.mkDerivation rec {
   name = "ntl-${version}";
-  version = "9.11.0";
+  version = "11.2.1";
   src = fetchurl {
     url = "http://www.shoup.net/ntl/ntl-${version}.tar.gz";
-    sha256 = "1wcwxpcby1c50llncz131334qq26lzh3dz21rahymgvakrq0369p";
+    sha256 = "04avzmqflx2a33n7v9jj32g83p7m6z712fg1mw308jk5ca2qp489";
   };
 
-  buildInputs = [ perl gmp libtool ];
+  buildInputs = [
+    gmp
+  ];
+
+  nativeBuildInputs = [
+    perl # needed for ./configure
+  ];
 
   sourceRoot = "${name}/src";
 
   enableParallelBuilding = true;
 
-  dontAddPrefix = true;
+  dontAddPrefix = true; # DEF_PREFIX instead
 
-  configureFlags = [ "DEF_PREFIX=$(out)" "WIZARD=off" "SHARED=on" "NATIVE=off" "CXX=c++" ];
+  # reference: http://shoup.net/ntl/doc/tour-unix.html
+  configureFlags = [
+    "DEF_PREFIX=$(out)"
+    "SHARED=on" # genereate a shared library (as well as static)
+    "NATIVE=off" # don't target code to current hardware (reproducibility, portability)
+    "TUNE=${
+      if tune then
+        "auto"
+      else if stdenv.targetPlatform.isx86 then
+        "x86" # "chooses options that should be well suited for most x86 platforms"
+      else
+        "generic" # "chooses options that should be OK for most platforms"
+    }"
+  ] ++ lib.optionals withGf2x [
+    "NTL_GF2X_LIB=on"
+    "GF2X_PREFIX=${gf2x}"
+  ];
 
-  # doCheck = true; # takes some time
+  doCheck = true; # takes some time
 
-  meta = {
+  meta = with lib; {
     description = "A Library for doing Number Theory";
     longDescription = ''
       NTL is a high-performance, portable C++ library providing data
@@ -30,7 +63,8 @@ stdenv.mkDerivation rec {
       the integers and over finite fields.
     '';
     homepage = http://www.shoup.net/ntl/;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with maintainers; [ timokau ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

ntl hasn't been updated in a while. So I'm doing that and adding myself
as the maintainer. I'm also adding some options and pinning the sage
dependency, since it is unfortunately not compatible with the latest ntl
yet.

I've also enabled the tests, since they don't take terribly long and are
worth the time in my opinion.

@7c6f434c (for the flint change)

The overrides in sages `default.nix` are really annoying to maintain (as seen in this patch). There has to be a better way than to "wire everything up" manually. Basically an overlay within nixpkgs.

@matthewbauer `git log` shows that you worked with overlays recently for the musl package set. Do you know if I could apply something similar for this purpose?

I basically want to pin some of sages dependencies. But since there are so many dependencies, its important that those overrides apply recursively.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

