### PR TITLE
Skarnet software: Rename attributes & split outputs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -362,6 +362,15 @@ inherit (pkgs.nixos {
       The module <option>services.networking.hostapd</option> now uses WPA2 by default.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      <varname>s6Dns</varname>, <varname>s6Networking</varname>,
+      <varname>s6LinuxUtils</varname> and <varname>s6PortableUtils</varname>
+      renamed to
+      <varname>s6-dns</varname>, <varname>s6-networking</varname>,
+      <varname>s6-linux-utils</varname> and <varname>s6-portable-utils</varname> respectively.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -14,15 +14,18 @@ in stdenv.mkDerivation rec {
     sha256 = "0skdv3wff1i78hb0y771apw0cak5rzxbwbh6l922snfm01z9k1ws";
   };
 
+  outputs = [ "lib" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--enable-force-devr"       # assume /dev/random works
-    "--libdir=\${prefix}/lib"
-    "--includedir=\${prefix}/include"
-    "--sysdepdir=\${prefix}/lib/skalibs/sysdeps"
+    "--libdir=\${lib}/lib"
+    "--dynlibdir=\${lib}/lib"
+    "--includedir=\${dev}/include"
+    "--sysdepdir=\${lib}/lib/skalibs/sysdeps"
   ]
   ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
   # On darwin, the target triplet from -dumpmachine includes version number, but
@@ -31,6 +34,11 @@ in stdenv.mkDerivation rec {
   # binary built on a different version of darwin.
   # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/skalibs
+    mv doc $doc/share/doc/skalibs/html
+  '';
 
   meta = {
     homepage = http://skarnet.org/software/skalibs/;

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     description = "A set of general-purpose C programming libraries";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -13,16 +13,24 @@ in stdenv.mkDerivation rec {
     sha256 = "0245rmk7wfyyfsi4g7f0niprwlvqlwkbyjxflb8kkbvhwfdavqip";
   };
 
+  outputs = [ "bin" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--includedir=\${prefix}/include"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-dynlib=${skalibs}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
   ];
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/s6-networking/
+    mv doc $doc/share/doc/s6-networking/html
+  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-linux-utils/;

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
     description = "A set of minimalistic Linux-specific system utilities";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -14,21 +14,31 @@ in stdenv.mkDerivation rec {
     sha256 = "1q0izb8ajzxl36fjpy4rn63sz01055r9s33fga99jprdmkkfzz6x";
   };
 
+  outputs = [ "bin" "lib" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--libdir=\${prefix}/lib"
-    "--includedir=\${prefix}/include"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-dynlib=${skalibs}/lib"
+    "--libdir=\${lib}/lib"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
   ]
   ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/execline
+    mv doc $doc/share/doc/execline/html
+    mv examples $doc/share/doc/execline/examples
+  '';
 
   meta = {
     homepage = http://skarnet.org/software/execline/;

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -11,14 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "0ca5iiq3n6isj64jb81xpwjzjx1q8jg145nnnn91ra2qqk93kqka";
   };
 
+  outputs = [ "bin" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-dynlib=${skalibs}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
   ]
   # On darwin, the target triplet from -dumpmachine includes version number, but
   # skarnet.org software uses the triplet to test binary compatibility.
@@ -26,6 +30,11 @@ stdenv.mkDerivation rec {
   # binary built on a different version of darwin.
   # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/s6-portable-utils/
+    mv doc $doc/share/doc/s6-portable-utils/html
+  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-portable-utils/;

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "A set of tiny general Unix utilities optimized for simplicity and small size";
     platforms = platforms.all;
     license = licenses.isc;
-    maintainers = with maintainers; [ pmahoney ];
+    maintainers = with maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -14,21 +14,31 @@ in stdenv.mkDerivation rec {
     sha256 = "10qvkh608nsx8gqs3pj4pb8aivwpshbmjw2766grgmrb35d31brl";
   };
 
+  outputs = [ "bin" "lib" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--includedir=\${prefix}/include"
-    "--libdir=\${prefix}/lib"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-dynlib=${skalibs}/lib"
+    "--libdir=\${lib}/lib"
+    "--libexecdir=\${lib}/libexec"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
   ]
   ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/s6-dns/
+    mv doc $doc/share/doc/s6-dns/html
+  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-dns/;

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     description = "A suite of DNS client programs and libraries for Unix systems";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, execline, fetchgit, s6, s6Dns, skalibs }:
+{ stdenv, execline, fetchgit, s6, s6-dns, skalibs }:
 
 let
 
@@ -14,27 +14,39 @@ in stdenv.mkDerivation rec {
     sha256 = "1qrhca8yjaysrqf7nx3yjfyfi9yly3rxpgrd2sqj0a0ckk73rv42";
   };
 
+  outputs = [ "bin" "lib" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-include=${execline}/include"
-    "--with-include=${s6}/include"
-    "--with-include=${s6Dns}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-lib=${execline}/lib"
-    "--with-lib=${s6}/lib/s6"
-    "--with-lib=${s6Dns}/lib"
-    "--with-dynlib=${skalibs}/lib"
-    "--with-dynlib=${execline}/lib"
-    "--with-dynlib=${s6}/lib"
-    "--with-dynlib=${s6Dns}/lib"
+    "--libdir=\${lib}/lib"
+    "--libexecdir=\${lib}/libexec"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-include=${execline.dev}/include"
+    "--with-include=${s6.dev}/include"
+    "--with-include=${s6-dns.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-lib=${execline.lib}/lib"
+    "--with-lib=${s6.out}/lib"
+    "--with-lib=${s6-dns.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+    "--with-dynlib=${execline.lib}/lib"
+    "--with-dynlib=${s6.out}/lib"
+    "--with-dynlib=${s6-dns.lib}/lib"
   ]
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/s6-networking/
+    mv doc $doc/share/doc/s6-networking/html
+  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6-networking/;

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
     description = "A suite of small networking utilities for Unix systems";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -14,25 +14,38 @@ in stdenv.mkDerivation rec {
     sha256 = "174a3l92nkhxrx8gq36xmb5a7krj40iz1xdiii25nxwjfiw5ynfb";
   };
 
+  outputs = [ "bin" "lib" "dev" "doc" "out" ];
+
   dontDisableStatic = true;
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-include=${execline}/include"
-    "--with-include=${s6}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-lib=${execline}/lib"
-    "--with-lib=${s6}/lib/s6"
-    "--with-dynlib=${skalibs}/lib"
-    "--with-dynlib=${execline}/lib"
-    "--with-dynlib=${s6}/lib"
+    "--libdir=\${lib}/lib"
+    "--libexecdir=\${lib}/libexec"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-include=${execline.dev}/include"
+    "--with-include=${s6.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-lib=${execline.lib}/lib"
+    "--with-lib=${s6.out}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+    "--with-dynlib=${execline.lib}/lib"
+    "--with-dynlib=${s6.out}/lib"
   ]
   ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/s6-rc/
+    mv doc $doc/share/doc/s6-rc/html
+    mv examples $doc/share/doc/s6-rc/examples
+  '';
 
   meta = {
     homepage = http://skarnet.org/software/s6-rc/;

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
     description = "A service manager for s6-based systems";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -14,22 +14,39 @@ in stdenv.mkDerivation rec {
     sha256 = "162hng8xcwjp8pr4d78zq3f82lm9c6ldbcfll0mjsmnxdds5hrsg";
   };
 
+  # NOTE lib: cannot split lib from bin at the moment,
+  # since some parts of lib depend on executables in bin.
+  # (the `*_startf` functions in `libs6`)
+
+  outputs = [ /*"bin" "lib"*/ "out" "dev" "doc" ];
+
   dontDisableStatic = true;
 
   enableParallelBuilding = true;
 
   configureFlags = [
     "--enable-absolute-paths"
-    "--with-sysdeps=${skalibs}/lib/skalibs/sysdeps"
-    "--with-include=${skalibs}/include"
-    "--with-include=${execline}/include"
-    "--with-lib=${skalibs}/lib"
-    "--with-lib=${execline}/lib"
-    "--with-dynlib=${skalibs}/lib"
-    "--with-dynlib=${execline}/lib"
+    "--libdir=\${out}/lib"
+    "--libexecdir=\${out}/libexec"
+    "--dynlibdir=\${out}/lib"
+    "--bindir=\${out}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-include=${execline.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-lib=${execline.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+    "--with-dynlib=${execline.lib}/lib"
   ]
   ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
   ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.system}");
+
+  postInstall = ''
+    mkdir -p $doc/share/doc/s6/
+    mv doc $doc/share/doc/s6/html
+    mv examples $doc/share/doc/s6/examples
+  '';
 
   meta = {
     homepage = http://www.skarnet.org/software/s6/;

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
     description = "skarnet.org's small & secure supervision software suite";
     platforms = stdenv.lib.platforms.all;
     license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney ];
+    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
   };
 
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -228,6 +228,10 @@ mapAliases ({
   ruby_2_5_0 = throw "deprecated 2018-0213: use ruby_2_5 instead";
   rubygems = throw "deprecated 2016-03-02: rubygems is now bundled with ruby";
   rxvt_unicode_with-plugins = rxvt_unicode-with-plugins; # added 2015-04-02
+  s6Dns = s6-dns; # added 2018-07-23
+  s6Networking = s6-networking; # added 2018-07-23
+  s6LinuxUtils = s6-linux-utils; # added 2018-07-23
+  s6PortableUtils = s6-portable-utils; # added 2018-07-23
   sam = deadpixi-sam; # added 2018-04-25
   samsungUnifiedLinuxDriver = samsung-unified-linux-driver; # added 2016-01-25
   saneBackends = sane-backends; # added 2016-01-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4929,13 +4929,13 @@ with pkgs;
 
   s3gof3r = callPackage ../tools/networking/s3gof3r { };
 
-  s6Dns = callPackage ../tools/networking/s6-dns { };
+  s6-dns = callPackage ../tools/networking/s6-dns { };
 
-  s6LinuxUtils = callPackage ../os-specific/linux/s6-linux-utils { };
+  s6-linux-utils = callPackage ../os-specific/linux/s6-linux-utils { };
 
-  s6Networking = callPackage ../tools/networking/s6-networking { };
+  s6-networking = callPackage ../tools/networking/s6-networking { };
 
-  s6PortableUtils = callPackage ../tools/misc/s6-portable-utils { };
+  s6-portable-utils = callPackage ../tools/misc/s6-portable-utils { };
 
   sablotron = callPackage ../tools/text/xml/sablotron { };
 


### PR DESCRIPTION
This (rather large) PR adds multiple outputs to all skarnet.org software. It also renames the attribute names of muilti-word packages to be more consistent.

In the future it might make sense to write a `buildSkarnetPackage` function to remove the duplication between most package derivations.

cc maintainer @pmahoney 

