### PR TITLE
ldmtool: init at 0.2.4

### DIFF
--- a/pkgs/tools/misc/ldmtool/default.nix
+++ b/pkgs/tools/misc/ldmtool/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, gtk-doc, pkgconfig, libuuid,
+  libtool, readline, gobjectIntrospection, json-glib, lvm2, libxslt, docbook_xsl }:
+
+stdenv.mkDerivation rec {
+   name = "ldmtool-${version}";
+   version = "0.2.4";
+
+   src = fetchFromGitHub {
+     owner = "mdbooth";
+     repo = "libldm";
+     rev = "libldm-${version}";
+     sha256 = "1fy5wbmk8kwl86lzswq0d1z2j5y023qzfm2ppm8knzv9c47kniqk";
+   };
+
+   preConfigure = ''
+     sed -i docs/reference/ldmtool/Makefile.am \
+       -e 's|-nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl|--nonet ${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl|g'
+   '';
+
+   configureScript = "sh autogen.sh";
+
+   nativeBuildInputs = [ pkgconfig ];
+   buildInputs = [ autoconf automake gtk-doc lvm2 libxslt.bin
+     libtool readline gobjectIntrospection json-glib libuuid
+   ];
+
+   meta = with stdenv.lib; {
+     description = "Tool and library for managing Microsoft Windows Dynamic Disks";
+     homepage = https://github.com/mdbooth/libldm;
+     maintainers = with maintainers; [ jensbin ];
+     license = licenses.gpl3;
+     platforms = platforms.linux;
+   };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2765,6 +2765,8 @@ with pkgs;
 
   gparted = callPackage ../tools/misc/gparted { };
 
+  ldmtool = callPackage ../tools/misc/ldmtool { };
+
   gpodder = callPackage ../applications/audio/gpodder { };
 
   gpp = callPackage ../development/tools/gpp { };


### PR DESCRIPTION
###### Motivation for this change
ldmtool / libldm is a tool and library for managing Microsoft Windows
Dynamic Disks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

