### PR TITLE
php: get rid of composableDerivation

### DIFF
--- a/pkgs/build-support/setup-hooks/remove-pytest-cache.sh
+++ b/pkgs/build-support/setup-hooks/remove-pytest-cache.sh
@@ -1,0 +1,1 @@
+postFixupHooks+=

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -1,21 +1,63 @@
 # pcre functionality is tested in nixos/tests/php-pcre.nix
-
-{ lib, stdenv, fetchurl, composableDerivation, flex, bison
-, mysql, libxml2, readline, zlib, curl, postgresql, gettext, html-tidy
+{ lib, stdenv, fetchurl, flex, bison
+, mysql, libxml2, readline, zlib, curl, postgresql, gettext
 , openssl, pcre, pkgconfig, sqlite, config, libjpeg, libpng, freetype
 , libxslt, libmcrypt, bzip2, icu, openldap, cyrus_sasl, libmhash, freetds
-, uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium }:
+, uwimap, pam, gmp, apacheHttpd, libiconv, systemd, libsodium, html-tidy
+}:
+
+with lib;
 
 let
-
+  php7 = versionAtLeast version "7.0";
   generic =
-    { version, sha256 }:
+  { version
+  , sha256
+  , imapSupport ? config.php.imap or (!stdenv.isDarwin)
+  , ldapSupport ? config.php.ldap or true
+  , mhashSupport ? config.php.mhash or true
+  , mysqlSupport ? (config.php.mysql or true) && (!php7)
+  , mysqlndSupport ? config.php.mysqlnd or false
+  , mysqliSupport ? config.php.mysqli or true
+  , pdo_mysqlSupport ? config.php.pdo_mysql or true
+  , libxml2Support ? config.php.libxml2 or true
+  , apxs2Support ? config.php.apxs2 or (!stdenv.isDarwin)
+  , embedSupport ? config.php.embed or false
+  , bcmathSupport ? config.php.bcmath or true
+  , socketsSupport ? config.php.sockets or true
+  , curlSupport ? config.php.curl or true
+  , curlWrappersSupport ? (config.php.curlWrappers or true) && (!php7)
+  , gettextSupport ? config.php.gettext or true
+  , pcntlSupport ? config.php.pcntl or true
+  , postgresqlSupport ? config.php.postgresql or true
+  , pdo_pgsqlSupport ? config.php.pdo_pgsql or true
+  , readlineSupport ? config.php.readline or true
+  , sqliteSupport ? config.php.sqlite or true
+  , soapSupport ? config.php.soap or true
+  , zlibSupport ? config.php.zlib or true
+  , opensslSupport ? config.php.openssl or true
+  , mbstringSupport ? config.php.mbstring or true
+  , gdSupport ? config.php.gd or true
+  , intlSupport ? config.php.intl or true
+  , exifSupport ? config.php.exif or true
+  , xslSupport ? config.php.xsl or false
+  , mcryptSupport ? config.php.mcrypt or true
+  , bz2Support ? config.php.bz2 or false
+  , zipSupport ? config.php.zip or true
+  , ftpSupport ? config.php.ftp or true
+  , fpmSupport ? config.php.fpm or true
+  , gmpSupport ? config.php.gmp or true
+  , mssqlSupport ? (config.php.mssql or (!stdenv.isDarwin)) && (!php7)
+  , ztsSupport ? config.php.zts or false
+  , calendarSupport ? config.php.calendar or true
+  , sodiumSupport ? (config.php.sodium or true) && (versionAtLeast version "7.2")
+  , tidySupport ? false
+  }:
 
