### PR TITLE
cloudfoundry-cli: 6.36.1 -> 6.37.0

### DIFF
--- a/pkgs/development/tools/cloudfoundry-cli/default.nix
+++ b/pkgs/development/tools/cloudfoundry-cli/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "cloudfoundry-cli-${version}";
-  version = "6.36.1";
+  version = "6.37.0";
 
   goPackagePath = "code.cloudfoundry.org/cli";
 
@@ -12,17 +12,18 @@ buildGoPackage rec {
     owner = "cloudfoundry";
     repo = "cli";
     rev = "v${version}";
-    sha256 = "19inl7qs2acs59p3gnl5zdsxym0wp2rn05q0zfg7rwf5sjh68amp";
+    sha256 = "1v4f1fyydpzkfir46g4ppbf3zmk3ym6kxswpkdjls8h3dbb2fbnv";
   };
 
   outputs = [ "out" ];
 
-  buildFlagsArray = ''
-    -ldflags= -X ${goPackagePath}/version.binaryVersion=${version}
+  buildPhase = ''
+    cd go/src/${goPackagePath}
+    CF_BUILD_DATE="1970-01-01" make build
   '';
 
   installPhase = ''
-    install -Dm555 go/bin/cli "$out/bin/cf"
+    install -Dm555 out/cf "$out/bin/cf"
     remove-references-to -t ${go} "$out/bin/cf"
     install -Dm444 -t "$out/share/bash-completion/completions/" "$src/ci/installers/completion/cf"
   '';


### PR DESCRIPTION
###### Motivation for this change
Fairly normal bump, but also upstream seems to have added new make build system - I've adapted the package to use that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

