### PR TITLE
xfce4-13.libxfce4util: 4.13.1 -> 4.13.2

### DIFF
--- a/pkgs/desktops/xfce4-13/libxfce4util/default.nix
+++ b/pkgs/desktops/xfce4-13/libxfce4util/default.nix
@@ -3,9 +3,9 @@
 mkXfceDerivation rec {
   category = "xfce";
   pname = "libxfce4util";
-  version = "4.13.1";
+  version = "4.13.2";
 
-  sha256 = "001ls90an2pi9l04g3r6syfa4lhyvjymp0r9djxrkc2q493mcv3d";
+  sha256 = "0sb6pzhmh0qzfdhixj1ard56zi68318k86z3a1h3f2fhqy7gyf98";
 
   buildInputs = [ gobjectIntrospection ];
 


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

