### PR TITLE
Revert "unixtools: link instead of copying"

### DIFF
--- a/pkgs/top-level/unix-tools.nix
+++ b/pkgs/top-level/unix-tools.nix
@@ -22,19 +22,16 @@ let
     in runCommand "${cmd}-${version}" {
       meta.platforms = map (n: { kernel.name = n; }) (attrNames providers);
       passthru = { inherit provider; };
-      preferLocalBuild = true;
     } ''
-      if ! [ -x ${bin} ]; then
-        echo Cannot find command ${cmd}
+      if ! [ -x "${bin}" ]; then
+        echo "Cannot find command ${cmd}"
         exit 1
       fi
 
-      mkdir -p $out/bin
-      ln -s ${bin} $out/bin/${cmd}
+      install -D "${bin}" "$out/bin/${cmd}"
 
-      if [ -f ${manpage} ]; then
-        mkdir -p $out/share/man/man1
-        ln -s ${manpage} $out/share/man/man1/${cmd}.1.gz
+      if [ -f "${manpage}" ]; then
+        install -D "${manpage}" $out/share/man/man1/${cmd}.1.gz
       fi
     '';
 


### PR DESCRIPTION
This reverts commit f1a14f98446c0d65152542eb1196c4112cce843a.



Fixes #43650. Haven't investigated "why" but let's get things working.

At least gets things as far as "extra-utils", which it doesn't now.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---