### PR TITLE
lollypop: wrap search provider

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -13,15 +13,15 @@ stdenv.mkDerivation rec  {
     sha256 = "1iwv0fj50h0xynv152anisbq29jfbmb9hpm60kaa9a9hdiypskcc";
   };
 
-  nativeBuildInputs = with python36Packages; [
+  nativeBuildInputs = [
     appstream-glib
     desktop-file-utils
     gobjectIntrospection
     meson
     ninja
     pkgconfig
+    python36Packages.wrapPython
     wrapGAppsHook
-    wrapPython
   ];
 
   buildInputs = [ glib ] ++ (with gnome3; [
@@ -41,7 +41,11 @@ stdenv.mkDerivation rec  {
     pylast
   ];
 
-  postFixup = "wrapPythonPrograms";
+  preFixup = ''
+    buildPythonPath "$out/libexec/lollypop-sp $pythonPath"
+
+    gappsWrapperArgs+=( --prefix PYTHONPATH : "$program_PYTHONPATH" )
+  '';
 
   postPatch = ''
     chmod +x ./meson_post_install.py


### PR DESCRIPTION
###### Motivation for this change
Just realized that there was a program `lollypop-sp` that wasn't wrapped.
It's a search provider so I think that's for Gnome so to test if it works it should show up as a search provider.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

