### PR TITLE
nixos/release: use real paths of netboot files

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -117,9 +117,9 @@ let
         ];
         postBuild = ''
           mkdir -p $out/nix-support
-          echo "file ${kernelTarget} $out/${kernelTarget}" >> $out/nix-support/hydra-build-products
-          echo "file initrd $out/initrd" >> $out/nix-support/hydra-build-products
-          echo "file ipxe $out/netboot.ipxe" >> $out/nix-support/hydra-build-products
+          echo "file ${kernelTarget} ${build.kernel}/${kernelTarget}" >> $out/nix-support/hydra-build-products
+          echo "file initrd ${build.netbootRamdisk}/initrd" >> $out/nix-support/hydra-build-products
+          echo "file ipxe ${build.netbootIpxeScript}/netboot.ipxe" >> $out/nix-support/hydra-build-products
         '';
         preferLocalBuild = true;
       };


### PR DESCRIPTION
###### Motivation for this change
Enabling placing netboot files in channels so we can add https://netboot.xyz support. See also antonym/netboot.xyz#37

I'm not sure if this works the way I hope it does, since the build product paths aren't within the derivation. Input from someone who knows things about hydra would be appreciated! If it doesn't work, I will open an alternative PR which copies the files instead (but increases the closure size of the release jobs by >500M and thus isn't very desirable…).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

