### PR TITLE
xfce4-13.xfce4-battery-plugin: init at 1.1.0

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -44,6 +44,8 @@ makeScope newScope (self: with self; {
 
   xfce4-appfinder = callPackage ./xfce4-appfinder { };
 
+  xfce4-battery-plugin = callPackage ./xfce4-battery-plugin { };
+
   xfce4-dev-tools = callPackage ./xfce4-dev-tools {
     mkXfceDerivation = mkXfceDerivation.override {
       xfce4-dev-tools = null;

--- a/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools ? null }:
+{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools }:
 
-{ category, pname, sha256 ? null, version, ... } @ args:
+{ category, pname, version, rev ? "${pname}-${version}", sha256, ... } @ args:
 
 let
   inherit (builtins) filter getAttr head isList;
@@ -20,12 +20,13 @@ let
 
     src = fetchgit {
       url = "git://git.xfce.org/${category}/${pname}";
-      rev = name;
-      inherit sha256;
+      inherit rev sha256;
     };
 
     enableParallelBuilding = true;
     outputs = [ "out" "dev" ];
+
+    preFixup = ''rm $out/share/icons/hicolor/icon-theme.cache || true'';
 
     meta = with stdenv.lib; {
       homepage = "https://git.xfce.org/${category}/${pname}/about";

--- a/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce4-13/mkXfceDerivation.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools }:
+{ stdenv, fetchgit, pkgconfig, xfce4-dev-tools, hicolor-icon-theme }:
 
 { category, pname, version, rev ? "${pname}-${version}", sha256, ... } @ args:
 
@@ -16,6 +16,7 @@ let
     name = "${pname}-${version}";
 
     nativeBuildInputs = [ pkgconfig xfce4-dev-tools ];
+    buildInputs = [ hicolor-icon-theme ];
     configureFlags = [ "--enable-maintainer-mode" ];
 
     src = fetchgit {
@@ -25,8 +26,6 @@ let
 
     enableParallelBuilding = true;
     outputs = [ "out" "dev" ];
-
-    preFixup = ''rm $out/share/icons/hicolor/icon-theme.cache || true'';
 
     meta = with stdenv.lib; {
       homepage = "https://git.xfce.org/${category}/${pname}/about";

--- a/pkgs/desktops/xfce4-13/xfce4-battery-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-battery-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-battery-plugin";
+  version = "1.1.0";
+  rev = version;
+  sha256 = "0mz0lj3wjrsj9n4wcqrvv08430g38nkjbdimxdy8316n6bqgngfn";
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+}


### PR DESCRIPTION
###### Motivation for this change

A panel plugin which displays battery status.

```mkXfceDerivation```: altered to allow git revision be different from ```"${pname}-${version}"```

```mkXfceDerivation```: added ```hicolor-icon-theme``` hook as it is needed for almost all XFCE applications

cc @yegortimoshenko as author of ```mkXfceDerivation```
cc @vcunat as xfce maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

