### PR TITLE
 oraclejdk: 8u171, 8u172 -> 8u181, 10.0.1 -> 10.0.2 [Critical security fixes]

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
@@ -28,7 +28,7 @@
 assert swingSupport -> xorg != null;
 
 let
-  version = "10.0.1";
+  version = "10.0.2";
 
   downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
 
@@ -51,19 +51,19 @@ let result = stdenv.mkDerivation rec {
       requireFile {
         name = "jdk-${version}_linux-x64_bin.tar.gz";
         url =  "${downloadUrlBase}/jdk10-downloads-4416644.html";
-        sha256 = "1975s6cn2lxb8jmxp236afvq6hhxqrx5jix8aqm46f5gwr2xd3mf";
+        sha256 = "0arpzac64apji1s8d0gzizkvrjz0fbhz7l34af1j0365ac6w4cv6";
       }
     else if packageType == "JRE" then
       requireFile {
         name = "jre-${version}_linux-x64_bin.tar.gz";
         url = "${downloadUrlBase}/jre10-downloads-4417026.html";
-        sha256 = "11pb8cwzmalc6ax735m84g13jh1mrfc8g84b5qypnmqjjdv6fpiq";
+        sha256 = "0pc4a0a3fl6874vfaflf6jvpm9da647vp41pj0hihkspjyjhjabx";
       }
     else if packageType == "ServerJRE" then
       requireFile {
         name = "serverjre-${version}_linux-x64_bin.tar.gz";
         url = "${downloadUrlBase}/sjre10-downloads-4417025.html";
-        sha256 = "0hvfqgr22sq9zyqc496vqgg5ail189h3a4pazp39i8n86brd48lw";
+        sha256 = "0hbcb4c6ncy0sbz02gyygyqcwkz0xpv4fwrx4sripia6vph9592c";
       }
     else abort "unknown package Type ${packageType}";
 

--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -1,11 +1,11 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "171";
+  patchVersion = "181";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "0dh5r02v40pinway952fflw2r0i1xi67hmyb87c278qfp4jn929p";
-  sha256.x86_64-linux = "10jr4z0bw9wcws5xgc4qkw101cadfx5bkyvcnc4l3v5axwvjipdn";
-  sha256.armv7l-linux = "1bqivmp1wfnypgg5bsfzi25yzl7vd2xncfap9mi8jn63aj633dw0";
-  sha256.aarch64-linux = "1016lf3g1syjsl29m58s2s2w9nkj4jkvxhqg4s35vy41cs2v77j7";
+  sha256.i686-linux = "0159q5wrlp24v8rc6m1cr3kq8nddpdjdprj3vsmf8z7vpwx052np";
+  sha256.x86_64-linux = "1lwiz44vlxn4hc5b43r9arad15lpjfbr7l6h5vafpgxzjmq5ci8q";
+  sha256.armv7l-linux = "0zpgb1hqf9zazic66c7nim036ac6ld3dhnsanx4ijlrl7kd3fbn7";
+  sha256.aarch64-linux = "191r926501cm6mz8p93ljdfxi0dgzw7ljjsrzsbmmxn4k0q2j0ad";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -1,11 +1,11 @@
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "172";
+  patchVersion = "181";
   downloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html;
-  sha256.i686-linux = "0csskx8xis0dr1948j76fgrwwsj4gzdbjqfi7if4v4j62b9i0hqa";
-  sha256.x86_64-linux = "0inkx73rwv7cvn9lqcr3hmnm0sr89h1fh29yamikb4dn02a0p818";
-  sha256.armv7l-linux = "1576cb0rlc42dsnmh388gy1wjas7ac6g135s8h74x8sm4b56qpln";
-  sha256.aarch64-linux = "0zpkmq8zxmpifawj611fg67srki63haz02rm6xwfc5qm2lxx5g6s";
+  sha256.i686-linux = "0159q5wrlp24v8rc6m1cr3kq8nddpdjdprj3vsmf8z7vpwx052np";
+  sha256.x86_64-linux = "1lwiz44vlxn4hc5b43r9arad15lpjfbr7l6h5vafpgxzjmq5ci8q";
+  sha256.armv7l-linux = "0zpgb1hqf9zazic66c7nim036ac6ld3dhnsanx4ijlrl7kd3fbn7";
+  sha256.aarch64-linux = "191r926501cm6mz8p93ljdfxi0dgzw7ljjsrzsbmmxn4k0q2j0ad";
   jceName = "jce_policy-8.zip";
   jceDownloadUrl = http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes
- Other changes and fixes

https://www.oracle.com/technetwork/java/javase/8u181-relnotes-4479407.html
http://www.oracle.com/technetwork/java/javase/10-0-2-relnotes-4477557.html
http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html#AppendixJAVA


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

