### PR TITLE
alacritty: add terminfo and man

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -4,11 +4,13 @@
   rustPlatform,
   cmake,
   makeWrapper,
+  ncurses,
   expat,
   pkgconfig,
   freetype,
   fontconfig,
   libX11,
+  gzip,
   libXcursor,
   libXxf86vm,
   libXi,
@@ -66,10 +68,14 @@ in buildRustPackage rec {
     cmake
     makeWrapper
     pkgconfig
+    ncurses
+    gzip
   ];
 
   buildInputs = rpathLibs
              ++ lib.optionals stdenv.isDarwin darwinFrameworks;
+
+ outputs = [ "out" "terminfo" ];
 
   postPatch = ''
     substituteInPlace copypasta/src/x11.rs \
@@ -94,6 +100,14 @@ in buildRustPackage rec {
     install -D alacritty-completions.zsh "$out/share/zsh/site-functions/_alacritty"
     install -D alacritty-completions.bash "$out/etc/bash_completion.d/alacritty-completions.bash"
     install -D alacritty-completions.fish "$out/share/fish/vendor_completions.d/alacritty.fish"
+
+    install -dm 755 "$out/share/man/man1"
+    gzip -c alacritty.man > "$out/share/man/man1/alacritty.1.gz"
+
+    install -dm 755 "$terminfo/share/terminfo/a/"
+    tic -x -o "$terminfo/share/terminfo" alacritty.info
+    mkdir -p $out/nix-support
+    echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

