### PR TITLE
termite: factor wrapper out into its own file

### DIFF
--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -1,55 +1,42 @@
-{ stdenv, fetchFromGitHub, lib, pkgconfig, vte, gtk3, ncurses, makeWrapper, wrapGAppsHook, symlinkJoin
-, configFile ? null
-}:
+{ stdenv, fetchFromGitHub, pkgconfig, vte, gtk3, ncurses, wrapGAppsHook }:
 
-let
+stdenv.mkDerivation rec {
+  name = "termite-${version}";
   version = "13";
-  termite = stdenv.mkDerivation {
-    name = "termite-${version}";
 
-    src = fetchFromGitHub {
-      owner = "thestinger";
-      repo = "termite";
-      rev = "v${version}";
-      sha256 = "02cn70ygl93ghhkhs3xdxn5b1yadc255v3yp8cmhhyzsv5027hvj";
-      fetchSubmodules = true;
-    };
-
-    # https://github.com/thestinger/termite/pull/516
-    patches = [ ./url_regexp_trailing.patch ./add_errno_header.patch
-                ] ++ lib.optional stdenv.isDarwin ./remove_ldflags_macos.patch;
-
-    makeFlags = [ "VERSION=v${version}" "PREFIX=" "DESTDIR=$(out)" ];
-
-    buildInputs = [ vte gtk3 ncurses ];
-
-    nativeBuildInputs = [ wrapGAppsHook pkgconfig ];
-
-    outputs = [ "out" "terminfo" ];
-
-    postInstall = ''
-      mkdir -p $terminfo/share
-      mv $out/share/terminfo $terminfo/share/terminfo
-
-      mkdir -p $out/nix-support
-      echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
-    '';
-
-    meta = with stdenv.lib; {
-      description = "A simple VTE-based terminal";
-      license = licenses.lgpl2Plus;
-      homepage = https://github.com/thestinger/termite/;
-      maintainers = with maintainers; [ koral garbas ];
-      platforms = platforms.all;
-    };
+  src = fetchFromGitHub {
+    owner = "thestinger";
+    repo = "termite";
+    rev = "v${version}";
+    sha256 = "02cn70ygl93ghhkhs3xdxn5b1yadc255v3yp8cmhhyzsv5027hvj";
+    fetchSubmodules = true;
   };
-in if configFile == null then termite else symlinkJoin {
-  name = "termite-with-config-${version}";
-  paths = [ termite ];
-  nativeBuildInputs = [ makeWrapper ];
-  postBuild = ''
-    wrapProgram $out/bin/termite \
-      --add-flags "--config ${configFile}"
+
+  # https://github.com/thestinger/termite/pull/516
+  patches = [ ./url_regexp_trailing.patch ./add_errno_header.patch
+              ] ++ stdenv.lib.optional stdenv.isDarwin ./remove_ldflags_macos.patch;
+
+  makeFlags = [ "VERSION=v${version}" "PREFIX=" "DESTDIR=$(out)" ];
+
+  buildInputs = [ vte gtk3 ncurses ];
+
+  nativeBuildInputs = [ wrapGAppsHook pkgconfig ];
+
+  outputs = [ "out" "terminfo" ];
+
+  postInstall = ''
+    mkdir -p $terminfo/share
+    mv $out/share/terminfo $terminfo/share/terminfo
+
+    mkdir -p $out/nix-support
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
   '';
-  passthru.terminfo = termite.terminfo;
+
+  meta = with stdenv.lib; {
+    description = "A simple VTE-based terminal";
+    license = licenses.lgpl2Plus;
+    homepage = https://github.com/thestinger/termite/;
+    maintainers = with maintainers; [ koral garbas ];
+    platforms = platforms.all;
+  };
 }

--- a/pkgs/applications/misc/termite/wrapper.nix
+++ b/pkgs/applications/misc/termite/wrapper.nix
@@ -1,0 +1,15 @@
+{  makeWrapper, wrapGAppsHook, symlinkJoin, configFile ? null, termite }:
+
+if configFile == null then termite else symlinkJoin {
+  name = "termite-with-config-${termite.version}";
+
+  paths = [ termite ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/termite \
+      --add-flags "--config ${configFile}"
+  '';
+
+  passthru.terminfo = termite.terminfo;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18493,9 +18493,11 @@ with pkgs;
     vte = gnome3.vte;
   };
 
-  termite = callPackage ../applications/misc/termite {
+  termite-unwrapped = callPackage ../applications/misc/termite {
     vte = gnome3.vte-ng;
   };
+
+  termite = callPackage ../applications/misc/termite/wrapper.nix { termite = termite-unwrapped; };
 
   termtosvg = callPackage ../tools/misc/termtosvg { };
 


### PR DESCRIPTION
###### Motivation for this change

Until now it's impossible to override the attrs of the actual build
instruction for the `termite` package like this:

```
termite.overrideAttrs (_: {
  # ...
})
```

This issue occurs since the `termite/default.nix` expressions returns
the `symlinkJoin` expression when I override termite (e.g. to provide a
config file).

I recently patched termite and wanted to apply this patch to my local
termite installation in my system config which is impossible this, so
splitting the wrapper and the build instruction into their own files
makes this way easier to maintian.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

