### PR TITLE
pythonPackages.image-match: init at 1.1.2

### DIFF
--- a/pkgs/development/python-modules/image-match/default.nix
+++ b/pkgs/development/python-modules/image-match/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytestrunner, dask, scikitimage, six }:
+
+buildPythonPackage {
+  pname = "image-match";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ascribe";
+    repo = "image-match";
+    rev = "1c5f3170555540bdf43ff8b8189c4e8c13a8b950";
+    sha256 = "0vlmpidmhkpgdzw2k03x5layhijcrjpmyfd93yv2ls77ihz00ix5";
+  };
+
+  buildInputs = [ pytestrunner dask ];
+
+  propagatedBuildInputs = [
+    scikitimage
+    six
+  ];
+
+  # remove elasticsearch requirement due to version incompatibility
+  postPatch = ''
+    substituteInPlace setup.py --replace "'elasticsearch>=5.0.0,<6.0.0'," ""
+  '';
+
+  # tests cannot work without elasticsearch
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ascribe/image-match;
+    description = "Quickly search over billions of images";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3143,6 +3143,8 @@ in {
 
   };
 
+  image-match = callPackage ../development/python-modules/image-match { };
+
   imbalanced-learn = callPackage ../development/python-modules/imbalanced-learn { };
 
   immutables = callPackage ../development/python-modules/immutables {};


### PR DESCRIPTION
###### Motivation for this change

Added image-match.

One problem with this is that `image-match` requires elasticsearch at below 6.0.0 according to setup.py. Since there is no elasticsearch below 6.0.0 in nixpkgs, I just ignored that dependency. I use image-match without touching the elasticsearch functionality.

I asked if they could bump up the version constraint anyway: https://github.com/ascribe/image-match/issues/97

Furthermore the I could not use `fetchPypi` due to: https://github.com/NixOS/nixpkgs/issues/43721

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

