### PR TITLE
xfce4-terminal: 0.8.6 -> 0.8.7.4

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-terminal/default.nix
@@ -3,9 +3,9 @@
 mkXfceDerivation rec {
   category = "apps";
   pname = "xfce4-terminal";
-  version = "0.8.6";
+  version = "0.8.7.4";
 
-  sha256 = "1a0b2ih552zhbbx1fc5ad80nafvkc5my3gw89as4mvycnhyd5inj";
+  sha256 = "1s1dq560icg602jjb2ja58x7hxg4ikp3jrrf74v3qgi0ir950k2y";
 
   buildInputs = [ gtk3 libxfce4ui vte ];
 


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

