### PR TITLE
treewide: Get rid off `crossAttrs`, and `makeStdenvCross`

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -1,5 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, substituteAll
-, hostPlatform
+{ stdenv, lib, fetchurl, fetchpatch, substituteAll
 , libXrender, libXinerama, libXcursor, libXv, libXext
 , libXfixes, libXrandr, libSM, freetype, fontconfig, zlib, libjpeg, libpng
 , libmng, which, libGLSupported, libGLU, openssl, dbus, cups, pkgconfig
@@ -16,8 +15,6 @@
 # darwin support
 , cf-private, libobjc, ApplicationServices, OpenGL, Cocoa, AGL, libcxx
 }:
-
-with stdenv.lib;
 
 let
   v_maj = "4.8";
@@ -51,12 +48,12 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /bin/pwd pwd
     substituteInPlace src/corelib/global/global.pri --replace /bin/ls ${coreutils}/bin/ls
     sed -e 's@/\(usr\|opt\)/@/var/empty/@g' -i config.tests/*/*.test -i mkspecs/*/*.conf
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     # remove impure reference to /usr/lib/libstdc++.6.dylib
     # there might be more references, but this is the only one I could find
     substituteInPlace tools/macdeployqt/tests/tst_deployment_mac.cpp \
       --replace /usr/lib/libstdc++.6.dylib "${stdenv.cc}/lib/libstdc++.6.dylib"
-  '' + stdenv.lib.optionalString stdenv.cc.isClang ''
+  '' + lib.optionalString stdenv.cc.isClang ''
     substituteInPlace src/3rdparty/webkit/Source/WebCore/html/HTMLImageElement.cpp \
       --replace 'optionalHeight > 0' 'optionalHeight != NULL'
 
