### PR TITLE
fix: atom crash on Glib-GIO-ERROR

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, makeWrapper, wrapGAppsHook, gvfs, atomEnv, gsettings_desktop_schemas, gtk3}:
+{ stdenv, pkgs, fetchurl, makeWrapper, wrapGAppsHook, gvfs, atomEnv, gtk3}:
 
 let
   common = pname: {version, sha256}: stdenv.mkDerivation rec {

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, makeWrapper, gvfs, atomEnv}:
+{ stdenv, pkgs, fetchurl, makeWrapper, gvfs, gtk3, atomEnv}:
 
 let
   common = pname: {version, sha256}: stdenv.mkDerivation rec {
@@ -24,7 +24,9 @@ let
       sed -i "s/${pname})/.${pname}-wrapped)/" $out/bin/${pname}
       # sed -i "s/'${pname}'/'.${pname}-wrapped'/" $out/bin/${pname}
       wrapProgram $out/bin/${pname} \
-        --prefix "PATH" : "${gvfs}/bin"
+        --prefix "PATH" : "${gvfs}/bin" \
+        --suffix "XDG_DATA_DIRS" : "${gtk3}/share/gsettings-schemas/${gtk3.name}/";
+
 
       fixupPhase
 

--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -19,7 +19,6 @@ let
     preFixup = ''
       gappsWrapperArgs+=(
         --prefix "PATH" : "${gvfs}/bin" \
-        --suffix "XDG_DATA_DIRS" : "${gsettings_desktop_schemas}/share/gsettings-schemas/${gsettings_desktop_schemas.name}"
       )
     '';
 
@@ -32,10 +31,6 @@ let
       rm -r $out/share/lintian
       rm -r $out/usr/
       sed -i "s/${pname})/.${pname}-wrapped)/" $out/bin/${pname}
-      # sed -i "s/'${pname}'/'.${pname}-wrapped'/" $out/bin/${pname}
-      #wrapProgram $out/bin/${pname} \
-      #  --prefix "PATH" : "${gvfs}/bin"
-
 
       fixupPhase
 


### PR DESCRIPTION
###### Motivation for this change
in  the recent unstable releases of nixos atom used to crash when opening file open/save dialogs.
This might be related to a similar issue happening with sakura (#21698, #21700) which is also the inspiration for this fix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

