### PR TITLE
"rm $out/share/icons/hicolor/icon-theme.cache" -> hicolor-icon-theme setup-hook

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file, libintl }:
+{ stdenv, fetchurl, gtk2, which, pkgconfig, intltool, file, libintl, hicolor-icon-theme }:
 
 with stdenv.lib;
 
@@ -15,17 +15,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig intltool libintl ];
-  buildInputs = [ gtk2 which file ];
+  buildInputs = [ gtk2 which file hicolor-icon-theme ];
 
   doCheck = true;
 
   enableParallelBuilding = true;
 
   patchPhase = "patchShebangs .";
-
-  # This file should normally require a gtk-update-icon-cache -q /usr/share/icons/hicolor command
-  # It have no reasons to exist in a redistribuable package
-  postInstall = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {
     description = "Small and lightweight IDE";

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit, autoconf, automake, libtool, gtk2, pkgconfig, perl,
 perlXMLParser, libxml2, gettext, python, libxml2Python, docbook5, docbook_xsl,
-libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui,
+libxslt, intltool, libart_lgpl, withGNOME ? false, libgnomeui, hicolor-icon-theme,
 gtk-mac-integration }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ gtk2 perlXMLParser libxml2 gettext python libxml2Python docbook5
-      libxslt docbook_xsl libart_lgpl ]
+      libxslt docbook_xsl libart_lgpl hicolor-icon-theme ]
       ++ stdenv.lib.optional withGNOME libgnomeui
       ++ stdenv.lib.optional stdenv.isDarwin gtk-mac-integration;
 
@@ -27,12 +27,6 @@ stdenv.mkDerivation rec {
   configureFlags = stdenv.lib.optionalString withGNOME "--enable-gnome";
 
   hardeningDisable = [ "format" ];
-
-  # This file should normally require a gtk-update-icon-cache -q /usr/share/icons/hicolor command
-  # It have no reasons to exist in a redistribuable package
-  postInstall = ''
-    rm $out/share/icons/hicolor/icon-theme.cache
-  '';
 
   meta = {
     description = "Gnome Diagram drawing software";

--- a/pkgs/applications/graphics/glabels/default.nix
+++ b/pkgs/applications/graphics/glabels/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, barcode, gnome3, autoreconfHook
 , gtk3, gtk-doc, libxml2, librsvg , libtool, libe-book
-, intltool, itstool, makeWrapper, pkgconfig, which
+, intltool, itstool, makeWrapper, pkgconfig, which, hicolor-icon-theme
 }:
 
 stdenv.mkDerivation rec {
@@ -17,11 +17,10 @@ stdenv.mkDerivation rec {
     barcode gtk3 gtk-doc gnome3.yelp-tools
     gnome3.gnome-common gnome3.gsettings-desktop-schemas
     itstool libxml2 librsvg libe-book libtool
-    
+    hicolor-icon-theme
   ];
 
   preFixup = ''
-    rm "$out/share/icons/hicolor/icon-theme.cache"
     wrapProgram "$out/bin/glabels-3" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
   '';

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -2,7 +2,7 @@
 , libpng, zlib, popt, boehmgc, libxml2, libxslt, glib, gtkmm2
 , glibmm, libsigcxx, lcms, boost, gettext, makeWrapper
 , gsl, python2, poppler, imagemagick, libwpg, librevenge
-, libvisio, libcdr, libexif, potrace, cmake
+, libvisio, libcdr, libexif, potrace, cmake, hicolor-icon-theme
 }:
 
 let
@@ -44,15 +44,13 @@ stdenv.mkDerivation rec {
     libXft libpng zlib popt boehmgc
     libxml2 libxslt glib gtkmm2 glibmm libsigcxx lcms boost gettext
     gsl poppler imagemagick libwpg librevenge
-    libvisio libcdr libexif potrace
+    libvisio libcdr libexif potrace hicolor-icon-theme
   ];
 
   enableParallelBuilding = true;
 
-  postInstall = ''
-    # Make sure PyXML modules can be found at run-time.
-    rm -f "$out/share/icons/hicolor/icon-theme.cache"
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  # Make sure PyXML modules can be found at run-time.
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     install_name_tool -change $out/lib/libinkscape_base.dylib $out/lib/inkscape/libinkscape_base.dylib $out/bin/inkscape
     install_name_tool -change $out/lib/libinkscape_base.dylib $out/lib/inkscape/libinkscape_base.dylib $out/bin/inkview
   '';

--- a/pkgs/applications/networking/newsreaders/liferea/default.nix
+++ b/pkgs/applications/networking/newsreaders/liferea/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, intltool, python3Packages, wrapGAppsHook
 , glib, libxml2, libxslt, sqlite, libsoup , webkitgtk, json-glib, gst_all_1
 , libnotify, gtk3, gsettings-desktop-schemas, libpeas, dconf, librsvg
-, gobjectIntrospection, glib-networking
+, gobjectIntrospection, glib-networking, hicolor-icon-theme
 }:
 
 let
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     glib gtk3 webkitgtk libxml2 libxslt sqlite libsoup gsettings-desktop-schemas
     libpeas gsettings-desktop-schemas json-glib dconf gobjectIntrospection
