### PR TITLE
perl-cross: 1.1.8 -> 1.2, needed for newer perl versions

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -156,11 +156,11 @@ let
       platforms = platforms.all;
     };
   } // stdenv.lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
-    crossVersion = "1.1.8";
+    crossVersion = "1.2";
 
     perl-cross-src = fetchurlBoot {
       url = "https://github.com/arsv/perl-cross/releases/download/${crossVersion}/perl-cross-${crossVersion}.tar.gz";
-      sha256 = "072j491rpz2qx2sngbg4flqh4lx5865zyql7b9lqm6s1kknjdrh8";
+      sha256 = "02cic7lk91hgmsg8klkm2kv88m2a8y22m4m8gl4ydxbap2z7g42r";
     };
 
     # https://github.com/arsv/perl-cross/issues/60

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -163,19 +163,10 @@ let
       sha256 = "02cic7lk91hgmsg8klkm2kv88m2a8y22m4m8gl4ydxbap2z7g42r";
     };
 
-    # https://github.com/arsv/perl-cross/issues/60
-    perl-cross-gcc7-patch = fetchpatch {
-      url = "https://github.com/arsv/perl-cross/commit/07208bc1707b8be3ea170c62c59120020cf0f87f.patch";
-      sha256 = "1gh8w9m5if2s0lrx2x8f8grp74d1l6d46m8jglpjm5a1kf55j810";
-    };
-
     depsBuildBuild = [ buildPackages.stdenv.cc makeWrapper ];
 
     postUnpack = ''
       unpackFile ${perl-cross-src}
-      cd perl-cross-*
-      patch -Np1 -i ${perl-cross-gcc7-patch}
-      cd ..
       cp -R perl-cross-${crossVersion}/* perl-${version}/
     '';
 


### PR DESCRIPTION
1.1.8 does not support the versions of perl in-tree.

As a result cross-compiling fails at perl which
blocks quite a few things :).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---



Mostly tested that this builds, with bias towards musl platforms O:).

Things like:

* `$ nix build -f . pkgsCross.musl64.perl -o perl-cross-musl64`
* `$ nix build -f . pkgsCross.aarch64-multiplatform-musl.perl -o perl-cross-aarch64`

cc @shlevy in case there's anything in particular that should be tested...?