### PR TITLE
kube-shell: init at 0.0.21

### DIFF
--- a/pkgs/development/tools/kube-shell/default.nix
+++ b/pkgs/development/tools/kube-shell/default.nix
@@ -1,0 +1,46 @@
+{ lib, pythonPackages, fetchFromGitHub }:
+
+let
+  inherit (pythonPackages) python;
+in
+pythonPackages.buildPythonApplication rec {
+  name = "kube-shell-${version}";
+  version = "0.0.21";
+
+  src = fetchFromGitHub {
+    sha256 = "0966szv0n6mpsxfphv8z4h1h1rikhx4k8z3v5p9b2vmmw8048rn5";
+    rev = "v${version}";
+    repo = "kube-shell";
+    owner = "cloudnativelabs";
+  };
+
+  buildInputs = with pythonPackages; [ pexpect ];
+
+  buildPhase = ''
+    export HOME=$(mktemp -d)
+    ${python.interpreter} setup.py build
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib/${python.libPrefix}/site-packages"
+    export PYTHONPATH="$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
+    ${python.interpreter} setup.py install \
+      --install-lib=$out/lib/${python.libPrefix}/site-packages \
+      --prefix="$out"
+  '';
+
+  checkPhase = ''
+    PATH="$out/bin:$PATH" ${python.interpreter} kubeshell/tests/test_cli.py
+  '';
+
+  meta = with lib; {
+    description = "An integrated shell for working with Kubernetes";
+    longDescription = ''
+      Rich command-line interface for kubectl with auto-completion and
+      syntax highlighting.
+    '';
+    homepage = "https://github.com/cloudnativelabs/kube-shell";
+    license = licenses.asl20;
+    maintainers = [ maintainers.carlosdagos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8261,6 +8261,8 @@ with pkgs;
 
   kube-aws = callPackage ../development/tools/kube-aws { };
 
+  kube-shell = callPackage ../development/tools/kube-shell { };
+
   Literate = callPackage ../development/tools/literate-programming/Literate {};
 
   lcov = callPackage ../development/tools/analysis/lcov { };


### PR DESCRIPTION
###### Motivation for this change

Nice shell for `kubectl` 😄 

I don't know if `development/tools` is the most appropriate place for this though. I'll happy to change it otherwise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

