### PR TITLE
postman: fix icon not found

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
   buildPhase = ":";   # nothing to build
 
   icon = fetchurl {
-    url = "https://www.getpostman.com/img-rebrand/logo.png";
-    sha256 = "0jdhl9c07b1723j2f172z3s5p5lh8sqa1rcvdzz3h6z5zwn21g7v";
+    url = "https://www.getpostman.com/img/v2/media-kit/Logo/PNG/pm-logo-horiz.png";
+    sha256 = "271b88317bd787f4a30ab374148e73314d60fb1b220ef791611774a061c49f30";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change
Postman doesn't build because the icon is no longer present at the old url

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

