### PR TITLE
Upstream sessions

### DIFF
--- a/nixos/modules/services/desktops/gnome3/gpaste.nix
+++ b/nixos/modules/services/desktops/gnome3/gpaste.nix
@@ -21,6 +21,7 @@ with lib;
   config = mkIf config.services.gnome3.gpaste.enable {
     environment.systemPackages = [ pkgs.gnome3.gpaste ];
     services.dbus.packages = [ pkgs.gnome3.gpaste ];
+    services.xserver.desktopManager.gnome3.sessionPath = [ pkgs.gnome3.gpaste ];
     systemd.packages = [ pkgs.gnome3.gpaste ];
   };
 }

--- a/nixos/modules/services/desktops/gnome3/gpaste.nix
+++ b/nixos/modules/services/desktops/gnome3/gpaste.nix
@@ -21,7 +21,6 @@ with lib;
   config = mkIf config.services.gnome3.gpaste.enable {
     environment.systemPackages = [ pkgs.gnome3.gpaste ];
     services.dbus.packages = [ pkgs.gnome3.gpaste ];
-    services.xserver.desktopManager.gnome3.sessionPath = [ pkgs.gnome3.gpaste ];
     systemd.packages = [ pkgs.gnome3.gpaste ];
   };
 }

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -96,13 +96,13 @@ in
           else if any (w: w.name == defaultDM) cfg.session.list then
             defaultDM
           else
-            throw ''
-              Default desktop manager (${defaultDM}) not found.
-              Probably you want to change
-                services.xserver.desktopManager.default = "${defaultDM}";
-              to one of
+            builtins.trace ''
+              Default desktop manager (${defaultDM}) not found at evaluation time.
+              These are the known valid session names:
                 ${concatMapStringsSep "\n  " (w: "services.xserver.desktopManager.default = \"${w.name}\";") cfg.session.list}
-            '';
+              It's also possible the default can be found in one of these packages:
+                ${concatMapStringsSep "\n  " (p: p.name) config.services.xserver.displayManager.extraSessionFilePackages}
+            '' defaultDM;
       };
 
     };

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -118,36 +118,17 @@ in {
 
     fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell-fonts ];
 
