### PR TITLE
cross stdenv: Forget `allowedRequisites = nulll;` on inline

### DIFF
--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -43,6 +43,7 @@ in lib.init bootStages ++ [
       # a different platform, and so are disabled.
       overrides = _: _: {};
       extraBuildInputs = [ ]; # Old ones run on wrong platform
+      allowedRequisites = null;
 
       cc = if crossSystem.useiOSPrebuilt or false
              then buildPackages.darwin.iosSdkPkgs.clang

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34,7 +34,8 @@ with pkgs;
       extraPackages = [];
       inherit bintools;
     };
-    allowedRequisites = stdenv.allowedRequisites ++ [ bintools ];
+    allowedRequisites =
+      lib.mapNullable (rs: rs ++ [ bintools ]) (stdenv.allowedRequisites or null);
   };
 
   # For convenience, allow callers to get the path to Nixpkgs.


### PR DESCRIPTION
###### Motivation for this change

https://hydra.nixos.org/eval/1470776 I broke all the cross builds in https://github.com/NixOS/nixpkgs/commit/b81ee9df9f4724b7c9ac611999758a85cf684cc4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

