### PR TITLE
osquery: 3.2.8 -> 3.2.9

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -20,7 +20,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "osquery-${version}";
-  version = "3.2.8";
+  version = "3.2.9";
 
   # this is what `osquery --help` will show as the version.
   OSQUERY_BUILD_VERSION = version;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     owner = "facebook";
     repo = "osquery";
     rev = version;
-    sha256 = "1py5jizl7z1f9xzpg7pylbdnawvvifiyv9gpjwiim8ilgkmpaiv4";
+    sha256 = "1fac0yj1701469qhbsp38ab2fmavm3jw6x278bf78yvxdi99ivai";
   };
 
   patches = [ ./misc.patch ];

--- a/pkgs/tools/system/osquery/misc.patch
+++ b/pkgs/tools/system/osquery/misc.patch
@@ -1,8 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 71921740..156ea6dc 100644
+index 0242fb71..5007aace 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -456,12 +456,6 @@ elseif(CLANG AND DEPS AND NOT FREEBSD)
+@@ -304,7 +304,6 @@ else()
+     # To be safe, only include them when building 'release' outputs.
+     add_compile_options(
+       -g
+-      -fno-limit-debug-info
+       -fPIE
+       -fpie
+       -fPIC
+@@ -449,12 +448,6 @@ elseif(CLANG AND DEPS AND NOT FREEBSD)
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto=thin")
  endif()
  
@@ -15,7 +23,7 @@ index 71921740..156ea6dc 100644
  # Make sure deps were built before compiling (else show warning).
  execute_process(
    COMMAND "${CMAKE_SOURCE_DIR}/tools/provision.sh" check "${CMAKE_BINARY_DIR}"
-@@ -528,6 +522,8 @@ endif()
+@@ -521,6 +514,8 @@ endif()
  
  if(APPLE)
    LOG_PLATFORM("OS X")
@@ -24,7 +32,7 @@ index 71921740..156ea6dc 100644
  elseif(OSQUERY_BUILD_PLATFORM STREQUAL "debian")
    LOG_PLATFORM("Debian")
  elseif(OSQUERY_BUILD_PLATFORM STREQUAL "ubuntu")
-@@ -577,7 +573,6 @@ if(POSIX AND DEPS)
+@@ -570,7 +565,6 @@ if(POSIX AND DEPS)
    endif()
  endif()
  
@@ -32,7 +40,7 @@ index 71921740..156ea6dc 100644
  include_directories("${CMAKE_SOURCE_DIR}/include")
  include_directories("${CMAKE_SOURCE_DIR}")
  
-@@ -668,18 +663,6 @@ if(FREEBSD OR "${HAVE_TR1_TUPLE}" STREQUAL "")
+@@ -661,18 +655,6 @@ if(FREEBSD OR "${HAVE_TR1_TUPLE}" STREQUAL "")
    add_definitions(-DGTEST_USE_OWN_TR1_TUPLE=0)
  endif()
  
@@ -52,10 +60,10 @@ index 71921740..156ea6dc 100644
    add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/linenoise-ng")
  endif()
 diff --git a/osquery/CMakeLists.txt b/osquery/CMakeLists.txt
-index c8cbac4e..a4382420 100644
+index e3842962..f405503d 100644
 --- a/osquery/CMakeLists.txt
 +++ b/osquery/CMakeLists.txt
-@@ -35,8 +35,6 @@ if(CLANG AND POSIX)
+@@ -33,8 +33,6 @@ if(CLANG AND POSIX)
      -Wextra
      -pedantic
      -Wuseless-cast
@@ -64,7 +72,7 @@ index c8cbac4e..a4382420 100644
      -Wno-unused-parameter
      -Wno-gnu-case-range
      -Weffc++
-@@ -65,14 +63,7 @@ endif()
+@@ -63,14 +61,7 @@ endif()
  
  # Construct a set of all object files, starting with third-party and all
  # of the osquery core objects (sources from ADD_CORE_LIBRARY macros).
@@ -80,7 +88,7 @@ index c8cbac4e..a4382420 100644
  
  # Add subdirectories
  add_subdirectory(config)
-@@ -153,10 +144,11 @@ if(APPLE OR LINUX)
+@@ -151,10 +142,11 @@ if(APPLE OR LINUX)
    ADD_OSQUERY_LINK_ADDITIONAL("rocksdb_lite")
  elseif(FREEBSD)
    ADD_OSQUERY_LINK_CORE("icuuc")
@@ -93,7 +101,7 @@ index c8cbac4e..a4382420 100644
  if(POSIX)
    ADD_OSQUERY_LINK_CORE("boost_system")
    ADD_OSQUERY_LINK_CORE("boost_filesystem")
-@@ -174,10 +166,10 @@ endif()
+@@ -172,10 +164,10 @@ endif()
  ADD_OSQUERY_LINK_CORE("glog${WO_KEY}")
  
  if(POSIX)
@@ -142,7 +150,7 @@ index ab91bd24..d8364991 100644
    ADD_OSQUERY_TEST_ADDITIONAL(${OSQUERY_LOGGER_KAFKA_PLUGINS_TESTS})
  endif()
 diff --git a/osquery/tables/CMakeLists.txt b/osquery/tables/CMakeLists.txt
-index dd78084f..158758e1 100644
+index 3ecbb711..af7220d3 100644
 --- a/osquery/tables/CMakeLists.txt
 +++ b/osquery/tables/CMakeLists.txt
 @@ -68,7 +68,7 @@ if(LINUX)


### PR DESCRIPTION
###### Motivation for this change

Latest bugfix release with the following notable changes:

* Memory leak resolve for dispatcher
  (https://github.com/facebook/osquery/commit/06d48654456e2b56091f0d35f55c234cc054d378)

* Fix include path on status.h
  (https://github.com/facebook/osquery/commit/5bd4984f2a5a38c4dd09e9271b162bbacff796ac)

Additionally the patch had to be rebased onto the 3.2.9 branch as it
added XCode support including some CLang flags (namely `-fno-limit-debug-info`)
which are unsupported on GCC.
(see https://github.com/facebook/osquery/commit/bccc28dd9851997b45b69c1dcb11a161763653f9)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

