### PR TITLE
xfce4-13: backport panel plugins and icon themes from xfce4-12

### DIFF
--- a/pkgs/desktops/xfce/art/xfce4-icon-theme.nix
+++ b/pkgs/desktops/xfce/art/xfce4-icon-theme.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk2 }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-icon-theme";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool gtk ];
+  buildInputs = [ intltool gtk2 ];
 
   meta = {
     homepage = http://www.xfce.org/;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, xfconf, gtk2 }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel xfconf gtk2 ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -92,4 +92,24 @@ makeScope newScope (self: with self; {
   xfce4-xkb-plugin = callPackage ./xfce4-xkb-plugin { };
 
   xfwm4 = callPackage ./xfwm4 { };
+
+  ## COMMON PARTS WITH XFCE 4.12
+
+  gtk-xfce-engine = callPackage ../xfce/core/gtk-xfce-engine.nix { withGtk3 = false; };
+
+  xfce4-icon-theme = callPackage ../xfce/art/xfce4-icon-theme.nix { };
+
+  xfwm4-themes = callPackage ../xfce/art/xfwm4-themes.nix { };
+
+  xfce4-embed-plugin = callPackage ../xfce/panel-plugins/xfce4-embed-plugin.nix { };
+
+  xfce4-hardware-monitor-plugin = callPackage ../xfce/panel-plugins/xfce4-hardware-monitor-plugin.nix { };
+
+  ## THIRD PARTY PLIGINS
+
+  xfce4-dockbarx-plugin = callPackage ../xfce/panel-plugins/xfce4-dockbarx-plugin.nix { };
+
+  xfce4-namebar-plugin = callPackage ../xfce/panel-plugins/xfce4-namebar-plugin.nix { };
+
+  xfce4-windowck-plugin = callPackage ../xfce/panel-plugins/xfce4-windowck-plugin.nix { };
 })

--- a/pkgs/desktops/xfce4-13/xfburn/default.nix
+++ b/pkgs/desktops/xfce4-13/xfburn/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, docbook_xsl, exo, gtk2, libburn, libICE, libisofs, libSM, libxfce4ui, libxslt }:
+{ mkXfceDerivation, docbook_xsl, exo, gtk2, libburn, libisofs, libxfce4ui, libxslt }:
 
 mkXfceDerivation rec {
   category = "apps";
@@ -14,5 +14,5 @@ mkXfceDerivation rec {
   sha256 = "1lmv48vqrlap1a2ha72g16vqly18zvcwj8y3f3f00l10pmn52bkp";
 
   nativeBuildInputs = [ libxslt ];
-  buildInputs = [ exo gtk2 libburn libICE libisofs libSM libxfce4ui ];
+  buildInputs = [ exo gtk2 libburn libisofs libxfce4ui ];
 }

--- a/pkgs/desktops/xfce4-13/xfce4-mixer/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-mixer/default.nix
@@ -1,5 +1,4 @@
-{ mkXfceDerivation, automakeAddFlags, dbus-glib, gst-plugins-base, gtk2
-, libICE, libSM, libunique, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+{ mkXfceDerivation, automakeAddFlags, dbus-glib, gtk2, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
 
 mkXfceDerivation rec {
   category = "apps";
@@ -17,11 +16,7 @@ mkXfceDerivation rec {
 
   buildInputs = [
     dbus-glib
-    gst-plugins-base
     gtk2
-    libICE
-    libSM
-    libunique
     libxfce4ui
     libxfce4util
     xfce4-panel


### PR DESCRIPTION
###### Motivation for this change

backport panel plugins and icon themes from xfce4-12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

