### PR TITLE
vulnix: 1.7 -> 1.7.1

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "vulnix";
-  version = "1.7";
+  version = "1.7.1";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "16228w0vakb515cnrk4akadh0m21abiv8rv574jarcsf7359xslj";
+    sha256 = "15c32976sgb5clixngi6z1fk5h02v1kn1a89h8rkbkvyhfnjgg8m";
   };
 
   buildInputs = [ ronn ];


### PR DESCRIPTION
###### Motivation for this change

Install failures since 3a0c4a8 due to a too restrictive requirements declaration.
 
Closes #43999

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

