### PR TITLE
volume_key: 0.3.10 → 0.3.11

### DIFF
--- a/pkgs/development/libraries/volume-key/default.nix
+++ b/pkgs/development/libraries/volume-key/default.nix
@@ -1,36 +1,27 @@
-{ stdenv, fetchgit, fetchpatch, autoreconfHook, pkgconfig, gettext, python2
-, swig, glib, utillinux, cryptsetup, nss, gpgme
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, gettext, python3
+, ncurses, swig, glib, utillinux, cryptsetup, nss, gpgme
 }:
 
 let
-  version = "0.3.10";
+  version = "0.3.11";
 in stdenv.mkDerivation rec {
   name = "volume_key-${version}";
 
   src = fetchgit {
     url = https://pagure.io/volume_key.git;
-    rev = "ece1ce305234da454e330905c615ec474d9781c5";
-    sha256 = "16qdi5s6ycsh0iyc362gly7ggrwamky8i0zgbd4ajp3ymk9vqdva";
+    rev = "volume_key-${version}";
+    sha256 = "1sqdbcih1c39bjiv4mm1m7acc3lfh2i2hf2r9i7rk8adfzq8awma";
   };
 
   outputs = [ "out" "man" "dev" "py" ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig gettext python2 swig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig gettext python3 ncurses swig ];
 
   buildInputs = [ glib cryptsetup nss utillinux gpgme ];
 
-  patches = [
-    # Use pkg-config for locating Python.h
-    # https://pagure.io/volume_key/pull-request/12
-    (fetchpatch {
-      url = https://pagure.io/fork/cathay4t/volume_key/c/8eda66d3b734ea335e37cf9d7d173b9e8ebe2fd9.patch;
-      sha256 = "01lr1zijk0imkk681zynm4w5ad3y6c9vdrmrzaib7w7ima75iczr";
-    })
-  ];
-
   makeFlags = [
-    "pyexecdir=$(py)/${python2.sitePackages}"
-    "pythondir=$(py)/${python2.sitePackages}"
+    "pyexecdir=$(py)/${python3.sitePackages}"
+    "pythondir=$(py)/${python3.sitePackages}"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

