### PR TITLE
lollypop: 0.9.519 -> 0.9.521

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -3,14 +3,14 @@
 , python36Packages, gnome3, glib, gst_all_1 }:
 
 stdenv.mkDerivation rec  {  
-  version = "0.9.519";
+  version = "0.9.521";
   name = "lollypop-${version}";
 
   src = fetchgit {
     url = "https://gitlab.gnome.org/World/lollypop";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    sha256 = "1v4p59w4yf86djk7xv1xwbximpjm64wn42il090w7q1wy04my6fl";
+    sha256 = "1iwv0fj50h0xynv152anisbq29jfbmb9hpm60kaa9a9hdiypskcc";
   };
 
   nativeBuildInputs = with python36Packages; [


### PR DESCRIPTION
###### Motivation for this change
An update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