-    services.xserver.desktopManager.session = singleton
-      { name = "gnome3";
-        bgSupport = true;
-        start = ''
-          # Set GTK_DATA_PREFIX so that GTK+ can find the themes
-          export GTK_DATA_PREFIX=${config.system.path}
+    services.xserver.displayManager.extraSessionFilePackages = [ pkgs.gnome3.gnome-session ];
 
-          # find theme engines
-          export GTK_PATH=${config.system.path}/lib/gtk-3.0:${config.system.path}/lib/gtk-2.0
+    # Override default mimeapps
+    environment.variables.XDG_DATA_DIRS = [ "${mimeAppsList}/share" ];
 
-          export XDG_MENU_PREFIX=gnome-
+    # Override GSettings schemas
+    environment.variables.NIX_GSETTINGS_OVERRIDES_DIR = "${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";
 
-          # Override default mimeapps
-          export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${mimeAppsList}/share
-
-          # Override gsettings-desktop-schema
-          export NIX_GSETTINGS_OVERRIDES_DIR=${nixos-gsettings-desktop-schemas}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas
-
-          # Let nautilus find extensions
-          export NAUTILUS_EXTENSION_DIR=${config.system.path}/lib/nautilus/extensions-3.0/
-
-          # Find the mouse
-          export XCURSOR_PATH=~/.icons:${config.system.path}/share/icons
-
-          ${pkgs.gnome3.gnome-session}/bin/gnome-session ${optionalString cfg.debug "--debug"} &
-          waitPID=$!
-        '';
-      };
-
-    services.xserver.updateDbusEnvironment = true;
+    # Let nautilus find extensions
+    # TODO: Create nautilus-with-extensions package
+    environment.variables.NAUTILUS_EXTENSION_DIR = "${config.system.path}/lib/nautilus/extensions-3.0";
 
     environment.variables.GIO_EXTRA_MODULES = [ "${lib.getLib pkgs.gnome3.dconf}/lib/gio/modules"
                                                 "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -143,6 +143,7 @@ in {
       fi
     '';
 
+    environment.variables.GNOME_SESSION_DEBUG = optionalString cfg.debug "1";
 
     # Override default mimeapps
     environment.variables.XDG_DATA_DIRS = [ "${mimeAppsList}/share" ];

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -54,6 +54,14 @@ in {
         description = "Enable Gnome 3 desktop manager.";
       };
 
+      sessionPath = mkOption {
+        default = [];
+        example = literalExample "[ pkgs.gnome3.gpaste ]";
+        description = "Additional list of packages to be added to the session search path.
+                       Useful for gnome shell extensions or gsettings-conditionated autostart.";
+        apply = list: list ++ [ pkgs.gnome3.gnome-shell pkgs.gnome3.gnome-shell-extensions ];
+      };
+
       extraGSettingsOverrides = mkOption {
         default = "";
         type = types.lines;
@@ -120,6 +128,22 @@ in {
 
     services.xserver.displayManager.extraSessionFilePackages = [ pkgs.gnome3.gnome-session ];
 
+    services.xserver.displayManager.sessionCommands = ''
+      if test "$XDG_CURRENT_DESKTOP" = "GNOME"; then
+          ${concatMapStrings (p: ''
+            if [ -d "${p}/share/gsettings-schemas/${p.name}" ]; then
+              export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${p}/share/gsettings-schemas/${p.name}
+            fi
+
+            if [ -d "${p}/lib/girepository-1.0" ]; then
+              export GI_TYPELIB_PATH=$GI_TYPELIB_PATH''${GI_TYPELIB_PATH:+:}${p}/lib/girepository-1.0
+              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${p}/lib
+            fi
+          '') cfg.sessionPath}
+      fi
+    '';
+
+
     # Override default mimeapps
     environment.variables.XDG_DATA_DIRS = [ "${mimeAppsList}/share" ];
 
@@ -133,7 +157,7 @@ in {
     environment.variables.GIO_EXTRA_MODULES = [ "${lib.getLib pkgs.gnome3.dconf}/lib/gio/modules"
                                                 "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"
                                                 "${pkgs.gnome3.gvfs}/lib/gio/modules" ];
-    environment.systemPackages = pkgs.gnome3.corePackages
+    environment.systemPackages = pkgs.gnome3.corePackages ++ cfg.sessionPath
       ++ (removePackagesByName pkgs.gnome3.optionalPackages config.environment.gnome3.excludePackages) ++ [
       pkgs.xdg-user-dirs # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
     ];

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -161,9 +161,6 @@ in {
           # Find the mouse
           export XCURSOR_PATH=~/.icons:${config.system.path}/share/icons
 
-          # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
-          ${pkgs.xdg-user-dirs}/bin/xdg-user-dirs-update
-
           ${pkgs.gnome3.gnome-session}/bin/gnome-session ${optionalString cfg.debug "--debug"} &
           waitPID=$!
         '';
@@ -175,7 +172,9 @@ in {
                                                 "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"
                                                 "${pkgs.gnome3.gvfs}/lib/gio/modules" ];
     environment.systemPackages = pkgs.gnome3.corePackages ++ cfg.sessionPath
-      ++ (removePackagesByName pkgs.gnome3.optionalPackages config.environment.gnome3.excludePackages);
+      ++ (removePackagesByName pkgs.gnome3.optionalPackages config.environment.gnome3.excludePackages) ++ [
+      pkgs.xdg-user-dirs # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
+    ];
 
     # Use the correct gnome3 packageSet
     networking.networkmanager.basePackages =

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -54,14 +54,6 @@ in {
         description = "Enable Gnome 3 desktop manager.";
       };
 
-      sessionPath = mkOption {
-        default = [];
-        example = literalExample "[ pkgs.gnome3.gpaste ]";
-        description = "Additional list of packages to be added to the session search path.
-                       Useful for gnome shell extensions or gsettings-conditionated autostart.";
-        apply = list: list ++ [ pkgs.gnome3.gnome-shell pkgs.gnome3.gnome-shell-extensions ];
-      };
-
       extraGSettingsOverrides = mkOption {
         default = "";
         type = types.lines;
@@ -138,17 +130,6 @@ in {
 
           export XDG_MENU_PREFIX=gnome-
 
-          ${concatMapStrings (p: ''
-            if [ -d "${p}/share/gsettings-schemas/${p.name}" ]; then
-              export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${p}/share/gsettings-schemas/${p.name}
-            fi
-
-            if [ -d "${p}/lib/girepository-1.0" ]; then
-              export GI_TYPELIB_PATH=$GI_TYPELIB_PATH''${GI_TYPELIB_PATH:+:}${p}/lib/girepository-1.0
-              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${p}/lib
-            fi
-          '') cfg.sessionPath}
-
           # Override default mimeapps
           export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${mimeAppsList}/share
 
@@ -171,7 +152,7 @@ in {
     environment.variables.GIO_EXTRA_MODULES = [ "${lib.getLib pkgs.gnome3.dconf}/lib/gio/modules"
                                                 "${pkgs.gnome3.glib-networking.out}/lib/gio/modules"
                                                 "${pkgs.gnome3.gvfs}/lib/gio/modules" ];
-    environment.systemPackages = pkgs.gnome3.corePackages ++ cfg.sessionPath
+    environment.systemPackages = pkgs.gnome3.corePackages
       ++ (removePackagesByName pkgs.gnome3.optionalPackages config.environment.gnome3.excludePackages) ++ [
       pkgs.xdg-user-dirs # Update user dirs as described in http://freedesktop.org/wiki/Software/xdg-user-dirs/
     ];

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -57,8 +57,12 @@ in {
       sessionPath = mkOption {
         default = [];
         example = literalExample "[ pkgs.gnome3.gpaste ]";
-        description = "Additional list of packages to be added to the session search path.
-                       Useful for gnome shell extensions or gsettings-conditionated autostart.";
+        description = ''
+          Additional list of packages to be added to the session search path.
+          Useful for GNOME Shell extensions or GSettings-conditional autostart.
+
+          Note that this should be a last resort; patching the package is preferred (see GPaste).
+        '';
         apply = list: list ++ [ pkgs.gnome3.gnome-shell pkgs.gnome3.gnome-shell-extensions ];
       };
 

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -186,9 +186,9 @@ let
       allowSubstitutes = false;
     }
     ''
-      mkdir -p "$out"
+      mkdir -p "$out/share/xsessions"
       ${concatMapStrings (n: ''
-        cat - > "$out/${n}.desktop" << EODESKTOP
+        cat - > "$out/share/xsessions/${n}.desktop" << EODESKTOP
         [Desktop Entry]
         Version=1.0
         Type=XSession

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -27,55 +27,26 @@ let
     Xft.hintstyle: hintslight
   '';
 
-  # file provided by services.xserver.displayManager.session.script
-  xsession = wm: dm: pkgs.writeScript "xsession"
+  # file provided by services.xserver.displayManager.session.wrapper
+  xsessionWrapper = pkgs.writeScript "xsession-wrapper"
     ''
       #! ${pkgs.bash}/bin/bash
 
-      # Expected parameters:
-      #   $1 = <desktop-manager>+<window-manager>
-
-      # Actual parameters (FIXME):
-      # SDDM is calling this script like the following:
-      #   $1 = /nix/store/xxx-xsession (= $0)
-      #   $2 = <desktop-manager>+<window-manager>
-      # SLiM is using the following parameter:
-      #   $1 = /nix/store/xxx-xsession <desktop-manager>+<window-manager>
-      # LightDM keeps the double quotes:
-      #   $1 = /nix/store/xxx-xsession "<desktop-manager>+<window-manager>"
-      # The fake/auto display manager doesn't use any parameters and GDM is
-      # broken.
-      # If you want to "debug" this script don't print the parameters to stdout
-      # or stderr because this script will be executed multiple times and the
-      # output won't be visible in the log when the script is executed for the
-      # first time (e.g. append them to a file instead)!
-
-      # All of the above cases are handled by the following hack (FIXME).
-      # Since this line is *very important* for *all display managers* it is
-      # very important to test changes to the following line with all display
-      # managers:
-      if [ "''${1:0:1}" = "/" ]; then eval exec "$1" "$2" ; fi
-
-      # Now it should be safe to assume that the script was called with the
-      # expected parameters.
+      # Shared environment setup for graphical sessions.
 
       . /etc/profile
       cd "$HOME"
 
-      # The first argument of this script is the session type.
-      sessionType="$1"
-      if [ "$sessionType" = default ]; then sessionType=""; fi
-
       ${optionalString cfg.startDbusSession ''
         if test -z "$DBUS_SESSION_BUS_ADDRESS"; then
-          exec ${pkgs.dbus.dbus-launch} --exit-with-session "$0" "$sessionType"
+          exec ${pkgs.dbus.dbus-launch} --exit-with-session "$0" "$@"
         fi
       ''}
 
       ${optionalString cfg.displayManager.job.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then
           export _DID_SYSTEMD_CAT=1
-          exec ${config.systemd.package}/bin/systemd-cat -t xsession "$0" "$sessionType"
+          exec ${config.systemd.package}/bin/systemd-cat -t xsession "$0" "$@"
         fi
       ''}
 
@@ -101,6 +72,7 @@ let
       ${config.systemd.package}/bin/systemctl --user import-environment DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS
 
       # Load X defaults.
+      # FIXME: Check XDG_SESSION_TYPE against x11
       ${xorg.xrdb}/bin/xrdb -merge ${xresourcesXft}
       if test -e ~/.Xresources; then
           ${xorg.xrdb}/bin/xrdb -merge ~/.Xresources
@@ -132,11 +104,32 @@ let
       # Allow the user to setup a custom session type.
       if test -x ~/.xsession; then
           exec ~/.xsession
-      else
-          if test "$sessionType" = "custom"; then
-              sessionType="" # fall-thru if there is no ~/.xsession
-          fi
       fi
+
+      if test "$1"; then
+          # Run the supplied session command. Remove any double quotes with eval.
+          eval exec "$@"
+      else
+          # Fall back to the default window/desktopManager
+          exec ${cfg.displayManager.session.script}
+      fi
+    '';
+
+  # file provided by services.xserver.displayManager.session.script
+  xsession = wm: dm: pkgs.writeScript "xsession"
+    ''
+      #! ${pkgs.bash}/bin/bash
+
+      # Legacy session script used to construct .desktop files from
+      # `services.xserver.displayManager.session` entries. Called from
+      # `sessionWrapper`.
+
+      # Expected parameters:
+      #   $1 = <desktop-manager>+<window-manager>
+
+      # The first argument of this script is the session type.
+      sessionType="$1"
+      if [ "$sessionType" = default ]; then sessionType=""; fi
 
       # The session type is "<desktop-manager>+<window-manager>", so
       # extract those (see:
@@ -194,7 +187,6 @@ let
         Type=XSession
         TryExec=${cfg.displayManager.session.script}
         Exec=${cfg.displayManager.session.script} "${n}"
-        X-GDM-BypassXsession=true
         Name=${n}
         Comment=
         EODESKTOP
@@ -292,6 +284,7 @@ in
               (filter (w: d.name != "none" || w.name != "none") wm));
           desktops = mkDesktops names;
           script = xsession wm dm;
+          wrapper = xsessionWrapper;
         };
       };
 

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -199,6 +199,10 @@ let
         Comment=
         EODESKTOP
       '') names}
+
+      ${concatMapStrings (pkg: ''
+        ${xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
+      '') cfg.displayManager.extraSessionFilePackages}
     '';
 
 in
@@ -242,6 +246,14 @@ in
         default = [ "nobody" ];
         description = ''
           A list of users which will not be shown in the display manager.
+        '';
+      };
+
+      extraSessionFilePackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        description = ''
+          A list of packages containing xsession files to be passed to the display manager.
         '';
       };
 

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -173,7 +173,7 @@ in
       ${optionalString cfg.gdm.debug "Enable=true"}
     '';
 
-    environment.etc."gdm/Xsession".source = "${pkgs.gnome3.gdm}/etc/gdm/Xsession";
+    environment.etc."gdm/Xsession".source = config.services.xserver.displayManager.session.wrapper;
 
     # GDM LFS PAM modules, adapted somehow to NixOS
     security.pam.services = {

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -109,7 +109,7 @@ in
         environment = {
           GDM_X_SERVER_EXTRA_ARGS = toString
             (filter (arg: arg != "-terminate") cfg.xserverArgs);
-          GDM_SESSIONS_DIR = "${cfg.session.desktops}";
+          GDM_SESSIONS_DIR = "${cfg.session.desktops}/share/xsessions";
           # Find the mouse
           XCURSOR_PATH = "~/.icons:${pkgs.gnome3.adwaita-icon-theme}/share/icons";
         };

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -173,6 +173,8 @@ in
       ${optionalString cfg.gdm.debug "Enable=true"}
     '';
 
+    environment.etc."gdm/Xsession".source = "${pkgs.gnome3.gdm}/etc/gdm/Xsession";
+
     # GDM LFS PAM modules, adapted somehow to NixOS
     security.pam.services = {
       gdm-launch-environment.text = ''

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -49,7 +49,7 @@ let
 
       [Seat:*]
       xserver-command = ${xserverWrapper}
-      session-wrapper = ${dmcfg.session.script}
+      session-wrapper = ${dmcfg.session.wrapper}
       ${optionalString cfg.greeter.enable ''
         greeter-session = ${cfg.greeter.name}
       ''}

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -176,19 +176,11 @@ in
           LightDM auto-login requires services.xserver.displayManager.lightdm.autoLogin.user to be set
         '';
       }
-      { assertion = cfg.autoLogin.enable -> elem defaultSessionName dmcfg.session.names;
+      { assertion = cfg.autoLogin.enable -> dmDefault != "none" || wmDefault != "none";
         message = ''
           LightDM auto-login requires that services.xserver.desktopManager.default and
           services.xserver.windowMananger.default are set to valid values. The current
           default session: ${defaultSessionName} is not valid.
-        '';
-      }
-      { assertion = hasDefaultUserSession -> elem defaultSessionName dmcfg.session.names;
-        message = ''
-          services.xserver.desktopManager.default and
-          services.xserver.windowMananger.default are not set to valid
-          values. The current default session: ${defaultSessionName}
-          is not valid.
         '';
       }
       { assertion = !cfg.greeter.enable -> (cfg.autoLogin.enable && cfg.autoLogin.timeout == 0);

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -45,7 +45,7 @@ let
         greeter-user = ${config.users.users.lightdm.name}
         greeters-directory = ${cfg.greeter.package}
       ''}
-      sessions-directory = ${dmcfg.session.desktops}
+      sessions-directory = ${dmcfg.session.desktops}/share/xsessions
 
       [Seat:*]
       xserver-command = ${xserverWrapper}

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -49,7 +49,7 @@ let
     MinimumVT=${toString (if xcfg.tty != null then xcfg.tty else 7)}
     ServerPath=${xserverWrapper}
     XephyrPath=${pkgs.xorg.xorgserver.out}/bin/Xephyr
-    SessionCommand=${dmcfg.session.script}
+    SessionCommand=${dmcfg.session.wrapper}
     SessionDir=${dmcfg.session.desktops}/share/xsessions
     XauthPath=${pkgs.xorg.xauth}/bin/xauth
     DisplayCommand=${Xsetup}

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -50,7 +50,7 @@ let
     ServerPath=${xserverWrapper}
     XephyrPath=${pkgs.xorg.xorgserver.out}/bin/Xephyr
     SessionCommand=${dmcfg.session.script}
-    SessionDir=${dmcfg.session.desktops}
+    SessionDir=${dmcfg.session.desktops}/share/xsessions
     XauthPath=${pkgs.xorg.xauth}/bin/xauth
     DisplayCommand=${Xsetup}
     DisplayStopCommand=${Xstop}

--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -14,7 +14,7 @@ let
       default_xserver ${dmcfg.xserverBin}
       xserver_arguments ${toString dmcfg.xserverArgs}
       sessiondir ${dmcfg.session.desktops}/share/xsessions
-      login_cmd exec ${pkgs.runtimeShell} ${dmcfg.session.script} "%session"
+      login_cmd exec ${pkgs.runtimeShell} ${dmcfg.session.wrapper} "%session"
       halt_cmd ${config.systemd.package}/sbin/shutdown -h now
       reboot_cmd ${config.systemd.package}/sbin/shutdown -r now
       logfile /dev/stderr

--- a/nixos/modules/services/x11/display-managers/slim.nix
+++ b/nixos/modules/services/x11/display-managers/slim.nix
@@ -13,7 +13,7 @@ let
       xauth_path ${dmcfg.xauthBin}
       default_xserver ${dmcfg.xserverBin}
       xserver_arguments ${toString dmcfg.xserverArgs}
-      sessiondir ${dmcfg.session.desktops}
+      sessiondir ${dmcfg.session.desktops}/share/xsessions
       login_cmd exec ${pkgs.runtimeShell} ${dmcfg.session.script} "%session"
       halt_cmd ${config.systemd.package}/sbin/shutdown -h now
       reboot_cmd ${config.systemd.package}/sbin/shutdown -r now

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -15,6 +15,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.displayManager.lightdm.autoLogin.enable = true;
       services.xserver.displayManager.lightdm.autoLogin.user = "alice";
       services.xserver.desktopManager.gnome3.enable = true;
+      services.xserver.desktopManager.default = "gnome";
 
       virtualisation.memorySize = 1024;
     };

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-plymouth=yes"
+    "--enable-gdm-xsession"
     "--with-initial-vt=7"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
   ];

--- a/pkgs/desktops/gnome-3/core/gnome-session/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-session/fix-paths.patch
@@ -1,0 +1,22 @@
+--- a/gnome-session/gnome-session.in
++++ b/gnome-session/gnome-session.in
+@@ -13,7 +13,7 @@
+   fi
+ fi
+ 
+-SETTING=$(gsettings get org.gnome.system.locale region)
++SETTING=$(@gsettings@ get org.gnome.system.locale region)
+ REGION=${SETTING#\'}
+ REGION=${REGION%\'}
+ 
+--- a/gnome-session/main.c
++++ b/gnome-session/main.c
+@@ -203,7 +203,7 @@
+         }
+         new_argv[i + 2] = NULL;
+         
+-        if (!execvp ("dbus-launch", new_argv)) {
++        if (!execvp ("@dbusLaunch@", new_argv)) {
+                 g_set_error (error, 
+                              G_SPAWN_ERROR,
+                              G_SPAWN_ERROR_FAILED,

--- a/pkgs/desktops/gnome-3/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gpaste/default.nix
@@ -10,6 +10,22 @@ stdenv.mkDerivation rec {
     sha256 = "1zfx73qpw976hyzp5k569lywsq2b6dbnnzf2cvhjvn3mvkw8pin2";
   };
 
+  patches = [
+    ./fix-paths.patch
+  ];
+
+  # TODO: switch to substituteAll with placeholder
+  # https://github.com/NixOS/nix/issues/1846
+  # https://github.com/NixOS/nixpkgs/pull/37693
+  postPatch = ''
+    substituteInPlace src/gnome-shell/extension.js \
+      --subst-var-by typelibPath "$out/lib/girepository-1.0"
+    substituteInPlace src/gnome-shell/prefs.js \
+      --subst-var-by typelibPath "$out/lib/girepository-1.0"
+    substituteInPlace src/libgpaste/settings/gpaste-settings.c \
+      --subst-var-by gschemasCompiled "$out/share/gsettings-schemas/${name}/glib-2.0/schemas"
+  '';
+
   nativeBuildInputs = [ autoreconfHook pkgconfig vala wrapGAppsHook ];
   buildInputs = [ glib gjs mutter gnome3.adwaita-icon-theme
                   gtk3 gnome3.gnome-control-center dbus

--- a/pkgs/desktops/gnome-3/misc/gpaste/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/misc/gpaste/fix-paths.patch
@@ -1,0 +1,55 @@
+--- a/src/gnome-shell/extension.js
++++ b/src/gnome-shell/extension.js
+@@ -7,6 +7,8 @@
+ 
+ const Config = imports.misc.config;
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@typelibPath@');
++
+ imports.gi.versions.Clutter = Config.LIBMUTTER_API_VERSION;
+ imports.gi.versions.GLib = '2.0';
+ imports.gi.versions.GPaste = '1.0';
+--- a/src/gnome-shell/prefs.js
++++ b/src/gnome-shell/prefs.js
+@@ -7,6 +7,8 @@
+ 
+ const Gettext = imports.gettext;
+ 
++imports.gi.GIRepository.Repository.prepend_search_path('@typelibPath@');
++
+ const GPaste = imports.gi.GPaste;
+ 
+ const ExtensionUtils = imports.misc.extensionUtils;
+--- a/src/libgpaste/settings/gpaste-settings.c
++++ b/src/libgpaste/settings/gpaste-settings.c
+@@ -22,6 +22,8 @@
+ 
+ typedef struct
+ {
++    GSettingsSchemaSource *schema_source;
++    GSettingsSchema *schema;
+     GSettings *settings;
+     GSettings *shell_settings;
+ 
+@@ -919,6 +921,8 @@
+     {
+         g_signal_handler_disconnect (settings, priv->c_signals[C_CHANGED]);
+         g_clear_object (&priv->settings);
++        g_settings_schema_unref (priv->schema);
++        g_settings_schema_source_unref (priv->schema_source);
+     }
+ 
+     if (shell_settings)
+@@ -1000,7 +1004,11 @@
+ g_paste_settings_init (GPasteSettings *self)
+ {
+     GPasteSettingsPrivate *priv = g_paste_settings_get_instance_private (self);
+-    GSettings *settings = priv->settings = g_settings_new (G_PASTE_SETTINGS_NAME);
++
++    // library used by introspection requires schemas but we cannot set XDG_DATA_DIRS for the library
++    GSettingsSchemaSource *schema_source = priv->schema_source = g_settings_schema_source_new_from_directory ("@gschemasCompiled@", NULL, FALSE, NULL);
++    priv->schema = g_settings_schema_source_lookup (schema_source, G_PASTE_SETTINGS_NAME, FALSE);
++    GSettings *settings = priv->settings = g_settings_new_full (priv->schema, NULL, NULL);
+ 
+     priv->history_name = NULL;
+     priv->launch_ui = NULL;


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/39871

This is just a first swallow, in the future pull requests we will want to convert more DEs and investigate Wayland.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested via one or more NixOS tests
     - [x] `gnome3`
     - [x] `gnome3-gdm`
- [x] Tried to run upstream xsession (GNOME) in VM
     - [x] with GDM
     - [x] with lightdm
     - [x] with SDDM
- [x] Tried to run legacy xsession (Xfce) in VM
     - [x] with lightdm
     - [x] with gdm
- [x] Tried to run legacy combined xsession (xmonad+xterm) in VM
     - [x] with lightdm
     - [x] with gdm
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @hedning, @worldofpeace 