### PR TITLE
Mingw fixes

### DIFF
--- a/pkgs/data/fonts/dejavu-fonts/default.nix
+++ b/pkgs/data/fonts/dejavu-fonts/default.nix
@@ -20,7 +20,7 @@ let
     # See http://dejavu-fonts.org/wiki/License for details
     license = stdenv.lib.licenses.free;
 
-    platforms = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.all;
   };
 
   full-ttf = stdenv.mkDerivation {

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -70,7 +70,7 @@ in stdenv.mkDerivation rec {
     homepage = http://xmlsoft.org/;
     description = "An XML parsing library for C";
     license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.eelco ];
   };
 }

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     homepage = http://xmlsoft.org/XSLT/;
     description = "A C library and tools to do XSL transformations";
     license = licenses.mit;
-    platforms = platforms.unix;
+    platforms = platforms.all;
     maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -34,7 +34,11 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional unicode "--enable-widec"
     ++ lib.optional enableStatic "--enable-static"
     ++ lib.optional (!withCxx) "--without-cxx"
-    ++ lib.optional (abiVersion == "5") "--with-abi-version=5";
+    ++ lib.optional (abiVersion == "5") "--with-abi-version=5"
+    ++ lib.optionals hostPlatform.isWindows [
+      "--enable-sp-funcs"
+      "--enable-term-driver"
+    ];
 
   # Only the C compiler, and explicitly not C++ compiler needs this flag on solaris:
   CFLAGS = lib.optionalString stdenv.isSunOS "-D_XOPEN_SOURCE_EXTENDED";

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -45,7 +45,9 @@ let
         if hostPlatform == buildPlatform
           then "./config"
         else if hostPlatform.isMinGW
-          then "./Configure mingw${toString hostPlatform.parsed.cpu.bits}"
+          then "./Configure mingw${optionalString
+                                     (hostPlatform.parsed.cpu.bits != 32)
+                                     (toString hostPlatform.parsed.cpu.bits)}"
         else if hostPlatform.isLinux
           then "./Configure linux-generic${toString hostPlatform.parsed.cpu.bits}"
         else if hostPlatform.isiOS

--- a/pkgs/os-specific/windows/libgnurx/default.nix
+++ b/pkgs/os-specific/windows/libgnurx/default.nix
@@ -1,0 +1,11 @@
+{ stdenv, fetchurl }:
+
+let
+  version = "2.5.1";
+in stdenv.mkDerivation rec {
+  name = "libgnurx-${version}";
+  src = fetchurl {
+    url = "mirror://sourceforge/mingw/Other/UserContributed/regex/mingw-regex-${version}/mingw-${name}-src.tar.gz";
+    sha256 = "0xjxcxgws3bblybw5zsp9a4naz2v5bs1k3mk8dw00ggc0vwbfivi";
+  };
+}

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -1,0 +1,80 @@
+{ pkgs, pkgsCross, lib }:
+
+let
+
+  emulators = {
+    mingw32 = "WINEDEBUG=-all ${pkgs.winePackages.minimal}/bin/wine";
+    mingwW64 = "WINEDEBUG=-all ${pkgs.wineWowPackages.minimal}/bin/wine";
+    # TODO: add some qemu-based emulaltors here
+  };
+
+  getExecutable = pkgs: pkgFun: exec:
+    "${pkgFun pkgs}${exec}${pkgs.hostPlatform.extensions.executable}";
+
+  compareTest = { emulator, pkgFun, hostPkgs, crossPkgs, exec, args ? [] }: let
+    pkgName = (pkgFun hostPkgs).name;
+    args' = lib.concatStringsSep " " args;
+  in pkgs.runCommand "test-${pkgName}-${crossPkgs.hostPlatform.config}" {
+    nativeBuildInputs = [ pkgs.dos2unix ];
+  } ''
+    HOME=$(pwd)
+    mkdir -p $out
+
+    # We need to remove whitespace, unfortunately
+    # Windows programs use \r but Unix programs use \n
+
+    # find expected value natively
+    ${getExecutable hostPkgs pkgFun exec} ${args'} \
+      | dos2unix > $out/expected
+
+    # run emulator to get actual value
+    ${emulator} ${getExecutable crossPkgs pkgFun exec} ${args'} \
+      | dos2unix > $out/actual
+
+    if [ "$(cat $out/actual)" != "$(cat $out/expected)" ]; then
+      echo "${pkgName} did not output expected value:"
+      cat $out/expected
+      echo "instead it output:"
+      cat $out/actual
+      exit 1
+    else
+      echo "${pkgName} test passed"
+      echo "both produced output:"
+      cat $out/actual
+    fi
+  '';
+
+in
+
+lib.mapAttrs (name: emulator: let
+  crossPkgs = pkgsCross.${name};
+
+  # Apply some transformation on windows to get dlls in the right
+  # place. Unfortunately mingw doesn’t seem to be able to do linking
+  # properly.
+  platformFun = pkg: if crossPkgs.hostPlatform.isWindows then
+    pkgs.buildEnv {
+      name = "${pkg.name}-winlinks";
+      paths = [pkg] ++ pkg.buildInputs;
+    } else pkg;
+in {
+
+  hello = compareTest {
+    inherit emulator crossPkgs;
+    hostPkgs = pkgs;
+    exec = "/bin/hello";
+    pkgFun = pkgs: pkgs.hello;
+  };
+
+  file = compareTest {
+    inherit emulator crossPkgs;
+    hostPkgs = pkgs;
+    exec = "/bin/file";
+    args = [
+      "${pkgs.file}/share/man/man1/file.1.gz"
+      "${pkgs.dejavu_fonts}/share/fonts/truetype/DejaVuMathTeXGyre.ttf"
+    ];
+    pkgFun = pkgs: platformFun pkgs.file;
+  };
+
+}) emulators

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -23,4 +23,6 @@ with pkgs;
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
   macOSSierraShared = callPackage ./macos-sierra-shared {};
+
+  cross = callPackage ./cross {};
 }

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, file, zlib }:
+{ stdenv, fetchurl, file, zlib, libgnurx }:
 
 stdenv.mkDerivation rec {
   name = "file-${version}";
@@ -13,10 +13,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib ]
+              ++ stdenv.lib.optional stdenv.hostPlatform.isWindows libgnurx;
 
   doCheck = true;
 
+  makeFlags = if stdenv.hostPlatform.isWindows then "FILE_COMPILE=file"
+              else null;
 
   meta = with stdenv.lib; {
     homepage = http://darwinsys.com/file;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14546,6 +14546,8 @@ with pkgs;
     };
 
     wxMSW = callPackage ../os-specific/windows/wxMSW-2.8 { };
+
+    libgnurx = callPackage ../os-specific/windows/libgnurx { };
   };
 
   wirelesstools = callPackage ../os-specific/linux/wireless-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2387,7 +2387,9 @@ with pkgs;
 
   figlet = callPackage ../tools/misc/figlet { };
 
-  file = callPackage ../tools/misc/file { };
+  file = callPackage ../tools/misc/file {
+    inherit (windows) libgnurx;
+  };
 
   filegive = callPackage ../tools/networking/filegive { };
 


### PR DESCRIPTION
###### Motivation for this change

Some non-mass rebuild fixes for mingw.

- unmark a few packages as unix only
- fixes builds of:
  - file
  - openssl
  - ncurses
- add ```libgnurx``` (needed for file)
- add two wine tests to verify executables work

