### PR TITLE
urbit: 0.4.5 -> 0.6.0

### DIFF
--- a/pkgs/misc/urbit/default.nix
+++ b/pkgs/misc/urbit/default.nix
@@ -1,5 +1,6 @@
-{ curl, fetchFromGitHub, gcc, git, gmp, libsigsegv, meson, ncurses, ninja,
-  openssl, pkgconfig, re2c, stdenv, zlib }:
+{ stdenv, fetchFromGitHub, curl, git, gmp, libsigsegv, meson, ncurses, ninja
+, openssl, pkgconfig, re2c, zlib
+}:
 
 stdenv.mkDerivation rec {
   name = "urbit-${version}";
@@ -14,21 +15,11 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ninja meson ];
-
-  buildInputs = with stdenv.lib; [
-    curl gcc git gmp libsigsegv ncurses openssl re2c zlib
-  ];
-
-  # uses 'readdir_r' deprecated by glibc 2.24
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  buildInputs = [ curl git gmp libsigsegv ncurses openssl re2c zlib ];
 
   postPatch = ''
     patchShebangs .
   '';
-
-  mesonFlags = [
-    "--buildtype=release"
-  ];
 
   meta = with stdenv.lib; {
     description = "An operating function";

--- a/pkgs/misc/urbit/default.nix
+++ b/pkgs/misc/urbit/default.nix
@@ -1,6 +1,5 @@
-{ autoconf, automake, cmake, curl, fetchFromGitHub, gcc, git, gmp, libsigsegv,
-  libtool, meson, ncurses, ninja, openssl, pkgconfig, python2, ragel, re2c,
-  stdenv, zlib }:
+{ curl, fetchFromGitHub, gcc, git, gmp, libsigsegv, meson, ncurses, ninja,
+  openssl, pkgconfig, re2c, stdenv, zlib }:
 
 stdenv.mkDerivation rec {
   name = "urbit-${version}";
@@ -14,33 +13,22 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [ pkgconfig ninja meson ];
+
   buildInputs = with stdenv.lib; [
-    autoconf automake cmake curl gcc git gmp libsigsegv libtool
-    meson ncurses ninja openssl pkgconfig python2 ragel re2c zlib
+    curl gcc git gmp libsigsegv ncurses openssl re2c zlib
   ];
 
   # uses 'readdir_r' deprecated by glibc 2.24
   NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
-  configurePhase = ''
-    :
-  '';
-
   postPatch = ''
     patchShebangs .
-    substituteInPlace scripts/build --replace 'meson .' 'meson --prefix $out .'
   '';
 
-  buildPhase = ''
-    git init .
-    ./scripts/bootstrap
-    ./scripts/build
-    ninja -C ./build/ install
-  '';
-
-  installPhase = ''
-    :
-  '';
+  mesonFlags = [
+    "--buildtype=release"
+  ];
 
   meta = with stdenv.lib; {
     description = "An operating function";


### PR DESCRIPTION
###### Motivation for this change

Version was out of date, and install procedure has changed (following https://urbit.org/docs/using/install/ )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

