### PR TITLE
paraview: 5.4.1 -> 5.5.2

### DIFF
--- a/pkgs/applications/graphics/paraview/default.nix
+++ b/pkgs/applications/graphics/paraview/default.nix
@@ -6,7 +6,7 @@ stdenv, fetchFromGitHub, cmake, makeWrapper
 
 stdenv.mkDerivation rec {
   name = "paraview-${version}";
-  version = "5.4.1";
+  version = "5.5.2";
 
   # fetching from GitHub instead of taking an "official" source
   # tarball because of missing submodules there
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     owner = "Kitware";
     repo = "ParaView";
     rev = "v${version}";
-    sha256 = "1ma02sdkz2apxnwcsyvxb26ibwnjh60p71gicw6nlp042acs6v74";
+    sha256 = "1jivph7lppnflmjsiirhgv0mnh8mxx41i1vzkk78ynn00rzacx3j";
     fetchSubmodules = true;
   };
 
@@ -22,13 +22,14 @@ stdenv.mkDerivation rec {
     "-DPARAVIEW_ENABLE_PYTHON=ON"
     "-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON"
     "-DPARAVIEW_ENABLE_EMBEDDED_DOCUMENTATION=OFF"
+    "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 
   # During build, binaries are called that rely on freshly built
   # libraries.  These reside in build/lib, and are not found by
   # default.
   preBuild = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib:$PWD/VTK/ThirdParty/vtkm/vtk-m/lib
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17646,7 +17646,7 @@ with pkgs;
 
   pavucontrol = callPackage ../applications/audio/pavucontrol { };
 
-  paraview = libsForQt5.callPackage ../applications/graphics/paraview { };
+  paraview = libsForQt59.callPackage ../applications/graphics/paraview { };
 
   packet = callPackage ../development/tools/packet { };
 


### PR DESCRIPTION
This update should also fix the build the hydra: one part of the
change is to build paraview with Qt-5.9, as this is the configuration
that paraview upstream supports.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