-    librsvg glib-networking libnotify
+    librsvg glib-networking libnotify hicolor-icon-theme
   ] ++ (with gst_all_1; [
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad
   ]);
@@ -28,7 +28,6 @@ in stdenv.mkDerivation rec {
   pythonPath = with python3Packages; [ pygobject3 pycairo ];
 
   preFixup = ''
-    rm "$out/share/icons/hicolor/icon-theme.cache"
     buildPythonPath "$out $pythonPath"
     gappsWrapperArgs+=(--prefix PYTHONPATH : "$program_PYTHONPATH")
   '';

--- a/pkgs/applications/networking/p2p/transmission/default.nix
+++ b/pkgs/applications/networking/p2p/transmission/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, intltool, file, wrapGAppsHook
-, openssl, curl, libevent, inotify-tools, systemd, zlib
+, openssl, curl, libevent, inotify-tools, systemd, zlib, hicolor-icon-theme
 , enableGTK3 ? false, gtk3
 , enableSystemd ? stdenv.isLinux
 , enableDaemon ? true
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool file openssl curl libevent zlib ]
     ++ optionals enableGTK3 [ gtk3 ]
     ++ optionals enableSystemd [ systemd ]
-    ++ optionals stdenv.isLinux [ inotify-tools ];
+    ++ optionals stdenv.isLinux [ inotify-tools ]
+    ++ optionals enableGTK3 [ hicolor-icon-theme ];
 
   postPatch = ''
     substituteInPlace ./configure \
@@ -38,10 +39,6 @@ stdenv.mkDerivation rec {
     ]
     ++ optional enableSystemd "--with-systemd-daemon"
     ++ optional enableGTK3 "--with-gtk";
-
-  preFixup = optionalString enableGTK3 ''
-    rm "$out/share/icons/hicolor/icon-theme.cache"
-  '';
 
   NIX_LDFLAGS = optionalString stdenv.isDarwin "-framework CoreFoundation";
 

--- a/pkgs/applications/office/gnucash/2.4.nix
+++ b/pkgs/applications/office/gnucash/2.4.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, libxml2, gconf, glib, gtk2, libgnomeui, libofx
 , libgtkhtml, gtkhtml, libgnomeprint, goffice, enchant, gettext, libbonoboui
 , intltool, perl, guile, slibGuile, swig, isocodes, bzip2, makeWrapper, libglade
