### PR TITLE
Loads qt plugin paths as registered...

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -51,6 +51,7 @@ let
   patches = {
     qtbase = [
       ./qtbase.patch
+      ./qtbase-additional.patch
       ./qtbase-darwin.patch
       ./qtbase-revert-no-macos10.10.patch
       ./qtbase-fixguicmake.patch

--- a/pkgs/development/libraries/qt-5/5.11/qtbase-additional.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtbase-additional.patch
@@ -1,0 +1,32 @@
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 5ae3fd62e5..ec3fccfc76 100644
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
+@@ -2533,6 +2533,27 @@ QStringList QCoreApplication::libraryPaths()
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+ 
++		{
++			// Start at the binary; this allows us to *always* start by stripping the last part.
++			QStringList components = applicationFilePath().split(QDir::separator());
++
++			// We don't care about /nix/store/nix-support, only /nix/store/*/nix-support
++			// This is why we're checking for more than 3 parts. It will bail out once /nix/xtore/*/nix-support/qt-plugin-paths has been tested.
++			while (components.length() > 3) {
++				components.removeLast();
++				const QString support_plugin_paths = QDir::cleanPath(QDir::separator() + components.join(QDir::separator()) + QStringLiteral("/nix-support/qt-plugin-paths"));
++				if (QFile::exists(support_plugin_paths)) {
++					QFile file(support_plugin_paths);
++					if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
++						QTextStream in(&file);
++						while (!in.atEnd()) {
++							app_libpaths->append(in.readLine());
++						}
++					}
++				}
++			}
++		}
++
+         // Add library paths derived from PATH
+         const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(':');
+         const QString plugindir = QStringLiteral("../" NIXPKGS_QT_PLUGIN_PREFIX);

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -51,6 +51,7 @@ let
   patches = {
     qtbase = [
       ./qtbase.patch
+      ./qtbase-additional.patch
       ./qtbase-darwin.patch
       ./qtbase-revert-no-macos10.10.patch
       ./qtbase-fixguicmake.patch

--- a/pkgs/development/libraries/qt-5/5.12/qtbase-additional.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtbase-additional.patch
@@ -1,0 +1,32 @@
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 5ae3fd62e5..ec3fccfc76 100644
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
+@@ -2533,6 +2533,27 @@ QStringList QCoreApplication::libraryPaths()
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+ 
++		{
++			// Start at the binary; this allows us to *always* start by stripping the last part.
++			QStringList components = applicationFilePath().split(QDir::separator());
++
++			// We don't care about /nix/store/nix-support, only /nix/store/*/nix-support
++			// This is why we're checking for more than 3 parts. It will bail out once /nix/xtore/*/nix-support/qt-plugin-paths has been tested.
++			while (components.length() > 3) {
++				components.removeLast();
++				const QString support_plugin_paths = QDir::cleanPath(QDir::separator() + components.join(QDir::separator()) + QStringLiteral("/nix-support/qt-plugin-paths"));
++				if (QFile::exists(support_plugin_paths)) {
++					QFile file(support_plugin_paths);
++					if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
++						QTextStream in(&file);
++						while (!in.atEnd()) {
++							app_libpaths->append(in.readLine());
++						}
++					}
++				}
++			}
++		}
++
+         // Add library paths derived from PATH
+         const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(':');
+         const QString plugindir = QStringLiteral("../" NIXPKGS_QT_PLUGIN_PREFIX);

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -38,7 +38,7 @@ let
   srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
 
   patches = {
-    qtbase = [ ./qtbase.patch ./qtbase-fixguicmake.patch ] ++ optional stdenv.isDarwin ./qtbase-darwin.patch;
+    qtbase = [ ./qtbase.patch ./qtbase-additional.patch ./qtbase-fixguicmake.patch ] ++ optional stdenv.isDarwin ./qtbase-darwin.patch;
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];

--- a/pkgs/development/libraries/qt-5/5.9/qtbase-additional.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtbase-additional.patch
@@ -1,0 +1,32 @@
+diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
+index 5ae3fd62e5..ec3fccfc76 100644
+--- a/src/corelib/kernel/qcoreapplication.cpp
++++ b/src/corelib/kernel/qcoreapplication.cpp
+@@ -2533,6 +2533,27 @@ QStringList QCoreApplication::libraryPaths()
+         QStringList *app_libpaths = new QStringList;
+         coreappdata()->app_libpaths.reset(app_libpaths);
+ 
++		{
++			// Start at the binary; this allows us to *always* start by stripping the last part.
++			QStringList components = applicationFilePath().split(QDir::separator());
++
++			// We don't care about /nix/store/nix-support, only /nix/store/*/nix-support
++			// This is why we're checking for more than 3 parts. It will bail out once /nix/xtore/*/nix-support/qt-plugin-paths has been tested.
++			while (components.length() > 3) {
++				components.removeLast();
++				const QString support_plugin_paths = QDir::cleanPath(QDir::separator() + components.join(QDir::separator()) + QStringLiteral("/nix-support/qt-plugin-paths"));
++				if (QFile::exists(support_plugin_paths)) {
++					QFile file(support_plugin_paths);
++					if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
++						QTextStream in(&file);
++						while (!in.atEnd()) {
++							app_libpaths->append(in.readLine());
++						}
++					}
++				}
++			}
++		}
++
+         // Add library paths derived from PATH
+         const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(':');
+         const QString plugindir = QStringLiteral("../" NIXPKGS_QT_PLUGIN_PREFIX);

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -386,7 +386,13 @@ stdenv.mkDerivation {
           sed -i "$dev/lib/pkgconfig/Qt5Core.pc" \
               -e "/^host_bins=/ c host_bins=$dev/bin"
         ''
-    );
+      )
+    + ''
+        # Adds `qtbase-bin` as a basic dependency to *all* qtbase builds.
+        mkdir -p $dev/nix-support
+        echo "$bin/$qtPluginPrefix" >> $dev/nix-support/qt-plugin-paths
+      ''
+   ;
 
   setupHook = ../hooks/qtbase-setup-hook.sh;
 


