### PR TITLE
stumpish: init at 0.0.1

### DIFF
--- a/pkgs/applications/window-managers/stumpish/default.nix
+++ b/pkgs/applications/window-managers/stumpish/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, substituteAll, fetchurl, fetchFromGitHub, bash, gnused, ncurses, xorg, rlwrap }:
+
+stdenv.mkDerivation rec {
+  pname = "stumpish";
+  version = "0.0.1";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "stumpwm";
+    repo = "stumpwm-contrib";
+    rev = "9f5f06652c480159ec57d1fd8751b16f02db06dc";
+    sha256 = "1dxzsnir3158p8y2128s08r9ca0ywr9mcznivmhn1lycw8mg4nfl";
+  };
+
+  buildInputs = [
+    gnused xorg.xprop rlwrap ncurses
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./paths.patch;
+      sed = "${gnused}/bin/sed";
+      xprop = "${xorg.xprop}/bin/xprop";
+      rlwrap = "${rlwrap}/bin/rlwrap";
+      tput = "${ncurses}/bin/tput";
+    })
+  ];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+  '';
+
+  installPhase = ''
+    cp util/stumpish/stumpish $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/stumpwm/stumpwm-contrib;
+    description = "STUMPwm Interactive SHell";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.ebzzry ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/window-managers/stumpish/paths.patch
+++ b/pkgs/applications/window-managers/stumpish/paths.patch
@@ -1,0 +1,87 @@
+diff --git a/util/stumpish/stumpish b/util/stumpish/stumpish
+index 830cb1b..64213dc 100755
+--- a/util/stumpish/stumpish
++++ b/util/stumpish/stumpish
+@@ -28,8 +28,8 @@ then
+ fi
+ 
+ # replace -E with -r option for old versions of GNU sed
+-if ! sed -E 1p /dev/null 2>/dev/null; then
+-    sed() { shift; command sed -r "$@"; }
++if ! @sed@ -E 1p /dev/null 2>/dev/null; then
++    sed() { shift; command @sed@ -r "$@"; }
+ fi
+ 
+ # parse C-style backslash sequences by default
+@@ -41,9 +41,9 @@ wait_result ()
+ {
+     while true
+     do
+-	RESULT=$(xprop -root -f STUMPWM_COMMAND_RESULT 8s \
++	RESULT=$(@xprop@ -root -f STUMPWM_COMMAND_RESULT 8s \
+ 	    STUMPWM_COMMAND_RESULT 2>/dev/null |
+-	    sed -E 's/\\([[:digit:]]+)/\\0\1/g')
++	    @sed@ -E 's/\\([[:digit:]]+)/\\0\1/g')
+ 	if echo "$RESULT" | grep -v -q 'not found.$'
+ 	then
+ 	    break
+@@ -52,7 +52,7 @@ wait_result ()
+ 	sleep $DELAY
+     done
+ 
+-    xprop -root -remove STUMPWM_COMMAND_RESULT
++    @xprop@ -root -remove STUMPWM_COMMAND_RESULT
+ 
+     if echo "$RESULT" | grep -q '= $'
+     then
+@@ -60,7 +60,7 @@ wait_result ()
+     fi
+ 
+     echo "$RESULT" |
+-    sed -E 's/[^"\\n]+"//
++    @sed@ -E 's/[^"\\n]+"//
+             /^"[[:space:]]*$/d
+             s/(^|[^\\])\\n/\1\
+ /g
+@@ -80,7 +80,7 @@ send_cmd ()
+ 	exit
+     fi
+ 
+-    xprop -root -f STUMPWM_COMMAND 8s -set STUMPWM_COMMAND "$cmd"
++    @xprop@ -root -f STUMPWM_COMMAND 8s -set STUMPWM_COMMAND "$cmd"
+ 
+     wait_result
+ }
+@@ -123,8 +123,8 @@ tput ()
+     local cap1=$1 cap2=$2
+     shift 2
+ 
+-    command tput $cap1 $@ 2>/dev/null ||
+-    command tput $cap2 $@ 2>/dev/null
++    command @tput@ $cap1 $@ 2>/dev/null ||
++    command @tput@ $cap2 $@ 2>/dev/null
+ }
+ 
+ READLINE=yes
+@@ -156,18 +156,18 @@ then
+ else
+     if [ -t 0 ]
+     then
+-	if ! type rlwrap 2>/dev/null >&2
++	if ! type @rlwrap@ 2>/dev/null >&2
+ 	then
+ 	    warn rlwrap not found, command completion won\'t work
+ 	elif [ $READLINE = yes ]
+ 	then
+ 	    COMMANDS="${TMPDIR:-/tmp}/stumpish.commands.$$"
+ 	    echo $(send_cmd "commands") |
+-	    sed -E 's/[[:space:]]+/\
++	    @sed@ -E 's/[[:space:]]+/\
+ /g' |
+ 	    sort > "$COMMANDS"
+ 	    trap 'rm -f "$COMMANDS"' exit int term
+-	    rlwrap -b '' -f "$COMMANDS" "$0" -r
++	    @rlwrap@ -b '' -f "$COMMANDS" "$0" -r
+ 	    exit
+ 	fi
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18385,6 +18385,8 @@ with pkgs;
 
   stp = callPackage ../applications/science/logic/stp {};
 
+  stumpish = callPackage ../applications/window-managers/stumpish {};
+
   stumpwm = callPackage ../applications/window-managers/stumpwm {
     version = "latest";
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

