### PR TITLE
gnome2.gconf: Adds python that is required by scripts in GConf

### DIFF
--- a/pkgs/desktops/gnome-2/platform/GConf/default.nix
+++ b/pkgs/desktops/gnome-2/platform/GConf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, dbus-glib, glib, ORBit2, libxml2
-, polkit, intltool }:
+, polkit, intltool, python }:
 
 stdenv.mkDerivation rec {
   name = "gconf-${version}";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib dbus-glib ];
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool python ];
 
   configureFlags =
     # fixes the "libgconfbackend-oldxml.so is not portable" error on darwin


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

