### PR TITLE
file: patch for CVE-2018-10360

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
   buildInputs = [ zlib ];
 
+  patches = [ ./file-5.33-CVE-2018-10360.patch ];
+
   doCheck = true;
 
 

--- a/pkgs/tools/misc/file/file-5.33-CVE-2018-10360.patch
+++ b/pkgs/tools/misc/file/file-5.33-CVE-2018-10360.patch
@@ -1,0 +1,18 @@
+Avoid reading past the end of buffer
+
+CVE-2018-10360
+
+https://github.com/file/file/commit/a642587a9c9e2dd7feacdf513c3643ce26ad3c22
+
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -842,7 +842,8 @@ do_core_note(struct magic_set *ms, unsigned char *nbuf, uint32_t type,
+ 
+ 				cname = (unsigned char *)
+ 				    &nbuf[doff + prpsoffsets(i)];
+-				for (cp = cname; *cp && isprint(*cp); cp++)
++				for (cp = cname; cp < nbuf + size && *cp
++				    && isprint(*cp); cp++)
+ 					continue;
+ 				/*
+ 				 * Linux apparently appends a space at the end


### PR DESCRIPTION
from Gentoo, based on upstream commit.





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---