### PR TITLE
WIP lib.duration: add basic duration functions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -17,6 +17,7 @@ let
 
     # datatypes
     attrsets = callLibs ./attrsets.nix;
+    durations = callLibs ./durations.nix;
     lists = callLibs ./lists.nix;
     strings = callLibs ./strings.nix;
     stringsWithDeps = callLibs ./strings-with-deps.nix;

--- a/lib/durations.nix
+++ b/lib/durations.nix
@@ -1,0 +1,245 @@
+/*
+ * Duration manipulation functions.
+ */
+
+{ lib }:
+
+with lib;
+with builtins;
+
+let
+
+  # Using the definitions of systemd.time(7).
+  unitToScale = rec {
+    us = 1;
+    usec = us;
+
+    ms = 1000 * us;
+    msec = ms;
+
+    s = 1000 * ms;
+    seconds = s;
+    second = s;
+    sec = s;
+
+    m = 60 * s;
+    minutes = m;
+    minute = m;
+    min = m;
+
+    h = 60 * m;
+    hours = h;
+    hour = h;
+    hr = h;
+
+    d = 24 * h;
+    days = d;
+    day = d;
+
+    w = 7 * d;
+    weeks = w;
+    week = w;
+
+    M = 2630016 * s;            # 30.44 days
+    months = M;
+    month = M;
+
+    y = 31557600 * s;           # 365.25 days
+    years = y;
+    year = y;
+  };
+
+  parseToNat = str:
+    let
+      maybeNat = fromJSON str;
+    in
+      if match "[[:space:]]*[[:digit:]]+" str != null && isInt maybeNat
+      then { ok = maybeNat; }
+      else { error = "Expected natural number but got \"${str}\"."; };
+
+  parseToScale = str:
+      if hasAttr str unitToScale
+      then { ok = unitToScale.${str}; }
+      else { error = "Expected time unit but got \"${str}\"."; };
+
+  scaleToMillis = magnitudeStr: unitStr:
+    let
+      maybeMagnitude = parseToNat magnitudeStr;
+      maybeScale = parseToScale unitStr;
+    in
+      if magnitudeStr == "" && unitStr == ""
+      then mkDuration 0
+      else
+        if maybeMagnitude ? ok
+        then
+          if maybeScale ? ok
+          then mkDuration (maybeMagnitude.ok * maybeScale.ok)
+          else maybeScale
+        else maybeMagnitude;
+
+  parseDuration = str:
+    let
+      err = msg: { error = "Invalid duration \"${str}\": ${msg}"; };
+      lstRaw = split "[[:space:]]*([a-zA-Z]+)[[:space:]]*" str;
+      lstParts = partition isString lstRaw;
+      magnitudes = lstParts.right;
+      units = map (xs: assert length xs == 1; head xs) lstParts.wrong ++ [""];
+      lstScaled = zipListsWith scaleToMillis magnitudes units;
+      add = acc: dur:
+        if acc ? duration
+        then
+          if dur ? duration
+          then mkDuration (acc.duration + dur.duration)
+          else err dur.error
+        else acc;
+    in
+      if str == ""
+      then err "Cannot be empty string."
+      else foldl' add (mkDuration 0) lstScaled;
+
+  # Duration value constructor.
+  mkDuration = ms: {
+    duration = ms;
+    __toString = self:
+      let
+        mkField = state: unit:
+          let
+            scale = unitToScale.${unit};
+            n = state.remainder / scale;
+          in
+            {
+              fields = state.fields ++ optional (n > 0) (toString n + unit);
+              remainder = state.remainder - n * scale;
+            };
+
+        zero = { fields = []; remainder = self.duration; };
+
+        result = foldl' mkField zero [ "y" "M" "w" "d" "h" "m" "s" "ms" "us" ];
+      in
+        toString result.fields;
+  };
+
+in
+
+rec {
+
+  # Parses a string representation of a time duration.
+  #
+  # The accepted syntax is
+  #
+  #     duration ::= (nat " "* unit " "*)+
+  #     nat ::= decimal-digit+
+  #     decimal-digit ::= "0" | "1" | … | "9"
+  #     unit ::=
+  #         "us" | "usec"
+  #       | "ms" | "msec"
+  #       |  "s" | "seconds" | "second" | "sec"
+  #       |  "m" | "minutes" | "minute" | "min"
+  #       |  "h" | "hours"   | "hour"   | "hr"
+  #       |  "d" | "days"    | "day"
+  #       |  "w" | "weeks"   | "week"
+  #       |  "M" | "months"  | "month"
+  #       |  "y" | "years"   | "year"
+  #
+  # and is a subset of the format supported by systemd as described in
+  # systemd.time(7).
+  #
+  # The return value is a set of the form
+  #
+  #     { duration = <duration in microseconds> ; … }
+  #
+  # on success and
+  #
+  #     { error = <error message> ; }
+  #
+  # on failure.
+  #
+  # Example:
+  #
+  #     nix-repl> with lib.durations; toUsec (parse "1d")
+  #     86400000000
+  #
+  #     nix-repl> with lib.durations; toUsec (parse "8d 30h 0m 177s 1ms")
+  #     799377001000
+  #
+  #     nix-repl> with lib.durations; parse "1dd"
+  #     { error = "Invalid duration \"1dd\": Expected time unit but got \"dd\"."; }
+  #
+  #     nix-repl> with lib.durations; parse "1h 10"
+  #     { error = "Invalid duration \"1h 10\": Expected time unit but got \"\"."; }
+  #
+  parse = parseDuration;
+
+  # Parses a string representation of a time duration.
+  #
+  # However, if given an integer as input this function will instead
+  # produce a duration of the integer value scaled by the given
+  # fallback unit.
+  #
+  # Example:
+  #
+  #    nix-repl> with lib.durations; toUsec (parseWithIntFallback "s" "5h")
+  #    18000000000
+  #
+  #    nix-repl> with lib.durations; toUsec (parseWithIntFallback "s" 5) 
+  #    5000000
+  #
+  #    nix-repl> with lib.durations; parseWithIntFallback "y" "foo"
+  #    { error = "Invalid duration \"foo\": Expected natural number but got \"\"."; }
+  parseWithIntFallback = fallbackUnit: value:
+    if isInt value
+    then mkDuration (value * unitToScale.${fallbackUnit})
+    else parse value;
+
+  # Given a duration returns the number of microseconds as an integer.
+  toUsec = d: d.duration;
+
+  # Given a duration returns the number of milliseconds as an integer.
+  toMsec = d: d.duration / (0.0 + unitToScale.ms);
+
+  # Given a duration returns the number of seconds as a float.
+  toSeconds = d: d.duration / (0.0 + unitToScale.s);
+
+  # Evaluates to 1 if tests pass, otherwise throws an error.
+  tests =
+    assert parse "" == {
+      error = "Invalid duration \"\": Cannot be empty string.";
+    };
+
+    assert parse "1" == {
+      error = "Invalid duration \"1\": Expected time unit but got \"\".";
+    };
+
+    assert parse "d" == {
+      error = "Invalid duration \"d\": Expected natural number but got \"\".";
+    };
+
+    assert toUsec (parse "1 us") == 1;
+    assert toUsec (parse "1 ms") == 1000;
+    assert toUsec (parse "5 msec") == 5000;
+    assert toUsec (parse "1 s") == 1000000;
+    assert toUsec (parse "1 m") == 60000000;
+    assert toUsec (parse "1 h") == 3600000000;
+    assert toUsec (parse "1 d") == 86400000000;
+    assert toUsec (parse "1 w") == 604800000000;
+    assert toUsec (parse "1 week") == 604800000000;
+    assert toUsec (parse "1 M") == 2630016000000;
+    assert toUsec (parse "1 months") == 2630016000000;
+    assert toUsec (parse "1 y") == 31557600000000;
+    assert toUsec (parse "1 years") == 31557600000000;
+    assert toUsec (parse "1 ms 10ms") == 11000;
+    assert toUsec (parse "1ms 1s") == 1001000;
+    assert toUsec (parse "   8d 30h 0m 177s 1ms ") == 799377001000;
+
+    assert toMsec (parse "500 ms") == 500.0;
+    assert toMsec (parse "500s 500ms") == 500500.0;
+
+    assert toSeconds (parse "500 ms") == 0.5;
+    assert toSeconds (parse "500s 500ms") == 500.5;
+
+    assert toString (parse "1ms 1s") == "1s 1ms";
+    assert toString (parse "8d 30h 0m 177s 1ms") == "1w 2d 6h 2m 57s 1ms";
+
+    1;
+
+}

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,6 +149,10 @@ checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-long-list.ni
 # Check loaOf with many merges of lists.
 checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-merges.nix
 
