### PR TITLE
add fetchclojar

### DIFF
--- a/pkgs/build-support/fetchclojar/default.nix
+++ b/pkgs/build-support/fetchclojar/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl }:
+{ version, artifactId, groupId, sha512, type ? "jar", suffix ? "" }:
+
+let
+  name = "${artifactId}-${version}";
+  m2Path = "${builtins.replaceStrings ["."] ["/"] groupId}/${artifactId}/${version}";
+  m2File = "${name}${suffix}.${type}";
+  src = fetchurl rec {
+      inherit sha512;
+      urls = [
+        "https://repo.clojars.org/${m2Path}/${m2File}"
+        "https://repo1.maven.org/maven2/${m2Path}/${m2File}"
+      ];
+  };
+in stdenv.mkDerivation rec {
+  inherit name m2Path m2File src;
+
+  installPhase = ''
+    mkdir -p $out/.m2/$m2Path
+    cp $src $out/.m2/$m2Path/$m2File
+  '';
+
+  phases = "installPhase";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -158,6 +158,8 @@ with pkgs;
 
   fetchbzr = callPackage ../build-support/fetchbzr { };
 
+  fetchclojar = callPackage ../build-support/fetchclojar { };
+
   fetchcvs = callPackage ../build-support/fetchcvs { };
 
   fetchdarcs = callPackage ../build-support/fetchdarcs { };


### PR DESCRIPTION
###### Motivation for this change
I'm working on a derivation that uses clojure and depends on clojar. I also want to create a tool clj2nix where I take all dependencies of a clojure project, calculate the sha sums and generate fetchclojar calls. Just for any work with clojure on nix, a clojar fetch helper function is needed.

This fetchclojar is based on fetchmaven under java-modules, because clojar is a maven2 repository, and many clojure dependencies use maven central dependencies. So for every depenency it makes sense to attempt both. This is the approach taken in the new dependency resolution tool for clojure called tools.deps https://github.com/clojure/tools.deps.alpha/blob/4f24e4ea6911e9a30a14979386f2b2cc3ad2ecc8/src/main/clojure/clojure/tools/deps/alpha/util/maven.clj#L56-L57

I hope this gets merged and I can continue my work on getting clojure based packages into nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

