### PR TITLE
sieve-connect: Init at 0.89

### DIFF
--- a/pkgs/applications/networking/sieve-connect/default.nix
+++ b/pkgs/applications/networking/sieve-connect/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages }: stdenv.mkDerivation rec {
+  name = "sieve-connect-${version}";
+  version = "0.89";
+
+  src = fetchFromGitHub {
+    owner = "philpennock";
+    repo = "sieve-connect";
+    rev = "v${version}";
+    sha256 = "0g7cv29wd5673inl4c87xb802k86bj6gcwh131xrbbg0a0g1c8fp";
+  };
+
+  buildInputs = [ perl ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  preBuild = ''
+    # Fixes failing build when not building in git repo
+    mkdir .git
+    touch .git/HEAD
+    echo "${version}" > versionfile
+    echo "$(date +%Y-%m-%d)" > datefile
+  '';
+
+  buildFlags = [ "PERL5LIB=${stdenv.lib.makePerlPath [ perlPackages.FileSlurp ]}" "bin" "man" ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/man/man1
+    install -m 755 sieve-connect $out/bin
+    gzip -c sieve-connect.1 > $out/share/man/man1/sieve-connect.1.gz
+
+    wrapProgram $out/bin/sieve-connect \
+      --prefix PERL5LIB : "${stdenv.lib.makePerlPath (with perlPackages; [
+        AuthenSASL Socket6 IOSocketInet6 IOSocketSSL NetSSLeay NetDNS PodUsage
+        TermReadKey TermReadLineGnu ])}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A client for the MANAGESIEVE Protocol";
+    longDescription = ''
+      This is sieve-connect. A client for the ManageSieve protocol,
+      as specifed in RFC 5804. Historically, this was MANAGESIEVE as
+      implemented by timsieved in Cyrus IMAP.
+    '';
+    homepage = https://github.com/philpennock/sieve-connect;
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5065,6 +5065,8 @@ with pkgs;
 
   siege = callPackage ../tools/networking/siege {};
 
+  sieve-connect = callPackage ../applications/networking/sieve-connect {};
+
   sigal = callPackage ../applications/misc/sigal {
     inherit (pythonPackages) buildPythonApplication fetchPypi;
   };


### PR DESCRIPTION
###### Motivation for this change

I use this tool to administrate the mail rules on my mail server.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

