### PR TITLE
nixos/switch-to-configuration: Never stop system.slice

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -166,6 +166,24 @@ while (my ($unit, $state) = each %{$activePrev}) {
 
     if (-e $prevUnitFile && ($state->{state} eq "active" || $state->{state} eq "activating")) {
         if (! -e $newUnitFile || abs_path($newUnitFile) eq "/dev/null") {
+            # Ignore (i.e. never stop) these units:
+            if ($unit eq "system.slice") {
+                # TODO: This can be removed a few months after 18.09 is out
+                # (i.e. after everyone switched away from 18.03).
+                # Problem: Restarting (stopping) system.slice would not only
+                # stop X11 but also most system units/services. We obviously
+                # don't want this happening to users when they switch from 18.03
+                # to 18.09 or nixos-unstable.
+                # Reason: The following change in systemd:
+                # https://github.com/systemd/systemd/commit/d8e5a9338278d6602a0c552f01f298771a384798
+                # The commit adds system.slice to the perpetual units, which
+                # means removing the unit file and adding it to the source code.
+                # This is done so that system.slice can't be stopped anymore but
+                # in our case it ironically would cause this script to stop
+                # system.slice because the unit was removed (and an older
+                # systemd version is still running).
+                next;
+            }
             my $unitInfo = parseUnit($prevUnitFile);
             $unitsToStop{$unit} = 1 if boolIsTrue($unitInfo->{'X-StopOnRemoval'} // "yes");
         }


### PR DESCRIPTION

###### Motivation for this change

Problem: Restarting (stopping) system.slice would not only stop X11 but
also most system units/services. We obviously don't want this happening
to users when they switch from 18.03 to 18.09 or nixos-unstable.

Reason: The following change in systemd:
https://github.com/systemd/systemd/commit/d8e5a9338278d6602a0c552f01f298771a384798

The commit adds system.slice to the perpetual units, which means
removing the unit file and adding it to the source code. This is done so
that system.slice can't be stopped anymore but in our case it ironically
would cause this script to stop system.slice because the unit file was
removed (and an older systemd version is still running).

Related issue: https://github.com/NixOS/nixpkgs/issues/39791

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

