### PR TITLE
doing: init at 1.0.10pre

### DIFF
--- a/pkgs/applications/misc/doing/Gemfile
+++ b/pkgs/applications/misc/doing/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'doing', '1.0.10pre'

--- a/pkgs/applications/misc/doing/Gemfile.lock
+++ b/pkgs/applications/misc/doing/Gemfile.lock
@@ -1,0 +1,25 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chronic (0.10.2)
+    deep_merge (1.2.1)
+    doing (1.0.10pre)
+      chronic (~> 0.10, >= 0.10.2)
+      deep_merge
+      gli (~> 2.17.1)
+      haml (= 4.0.3)
+      json (~> 1.8.1)
+    gli (2.17.1)
+    haml (4.0.3)
+      tilt
+    json (1.8.6)
+    tilt (2.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  doing (= 1.0.10pre)
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/applications/misc/doing/default.nix
+++ b/pkgs/applications/misc/doing/default.nix
@@ -1,0 +1,25 @@
+{ lib, bundlerEnv, ruby
+}:
+
+# Bundix:
+# nix-shell -p bundix zlib
+bundlerEnv rec {
+  pname = "doing";
+  version = (import ./gemset.nix).doing.version;
+
+  inherit ruby;
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "A command line tool for keeping track of what you’re doing and tracking what you’ve done.";
+    longDescription = ''
+      doing is a basic CLI for adding and listing "what was I doing" reminders
+      in a TaskPaper-formatted text file. It allows for multiple
+      sections/categories and flexible output formatting.
+    '';
+    homepage    = http://brettterpstra.com/projects/doing/;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ ktf ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/doing/gemset.nix
+++ b/pkgs/applications/misc/doing/gemset.nix
@@ -1,0 +1,60 @@
+{
+  chronic = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+  deep_merge = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1q3picw7zx1xdkybmrnhmk2hycxzaa0jv4gqrby1s90dy5n7fmsb";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  doing = {
+    dependencies = ["chronic" "deep_merge" "gli" "haml" "json"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y42yc7h45sz9hqj3g1dd77ipx58l7v64i7mrsj3is2f5rszd1rv";
+      type = "gem";
+    };
+    version = "1.0.10pre";
+  };
+  gli = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0g7g3lxhh2b4h4im58zywj9vcfixfgndfsvp84cr3x67b5zm4kaq";
+      type = "gem";
+    };
+    version = "2.17.1";
+  };
+  haml = {
+    dependencies = ["tilt"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l9zhfdk9z7xjfdp108r9fw4xa55hflin7hh3lpafbf9bdz96knr";
+      type = "gem";
+    };
+    version = "4.0.3";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qmj7fypgb9vag723w1a49qihxrcf5shzars106ynw2zk352gbv5";
+      type = "gem";
+    };
+    version = "1.8.6";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0020mrgdf11q23hm1ddd6fv691l51vi10af00f137ilcdb2ycfra";
+      type = "gem";
+    };
+    version = "2.0.8";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21973,4 +21973,5 @@ with pkgs;
 
   powershell = callPackage ../shells/powershell { };
 
+  doing = callPackage ../applications/misc/doing  { };
 }


### PR DESCRIPTION
###### Motivation for this change

Adds the `doing` application.
 
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