-    let php7 = lib.versionAtLeast version "7.0";
-        mysqlndSupport = config.php.mysqlnd or false;
-        mysqlBuildInputs = lib.optional (!mysqlndSupport) mysql.connector-c;
-
-    in composableDerivation.composableDerivation {} (fixed: {
+    let
+      mysqlBuildInputs = optional (!mysqlndSupport) mysql.connector-c;
+      libmcrypt' = libmcrypt.override { disablePosixThreads = true; };
+    in stdenv.mkDerivation {
 
       inherit version;
 
@@ -25,258 +67,99 @@ let
 
       nativeBuildInputs = [ pkgconfig ];
       buildInputs = [ flex bison pcre ]
-        ++ lib.optional stdenv.isLinux systemd;
+        ++ optional stdenv.isLinux systemd
+        ++ optionals imapSupport [ uwimap openssl pam ]
+        ++ optionals curlSupport [ curl openssl ]
+        ++ optionals ldapSupport [ openldap openssl ]
+        ++ optionals gdSupport [ libpng libjpeg freetype ]
+        ++ optionals opensslSupport [ openssl openssl.dev ]
+        ++ optional apxs2Support apacheHttpd
+        ++ optional (ldapSupport && stdenv.isLinux) cyrus_sasl
+        ++ optional mhashSupport libmhash
+        ++ optional zlibSupport zlib
+        ++ optional libxml2Support libxml2
+        ++ optional readlineSupport readline
+        ++ optional sqliteSupport sqlite
+        ++ optional postgresqlSupport postgresql
+        ++ optional pdo_pgsqlSupport postgresql
+        ++ optional pdo_mysqlSupport mysqlBuildInputs
+        ++ optional mysqlSupport mysqlBuildInputs
+        ++ optional mysqliSupport mysqlBuildInputs
+        ++ optional gmpSupport gmp
+        ++ optional gettextSupport gettext
+        ++ optional intlSupport icu
+        ++ optional xslSupport libxslt
+        ++ optional mcryptSupport libmcrypt'
+        ++ optional bz2Support bzip2
+        ++ optional (mssqlSupport && !stdenv.isDarwin) freetds
+        ++ optional sodiumSupport libsodium
+        ++ optional tidySupport html-tidy;
 
-      CXXFLAGS = lib.optional stdenv.cc.isClang "-std=c++11";
+      CXXFLAGS = optional stdenv.cc.isClang "-std=c++11";
 
-      flags = {
 
-        # much left to do here...
+      configureFlags = [
+        "--with-config-file-scan-dir=/etc/php.d"
+        "--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"
+      ]
+      ++ optional stdenv.isDarwin "--with-iconv=${libiconv}"
+      ++ optional stdenv.isLinux  "--with-fpm-systemd"
+      ++ optionals imapSupport [
+        "--with-imap=${uwimap}"
+        "--with-imap-ssl"
+      ]
+      ++ optionals ldapSupport [
+        "--with-ldap=/invalid/path"
+        "LDAP_DIR=${openldap.dev}"
+        "LDAP_INCDIR=${openldap.dev}/include"
+        "LDAP_LIBDIR=${openldap.out}/lib"
+      ]
+      ++ optional (ldapSupport && stdenv.isLinux)   "--with-ldap-sasl=${cyrus_sasl.dev}"
+      ++ optional apxs2Support "--with-apxs2=${apacheHttpd.dev}/bin/apxs"
+      ++ optional embedSupport "--enable-embed"
+      ++ optional mhashSupport "--with-mhash"
+      ++ optional curlSupport "--with-curl=${curl.dev}"
+      ++ optional curlWrappersSupport "--with-curlwrappers"
+      ++ optional zlibSupport "--with-zlib=${zlib.dev}"
+      ++ optional libxml2Support "--with-libxml-dir=${libxml2.dev}"
+      ++ optional pcntlSupport "--enable-pcntl"
+      ++ optional readlineSupport "--with-readline=${readline.dev}"
+      ++ optional sqliteSupport "--with-pdo-sqlite=${sqlite.dev}"
+      ++ optional postgresqlSupport "--with-pgsql=${postgresql}"
+      ++ optional pdo_pgsqlSupport "--with-pdo-pgsql=${postgresql}"
+      ++ optional pdo_mysqlSupport "--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else mysql.connector-c}"
+      ++ optional mysqlSupport "--with-mysql${if mysqlndSupport then "=mysqlnd" else ""}"
+      ++ optionals mysqliSupport [
+        "--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${mysql.connector-c}/bin/mysql_config"}"
+      ]
+      ++ optional bcmathSupport "--enable-bcmath"
+      # FIXME: Our own gd package doesn't work, see https://bugs.php.net/bug.php?id=60108.
+      ++ optionals gdSupport [
+        "--with-gd"
+        "--with-freetype-dir=${freetype.dev}"
+        "--with-png-dir=${libpng.dev}"
+        "--with-jpeg-dir=${libjpeg.dev}"
+      ]
+      ++ optional gmpSupport "--with-gmp=${gmp.dev}"
+      ++ optional soapSupport "--enable-soap"
+      ++ optional socketsSupport "--enable-sockets"
+      ++ optional opensslSupport "--with-openssl"
+      ++ optional mbstringSupport "--enable-mbstring"
+      ++ optional gettextSupport "--with-gettext=${gettext}"
+      ++ optional intlSupport "--enable-intl"
+      ++ optional exifSupport "--enable-exif"
+      ++ optional xslSupport "--with-xsl=${libxslt.dev}"
+      ++ optional mcryptSupport "--with-mcrypt=${libmcrypt'}"
+      ++ optional bz2Support "--with-bz2=${bzip2.dev}"
+      ++ optional zipSupport "--enable-zip"
+      ++ optional ftpSupport "--enable-ftp"
+      ++ optional fpmSupport "--enable-fpm"
+      ++ optional (mssqlSupport && !stdenv.isDarwin) "--with-mssql=${freetds}"
+      ++ optional ztsSupport "--enable-maintainer-zts"
+      ++ optional calendarSupport "--enable-calendar"
+      ++ optional sodiumSupport "--with-sodium=${libsodium.dev}"
+      ++ optional tidySupport "--with-tidy=${html-tidy}";
 
-        # SAPI modules:
-
-        apxs2 = {
-          configureFlags = ["--with-apxs2=${apacheHttpd.dev}/bin/apxs"];
-          buildInputs = [apacheHttpd];
-        };
-
-        embed = {
-          configureFlags = ["--enable-embed"];
-        };
-
-        # Extensions
-        imap = {
-          configureFlags = [
-            "--with-imap=${uwimap}"
-            "--with-imap-ssl"
-            ];
-          buildInputs = [ uwimap openssl pam ];
-        };
-
-        ldap = {
-          configureFlags = [
-            "--with-ldap=/invalid/path"
-            "LDAP_DIR=${openldap.dev}"
-            "LDAP_INCDIR=${openldap.dev}/include"
-            "LDAP_LIBDIR=${openldap.out}/lib"
-            (lib.optional stdenv.isLinux "--with-ldap-sasl=${cyrus_sasl.dev}")
-            ];
-          buildInputs = [openldap openssl] ++ lib.optional stdenv.isLinux cyrus_sasl;
-        };
-
-        mhash = {
-          configureFlags = ["--with-mhash"];
-          buildInputs = [libmhash];
-        };
-
-        curl = {
-          configureFlags = ["--with-curl=${curl.dev}"];
-          buildInputs = [curl openssl];
-        };
-
-        curlWrappers = {
-          configureFlags = ["--with-curlwrappers"];
-        };
-
-        zlib = {
-          configureFlags = ["--with-zlib=${zlib.dev}"];
-          buildInputs = [zlib];
-        };
-
-        libxml2 = {
-          configureFlags = [
-            "--with-libxml-dir=${libxml2.dev}"
-            ];
-          buildInputs = [ libxml2 ];
-        };
-
-        pcntl = {
-          configureFlags = [ "--enable-pcntl" ];
-        };
-
-        readline = {
-          configureFlags = ["--with-readline=${readline.dev}"];
-          buildInputs = [ readline ];
-        };
-
-        sqlite = {
-          configureFlags = ["--with-pdo-sqlite=${sqlite.dev}"];
-          buildInputs = [ sqlite ];
-        };
-
-        postgresql = {
-          configureFlags = ["--with-pgsql=${postgresql}"];
-          buildInputs = [ postgresql ];
-        };
-
-        pdo_pgsql = {
-          configureFlags = ["--with-pdo-pgsql=${postgresql}"];
-          buildInputs = [ postgresql ];
-        };
-
-        mysql = {
-          configureFlags = ["--with-mysql${if mysqlndSupport then "=mysqlnd" else ""}"];
-          buildInputs = mysqlBuildInputs;
-        };
-
-        mysqli = {
-          configureFlags = ["--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${mysql.connector-c}/bin/mysql_config"}"];
-          buildInputs = mysqlBuildInputs;
-        };
-
-        mysqli_embedded = {
-          configureFlags = ["--enable-embedded-mysqli"];
-          depends = "mysqli";
-          assertion = fixed.mysqliSupport;
-        };
-
-        pdo_mysql = {
-          configureFlags = ["--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else mysql.connector-c}"];
-          buildInputs = mysqlBuildInputs;
-        };
-
-        bcmath = {
-          configureFlags = ["--enable-bcmath"];
-        };
-
-        gd = {
-          # FIXME: Our own gd package doesn't work, see https://bugs.php.net/bug.php?id=60108.
-          configureFlags = [
-            "--with-gd"
-            "--with-freetype-dir=${freetype.dev}"
-            "--with-png-dir=${libpng.dev}"
-            "--with-jpeg-dir=${libjpeg.dev}"
-          ];
-          buildInputs = [ libpng libjpeg freetype ];
-        };
-
-        gmp = {
-          configureFlags = ["--with-gmp=${gmp.dev}"];
-          buildInputs = [ gmp ];
-        };
-
-        soap = {
-          configureFlags = ["--enable-soap"];
-        };
-
-        sockets = {
-          configureFlags = ["--enable-sockets"];
-        };
-
-        openssl = {
-          configureFlags = ["--with-openssl"];
-          buildInputs = [openssl openssl.dev];
-        };
-
-        mbstring = {
-          configureFlags = ["--enable-mbstring"];
-        };
-
-        gettext = {
-          configureFlags = ["--with-gettext=${gettext}"];
-          buildInputs = [gettext];
-        };
-
-        intl = {
-          configureFlags = ["--enable-intl"];
-          buildInputs = [icu];
-        };
-
-        exif = {
-          configureFlags = ["--enable-exif"];
-        };
-
-        xsl = {
-          configureFlags = ["--with-xsl=${libxslt.dev}"];
-          buildInputs = [libxslt];
-        };
-
-        mcrypt = let libmcrypt' = libmcrypt.override { disablePosixThreads = true; }; in {
-          configureFlags = ["--with-mcrypt=${libmcrypt'}"];
-          buildInputs = [libmcrypt'];
-        };
-
-        bz2 = {
-          configureFlags = ["--with-bz2=${bzip2.dev}"];
-          buildInputs = [bzip2];
-        };
-
-        zip = {
-          configureFlags = ["--enable-zip"];
-        };
-
-        ftp = {
-          configureFlags = ["--enable-ftp"];
-        };
-
-        fpm = {
-          configureFlags = ["--enable-fpm"];
-        };
-
-        mssql = stdenv.lib.optionalAttrs (!stdenv.isDarwin) {
-          configureFlags = ["--with-mssql=${freetds}"];
-          buildInputs = [freetds];
-        };
-
-        zts = {
-          configureFlags = ["--enable-maintainer-zts"];
-        };
-
-        calendar = {
-          configureFlags = ["--enable-calendar"];
-        };
-
-        sodium = {
-          configureFlags = ["--with-sodium=${libsodium.dev}"];
-          buildInputs = [libsodium];
-        };
-
-        tidy = {
-          configureFlags = [ "--with-tidy=${html-tidy}" ];
-          buildInputs = [ html-tidy ];
-        };
-      };
-
-      cfg = {
-        imapSupport = config.php.imap or (!stdenv.isDarwin);
-        ldapSupport = config.php.ldap or true;
-        mhashSupport = config.php.mhash or true;
-        mysqlSupport = (!php7) && (config.php.mysql or true);
-        mysqliSupport = config.php.mysqli or true;
-        pdo_mysqlSupport = config.php.pdo_mysql or true;
-        libxml2Support = config.php.libxml2 or true;
-        apxs2Support = config.php.apxs2 or (!stdenv.isDarwin);
-        embedSupport = config.php.embed or false;
-        bcmathSupport = config.php.bcmath or true;
-        socketsSupport = config.php.sockets or true;
-        curlSupport = config.php.curl or true;
-        curlWrappersSupport = (!php7) && (config.php.curlWrappers or true);
-        gettextSupport = config.php.gettext or true;
-        pcntlSupport = config.php.pcntl or true;
-        postgresqlSupport = config.php.postgresql or true;
-        pdo_pgsqlSupport = config.php.pdo_pgsql or true;
-        readlineSupport = config.php.readline or true;
-        sqliteSupport = config.php.sqlite or true;
-        soapSupport = config.php.soap or true;
-        zlibSupport = config.php.zlib or true;
-        opensslSupport = config.php.openssl or true;
-        mbstringSupport = config.php.mbstring or true;
-        gdSupport = config.php.gd or true;
-        intlSupport = config.php.intl or true;
-        exifSupport = config.php.exif or true;
-        xslSupport = config.php.xsl or false;
-        mcryptSupport = config.php.mcrypt or true;
-        bz2Support = config.php.bz2 or false;
-        zipSupport = config.php.zip or true;
-        ftpSupport = config.php.ftp or true;
-        fpmSupport = config.php.fpm or true;
-        gmpSupport = config.php.gmp or true;
-        mssqlSupport = (!php7) && (config.php.mssql or (!stdenv.isDarwin));
-        ztsSupport = config.php.zts or false;
-        calendarSupport = config.php.calendar or true;
-        sodiumSupport = (lib.versionAtLeast version "7.2") && config.php.sodium or true;
-        tidySupport = php7 && config.php.tidy or true;
-      };
 
       hardeningDisable = [ "bindnow" ];
 
@@ -297,12 +180,6 @@ let
         configureFlags+=(--with-config-file-path=$out/etc \
           --includedir=$dev/include)
       '';
-
-      configureFlags = [
-        "--with-config-file-scan-dir=/etc/php.d"
-        "--with-pcre-regex=${pcre.dev} PCRE_LIBDIR=${pcre}"
-      ] ++ lib.optional stdenv.isDarwin "--with-iconv=${libiconv}"
-        ++ lib.optional stdenv.isLinux  "--with-fpm-systemd";
 
       postInstall = ''
         cp php.ini-production $out/etc/php.ini
@@ -332,7 +209,7 @@ let
 
       patches = if !php7 then [ ./fix-paths.patch ] else [ ./fix-paths-php7.patch ];
 
-      postPatch = lib.optional stdenv.isDarwin ''
+      postPatch = optional stdenv.isDarwin ''
         substituteInPlace configure --replace "-lstdc++" "-lc++"
       '';
 
@@ -340,7 +217,7 @@ let
 
       outputs = [ "out" "dev" ];
 
-    });
+    };
 
 in {
   php56 = generic {

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pkgconfig
+, gtk3
+, libjpeg
+, libtiff
+, SDL
+, gst-plugins-base
+, libnotify
+, freeglut
+, xorg
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "wxPython";
+  version = "4.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8d0dfc0146c24749ce00d575e35cc2826372e809d5bc4a57bde6c89031b59e75";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    gtk3 libjpeg libtiff SDL gst-plugins-base libnotify freeglut xorg.libSM
+    which
+  ];
+
+
+  meta = {
+    description = "Cross platform GUI toolkit for Python, Phoenix version";
+    homepage = http://wxpython.org/;
+    license = lib.licenses.wxWindows;
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

I'm not using php so please test. Will merge within a week.

Note that, after https://github.com/NixOS/nixpkgs/pull/43886, this is the last derivation using `composableDerivation`. Therefore, when both have been merged we can remove `composableDerivation` and supporting code in `lib/deprecated.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

