### PR TITLE
Fix pname to ename propagation if null

### DIFF
--- a/pkgs/build-support/emacs/melpa.nix
+++ b/pkgs/build-support/emacs/melpa.nix
@@ -13,7 +13,7 @@ with lib;
   /*
     ename: Original Emacs package name, possibly containing special symbols.
   */
-, ename ? pname
+, ename ? null
 , version
 , recipe
 , meta ? {}
@@ -29,6 +29,11 @@ let
 in
 
 import ./generic.nix { inherit lib stdenv emacs texinfo; } ({
+
+  ename =
+    if isNull(ename)
+    then pname
+    else ename;
 
   melpa = fetchFromGitHub {
     owner = "melpa";


### PR DESCRIPTION
###### Motivation for this change
Fix for #44049

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

