### PR TITLE
elementary-cmake-modules: add version

### DIFF
--- a/pkgs/development/libraries/elementary-cmake-modules/default.nix
+++ b/pkgs/development/libraries/elementary-cmake-modules/default.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig }:
 
-stdenv.mkDerivation {
-  name = "elementary-cmake-modules";
+stdenv.mkDerivation rec {
+  name = "elementary-cmake-modules-${version}";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";


### PR DESCRIPTION
###### Motivation for this change
Part of #43717

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

