### PR TITLE
polybar-git: init at 2018-06-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3244,6 +3244,11 @@
     github = "relrod";
     name = "Ricky Elrod";
   };
+  rembo10 = {
+    email = "rembo10@users.noreply.github.com";
+    github = "rembo10";
+    name = "rembo10";
+  };
   renzo = {
     email = "renzocarbonara@gmail.com";
     github = "k0001";

--- a/pkgs/applications/misc/polybar/git.nix
+++ b/pkgs/applications/misc/polybar/git.nix
@@ -1,0 +1,70 @@
+{ cairo, cmake, fetchgit, libXdmcp, libpthreadstubs, libxcb, pcre, pkgconfig
+, python2 , stdenv, xcbproto, xcbutil, xcbutilimage, xcbutilrenderutil
+, xcbutilwm, xcbutilxrm, fetchpatch, makeWrapper
+
+# optional packages-- override the variables ending in 'Support' to enable or
+# disable modules
+, alsaSupport   ? true,  alsaLib       ? null
+, paSupport     ? true,  libpulseaudio ? null
+, iwSupport     ? true,  wirelesstools ? null
+, githubSupport ? false, curl          ? null
+, mpdSupport    ? false, mpd_clientlib ? null
+, i3Support ? false, i3GapsSupport ? false, i3 ? null, i3-gaps ? null, jsoncpp ? null
+}:
+
+assert alsaSupport   -> alsaLib       != null;
+assert paSupport     -> libpulseaudio != null;
+assert githubSupport -> curl          != null;
+assert iwSupport     -> wirelesstools != null;
+assert mpdSupport    -> mpd_clientlib != null;
+
+assert i3Support     -> ! i3GapsSupport && jsoncpp != null && i3      != null;
+assert i3GapsSupport -> ! i3Support     && jsoncpp != null && i3-gaps != null;
+
+stdenv.mkDerivation rec {
+    name = "polybar-git-${version}";
+    version = "2018-06-23";
+    src = fetchgit {
+      url = "https://github.com/jaagr/polybar";
+      rev = "028b1413ef9490cdcb21348ea0ca704828ef538e";
+      sha256 = "01mqwnlq7d9c503c5cnc19hl7hvk03fmih1wis7zljxdiz5hb82d";
+    };
+
+    meta = with stdenv.lib; {
+      description = "A fast and easy-to-use tool for creating status bars.";
+      longDescription = ''
+        Polybar aims to help users build beautiful and highly customizable
+        status bars for their desktop environment, without the need of
+        having a black belt in shell scripting.
+      '';
+      license = licenses.mit;
+      maintainers = [ maintainers.rembo10 ];
+      platforms = platforms.unix;
+    };
+
+    buildInputs = [
+      cairo libXdmcp libpthreadstubs libxcb pcre python2 xcbproto xcbutil
+      xcbutilimage xcbutilrenderutil xcbutilwm xcbutilxrm
+
+      (if alsaSupport   then alsaLib       else null)
+      (if paSupport     then libpulseaudio else null)
+      (if githubSupport then curl          else null)
+      (if iwSupport     then wirelesstools else null)
+      (if mpdSupport    then mpd_clientlib else null)
+
+      (if i3Support || i3GapsSupport then jsoncpp else null)
+      (if i3Support then i3 else null)
+      (if i3GapsSupport then i3-gaps else null)
+
+      (if i3Support || i3GapsSupport then makeWrapper else null)
+    ];
+
+    fixupPhase = if (i3Support || i3GapsSupport) then ''
+    wrapProgram $out/bin/polybar \
+      --prefix PATH : "${if i3Support then i3 else i3-gaps}/bin"
+  '' else null;
+
+    nativeBuildInputs = [
+      cmake pkgconfig
+    ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17449,6 +17449,8 @@ with pkgs;
 
   polybar = callPackage ../applications/misc/polybar { };
 
+  polybar-git = callPackage ../applications/misc/polybar/git.nix { };
+
   ptex = callPackage ../development/libraries/ptex {};
 
   rssguard = libsForQt5.callPackage ../applications/networking/feedreaders/rssguard { };


### PR DESCRIPTION
###### Motivation for this change
The last release is from Dec 2017 and there have been a lot of updates since then.
Basically just copied the default.nix, changed the commit, hash & version, and added the pulseaudio support (copied the lines from the other optional dependencies)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

