### PR TITLE
nixos/avahi: add support for extraConfig

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -37,6 +37,7 @@ let
 
     [reflector]
     enable-reflector=${yesNo reflector}
+    ${extraConfig}
   '';
 
 in
@@ -173,6 +174,14 @@ in
         description = ''
           Number of resource records to be cached per interface. Use 0 to
           disable caching. Avahi daemon defaults to 4096 if not set.
+        '';
+      };
+
+      extraConfig = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra config to append to avahi-daemon.conf.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Allow setting additional options for [`avahi-daemon.conf`](http://manpages.ubuntu.com/manpages/bionic/man5/avahi-daemon.conf.5.html).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

