### PR TITLE
 android-file-transfer: init at 3.4 

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -1,0 +1,27 @@
+{ lib, stdenv, fetchFromGitHub, cmake, fuse, readline, pkgconfig, qtbase }:
+
+stdenv.mkDerivation rec {
+  name = "android-file-transfer-${version}";
+  version = "3.4";
+  src = fetchFromGitHub {
+    owner = "whoozle";
+    repo = "android-file-transfer-linux";
+    rev = "v${version}";
+    sha256 = "1xwl0vk57174gdjhgqkzrirwzd2agdm84q30dq9q376ixgxjrifc";
+  };
+  buildInputs = [ cmake fuse readline pkgconfig qtbase ];
+  buildPhase = ''
+    cmake .
+    make
+  '';
+  installPhase = ''
+    make install
+  '';
+  meta = with stdenv.lib; {
+    description = "Reliable MTP client with minimalistic UI";
+    homepage = http://whoozle.github.io/android-file-transfer-linux/;
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.xaverdh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20987,6 +20987,8 @@ with pkgs;
 
   ### MISC
 
+  android-file-transfer = libsForQt5.callPackage ../tools/filesystems/android-file-transfer { };
+
   antimicro = libsForQt5.callPackage ../tools/misc/antimicro { };
 
   atari800 = callPackage ../misc/emulators/atari800 { };


### PR DESCRIPTION
###### Motivation for this change

This adds the android-file-transfer (Android File Transfer For Linux) package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

