### PR TITLE
ocamlPackages.labltk: init at 8.06

### DIFF
--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -52,5 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "http://labltk.forge.ocamlcore.org/";
     license = stdenv.lib.licenses.lgpl21;
     inherit (ocaml.meta) platforms;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchurl, ocaml, findlib, tcl, tk }:
+
+let param = {
+  "4.04" = {
+    version = "8.06.2";
+    key = "1628";
+    sha256 = "1p97j9s33axkb4yyl0byhmhlyczqarb886ajpyggizy2br3a0bmk";
+  };
+  "4.05" = {
+    version = "8.06.3";
+    key = "1701";
+    sha256 = "1rka9jpg3kxqn7dmgfsa7pmsdwm16x7cn4sh15ijyyrad9phgdxn";
+  };
+  "4.06" = {
+    version = "8.06.4";
+    key = "1727";
+    sha256 = "0j3rz0zz4r993wa3ssnk5s416b1jhj58l6z2jk8238a86y7xqcii";
+  };
+  "4.07" = {
+    version = "8.06.5";
+    key = "1764";
+    sha256 = "0wgx65y1wkgf22ihpqmspqfp95fqbj3pldhp1p3b1mi8rmc37zwj";
+  };
+}."${builtins.substring 0 4 ocaml.version}";
+in
+
+stdenv.mkDerivation rec {
+  inherit (param) version;
+  name = "ocaml${ocaml.version}-labltk-${version}";
+
+  src = fetchurl {
+    url = "https://forge.ocamlcore.org/frs/download.php/${param.key}/labltk-${param.version}.tar.gz";
+    inherit (param) sha256;
+  };
+
+  buildInputs = [ ocaml findlib tcl tk ];
+
+  configureFlags = [ "--use-findlib" "--installbindir" "$(out)/bin" ];
+  dontAddPrefix = true;
+
+  buildFlags = [ "all" "opt" ];
+
+  createFindlibDestdir = true;
+
+  postInstall = ''
+    mkdir -p $OCAMLFIND_DESTDIR/stublibs
+    mv $OCAMLFIND_DESTDIR/labltk/dlllabltk.so $OCAMLFIND_DESTDIR/stublibs/
+  '';
+
+  meta = {
+    description = "OCaml interface to Tcl/Tk, including OCaml library explorer OCamlBrowser";
+    homepage = "http://labltk.forge.ocamlcore.org/";
+    license = stdenv.lib.licenses.lgpl21;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -366,6 +366,8 @@ let
       gtkmathview = callPackage ../development/libraries/gtkmathview { };
     };
 
+    labltk = callPackage ../development/ocaml-modules/labltk { };
+
     lambdaTerm-1_6 = callPackage ../development/ocaml-modules/lambda-term/1.6.nix { lwt = lwt2; };
     lambdaTerm =
       if lib.versionOlder "4.02" ocaml.version


### PR DESCRIPTION
LablTk is an OCaml interface to the Tcl/Tk GUI framework.

homepage: http://labltk.forge.ocamlcore.org/

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/43512#issuecomment-405051777
cc/ @ghasshee

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

