### PR TITLE
python3.pkgs.black: 18.4a0 -> 18.6b4

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -1,17 +1,28 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, attrs, click }:
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+, attrs, click, toml, appdirs
+, glibcLocales, pytest }:
 
 buildPythonPackage rec {
   pname = "black";
-  version = "18.4a0";
+  version = "18.6b4";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04dffr4wmzs4vf2xj0cxp03hv04x0kk06qyzx6jjrp1mq0z3n2rr";
+    sha256 = "0i4sfqgz6w15vd50kbhi7g7rifgqlf8yfr8y78rypd56q64qn592";
   };
 
-  propagatedBuildInputs = [ attrs click ];
+  checkInputs =  [ pytest glibcLocales ];
+
+  checkPhase = ''
+    # no idea, why those fail.
+    LC_ALL="en_US.UTF-8" HOME="$NIX_BUILD_TOP" \
+      pytest \
+        -k "not test_cache_multiple_files and not test_failed_formatting_does_not_get_cached"
+  '';
+
+  propagatedBuildInputs = [ attrs appdirs click toml ];
 
   meta = with stdenv.lib; {
     description = "The uncompromising Python code formatter";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

