### PR TITLE
ipgrep: init at 1.0

### DIFF
--- a/pkgs/tools/networking/ipgrep/default.nix
+++ b/pkgs/tools/networking/ipgrep/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pythonPackages, makeWrapper }:
+
+pythonPackages.buildPythonApplication rec {
+  version = "1.0";
+  pname = "ipgrep";
+
+  src = fetchFromGitHub {
+    owner = "jedisct1";
+    repo = pname;
+    rev = version;
+    sha256 = "1qaxvbqdalvz05aplhhrg7s4h7yx4clbfd50k46bgavhgcqqv8n3";
+  };
+
+  patchPhase = ''
+    mkdir -p ${pname} 
+    substituteInPlace setup.py \
+      --replace "'scripts': []" "'scripts': { '${pname}.py' }"
+  '';
+
+  propagatedBuildInputs = with pythonPackages; [
+    pycares
+    urllib3
+    requests
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Extract, defang, resolve names and IPs from text";
+    longDescription = ''
+      ipgrep extracts possibly obfuscated host names and IP addresses
+      from text, resolves host names, and prints them, sorted by ASN.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -662,6 +662,8 @@ with pkgs;
 
   imgpatchtools = callPackage ../development/mobile/imgpatchtools { };
 
+  ipgrep = callPackage ../tools/networking/ipgrep { };
+
   lastpass-cli = callPackage ../tools/security/lastpass-cli { };
 
   pacparser = callPackage ../tools/networking/pacparser { };


### PR DESCRIPTION
###### Motivation for this change

A very useful utility. Just throw some text file at it, and it will tell you lots of things about the domain names and IP addresses in it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

