### PR TITLE
xfce4-notifyd: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-notifyd/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-notifyd/default.nix
@@ -1,13 +1,12 @@
-{ mkXfceDerivation, dbus_glib, exo, gtk3, libnotify, libxfce4ui, libxfce4util
+{ mkXfceDerivation, dbus-glib, exo, gtk3, libnotify, libxfce4ui, libxfce4util
 , xfce4-panel, xfconf }:
 
 mkXfceDerivation rec {
   category = "apps";
   pname = "xfce4-notifyd";
-  version = "0.4.1";
+  version = "0.4.2";
 
-  sha256 = "12mqi0q1hcjm16f4pndq7l58h2n0nq160r5fqx8ns320i83nh94k";
+  sha256 = "1zxwzigrhms74crasbqpnzidmq2mnyxpmc9pqr4p4qj14yw4sam9";
 
-  nativeBuildInputs = [ dbus_glib exo ];
-  buildInputs = [ gtk3 libnotify libxfce4ui libxfce4util xfce4-panel xfconf ];
+  buildInputs = [ dbus-glib exo gtk3 libnotify libxfce4ui libxfce4util xfce4-panel xfconf ];
 }


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

