### PR TITLE
Backport of #43811 jdk updates (help needed) 

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
@@ -29,7 +29,7 @@ assert stdenv.system == "x86_64-linux";
 assert swingSupport -> xorg != null;
 
 let
-  version = "10.0.1";
+  version = "10.0.2";
 
   downloadUrlBase = http://www.oracle.com/technetwork/java/javase/downloads;
 
@@ -52,19 +52,19 @@ let result = stdenv.mkDerivation rec {
       requireFile {
         name = "jdk-${version}_linux-x64_bin.tar.gz";
         url =  "${downloadUrlBase}/jdk10-downloads-4416644.html";
-        sha256 = "1975s6cn2lxb8jmxp236afvq6hhxqrx5jix8aqm46f5gwr2xd3mf";
+        sha256 = "0arpzac64apji1s8d0gzizkvrjz0fbhz7l34af1j0365ac6w4cv6";
       }
     else if packageType == "JRE" then
       requireFile {
         name = "jre-${version}_linux-x64_bin.tar.gz";
         url = "${downloadUrlBase}/jre10-downloads-4417026.html";
-        sha256 = "11pb8cwzmalc6ax735m84g13jh1mrfc8g84b5qypnmqjjdv6fpiq";
+        sha256 = "0pc4a0a3fl6874vfaflf6jvpm9da647vp41pj0hihkspjyjhjabx";
       }
     else if packageType == "ServerJRE" then
       requireFile {
         name = "serverjre-${version}_linux-x64_bin.tar.gz";
         url = "${downloadUrlBase}/sjre10-downloads-4417025.html";
-        sha256 = "0hvfqgr22sq9zyqc496vqgg5ail189h3a4pazp39i8n86brd48lw";
+        sha256 = "0hbcb4c6ncy0sbz02gyygyqcwkz0xpv4fwrx4sripia6vph9592c";
       }
     else abort "unknown package Type ${packageType}";
 


### PR DESCRIPTION
Backport of parts of #43811

oraclejdk: 10.0.1 -> 10.0.2 [Critical security fixes]

(cherry picked from commit defa76037fcc12560b6e6ff36860d58096ba39bb)

###### Motivation for this change
I am unsure what the correct approach here. From the release notes, it seems like we should drop the oraclejdk8psu_distro entirely, but is that a sensible thing to do on our stable branch?

Opinions wanted. :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

