### PR TITLE
rubocop: 0.55.0 -> 0.58.1

### DIFF
--- a/pkgs/development/tools/rubocop/Gemfile.lock
+++ b/pkgs/development/tools/rubocop/Gemfile.lock
@@ -2,21 +2,23 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    jaro_winkler (1.5.1)
     parallel (1.12.1)
-    parser (2.5.1.0)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     rainbow (3.0.0)
     rake (12.3.1)
-    rubocop (0.55.0)
+    rubocop (0.58.1)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    unicode-display_width (1.3.2)
+    unicode-display_width (1.4.0)
 
 PLATFORMS
   ruby
@@ -26,4 +28,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/pkgs/development/tools/rubocop/gemset.nix
+++ b/pkgs/development/tools/rubocop/gemset.nix
@@ -7,6 +7,14 @@
     };
     version = "2.4.0";
   };
+  jaro_winkler = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rr797nqz081bfk30m2apj5h24bg5d1jr1c8p3xwx4hbwsrbclah";
+      type = "gem";
+    };
+    version = "1.5.1";
+  };
   parallel = {
     source = {
       remotes = ["https://rubygems.org"];
@@ -19,18 +27,18 @@
     dependencies = ["ast"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1af7aa1c2npi8dkshgm3f8qyacabm94ckrdz7b8vd3f8zzswqzp9";
+      sha256 = "1zp89zg7iypncszxsjp8kiccrpbdf728jl449g6cnfkz990fyb5k";
       type = "gem";
     };
-    version = "2.5.1.0";
+    version = "2.5.1.2";
   };
   powerpack = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1fnn3fli5wkzyjl4ryh0k90316shqjfnhydmc7f8lqpi0q21va43";
+      sha256 = "1r51d67wd467rpdfl6x43y84vwm8f5ql9l9m85ak1s2sp3nc5hyv";
       type = "gem";
     };
-    version = "0.1.1";
+    version = "0.1.2";
   };
   rainbow = {
     source = {
@@ -49,13 +57,13 @@
     version = "12.3.1";
   };
   rubocop = {
-    dependencies = ["parallel" "parser" "powerpack" "rainbow" "ruby-progressbar" "unicode-display_width"];
+    dependencies = ["jaro_winkler" "parallel" "parser" "powerpack" "rainbow" "ruby-progressbar" "unicode-display_width"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17qnk66q4diny1bvzbwsl1d5a26nj0mjzc2425h6nyp3xqjipz11";
+      sha256 = "0s2qlrdx2f7653kmzwm58c8izyvgyjrzjrz76l2b005f2816kji6";
       type = "gem";
     };
-    version = "0.55.0";
+    version = "0.58.1";
   };
   ruby-progressbar = {
     source = {
@@ -68,9 +76,9 @@
   unicode-display_width = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0x31fgv1acywbb50prp7y4fr677c2d9gsl6wxmfcrlxbwz7nxn5n";
+      sha256 = "0040bsdpcmvp8w31lqi2s9s4p4h031zv52401qidmh25cgyh4a57";
       type = "gem";
     };
-    version = "1.3.2";
+    version = "1.4.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Package update.

`Gemfile.lock` updated with `bundle lock --update`, `gemset.nix` created with `bundix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

