### PR TITLE
Remove `pythonPackages.flask_cache`

### DIFF
--- a/pkgs/development/python-modules/graphite-api/default.nix
+++ b/pkgs/development/python-modules/graphite-api/default.nix
@@ -1,0 +1,45 @@
+{ buildPythonPackage, fetchFromGitHub, lib, flask, flask-caching, cairocffi, pyparsing, pytz, pyyaml
+, raven, six, structlog, tzlocal, nose, mock, cairo, isPyPy
+}:
+
+buildPythonPackage rec {
+  pname = "graphite-api";
+  version = "1.1.3";
+
+  disabled = isPyPy;
+
+  src = fetchFromGitHub {
+    owner = "brutasse";
+    repo = "graphite-api";
+    rev = version;
+    sha256 = "0sz3kav2024ms2z4q03pigcf080gsr5v774z9bp3zw29k2p47ass";
+  };
+
+  # https://github.com/brutasse/graphite-api/pull/239 rebased onto 1.1.3
+  patches = [ ./flask-caching-rebased.patch ];
+
+  checkPhase = "nosetests";
+
+  propagatedBuildInputs = [
+    flask
+    flask-caching
+    cairocffi
+    pyparsing
+    pytz
+    pyyaml
+    raven
+    six
+    structlog
+    tzlocal
+  ];
+
+  checkInputs = [ nose mock ];
+
+  LD_LIBRARY_PATH = "${cairo.out}/lib";
+
+  meta = with lib; {
+    description = "Graphite-web, without the interface. Just the rendering HTTP API";
+    homepage = https://github.com/brutasse/graphite-api;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/graphite-api/flask-caching-rebased.patch
+++ b/pkgs/development/python-modules/graphite-api/flask-caching-rebased.patch
@@ -1,0 +1,132 @@
+diff --git a/graphite_api/config.py b/graphite_api/config.py
+index 5e1e382..dc033a8 100644
+--- a/graphite_api/config.py
++++ b/graphite_api/config.py
+@@ -112,11 +112,11 @@ def configure(app):
+     app.cache = None
+     if 'cache' in config:
+         try:
+-            from flask.ext.cache import Cache
++            from flask_caching import Cache
+         except ImportError:
+             warnings.warn("'cache' is provided in the configuration but "
+-                          "Flask-Cache is not installed. Please `pip install "
+-                          "Flask-Cache`.")
++                          "flask-caching is not installed. Please `pip "
++                          "install flask-caching`.")
+         else:
+             cache_conf = {'CACHE_DEFAULT_TIMEOUT': 60,
+                           'CACHE_KEY_PREFIX': 'graphite-api:'}
+diff --git a/requirements.txt b/requirements.txt
+index c68b446..7826b0c 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,5 +1,5 @@
+ Flask
+-Flask-Cache
++Flask-Caching
+ cairocffi
+ pyparsing>=1.5.7
+ pytz
+diff --git a/setup.py b/setup.py
+index 0337cbe..df07989 100644
+--- a/setup.py
++++ b/setup.py
+@@ -38,7 +38,7 @@ setup(
+     extras_require={
+         'sentry': ['raven[flask]'],
+         'cyanite': ['cyanite'],
+-        'cache': ['Flask-Cache'],
++        'cache': ['Flask-Caching'],
+         'statsd': ['statsd'],
+     },
+     zip_safe=False,
+diff --git a/tests/test_render.py b/tests/test_render.py
+index be5609d..a0e7190 100644
+--- a/tests/test_render.py
++++ b/tests/test_render.py
+@@ -8,7 +8,7 @@ from graphite_api._vendor import whisper
+ from . import TestCase, WHISPER_DIR
+ 
+ try:
+-    from flask.ext.cache import Cache
++    from flask_caching import Cache
+ except ImportError:
+     Cache = None
+ 
+diff --git a/tox.ini b/tox.ini
+index 85a0abb..c820393 100644
+--- a/tox.ini
++++ b/tox.ini
+@@ -47,7 +47,7 @@ basepython = python2.7
+ deps =
+ 	{[testenv]deps}
+ 	Flask
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 	mock
+ 
+@@ -56,7 +56,7 @@ basepython = python3.3
+ deps =
+ 	{[testenv]deps}
+ 	Flask
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 
+ [testenv:py34]
+@@ -66,7 +66,7 @@ commands =
+ deps =
+ 	{[testenv]deps}
+ 	Flask
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 
+ [testenv:py35]
+@@ -76,7 +76,7 @@ commands =
+ deps =
+ 	{[testenv]deps}
+ 	Flask
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 
+ [testenv:pyparsing1]
+@@ -84,7 +84,7 @@ basepython = python2.7
+ deps =
+ 	{[testenv]deps}
+ 	Flask
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing==1.5.7
+ 	mock
+ 
+@@ -93,7 +93,7 @@ basepython = pypy
+ deps =
+ 	{[testenv]deps}
+ 	Flask
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 	mock
+ 
+@@ -102,7 +102,7 @@ basepython = python2.7
+ deps =
+ 	{[testenv]deps}
+ 	Flask<0.9
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 	mock
+ 
+@@ -111,7 +111,7 @@ basepython = python2.7
+ deps =
+ 	{[testenv]deps}
+ 	Flask<0.10
+-	Flask-Cache
++	Flask-Caching
+ 	pyparsing
+ 	mock
+ 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15821,44 +15821,7 @@ EOF
     };
   };
 
