### PR TITLE
singular: 4.1.1p1 -> 4.1.1p2

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchurl, gmp, bison, perl, ncurses, readline, coreutils, pkgconfig
+, lib
 , autoreconfHook
 , file
 , flint
@@ -9,21 +10,25 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "singular-${version}${patchVersion}";
-  version = "4.1.1";
-  patchVersion = "p1";
+  name = "singular-${version}";
+  version = "4.1.1p2";
 
-  urlVersion = builtins.replaceStrings [ "." ] [ "-" ] version;
-  src = fetchurl {
-    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${urlVersion}/singular-${version}${patchVersion}.tar.gz";
-    sha256 = "0wvgz7l1b7zkpmim0r3mvv4fp8xnhlbz4c7hc90rn30snlansnf1";
+  src = let
+    # singular sorts its tarballs in directories by base release (without patch version)
+    # for example 4.1.1p1 will be in the directory 4-1-1
+    baseVersion = builtins.head (lib.splitString "p" version);
+    urlVersion = builtins.replaceStrings [ "." ] [ "-" ] baseVersion;
+  in
+  fetchurl {
+    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${urlVersion}/singular-${version}.tar.gz";
+    sha256 = "07x9kri8vl4galik7lr6pscq3c51n8570pyw64i7gbj0m706f7wf";
   };
 
   configureFlags = [
     "--with-ntl=${ntl}"
-  ] ++stdenv.lib.optionals enableFactory [
+  ] ++ lib.optionals enableFactory [
     "--enable-factory"
-  ] ++ stdenv.lib.optionals enableGfanlib [
+  ] ++ lib.optionals enableGfanlib [
     "--enable-gfanlib"
   ];
 
@@ -42,7 +47,7 @@ stdenv.mkDerivation rec {
     readline
     ntl
     flint
-  ] ++ stdenv.lib.optionals enableGfanlib [
+  ] ++ lib.optionals enableGfanlib [
     cddlib
   ];
   nativeBuildInputs = [
@@ -60,10 +65,12 @@ stdenv.mkDerivation rec {
       -i '{}' ';'
   '';
 
-  hardeningDisable = stdenv.lib.optional stdenv.isi686 "stackprotector";
+  hardeningDisable = lib.optional stdenv.isi686 "stackprotector";
 
   # The Makefile actually defaults to `make install` anyway
-  buildPhase = "true;";
+  buildPhase = ''
+    # do nothing
+  '';
 
   installPhase = ''
     mkdir -p "$out"
@@ -77,7 +84,7 @@ stdenv.mkDerivation rec {
   # simple test to make sure singular starts and finds its libraries
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/Singular -c 'LIB "freegb.lib"; exit;'
+    "$out/bin/Singular" -c 'LIB "freegb.lib"; exit;'
     if [ $? -ne 0 ]; then
         echo >&2 "Error loading the freegb library in Singular."
         exit 1
@@ -86,9 +93,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A CAS for polynomial computations";
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ raskin timokau ];
+    # 32 bit x86 fails with some link error: `undefined reference to `__divmoddi4@GCC_7.0.0'`
     platforms = subtractLists platforms.i686 platforms.linux;
     license = licenses.gpl3; # Or GPLv2 at your option - but not GPLv4
     homepage = http://www.singular.uni-kl.de;


### PR DESCRIPTION
###### Motivation for this change

Minor patch update and some formatting improvements.

I have also added myself as the maintainer and simplified the version attribute (at the cost of some complexity for computing the source URL). That should help the package update bot in doing our work for us.

That is not necessary for this to be merged, but it would be nice if someone with access to a 32 bit, x86 linux machine could test this build. I'd guess that whatever issue there was with that is fixed by now.

@7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