-, libgsf, libart_lgpl, perlPackages, aqbanking, gwenhywfar
+, libgsf, libart_lgpl, perlPackages, aqbanking, gwenhywfar, hicolor-icon-theme
 }:
 
 /* If you experience GConf errors when running GnuCash on NixOS, see
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
     libgnomeprint goffice enchant gettext intltool perl guile slibGuile
     swig isocodes bzip2 makeWrapper libofx libglade libgsf libart_lgpl
     perlPackages.DateManip perlPackages.FinanceQuote aqbanking gwenhywfar
+    hicolor-icon-theme
   ];
   propagatedUserEnvPkgs = [ gconf ];
 
@@ -49,8 +50,6 @@ stdenv.mkDerivation rec {
         --set GCONF_CONFIG_SOURCE 'xml::~/.gconf'                       \
         --prefix PATH ":" "$out/bin:${stdenv.lib.makeBinPath [ perl gconf ]}"
     done
-
-    rm $out/share/icons/hicolor/icon-theme.cache
   '';
 
   # The following settings fix failures in the test suite. It's not required otherwise.

--- a/pkgs/applications/office/gnucash/2.6.nix
+++ b/pkgs/applications/office/gnucash/2.6.nix
@@ -3,7 +3,7 @@
 , glib, gtk2, libofx, aqbanking, gwenhywfar, libgnomecanvas, goffice
 , webkit, glibcLocales, gsettings-desktop-schemas, dconf
 , gettext, swig, slibGuile, enchant, bzip2, isocodes, libdbi, libdbiDrivers
-, pango, gdk_pixbuf
+, pango, gdk_pixbuf, hicolor-icon-theme
 }:
 
 /*
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     libxml2 libxslt glibcLocales gettext swig enchant
     bzip2 isocodes
     # glib, gtk...
-    glib gtk2 goffice webkit
+    glib gtk2 goffice webkit hicolor-icon-theme
     # gnome...
     dconf gconf libgnomecanvas gsettings-desktop-schemas
     # financial
@@ -83,8 +83,6 @@ stdenv.mkDerivation rec {
         --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules"  \
         --prefix PATH ":" "$out/bin:${stdenv.lib.makeBinPath [ perl gconf ]}"
     done
-
-    rm $out/share/icons/hicolor/icon-theme.cache
   '';
 
   # The following settings fix failures in the test suite. It's not required otherwise.

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify
     gst_all_1.gstreamer gst_all_1.gst-plugins-base dbus-glib udev
-    libgudev
+    libgudev hicolor-icon-theme
   ] ++ (if useFfmpeg then [ ffmpeg ] else [ patched_libav_12 ])
   ++ lib.optional useFdk fdk_aac;
 
@@ -80,11 +80,6 @@ stdenv.mkDerivation rec {
 
   preBuild = ''
     cd build
-  '';
-
-  # icon-theme.cache belongs in the icon theme, not in individual packages
-  postInstall = ''
-    rm $out/share/icons/hicolor/icon-theme.cache
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/xfce/applications/orage.nix
+++ b/pkgs/desktops/xfce/applications/orage.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, bison, flex, intltool, gtk, libical, dbus-glib, tzdata
-, libnotify, popt, xfce
-}:
+, libnotify, popt, xfce, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
@@ -34,8 +33,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gtk libical dbus-glib libnotify popt xfce.libxfce4util
     xfce.xfce4-panel ];
-
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache ";
 
   meta = {
     homepage = http://www.xfce.org/projects/;

--- a/pkgs/desktops/xfce/applications/xfce4-notifyd.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-notifyd.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, libnotify
-, gtk , libxfce4util, libxfce4ui, xfconf }:
+, gtk , libxfce4util, libxfce4ui, xfconf, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   p_name  = "xfce4-notifyd";
@@ -13,10 +13,9 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libnotify gtk libxfce4util libxfce4ui xfconf ];
+  buildInputs = [ intltool libnotify gtk libxfce4util libxfce4ui xfconf hicolor-icon-theme ];
 
   preFixup = ''
-    rm $out/share/icons/hicolor/icon-theme.cache
     # to be able to run the daemon we need it in PATH
     ln -rs $out/lib/xfce4/notifyd/xfce4-notifyd $out/bin
   '';

--- a/pkgs/desktops/xfce/core/thunar-build.nix
+++ b/pkgs/desktops/xfce/core/thunar-build.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, intltool
 , gtk, dbus-glib, libstartup_notification, libnotify, libexif, pcre, udev
-, exo, libxfce4util, xfconf, xfce4-panel, wrapGAppsHook
+, exo, libxfce4util, xfconf, xfce4-panel, hicolor-icon-theme, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -26,12 +26,11 @@ stdenv.mkDerivation rec {
     intltool
     gtk dbus-glib libstartup_notification libnotify libexif pcre udev
     exo libxfce4util xfconf xfce4-panel
+    hicolor-icon-theme
   ];
   # TODO: optionality?
 
   enableParallelBuilding = true;
-
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {
     homepage = http://thunar.xfce.org/;

--- a/pkgs/desktops/xfce/core/thunar-volman.nix
+++ b/pkgs/desktops/xfce/core/thunar-volman.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, exo, gtk, libxfce4util, libxfce4ui
-, xfconf, udev, libgudev, libnotify }:
+, xfconf, udev, libgudev, libnotify, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   p_name  = "thunar-volman";
@@ -15,9 +15,8 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ pkgconfig intltool exo gtk udev libgudev libxfce4ui libxfce4util
-      xfconf libnotify
+      xfconf libnotify hicolor-icon-theme
     ];
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-battery-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-battery-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk, hicolor-icon-theme }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk hicolor-icon-theme ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-clipman-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-clipman-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk, hicolor-icon-theme }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk hicolor-icon-theme ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpufreq-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpufreq-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk, hicolor-icon-theme }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -15,11 +15,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool ];
 
-  buildInputs = [ libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
+  buildInputs = [ libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk hicolor-icon-theme ];
 
   enableParallelBuilding = true;
-
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4-panel, libxfce4ui, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, exo, libXtst, xproto, libxfce4util, xfce4-panel, libxfce4ui, xfconf, gtk, hicolor-icon-theme }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4-panel xfconf gtk ];
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+  buildInputs = [ intltool glib exo libXtst xproto libxfce4util libxfce4ui xfce4-panel xfconf gtk hicolor-icon-theme ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-netload-plugin.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk}:
+{ stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4-panel, libxfce4ui, libxfcegui4, xfconf, gtk, hicolor-icon-theme }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,8 +13,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk ];
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
+  buildInputs = [ intltool libxfce4util libxfce4ui xfce4-panel libxfcegui4 xfconf gtk hicolor-icon-theme ];
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, libxfce4util, xfce4panel_gtk3, xfconf
-, gtk3, libpulseaudio
+, gtk3, libpulseaudio, hicolor-icon-theme
 , withKeybinder ? true, keybinder3
 , withLibnotify ? true, libnotify
 }:
@@ -21,11 +21,9 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   nativeBuildInputs = [ pkgconfig intltool ];
-  buildInputs = [ libxfce4util xfce4panel_gtk3 xfconf gtk3 libpulseaudio ]
+  buildInputs = [ libxfce4util xfce4panel_gtk3 xfconf gtk3 libpulseaudio hicolor-icon-theme ]
     ++ optional withKeybinder keybinder3
     ++ optional withLibnotify libnotify;
-
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk, libxml2, libsoup, upower,
-libxfce4ui, libxfce4util, xfce4-panel }:
+libxfce4ui, libxfce4util, xfce4-panel, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
@@ -15,11 +15,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool ];
 
   buildInputs = [ gtk libxml2 libsoup upower libxfce4ui libxfce4util
-   xfce4-panel ];
+   xfce4-panel hicolor-icon-theme ];
 
   enableParallelBuilding = true;
-
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   meta = {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";

--- a/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/archive/default.nix
@@ -2,7 +2,7 @@
 , gtk
 , thunarx-2-dev
 , exo, libxfce4util, libxfce4ui
-, xfconf, udev, libnotify
+, xfconf, udev, libnotify, hicolor-icon-theme
 }:
 
 stdenv.mkDerivation rec {
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     xfce4-dev-tools
     thunarx-2-dev
     exo gtk libxfce4util libxfce4ui
-    xfconf udev libnotify
+    xfconf udev libnotify hicolor-icon-theme
   ];
 
   preConfigure = ''
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
     pushd $out/libexec/thunar-archive-plugin > /dev/null
     ln -s ./file-roller.tap org.gnome.FileRoller.tap
     popd > /dev/null
-    rm $out/share/icons/hicolor/icon-theme.cache
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig
 , gtk
-, thunarx-2-dev, python2
+, thunarx-2-dev, python2, hicolor-icon-theme
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk
-    thunarx-2-dev python2
+    thunarx-2-dev python2 hicolor-icon-theme
   ];
 
   configurePhase = "python2 waf configure --prefix=$out";
@@ -27,8 +27,6 @@ stdenv.mkDerivation rec {
   installPhase = ''
     python2 waf install
   '';
-
-  preFixup = "rm $out/share/icons/hicolor/icon-theme.cache";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

There is (almost empty) ```hicolor-icon-theme``` package which does "rm $out/share/icons/hicolor/icon-theme.cache" and also collects icon paths into ```$XDG_ICON_DIRS```

I assume it is preferred to ad-hoc "rm $out/share/icons/hicolor/icon-theme.cache" in ```postInstall```

Related https://github.com/NixOS/nixpkgs/issues/39057 https://github.com/NixOS/nixpkgs/pull/43150

cc @jtojnar 
