### PR TITLE
[wip] {cc,bintools}-wrapper: handle $out/nix-support/skip-flags

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -11,6 +11,15 @@ set -u
 [[ -z ${strictDeps-} ]] || (( "$hostOffset" < 0 )) || return 0
 
 bintoolsWrapper_addLDVars () {
+    # If a package has this file, we will not add any flags
+    # automatically. This is needed to fix the ARG_MAX issue in
+    # Haskell packages where many unused Haskell LDFLAGS are added.
+    # This causes some packages with large dependency graphs to hit
+    # the ARG_MAX threshold on macOS (and even Linux!)
+    if [[ -f "$1/nix-support/skip-flags" ]]; then
+        return
+    fi
+
     # See ../setup-hooks/role.bash
     local role_post role_pre
     getHostRoleEnvHook

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -66,6 +66,15 @@ set -u
 # over no state, and there's no @-substitutions within, so any redefined
 # function is guaranteed to be exactly the same.
 ccWrapper_addCVars () {
+    # If a package has this file, we will not add any flags
+    # automatically. This is needed to fix the ARG_MAX issue in
+    # Haskell packages where many unused Haskell LDFLAGS are added.
+    # This causes some packages with large dependency graphs to hit
+    # the ARG_MAX threshold on macOS (and even Linux!)
+    if [[ -f "$1/nix-support/skip-flags" ]]; then
+        return
+    fi
+
     # See ../setup-hooks/role.bash
     local role_post role_pre
     getHostRoleEnvHook

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -422,6 +422,13 @@ stdenv.mkDerivation ({
     ''}
     ${optionalString enableSeparateDataOutput "mkdir -p $data"}
 
+    # Try to prevent hitting ARG_MAX
+    # skip-flags tells the wrappers to skip adding the LDFLAGS &
+    # CFLAGS automatically. This is unused in Haskell packages where
+    # dependencies are handled right here in the generic builder.
+    mkdir -p $out/nix-support
+    echo > $out/nix-support/skip-flags
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
This is a new flag that is checked to prevent the wrappers from adding
CFLAGS & LDFLAGS. It should be used sparingly but in the case of
Haskell packages, it is necessary to avoid hitting ARG_MAX limits.
Haskell has its own way of handling deps which is done in
generic-builder.nix. Skipping the {C,LD}FLAGS is a harmless way to
reduce ARG_MAX.

Related to PR #43713.

/cc @angerman @ericson2314 @peti

This is still a work in progress. Unfortunately it is a mass-rebuild so it could take a while. I am still waiting on building the stdenv. It should accomplish the same thing as PR #43713 with the upside of avoiding the need to move the ```--libdir`` flag.