### PR TITLE
bazel: patch runfiles.bash to include defaultShellPath in PATH

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -105,6 +105,11 @@ stdenv.mkDerivation rec {
 		  src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java \
       --replace /bin:/usr/bin ${defaultShellPath}
 
+    # append the PATH with defaultShellPath in tools/bash/runfiles/runfiles.bash
+    echo "PATH=$PATH:${defaultShellPath}" >> runfiles.bash.tmp
+    cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
+    mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
+
     patchShebangs .
   '';
 


### PR DESCRIPTION
###### Motivation for this change

[rules_typescript](https://github.com/bazelbuild/rules_typescript/blob/a8bc2ee4db7dc85aeeb42983aafd0a6dee5a4623/internal/build_defs.bzl#L67-L77) invokes a shell without passing the `use_default_shell_env=True` and this ends up not using the [custom bash](https://github.com/NixOS/nixpkgs/blob/0d8076b99cce5c6638abeb28153c42f698e1bc18/pkgs/development/tools/build-managers/bazel/default.nix#L52-L75) that we create for Bazel.

This PR patches [runfiles.bash](https://github.com/bazelbuild/bazel/blob/fe187cb2d5dde1448500201eb762b161a5fa238e/tools/bash/runfiles/runfiles.bash) to include the `defaultShellPath` that we create to the known PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes #43955 

cc @mboes @Profpatsch 