### PR TITLE
xfce4-13.parole: 0.9.2 -> 1.0.1

### DIFF
--- a/pkgs/desktops/xfce4-13/parole/default.nix
+++ b/pkgs/desktops/xfce4-13/parole/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, makeWrapper, wrapGAppsHook, dbus, dbus_glib
+{ mkXfceDerivation, makeWrapper, wrapGAppsHook, dbus, dbus-glib
 , gst-plugins-bad ? null, gst-plugins-base, gst-plugins-good
 , gst-plugins-ugly ? null, gtk3, libnotify, libxfce4ui, libxfce4util
 , taglib ? null, xfconf }:
@@ -8,9 +8,9 @@
 mkXfceDerivation rec {
   category = "apps";
   pname = "parole";
-  version = "0.9.2";
+  version = "1.0.1";
 
-  sha256 = "07i9d7xn2ys3z71sxvr53idq4ivy94pqgxvr0k78crva39ls08s5";
+  sha256 = "0zq1imbjqmwfk3yrsha2s7lclzbh8xgggz0rbksa51siqk73swbb";
 
   postPatch = ''
     substituteInPlace src/plugins/mpris2/Makefile.am \
@@ -21,7 +21,7 @@ mkXfceDerivation rec {
 
   buildInputs = [
     dbus
-    dbus_glib
+    dbus-glib
     gst-plugins-bad
     gst-plugins-base
     gst-plugins-good


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

