### PR TITLE
pyserial: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/pyserial/default.nix
+++ b/pkgs/development/python-modules/pyserial/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
   };
 
   checkPhase = "python -m unittest discover -s test";
-  doInstallCheck = !hostPlatform.isDarwin; # broken on darwin
+  doCheck = !hostPlatform.isDarwin; # broken on darwin
 
   meta = with lib; {
     homepage = "https://github.com/pyserial/pyserial";


### PR DESCRIPTION
###### Motivation for this change
Disables hanging tests to fix the build

[py2](https://hydra.nixos.org/job/nixpkgs/trunk/python27Packages.pyserial.x86_64-darwin)
[py3](https://hydra.nixos.org/job/nixpkgs/trunk/python36Packages.pyserial.x86_64-darwin)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

