### PR TITLE
gitlab: fix module and corresponding test

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -658,7 +658,7 @@ in {
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        TimeoutSec = "infinity";
+        TimeoutSec = "1day";
         Restart = "on-failure";
         WorkingDirectory = "${cfg.packages.gitlab}/share/gitlab";
         ExecStart = "${cfg.packages.gitlab.rubyEnv}/bin/unicorn -c ${cfg.statePath}/config/unicorn.rb -E production";

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -569,6 +569,10 @@ in {
         ${pkgs.openssl}/bin/openssl rand -hex 32 > ${cfg.statePath}/config/gitlab_shell_secret
 
         mkdir -p /run/gitlab
+
+        mkdir -p ${cfg.statePath}/uploads
+        ln -sf ${cfg.statePath}/uploads /run/gitlab/uploads
+
         mkdir -p ${cfg.statePath}/log
         [ -d /run/gitlab/log ] || ln -sf ${cfg.statePath}/log /run/gitlab/log
         [ -d /run/gitlab/tmp ] || ln -sf ${cfg.statePath}/tmp /run/gitlab/tmp
@@ -590,7 +594,7 @@ in {
         if [ -e ${cfg.statePath}/lib ]; then
           rm ${cfg.statePath}/lib
         fi
-        ln -sf ${pkgs.gitlab}/share/gitlab/lib ${cfg.statePath}/lib
+        ln -sf ${cfg.packages.gitlab}/share/gitlab/lib ${cfg.statePath}/lib
         cp ${cfg.packages.gitlab}/share/gitlab/VERSION ${cfg.statePath}/VERSION
 
         # JSON is a subset of YAML

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -297,7 +297,7 @@ in rec {
   tests.fsck = callTest tests/fsck.nix {};
   tests.fwupd = callTest tests/fwupd.nix {};
   tests.gdk-pixbuf = callTest tests/gdk-pixbuf.nix {};
-  #tests.gitlab = callTest tests/gitlab.nix {};
+  tests.gitlab = callTest tests/gitlab.nix {};
   tests.gitolite = callTest tests/gitolite.nix {};
   tests.gjs = callTest tests/gjs.nix {};
   tests.gocd-agent = callTest tests/gocd-agent.nix {};

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -7,8 +7,8 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   nodes = {
-    gitlab = { ... }: {
-      virtualisation.memorySize = 768;
+    gitlab = { config, ... }: {
+      virtualisation.memorySize = 2048;
 
       services.nginx = {
         enable = true;

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -19,7 +19,7 @@ import ./make-test.nix ({ pkgs, ...} : {
         };
       };
 
-      systemd.services.gitlab.serviceConfig.TimeoutStartSec = "10min";
+      systemd.services.gitlab.serviceConfig.TimeoutStartSec = "30min";
       services.gitlab = {
         enable = true;
         databasePassword = "dbPassword";


### PR DESCRIPTION
###### Motivation for this change

This fixes some things I've encountered while trying to use this module:
- uploads symlink from store was broken, causing migrations on fresh
  installation to fail
- Get `lib` folder from configured package, not from a global `gitlab`
  one
- Increase memory limit, so the test will be able to pass

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

