### PR TITLE
pssh: ensure runtime dependencies are propagated

### DIFF
--- a/pkgs/tools/networking/pssh/default.nix
+++ b/pkgs/tools/networking/pssh/default.nix
@@ -20,6 +20,8 @@ pythonPackages.buildPythonApplication rec {
     done
   '';
 
+  propagatedBuildDependencies = [ openssh rsync ];
+
   meta = with stdenv.lib; {
     description = "Parallel SSH Tools";
     longDescription = ''


### PR DESCRIPTION
###### Motivation for this change
Makes sure that `openssh` and `rsync` are present when running `pssh` or `prsync`.  These tools give very confusing error messages if they aren't.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

