### PR TITLE
ia-writer-duospace: init at 20180721

### DIFF
--- a/pkgs/data/fonts/ia-writer-duospace/default.nix
+++ b/pkgs/data/fonts/ia-writer-duospace/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchFromGitHub }:
+
+let
+  version = "20180721";
+in fetchFromGitHub rec {
+  name = "ia-writer-duospace-${version}";
+
+  owner = "iaolo";
+  repo = "iA-Fonts";
+  rev = "55edf60f544078ab1e14987bc67e9029a200e0eb";
+  sha256 = "0932lcxf861vb3hz52z1xj8r99ag9sdyqsnq9brv7gc4kp2l339c";
+
+  postFetch = ''
+    tar --strip-components=1 -xzvf $downloadedFile
+    mkdir -p $out/share/fonts/opentype
+    cp "iA Writer Duospace/OTF (Mac)/"*.otf $out/share/fonts/opentype/
+  '';
+
+  meta = with lib; {
+    description = "iA Writer Duospace Typeface";
+    homepage = https://ia.net/topics/in-search-of-the-perfect-writing-font;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14739,6 +14739,8 @@ with pkgs;
 
   hanazono = callPackage ../data/fonts/hanazono { };
 
+  ia-writer-duospace = callPackage ../data/fonts/ia-writer-duospace { };
+
   ibm-plex = callPackage ../data/fonts/ibm-plex { };
 
   iconpack-obsidian = callPackage ../data/icons/iconpack-obsidian { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

