### PR TITLE
mfcl8690cdw: init lpdr and cupswrapper at 1.0.2/1.0.3

### DIFF
--- a/pkgs/misc/cups/drivers/mfcl8690cdwcupswrapper/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwcupswrapper/default.nix
@@ -1,0 +1,45 @@
+{ coreutils, dpkg, fetchurl, gnugrep, gnused, makeWrapper,
+mfcl8690cdwlpr, perl, stdenv}:
+
+stdenv.mkDerivation rec {
+  name = "mfcl8690cdwcupswrapper-${version}";
+  version = "1.3.0-0";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf103250/${name}.i386.deb";
+    sha256 = "16nnh3hd5yv0m4191wja9fvxxzngzfccfj2rfhcswbakajyk5ywn";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    basedir=${mfcl8690cdwlpr}/opt/brother/Printers/mfcl8690cdw
+    dir=$out/opt/brother/Printers/mfcl8690cdw
+
+    substituteInPlace $dir/cupswrapper/brother_lpdwrapper_mfcl8690cdw \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "basedir =~" "basedir = \"$basedir/\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
+
+    wrapProgram $dir/cupswrapper/brother_lpdwrapper_mfcl8690cdw \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln $dir/cupswrapper/brother_lpdwrapper_mfcl8690cdw $out/lib/cups/filter
+    ln $dir/cupswrapper/brother_mfcl8690cdw_printer_en.ppd $out/share/cups/model
+    '';
+
+  meta = {
+    description = "Brother MFC-L8690CDW CUPS wrapper driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.unfree;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.fuzzy-id ];
+  };
+}

--- a/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl8690cdwlpr/default.nix
@@ -1,0 +1,45 @@
+{ coreutils, dpkg, fetchurl, file, ghostscript, gnugrep, gnused,
+makeWrapper, perl, pkgs, stdenv, which }:
+
+stdenv.mkDerivation rec {
+  name = "mfcl8690cdwlpr-${version}";
+  version = "1.2.0-0";
+
+  src = fetchurl {
+    url = "http://download.brother.com/welcome/dlf103241/${name}.i386.deb";
+    sha256 = "02k43nh51pn4lf7gaid9yhil0a3ikpy4krw7dhgphmm5pap907sx";
+  };
+
+  nativeBuildInputs = [ dpkg makeWrapper ];
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    dpkg-deb -x $src $out
+
+    dir=$out/opt/brother/Printers/mfcl8690cdw
+    filter=$dir/lpd/filter_mfcl8690cdw
+
+    substituteInPlace $filter \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir/\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
+
+    wrapProgram $filter \
+      --prefix PATH : ${stdenv.lib.makeBinPath [
+      coreutils file ghostscript gnugrep gnused which
+      ]}
+
+    # need to use i686 glibc here, these are 32bit proprietary binaries
+    interpreter=${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2
+    patchelf --set-interpreter "$interpreter" $dir/lpd/brmfcl8690cdwfilter
+  '';
+
+  meta = {
+    description = "Brother MFC-L8690CDW LPR printer driver";
+    homepage = http://www.brother.com/;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.fuzzy-id ];
+    platforms = [ "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21515,6 +21515,9 @@ with pkgs;
   mfcl2740dwcupswrapper = callPackage ../misc/cups/drivers/mfcl2740dwcupswrapper { };
   mfcl2740dwlpr = callPackage ../misc/cups/drivers/mfcl2740dwlpr { };
 
+  mfcl8690cdwcupswrapper = callPackage ../misc/cups/drivers/mfcl8690cdwcupswrapper { };
+  mfcl8690cdwlpr = callPackage ../misc/cups/drivers/mfcl8690cdwlpr { };
+
   samsung-unified-linux-driver_1_00_37 = callPackage ../misc/cups/drivers/samsung { };
   samsung-unified-linux-driver_4_01_17 = callPackage ../misc/cups/drivers/samsung/4.01.17.nix { };
   samsung-unified-linux-driver = callPackage ../misc/cups/drivers/samsung/4.00.39 { };


### PR DESCRIPTION
###### Motivation for this change

Provide printer driver for Brother MFC-L8690CDW.

Works for me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

