### PR TITLE
1password: 0.4.1 -> 0.5.1

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   name = "1password-${version}";
-  version = "0.4.1";
+  version = "0.5.1";
   src =
     if stdenv.system == "i686-linux" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip";
-        sha256 = "1yzzh1f6hx7vwdgzp0znsjarjiw4xqmmrkc5xwywgjpg81qqpl8c";
+        sha256 = "08kzjilxpkvlwqjyxnic1n6xiy6gkndijwxdksm59k7c56mdawsz";
         stripRoot = false;
       }
     else if stdenv.system == "x86_64-linux" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip";
-        sha256 = "0dgj1zqmpdbnsz2v2j7nqm232cdgyp9wagc089dxi4hbzkmfcvzx";
+        sha256 = "1bsbzaqws0z991r6rkjrxay74fj4g5ld4d748ygr0950zwi1m3h7";
         stripRoot = false;
       }
     else if stdenv.system == "x86_64-darwin" then
       fetchzip {
         url = "https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_darwin_amd64_v${version}.zip";
-        sha256 = "116bvyfg38npdhlzaxan5y47cbw7jvj94q5w6v71kxsjzxk9l44a";
+        sha256 = "1dhr8m9icip27v802gxl1vhl9rf0jq5awirdm72lqmlypj86df0g";
         stripRoot = false;
       }
     else throw "Architecture not supported";
@@ -34,13 +34,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "1Password command-line tool";
-    homepage    = [
-      "https://blog.agilebits.com/2017/09/06/announcing-the-1password-command-line-tool-public-beta/"
-      "https://app-updates.agilebits.com/product_history/CLI"
-    ];
-    maintainers = with maintainers; [ joelburget ];
-    license     = licenses.unfree;
-    platforms   = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
+    description  = "1Password command-line tool";
+    homepage     = https://support.1password.com/command-line/;
+    downloadPage = https://app-updates.agilebits.com/product_history/CLI;
+    maintainers  = with maintainers; [ joelburget ];
+    license      = licenses.unfree;
+    platforms    = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

