### PR TITLE
yaxg: init at 2018-07-20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2720,6 +2720,11 @@
     github = "neeasade";
     name = "Nathan Isom";
   };
+  neonfuz = {
+    email = "neonfuz@gmail.com";
+    github = "neonfuz";
+    name = "Sage Raflik";
+  };
   nequissimus = {
     email = "tim@nequissimus.com";
     github = "nequissimus";

--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   name = "yaxg-${version}";
-  version = "unstable-2018-07-20";
+  version = "unstable-2018-05-03";
 
   src = fetchFromGitHub {
     owner = "DanielFGray";
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin/
     mv yaxg $out/bin/
     chmod +x $out/bin/yaxg
-    wrapProgram $out/bin/yaxg --prefix PATH : ${
-      stdenv.lib.makeBinPath [ maim slop ffmpeg byzanz libnotify xdpyinfo ]}
+    wrapProgram $out/bin/yaxg --prefix PATH : ${ stdenv.lib.makeBinPath [ maim slop ffmpeg byzanz libnotify xdpyinfo ]}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, makeWrapper,
+  maim, slop, ffmpeg, byzanz, libnotify, xdpyinfo }:
+
+stdenv.mkDerivation rec {
+  name = "yaxg-${version}";
+  version = "unstable-2018-07-20";
+
+  src = fetchFromGitHub {
+    owner = "DanielFGray";
+    repo = "yaxg";
+    rev = "9d6af75da2ec25dba4b8d784e431064033d67ad2";
+    sha256 = "01p6ghp1vfrlnrm78bgbl9ppqwsdxh761g0qa172dpvsqg91l1p6";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ maim slop ffmpeg byzanz libnotify xdpyinfo ];
+
+  installPhase = ''
+    mkdir -p $out/bin/ $out/lib/yaxg/
+    cp yaxg $out/lib/yaxg/
+    chmod +x $out/lib/yaxg/yaxg
+    makeWrapper $out/lib/yaxg/yaxg $out/bin/yaxg --prefix PATH : ${
+      stdenv.lib.makeBinPath [ maim slop ffmpeg byzanz libnotify xdpyinfo ]}
+  '';
+
+  meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
+    description = "Yet Another X Grabber script";
+    longDescription = ''
+      Capture and record your screen with callbacks. Wraps maim, slop, ffmpeg,
+      and byzanz to enable still image, video, or gif recording of part or all
+      of your screen. Similar command-line interface to scrot but is overall
+      more flexible and less buggy.
+    '';
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ neonfuz ];
+  };
+}

--- a/pkgs/tools/graphics/yaxg/default.nix
+++ b/pkgs/tools/graphics/yaxg/default.nix
@@ -16,10 +16,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ maim slop ffmpeg byzanz libnotify xdpyinfo ];
 
   installPhase = ''
-    mkdir -p $out/bin/ $out/lib/yaxg/
-    cp yaxg $out/lib/yaxg/
-    chmod +x $out/lib/yaxg/yaxg
-    makeWrapper $out/lib/yaxg/yaxg $out/bin/yaxg --prefix PATH : ${
+    mkdir -p $out/bin/
+    mv yaxg $out/bin/
+    chmod +x $out/bin/yaxg
+    wrapProgram $out/bin/yaxg --prefix PATH : ${
       stdenv.lib.makeBinPath [ maim slop ffmpeg byzanz libnotify xdpyinfo ]}
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21827,6 +21827,8 @@ with pkgs;
 
   yara = callPackage ../tools/security/yara { };
 
+  yaxg = callPackage ../tools/graphics/yaxg {};
+
   zap = callPackage ../tools/networking/zap { };
 
   zdfmediathk = callPackage ../applications/video/zdfmediathk { };


### PR DESCRIPTION
###### Motivation for this change
This adds yaxg, a screenshot / screen recording tool similar to scrot. This wraps maim, slop, ffmpeg, and byzanz for all of it's functionality, all of which are already in nixos, so this is a pretty simple inclusion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

