### PR TITLE
singularity-tools: create required bind points

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -116,7 +116,7 @@
   ./programs/shadow.nix
   ./programs/shell.nix
   ./programs/spacefm.nix
-  ./programs/singularity.nix
+  ./programs/singularity/default.nix
   ./programs/ssh.nix
   ./programs/ssmtp.nix
   ./programs/sysdig.nix

--- a/nixos/modules/programs/singularity/default.nix
+++ b/nixos/modules/programs/singularity/default.nix
@@ -3,13 +3,17 @@
 with lib;
 let
   cfg = config.programs.singularity;
+  singularity = pkgs.singularity.overrideAttrs (attrs : {
+    patches = [ ./suid.patch ];
+  });
 in {
   options.programs.singularity = {
     enable = mkEnableOption "Singularity";
   };
 
   config = mkIf cfg.enable {
-      environment.systemPackages = [ pkgs.singularity ];
+      environment.systemPackages = [ singularity ];
+      security.wrappers.singularity-suid.source = "${singularity}/libexec/singularity/bin/starter-suid";
       systemd.tmpfiles.rules = [ "d /var/singularity/mnt/session 0770 root root -"
                                  "d /var/singularity/mnt/final 0770 root root -"
                                  "d /var/singularity/mnt/overlay 0770 root root -"

--- a/nixos/modules/programs/singularity/suid.patch
+++ b/nixos/modules/programs/singularity/suid.patch
@@ -1,0 +1,55 @@
+diff --git source/src/cmd/singularity/cli/actions.go source/src/cmd/singularity/cli/actions.go
+index d3f46be..381dc6b 100644
+--- source/src/cmd/singularity/cli/actions.go
++++ source/src/cmd/singularity/cli/actions.go
+@@ -261,7 +261,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
+ 	uid := uint32(os.Getuid())
+ 	gid := uint32(os.Getgid())
+ 
+-	starter := buildcfg.LIBEXECDIR + "/singularity/bin/starter-suid"
++	starter := "/run/wrappers/bin/singularity-suid"
+ 
+ 	engineConfig := singularity.NewConfig()
+ 
+diff --git source/src/cmd/singularity/cli/inspect.go source/src/cmd/singularity/cli/inspect.go
+index 165b294..c5c7e02 100644
+--- source/src/cmd/singularity/cli/inspect.go
++++ source/src/cmd/singularity/cli/inspect.go
+@@ -18,7 +18,6 @@ import (
+ 	"github.com/opencontainers/runtime-tools/generate"
+ 	"github.com/spf13/cobra"
+ 	"github.com/sylabs/singularity/src/docs"
+-	"github.com/sylabs/singularity/src/pkg/buildcfg"
+ 	"github.com/sylabs/singularity/src/pkg/sylog"
+ 	"github.com/sylabs/singularity/src/pkg/util/exec"
+ 
+@@ -197,7 +196,7 @@ var InspectCmd = &cobra.Command{
+ }
+ 
+ func getFileContent(abspath, name string, args []string) (string, error) {
+-	starter := buildcfg.LIBEXECDIR + "/singularity/bin/starter-suid"
++	starter := "/run/wrappers/bin/singularity-suid"
+ 	procname := "Singularity inspect"
+ 	Env := []string{sylog.GetEnvVar(), "SRUNTIME=singularity"}
+ 
+diff --git source/src/cmd/singularity/cli/run_help.go source/src/cmd/singularity/cli/run_help.go
+index 771ed68..4918ffd 100644
+--- source/src/cmd/singularity/cli/run_help.go
++++ source/src/cmd/singularity/cli/run_help.go
+@@ -15,7 +15,6 @@ import (
+ 	"github.com/opencontainers/runtime-tools/generate"
+ 	"github.com/spf13/cobra"
+ 	"github.com/sylabs/singularity/src/docs"
+-	"github.com/sylabs/singularity/src/pkg/buildcfg"
+ 	"github.com/sylabs/singularity/src/pkg/sylog"
+ 	"github.com/sylabs/singularity/src/pkg/util/exec"
+ 	"github.com/sylabs/singularity/src/runtime/engines/config"
+@@ -44,7 +43,7 @@ var RunHelpCmd = &cobra.Command{
+ 		abspath, err := filepath.Abs(args[0])
+ 		name := filepath.Base(abspath)
+ 		a := []string{"/bin/cat", "/.singularity.d/runscript.help"}
+-		starter := buildcfg.LIBEXECDIR + "/singularity/bin/starter-suid"
++		starter := "/run/wrappers/bin/singularity-suid"
+ 		procname := "Singularity help"
+ 		Env := []string{sylog.GetEnvVar(), "SRUNTIME=singularity"}
+ 

--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -1,57 +1,83 @@
-{ stdenv
+{stdenv
+, lib
+, fetchgit
 , fetchFromGitHub
-, autoreconfHook
-, gnutar
-, which
-, gnugrep
-, coreutils
-, python
-, e2fsprogs
-, makeWrapper
-, squashfsTools
-, gzip
-, gnused
-, curl
 , utillinux
-, libarchive
-, file
- }:
+, openssl
+, coreutils
+, gawk
+, go
+, which
+, makeWrapper
+, squashfsTools}:
 
-stdenv.mkDerivation rec {
+with lib;
+
+let
+
+  goDeps = import ./deps.nix;
+
+  installGoDep = {goPackagePath, fetch}:
+  let gosrc = fetchgit { inherit (fetch) url rev sha256; };
+  in ''
+    mkdir -p src/$(dirname ${goPackagePath})
+    cp -r ${gosrc} src/${goPackagePath}
+  '';
+
+in stdenv.mkDerivation rec {
   name = "singularity-${version}";
-  version = "2.6.0";
-
-  enableParallelBuilding = true;
-
-  patches = [ ./env.patch ];
-
-  preConfigure = ''
-    sed -i 's/-static//g' src/Makefile.am
-    patchShebangs .
-  '';
-
-  configureFlags = [ "--localstatedir=/var" ];
-  installFlags = "CONTAINER_MOUNTDIR=dummy CONTAINER_FINALDIR=dummy CONTAINER_OVERLAY=dummy SESSIONDIR=dummy";
-
-  fixupPhase = ''
-    patchShebangs $out
-    for f in $out/libexec/singularity/helpers/help.sh $out/libexec/singularity/cli/*.exec $out/libexec/singularity/bootstrap-scripts/*.sh ; do
-      chmod a+x $f
-      sed -i 's| /sbin/| |g' $f
-      sed -i 's| /bin/bash| ${stdenv.shell}|g' $f
-      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath buildInputs}
-    done
-  '';
+  version = "3.0.1";
 
   src = fetchFromGitHub {
-    owner = "singularityware";
+    owner = "sylabs";
     repo = "singularity";
-    rev = version;
-    sha256 = "0bi7acgppbkfbra8r29s1ldq02lazdww0z2h1rfvv8spr8dzzi94";
+    rev = "v${version}";
+    sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";
   };
 
-  nativeBuildInputs = [ autoreconfHook makeWrapper ];
-  buildInputs = [ coreutils gnugrep python e2fsprogs which gnutar squashfsTools gzip gnused curl utillinux libarchive file ];
+
+  buildInputs = [ go utillinux openssl which makeWrapper ];
+  propagatedBuildInputs = [ coreutils squashfsTools ];
+
+  configurePhase = ''
+    cd $TMPDIR
+    mkdir -p src/github.com/sylabs/
+    mv source src/github.com/sylabs/singularity
+    ${concatMapStringsSep "\n" installGoDep goDeps}
+    export GOPATH=$PWD
+    chmod a+rw -R src
+    find . -name vendor -type d -print0 | xargs -0 rm -rf
+
+    cd src/github.com/sylabs/singularity
+
+    patchShebangs .
+    sed -i 's|defaultEnv := "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"|defaultEnv := "${stdenv.lib.makeBinPath propagatedBuildInputs}"|' src/cmd/singularity/cli/singularity.go
+
+    ./mconfig -V ${version} -p $out --localstatedir=/var
+    touch builddir/.dep-done
+    touch builddir/vendors-done
+
+    # Don't install SUID binaries
+    sed -i 's/-m 4755/-m 755/g' builddir/Makefile
+
+    # Point to base gopath
+    sed -i "s|^cni_vendor_GOPATH :=.*\$|cni_vendor_GOPATH := $GOPATH/src/github.com/containernetworking/plugins/plugins|" builddir/Makefile
+  '';
+
+  buildPhase = ''
+    make -C builddir
+  '';
+
+  installPhase = ''
+    make -C builddir install LOCALSTATEDIR=$out/var
+    chmod 755 $out/libexec/singularity/bin/starter-suid
+  '';
+
+  postFixup = ''
+    # These etc scripts shouldn't have their paths patched
+    cp etc/actions/* $out/etc/singularity/actions/
+  '';
+
 
   meta = with stdenv.lib; {
     homepage = http://singularity.lbl.gov/;

--- a/pkgs/applications/virtualization/singularity/deps.nix
+++ b/pkgs/applications/virtualization/singularity/deps.nix
@@ -1,0 +1,669 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/Microsoft/go-winio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Microsoft/go-winio";
+      rev =  "7da180ee92d8bd8bb8c37fc560e673e6557c392f";
+      sha256 = "19gjjhmzswhm11wzj38r5alxypmflmy0z42flhc3czhmmwv7b1av";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alexflint/go-filemutex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alexflint/go-filemutex";
+      rev =  "d358565f3c3f5334209f1e80693e4f621650c489";
+      sha256 = "19fzbm0x8821awsmqj9ig49dxxkd72p1yfqbijmdwwszvw2r0ggz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev =  "3a771d992973f24aa725d07868b467d1ddfceafb";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/blang/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blang/semver";
+      rev =  "2ee87856327ba09384cabd113bc6b5d174e9ec0f";
+      sha256 = "13ws259bwcibkclbr82ilhk6zadm63kxklxhk12wayklj8ghhsmy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/containerd/cgroups";
+    fetch = {
+      type = "git";
+      url = "https://github.com/containerd/cgroups";
+      rev =  "5017d4e9a9cf2d4381db99eacd9baf84b95bfb14";
+      sha256 = "02pvcmj91j3maa9j1v91m2z9kpa6p822h06r007b3pl7h0paiqnj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/containerd/continuity";
+    fetch = {
+      type = "git";
+      url = "https://github.com/containerd/continuity";
+      rev =  "246e49050efdf45e8f17fbbcf1547ee376f9939e";
+      sha256 = "1zc1f0yixf32lprp5r77z2j9xq7fk0hijq8xzl08j4zrk0fcy8aq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/containernetworking/cni";
+    fetch = {
+      type = "git";
+      url = "https://github.com/containernetworking/cni";
+      rev =  "a7885cb6f8ab03fba07852ded351e4f5e7a112bf";
+      sha256 = "00ajs2r5r2z3l0vqwxrcwhjfc9px12qbcv5vnvs2mdipvvls1y2y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/containernetworking/plugins";
+    fetch = {
+      type = "git";
+      url = "https://github.com/containernetworking/plugins";
+      rev =  "2b8b1ac0af4568e928d96ccc5f47b075416eeabd";
+      sha256 = "1yl9m8pwjmqxj3hf0w9s6rykszhcww54z07yjgxzabmqf2dhchxv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/containers/image";
+    fetch = {
+      type = "git";
+      url = "https://github.com/containers/image";
+      rev =  "2e4f799f5eba49a2498d2793cfb2a4bc823ca3f6";
+      sha256 = "0b9symgbkd2vgvp7mfpz1l03i2zivwbc5ycccwv78b1ikk9m6b75";
+    };
+  }
+  {
+    goPackagePath  = "github.com/containers/storage";
+    fetch = {
+      type = "git";
+      url = "https://github.com/containers/storage";
+      rev =  "88d80428f9b146f8f9fe7e2e8cc8688a5aae1a4e";
+      sha256 = "13fagjisbg55dhgjd72h0hiy6jfg8ggkcnjl5haqj13c2gkf6sam";
+    };
+  }
+  {
+    goPackagePath  = "github.com/coreos/go-iptables";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-iptables";
+      rev =  "b5b1876b170881a8259f036445ee89c8669db386";
+      sha256 = "1s1c04x47pk3168606x4vkg4avs8a7m407hpha8py1xni08cgb6m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev =  "39ca1b05acc7ad1220e09f133283b8859a8b71ab";
+      sha256 = "1kzqrrzqspa5qm7kwslxl3m16lqzns23c24rv474ajzwmj3ixmx1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cpuguy83/go-md2man";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev =  "20f5889cbdc3c73dbd2862796665e7c465ade7d1";
+      sha256 = "1w22dfdamsq63b5rvalh9k2y7rbwfkkjs7vm9vd4a13h2ql70lg2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/d2g/dhcp4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/d2g/dhcp4";
+      rev =  "a1d1b6c41b1ce8a71a5121a9cee31809c4707d9c";
+      sha256 = "191hzw6yqzkm042h6miyycq3g0zrhqjhhpl27f8vhwzp4wanasiz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/d2g/dhcp4client";
+    fetch = {
+      type = "git";
+      url = "https://github.com/d2g/dhcp4client";
+      rev =  "e612998962035b93ba16cfd1ad2f3221985c1b8c";
+      sha256 = "1612wh99fblc9ashmm6mjc9110fhal95z0mn9qn7av3px13yd9fs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/distribution";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/distribution";
+      rev =  "749f6afb4572201e3c37325d0ffedb6f32be8950";
+      sha256 = "05jn2wvikyw0pbmi74w5axr0zgxn5y3ynn9rhsq87rmwqj7raxhd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/docker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/docker";
+      rev =  "da99009bbb1165d1ac5688b5c81d2f589d418341";
+      sha256 = "02hhx7s8vm45rcl2mx9xamkncl2pb6qhsmz35mffbg4n6l5rn5x5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/docker-credential-helpers";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/docker-credential-helpers";
+      rev =  "d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1";
+      sha256 = "1ff829h5p1j6qiivjvnwyiybrff3dddv1ij71nz5whmgavdqgd49";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/go-connections";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-connections";
+      rev =  "3ede32e2033de7505e6500d6c868c2b9ed9f169d";
+      sha256 = "0v1pkr8apwmhyzbjfriwdrs1ihlk6pw7izm57r24mf9jdmg3fyb0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/go-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-metrics";
+      rev =  "399ea8c73916000c64c2c76e8da00ca82f8387ab";
+      sha256 = "0najfy92fq05b330cnjk5b326yi7dnnmvzfk6g5lsa1fci78yzw4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/go-units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-units";
+      rev =  "47565b4f722fb6ceae66b95f853feed578a4a51c";
+      sha256 = "0npxsb3pp89slwf4a73fxm20hykad8xggij6i6hcd5jy19bjrd93";
+    };
+  }
+  {
+    goPackagePath  = "github.com/docker/libtrust";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/libtrust";
+      rev =  "aabc10ec26b754e797f9028f4589c5b7bd90dc20";
+      sha256 = "1lwslbggzc2b0c4wxl5pn6i2nfgz5jz8f7s7vnid9mrlsk59h7s1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev =  "0ca9ea5df5451ffdf184b4428c902747c2c11cd7";
+      sha256 = "0skwmimpy7hlh7pva2slpcplnm912rp3igs98xnqmn859kwa5v8g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/globalsign/mgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/globalsign/mgo";
+      rev =  "113d3961e7311526535a1ef7042196563d442761";
+      sha256 = "0m05ay993vv2jkc46bbdnq371s5jc0an2cycsj7p3b6lmv84jk9f";
+    };
+  }
+  {
+    goPackagePath  = "github.com/godbus/dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev =  "a389bdde4dd695d414e47b755e95e72b7826432c";
+      sha256 = "1ckvg15zdsgmbn4mi36cazkb407ixc9mmyf7vwj8b8wi3d00rgn9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "1adfc126b41513cc696b209667c8656ea7aac67c";
+      sha256 = "1j7azzlnihcvnd1apw5zr0bz30h7n0gyimqqkgc76vzb1n5dpi7m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "b4deda0973fb4c70b50d226b1af49f3da59f5265";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/context";
+      rev =  "08b5f424b9271eedf6f9f0ce86cb9396ed337a42";
+      sha256 = "03p4hn87vcmfih0p9w663qbx9lpsf7i7j3lc7yl7n84la3yz63m4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev =  "e3702bed27f0d39777b0b37b664b6280e8ef8fbf";
+      sha256 = "0pvzm23hklxysspnz52mih6h1q74vfrdhjfm1l3sa9r8hhqmmld2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "ea4d1f681babbce9545c9c5f3d5194a789c89f5b";
+      sha256 = "1bhgs2542qs49p1dafybqxfs2qc072xv41w5nswyrknwyjxxs2a1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/errwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/errwrap";
+      rev =  "7554cd9344cec97297fa6649b055a8c98c2a1e55";
+      sha256 = "0kmv0p605di6jc8i1778qzass18m0mv9ks9vxxrfsiwcp4la82jf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/go-multierror";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-multierror";
+      rev =  "b7773ae218740a7be65057fc60b366a49b538a44";
+      sha256 = "09904bk7ac6qs9dgiv23rziq9h3makb9qg4jvxr71rlydsd7psfd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/j-keck/arping";
+    fetch = {
+      type = "git";
+      url = "https://github.com/j-keck/arping";
+      rev =  "2cf9dc699c5640a7e2c81403a44127bf28033600";
+      sha256 = "1bid8mpx3j4546ni0a6q5xyz7hb854g95qnxqmg5jzs9vrcird3c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kubernetes-sigs/cri-o";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes-sigs/cri-o";
+      rev =  "8afc34092907d146906fcc31af112b2b46e7b5cd";
+      sha256 = "0ghcjvk7grdcwb1936mnj56a7rla804glfknid9kmr3kgny3yi43";
+    };
+  }
+  {
+    goPackagePath  = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev =  "c2353362d570a7bfa228149c62842019201cfb71";
+      sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev =  "9e777a8366cce605130a531d2cd6363d07ad7317";
+      sha256 = "0vkrfrz3fzn5n6ix4k8s0cg0b448459sldq8bp4riavsxm932jzb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-shellwords";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-shellwords";
+      rev =  "02e3cf038dcea8290e44424da473dd12be796a8a";
+      sha256 = "1pg7pl25wvpl2dbpyrv9p1r7prnqimxlf6136vn0dfm54j2x4mnr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev =  "c12348ce28de40eed0136aa2b644d0ee0650e56c";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mtrmac/gpgme";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mtrmac/gpgme";
+      rev =  "b2432428689ca58c2b8e8dea9449d3295cf96fc9";
+      sha256 = "0hs9gfwf3cmnvmmxb485icwlv8h8xnny3p52bj7qwv251pvwsnaf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/go-digest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/go-digest";
+      rev =  "279bed98673dd5bef374d3b6e4b09e2af76183bf";
+      sha256 = "01gc7fpn8ax429024p2fcx3yb18axwz5bjf2hqxlii1jbsgw4bh9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/image-spec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/image-spec";
+      rev =  "e562b04403929d582d449ae5386ff79dd7961a11";
+      sha256 = "0j24nk975di8hcv6ycn2p2hhw1xdiy4bpxamr6wn12k21kadlp7s";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/image-tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sylabs/image-tools";
+      rev =  "2814f498056809a9d5baaf76d1d82312180a5888";
+      sha256 = "0q3ljb51df5hc58rhp5xni2gsy3gkxn47d9dwyfcffnq8kpf9d8a";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/runc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/runc";
+      rev =  "baf6536d6259209c3edfa2b22237af82942d3dfa";
+      sha256 = "09fm7f1k4lvx8v3crqb0cli1x2brlz8ka7f7qa8d2sb6ln58h7w7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/runtime-spec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/runtime-spec";
+      rev =  "5806c35637336642129d03657419829569abc5aa";
+      sha256 = "13vw1b3j9sx7d5fr3w3jdg137nnqcr50fqchq8z8nf6s18lkhj93";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/runtime-tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/runtime-tools";
+      rev =  "1c243a8a8eb44d491790798afc9b634c6f6a6380";
+      sha256 = "1ll5wrbn84yb2l7k6hpwwj06wywib7ar4z1bhh1rc5h9xajng7jq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opencontainers/selinux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/selinux";
+      rev =  "ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d";
+      sha256 = "1n283j7rsim7gysm91x99c41d7vnsjsgfm4dy11fnzpkpzfiksq5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev =  "c01d1270ff3e442a8a57cddc1c92dc1138598194";
+      sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pquerna/ffjson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pquerna/ffjson";
+      rev =  "d49c2bc1aa135aad0c6f4fc2056623ec78f5d5ac";
+      sha256 = "069w276lch2hhkvz26wdla8d4s0cg842bhqmih4sa33dsinlgs8g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev =  "faf4ec335fe01ae5a6a0eaa34a5a9333bfbd1a30";
+      sha256 = "08xgqgx7vc27zc30chgi09lwrnvxr338dn624xnw4ysfm9r6lxrz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev =  "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c";
+      sha256 = "19y4ywsivhpxj7ikf2j0gm9k3cmyw37qcbfi78n526jxcc7kw998";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev =  "7600349dcfe1abd18d72d3a1770870d9800a7801";
+      sha256 = "0lsp94dqpj35dny4m4x15kg4wgwawlm3in7cnpajkkacgyxagk5f";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev =  "7d6f385de8bea29190f15ba9931442a0eaef9af7";
+      sha256 = "18cish8yas5r6xhgp8p8n7lg4wh3d4szzirszxra8m7rwy3swxxq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev =  "55d61fa8aa702f59229e6cff85793c22e580eaf5";
+      sha256 = "0qmavm5d14kj6im6sqzpqnlhpy524428vkn4hnfwknndr9rycmn0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/safchain/ethtool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/safchain/ethtool";
+      rev =  "6e3f4faa84e1d8d48afec75ed064cf3611d3f8bf";
+      sha256 = "15xjvny8bfhhjvvv654pimxxw5cd02q8skp1siwbfvrlw598j4lm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/satori/go.uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/satori/go.uuid";
+      rev =  "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3";
+      sha256 = "1j4s5pfg2ldm35y8ls8jah4dya2grfnx2drb4jcbjsyrp4cm5yfb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/seccomp/libseccomp-golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/seccomp/libseccomp-golang";
+      rev =  "e3496e3a417d1dc9ecdceca5af2513271fed37a0";
+      sha256 = "0z8v90nk22h8r5licav1a8cbn6k7bs47l0j1crw7bjl9hv1bmr71";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "c155da19408a8799da419ed3eeb0cb5db0ad5dbc";
+      sha256 = "0g5z7al7kky11ai2dhac6gkp3b5pxsvx72yj3xg4wg3265gbn7yz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "1e58aa3361fd650121dceeedc399e7189c05674a";
+      sha256 = "1d6dy60dw7i2mcab10yp99wi5w28jzhzzf16w4ys6bna7ymndiin";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "583c0c0531f06d5278b7d917446061adc344b5cd";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sylabs/sif";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sylabs/sif";
+      rev =  "177b9338f1ab9123be5b6217740be1f0ce924206";
+      sha256 = "1dwpml36n06hglp2km1wsfzdiw1yva6a0h00f1y2933m3i8r3k2w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/syndtr/gocapability";
+    fetch = {
+      type = "git";
+      url = "https://github.com/syndtr/gocapability";
+      rev =  "33e07d32887e1e06b7c025f27ce52f62c7990bc0";
+      sha256 = "1x88c0b320b13w7samicf19dqx9rr4dnrh3yglk3cba21nwsp57i";
+    };
+  }
+  {
+    goPackagePath  = "github.com/vishvananda/netlink";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vishvananda/netlink";
+      rev =  "a2ad57a690f3caf3015351d2d6e1c0b95c349752";
+      sha256 = "0hpzghf1a4cwawzhkiwdzin80h6hd09fskl77d5ppgc084yvj8x0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/vishvananda/netns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vishvananda/netns";
+      rev =  "be1fbeda19366dea804f00efff2dd73a1642fdcc";
+      sha256 = "0j0xin37zp34ajmhsgfbxr8l7vrljf1lc6z3j3miidlmfwcl2s0m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xeipuuv/gojsonpointer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xeipuuv/gojsonpointer";
+      rev =  "4e3ac2762d5f479393488629ee9370b50873b3a6";
+      sha256 = "13y6iq2nzf9z4ls66bfgnnamj2m3438absmbpqry64bpwjfbsi9q";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xeipuuv/gojsonreference";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xeipuuv/gojsonreference";
+      rev =  "bd5ef7bd5415a7ac448318e64f11a24cd21e594b";
+      sha256 = "1xby79padc7bmyb8rfbad8wfnfdzpnh51b1n8c0kibch0kwc1db5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xeipuuv/gojsonschema";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xeipuuv/gojsonschema";
+      rev =  "1d523034197ff1f222f6429836dd36a2457a1874";
+      sha256 = "1z8c6x8sfh6d1ib2lm2jps7r139qip6h3zik3fxhy1yr1380qbzp";
+    };
+  }
+  {
+    goPackagePath  = "go4.org";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go4org/go4";
+      rev =  "9599cf28b011184741f249bd9f9330756b506cbc";
+      sha256 = "0hssb6jmpjxvdx2k1zx0l2dbwpx52zxcq5n2bhqivr670r4wdrkq";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sylabs/golang-x-crypto";
+      rev =  "4bce89e8e9a9f84a4cf02b9842c3eaff2af0a856";
+      sha256 = "11wi2zd055ym9m36ba007rdg4ghrwaiqxc77qyqc37ln7l7accr9";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "db08ff08e8622530d9ed3a0e8ac279f6d4c02196";
+      sha256 = "1f6q8kbijnrfy6wjqxrzgjf38ippckc5w34lhqsjs7kq045aar9a";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "6c888cc515d3ed83fc103cf1d84468aad274b0a7";
+      sha256 = "18anqrdajp4p015v3f5y641k3lmgp2jr0lfyx0pb3ia0qvn93mrp";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/cheggaaa/pb.v1";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cheggaaa/pb";
+      rev =  "2af8bbdea9e99e83b3ac400d8f6b6d1b8cbbf338";
+      sha256 = "0vxqiw6f3xyv0zy3g4lksf8za0z8i0hvfpw92hqimsy84f79j3dp";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+]


### PR DESCRIPTION
###### Motivation for this change

Latest version of singularity requires the creation of /root and two bind points in /etc/. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

