### PR TITLE
Openssl in coreutils makes *sum programs much faster (RFC)

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -1,6 +1,5 @@
 { stdenv, lib, buildPackages
-, autoreconfHook, texinfo, fetchurl, perl, xz, libiconv, gmp ? null
-, openssl ? null
+, autoreconfHook, texinfo, fetchurl, perl, xz, libiconv, openssl, gmp ? null
 , hostPlatform, buildPlatform
 , aclSupport ? false, acl ? null
 , attrSupport ? false, attr ? null
@@ -38,7 +37,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "info" ];
 
   nativeBuildInputs = [ perl xz.bin ];
-  configureFlags = optional (openssl != null) "--with-openssl"
+  configureFlags = [ "--with-openssl" ]
     ++ optional (singleBinary != false)
       ("--enable-single-binary" + optionalString (isString singleBinary) "=${singleBinary}")
     ++ optional hostPlatform.isSunOS "ac_cv_func_inotify_init=no"


### PR DESCRIPTION
sha256sum, md5sum,. run much faster. Factor 2x to 4x.

You can evaluate that by comparing the cpu time of your 'time sha256sum bigfile' and 'time openssl sha256 bigfile'.

What do you think? I use these a lot, and I guess that git-annex users too.