### PR TITLE
rshell: init at 0.0.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -589,6 +589,11 @@
     github = "c0bw3b";
     name = "Renaud";
   };
+  c0deaddict = {
+    email = "josvanbakel@protonmail.com";
+    github = "c0deaddict";
+    name = "Jos van Bakel";
+  };
   c0dehero = {
     email = "codehero@nerdpol.ch";
     name = "CodeHero";

--- a/pkgs/development/tools/rshell/default.nix
+++ b/pkgs/development/tools/rshell/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonApplication, fetchPypi, pyserial, pyudev }:
+
+buildPythonApplication rec {
+  pname = "rshell";
+  version = "0.0.14";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12gh9l13lwnlp330jl3afy3wgfkpjvdxr43flrg9k9kyyhbr191g";
+  };
+
+  propagatedBuildInputs = [ pyserial pyudev ];
+
+  meta = with lib; {
+    homepage = https://github.com/dhylands/rshell;
+    description = "Remote Shell for MicroPython";
+    license = licenses.mit;
+    maintainers = with maintainers; [ c0deaddict ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11717,6 +11717,8 @@ with pkgs;
 
   ronn = callPackage ../development/tools/ronn { };
 
+  rshell = python3.pkgs.callPackage ../development/tools/rshell { };
+
   rubberband = callPackage ../development/libraries/rubberband {
     inherit (vamp) vampSDK;
   };


### PR DESCRIPTION
###### Motivation for this change

Package is not nixpkgs yet.

###### Things done

Added rshell python application.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

