### PR TITLE
postgresql updates: 10.4, 9.6.9, 9.5.13, 9.4.18, 9.3.23, CVE-2018-1115

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -107,9 +107,9 @@ in {
   };
 
   postgresql95 = common {
-    version = "9.5.12";
+    version = "9.5.13";
     psqlSchema = "9.5";
-    sha256 = "167nlrpsnqz63gafgn21j4yc2f5g1mpfkz8qxjxk2xs6crf6zs02";
+    sha256 = "1vm55q9apja6lg672m9xl1zq3iwv2zwnn0d0qr003zan1dmbh22l";
   };
 
   postgresql96 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -113,9 +113,9 @@ in {
   };
 
   postgresql96 = common {
-    version = "9.6.8";
+    version = "9.6.9";
     psqlSchema = "9.6";
-    sha256 = "0w7bwf19wbdd3jjbjv03cnx56qka4801srcbsayk9v792awv7zga";
+    sha256 = "0biy8j69dbvdmrag55pdszpc0702agzqhhcwdx21xp02mzim4ydr";
   };
 
   postgresql100 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -101,9 +101,9 @@ in {
   };
 
   postgresql94 = common {
-    version = "9.4.17";
+    version = "9.4.18";
     psqlSchema = "9.4";
-    sha256 = "1inpkwbr2xappz3kq3jr3hsn6mwn167nijcx406q8aq56p9hqcks";
+    sha256 = "1h64yjyrlz3ppsp9k6sm4jihg6n9i7mqhkx4p0hymqzmnbr3g0s2";
   };
 
   postgresql95 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -95,9 +95,9 @@ let
 in {
 
   postgresql93 = common {
-    version = "9.3.22";
+    version = "9.3.23";
     psqlSchema = "9.3";
-    sha256 = "06p9rk2bav41ybp8ra1bpf44avw9kl5s1wyql21n5awvlm5fs60v";
+    sha256 = "1jzncs7b6zrcgpnqjbjcc4y8303a96zqi3h31d3ix1g3vh31160x";
   };
 
   postgresql94 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -119,9 +119,9 @@ in {
   };
 
   postgresql100 = common {
-    version = "10.3";
+    version = "10.4";
     psqlSchema = "10.0";
-    sha256 = "06lkcwsf851z49zqcws5yc77s2yrbaazf2nvbk38hpp31rw6i8kf";
+    sha256 = "0j000bcs9w8wrllg8m7j1lxsd3n2x0yzkack5p35cmxx20iq2q0v";
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
Fixes [CVE-2018-1115](https://nvd.nist.gov/vuln/detail/CVE-2018-11235) in 10.4 and 9.6.9, for https://github.com/NixOS/nixpkgs/issues/43846

All release notes at https://www.postgresql.org/docs/10/static/release.html

Ping @thoughtpolice @lsix @adisbladis @fpletz  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

