### PR TITLE
amazon-ecr-credential-helper: init at 0.1.0

### DIFF
--- a/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
+++ b/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
@@ -1,0 +1,23 @@
+{ buildGoPackage, fetchFromGitHub, lib, ... }:
+
+buildGoPackage rec {
+  name = "amazon-ecr-credential-helper-${version}";
+  version = "0.1.0";
+
+  goPackagePath = "github.com/awslabs/amazon-ecr-credential-helper";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "amazon-ecr-credential-helper";
+    rev = "v${version}";
+    sha256 = "0mpwm21fphg117ryxda7696s8bnvi4bbc8rvi4zp2m1rhl04j2yy";
+  };
+
+  meta = with lib; {
+    description = "The Amazon ECR Docker Credential Helper is a credential helper for the Docker daemon that makes it easier to use Amazon Elastic Container Registry";
+    homepage = https://github.com/awslabs/amazon-ecr-credential-helper;
+    license = licenses.asl20 ;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15649,6 +15649,8 @@ with pkgs;
 
   docker-distribution = callPackage ../applications/virtualization/docker/distribution.nix { };
 
+  amazon-ecr-credential-helper = callPackage ../tools/admin/amazon-ecr-credential-helper { };
+
   docker-credential-gcr = callPackage ../tools/admin/docker-credential-gcr { };
 
   doodle = callPackage ../applications/search/doodle { };


### PR DESCRIPTION
###### Motivation for this change

The Amazon ECR Docker Credential Helper is a credential helper for the Docker daemon that makes it easier to use Amazon Elastic Container Registry.

https://github.com/awslabs/amazon-ecr-credential-helper

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

