### PR TITLE
[WIP] sage: use proper overlays

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -3,199 +3,185 @@
 }:
 
 let
-  inherit (nixpkgs) fetchpatch fetchurl symlinkJoin fetchFromGitHub callPackage nodePackages_8_x;
+  inherit (sagepkgs) fetchpatch fetchurl symlinkJoin fetchFromGitHub callPackage nodePackages_8_x;
 
-  # https://trac.sagemath.org/ticket/15980 for tracking of python3 support
-  python = nixpkgs.python2.override {
-    packageOverrides = self: super: {
-      cypari2 = super.cypari2.override { inherit pari; };
+  sagepkgs = import nixpkgs.path {
+    overlays = [
+      (self: super: {
+        # https://trac.sagemath.org/ticket/15980 for tracking of python3 support
+        python2 = super.python2.override {
+          packageOverrides = pSelf: pSuper: { # distinguish from nixpkgs self/super
+            # python packages that appear unmaintained and were not accepted into the nixpkgs
+            # tree because of that. These packages are only dependencies of the more-or-less
+            # deprecated sagenb. However sagenb is still a default dependency and the doctests
+            # depend on it.
+            # See https://github.com/NixOS/nixpkgs/pull/38787 for a discussion.
+            flask-oldsessions = pSelf.callPackage ./flask-oldsessions.nix {};
+            flask-openid = pSelf.callPackage ./flask-openid.nix {};
+            python-openid = pSelf.callPackage ./python-openid.nix {};
 
-      cysignals = super.cysignals.override { inherit pari; };
+            pybrial = pSelf.callPackage ./pybrial.nix {};
 
-      cvxopt = super.cvxopt.override { inherit glpk; };
+            sagelib = pSelf.callPackage ./sagelib.nix {
+              pynac = self.pynac;
+              linbox = self.linbox.override { withSage = true; };
+            };
 
-      # python packages that appear unmaintained and were not accepted into the nixpkgs
-      # tree because of that. These packages are only dependencies of the more-or-less
-      # deprecated sagenb. However sagenb is still a default dependency and the doctests
-      # depend on it.
-      # See https://github.com/NixOS/nixpkgs/pull/38787 for a discussion.
-      flask-oldsessions = self.callPackage ./flask-oldsessions.nix {};
-      flask-openid = self.callPackage ./flask-openid.nix {};
-      python-openid = self.callPackage ./python-openid.nix {};
+            sagenb = pSelf.callPackage ./sagenb.nix {
+              mathjax = nodePackages_8_x.mathjax;
+            };
 
-      pybrial = self.callPackage ./pybrial.nix {};
+            sagedoc = pSelf.callPackage ./sagedoc.nix { };
 
-      sagelib = self.callPackage ./sagelib.nix {
-        inherit flint ecl pari glpk eclib;
-        inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
-        linbox = nixpkgs.linbox.override { withSage = true; };
-      };
+            env-locations = pSelf.callPackage ./env-locations.nix {
+              # Sage expects those in the same directory.
+              pari_data = symlinkJoin {
+                name = "pari_data";
+                paths = with self; [
+                  pari-galdata
+                  pari-seadata-small
+                ];
+              };
+              three = nodePackages_8_x.three;
+              mathjax = nodePackages_8_x.mathjax;
+            };
 
-      sagenb = self.callPackage ./sagenb.nix {
-        mathjax = nodePackages_8_x.mathjax;
-      };
+            sagePython2Env = let
+              pythonRuntimeDeps = with self.python2.pkgs; [
+                sagelib
+                pybrial
+                sagenb
+                cvxopt
+                networkx
+                service-identity
+                psutil
+                sympy
+                fpylll
+                matplotlib
+                scipy
+                ipywidgets
+                rpy2
+                sphinx
+                typing
+                pillow
+              ];
+            in
+              self.python2.buildEnv.override {
+              extraLibs = pythonRuntimeDeps;
+              ignoreCollisions = true;
+            } // { extraLibs = pythonRuntimeDeps; }; # make the libs accessible
 
-      sagedoc = self.callPackage ./sagedoc.nix {
-        inherit sage-src;
-      };
+            sage-env = pSelf.callPackage ./sage-env.nix {
+              pynac = self.pynac;
+              pkg-config = self.pkgconfig; # not to confuse with pythonPackages.pkgconfig
+            };
 
-      env-locations = self.callPackage ./env-locations.nix {
-        inherit pari_data ecl pari;
-        inherit singular;
-        three = nodePackages_8_x.three;
-        mathjax = nodePackages_8_x.mathjax;
-      };
+            sage-with-env = pSelf.callPackage ./sage-with-env.nix {
+              pynac = self.pynac;
+              pkg-config = self.pkgconfig; # not to confuse with pythonPackages.pkgconfig
+              three = nodePackages_8_x.three;
+            };
 
-      sage-env = self.callPackage ./sage-env.nix {
-        inherit sage-src python rWrapper openblas-cblas-pc glpk ecl singular eclib pari palp flint pynac pythonEnv;
-        pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
-      };
+            sage = pSelf.callPackage ./sage.nix { };
 
-      sage-with-env = self.callPackage ./sage-with-env.nix {
-        inherit pari eclib pythonEnv;
-        inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
-        pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
-        three = nodePackages_8_x.three;
-      };
+            sage-wrapper = pSelf.callPackage ./sage-wrapper.nix {
+              inherit withDoc;
+            };
+          };
+        };
 
-      sage = self.callPackage ./sage.nix { };
+        # update causes issues
+        # https://groups.google.com/forum/#!topic/sage-packaging/cS3v05Q0zso
+        # https://trac.sagemath.org/ticket/24735
+        singular = super.singular.overrideAttrs (oldAttrs: {
+          name = "singular-4.1.0p3";
+          src = fetchurl {
+            url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/4-1-0/singular-4.1.0p3.tar.gz";
+            sha256 = "105zs3zk46b1cps403ap9423rl48824ap5gyrdgmg8fma34680a4";
+          };
+        });
 
-      sage-wrapper = self.callPackage ./sage-wrapper.nix {
-        inherit sage-src withDoc;
-      };
-    };
-  };
+        # sage currently uses an unreleased version of pari
+        pari = (super.pari.override { withThread = false; }).overrideAttrs (attrs: rec {
+          version = "2.10-1280-g88fb5b3"; # on update remove pari-stackwarn patch from `sage-src.nix`
+          src = fetchurl {
+            url = "mirror://sageupstream/pari/pari-${version}.tar.gz";
+            sha256 = "19gbsm8jqq3hraanbmsvzkbh88iwlqbckzbnga3y76r7k42akn7m";
+          };
+        });
 
-  openblas-blas-pc = callPackage ./openblas-pc.nix { name = "blas"; };
-  openblas-cblas-pc = callPackage ./openblas-pc.nix { name = "cblas"; };
-  openblas-lapack-pc = callPackage ./openblas-pc.nix { name = "lapack"; };
+        # With openblas (64 bit), the tests fail the same way as when sage is build with
+        # openblas instead of openblasCompat. Apparently other packages somehow use flints
+        # blas when it is available. Alternative would be to override flint to use
+        # openblasCompat.
+        flint = super.flint.override { withBlas = false; };
 
-  sage-src = callPackage ./sage-src.nix {};
+        # https://trac.sagemath.org/ticket/24824
+        glpk = super.glpk.overrideAttrs (attrs: rec {
+          version = "4.63";
+          name = "glpk-${version}";
+          src = fetchurl {
+            url = "mirror://gnu/glpk/${name}.tar.gz";
+            sha256 = "1xp7nclmp8inp20968bvvfcwmz3mz03sbm0v3yjz8aqwlpqjfkci";
+          };
+          patches = (attrs.patches or []) ++ [
+            # Alternatively patch sage with debians
+            # https://sources.debian.org/data/main/s/sagemath/8.1-7/debian/patches/t-version-glpk-4.60-extra-hack-fixes.patch
+            # The header of that debian patch contains a good description of the issue. The gist of it:
+            # > If GLPK in Sage causes one error, and this is caught by Sage and recovered from, then
+            # > later (because upstream GLPK does not clear the "error" flag) Sage will append
+            # > all subsequent terminal output of GLPK into the error_message string but not
+            # > actually forward it to the user's terminal. This breaks some doctests.
+            (fetchpatch {
+              name = "error_recovery.patch";
+              url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/error_recovery.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+              sha256 = "0z99z9gd31apb6x5n5n26411qzx0ma3s6dnznc4x61x86bhq31qf";
+            })
 
-  pythonRuntimeDeps = with python.pkgs; [
-    sagelib
-    pybrial
-    sagenb
-    cvxopt
-    networkx
-    service-identity
-    psutil
-    sympy
-    fpylll
-    matplotlib
-    scipy
-    ipywidgets
-    rpy2
-    sphinx
-    typing
-    pillow
-  ];
+            # Allow setting a exact verbosity level (OFF|ERR|ON|ALL|DBG)
+            (fetchpatch {
+              name = "exact_verbosity.patch";
+              url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/glp_exact_verbosity.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+              sha256 = "15gm5i2alqla3m463i1qq6jx6c0ns6lip7njvbhp37pgxg4s9hx8";
+            })
+          ];
+        });
 
-  pythonEnv = python.buildEnv.override {
-    extraLibs = pythonRuntimeDeps;
-    ignoreCollisions = true;
-  } // { extraLibs = pythonRuntimeDeps; }; # make the libs accessible
+        # https://trac.sagemath.org/ticket/22191
+        ecl = super.ecl_16_1_2;
 
-  # needs to be rWrapper, standard "R" doesn't include default packages
-  rWrapper = nixpkgs.rWrapper.override {
-    # https://trac.sagemath.org/ticket/25674
-    R = nixpkgs.R.overrideAttrs (attrs: rec {
-      name = "R-3.4.4";
-      src = fetchurl {
-        url = "http://cran.r-project.org/src/base/R-3/${name}.tar.gz";
-        sha256 = "0dq3jsnwsb5j3fhl0wi3p5ycv8avf8s5j1y4ap3d2mkjmcppvsdk";
-      };
-    });
-  };
+        # https://trac.sagemath.org/ticket/25674
+        R = super.R.overrideAttrs (attrs: rec {
+          name = "R-3.4.4";
+          src = fetchurl {
+            url = "http://cran.r-project.org/src/base/R-3/${name}.tar.gz";
+            sha256 = "0dq3jsnwsb5j3fhl0wi3p5ycv8avf8s5j1y4ap3d2mkjmcppvsdk";
+          };
+        });
 
-  # update causes issues
-  # https://groups.google.com/forum/#!topic/sage-packaging/cS3v05Q0zso
-  # https://trac.sagemath.org/ticket/24735
-  singular = nixpkgs.singular.overrideAttrs (oldAttrs: {
-    name = "singular-4.1.0p3";
-    src = fetchurl {
-      url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/4-1-0/singular-4.1.0p3.tar.gz";
-      sha256 = "105zs3zk46b1cps403ap9423rl48824ap5gyrdgmg8fma34680a4";
-    };
-  });
+        openblas-blas-pc = callPackage ./openblas-pc.nix { name = "blas"; };
+        openblas-cblas-pc = callPackage ./openblas-pc.nix { name = "cblas"; };
+        openblas-lapack-pc = callPackage ./openblas-pc.nix { name = "lapack"; };
 
-  # *not* to confuse with the python package "pynac"
-  # https://trac.sagemath.org/ticket/24838 (depends on arb update)
-  pynac = nixpkgs.pynac.override { inherit singular; };
+        sage-src = callPackage ./sage-src.nix {};
 
-  eclib = nixpkgs.eclib.override { inherit pari; };
-
-  # With openblas (64 bit), the tests fail the same way as when sage is build with
-  # openblas instead of openblasCompat. Apparently other packages somehow use flints
-  # blas when it is available. Alternative would be to override flint to use
-  # openblasCompat.
-  flint = nixpkgs.flint.override { withBlas = false; };
-
-  # Multiple palp dimensions need to be available and sage expects them all to be
-  # in the same folder.
-  palp = symlinkJoin {
-    name = "palp-${nixpkgs.palp.version}";
-    paths = [
-      (nixpkgs.palp.override { dimensions = 4; doSymlink = false; })
-      (nixpkgs.palp.override { dimensions = 5; doSymlink = false; })
-      (nixpkgs.palp.override { dimensions = 6; doSymlink = true; })
-      (nixpkgs.palp.override { dimensions = 11; doSymlink = false; })
-    ];
-  };
-
-  # Sage expects those in the same directory.
-  pari_data = symlinkJoin {
-    name = "pari_data";
-    paths = with nixpkgs; [
-      pari-galdata
-      pari-seadata-small
-    ];
-  };
-
-  # https://trac.sagemath.org/ticket/22191
-  ecl = nixpkgs.ecl_16_1_2;
-
-  # sage currently uses an unreleased version of pari
-  pari = (nixpkgs.pari.override { withThread = false; }).overrideAttrs (attrs: rec {
-    version = "2.10-1280-g88fb5b3"; # on update remove pari-stackwarn patch from `sage-src.nix`
-    src = fetchurl {
-      url = "mirror://sageupstream/pari/pari-${version}.tar.gz";
-      sha256 = "19gbsm8jqq3hraanbmsvzkbh88iwlqbckzbnga3y76r7k42akn7m";
-    };
-  });
-
-  # https://trac.sagemath.org/ticket/24824
-  glpk = nixpkgs.glpk.overrideAttrs (attrs: rec {
-    version = "4.63";
-    name = "glpk-${version}";
-    src = fetchurl {
-      url = "mirror://gnu/glpk/${name}.tar.gz";
-      sha256 = "1xp7nclmp8inp20968bvvfcwmz3mz03sbm0v3yjz8aqwlpqjfkci";
-    };
-    patches = (attrs.patches or []) ++ [
-      # Alternatively patch sage with debians
-      # https://sources.debian.org/data/main/s/sagemath/8.1-7/debian/patches/t-version-glpk-4.60-extra-hack-fixes.patch
-      # The header of that debian patch contains a good description of the issue. The gist of it:
-      # > If GLPK in Sage causes one error, and this is caught by Sage and recovered from, then
-      # > later (because upstream GLPK does not clear the "error" flag) Sage will append
-      # > all subsequent terminal output of GLPK into the error_message string but not
-      # > actually forward it to the user's terminal. This breaks some doctests.
-      (fetchpatch {
-        name = "error_recovery.patch";
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/error_recovery.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-        sha256 = "0z99z9gd31apb6x5n5n26411qzx0ma3s6dnznc4x61x86bhq31qf";
-      })
-
-      # Allow setting a exact verbosity level (OFF|ERR|ON|ALL|DBG)
-      (fetchpatch {
-        name = "exact_verbosity.patch";
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/glp_exact_verbosity.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-        sha256 = "15gm5i2alqla3m463i1qq6jx6c0ns6lip7njvbhp37pgxg4s9hx8";
+        # Multiple palp dimensions need to be available and sage expects them all to be
+        # in the same folder.
+        palp = symlinkJoin {
+          name = "palp-${super.palp.version}";
+          paths = [
+            (super.palp.override { dimensions = 4; doSymlink = false; })
+            (super.palp.override { dimensions = 5; doSymlink = false; })
+            (super.palp.override { dimensions = 6; doSymlink = true; })
+            (super.palp.override { dimensions = 11; doSymlink = false; })
+          ];
+        };
       })
     ];
-  });
+  };
 in
-  python.pkgs.sage-wrapper // {
-    doc = python.pkgs.sagedoc;
-    lib = python.pkgs.sagelib;
+  sagepkgs.python.pkgs.sage-wrapper // {
+    doc = sagepkgs.python.pkgs.sagedoc;
+    lib = sagepkgs.python.pkgs.sagelib;
+    overlay = sagepkgs;
   }

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -11,7 +11,7 @@
 , gnused
 , gnugrep
 , binutils
-, pythonEnv
+, sagePython2Env
 , python3
 , pkg-config
 , pari
@@ -51,7 +51,7 @@ let
   runtimepath = (lib.makeBinPath ([
     "@sage-local@"
     "@sage-local@/build"
-    pythonEnv
+    sagePython2Env
     # empty python env to add python wrapper that clears PYTHONHOME (see
     # wrapper.nix). This is necessary because sage will call the python3 binary
     # (from python2 code). The python2 PYTHONHOME (again set in wrapper.nix)
@@ -73,6 +73,7 @@ let
     singular
     giac
     palp
+    # needs to be rWrapper, standard "R" doesn't include default packages
     rWrapper
     gfan
     cddlib

--- a/pkgs/applications/science/math/sage/sage-with-env.nix
+++ b/pkgs/applications/science/math/sage/sage-with-env.nix
@@ -26,12 +26,12 @@
 , ntl
 , ecm
 , pynac
-, pythonEnv
+, sagePython2Env
 }:
 
 let
   buildInputs = [
-    pythonEnv # for patchShebangs
+    sagePython2Env # for patchShebangs
     makeWrapper
     pkg-config
     openblasCompat # lots of segfaults with regular (64 bit) openblas
@@ -80,7 +80,7 @@ let
       []
     );
 
-  allInputs = lib.remove null (buildInputs ++ pythonEnv.extraLibs);
+  allInputs = lib.remove null (buildInputs ++ sagePython2Env.extraLibs);
   transitiveDeps = lib.unique (builtins.concatLists (map transitiveClosure allInputs ));
   # fix differences between spkg and sage names
   # (could patch sage instead, but this is more lightweight and also works for packages depending on sage)


### PR DESCRIPTION
###### Motivation for this change

Sage has lots of dependencies and integrates tightly with them. Some of them have to be (temporarily) pinned at older versions. Currently that is done by simply using `<pkg>.override`. But since there are so many dependencies, they are likely to depend on each other. That makes it necessary to "wire them up" using lots of `inherit`'s (as seen in #43679).

Since `packageOverrides` was deprecated, I'm unsure how to solve this. Here I use the variant mentioned in the manual, but not used anywhere in nixpkgs (yet). That re-imports nixpkgs however:

```
sagepkgs = import nixpkgs.path {
    overlays = [ ... ];
}
```

Is this a terrible idea? Will this lead to even more memory consumption? Will this ignore all previous user-defined overlays? Is there a better way?

@grahamc @matthewbauer @7c6f434c @FRidh 

Other than the change from simple `.override` to overlays nothing has changed. So there is no need to review the details here (although you're of course free to do so).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

