### PR TITLE
Cherry-pick commit that fixes libreoffice wrapper to release-18.04

### DIFF
--- a/pkgs/applications/office/libreoffice/wrapper.sh
+++ b/pkgs/applications/office/libreoffice/wrapper.sh
@@ -8,21 +8,8 @@ if uname | grep Linux > /dev/null &&
     dbus_tmp_dir="/run/user/$(id -u)/libreoffice-dbus"
     mkdir "$dbus_tmp_dir"
     dbus_socket_dir="$(mktemp -d -p "$dbus_tmp_dir")"
-<<<<<<< HEAD
-    cat "@dbus@/share/dbus-1/system.conf" |
-        grep -v '[<]user[>]messagebus' > "$dbus_socket_dir/system.conf"
-    if test -z "$DBUS_SESSION_BUS_ADDRESS"; then
-        "@dbus@"/bin/dbus-daemon --nopidfile --nofork --config-file "@dbus@"/share/dbus-1/session.conf --address "unix:path=$dbus_socket_dir/session"  >&2 &
-        export DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_socket_dir/session"
-    fi
-    if test -z "$DBUS_SYSTEM_BUS_ADDRESS"; then
-        "@dbus@"/bin/dbus-daemon --nopidfile --nofork --config-file "$dbus_socket_dir/system.conf" --address "unix:path=$dbus_socket_dir/system" >&2 &
-        export DBUS_SYSTEM_BUS_ADDRESS="unix:path=$dbus_socket_dir/system"
-    fi
-=======
     "@dbus@"/bin/dbus-daemon --nopidfile --nofork --config-file "@dbus@"/share/dbus-1/session.conf --address "unix:path=$dbus_socket_dir/session"  &> /dev/null &
     export DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_socket_dir/session"
->>>>>>> 1f52bfb67cf... libreoffice: wrapper: do not set SAL_USE_VCLPLUGIN for now
 fi
 
 "@libreoffice@/bin/$(basename "$0")" "$@"

--- a/pkgs/applications/office/libreoffice/wrapper.sh
+++ b/pkgs/applications/office/libreoffice/wrapper.sh
@@ -1,6 +1,6 @@
 #!@bash@/bin/bash
 export JAVA_HOME="${JAVA_HOME:-@jdk@}"
-export SAL_USE_VCLPLUGIN="${SAL_USE_VCLPLUGIN:-gen}"
+#export SAL_USE_VCLPLUGIN="${SAL_USE_VCLPLUGIN:-gen}"
 
 if uname | grep Linux > /dev/null && 
        ! ( test -n "$DBUS_SESSION_BUS_ADDRESS" && 
@@ -8,6 +8,7 @@ if uname | grep Linux > /dev/null &&
     dbus_tmp_dir="/run/user/$(id -u)/libreoffice-dbus"
     mkdir "$dbus_tmp_dir"
     dbus_socket_dir="$(mktemp -d -p "$dbus_tmp_dir")"
+<<<<<<< HEAD
     cat "@dbus@/share/dbus-1/system.conf" |
         grep -v '[<]user[>]messagebus' > "$dbus_socket_dir/system.conf"
     if test -z "$DBUS_SESSION_BUS_ADDRESS"; then
@@ -18,6 +19,10 @@ if uname | grep Linux > /dev/null &&
         "@dbus@"/bin/dbus-daemon --nopidfile --nofork --config-file "$dbus_socket_dir/system.conf" --address "unix:path=$dbus_socket_dir/system" >&2 &
         export DBUS_SYSTEM_BUS_ADDRESS="unix:path=$dbus_socket_dir/system"
     fi
+=======
+    "@dbus@"/bin/dbus-daemon --nopidfile --nofork --config-file "@dbus@"/share/dbus-1/session.conf --address "unix:path=$dbus_socket_dir/session"  &> /dev/null &
+    export DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_socket_dir/session"
+>>>>>>> 1f52bfb67cf... libreoffice: wrapper: do not set SAL_USE_VCLPLUGIN for now
 fi
 
 "@libreoffice@/bin/$(basename "$0")" "$@"


### PR DESCRIPTION
###### Motivation for this change

This fixes #43801 by cherry-picking https://github.com/NixOS/nixpkgs/commit/1f52bfb67cfb0c2ceec862e1aab9f5667c9100ee and then correcting merging errors.

cc @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

