### PR TITLE
sddm: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/applications/display-managers/sddm/default.nix
+++ b/pkgs/applications/display-managers/sddm/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "0.17.0";
+  version = "0.18.0";
 
 in mkDerivation rec {
   name = "sddm-${version}";
@@ -13,12 +13,11 @@ in mkDerivation rec {
     owner = "sddm";
     repo = "sddm";
     rev = "v${version}";
-    sha256 = "1m35ly6miwy8ivsln3j1bfv0nxbc4gyqnj7f847zzp53jsqrm3mq";
+    sha256 = "16xnm02iqgy4hydzd6my0widq981glbazbhxnihhclgsaczh8mfq";
   };
 
   patches = [
     ./sddm-ignore-config-mtime.patch
-    ./qt511.patch
   ];
 
   postPatch =


### PR DESCRIPTION
###### Motivation for this change

@adisbladis @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

