### PR TITLE
build-idris-package: add ipkgName

### DIFF
--- a/pkgs/development/idris-modules/bi.nix
+++ b/pkgs/development/idris-modules/bi.nix
@@ -8,6 +8,7 @@ build-idris-package  {
   name = "bi";
   version = "2018-06-25";
 
+  ipkgName = "Bi";
   idrisDeps = [ contrib pruviloj ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/bifunctors.nix
+++ b/pkgs/development/idris-modules/bifunctors.nix
@@ -13,10 +13,6 @@ build-idris-package  {
     sha256 = "0cfp58lhm2g0g1vrpb0mh71qb44n2yvg5sil9ndyf2sqd5ria6yq";
   };
 
-  postUnpack = ''
-    rm source/test.ipkg
-  '';
-
   meta = {
     description = "A small bifunctor library for idris";
     homepage = https://github.com/japesinator/Idris-Bifunctors;

--- a/pkgs/development/idris-modules/canvas.nix
+++ b/pkgs/development/idris-modules/canvas.nix
@@ -6,6 +6,8 @@ build-idris-package  {
   name = "canvas";
   version = "2017-11-09";
 
+  ipkgName = "idriscanvas";
+
   src = fetchFromGitHub {
     owner = "JinWuZhao";
     repo = "idriscanvas";

--- a/pkgs/development/idris-modules/coda.nix
+++ b/pkgs/development/idris-modules/coda.nix
@@ -6,6 +6,8 @@ build-idris-package  {
   name = "coda";
   version = "2018-01-25";
 
+  ipkgName = "Coda";
+
   src = fetchFromGitHub {
     owner = "ostera";
     repo = "idris-coda";

--- a/pkgs/development/idris-modules/containers.nix
+++ b/pkgs/development/idris-modules/containers.nix
@@ -17,10 +17,6 @@ build-idris-package  {
     sha256 = "0vyjadd9sb8qcbzvzhnqwc8wa7ma770c10xhn96jsqsnzr81k52d";
   };
 
-  postUnpack = ''
-    rm source/containers-travis.ipkg
-  '';
-
   meta = {
     description = "Various data structures for use in the Idris Language.";
     homepage = https://github.com/jfdm/idris-containers;

--- a/pkgs/development/idris-modules/electron.nix
+++ b/pkgs/development/idris-modules/electron.nix
@@ -18,11 +18,6 @@ build-idris-package  {
     sha256 = "1rpa7yjvfpzl06h0qbk54jd2n52nmgpf7nq5aamcinqh7h5gbiwn";
   };
 
-  postUnpack = ''
-    rm source/example_main.ipkg
-    rm source/example_view.ipkg
-  '';
-
   meta = {
     description = "Electron bindings for Idris";
     homepage = https://github.com/jheiling/idris-electron;

--- a/pkgs/development/idris-modules/free.nix
+++ b/pkgs/development/idris-modules/free.nix
@@ -6,6 +6,8 @@ build-idris-package  {
   name = "free";
   version = "2017-07-03";
 
+  ipkgName = "idris-free";
+
   src = fetchFromGitHub {
     owner = "idris-hackers";
     repo = "idris-free";

--- a/pkgs/development/idris-modules/hamt.nix
+++ b/pkgs/development/idris-modules/hamt.nix
@@ -5,7 +5,7 @@
 , lib
 }:
 build-idris-package  {
-  name = "idris-hamt";
+  name = "hamt";
   version = "2016-11-15";
 
   idrisDeps = [ contrib effects ];

--- a/pkgs/development/idris-modules/hrtime.nix
+++ b/pkgs/development/idris-modules/hrtime.nix
@@ -7,6 +7,7 @@ build-idris-package  {
   name = "hrtime";
   version = "2017-04-16";
 
+  ipkgName = "hrTime";
   idrisDeps = [ idrisscript ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/idrishighlighter.nix
+++ b/pkgs/development/idris-modules/idrishighlighter.nix
@@ -8,6 +8,7 @@ build-idris-package  {
   name = "idrishighlighter";
   version = "2018-02-22";
 
+  ipkgName = "idris-code-highlighter";
   idrisDeps = [ effects lightyear ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/jheiling-js.nix
+++ b/pkgs/development/idris-modules/jheiling-js.nix
@@ -8,6 +8,7 @@ build-idris-package  {
   name = "jheiling-js";
   version = "2016-03-09";
 
+  ipkgName = "js";
   idrisDeps = [ contrib jheiling-extras ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/mhd.nix
+++ b/pkgs/development/idris-modules/mhd.nix
@@ -9,6 +9,7 @@ build-idris-package  {
   name = "mhd";
   version = "2016-04-22";
 
+  ipkgName = "MHD";
   idrisDeps = [ contrib effects ];
 
   extraBuildInputs = [ libmicrohttpd ];

--- a/pkgs/development/idris-modules/patricia.nix
+++ b/pkgs/development/idris-modules/patricia.nix
@@ -16,10 +16,6 @@ build-idris-package  {
     sha256 = "093q3qjmr93wv8pqwk0zfm3hzf14c235k9c9ip53rhg6yzcm0yqz";
   };
 
-  postUnpack = ''
-    rm source/patricia-nix.ipkg
-  '';
-
   meta = {
     description = "Immutable map from integer keys to values based on patricia tree. Basically persistent array.";
     homepage = https://github.com/ChShersh/idris-patricia;

--- a/pkgs/development/idris-modules/permutations.nix
+++ b/pkgs/development/idris-modules/permutations.nix
@@ -13,10 +13,6 @@ build-idris-package  {
     sha256 = "1dirzqy40fczbw7gp2jr51lzqsnq5vcx9z5l6194lcrq2vxgzv1s";
   };
 
-  postUnpack = ''
-    rm source/test.ipkg
-  '';
-
   meta = {
     description = "Type-safe way of working with permutations in Idris";
     homepage = https://github.com/vmchale/permutations;

--- a/pkgs/development/idris-modules/recursion_schemes.nix
+++ b/pkgs/development/idris-modules/recursion_schemes.nix
@@ -20,10 +20,6 @@ build-idris-package  {
     sha256 = "0rbx0yqa0fb7h7qfsvqvirc5q85z51rcwbivn6351jgn3a0inmhf";
   };
 
-  postUnpack = ''
-    rm source/test.ipkg
-  '';
-
   meta = {
     description = "Recursion schemes for Idris";
     homepage = https://github.com/vmchale/recursion_schemes;

--- a/pkgs/development/idris-modules/refined.nix
+++ b/pkgs/development/idris-modules/refined.nix
@@ -6,16 +6,14 @@ build-idris-package  {
   name = "refined";
   version = "2017-12-28";
 
+  ipkgName = "idris-refined";
+
   src = fetchFromGitHub {
     owner = "janschultecom";
     repo = "idris-refined";
     rev = "e21cdef16106a77b42d193806c1749ba6448a128";
     sha256 = "1am7kfc51p2zlml954v8cl9xvx0g0f1caq7ni3z36xvsd7fh47yh";
   };
-
-  postUnpack = ''
-    rm source/idris-refined-test.ipkg
-  '';
 
   meta = {
     description = "Port of Scala/Haskell Refined library to Idris";

--- a/pkgs/development/idris-modules/snippets.nix
+++ b/pkgs/development/idris-modules/snippets.nix
@@ -7,6 +7,7 @@ build-idris-package  {
   name = "snippets";
   version = "2018-03-17";
 
+  ipkgName = "idris-snippets";
   idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/tap.nix
+++ b/pkgs/development/idris-modules/tap.nix
@@ -7,6 +7,7 @@ build-idris-package  {
   name = "tap";
   version = "2017-04-08";
 
+  ipkgName = "TAP";
   idrisDeps = [ contrib ];
 
   src = fetchFromGitHub {
@@ -15,10 +16,6 @@ build-idris-package  {
     rev = "0d019333e1883c1d60e151af1acb02e2b531e72f";
     sha256 = "0fhlmmivq9xv89r7plrnhmvay1j7bapz3wh7y8lygwvcrllh9zxs";
   };
-
-  postUnpack = ''
-    rm source/Draft.ipkg
-  '';
 
   meta = {
     description = "A simple TAP producer and consumer/reporter for Idris";

--- a/pkgs/development/idris-modules/tparsec.nix
+++ b/pkgs/development/idris-modules/tparsec.nix
@@ -6,6 +6,8 @@ build-idris-package  {
   name = "tparsec";
   version = "2018-06-26";
 
+  ipkgName = "TParsec";
+
   src = fetchFromGitHub {
     owner = "gallais";
     repo = "idris-tparsec";

--- a/pkgs/development/idris-modules/vdom.nix
+++ b/pkgs/development/idris-modules/vdom.nix
@@ -6,6 +6,8 @@ build-idris-package  {
   name = "vdom";
   version = "0.6.0";
 
+  ipkgName = "idris-vdom";
+
   src = fetchFromGitHub {
     owner = "brandondyck";
     repo = "idris-vdom";

--- a/pkgs/development/idris-modules/yaml.nix
+++ b/pkgs/development/idris-modules/yaml.nix
@@ -8,6 +8,7 @@ build-idris-package  {
   name = "yaml";
   version = "2018-01-25";
 
+  ipkgName = "Yaml";
   idrisDeps = [ contrib lightyear ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/idris-modules/yampa.nix
+++ b/pkgs/development/idris-modules/yampa.nix
@@ -7,6 +7,7 @@ build-idris-package  {
   name = "yampa";
   version = "2016-07-05";
 
+  ipkgName = "idris-yampa";
   idrisDeps = [ bifunctors ];
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Add the following attributes to `build-idris-package`:
- `ipkgName`: specify base name of the ipkg file explicitly, since `*.ipkg` fails if there are more than 1 ipkg files in the source root directory, defaults to `*` as before
- `extraInstallPhase`: extra commands for the `installPhase` to be able to install executables, since `idris --install` only install libs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Infinisil 