### PR TITLE
cups-toshiba-estudio: 7.51 -> 7.89

### DIFF
--- a/pkgs/misc/cups/drivers/estudio/default.nix
+++ b/pkgs/misc/cups/drivers/estudio/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cups-toshiba-estudio-${version}";
-  version = "7.51";
+  version = "7.89";
 
   src = fetchurl {
-    url = http://business.toshiba.com/downloads/KB/f1Ulds/14079/TOSHIBA_ColorMFP_CUPS.tar;
-    sha256 = "3741bb79723495da5cb5a3971ae8c6042b6c71a6264af8f25aecf721f1f0752f";
+    url = http://business.toshiba.com/downloads/KB/f1Ulds/15178/TOSHIBA_ColorMFP_CUPS.tar;
+    sha256 = "0qz4r7q55i0adf4fv3aqnfqgi2pz3jb1jixkqm9x6nk4vanyjf4r";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change
Adding `pkgs.cups-toshiba-estudio` to `services.printing.drivers` no longer works (404 on download URL)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Tested printing manually

---