### PR TITLE
networkmanager: fix VPN activation through nm-applet

### DIFF
--- a/pkgs/tools/networking/network-manager/applet.nix
+++ b/pkgs/tools/networking/network-manager/applet.nix
@@ -20,6 +20,25 @@ in stdenv.mkDerivation rec {
       url = https://gitlab.gnome.org/GNOME/network-manager-applet/merge_requests/12.patch;
       sha256 = "0q5qbjpbrfvhqsprnwjwz4c42nly59cgnbn41w2zlxvqf29gjvwk";
     })
+
+    # following 3 patches:
+    # https://gitlab.gnome.org/GNOME/network-manager-applet/issues/11
+    # should be fixed in 1.8.16
+    (fetchpatch {
+      name = "0001-connection-editor-hold-GApplication-while-the-import.patch";
+      url = https://gitlab.gnome.org/GNOME/network-manager-applet/commit/419c459e70ac752eb9226b0db1192fb0433d5d5e.patch;
+      sha256 = "0zi4fn2ynymi6ckkdrj8vcl78pwmkan4n8l53axaqb4kn0wnahdj";
+    })
+    (fetchpatch {
+      name = "0002-connection-list-attempt-a-VPN-import-first.patch";
+      url = https://gitlab.gnome.org/GNOME/network-manager-applet/commit/9d79ffdb148b31c7194c66946c87b6cd57ed54a3.patch;
+      sha256 = "1v0pdvkglrcfl1khp9j17cw0gvwg8scdha0wfziy054s1r6kyj23";
+    })
+    (fetchpatch {
+       name = "0003-bluetooth-fix-an-assert-failure-on-creation-cancella.patch";
+       url = https://gitlab.gnome.org/GNOME/network-manager-applet/commit/516f3f6c70ef9694d6004c64d50a9f3cd2725ab7.patch;
+       sha256 = "1msk4hmri3x5chmclxm7sdj1v9jg7pxqqrarlvsmfmshdwq4ljwk";
+    })
   ];
 
   mesonFlags = [

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -71,6 +71,10 @@ in stdenv.mkDerivation rec {
       url = https://bugzilla.gnome.org/attachment.cgi?id=372953;
       sha256 = "1crjplyiiipkhjjlifrv6hhvxinlcxd6irp9ijbc7jij31g44i0a";
     })
+    (fetchurl {
+      url = https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/0a3755c1799d3a4dc1875d4c59c7c568a64c8456.patch;
+      sha256 = "af1717f7c6fdd6dadb4082dd847f4bbc42cf1574833299f3e47024e785533f2e";
+    })
     (substituteAll {
       src = ./fix-paths.patch;
       inherit inetutils kmod openconnect;

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -9,11 +9,11 @@ let
   pname = "NetworkManager";
 in stdenv.mkDerivation rec {
   name = "network-manager-${version}";
-  version = "1.12.0";
+  version = "1.12.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "15bzjkrfa7sw5p5hkdha4a67y1zfnzh1s6za11sh8s1yxmyvkziq";
+    sha256 = "09hsh34m8hg4m402pw5n11f29vsfjw6lm3p5m56yxwq57bwnzq3b";
   };
 
   outputs = [ "out" "dev" ];
@@ -66,11 +66,6 @@ in stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # https://bugzilla.gnome.org/show_bug.cgi?id=796752
-    (fetchurl {
-      url = https://bugzilla.gnome.org/attachment.cgi?id=372955;
-      sha256 = "17rl19lprnsz4wjmp54c1qw6a3pf8x97bhd69xavwy7cx6z84b3n";
-    })
     # https://bugzilla.gnome.org/show_bug.cgi?id=796751
     (fetchurl {
       url = https://bugzilla.gnome.org/attachment.cgi?id=372953;


### PR DESCRIPTION
###### Motivation for this change
Currently, activating VPN connections via nm-applet fails, but still is possible via `nmcli con up $name`.

That's fixed in the commit cherry-picked here, I can now activate VPN connections using nm-applet. Will be fixed in NetworkManager 1.13.0 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

