### PR TITLE
ocamlPackages: bigstringaf init; angstrom update; httpaf init

### DIFF
--- a/pkgs/development/ocaml-modules/angstrom/default.nix
+++ b/pkgs/development/ocaml-modules/angstrom/default.nix
@@ -1,22 +1,24 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, alcotest, result }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, alcotest, result
+, bigstringaf
+}:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4.03"
 then throw "angstrom is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  version = "0.8.1";
+  version = "0.10.0";
   name = "ocaml${ocaml.version}-angstrom-${version}";
 
   src = fetchFromGitHub {
     owner  = "inhabitedtype";
     repo   = "angstrom";
     rev    = "${version}";
-    sha256 = "067r3vy5lac1bfx947gy722amna3dbcak54nlh24vx87pmcq31qc";
+    sha256 = "0lh6024yf9ds0nh9i93r9m6p5psi8nvrqxl5x7jwl13zb0r9xfpw";
   };
 
   buildInputs = [ ocaml findlib jbuilder alcotest ];
-  propagatedBuildInputs = [ result ];
+  propagatedBuildInputs = [ bigstringaf result ];
 
   buildPhase = "jbuilder build -p angstrom";
 

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, alcotest }:
+
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
+then throw "bigstringaf is not available for OCaml ${ocaml.version}"
+else
+
+stdenv.mkDerivation rec {
+  version = "0.3.0";
+  name = "ocaml${ocaml.version}-bigstringaf-${version}";
+
+  src = fetchFromGitHub {
+    owner = "inhabitedtype";
+    repo = "bigstringaf";
+    rev = version;
+    sha256 = "1yx6hv8rk0ldz1h6kk00rwg8abpfc376z00aifl9f5rn7xavpscs";
+  };
+
+  buildInputs = [ ocaml findlib jbuilder alcotest ];
+
+  doCheck = true;
+  checkPhase = "dune runtest";
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    description = "Bigstring intrinsics and fast blits based on memcpy/memmove";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/development/ocaml-modules/httpaf/default.nix
+++ b/pkgs/development/ocaml-modules/httpaf/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder
+, angstrom, faraday, alcotest
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.4.1";
+  name = "ocaml${ocaml.version}-httpaf-${version}";
+
+  src = fetchFromGitHub {
+    owner = "inhabitedtype";
+    repo = "httpaf";
+    rev = version;
+    sha256 = "0i2r004ihj00hd97475y8nhjqjln58xx087zcjl0dfp0n7q80517";
+  };
+
+  buildInputs = [ ocaml findlib jbuilder alcotest ];
+  propagatedBuildInputs = [ angstrom faraday ];
+
+  buildPhase = "dune build -p httpaf";
+
+  doCheck = true;
+  checkPhase = "dune runtest -p httpaf";
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
+    description = "A high-performance, memory-efficient, and scalable web server for OCaml";
+    license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -319,6 +319,8 @@ let
 
     hex = callPackage ../development/ocaml-modules/hex { };
 
+    httpaf = callPackage ../development/ocaml-modules/httpaf { };
+
     inifiles = callPackage ../development/ocaml-modules/inifiles { };
 
     iri = callPackage ../development/ocaml-modules/iri { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -71,6 +71,8 @@ let
 
     batteries = callPackage ../development/ocaml-modules/batteries { };
 
+    bigstringaf = callPackage ../development/ocaml-modules/bigstringaf { };
+
     bitstring = callPackage ../development/ocaml-modules/bitstring { };
 
     bitv = callPackage ../development/ocaml-modules/bitv { };


### PR DESCRIPTION
###### Motivation for this change

http/af is a high-performance, memory-efficient, and scalable web server for OCaml.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

