### PR TITLE
pet: init at 0.3.2

### DIFF
--- a/pkgs/development/tools/pet/default.nix
+++ b/pkgs/development/tools/pet/default.nix
@@ -1,0 +1,25 @@
+{ buildGoPackage, fetchFromGitHub, lib }:
+
+buildGoPackage rec {
+  name = "pet-${version}";
+  version = "0.3.2";
+
+  goPackagePath = "github.com/knqyf263/pet";
+
+  src = fetchFromGitHub {
+    owner = "knqyf263";
+    repo = "pet";
+    rev = "v${version}";
+    sha256 = "1zv2jfgh5nqd4cwr1ljm5p4rqam7hq3a6asfmhr3lcnp7sz9b8fr";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with lib; {
+    description = "Simple command-line snippet manager, written in Go";
+    homepage = https://github.com/knqyf263/pet;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/pet/deps.nix
+++ b/pkgs/development/tools/pet/deps.nix
@@ -1,0 +1,155 @@
+[
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "a368813c5e648fee92e5f6c30e3944ff9d5e8895";
+      sha256 = "1sjxs2lwc8jpln80s4rlzp7nprbcljhy5mz4rf9995gq93wqnym5";
+    };
+  }
+  {
+    goPackagePath = "github.com/briandowns/spinner";
+    fetch = {
+      type = "git";
+      url = "https://github.com/briandowns/spinner";
+      rev = "5b875a9171af19dbde37e70a8fcbe2ebd7285e05";
+      sha256 = "0vq78qmg07dm9vnjqz17ca9qml8np7f9vj9igsira7a39xg09ivg";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/readline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/readline";
+      rev = "2972be24d48e78746da79ba8e24e8b488c9880de";
+      sha256 = "104q8dazj8yf6b089jjr82fy9h1g80zyyzvp3g8b44a7d8ngjj6r";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "2d684516a8861da43017284349b7e303e809ac21";
+      sha256 = "1fcfmz4wji3gqmmsdx493r7d101s58hwjalqps6hy25nva5pvmfs";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-github";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-github";
+      rev = "c0b63e2f9bb198baf328c8abf1ddcbe05ff9427e";
+      sha256 = "1a4skdbzxnyj3irqrmhhj4c9cimga0k5sd0vykjfqj7c8c5bwbd5";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-querystring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-querystring";
+      rev = "53e6ce116135b80d037921a7fdd5138cf32d7a8a";
+      sha256 = "0lkbm067nhmxk66pyjx59d77dbjjzwyi43gdvzyx2f8m1942rq7f";
+    };
+  }
+  {
+    goPackagePath = "github.com/jroimartin/gocui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jroimartin/gocui";
+      rev = "c055c87ae801372cd74a0839b972db4f7697ae5f";
+      sha256 = "1b1cbjg925l1c5v3ls8amni9716190yzf847cqs9wjnj82z8qa47";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb";
+      sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
+    };
+  }
+  {
+    goPackagePath = "github.com/nsf/termbox-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsf/termbox-go";
+      rev = "5c94acc5e6eb520f1bcd183974e01171cc4c23b3";
+      sha256 = "1fi8imdgwvlsgifw2qfl3ww0lsrgkfsimkzz7bnrq41nar78s0fw";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "816c9085562cd7ee03e7f8188a1cfd942858cded";
+      sha256 = "1ws5crb7c70wdicavl6qr4g03nn6m92zd6wwp9n2ygz5c8rmxh8k";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "a114f312e075f65bf30d6d9a1430113f857e543b";
+      sha256 = "10lmi5ni06yijxg02fcic5b7ycjkia12yma4a4lz8a56j30wykx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "3ebe029320b2676d667ae88da602a5f854788a8a";
+      sha256 = "11yxs0wqy70wj106fkz8r923yg4ncnc2mbw33v48zmlg4a1rasgp";
+    };
+  }
+  {
+    goPackagePath = "github.com/xanzy/go-gitlab";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xanzy/go-gitlab";
+      rev = "696e3cf592c0f71a0fce1934ad500376abe2e12d";
+      sha256 = "1wjn991i161z4xqply3lxvvjgnisdrbkiadr0h0n01k40hymdx6h";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "a2144134853fc9a27a7b1e3eb4f19f1a76df13c9";
+      sha256 = "0hjjk6k9dq7zllwsw9icdfbli12ii379q2lajd6l7lyw72wy28by";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1";
+      sha256 = "018zmn4kmg2mbngcciqal54slc3pl4ry5vlv0bw36fcxvnazxnbp";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "ef147856a6ddbb60760db74283d2424e98c87bff";
+      sha256 = "1q1vm1z40fx1grlrm7az4rln6v5pj9xi5n1cjqg5xgq4dsk9132y";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "ac767d655b305d4e9612f5f6e33120b9176c4ad4";
+      sha256 = "1ds29n5lh4j21hmzxz7vk7hv1k6sixc7f0zsdc9xqdg0j7d212zm";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -168,6 +168,8 @@ with pkgs;
 
   packer = callPackage ../development/tools/packer { };
 
+  pet = callPackage ../development/tools/pet { };
+
   mht2htm = callPackage ../tools/misc/mht2htm { };
 
   fetchpatch = callPackage ../build-support/fetchpatch { };


### PR DESCRIPTION
###### Motivation for this change

pet: CLI Snippet Manager. Simple command-line snippet manager, written in Go.

https://github.com/knqyf263/pet

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

