### PR TITLE
kubetail: init at 1.6.1

### DIFF
--- a/pkgs/applications/networking/cluster/kubetail/default.nix
+++ b/pkgs/applications/networking/cluster/kubetail/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, lib, ... }:
+
+stdenv.mkDerivation rec {
+  name = "kubetail-${version}";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "johanhaleby";
+    repo = "kubetail";
+    rev = "${version}";
+    sha256 = "10ql1kdsmyrk73jb6f5saf2q38znm0vdihscj3c9n0qhyhk9blpl";
+  };
+
+  installPhase = ''
+    install -Dm755 kubetail $out/bin/kubetail
+  '';
+
+  meta = with lib; {
+    description = "Bash script to tail Kubernetes logs from multiple pods at the same time";
+    longDescription = ''
+      Bash script that enables you to aggregate (tail/follow) logs from
+      multiple pods into one stream. This is the same as running "kubectl logs
+      -f " but for multiple pods.
+    '';
+    homepage = https://github.com/johanhaleby/kubetail;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kalbasit ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16943,6 +16943,8 @@ with pkgs;
 
   kubernetes-helm = callPackage ../applications/networking/cluster/helm { };
 
+  kubetail = callPackage ../applications/networking/cluster/kubetail { } ;
+
   kupfer = callPackage ../applications/misc/kupfer { };
 
   lame = callPackage ../development/libraries/lame { };


### PR DESCRIPTION
###### Motivation for this change

Kubetail is very useful when working with kubernetes.

https://github.com/johanhaleby/kubetail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

