### PR TITLE
rdocker: init at unstable-2018-07-17

### DIFF
--- a/pkgs/development/tools/rdocker/default.nix
+++ b/pkgs/development/tools/rdocker/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, makeWrapper, openssh }:
+
+stdenv.mkDerivation rec {
+  name = "rdocker-${version}";
+  version = "unstable-2018-07-17";
+
+  src = fetchFromGitHub {
+    owner = "dvddarias";
+    repo = "rdocker";
+    rev = "949377de0154ade2d28c6d4c4ec33b65ea813b5a";
+    sha256 = "1mwg9zh144q4fqk9016v2d347vzch8sxlixaxrz0ci9dxvs6ibd4";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm755 rdocker.sh $out/bin/rdocker
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/rdocker \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ openssh ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Securely control a remote docker daemon CLI using ssh forwarding, no SSL setup needed";
+    homepage = https://github.com/dvddarias/rdocker;
+    maintainers = [ stdenv.lib.maintainers.pneumaticat ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8450,6 +8450,8 @@ with pkgs;
 
   hammer = callPackage ../development/tools/parsing/hammer { };
 
+  rdocker = callPackage ../development/tools/rdocker { };
+
   redis-dump = callPackage ../development/tools/redis-dump { };
 
   redo = callPackage ../development/tools/build-managers/redo { };


### PR DESCRIPTION
###### Motivation for this change

[rdocker](https://github.com/dvddarias/rdocker) is a tool for remote Docker socket forwarding.

###### Things done

Not sure if the wrapping with openssh is really necessary; rdocker.sh is just a bash script that calls `ssh`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

