### PR TITLE
xfce4-13.xfce4-taskmanager: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-taskmanager/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-taskmanager/default.nix
@@ -7,9 +7,9 @@ in
 mkXfceDerivation rec {
   category = "apps";
   pname = "xfce4-taskmanager";
-  version = "1.2.0";
+  version = "1.2.1";
 
-  sha256 = "1lx66lhzfzhysymcbzfq9nrafyfmwdb79lli9kvhz6m12dhz6j18";
+  sha256 = "1p0496r1fb5zqvn6c41kb6rjqwlqghqahgg6hkzw0gjy911im99w";
 
   nativeBuildInputs = [ exo ];
   buildInputs = [ gtk2 gtk3 libwnck3 libXmu ];


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

