### PR TITLE
neovim: fix the xsel path in the clipboard runtime provider

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -60,7 +60,7 @@ let
     '';
 
     postInstall = stdenv.lib.optionalString stdenv.isLinux ''
-      sed -i -e "s|'xsel|'${xsel}/bin/xsel|" $out/share/nvim/runtime/autoload/provider/clipboard.vim
+      sed -i -e "s|'xsel|'${xsel}/bin/xsel|g" $out/share/nvim/runtime/autoload/provider/clipboard.vim
     '' + stdenv.lib.optionalString (withJemalloc && stdenv.isDarwin) ''
       install_name_tool -change libjemalloc.1.dylib \
                 ${jemalloc}/lib/libjemalloc.1.dylib \


### PR DESCRIPTION
###### Motivation for this change

Currently the `share/nvim/runtime/autoload/provider/clipboard.vim` file has the following content:

```vimL
  elseif exists('$DISPLAY') && executable('/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel') && s:cmd_ok('xsel -o -b')
    let s:copy['+'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel --nodetach -i -b'
    let s:paste['+'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel -o -b'
    let s:copy['*'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel --nodetach -i -p'
    let s:paste['*'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel -o -p'
    return '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel'
```

as you can see, the `s:cmd_ok('xsel -o -b')` never evaluates to true and the X11 clipboard does not work. This PR changes the sed command to replace all occurrences of `'xsel` so the command works. Here's the same snippet after the build:


```vimL
  elseif exists('$DISPLAY') && executable('/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel') && s:cmd_ok('/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel -o -b')
    let s:copy['+'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel --nodetach -i -b'
    let s:paste['+'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel -o -b'
    let s:copy['*'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel --nodetach -i -p'
    let s:paste['*'] = '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel -o -p'
    return '/nix/store/rl7q8rr97aasvx0bq3aimd50pf0nf4bk-xsel-unstable-2016-09-02/bin/xsel'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes kalbasit/system#17