### PR TITLE
gnome3.gjs: 1.52.3 -> 1.53.3

### DIFF
--- a/pkgs/desktops/gnome-3/core/gjs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gjs/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gjs-${version}";
-  version = "1.53.3";
+  version = "1.53.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "12abmzjiankvfzqsz8iw4cvm4k36id1i00i644m05nwngpb9fxlk";
+    sha256 = "0mrs1bbvmcm9sl1jis53shcbcybh0p3ycj9wcms2qqx3xqlj6xn1";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gjs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gjs/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gjs-${version}";
-  version = "1.52.3";
+  version = "1.53.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${gnome3.versionBranch version}/${name}.tar.xz";
-    sha256 = "1z4n15wdz6pbqd2hfzrqc8mmprhv50v4jk43p08v0xv07yldh8ff";
+    sha256 = "12abmzjiankvfzqsz8iw4cvm4k36id1i00i644m05nwngpb9fxlk";
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

I was told that the infamous gnome memory leak was finally fixed upstream:
    
https://bugs.launchpad.net/gnome-shell/+bug/1672297/comments/93

I am running this version on my work Ubuntu and it is a great improvement.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

