### PR TITLE
bittornado: init at unstable-2018-02-09

### DIFF
--- a/pkgs/tools/networking/p2p/bittornado/default.nix
+++ b/pkgs/tools/networking/p2p/bittornado/default.nix
@@ -1,0 +1,26 @@
+{ lib, python3, fetchFromGitHub }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "BitTornado";
+  version = "unstable-2018-02-09";
+
+  src = fetchFromGitHub {
+    owner = "effigies";
+    repo = "BitTornado";
+    rev = "a3e6d8bcdf9d99de064dc58b4a3e909e0349e589";
+    sha256 = "099bci3as592psf8ymmz225qyz2lbjhya7g50cb7hk64k92mqk9k";
+  };
+
+  postFixup = ''
+    for i in $(ls $out/bin); do		
+      mv $out/bin/$i $out/bin/''${i%.py}
+    done
+  '';
+
+  meta = with lib; {
+    inherit (src.meta) homepage;
+    description = "John Hoffman's fork of the original bittorrent";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -846,6 +846,8 @@ with pkgs;
 
   bitbucket-cli = python2Packages.bitbucket-cli;
 
+  bittornado = callPackage ../tools/networking/p2p/bittornado { };
+
   blink = callPackage ../applications/networking/instant-messengers/blink { };
 
   blockhash = callPackage ../tools/graphics/blockhash { };


### PR DESCRIPTION
###### Motivation for this change
For adding bittorrent content to git-annex, which needs the `btshowmetainfo` executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @FRidh who removed the previous version of BitTornado in https://github.com/NixOS/nixpkgs/commit/63b73234029df4e31d9a4c0788ce59847422e0eb