### PR TITLE
cntlm: add support for darwin

### DIFF
--- a/pkgs/tools/networking/cntlm/default.nix
+++ b/pkgs/tools/networking/cntlm/default.nix
@@ -11,6 +11,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ which ];
 
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure --replace "xlc_r gcc" "xlc_r gcc $CC"
+    substitute Makefile Makefile.$CC --replace "CC=gcc" "CC=$CC"
+  '';
+
   installPhase = ''
     mkdir -p $out/bin; cp cntlm $out/bin/;
     mkdir -p $out/share/; cp COPYRIGHT README VERSION doc/cntlm.conf $out/share/;
@@ -21,11 +26,12 @@ stdenv.mkDerivation rec {
     description = "NTLM/NTLMv2 authenticating HTTP proxy";
     homepage = http://cntlm.sourceforge.net/;
     license = licenses.gpl2;
-    maintainers = 
+    maintainers =
       [
         maintainers.qknight
         maintainers.markWot
+        maintainers.carlosdagos
       ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Hi all,

This adds Darwin support to cntlm 😄 

Thanks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

