### PR TITLE
eot_utilities: change platforms to unix

### DIFF
--- a/pkgs/tools/misc/eot-utilities/default.nix
+++ b/pkgs/tools/misc/eot-utilities/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     description = "Create Embedded Open Type from OpenType or TrueType font";
     license = stdenv.lib.licenses.w3c;
     maintainers = with stdenv.lib.maintainers; [ leenaars ];
-    platforms = with stdenv.lib.platforms; linux; 
+    platforms = with stdenv.lib.platforms; unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This works on Darwin too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

