### PR TITLE
vulnix: 1.6.3 -> 1.7

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -2,16 +2,21 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "vulnix";
-  version = "1.6.3";
+  version = "1.7";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0ia71l0210dgcxf63bg07csx40nmpdghr4mszz91qrri7lsa5qqi";
+    sha256 = "16228w0vakb515cnrk4akadh0m21abiv8rv574jarcsf7359xslj";
   };
 
   buildInputs = [ ronn ];
 
-  checkInputs = with pythonPackages; [ freezegun pytest pytestcov pytest-flake8 ];
+  checkInputs = with pythonPackages; [
+    freezegun
+    pytest
+    pytestcov
+    pytest-flake8
+  ];
 
   propagatedBuildInputs = [
     nix
@@ -27,9 +32,7 @@ pythonPackages.buildPythonApplication rec {
 
   outputs = [ "out" "doc" ];
 
-  postBuild = ''
-    make -C doc
-  '';
+  postBuild = "make -C doc";
 
   checkPhase = "py.test src/vulnix";
 
@@ -45,7 +48,7 @@ pythonPackages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     description = "NixOS vulnerability scanner";
     homepage = https://github.com/flyingcircusio/vulnix;
-    license = licenses.bsd2;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ ckauhaus plumps ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The updated version brings selective whitelisting, i.e. when some CVEs
of a package are whitelisted and others are not, only the new CVEs are
reported.

###### Things done

Update version, correct license to match upstream BSD-3-Clause, clean up source.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) 165915112 -> 165927872
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
