### PR TITLE
psc-package: 0.3.2 -> 0.4.1

### DIFF
--- a/pkgs/development/compilers/purescript/psc-package/default.nix
+++ b/pkgs/development/compilers/purescript/psc-package/default.nix
@@ -4,23 +4,24 @@ with lib;
 
 mkDerivation rec {
   pname = "psc-package";
-  version = "0.3.2";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "purescript";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1zpzcyh82xl0grvgcj8b7yzh053i9z94kbym5qrv413pcx7w50cm";
+    sha256 = "1pbgijglyqrm998a6z5ahp4phd72crzr3s8vq17a9dz3i0a9hcj5";
   };
 
   isLibrary = false;
   isExecutable = true;
 
   executableHaskellDepends = with haskellPackages; [
-    aeson aeson-pretty optparse-applicative system-filepath turtle
+    aeson aeson-pretty either errors optparse-applicative
+    system-filepath turtle
   ];
 
-  description = "An experimental package manager for PureScript";
+  description = "A package manager for PureScript based on package sets";
   license = licenses.bsd3;
   maintainers = with lib.maintainers; [ Profpatsch ];
 }


### PR DESCRIPTION
###### Motivation for this change

psc-package: 0.3.2 -> 0.4.1

Updates that remove features and improve user experience.

Adds warnings for trying to install packages without (purescript/psc-package#126 by @Dretch)
Filters "installing" messages for build (purescript/psc-package#130 by @Dretch)
Adds options for limiting jobs for install (purescript/psc-package#127 by @vladciobanu)
Per purescript/psc-package#121, removes the confusing misfeature "add-from-bower", which led to many users thinking this command was for adding "extra-deps" like Stack. See the thread for details on how you could readily replace this command if you used it before.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

