### PR TITLE
xfconf: 4.13.4 -> 4.13.5

### DIFF
--- a/pkgs/desktops/xfce4-13/xfconf/default.nix
+++ b/pkgs/desktops/xfce4-13/xfconf/default.nix
@@ -3,9 +3,9 @@
 mkXfceDerivation rec {
   category = "xfce";
   pname = "xfconf";
-  version = "4.13.4";
+  version = "4.13.5";
 
-  sha256 = "1bm4q06rwlmkmcy6qnwm6l70w6749iqfrmsrgj3y1jb2sacc3pd4";
+  sha256 = "0xpnwb04yw5qdn0bj8b740a7rmiy316vhja5pp8p6sdiqm32yi8a";
 
   buildInputs = [ libxfce4util ];
 }


### PR DESCRIPTION
###### Motivation for this change

minur update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

