### PR TITLE
haskell: remove unused LDFLAGS in generic-builder

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -145,8 +145,8 @@ self: super: builtins.intersectAttrs super {
   gtksourceview2 = addPkgconfigDepend super.gtksourceview2 pkgs.gtk2;
   gtk-traymanager = addPkgconfigDepend super.gtk-traymanager pkgs.gtk3;
 
-  # Add necessary reference to gtk3 package, plus specify needed dbus version, plus turn on strictDeps to fix build
-  taffybar = ((addPkgconfigDepend super.taffybar pkgs.gtk3).overrideDerivation (drv: { strictDeps = true; }));
+  # Add necessary reference to gtk3 package
+  taffybar = addPkgconfigDepend super.taffybar pkgs.gtk3;
 
   # Add necessary reference to gtk3 package
   gi-dbusmenugtk3 = addPkgconfigDepend super.gi-dbusmenugtk3 pkgs.gtk3;

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -213,6 +213,19 @@ let
 
   buildPkgDb = ghcName: packageConfDir: ''
     if [ -d "$p/lib/${ghcName}/package.conf.d" ]; then
+
+      # Remove ldflags to lessen number of args. Once we have found a
+      # package config for this package we can safely assume that GHC
+      # can use the package configuration to discover everything. That
+      # means it should not need the traditional unix style `-L' flag
+      # anymore. This is kind of a hack but one that can cut down on
+      # LDFLAGS tremendously helping to alleviate the ARG_MAX limit
+      # issue found in Nixpkgs.
+      NIX_LDFLAGS=$(echo "$NIX_LDFLAGS" | \
+                    sed "s,-L$p/lib\( \+\|$\),,g")
+      NIX_BUILD_LDFLAGS=$(echo "$NIX_BUILD_LDFLAGS" | \
+                          sed "s,-L$p/lib\( \+\|$\),,g")
+
       cp -f "$p/lib/${ghcName}/package.conf.d/"*.conf ${packageConfDir}/
       continue
     fi


### PR DESCRIPTION
Once haskell has found a package.conf.d file, it no longer needs the
traditional -L flag. This commit removes the additional arguments from
NIX_LDFLAGS to prevent some systems from hitting the ARG_MAX limit.
This should accomplish the same thing as moving the $libdir somewhere
else without some of the breakages that would come with.

I don't have a macOS machine right now so cannot verify that this fixes the original issue. I can verify that it correctly removes the extra args from NIX_LDFLAGS though.

/cc @angerman @peti @Ericson2314 @domenkozar @nh2