### PR TITLE
slic3r-prusa3d: 1.40.1 -> 1.41.0

### DIFF
--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, makeWrapper, which, cmake, perl, perlPackages,
   boost, tbb, wxGTK30, pkgconfig, gtk3, fetchurl, gtk2, libGLU,
-  glew, eigen, curl }:
+  glew, eigen, curl, gtest, nlopt, pcre, xorg }:
 let
   AlienWxWidgets = perlPackages.buildPerlPackage rec {
     name = "Alien-wxWidgets-0.69";
@@ -33,22 +33,28 @@ let
 in
 stdenv.mkDerivation rec {
   name = "slic3r-prusa-edition-${version}";
-  version = "1.40.1";
+  version = "1.41.0";
 
   enableParallelBuilding = true;
 
-  buildInputs = [
+  nativeBuildInputs = [
     cmake
-    curl
-    perl
     makeWrapper
+  ];
+
+  buildInputs = [
+    curl
     eigen
     glew
+    pcre
+    perl
     tbb
     which
     Wx
     WxGLCanvas
-  ] ++ (with perlPackages; [
+    xorg.libXdmcp
+    xorg.libpthreadstubs
+  ] ++ checkInputs ++ (with perlPackages; [
     boost
     ClassXSAccessor
     EncodeLocale
@@ -72,16 +78,24 @@ stdenv.mkDerivation rec {
     XMLSAX
   ]);
 
+  checkInputs = [ gtest ];
+
+  # The build system uses custom logic - defined in
+  # xs/src/libnest2d/cmake_modules/FindNLopt.cmake in the package source -
+  # for finding the nlopt library, which doesn't pick up the package in the nix store.
+  # We need to set the path via the NLOPT environment variable instead.
+  NLOPT = "${nlopt}";
+
   prePatch = ''
     # In nix ioctls.h isn't available from the standard kernel-headers package
     # on other distributions. As the copy in glibc seems to be identical to the
     # one in the kernel, we use that one instead.
     sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' xs/src/libslic3r/GCodeSender.cpp
 
-    # PERL_VENDORARCH and PERL_VENDORLIB aren't detected correctly by the build
+    # PERL_VENDORARCH and PERL_VENDORLIB aren't set correctly by the build
     # system, so we have to override them. Setting them as environment variables
-    # doesn't work though, so patching the paths directly in the CMakeLists.txt
-    # seems to be the easisest way.
+    # doesn't work though, so substituting the paths directly in CMakeLists.txt
+    # seems to be the easiest way.
     sed -i "s|\''${PERL_VENDORARCH}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
     sed -i "s|\''${PERL_VENDORLIB}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
   '';
@@ -100,7 +114,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "prusa3d";
     repo = "Slic3r";
-    sha256 = "022mdz8824wg68qwgd49gnplw7wn84hqw113xh8l25v3j1jb9zmc";
+    sha256 = "1al60hrqbhl05dnsr99hzbmxmn26fyx19sc5zxv816x3q6px9n2d";
     rev = "version_${version}";
   };
 
@@ -108,7 +122,7 @@ stdenv.mkDerivation rec {
     description = "G-code generator for 3D printer";
     homepage = https://github.com/prusa3d/Slic3r;
     license = licenses.agpl3;
-    platforms = platforms.linux;
+    platforms = subtractLists ["aarch64-linux"] platforms.linux;
     maintainers = with maintainers; [ tweber ];
   };
 }

--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -73,7 +73,15 @@ stdenv.mkDerivation rec {
   ]);
 
   prePatch = ''
+    # In nix ioctls.h isn't available from the standard kernel-headers package
+    # on other distributions. As the copy in glibc seems to be identical to the
+    # one in the kernel, we use that one instead.
     sed -i 's|"/usr/include/asm-generic/ioctls.h"|<asm-generic/ioctls.h>|g' xs/src/libslic3r/GCodeSender.cpp
+
+    # PERL_VENDORARCH and PERL_VENDORLIB aren't detected correctly by the build
+    # system, so we have to override them. Setting them as environment variables
+    # doesn't work though, so patching the paths directly in the CMakeLists.txt
+    # seems to be the easisest way.
     sed -i "s|\''${PERL_VENDORARCH}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
     sed -i "s|\''${PERL_VENDORLIB}|$out/lib/slic3r-prusa3d|g" xs/CMakeLists.txt
   '';

--- a/pkgs/applications/misc/slic3r/prusa3d.nix
+++ b/pkgs/applications/misc/slic3r/prusa3d.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation rec {
     description = "G-code generator for 3D printer";
     homepage = https://github.com/prusa3d/Slic3r;
     license = licenses.agpl3;
-    platforms = subtractLists ["aarch64-linux"] platforms.linux;
     maintainers = with maintainers; [ tweber ];
+    broken = stdenv.hostPlatform.isAarch64;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

~~1.41.0 isn't out yet, but I want to document what needs to be updated for the final release.~~

The latest alpha needs a few more dependencies. Also NLOPT needs to be set manually, as the package isn't found otherwise. :/

`gtest` is needed although it seems unittests aren't even build by default. Might be worth it to report that to upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

