### PR TITLE
elpa: fix evaluation

### DIFF
--- a/pkgs/applications/editors/emacs-modes/elpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/elpa-packages.nix
@@ -25,7 +25,7 @@ self:
     super = removeAttrs imported [ "dash" ];
 
     elpaBuild = import ../../../build-support/emacs/elpa.nix {
-      inherit fetchurl lib stdenv texinfo;
+      inherit lib stdenv texinfo;
       inherit (self) emacs;
     };
 


### PR DESCRIPTION
###### Motivation for this change

This commit https://github.com/NixOS/nixpkgs/commit/52f53c69ce6dbc5538f7e4cd22f9d93baf1f64a2#diff-042e9fdbafb1ed159eb334bd5f71c0c1L3

broke the evaluation of the elpa builder

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

