### PR TITLE
Optional static libraries for krb5 and openssl

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -3,6 +3,9 @@
 
 # Extra Arguments
 , type ? ""
+# This is called "staticOnly" because krb5 does not support
+# builting both static and shared, see below.
+, staticOnly ? false
 }:
 
 let
@@ -22,6 +25,9 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   configureFlags = [ "--with-tcl=no" "--localstatedir=/var/lib"]
+    # krb5's ./configure does not allow passing --enable-shared and --enable-static at the same time.
+    # See https://bbs.archlinux.org/viewtopic.php?pid=1576737#p1576737
+    ++ optional staticOnly [ "--enable-static" "--disable-shared" ]
     ++ optional stdenv.isFreeBSD ''WARN_CFLAGS=""''
     ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform)
        [ "krb5_cv_attr_constructor_destructor=yes,yes"

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -3,6 +3,7 @@
 , fetchpatch
 , withCryptodev ? false, cryptodevHeaders
 , enableSSL2 ? false
+, static ? false
 }:
 
 with stdenv.lib;
@@ -62,7 +63,7 @@ let
     '';
 
     configureFlags = [
-      "shared"
+      "shared" # "shared" builds both shared and static libraries
       "--libdir=lib"
       "--openssldir=etc/ssl"
     ] ++ stdenv.lib.optionals withCryptodev [
@@ -75,13 +76,16 @@ let
 
     enableParallelBuilding = true;
 
-    postInstall = ''
+    postInstall =
+    stdenv.lib.optionalString (!static) ''
       # If we're building dynamic libraries, then don't install static
       # libraries.
       if [ -n "$(echo $out/lib/*.so $out/lib/*.dylib $out/lib/*.dll)" ]; then
           rm "$out/lib/"*.a
       fi
 
+    '' +
+    ''
       mkdir -p $bin
       mv $out/bin $bin/
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/43795

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @dtzWill @angerman 