### PR TITLE
gpm: patch to fix w/musl, good for general use

### DIFF
--- a/pkgs/servers/gpm/default.nix
+++ b/pkgs/servers/gpm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, automake, autoconf, libtool, flex, bison, texinfo
+{ stdenv, fetchurl, automake, autoconf, libtool, flex, bison, texinfo, fetchpatch
 
 # Optional Dependencies
 , ncurses ? null
@@ -13,7 +13,6 @@ stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    sed '1i#include <sys/types.h>' -i src/daemon/open_console.c
     substituteInPlace src/prog/gpm-root.y --replace __sigemptyset sigemptyset
   '';
 
@@ -22,6 +21,22 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  patches = [
+    # musl compat patches, safe everywhere
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/musl/5aed405d87dfa92a5cab1596f898e9dea07169b8/sys-libs/gpm/files/gpm-1.20.7-musl-missing-headers.patch";
+      sha256 = "1g338m6j1sba84wlqp1r6rpabj5nm6ki577hjalg46czg0lfp20h";
+    })
+    # Touches same code as glibc fix in postPatch above, but on the non-glibc route
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/musl/5aed405d87dfa92a5cab1596f898e9dea07169b8/sys-libs/gpm/files/gpm-1.20.7-musl-portable-sigaction.patch";
+      sha256 = "0hfdqm9977hd5dpzn05y0a6jbj55w1kp4hd9gyzmg9wslmxni4rg";
+    })
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/gentoo/musl/5aed405d87dfa92a5cab1596f898e9dea07169b8/sys-libs/gpm/files/gpm-1.20.7-sysmacros.patch";
+      sha256 = "0lg4l9phvy2n8gy17qsn6zn0qq52vm8g01pgq5kqpr8sd3fb21c2";
+    })
+  ];
   preConfigure = ''
     ./autogen.sh
   '';


### PR DESCRIPTION
Two of the patches fix same issues we fix for glibc,
one of which this replaces (the other touches same
code but on the not-glibc path).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---