### PR TITLE
xfce4-13.mousepad: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -19,9 +19,7 @@ makeScope newScope (self: with self; {
 
   libxfce4ui = callPackage ./libxfce4ui { };
 
-  mousepad = callPackage ./mousepad {
-    inherit (gnome3) gtksourceview;
-  };
+  mousepad = callPackage ./mousepad { };
 
   orage = callPackage ./orage { };
 

--- a/pkgs/desktops/xfce4-13/mousepad/default.nix
+++ b/pkgs/desktops/xfce4-13/mousepad/default.nix
@@ -1,12 +1,12 @@
-{ mkXfceDerivation, exo, wrapGAppsHook, dbus_glib ? null, gtk3, gtksourceview }:
+{ mkXfceDerivation, exo, wrapGAppsHook, dbus-glib, gtk3, gtksourceview3 }:
 
 mkXfceDerivation rec {
   category = "apps";
   pname = "mousepad";
-  version = "0.4.0";
+  version = "0.4.1";
 
-  sha256 = "0mm90iq2yd3d0qbgsjyk3yj25k0gm3p34jazl640vixk84v20lyw";
+  sha256 = "0pr1w9n0qq2raxhy78982i9g17x0ya02q7vdrn0wb2bpk74hlki5";
 
   nativeBuildInputs = [ exo wrapGAppsHook ];
-  buildInputs = [ dbus_glib gtk3 gtksourceview ];
+  buildInputs = [ dbus-glib gtk3 gtksourceview3 ];
 }


### PR DESCRIPTION
###### Motivation for this change

minor update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

