### PR TITLE
nixos/release: pass individual netboot files through

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -122,6 +122,8 @@ let
           echo "file ipxe $out/netboot.ipxe" >> $out/nix-support/hydra-build-products
         '';
         preferLocalBuild = true;
+        # Allow acquiring individual files from netboot channel attr
+        inherit (build) netbootRamdisk kernel netbootIpxeScript;
       };
 
 in rec {


### PR DESCRIPTION
###### Motivation for this change
Enabling placing netboot files in channels so we can add https://netboot.xyz support. See also antonym/netboot.xyz#37

Would be nice to backport to 18.03, not sure if that's ok?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

