### PR TITLE
xfce4-13.xfwm4: fix build (add libXdamage dependency)

### DIFF
--- a/pkgs/desktops/xfce4-13/xfwm4/default.nix
+++ b/pkgs/desktops/xfce4-13/xfwm4/default.nix
@@ -1,6 +1,6 @@
-{ mkXfceDerivation, exo, dbus_glib, epoxy ? null, gtk2, libICE, libSM
-, libstartup_notification ? null, libxfce4ui, libxfce4util, libwnck
-, libXpresent ? null, xfconf }:
+{ mkXfceDerivation, exo, dbus-glib, epoxy, gtk2, libXdamage
+, libstartup_notification, libxfce4ui, libxfce4util, libwnck
+, libXpresent, xfconf }:
 
 mkXfceDerivation rec {
   category = "xfce";
@@ -12,11 +12,10 @@ mkXfceDerivation rec {
   nativeBuildInputs = [ exo ];
 
   buildInputs = [
-    dbus_glib
+    dbus-glib
     epoxy
     gtk2
-    libICE
-    libSM
+    libXdamage
     libstartup_notification
     libxfce4ui
     libxfce4util


### PR DESCRIPTION
###### Motivation for this change

fix build (add libXdamage dependency)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