@@ -65,14 +62,15 @@ stdenv.mkDerivation rec {
   '';
 
   patches =
-    [ ./glib-2.32.patch
+    lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+      ./glib-2.32.patch
       ./libressl.patch
       ./parallel-configure.patch
       ./clang-5-darwin.patch
       ./qt-4.8.7-unixmake-darwin.patch
       (substituteAll {
         src = ./dlopen-absolute-paths.diff;
-        cups = if cups != null then stdenv.lib.getLib cups else null;
+        cups = if cups != null then lib.getLib cups else null;
         icu = icu.out;
         libXfixes = libXfixes.out;
         glibc = stdenv.cc.libc.out;
@@ -89,25 +87,25 @@ stdenv.mkDerivation rec {
         sha256 = "07lrva7bjh6i40p7b3ml26a2jlznri8bh7y7iyx5zmvb1gfxmj34";
       })
     ]
-    ++ stdenv.lib.optional gtkStyle (substituteAll ({
+    ++ lib.optional gtkStyle (substituteAll ({
         src = ./dlopen-gtkstyle.diff;
         # substituteAll ignores env vars starting with capital letter
         gtk = gtk2.out;
-      } // stdenv.lib.optionalAttrs gnomeStyle {
+      } // lib.optionalAttrs gnomeStyle {
         gconf = GConf.out;
         libgnomeui = libgnomeui.out;
         gnome_vfs = gnome_vfs.out;
       }))
-    ++ stdenv.lib.optional flashplayerFix (substituteAll {
+    ++ lib.optional flashplayerFix (substituteAll {
         src = ./dlopen-webkit-nsplugin.diff;
         gtk = gtk2.out;
         gdk_pixbuf = gdk_pixbuf.out;
       })
-    ++ stdenv.lib.optional stdenv.isAarch64 (fetchpatch {
+    ++ lib.optional stdenv.isAarch64 (fetchpatch {
         url = "https://src.fedoraproject.org/rpms/qt/raw/ecf530486e0fb7fe31bad26805cde61115562b2b/f/qt-aarch64.patch";
         sha256 = "1fbjh78nmafqmj7yk67qwjbhl3f6ylkp6x33b1dqxfw9gld8b3gl";
       })
-    ++ stdenv.lib.optionals stdenv.hostPlatform.isMusl [
+    ++ lib.optionals stdenv.hostPlatform.isMusl [
         ./qt-musl.patch
         ./qt-musl-iconv-no-bom.patch
         ./patch-qthread-stacksize.diff
@@ -127,15 +125,27 @@ stdenv.mkDerivation rec {
       --jobs=$NIX_BUILD_CORES
     "
     unset LD # Makefile uses gcc for linking; setting LD interferes
-  '' + optionalString stdenv.cc.isClang ''
+  '' + lib.optionalString stdenv.cc.isClang ''
     sed -i 's/QMAKE_CC = gcc/QMAKE_CC = clang/' mkspecs/common/g++-base.conf
     sed -i 's/QMAKE_CXX = g++/QMAKE_CXX = clang++/' mkspecs/common/g++-base.conf
+  '' + lib.optionalString stdenv.hostPlatform.isWindows ''
+    sed -i -e 's/ g++/ ${stdenv.cc.targetPrefix}g++/' \
+      -e 's/ gcc/ ${stdenv.cc.targetPrefix}gcc/' \
+      -e 's/ ar/ ${stdenv.cc.targetPrefix}ar/' \
+      -e 's/ strip/ ${stdenv.cc.targetPrefix}strip/' \
+      -e 's/ windres/ ${stdenv.cc.targetPrefix}windres/' \
+      mkspecs/win32-g++/qmake.conf
   '';
 
   prefixKey = "-prefix ";
 
-  configureFlags =
-    ''
+  ${if stdenv.hostPlatform == stdenv.buildPlatform then null else "configurePlatforms"} = [];
+  configureFlags = let
+    platformFlag =
+      if stdenv.hostPlatform != stdenv.buildPlatform
+      then "-xplatform"
+      else "-platform";
+    in (if stdenv.hostPlatform == stdenv.buildPlatform then ''
       -v -no-separate-debug-info -release -fast -confirm-license -opensource
 
       -${if stdenv.isFreeBSD then "no-" else ""}opengl -xrender -xrandr -xinerama -xcursor -xinput -xfixes -fontconfig
@@ -152,23 +162,30 @@ stdenv.mkDerivation rec {
 
       -no-phonon ${if buildWebkit then "" else "-no"}-webkit ${if buildMultimedia then "" else "-no"}-multimedia -audio-backend
       ${if developerBuild then "-developer-build" else ""}
-    '' + optionalString stdenv.isDarwin "-platform unsupported/macx-clang-libc++";
+    '' else ''
+      -static -release -confirm-license -opensource
+      -no-opengl -no-phonon
+      -no-svg
+      -make qmake -make libs -nomake tools
+      -nomake demos -nomake examples -nomake docs
+    '') + lib.optionalString stdenv.hostPlatform.isDarwin "${platformFlag} unsupported/macx-clang-libc++"
+        + lib.optionalString stdenv.hostPlatform.isMinGW  "${platformFlag} win32-g++-4.6";
 
   propagatedBuildInputs =
     [ libXrender libXrandr libXinerama libXcursor libXext libXfixes libXv libXi
       libSM zlib libpng openssl dbus freetype fontconfig glib ]
         # Qt doesn't directly need GLU (just GL), but many apps use, it's small and doesn't remain a runtime-dep if not used
-    ++ optional libGLSupported libGLU
-    ++ optional ((buildWebkit || buildMultimedia) && stdenv.isLinux ) alsaLib
-    ++ optionals (buildWebkit || buildMultimedia) [ gstreamer gst-plugins-base ];
+    ++ lib.optional libGLSupported libGLU
+    ++ lib.optional ((buildWebkit || buildMultimedia) && stdenv.isLinux ) alsaLib
+    ++ lib.optionals (buildWebkit || buildMultimedia) [ gstreamer gst-plugins-base ];
 
   # The following libraries are only used in plugins
   buildInputs =
     [ cups # Qt dlopen's libcups instead of linking to it
       postgresql sqlite libjpeg libmng libtiff icu ]
-    ++ optionals (mysql != null) [ mysql.connector-c ]
-    ++ optionals gtkStyle [ gtk2 gdk_pixbuf ]
-    ++ optionals stdenv.isDarwin [ cf-private ApplicationServices OpenGL Cocoa AGL libcxx libobjc ];
+    ++ lib.optionals (mysql != null) [ mysql.connector-c ]
+    ++ lib.optionals gtkStyle [ gtk2 gdk_pixbuf ]
+    ++ lib.optionals stdenv.isDarwin [ cf-private ApplicationServices OpenGL Cocoa AGL libcxx libobjc ];
 
   nativeBuildInputs = [ perl pkgconfig which ];
 
@@ -177,14 +194,14 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE =
     # with gcc7 the warnings blow the log over Hydra's limit
     [ "-Wno-expansion-to-defined" "-Wno-unused-local-typedefs" ]
-    ++ optional stdenv.isLinux "-std=gnu++98" # gnu++ in (Obj)C flags is no good on Darwin
-    ++ optionals (stdenv.isFreeBSD || stdenv.isDarwin)
+    ++ lib.optional stdenv.isLinux "-std=gnu++98" # gnu++ in (Obj)C flags is no good on Darwin
+    ++ lib.optionals (stdenv.isFreeBSD || stdenv.isDarwin)
       [ "-I${glib.dev}/include/glib-2.0" "-I${glib.out}/lib/glib-2.0/include" ]
-    ++ optional stdenv.isDarwin "-I${libcxx}/include/c++/v1";
+    ++ lib.optional stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
-  NIX_LDFLAGS = optionalString (stdenv.isFreeBSD || stdenv.isDarwin) "-lglib-2.0";
+  NIX_LDFLAGS = lib.optionalString (stdenv.isFreeBSD || stdenv.isDarwin) "-lglib-2.0";
 
-  preBuild = optionalString stdenv.isDarwin ''
+  preBuild = lib.optionalString stdenv.isDarwin ''
     # resolve "extra qualification on member" error
     sed -i 's/struct ::TabletProximityRec;/struct TabletProximityRec;/' \
       src/gui/kernel/qt_cocoa_helpers_mac_p.h
@@ -196,44 +213,19 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     rm -rf $out/tests
+  ''
+  # I don't know why it does not install qmake
+  + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    cp bin/qmake* $out/bin
   '';
 
-  crossAttrs = {
-    # I've not tried any case other than i686-pc-mingw32.
-    # -nomake tools:   it fails linking some asian language symbols
-    # -no-svg: it fails to build on mingw64
-    configureFlags = ''
-      -static -release -confirm-license -opensource
-      -no-opengl -no-phonon
-      -no-svg
-      -make qmake -make libs -nomake tools
-      -nomake demos -nomake examples -nomake docs
-    '' + optionalString hostPlatform.isMinGW " -xplatform win32-g++-4.6";
-    patches = [];
-    preConfigure = ''
-      sed -i -e 's/ g++/ ${stdenv.cc.targetPrefix}g++/' \
-        -e 's/ gcc/ ${stdenv.cc.targetPrefix}gcc/' \
-        -e 's/ ar/ ${stdenv.cc.targetPrefix}ar/' \
-        -e 's/ strip/ ${stdenv.cc.targetPrefix}strip/' \
-        -e 's/ windres/ ${stdenv.cc.targetPrefix}windres/' \
-        mkspecs/win32-g++/qmake.conf
-    '';
-
-    # I don't know why it does not install qmake
-    postInstall = ''
-      cp bin/qmake* $out/bin
-    '';
-    configurePlatforms = [];
-    dontStrip = true;
-  } // optionalAttrs hostPlatform.isMinGW {
-    propagatedBuildInputs = [ ];
-  };
+  dontStrip = if stdenv.hostPlatform == stdenv.buildPlatform then null else true;
 
   meta = {
     homepage    = http://qt-project.org/;
     description = "A cross-platform application framework for C++";
-    license     = licenses.lgpl21Plus; # or gpl3
-    maintainers = with maintainers; [ orivej lovek323 phreedom sander ];
-    platforms   = platforms.unix;
+    license     = lib.licenses.lgpl21Plus; # or gpl3
+    maintainers = with lib.maintainers; [ orivej lovek323 phreedom sander ];
+    platforms   = lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -28,46 +28,40 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  crossAttrs = {
+  # This program does not cross-build fine. So I only cross-build some parts
+  # I need for the linux perf tool.
+  # On the awful cross-building:
+  # http://comments.gmane.org/gmane.comp.sysutils.elfutils.devel/2005
+  #
+  # I wrote this testing for the nanonote.
 
-    /* Having bzip2 will harm, because anything using elfutils
-       as buildInput cross-building, will not be able to run 'bzip2' */
-    propagatedBuildInputs = [ zlib.crossDrv ];
+  buildPhase = if stdenv.hostPlatform == stdenv.buildPlatform then null else ''
+    pushd libebl
+    make
+    popd
+    pushd libelf
+    make
+    popd
+    pushd libdwfl
+    make
+    popd
+    pushd libdw
+    make
+    popd
+  '';
 
-    # This program does not cross-build fine. So I only cross-build some parts
-    # I need for the linux perf tool.
-    # On the awful cross-building:
-    # http://comments.gmane.org/gmane.comp.sysutils.elfutils.devel/2005
-    #
-    # I wrote this testing for the nanonote.
-    buildPhase = ''
-      pushd libebl
-      make
-      popd
-      pushd libelf
-      make
-      popd
-      pushd libdwfl
-      make
-      popd
-      pushd libdw
-      make
-      popd
-    '';
-
-    installPhase = ''
-      pushd libelf
-      make install
-      popd
-      pushd libdwfl
-      make install
-      popd
-      pushd libdw
-      make install
-      popd
-      cp version.h $out/include
-    '';
-  };
+  installPhase = if stdenv.hostPlatform == stdenv.buildPlatform then null else ''
+    pushd libelf
+    make install
+    popd
+    pushd libdwfl
+    make install
+    popd
+    pushd libdw
+    make install
+    popd
+    cp version.h $out/include
+  '';
 
   meta = {
     homepage = https://sourceware.org/elfutils/;

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -12,12 +12,10 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ m4 ];
 
-  crossAttrs = {
-    preConfigure = ''
-      export ac_cv_func_malloc_0_nonnull=yes
-      export ac_cv_func_realloc_0_nonnull=yes
-    '';
-  };
+  preConfigure = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
 
   meta = {
     branch = "2.5.35";

--- a/pkgs/development/tools/parsing/flex/2.6.1.nix
+++ b/pkgs/development/tools/parsing/flex/2.6.1.nix
@@ -12,22 +12,19 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ m4 ];
 
+  preConfigure = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
+
   postConfigure = stdenv.lib.optionalString (stdenv.isDarwin || stdenv.isCygwin) ''
     sed -i Makefile -e 's/-no-undefined//;'
   '';
 
-  crossAttrs = {
-
-    # disable tests which can't run on build machine
-    postPatch = ''
-      substituteInPlace Makefile.in --replace "tests" " ";
-    '';
-
-    preConfigure = ''
-      export ac_cv_func_malloc_0_nonnull=yes
-      export ac_cv_func_realloc_0_nonnull=yes
-    '';
-  };
+  # disable tests which can't run on build machine
+  postPatch = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    substituteInPlace Makefile.in --replace "tests" " ";
+  '';
 
   meta = {
     homepage = https://github.com/westes/flex;

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -87,7 +87,7 @@ rec {
                  (hostPlatform.isAarch64 || hostPlatform.isMips || hostPlatform.libc == "musl")
                  pkgs.updateAutotoolsGnuConfigScriptsHook
             ;
-        } // args.crossAttrs or {});
+        });
   };
 
 

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -53,35 +53,6 @@ rec {
       });
     };
 
-
-  # Return a modified stdenv that adds a cross compiler to the
-  # builds.
-  makeStdenvCross = { stdenv
-                    , cc
-                    , buildPlatform, hostPlatform, targetPlatform
-                    , # Prior overrides are surely not valid as packages built
-                      # with this run on a different platform, so disable by
-                      # default.
-                      overrides ? _: _: {}
-                    } @ overrideArgs:
-    overrideArgs.stdenv.override (old: {
-      inherit
-        buildPlatform hostPlatform targetPlatform
-        cc overrides;
-
-      allowedRequisites = null;
-      extraNativeBuildInputs = old.extraNativeBuildInputs
-           # without proper `file` command, libtool sometimes fails
-           # to recognize 64-bit DLLs
-        ++ stdenv.lib.optional (hostPlatform.config == "x86_64-w64-mingw32") pkgs.file
-        ++ stdenv.lib.optional
-             (hostPlatform.isAarch64 || hostPlatform.isMips || hostPlatform.libc == "musl")
-             pkgs.updateAutotoolsGnuConfigScriptsHook
-        ;
-
-      extraBuildInputs = [ ]; # Old ones run on wrong platform
-    });
-
   /* Modify a stdenv so that the specified attributes are added to
      every derivation returned by its mkDerivation function.
 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -34,17 +34,31 @@ in lib.init bootStages ++ [
   (buildPackages: {
     inherit config overlays;
     selfBuild = false;
-    stdenv = buildPackages.makeStdenvCross {
-      inherit (buildPackages) stdenv;
+    stdenv = buildPackages.stdenv.override (old: rec {
       buildPlatform = localSystem;
       hostPlatform = crossSystem;
       targetPlatform = crossSystem;
+
+      # Prior overrides are surely not valid as packages built with this run on
+      # a different platform, and so are disabled.
+      overrides = _: _: {};
+      extraBuildInputs = [ ]; # Old ones run on wrong platform
+
       cc = if crossSystem.useiOSPrebuilt or false
              then buildPackages.darwin.iosSdkPkgs.clang
            else if crossSystem.useAndroidPrebuilt
              then buildPackages.androidenv."androidndkPkgs_${crossSystem.ndkVer}".gcc
            else buildPackages.gcc;
-    };
+
+      extraNativeBuildInputs = old.extraNativeBuildInputs
+           # without proper `file` command, libtool sometimes fails
+           # to recognize 64-bit DLLs
+        ++ lib.optional (hostPlatform.config == "x86_64-w64-mingw32") buildPackages.file
+        ++ lib.optional
+             (hostPlatform.isAarch64 || hostPlatform.isMips || hostPlatform.libc == "musl")
+             buildPackages.updateAutotoolsGnuConfigScriptsHook
+        ;
+    });
   })
 
 ]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -164,7 +164,7 @@ rec {
 
       derivationArg =
         (removeAttrs attrs
-          ["meta" "passthru" "crossAttrs" "pos"
+          ["meta" "passthru" "pos"
            "doCheck" "doInstallCheck"
            "checkInputs" "installCheckInputs"
            "__impureHostDeps" "__propagatedImpureHostDeps"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6334,13 +6334,7 @@ with pkgs;
     { substitutions = { gcc = gcc-unwrapped; }; }
     ../development/compilers/gcc/libstdc++-hook.sh;
 
-  # Can't just overrideCC, because then the stdenv-cross mkDerivation will be
-  # thrown away. TODO: find a better solution for this.
-  crossLibcStdenv = buildPackages.makeStdenvCross {
-    inherit (buildPackages.buildPackages) stdenv;
-    inherit buildPlatform hostPlatform targetPlatform;
-    cc = buildPackages.gccCrossStageStatic;
-  };
+  crossLibcStdenv = overrideCC stdenv buildPackages.gccCrossStageStatic;
 
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.


### PR DESCRIPTION
###### Motivation for this change

Fixes #33302. `makeStdenvCross` is no good because it is useless on its own (the stages aren't set up). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