### PR DESCRIPTION
### Motivation for this change

#### Fixes Qt plugin loading

This error message:

> This application failed to start because it could not find or load the Qt platform plugin "xcb"

This is a sturdier(?) fix to #24256. The current fixes doesn't seem to work properly in some situation.

What is going on *currently* is that for *any* Qt plugin, they will be loaded according to the environment, and according to some hard-coded paths relative to components of PATH. This will not work properly when the environment is cleared or manipulated. (With non-NixOS platforms, using nix-shell to start a Qt application when none have been installed using nix may cause such failure.)

Furthermore, there is an issue. See how I said "components of PATH", well, the platform plugins are taken either from QT_PLUGIN_PATH (that's an upstream variable) or [from a path relative to the PATH components](https://github.com/NixOS/nixpkgs/blob/cbbabf7c0875953049639ddc58c57aab878153d5/pkgs/development/libraries/qt-5/5.11/qtbase.patch#L890-L902).

```
~/tmp/nixpkgs/nixpkgs-qt $ nix-shell -p qt5.qtbase.bin --pure
[nix-shell:~/tmp/nixpkgs/nixpkgs-qt]$ (IFS=: ; for p in $QT_PLUGIN_PATH; do echo $p; done | grep -i qt)
[nix-shell:~/tmp/nixpkgs/nixpkgs-qt]$ (IFS=: ; for p in $PATH; do echo $p; done | grep -i qt)
```

The current qt5.qtbase.bin does not create `$bin/bin`, which is why (AFAICT) it is not added to the PATH. (In a previous revision, I tested adding a `bin` folder and it seemed to help.)

What this change does is it collects all plugin paths from qtbase up to the built package, using a setup hook. The generated file is then found by the application and then used to seed the plugin paths.

It prefixes the plugin paths with those collected paths; this means that previous QT_PLUGIN_PATH and PATH based shenanigans should still work; it will *prefer* compiled-in paths. The behaviour is opt-out via `dontAddPluginPaths` though I'm not sure if there are any reasons to opt out.

#### Possibly fixes mismatched Qt versions

I hope this fixes #30551, but I have a hard time reproducing the issue. The issue, AFAICT, is when software is compiled with Qt 5.X.Y and ran with 5.X.Z, where both X are the same, and Y and Z differ.

I would like a step-by-step repro of this issue, as I was unable to reproduce it faithfully. I got it *one time* when trying to force it, but I must have goofed up when reproducing it, as I was unable to reproduce it.

### Request for comments

First of all, let's talk about the implementation. If the implementation seems right, THEN we'll talk about the colour of the bike shed.

That said, I have a couple questions.

#### The approach

Is it a good approach to save those plugin paths that way?

I personally feel it's right, otherwise those compiled application will search *wherever* to find a match for a probably Qt library. This means that installing in your environment from a different channel may cause either system apps or user environment apps to stop working. This should fix this issue.

Then, are the details right enough? Should `nix-support` be used for this, or are there more appropriate folders?

#### First time setup hook

Is this done correctly? I think that unless someone removes genericBuild from their builders, this should always run when `qtbase` or any packages depending on `qtbase` are in the mix, right?

##### Issue with cyclic dependencies

There is a `FIXME`  comment in the setup-hooks. See the (github) comment I left in the setup hooks file.

```
cycle detected in the references of '/nix/store/dkaprffmpi2aql8c0a2kxsid9pfvf5zj-qtsvg-5.11.1' from '/nix/store/v91n5pqk908brijpcd23wfrp4pkrg5g0-qtsvg-5.11.1-bin'
```

#### C++/Qt code quality

I always hate hacking on C++, I know enough of it to be dangerous, I'd even say I know enough of it to know what I did is probably not bad, but I'm not sure if it's good.

First, the C++ code itself I think is ok. RAII makes it so I don't have to release anything I added?

Then, Qt code, are there any tricks, shortcuts I could have used?

I think climbing up from `::applicationFilePath` is sane, then I'm looking up until I reach the nix store. This means that applications deeply nested (e.g. libexec) will also be able to read the paths.

#### Testing this

Any known recalcitrant Qt packages to test? Right now I haven't made in-depth tests, only superficially verified it works. I will test a bunch more later, unless there are known trick to test this.

As for what I tested, here is an example using `quaternion`.

> A not working, 18.03 install, nix-shell to nixos-unstable:
> ```
> [nix-shell:~/tmp/nixpkgs/nixpkgs-qt]$ export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib
> [nix-shell:~/tmp/nixpkgs/nixpkgs-qt]$ quaternion
> qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
> This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
> Aborted
> ```
> 
> Working quaternion, from a 18.03 install, nix-shell to nixos-unstable+patch.
> ```
> [nix-shell:~/tmp/nixpkgs/nixpkgs-qt]$ export LD_LIBRARY_PATH=/run/opengl-driver/lib:/run/opengl-driver-32/lib
> [nix-shell:~/tmp/nixpkgs/nixpkgs-qt]$ quaternion
> QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/run/user/1000/runtime-samuel'
> QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/run/user/1000/runtime-samuel'
> [... it works ...]
> ```

I also verified with `strace` that it reads the paths inside `nix-support`.

Using `dontAddPluginPaths` I also verified how apps will work if they don't find the `nix-support` path; they simply go back to working the way they worked before.

### What's left to do?

 * [ ] Answer to feedback.
 * [ ] Also port to 5.6 (trivial).
 * [ ] Merge with other qtbase patches? If not, at least rename the patch.
 * [ ] Test on other Linux.
 * [ ] Test on macOS.

* * *

Commit message:

> ###### Loads qt plugin paths as registered...
> 
> This adds the list of Qt plugin paths into builds using `qtbase`.
> 
> The plugins list will be added to the Qt plugin path through the
> additional patch.
> 
> This ensures that no special environment is required to get the desired
> plugin path for Qt software.
> 
> This should fix all issues where Qt is unable to load its platform
> plugin.
> 
> This may fix the issue where Qt tries to load a mismatched version of a
> plugin.



### Things done

> *Cut the things done part, until this is ready to be merged.*
>
> *Note that this is tested on nixos only, and built using sandboxing.


* * *

Additional notes:

 * #30775 had a minor Qt bump mixed-and-mismatched causing a failure.