### PR TITLE
python: init ephemeral_port_reserve at v1.1.0

### DIFF
--- a/pkgs/development/python-modules/ephemeral-port-reserve/default.nix
+++ b/pkgs/development/python-modules/ephemeral-port-reserve/default.nix
@@ -1,0 +1,16 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+buildPythonPackage rec {
+  version = "1.1.0";
+  pname = "ephemeral_port_reserve";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "28790de943c1bceaf33e0f29eda3533e91231e42e1da683eabc0ae8e2498d070";
+  };
+
+  meta = with stdenv.lib; {
+    maintainers = with maintainers; [ jb55 ];
+    platforms = platforms.unix;
+    description = "Find an unused port, reliably";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17872,6 +17872,8 @@ EOF
 
   ephem = callPackage ../development/python-modules/ephem { };
 
+  ephemeral_port_reserve = callPackage ../development/python-modules/ephemeral-port-reserve { };
+
   voluptuous = callPackage ../development/python-modules/voluptuous { };
 
   voluptuous-serialize = callPackage ../development/python-modules/voluptuous-serialize { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

