### PR TITLE
pythonPackages.trezor: disable build

### DIFF
--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -1,10 +1,12 @@
 { lib, fetchPypi, buildPythonPackage,
-  protobuf, hidapi, ecdsa, mnemonic, requests, pyblake2, click, libusb1, rlp
+  protobuf, hidapi, ecdsa, mnemonic, requests, pyblake2, click, libusb1, rlp, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "trezor";
   version = "0.9.1";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
###### Motivation for this change

It seems as recent versions of `trezor` don't work with python 2.x:

```
/build/trezor-0.9.1/dist /build/trezor-0.9.1
Processing ./trezor-0.9.1-py2-none-any.whl
trezor requires Python '>=3.3' but the running Python is 2.7.15
builder for '/nix/store/aqyxki0ckanjk4r1f0an4kj1w4s3kk4f-python2.7-trezor-0.9.1.drv' failed with exit code 1
cannot build derivation '/nix/store/gp4smkzc9r87lzajs17jnq4rh2ayc5q0-python2.7-keepkey-4.0.0.drv': 1 dependencies couldn't be built
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