+# Check duration.
+checkConfigOutput "1s 1ms" config.result ./declare-duration.nix ./define-duration-ok.nix
+checkConfigError 'The option value .* in .* is not of type.*time duration.*' config.result ./declare-duration.nix ./define-duration-error.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/declare-duration.nix
+++ b/lib/tests/modules/declare-duration.nix
@@ -1,0 +1,18 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options = {
+    value = mkOption {
+      type = types.duration;
+      apply = durations.parse;
+    };
+
+    result = mkOption {
+      type = types.str;
+    };
+  };
+
+  config.result = toString config.value;
+}

--- a/lib/tests/modules/define-duration-error.nix
+++ b/lib/tests/modules/define-duration-error.nix
@@ -1,0 +1,7 @@
+{ config, lib, ... }:
+
+{
+  config = {
+    value = "bad duration";
+  };
+}

--- a/lib/tests/modules/define-duration-ok.nix
+++ b/lib/tests/modules/define-duration-ok.nix
@@ -1,0 +1,7 @@
+{ config, lib, ... }:
+
+{
+  config = {
+    value = "1s 1ms";
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -412,6 +412,14 @@ rec {
         functor = (defaultFunctor name) // { payload = values; binOp = a: b: unique (a ++ b); };
       };
 
+    # A duration in time.
+    duration = mkOptionType rec {
+      name = "duration";
+      description = "time duration";
+      check = x: !(lib.durations.parse x ? error);
+      merge = mergeOneOption;
+    };
+
     # Either value of type `t1` or `t2`.
     either = t1: t2: mkOptionType rec {
       name = "either";


### PR DESCRIPTION
###### Motivation for this change

I wanted a more structured and unified way to represent various time durations (e.g. timeouts and such things) in [Home Manager](https://github.com/rycee/home-manager) and figured it was general enough that there might be an interest to add it to Nixpkgs instead of just HM.

While the majority of code is centered around a few utility functions, my main interest is the included `duration` type for the module system. Using it you can have a module along the lines

```nix
{ config, lib, ... }:

with lib;

{
  options = {
    value = mkOption {
      type = types.duration;
      apply = durations.parse;
    };

    result = mkOption {
      type = types.str;
    };
  };

  config = {
    value = "1d 12h";
    result = "In millis: ${toString (durations.toMillis config.value)}";
  };
}
```

and `result` would then contain "In millis: 129600000".

I don't consider this ready for merge yet, this is mainly for discussion whether it is of any interest for inclusion in Nixpkgs.

###### Things done

The included tests pass.