### PR TITLE
pyre: 0.0.8 -> 0.0.10

### DIFF
--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -2,7 +2,7 @@
 let
   # Manually set version - the setup script requires
   # hg and git + keeping the .git directory around.
-  version = "0.0.8";
+  version = "0.0.10";
   versionFile = writeScript "version.ml" ''
     cat > "./version.ml" <<EOF
     let build_info () =
@@ -18,7 +18,7 @@ in stdenv.mkDerivation {
     owner = "facebook";
     repo = "pyre-check";
     rev = "v${version}";
-    sha256 = "0c4km27xnzsqcqvjqxmqak37x473z6azlbldy7f05ghkms7mchrw";
+    sha256 = "17fk2izq434jsr8dfz828754356qdwa6zv0lbzm6z1kgq4jg7brv";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -33,6 +33,7 @@ in stdenv.mkDerivation {
     ppx_deriving_yojson
     ocamlbuild
     ppxlib
+    # python36Packages.python36Full # TODO
   ];
 
   buildPhase = ''
@@ -52,13 +53,14 @@ in stdenv.mkDerivation {
 
   checkPhase = ''
     make test
+    # ./scripts/run-python-tests.sh # TODO: once typeshed and python bits are added
   '';
 
   # Note that we're not installing the typeshed yet.
   # Improvement for a future version.
   installPhase = ''
     mkdir -p $out/bin
-    cp _build/all/main.native $out/bin/pyre
+    cp _build/all/main.native $out/bin/pyre.bin
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
renamed pyre to pyre.bin; see upstream issue at:
https://github.com/facebook/pyre-check/issues/79#issuecomment-407150170

###### Motivation for this change

* updating pyre version
* renaming binary executable appropriately, to be compatible with future python support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

