### PR TITLE
yakuake: fix meta

### DIFF
--- a/pkgs/applications/misc/yakuake/default.nix
+++ b/pkgs/applications/misc/yakuake/default.nix
@@ -65,6 +65,6 @@ mkDerivation rec {
     homepage = https://yakuake.kde.org;
     description = "Quad-style terminal emulator for KDE";
     maintainers = with lib.maintainers; [ fridh ];
-    licenses = lib.licenses.gpl2;
+    license = lib.licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

