### PR TITLE
minicom: Add macOS support

### DIFF
--- a/pkgs/tools/misc/minicom/default.nix
+++ b/pkgs/tools/misc/minicom/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig
-, ncurses }:
+, ncurses, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "minicom-2.7.1";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wa1l36fa4npd21xa9nz60yrqwkk5cq713fa3p5v0zk7g9mq6bsk";
   };
 
-  buildInputs = [ ncurses ];
+  buildInputs = [ ncurses ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
       download.
     '';
     maintainers = with maintainers; [ peterhoeg ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested without sandboxing on macOS
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

