### PR TITLE
nix-index: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/package-management/nix-index/default.nix
+++ b/pkgs/tools/package-management/nix-index/default.nix
@@ -4,15 +4,15 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "nix-index-${version}";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "bennofs";
     repo = "nix-index";
     rev = "v${version}";
-    sha256 = "1lmg65yqkwf2a5qxm3dmv8158kqhnriir062vlgar5wimf409rm5";
+    sha256 = "17pms3cq3i3jan1irxgqfr3nrjy6zb21y07pwqp9v08hyrjpfqin";
   };
-  cargoSha256 = "0cxdrzjmqq3ywdh0f5mzkcf50hbbgd3bak4398v2ls5gy5s9fcz2";
+  cargoSha256 = "0b7xwcgjds80g08sx91lqip8syb52n458si4q4xycvvsand5fa10";
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl curl];
 


### PR DESCRIPTION
###### Motivation for this change
Specifically for `--show-trace` passthrough

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

