### PR TITLE
mpd: add nfs and smb support

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -55,11 +55,11 @@ in {
       };
 
       musicDirectory = mkOption {
-        type = types.path;
+        type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
         default = "${cfg.dataDir}/music";
         defaultText = ''''${dataDir}/music'';
         description = ''
-          The directory where mpd reads music from.
+          The directory or NFS/SMB network share where mpd reads music from.
         '';
       };
 

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -84,8 +84,8 @@ in stdenv.mkDerivation rec {
     ++ opt clientSupport mpd_clientlib
     ++ opt opusSupport libopus
     ++ opt soundcloudSupport yajl
-    ++ opt nfsSupport libnfs
-    ++ opt smbSupport smbclient;
+    ++ opt (!stdenv.isDarwin && nfsSupport) libnfs
+    ++ opt (!stdenv.isDarwin && smbSupport) smbclient;
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
@@ -120,8 +120,8 @@ in stdenv.mkDerivation rec {
       (mkFlag clientSupport "libmpdclient")
       (mkFlag opusSupport "opus")
       (mkFlag soundcloudSupport "soundcloud")
-      (mkFlag nfsSupport "libnfs")
-      (mkFlag smbSupport "smbclient")
+      (mkFlag (!stdenv.isDarwin && nfsSupport) "libnfs")
+      (mkFlag (!stdenv.isDarwin && smbSupport) "smbclient")
       "--enable-debug"
       "--with-zeroconf=avahi"
     ]

--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -26,6 +26,8 @@
 , clientSupport ? true, mpd_clientlib
 , opusSupport ? true, libopus
 , soundcloudSupport ? true, yajl
+, nfsSupport ? true, libnfs
+, smbSupport ? true, smbclient
 }:
 
 assert avahiSupport -> avahi != null && dbus != null;
@@ -81,7 +83,9 @@ in stdenv.mkDerivation rec {
     ++ opt icuSupport icu
     ++ opt clientSupport mpd_clientlib
     ++ opt opusSupport libopus
-    ++ opt soundcloudSupport yajl;
+    ++ opt soundcloudSupport yajl
+    ++ opt nfsSupport libnfs
+    ++ opt smbSupport smbclient;
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
@@ -116,6 +120,8 @@ in stdenv.mkDerivation rec {
       (mkFlag clientSupport "libmpdclient")
       (mkFlag opusSupport "opus")
       (mkFlag soundcloudSupport "soundcloud")
+      (mkFlag nfsSupport "libnfs")
+      (mkFlag smbSupport "smbclient")
       "--enable-debug"
       "--with-zeroconf=avahi"
     ]


### PR DESCRIPTION
###### Motivation for this change

MPD supports so-called [storage plugins](https://www.musicpd.org/doc/user/storage_plugins.html). This allows it to directly access NFS and SMB shares without the need for mounting them and is a useful feature in a satellite setup, see also #41367. To make use of them in NixOS the `services.mpd.musicDirectory` option needs to allow for more than just paths.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @andir