### PR TITLE
pythonPackages.imgaug: init at 0.2.6

### DIFF
--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, scikitimage, opencv3, six }:
+
+buildPythonPackage rec {
+  pname = "imgaug";
+  version = "0.2.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wy8ydkqq0jrwxwdv04q89n3gwsr9pjaspsbw26ipg5a5lnhb9c2";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    scikitimage
+    opencv3
+    six
+  ];
+
+  # disable tests when there are no tests in the PyPI archive
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/aleju/imgaug;
+    description = "Image augmentation for machine learning experiments";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6508,6 +6508,8 @@ in {
     };
   };
 
+  imgaug = callPackage ../development/python-modules/imgaug { };
+
   inflection = callPackage ../development/python-modules/inflection { };
 
   influxdb = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Added pythonPackages.imgaug. Should work on python 3.6 and python 2.

One thing I didn't understand is why `nix_run_setup test` would result in a segmentation fault. The current `imgaug.tar.gz` does not bundle any tests in the source archive so there are no tests to run anyway. But can there be a better error than just segmentation fault?

Also while `imgaug` doesn't require `dask`, the `scikit-image` when installed by `setup.py` appears to require `dask` now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).