### PR TITLE
qemu: 2.12.1 -> 3.0.0

### DIFF
--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -1,11 +1,15 @@
 # QEMU flags shared between various Nix expressions.
 { pkgs }:
 
+let
+  zeroPad = n: if n < 10 then "0${toString n}" else toString n;
+in
+
 {
 
   qemuNICFlags = nic: net: machine:
-    [ "-net nic,vlan=${toString nic},macaddr=52:54:00:12:${toString net}:${toString machine},model=virtio"
-      "-net vde,vlan=${toString nic},sock=$QEMU_VDE_SOCKET_${toString net}"
+    [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=52:54:00:12:${zeroPad net}:${zeroPad machine}"
+      "-netdev vde,id=vlan${toString nic},sock=$QEMU_VDE_SOCKET_${toString net}"
     ];
 
   qemuSerialDevice = if pkgs.stdenv.isi686 || pkgs.stdenv.isx86_64 then "ttyS0"

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -68,7 +68,9 @@ let
           # again when it deletes link-local addresses.) Ideally we'd
           # turn off the DHCP server, but qemu does not have an option
           # to do that.
-          my $startCommand = "qemu-kvm -m 768 -net nic,vlan=0,model=virtio -net 'user,vlan=0,net=169.0.0.0/8,guestfwd=tcp:169.254.169.254:80-cmd:${pkgs.micro-httpd}/bin/micro_httpd ${metaData}'";
+          my $startCommand = "qemu-kvm -m 768";
+          $startCommand .= " -device virtio-net-pci,netdev=vlan0";
+          $startCommand .= " -netdev 'user,id=vlan0,net=169.0.0.0/8,guestfwd=tcp:169.254.169.254:80-cmd:${pkgs.micro-httpd}/bin/micro_httpd ${metaData}'";
           $startCommand .= " -drive file=$diskImage,if=virtio,werror=report";
           $startCommand .= " \$QEMU_OPTS";
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -22,8 +22,6 @@
 
 with stdenv.lib;
 let
-  version = "2.12.1";
-  sha256 = "1jp5y56682bgpfjapagxjfrjdvqkal34pj9qzn6kj8fqaad80l21";
   audio = optionalString (hasSuffix "linux" stdenv.system) "alsa,"
     + optionalString pulseSupport "pa,"
     + optionalString sdlSupport "sdl,";
@@ -36,6 +34,7 @@ let
 in
 
 stdenv.mkDerivation rec {
+  version = "3.0.0";
   name = "qemu-"
     + stdenv.lib.optionalString xenSupport "xen-"
     + stdenv.lib.optionalString hostCpuOnly "host-cpu-only-"
@@ -43,8 +42,8 @@ stdenv.mkDerivation rec {
     + version;
 
   src = fetchurl {
-    url = "http://wiki.qemu.org/download/qemu-${version}.tar.bz2";
-    inherit sha256;
+    url = "https://wiki.qemu.org/download/qemu-${version}.tar.bz2";
+    sha256 = "1s7bm2xhcxbc9is0rg8xzwijx7azv67skq7mjc58spsgc2nn4glk";
   };
 
   buildInputs =


### PR DESCRIPTION
do not merge, it is just to test the build on different platforms

I am not sure if it is a good idea to merge ```qemu-3.0.0-rc1```, but ```qemu-3.0.0``` may be ready by the time of ```nixos-18.09``` so the testing of ```3.0.0-rc1``` on ```nixos-unstable``` may have sense.
