### PR TITLE
appleseed: Fix non-executable items and Python bindings

### DIFF
--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -3,7 +3,10 @@ eigen3_3, libpng, python, libGLU, qt4, openexr, openimageio,
 opencolorio, xercesc, ilmbase, osl, seexpr
 }:
 
-let boost_static = boost165.override { enableStatic = true; };
+let boost_static = boost165.override {
+  enableStatic = true;
+  enablePython = true;
+};
 in stdenv.mkDerivation rec {
 
   name = "appleseed-${version}";
@@ -28,9 +31,7 @@ in stdenv.mkDerivation rec {
       "-DUSE_EXTERNAL_OSL=ON" "-DWITH_CLI=ON" "-DWITH_STUDIO=ON" "-DWITH_TOOLS=ON"
       "-DUSE_EXTERNAL_PNG=ON" "-DUSE_EXTERNAL_ZLIB=ON"
       "-DUSE_EXTERNAL_EXR=ON" "-DUSE_EXTERNAL_SEEXPR=ON"
-      "-DWITH_PYTHON2_BINDINGS=ON"
-      # TODO: Look further into this if someone needs Python 3.x:
-      # "-DWITH_PYTHON3_BINDINGS=ON"
+      "-DWITH_PYTHON=ON"
       "-DWITH_DISNEY_MATERIAL=ON"
       "-DUSE_SSE=ON"
       "-DUSE_SSE42=ON"
@@ -44,6 +45,11 @@ in stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.linux;
   };
+
+  # Work around a bug in the CMake build:
+  postInstall = ''
+    chmod a+x $out/bin/*
+  '';
 }
 
 # TODO: Is the below problematic?

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -569,6 +569,11 @@ in {
 
   appdirs = callPackage ../development/python-modules/appdirs { };
 
+  appleseed = disabledIf isPy3k
+    (toPythonModule (pkgs.appleseed.override {
+      inherit (self) python;
+    }));
+
   application = callPackage ../development/python-modules/application { };
 
   appnope = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

I realized a few things:

- I wasn't actually building the Python bindings to Appleseed because Boost was missing Python bindings and because I was using the wrong CMake flags (and this made some comments also wrong)
- The build was failing to mark some things executable in the `bin` directory (which I didn't realize were even supposed to be executable), and this was breaking some less-obvious features when using Appleseed with Blender via Blenderseed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

