### PR TITLE
mupdf: fix on darwin

### DIFF
--- a/pkgs/applications/misc/mupdf/darwin.patch
+++ b/pkgs/applications/misc/mupdf/darwin.patch
@@ -21,7 +21,7 @@ diff --git a/Makerules b/Makerules
 -SYS_GLUT_CFLAGS :=
 -SYS_GLUT_LIBS := -lglut -lGL
 -
- ifeq "$(shell pkg-config --exists 'libcrypto <= 1.0.1t' && echo yes)" "yes"
+ ifeq "$(shell pkg-config --exists 'libcrypto >= 1.1.0' && echo yes)" "yes"
  HAVE_LIBCRYPTO := yes
  SYS_LIBCRYPTO_CFLAGS := -DHAVE_LIBCRYPTO $(shell pkg-config --cflags libcrypto)
 @@ -113,7 +101,7 @@ SYS_CURL_CFLAGS += $(shell pkg-config --cflags openssl)
@@ -33,3 +33,15 @@ diff --git a/Makerules b/Makerules
  
  ifeq "$(shell pkg-config --exists x11 xext && echo yes)" "yes"
  HAVE_X11 := yes
+diff --git a/platform/gl/gl-main.c b/platform/gl/gl-main.c
+index d58f7ba..808af18 100644
+--- a/platform/gl/gl-main.c
++++ b/platform/gl/gl-main.c
+@@ -16,6 +16,7 @@ void glutExit(void) {}
+ void glutMouseWheelFunc(void *fn) {}
+ void glutInitErrorFunc(void *fn) {}
+ void glutInitWarningFunc(void *fn) {}
++#define glutSetOption(X,Y)
+ #endif
+ 
+ enum


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The fix for non-freglut is from upstream: http://git.ghostscript.com/?p=mupdf.git;a=blob;f=platform/gl/gl-ui.c;h=7ce94500922f5b8158fba2db484fb13a202fb272;hb=HEAD