### PR TITLE
make-tarball: also check for licenses & versions

### DIFF
--- a/maintainers/scripts/find-bad-packages.nix
+++ b/maintainers/scripts/find-bad-packages.nix
@@ -1,0 +1,31 @@
+# to run: nix-env -qa -f find-missing-versions.nix
+
+{ condition ? v: (builtins.parseDrvName v.name).version == ""
+, conditionName ? "missing version numbers"
+, nixpkgs ? import <nixpkgs> { config = {
+                                 allowUnsupportedSystem = true;
+                                 allowInsecure = true;
+                                 allowUnfree = true;
+                               };
+                             }
+}:
+
+with nixpkgs.lib;
+
+let toplevel = filterAttrs (n: v: let v' = tryEval v; in
+                    v'.success
+                 && isDerivation v'.value
+                 && v'.value.meta.available or false
+                 && (tryEval v'.value.name).success
+                 && (condition v'.value)
+               ) nixpkgs;
+    badPackages = attrNames toplevel;
+    inherit (nixpkgs) lib;
+    inherit (builtins) elem tryEval currentSystem;
+    inherit (lib) filterAttrs isDerivation const;
+in if badPackages == [] then []
+   else throw ''
+Some packages are ${conditionName}. Here is the list:
+
+- ${concatStringsSep "\n- " badPackages}
+   ''

--- a/maintainers/scripts/find-bad-packages.nix
+++ b/maintainers/scripts/find-bad-packages.nix
@@ -1,13 +1,8 @@
 # to run: nix-env -qa -f find-missing-versions.nix
 
-{ condition ? v: (builtins.parseDrvName v.name).version == ""
-, conditionName ? "missing version numbers"
-, nixpkgs ? import <nixpkgs> { config = {
-                                 allowUnsupportedSystem = true;
-                                 allowInsecure = true;
-                                 allowUnfree = true;
-                               };
-                             }
+{ condition
+, conditionName
+, nixpkgs ? import ../.. { }
 }:
 
 with nixpkgs.lib;
@@ -17,6 +12,7 @@ let toplevel = filterAttrs (n: v: let v' = tryEval v; in
                  && isDerivation v'.value
                  && v'.value.meta.available or false
                  && (tryEval v'.value.name).success
+                 && !(v.meta.isHook or false)
                  && (condition v'.value)
                ) nixpkgs;
     badPackages = attrNames toplevel;
@@ -27,5 +23,5 @@ in if badPackages == [] then []
    else throw ''
 Some packages are ${conditionName}. Here is the list:
 
-- ${concatStringsSep "\n- " badPackages}
+- [ ] ${concatStringsSep "\n- [ ] " badPackages}
    ''

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -114,7 +114,7 @@ rec {
 
   # Make a package that just contains a setup hook with the given contents.
   makeSetupHook = { name ? "hook", deps ? [], substitutions ? {} }: script:
-    runCommand name substitutions
+    runCommand name (substitutions // { meta = { isHook = true; }; })
       (''
         mkdir -p $out/nix-support
         cp ${script} $out/nix-support/setup-hook

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -172,6 +172,7 @@ let
     badPlatforms = platforms;
     # Hydra build timeout
     timeout = int;
+    isHook = bool;
   };
 
   checkMetaAttr = k: v:

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -100,6 +100,14 @@ releaseTools.sourceTarball rec {
     nix-instantiate --eval --strict --show-trace ./maintainers/scripts/eval-release.nix > /dev/null
     stopNest
 
+    header "checking for missing versions"
+    nix-instantiate --arg condition 'v: (builtins.parseDrvName v.name).version == ""' --argstr conditionName 'missing version numbers' --show-trace ./maintainers/scripts/find-bad-packages.nix
+    stopNest
+
+    header "checking for missing licenses"
+    nix-instantiate --arg condition 'v: (v ? meta) && (v.meta.license or null == null)' --argstr conditionName 'missing licenses' --show-trace ./maintainers/scripts/find-bad-packages.nix
+    stopNest
+
     header "checking find-tarballs.nix"
     nix-instantiate --readonly-mode --eval --strict --show-trace --json \
        ./maintainers/scripts/find-tarballs.nix \

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -101,11 +101,17 @@ releaseTools.sourceTarball rec {
     stopNest
 
     header "checking for missing versions"
-    nix-instantiate --arg condition 'v: (builtins.parseDrvName v.name).version == ""' --argstr conditionName 'missing version numbers' --show-trace ./maintainers/scripts/find-bad-packages.nix
+    nix-instantiate --show-trace \
+       --arg condition 'v: (builtins.parseDrvName v.name).version == ""' \
+       --argstr conditionName 'missing version numbers' \
+       ./maintainers/scripts/find-bad-packages.nix
     stopNest
 
     header "checking for missing licenses"
-    nix-instantiate --arg condition 'v: (v ? meta) && (v.meta.license or null == null)' --argstr conditionName 'missing licenses' --show-trace ./maintainers/scripts/find-bad-packages.nix
+    nix-instantiate  --show-trace \
+      --arg condition 'v: (v.meta.license or null == null)' \
+      --argstr conditionName 'missing licenses' \
+      ./maintainers/scripts/find-bad-packages.nix
     stopNest
 
     header "checking find-tarballs.nix"


### PR DESCRIPTION
This will block releases on missing licenses & version numbers.

Closes #43231

Note that this is still broken! This should not be merged until #43716 & #43717 are closed.