-  graphite_api = buildPythonPackage rec {
-    name = "graphite-api-1.0.1";
-    disabled = isPyPy;
-
-    src = pkgs.fetchgit {
-      url = "https://github.com/brutasse/graphite-api.git";
-      rev = "b6f75e8a08fae695c094fece6de611b893fc65fb";
-      sha256 = "1n8h5krhv7hzmn336y9vjrmv6b6009lz5hj0d9wz7v1k2500ws5k";
-    };
-
-    checkPhase = "nosetests";
-
-    propagatedBuildInputs = with self; [
-      flask
-      flask-caching
-      cairocffi
-      pyparsing
-      pytz
-      pyyaml
-      raven
-      six
-      structlog
-      tzlocal
-    ];
-
-    buildInputs = with self; [
-      nose
-      mock
-    ];
-
-    LD_LIBRARY_PATH = "${pkgs.cairo.out}/lib";
-
-    meta = {
-      description = "Graphite-web, without the interface. Just the rendering HTTP API";
-      homepage = https://github.com/brutasse/graphite-api;
-      license = licenses.asl20;
-    };
-  };
+  graphite_api = callPackage ../development/python-modules/graphite-api { };
 
   graphite_beacon = buildPythonPackage rec {
     name = "graphite_beacon-0.27.0";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5499,23 +5499,6 @@ in {
 
   flask-babel = callPackage ../development/python-modules/flask-babel { };
 
-  flask_cache = buildPythonPackage rec {
-    name = "Flask-Cache-0.13.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/F/Flask-Cache/${name}.tar.gz";
-      sha256 = "90126ca9bc063854ef8ee276e95d38b2b4ec8e45fd77d5751d37971ee27c7ef4";
-    };
-
-    propagatedBuildInputs = with self; [ werkzeug flask ];
-
-    meta = {
-      homepage = https://github.com/thadeusb/flask-cache;
-      description = "Adds cache support to your Flask application";
-      license = "BSD";
-    };
-  };
-
   flask-caching = callPackage ../development/python-modules/flask-caching { };
 
   flask-common = callPackage ../development/python-modules/flask-common { };
@@ -15852,7 +15835,7 @@ EOF
 
     propagatedBuildInputs = with self; [
       flask
-      flask_cache
+      flask-caching
       cairocffi
       pyparsing
       pytz


### PR DESCRIPTION
###### Motivation for this change

* See the first commit (d3d1b88) for the original motivation

* The second commit moves the `graphite_api` expression (which was changed previously) into its own file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

