### PR TITLE
dbxml: init at 6.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -862,6 +862,11 @@
     github = "danharaj";
     name = "Dan Haraj";
   };
+  danieldk = {
+    email = "me@danieldk.eu";
+    github = "danieldk";
+    name = "Daniël de Kok";
+  };
   danielfullmer = {
     email = "danielrf12@gmail.com";
     github = "danielfullmer";

--- a/pkgs/development/libraries/dbxml/cxx11.patch
+++ b/pkgs/development/libraries/dbxml/cxx11.patch
@@ -1,0 +1,59 @@
+diff -urN dbxml-6.1.4.orig/dbxml/src/dbxml/nodeStore/NsUpdate.cpp dbxml-6.1.4/dbxml/src/dbxml/nodeStore/NsUpdate.cpp
+--- dbxml-6.1.4.orig/dbxml/src/dbxml/nodeStore/NsUpdate.cpp	2017-05-01 16:05:29.000000000 +0100
++++ dbxml-6.1.4/dbxml/src/dbxml/nodeStore/NsUpdate.cpp	2017-09-04 11:50:20.000000000 +0100
+@@ -1359,21 +1359,13 @@
+ void NsUpdate::attributeRemoved(const DbXmlNodeImpl &node)
+ {
+ 	string key = makeKey(node);
+-#if defined(_MSC_VER) && (_MSC_VER>1600)
+ 	attrMap_.insert(make_pair(key,node.getIndex()));
+-#else
+-	attrMap_.insert(make_pair<const std::string, int>(key,node.getIndex()));
+-#endif
+ }
+ 
+ void NsUpdate::textRemoved(const DbXmlNodeImpl &node)
+ {
+ 	string key = makeKey(node);
+-#if defined(_MSC_VER) && (_MSC_VER>1600)
+ 	textDeleteMap_.insert(make_pair(key,node.getIndex()));
+-#else
+-	textDeleteMap_.insert(make_pair<const std::string, int>(key,node.getIndex()));
+-#endif
+ }
+ 
+ void NsUpdate::textRemoved(int index, const NsNid &nid,
+@@ -1381,21 +1373,13 @@
+ 			   const std::string &cname)
+ {
+ 	string key = makeKey(nid, did, cname);
+-#if defined(_MSC_VER) && (_MSC_VER>1600)
+ 	textDeleteMap_.insert(make_pair(key,index));
+-#else
+-	textDeleteMap_.insert(make_pair<const std::string, int>(key,index));
+-#endif
+ }
+ 
+ void NsUpdate::textInserted(int index, const DbXmlNodeImpl &node)
+ {
+ 	string key = makeKey(node);
+-#if defined(_MSC_VER) && (_MSC_VER>1600)
+ 	textInsertMap_.insert(make_pair(key,index));
+-#else
+-	textInsertMap_.insert(make_pair<const std::string, int>(key,index));
+-#endif
+ }
+ 
+ void NsUpdate::textInserted(int index, const NsNid &nid,
+@@ -1403,11 +1387,7 @@
+ 			    const std::string &cname)
+ {
+ 	string key = makeKey(nid, did, cname);
+-#if defined(_MSC_VER) && (_MSC_VER>1600)
+ 	textInsertMap_.insert(make_pair(key,index));
+-#else
+-	textInsertMap_.insert(make_pair<const std::string, int>(key,index));
+-#endif
+ }
+ 
+ //

--- a/pkgs/development/libraries/dbxml/default.nix
+++ b/pkgs/development/libraries/dbxml/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, db62, xercesc, xqilla }:
+
+stdenv.mkDerivation rec {
+  name = "dbxml-${version}";
+  version = "6.1.4";
+
+  src = fetchurl {
+    url = "http://download.oracle.com/berkeley-db/${name}.tar.gz";
+    sha256 = "a8fc8f5e0c3b6e42741fa4dfc3b878c982ff8f5e5f14843f6a7e20d22e64251a";
+  };
+
+  patches = [
+    ./cxx11.patch
+    ./incorrect-optimization.patch
+  ];
+
+  buildInputs = [
+    db62 xercesc xqilla
+  ];
+
+  configureFlags = [
+    "--with-berkeleydb=${db62.out}"
+    "--with-xerces=${xercesc}"
+    "--with-xqilla=${xqilla}"
+  ];
+
+  preConfigure = ''
+    cd dbxml
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.oracle.com/database/berkeley-db/xml.html;
+    description = "Embeddable XML database based on Berkeley DB";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/dbxml/incorrect-optimization.patch
+++ b/pkgs/development/libraries/dbxml/incorrect-optimization.patch
@@ -1,0 +1,34 @@
+Patch provided by Lauren Foutz. See:
+https://community.oracle.com/thread/4093422
+
+--- dbxml-6.1.4-orig/dbxml/src/dbxml/query/ParentOfChildJoinQP.cpp
++++ dbxml-6.1.4/dbxml/src/dbxml/query/ParentOfChildJoinQP.cpp
+@@ -139,28 +139,16 @@ bool ParentOfChildIterator::doJoin(Dynam
+ 
+ 	// Invarient 4: When ancestorStack_ is empty we can output the
+ 	// buffered results_, since any more results will come after them in
+ 	// document order.
+ 
+ 	while(true) {
+ 		context->testInterrupt();
+ 
+-		/* 
+-		 * If current parent's node level already be larger than
+-		 * childen's, abandon current parent and move to next one.
+-		 */
+-		if (parents_ != NULL && 
+-		    parents_->getNodeLevel() > children_->getNodeLevel()) {
+-			if(!parents_->next(context)) {
+-				delete parents_;
+-				parents_ = 0;
+-			}
+-		}
+-
+ 		int cmp = parents_ == 0 ? -1 : isDescendantOf(children_, parents_, /*orSelf*/false);
+ 		if(cmp < 0) {
+ 			if(!ancestorStack_.empty()) {
+ 				// We've found the closest ancestor - is it a parent?
+ 				if(ancestorStack_.back()->getNodeLevel() == (children_->getNodeLevel() - 1)) {
+ 					// Maintain invarient 3
+ 					if(results_.empty() || NodeInfo::compare(results_.back(), ancestorStack_.back()) < 0)
+ 						results_.push_back(ancestorStack_.back());

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8989,6 +8989,8 @@ with pkgs;
   db60 = callPackage ../development/libraries/db/db-6.0.nix { };
   db62 = callPackage ../development/libraries/db/db-6.2.nix { };
 
+  dbxml = callPackage ../development/libraries/dbxml { };
+
   dbus = callPackage ../development/libraries/dbus { };
   dbus_cplusplus  = callPackage ../development/libraries/dbus-cplusplus { };
   dbus-glib       = callPackage ../development/libraries/dbus-glib { };


### PR DESCRIPTION
Website: https://www.oracle.com/database/berkeley-db/xml.html
Changelog: http://download.oracle.com/otndocs/products/berkeleydb/html/dbxml614.html

###### Motivation for this change

Berkeley XML is a somewhat widely used XML database on top of Berkeley DB, XQilla, and XercesC.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

