### PR TITLE
buildMaven: Check for authenticated attribute

### DIFF
--- a/pkgs/build-support/build-maven.nix
+++ b/pkgs/build-support/build-maven.nix
@@ -16,10 +16,11 @@ infoFile: let
   script = writeText "build-maven-repository.sh" ''
     ${lib.concatStrings (map (dep: let
       inherit (dep)
-        url sha1 groupId artifactId version
-        authenticated metadata repository-id;
+        url sha1 groupId artifactId
+        version metadata repository-id;
 
       versionDir = dep.unresolved-version or version;
+      authenticated = dep.authenticated or false;
 
       fetch = (if authenticated then requireFile else fetchurl) {
         inherit url sha1;


### PR DESCRIPTION
###### Motivation for this change

The `authenticated` attribute is not always present in the
`project-info.json` produced by maven2nix[0]

We therefore check for its presence, and default it to false.

[0]: https://github.com/NixOS/mvn2nix-maven-plugin/issues/5#issuecomment-311846950

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

