### PR TITLE
ristretto: 0.8.2 -> 0.8.3

### DIFF
--- a/pkgs/desktops/xfce4-13/ristretto/default.nix
+++ b/pkgs/desktops/xfce4-13/ristretto/default.nix
@@ -1,10 +1,10 @@
-{ mkXfceDerivation, automakeAddFlags, exo, dbus_glib, gtk2, libexif
+{ mkXfceDerivation, automakeAddFlags, exo, dbus-glib, gtk2, libexif
 , libxfce4ui, libxfce4util, xfconf }:
 
 mkXfceDerivation rec {
   category = "apps";
   pname = "ristretto";
-  version = "0.8.2";
+  version = "0.8.3";
 
   postPatch = ''
     automakeAddFlags src/Makefile.am ristretto_CFLAGS DBUS_GLIB_CFLAGS
@@ -12,7 +12,7 @@ mkXfceDerivation rec {
   '';
 
   nativeBuildInputs = [ automakeAddFlags exo ];
-  buildInputs = [ dbus_glib gtk2 libexif libxfce4ui libxfce4util xfconf ];
+  buildInputs = [ dbus-glib gtk2 libexif libxfce4ui libxfce4util xfconf ];
 
-  sha256 = "0ra50452ldk91pvhcpl3f3rhdssw3djfr6cm0hc29v8r58am0wni";
+  sha256 = "02i61ddzpv0qjwahkksnzla57zdmkywyg1qrqs57z4bzj6l4nmkx";
 }


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

