### PR TITLE
xfce4-13.xfce4-dict: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-dict/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-dict/default.nix
@@ -3,9 +3,9 @@
 mkXfceDerivation rec {
   category = "apps";
   pname = "xfce4-dict";
-  version = "0.8.0";
+  version = "0.8.1";
 
-  sha256 = "1r1k9cgl7zkn3q4mjf7qjql6vlxkb2m0spgj9p646mw7bnhbf9wr";
+  sha256 = "0kxirzqmpp7qlr8220i8kipz4bgzkam7h1lpx7yzld5xf7wdzvaf";
 
   patches = [ ./configure-gio.patch ];
 


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

