### PR TITLE
refind: 0.11.2 -> 0.11.3

### DIFF
--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -13,12 +13,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "refind-${version}";
-  version = "0.11.2";
+  version = "0.11.3";
   srcName = "refind-src-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/refind/${version}/${srcName}.tar.gz";
-    sha256 = "1k0xpm4y0gk1rxqdyprqyqpg5j16xw3l2gm3d9zpi5n9id43jkzn";
+    sha256 = "13q1yap9r4lzm5xjx1zi434gckd3gk5p8n4vh6jav0h3r3ayp633";
   };
 
   buildInputs = [ gnu-efi ];


### PR DESCRIPTION
###### Motivation for this change

[New update](https://sourceforge.net/projects/refind/files/0.11.3/), [changes here](https://sourceforge.net/p/refind/code/ci/db1c0d4a77b7b267574be938468d4034e8ae1765/tree/NEWS.txt).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ❌ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ❌ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Test of `bin/` not done as I am unsure how they even acted beforehand.

What was tested was updating my local install of rEFInd on my computers.

```
/nix/store/a40ynmfd0r63n1qasjwnsmm696jc53sg-refind-0.11.2          31488168
/nix/store/4gzw8kwx3dkgndc3yj5999w1gbzyvj7q-refind-0.11.3          30824472
```
`-663696`.

---

