### PR TITLE
python37.pkgs.{pycodestyle,pyflakes,flake8,pystemmer}

### DIFF
--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, python, fetchPypi, buildPythonPackage, cython }:
+
+buildPythonPackage rec {
+  pname = "PyStemmer";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d1ac14eb64978c1697fcfba76e3ac7ebe24357c9428e775390f634648947cb91";
+  };
+
+  nativeBuildInputs = [ cython ];
+
+  preBuild = ''
+    cython src/Stemmer.pyx
+  '';
+
+  checkPhase = ''
+    ${python.interpreter} runtests.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Snowball stemming algorithms, for information retrieval";
+    homepage = http://snowball.tartarus.org/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, PyStemmer, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "snowballstemmer";
+  version = "1.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128";
+  };
+
+  # No tests included
+  doCheck = false;
+
+  propagatedBuildInputs = [ PyStemmer ];
+
+  meta = with stdenv.lib; {
+    description = "16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms";
+    homepage = http://sigal.saimon.org/en/latest/index.html;
+    license = licenses.bsd3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10966,25 +10966,7 @@ in {
     };
   };
 
-  PyStemmer = buildPythonPackage (rec {
-    name = "PyStemmer-1.3.0";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/P/PyStemmer/${name}.tar.gz";
-      sha256 = "d1ac14eb64978c1697fcfba76e3ac7ebe24357c9428e775390f634648947cb91";
-    };
-
-    checkPhase = ''
-      ${python.interpreter} runtests.py
-    '';
-
-    meta = {
-      description = "Snowball stemming algorithms, for information retrieval";
-      homepage = http://snowball.tartarus.org/;
-      license = licenses.mit;
-      platforms = platforms.unix;
-    };
-  });
+  PyStemmer = callPackage ../development/python-modules/pystemmer {};
 
   Pyro = callPackage ../development/python-modules/pyro { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12573,26 +12573,7 @@ in {
     };
   };
 
-  snowballstemmer = buildPythonPackage rec {
-    name = "snowballstemmer-1.2.1";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/snowballstemmer/${name}.tar.gz";
-      sha256 = "919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128";
-    };
-
-    # No tests included
-    doCheck = false;
-
-    propagatedBuildInputs = with self; [ PyStemmer ];
-
-    meta = {
-      description = "16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms";
-      homepage = http://sigal.saimon.org/en/latest/index.html;
-      license = licenses.bsd3;
-      platforms = platforms.unix;
-    };
-  };
+  snowballstemmer = callPackage ../development/python-modules/snowballstemmer { };
 
   spake2 = callPackage ../development/python-modules/spake2 { };
 


### PR DESCRIPTION
###### Motivation for this change

flake8 was bumped to a pre-release since it already contains fixes for pyflakes, but the author is too busy making a new release. This fixes were required to get basic linter infrastructure ready for python37.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

