### PR TITLE
pythonPackages.fastpair: init at 2016-07-05

### DIFF
--- a/pkgs/development/python-modules/fastpair/default.nix
+++ b/pkgs/development/python-modules/fastpair/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytestrunner, pytest, scipy }:
+
+buildPythonPackage {
+  pname = "fastpair";
+  version = "2016-07-05";
+
+  src = fetchFromGitHub {
+    owner = "carsonfarmer";
+    repo = "fastpair";
+    rev = "92364962f6b695661f35a117bf11f96584128a8d";
+    sha256 = "1pv9sxycxdk567s5gs947rhlqngrb9nn9yh4dhdvg1ix1i8dca71";
+  };
+
+  buildInputs = [ pytestrunner ];
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [
+    scipy
+  ];
+
+  checkPhase = ''
+    py.test fastpair
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/carsonfarmer/fastpair;
+    description = "Data-structure for the dynamic closest-pair problem";
+    license = licenses.mit;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5352,6 +5352,8 @@ in {
 
   fastimport = callPackage ../development/python-modules/fastimport { };
 
+  fastpair = callPackage ../development/python-modules/fastpair { };
+
   fastrlock = callPackage ../development/python-modules/fastrlock {};
 
   feedgen = callPackage ../development/python-modules/feedgen { };


### PR DESCRIPTION
###### Motivation for this change

Added python package fastpair. However this does not have a version as it is not released on PyPi.

So I used the date of the last commit as the version. I hope that is correct.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

