### PR TITLE
lollypop-portal: add version

### DIFF
--- a/pkgs/misc/lollypop-portal/default.nix
+++ b/pkgs/misc/lollypop-portal/default.nix
@@ -3,7 +3,7 @@
 , kid3, easytag, gobjectIntrospection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "lollypop-portal";
+  name = "lollypop-portal-${version}";
   version = "0.9.7";
 
   src = fetchFromGitLab {


### PR DESCRIPTION
###### Motivation for this change
The deception my eyes did to me when I made this pr :rofl: 

Also incidentally part of #43717

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

