### PR TITLE
pcl: boost167 compatibility

### DIFF
--- a/pkgs/development/libraries/pcl/default.nix
+++ b/pkgs/development/libraries/pcl/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, cmake, qhull, flann, boost, vtk, eigen, pkgconfig, qtbase
+{ stdenv, fetchFromGitHub, fetchpatch, cmake
+, qhull, flann, boost, vtk, eigen, pkgconfig, qtbase
 , libusb1, libpcap, libXt, libpng, Cocoa, AGL, cf-private, OpenGL
 }:
 
@@ -11,6 +12,14 @@ stdenv.mkDerivation rec {
     rev = name;
     sha256 = "05wvqqi2fyk5innw4mg356r71c1hmc9alc7xkf4g81ds3b3867xq";
   };
+
+  patches = [
+    # boost-1.67 compatibility
+    (fetchpatch {
+      url = "https://github.com/PointCloudLibrary/pcl/commit/2309bdab20fb2a385d374db6a87349199279db18.patch";
+      sha256 = "112p4687xrm0vsm0magmkvsm1hpks9hj42fm0lncy3yy2j1v3r4h";
+      name = "boost167-random.patch";
+  })];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Cherry pick an upstream commit not yet available in a tagged release.

###### Motivation for this change
Fix a broken build on NixOS. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

