### PR TITLE
python3Packages.zconfig: remove test that relies on setlocale failing

### DIFF
--- a/pkgs/development/python-modules/zconfig/default.nix
+++ b/pkgs/development/python-modules/zconfig/default.nix
@@ -15,7 +15,8 @@ buildPythonPackage rec {
     sha256 = "de0a802e5dfea3c0b3497ccdbe33a5023c4265f950f33e35dd4cf078d2a81b19";
   };
 
-  patches = [ ./skip-broken-test.patch ];
+  patches = [ ./skip-broken-test.patch ]
+    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./remove-setlocale-test.patch;
 
   buildInputs = [ manuel docutils ];
   propagatedBuildInputs = [ zope_testrunner ];

--- a/pkgs/development/python-modules/zconfig/remove-setlocale-test.patch
+++ b/pkgs/development/python-modules/zconfig/remove-setlocale-test.patch
@@ -1,0 +1,24 @@
+From 43fd87037be1c98b6afa20f179f2e2d8ef5491ba Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Fri, 20 Jul 2018 10:07:22 -0500
+Subject: [PATCH] remove test that fails w/musl (setlocale() always succeeds)
+
+---
+ ZConfig/tests/test_datatypes.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/ZConfig/tests/test_datatypes.py b/ZConfig/tests/test_datatypes.py
+index 7c8d80c..addecd2 100644
+--- a/ZConfig/tests/test_datatypes.py
++++ b/ZConfig/tests/test_datatypes.py
+@@ -229,7 +229,6 @@ class DatatypeTestCase(unittest.TestCase):
+         convert = self.types.get("locale")
+         # Python supports "C" even when the _locale module is not available
+         self.assertEqual(convert("C"), "C")
+-        self.assertRaises(ValueError, convert, "locale-does-not-exist")
+ 
+     def test_datatype_port(self):
+         convert = self.types.get("port-number")
+-- 
+2.18.0
+


### PR DESCRIPTION
Fix w/musl.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---