### PR TITLE
plex-media-player: init at 2.14.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2057,6 +2057,11 @@
     github = "kuznero";
     name = "Roman Kuznetsov";
   };
+  kylewlacy = {
+    email = "kylelacy+nix@pm.me";
+    github = "kylewlacy";
+    name = "Kyle Lacy";
+  };
   lasandell = {
     email = "lasandell@gmail.com";
     github = "lasandell";

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -1,0 +1,86 @@
+{ stdenv, fetchFromGitHub, fetchurl, makeDesktopItem, pkgconfig, cmake, python3
+, libX11, libXrandr, qtbase, qtwebchannel, qtwebengine, qtx11extras
+, libvdpau, SDL2, mpv, libGL }:
+let
+  # During compilation, a CMake bundle is downloaded from `artifacts.plex.tv`,
+  # which then downloads a handful of web client-related files. To enable
+  # sandboxed builds, we manually download them and save them so these files
+  # are fetched ahead-of-time instead of during the CMake build. Whenever
+  # plex-media-player is updated, the versions for these files are changed,
+  # so the build IDs (and SHAs) below will need to be updated!
+  depSrcs = rec {
+    webClientBuildId = "56-23317d81e49651";
+    webClientDesktopBuildId = "3.57.1-1e49651";
+    webClientTvBuildId = "3.60.1-23317d8";
+
+    webClient = fetchurl {
+      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/buildid.cmake";
+      sha256 = "1a48a65zzdx347kfnxriwkb0yjlhvn2g8jkda5pz10r3lwja0gbi";
+    };
+    webClientDesktopHash = fetchurl {
+      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1";
+      sha256 = "04wdgpsh33y8hyjhjrfw6ymf9g002jny7hvhld4xp33lwxhd2j5w";
+    };
+    webClientDesktop = fetchurl {
+      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-desktop-${webClientDesktopBuildId}.tar.xz";
+      sha256 = "1asw9f84z9sm3w7ifnc7j631j84rgx23c6msmn2dnw48ckv3bj2z";
+    };
+    webClientTvHash = fetchurl {
+      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz.sha1";
+      sha256 = "0d1hsvmpwczwx442f8qdvfr8c3w84630j9qwpg2y4qm423sgdvja";
+    };
+    webClientTv = fetchurl {
+      url = "https://artifacts.plex.tv/web-client-pmp/${webClientBuildId}/web-client-tv-${webClientTvBuildId}.tar.xz";
+      sha256 = "1ih3l5paf1jl68b1xq3iqqmvs3m07fybz57hcz4f78v0gwq2kryq";
+    };
+  };
+in stdenv.mkDerivation rec {
+  name = "plex-media-player-${version}";
+  version = "2.14.1.880";
+  vsnHash = "301a4b6c";
+
+  src = fetchFromGitHub {
+    owner = "plexinc";
+    repo = "plex-media-player";
+    rev = "v${version}-${vsnHash}";
+    sha256 = "0xz41r697vl6s3qvy6jwriv3pb9cfy61j6sydvdq121x5a0jnh9a";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake python3 ];
+  buildInputs = [ libX11 libXrandr qtbase qtwebchannel qtwebengine qtx11extras
+                  libvdpau SDL2 mpv libGL ];
+
+  desktopItem = makeDesktopItem {
+    name = "plex-media-player";
+    exec = "plexmediaplayer";
+    icon = "plex-media-player";
+    comment = "View your media";
+    desktopName = "Plex Media Player";
+    genericName = "Media Player";
+    categories = "AudioVideo;Video;Player;TV;";
+  };
+
+  preConfigure = with depSrcs; ''
+    mkdir -p build/dependencies
+    ln -s ${webClient} build/dependencies/buildid-${webClientBuildId}.cmake
+    ln -s ${webClientDesktopHash} build/dependencies/web-client-desktop-${webClientDesktopBuildId}.tar.xz.sha1
+    ln -s ${webClientDesktop} build/dependencies/web-client-desktop-${webClientDesktopBuildId}.tar.xz
+    ln -s ${webClientTvHash} build/dependencies/web-client-tv-${webClientTvBuildId}.tar.xz.sha1
+    ln -s ${webClientTv} build/dependencies/web-client-tv-${webClientTvBuildId}.tar.xz
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/{applications,pixmaps}
+    cp ${src}/resources/images/icon.png $out/share/pixmaps/plex-media-player.png
+    cp ${desktopItem}/share/applications/* $out/share/applications
+  '';
+
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DQTROOT=${qtbase}" ];
+
+  meta = with stdenv.lib; {
+    description = "Streaming media player for Plex";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ kylewlacy ];
+    homepage = https://plex.tv;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17830,6 +17830,8 @@ with pkgs;
     gtksharp = gtk-sharp-2_0;
   };
 
+  plex-media-player = libsForQt59.callPackage ../applications/video/plex-media-player { };
+
   plover = recurseIntoAttrs (callPackage ../applications/misc/plover { });
 
   plugin-torture = callPackage ../applications/audio/plugin-torture { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the official "next generation" [Plex Media Player](https://github.com/plexinc/plex-media-player) client. It pairs well with `plex-media-server`, which is already in Nixpkgs!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(PMP's build system is fairly complicated since it downloads CMake bundles that download _other_ files at build time. In the same vein as the AUR pacakge, and to ensure the build works during sandboxed builds, all of the downloaded files are fetched _before_ building, using `fetchurl`. If anyone has any suggestions for refactoring the `preConfigure` step, I'm open to ideas!)

