### PR TITLE
pythonPackages.xgboost: fix build

### DIFF
--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -9,13 +9,13 @@ assert ncclSupport -> cudaSupport;
 
 stdenv.mkDerivation rec {
   name = "xgboost-${version}";
-  version = "0.7";
+  version = "0.72";
 
   # needs submodules
   src = fetchgit {
     url = "https://github.com/dmlc/xgboost";
     rev = "refs/tags/v${version}";
-    sha256 = "1wxh020l4q037hc5z7vgxflb70l41a97anl8g6y4wxb74l5zv61l";
+    sha256 = "1d4kw2jm7d12g8qwi7p9r3429y7sjks9xp9yhvfpx5jh7qakkxj6";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/xgboost/lib-path-for-python.patch
+++ b/pkgs/development/python-modules/xgboost/lib-path-for-python.patch
@@ -1,0 +1,59 @@
+diff --git a/python-package/setup.py b/python-package/setup.py
+index e6c3386f..4ed0a8bd 100644
+--- a/python-package/setup.py
++++ b/python-package/setup.py
+@@ -16,8 +16,6 @@ libpath_py = os.path.join(CURRENT_DIR, 'xgboost/libpath.py')
+ libpath = {'__file__': libpath_py}
+ exec(compile(open(libpath_py, "rb").read(), libpath_py, 'exec'), libpath, libpath)
+ 
+-LIB_PATH = [os.path.relpath(libfile, CURRENT_DIR) for libfile in libpath['find_lib_path']()]
+-print("Install libxgboost from: %s" % LIB_PATH)
+ # Please use setup_pip.py for generating and deploying pip installation
+ # detailed instruction in setup_pip.py
+ setup(name='xgboost',
+@@ -35,7 +33,6 @@ setup(name='xgboost',
+       # this will use MANIFEST.in during install where we specify additional files,
+       # this is the golden line
+       include_package_data=True,
+-      data_files=[('xgboost', LIB_PATH)],
+       license='Apache-2.0',
+       classifiers=['License :: OSI Approved :: Apache Software License'],
+       url='https://github.com/dmlc/xgboost')
+diff --git a/python-package/xgboost/libpath.py b/python-package/xgboost/libpath.py
+index d87922c0..859a30fb 100644
+--- a/python-package/xgboost/libpath.py
++++ b/python-package/xgboost/libpath.py
+@@ -19,32 +19,4 @@ def find_lib_path():
+     lib_path: list(string)
+        List of all found library path to xgboost
+     """
+-    curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+-    # make pythonpack hack: copy this directory one level upper for setup.py
+-    dll_path = [curr_path, os.path.join(curr_path, '../../lib/'),
+-                os.path.join(curr_path, './lib/'),
+-                os.path.join(sys.prefix, 'xgboost')]
+-    if sys.platform == 'win32':
+-        if platform.architecture()[0] == '64bit':
+-            dll_path.append(os.path.join(curr_path, '../../windows/x64/Release/'))
+-            # hack for pip installation when copy all parent source directory here
+-            dll_path.append(os.path.join(curr_path, './windows/x64/Release/'))
+-        else:
+-            dll_path.append(os.path.join(curr_path, '../../windows/Release/'))
+-            # hack for pip installation when copy all parent source directory here
+-            dll_path.append(os.path.join(curr_path, './windows/Release/'))
+-        dll_path = [os.path.join(p, 'xgboost.dll') for p in dll_path]
+-    elif sys.platform.startswith('linux') or sys.platform.startswith('freebsd'):
+-        dll_path = [os.path.join(p, 'libxgboost.so') for p in dll_path]
+-    elif sys.platform == 'darwin':
+-        dll_path = [os.path.join(p, 'libxgboost.dylib') for p in dll_path]
+-
+-    lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
+-
+-    # From github issues, most of installation errors come from machines w/o compilers
+-    if not lib_path and not os.environ.get('XGBOOST_BUILD_DOC', False):
+-        raise XGBoostLibraryNotFound(
+-            'Cannot find XGBoost Library in the candidate path, ' +
+-            'did you install compilers and run build.sh in root path?\n'
+-            'List of candidates:\n' + ('\n'.join(dll_path)))
+-    return lib_path
++    return ["@libpath@/libxgboost.so"]


### PR DESCRIPTION
###### Motivation for this change

Fixes the broken path detection of the `xgboost` python package and replaces it with a simple path that substitutes the storepath of `libxgboost.so`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

