### PR TITLE
pipenv: 2018.5.18 -> 2018.7.1

### DIFF
--- a/pkgs/development/python-modules/arpeggio/default.nix
+++ b/pkgs/development/python-modules/arpeggio/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, glibcLocales
+}:
+
+buildPythonPackage rec {
+  pname = "Arpeggio";
+  version = "1.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0rvgwc2nxqf22fjnggswqw2i3sn1f2hhq043vhjr3af7ldfai3l2";
+  };
+
+  # Shall not be needed for next release
+  LC_ALL = "en_US.UTF-8";
+  buildInputs = [ glibcLocales ];
+
+  meta = {
+    description = "Packrat parser interpreter";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchFromGitHub, python
-, isPy3k, attrs, coverage, enum34
+, isPy3k, attrs, coverage, enum34, fetchPypi
 , doCheck ? true, pytest, pytest_xdist, flake8, flaky, mock
 }:
 buildPythonPackage rec {
@@ -9,23 +9,24 @@ buildPythonPackage rec {
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "3.45.2";
+  version = "3.66.2";
   pname = "hypothesis";
 
-  # Upstream prefers github tarballs
+  # Use github tarballs that includes tests
   src = fetchFromGitHub {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
-    rev = version;
-    sha256 = "063sn5m1966gvm3wrlxczdq4vw0r94h3nd9xpr94qxahpg2r4bpb";
+    rev = "hypothesis-python-${version}";
+    sha256 = "17ywbwa76z7f0pgash0003fvm25fsj7hxdrdiprdbv99y3i8bm88";
   };
+
+  postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
 
   propagatedBuildInputs = [ attrs coverage ] ++ lib.optional (!isPy3k) [ enum34 ];
 
   checkInputs = [ pytest pytest_xdist flaky mock ];
   inherit doCheck;
 
-  # https://github.com/DRMacIver/hypothesis/issues/300
   checkPhase = ''
     rm tox.ini # This file changes how py.test runs and breaks it
     py.test tests/cover

--- a/pkgs/development/python-modules/invoke/default.nix
+++ b/pkgs/development/python-modules/invoke/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "invoke";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0aiy1xvk1f91246zxd1zqrm679vdvd10h843a2na41cqr3cflpi6";
+  };
+
+  # errors with vendored libs
+  doCheck = false;
+
+  meta = {
+    description = "Pythonic task execution";
+    license = lib.licenses.bsd2;
+  };
+}

--- a/pkgs/development/python-modules/parver/default.nix
+++ b/pkgs/development/python-modules/parver/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, attrs
+, pytest
+, hypothesis
+, pretend
+, arpeggio
+}:
+
+buildPythonPackage rec {
+  pname = "parver";
+  version = "0.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "05dsjmk3ckd175ln8smxr1f6l6qsrjyd8s5vfqc5x7fii3vgyjmc";
+  };
+
+  propagatedBuildInputs = [ six attrs arpeggio ];
+  checkInputs = [ pytest hypothesis pretend ];
+
+  meta = {
+    description = "parver allows parsing and manipulation of PEP 440 version numbers.";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -2,16 +2,16 @@
 with python3Packages; buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "pipenv";
-    version = "2018.5.18";
+    version = "2018.7.1";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1knyknmykjj7gixdpfyns77sv4mizl68addk09ajmw9z5aqaif84";
+      sha256 = "0fpnfxdkymz9an3m6isq5g24ykd6hnkjc8llfnvbmnakz1sd0sxv";
     };
 
     LC_ALL = "en_US.UTF-8";
 
-    propagatedBuildInputs = [ pew pip requests flake8 ];
+    propagatedBuildInputs = [ pew pip requests flake8 parver invoke ];
 
     doCheck = false;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -264,6 +264,10 @@ in {
 
   discordpy = callPackage ../development/python-modules/discordpy { };
 
+  parver = callPackage ../development/python-modules/parver { };
+  arpeggio = callPackage ../development/python-modules/arpeggio { };
+  invoke = callPackage ../development/python-modules/invoke { };
+
   distorm3 = callPackage ../development/python-modules/distorm3 { };
 
   dogtail = callPackage ../development/python-modules/dogtail { };


### PR DESCRIPTION
###### Things done

Checked that pipenv works.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

