### PR TITLE
k8s: Don't lose rbac submodule with no explicit options

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/dashboard.nix
+++ b/nixos/modules/services/cluster/kubernetes/dashboard.nix
@@ -10,8 +10,8 @@ in {
 
     rbac = mkOption {
       description = "Role-based access control (RBAC) options";
+      default = {};
       type = types.submodule {
-
         options = {
           enable = mkOption {
             description = "Whether to enable role based access control is enabled for kubernetes dashboard";
@@ -24,7 +24,6 @@ in {
             type = types.bool;
             default = false;
           };
-          
         };
       };
     };


### PR DESCRIPTION
###### Motivation for this change
Fixes #43726

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

