### PR TITLE
rustup: 1.11.0 -> 1.13.0

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -4,29 +4,26 @@ Date: Sat, 28 Oct 2017 17:58:17 +0200
 Subject: [PATCH] nix customization: patchelf installed binaries
 
 ---
- src/rustup-dist/src/component/package.rs | 24 +++++++++++++++++++++++-
- 1 file changed, 23 insertions(+), 1 deletion(-)
+ src/rustup-dist/src/component/package.rs | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/src/rustup-dist/src/component/package.rs b/src/rustup-dist/src/component/package.rs
-index 8aa63db9..4d219826 100644
+index 70c54dcd..f0318986 100644
 --- a/src/rustup-dist/src/component/package.rs
 +++ b/src/rustup-dist/src/component/package.rs
-@@ -99,7 +99,13 @@ impl Package for DirectoryPackage {
+@@ -100,7 +100,10 @@ impl Package for DirectoryPackage {
              let src_path = root.join(&path);
  
              match &*part.0 {
--                "file" => try!(builder.copy_file(path.clone(), &src_path)),
+-                "file" => builder.copy_file(path.clone(), &src_path)?,
 +                "file" => {
-+                    try!(builder.copy_file(path.clone(), &src_path));
-+                    nix_patchelf_if_needed(
-+                        &target.prefix().path().join(path.clone()),
-+                        &src_path,
-+                    )
++                    builder.copy_file(path.clone(), &src_path)?;
++                    nix_patchelf_if_needed(&target.prefix().path().join(path.clone()), &src_path)
 +                }
-                 "dir" => try!(builder.copy_dir(path.clone(), &src_path)),
+                 "dir" => builder.copy_dir(path.clone(), &src_path)?,
                  _ => return Err(ErrorKind::CorruptComponent(name.to_owned()).into()),
              }
-@@ -117,6 +123,22 @@ impl Package for DirectoryPackage {
+@@ -118,6 +121,22 @@ impl Package for DirectoryPackage {
      }
  }
  
@@ -50,5 +47,5 @@ index 8aa63db9..4d219826 100644
  // binaries are executable and directories readable. This shouldn't be
  // necessary: the source files *should* have the right permissions,
 -- 
-2.14.1
+2.17.1
 

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -4,16 +4,16 @@
 
 rustPlatform.buildRustPackage rec {
   name = "rustup-${version}";
-  version = "1.11.0";
-
-  cargoSha256 = "1r9mnj3x9sn16hi1r09gl5q0cnsa2g6kbjw2g115858i2a9k6hkr";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "rust-lang-nursery";
     repo = "rustup.rs";
     rev = version;
-    sha256 = "05rbgkz4fk6c1x6bpmpx108bg2qcrf6vv3yfz378s7bmr3l319iz";
+    sha256 = "1h0786jx64nc9q8x6fv7a5sf1xijxhn02m2pq5v2grl9ks0vxidn";
   };
+
+  cargoSha256 = "09lbm2k189sri3vwcwzv7j07ah39c8ajbpkg0kzvjsjwr7ypli8a";
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -32,10 +32,12 @@ rustPlatform.buildRustPackage rec {
     '')
   ];
 
+  doCheck = !stdenv.isAarch64;
+
   postInstall = ''
     pushd $out/bin
     mv rustup-init rustup
-    for link in cargo rustc rustdoc rust-gdb rust-lldb rls rustfmt cargo-fmt; do
+    for link in cargo rustc rustdoc rust-gdb rust-lldb rls rustfmt cargo-fmt cargo-clippy; do
       ln -s rustup $link
     done
     popd


### PR DESCRIPTION
[changelog](https://github.com/rust-lang-nursery/rustup.rs/blob/master/CHANGELOG.md#1130)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @Mic92 
