### PR TITLE
Fix build of haskell.packages.ghc822.tensorflow

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2392,6 +2392,7 @@ extra-packages:
   - http-conduit ^>= 2.2                # pre-lts-11.x versions neeed by git-annex 6.20180227
   - inline-c < 0.6                      # required on GHC 8.0.x
   - inline-c-cpp < 0.2                  # required on GHC 8.0.x
+  - lens-labels == 0.1.*                # required for proto-lens-descriptors
   - mtl < 2.2                           # newer versions require transformers > 0.4.x, which we cannot provide in GHC 7.8.x
   - mtl-prelude < 2                     # required for to build postgrest on mtl 2.1.x platforms
   - network == 2.6.3.1                  # newer versions don't compile with GHC 7.4.x and below
@@ -2399,6 +2400,9 @@ extra-packages:
   - persistent >=2.5 && <2.8            # pre-lts-11.x versions neeed by git-annex 6.20180227
   - persistent-sqlite < 2.7             # pre-lts-11.x versions neeed by git-annex 6.20180227
   - primitive == 0.5.1.*                # required to build alex with GHC 6.12.3
+  - proto-lens == 0.2.*                 # required for tensorflow-proto-0.1.x on GHC 8.2.x
+  - proto-lens-protoc == 0.2.*          # required for tensorflow-proto-0.1.x on GHC 8.2.x
+  - proto-lens-protobuf-types == 0.2.*  # required for tensorflow-proto-0.1.x on GHC 8.2.x
   - QuickCheck < 2                      # required by test-framework-quickcheck and its users
   - resourcet ==1.1.*                   # pre-lts-11.x versions neeed by git-annex 6.20180227
   - seqid < 0.2                         # newer versions depend on transformers 0.4.x which we cannot provide in GHC 7.8.x

--- a/pkgs/development/libraries/libtensorflow/default.nix
+++ b/pkgs/development/libraries/libtensorflow/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, patchelf }:
+stdenv.mkDerivation rec {
+  pname = "libtensorflow";
+  version = "1.8.0";
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "https://storage.googleapis.com/tensorflow/${pname}/${pname}-cpu-linux-x86_64-${version}.tar.gz";
+    sha256 = "0qzy15rc3x961cyi3bqnygrcnw4x69r28xkwhpwrv1r0gi6k73ha";
+  };
+
+  # Patch library to use our libc, libstdc++ and others
+  buildCommand = ''
+    . $stdenv/setup
+    mkdir -pv $out
+    tar -C $out -xzf $src
+    chmod +w $out/lib/libtensorflow.so
+    chmod +w $out/lib/libtensorflow_framework.so
+    ${patchelf}/bin/patchelf --set-rpath "${stdenv.cc.libc}/lib:${stdenv.cc.cc.lib}/lib:$out/lib" $out/lib/libtensorflow.so
+    ${patchelf}/bin/patchelf --set-rpath "${stdenv.cc.libc}/lib:${stdenv.cc.cc.lib}/lib" $out/lib/libtensorflow_framework.so
+    chmod -w $out/lib/libtensorflow.so
+    chmod -w $out/lib/libtensorflow_framework.so
+  '';
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = "C API for TensorFlow";
+    license = licenses.asl20;
+    maintainers = [maintainers.basvandijk];
+    platforms = platforms.linux;
+    homepage = https://www.tensorflow.org/versions/master/install/install_c;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -860,6 +860,8 @@ with pkgs;
 
   tensor = libsForQt5.callPackage ../applications/networking/instant-messengers/tensor { };
 
+  libtensorflow = callPackage ../development/libraries/libtensorflow { };
+
   blink1-tool = callPackage ../tools/misc/blink1-tool { };
 
   bliss = callPackage ../applications/science/math/bliss { };


### PR DESCRIPTION
###### Motivation for this change

`haskell.packages.ghc822.tensorflow` currently fails to build. This fixes that.

@peti this requires a newly generated `hackage-packages.nix` with https://github.com/NixOS/cabal2nix/pull/361.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

