### PR TITLE
xfce4-13.xfce4-volumed-pulse: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-volumed-pulse/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-volumed-pulse/default.nix
@@ -1,13 +1,13 @@
-{ lib, mkXfceDerivation, gtk2, libnotify ? null, libpulseaudio, keybinder, xfconf }:
+{ lib, mkXfceDerivation, gtk3, libnotify ? null, libpulseaudio, keybinder3, xfconf }:
 
 mkXfceDerivation rec {
   category = "apps";
   pname = "xfce4-volumed-pulse";
-  version = "0.2.2";
+  version = "0.2.3";
 
-  sha256 = "0ccb98b433lx5fgdqd3nqqppg4sldr5p1is6pnx85h9wyxx5svhp";
+  sha256 = "1rsjng9qmq7vzrx5bfxq76h63y501cfl1mksrxkf1x39by9r628j";
 
-  buildInputs = [ gtk2 libnotify libpulseaudio keybinder xfconf ];
+  buildInputs = [ gtk3 libnotify libpulseaudio keybinder3 xfconf ];
 
   meta = with lib; {
     license = licenses.gpl3Plus;


### PR DESCRIPTION
###### Motivation for this change

minor update, upstream (XFCE 4.13) switched to ```gtk3``` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

