### PR TITLE
polybar: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -8,6 +8,7 @@
 , iwSupport     ? true,  wirelesstools ? null
 , githubSupport ? false, curl          ? null
 , mpdSupport    ? false, mpd_clientlib ? null
+, pulseSupport  ? false, libpulseaudio ? null
 , i3Support ? false, i3GapsSupport ? false, i3 ? null, i3-gaps ? null, jsoncpp ? null
 }:
 
@@ -15,17 +16,18 @@ assert alsaSupport   -> alsaLib       != null;
 assert githubSupport -> curl          != null;
 assert iwSupport     -> wirelesstools != null;
 assert mpdSupport    -> mpd_clientlib != null;
+assert pulseSupport  -> libpulseaudio != null;
 
 assert i3Support     -> ! i3GapsSupport && jsoncpp != null && i3      != null;
 assert i3GapsSupport -> ! i3Support     && jsoncpp != null && i3-gaps != null;
 
 stdenv.mkDerivation rec {
     name = "polybar-${version}";
-    version = "3.1.0";
+    version = "3.2.0";
     src = fetchgit {
       url = "https://github.com/jaagr/polybar";
-      rev = "bf16a4d415ea7d8845f578544de0c71e56ad314e";
-      sha256 = "1jcvqxl0477j0snvh1rzqsm1dkfsybix2lgrlsgiczdxfknwz8iy";
+      rev = version;
+      sha256 = "0p94brndysvmmbidhl4ds4w3qvddb752s4vryp0qckb0hz3knqk8";
     };
 
     meta = with stdenv.lib; {
@@ -48,6 +50,7 @@ stdenv.mkDerivation rec {
       (if githubSupport then curl          else null)
       (if iwSupport     then wirelesstools else null)
       (if mpdSupport    then mpd_clientlib else null)
+      (if pulseSupport  then libpulseaudio else null)
 
       (if i3Support || i3GapsSupport then jsoncpp else null)
       (if i3Support then i3 else null)


### PR DESCRIPTION
Also adds support for internal/pulseaudio

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

