### PR TITLE
nvtop: init at 0.2.2

### DIFF
--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, nvidia_x11, cudatoolkit, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "nvtop-${version}";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Syllo";
+    repo  = "nvtop";
+    rev = version;
+    sha256 = "0gampikzmd1l0vdhvarl0hckl6kmjh2rwcllpg6rrm2p75njw7hv";
+  };
+
+  cmakeFlags = [
+    "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
+    "-DNVML_LIBRARIES=${nvidia_x11}/lib/libnvidia-ml.so.390.67"
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ncurses nvidia_x11 cudatoolkit ];
+
+  meta = with stdenv.lib; {
+    description = "A (h)top like like task monitor for NVIDIA GPUs";
+    homepage = https://github.com/Syllo/nvtop;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ willibutz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11119,6 +11119,10 @@ with pkgs;
 
   nvidia-video-sdk = callPackage ../development/libraries/nvidia-video-sdk { };
 
+  nvtop = callPackage ../tools/system/nvtop {
+    nvidia_x11 = linuxPackages.nvidia_x11.override { libsOnly = true; };
+  };
+
   ocl-icd-oclhGen = oclh: callPackage ../development/libraries/ocl-icd { opencl-headers = oclh; };
   ocl-icd-oclh_1_2 = ocl-icd-oclhGen opencl-headers_1_2;
   ocl-icd-oclh_2_2 = ocl-icd-oclhGen opencl-headers_2_2;


### PR DESCRIPTION
This adds `nvtop` which is a htop-like tool for NVIDIA GPUs.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---