### PR TITLE
POWER9 architecture support : Add initial support to create a powerpc64le boostrap

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -45,6 +45,14 @@ rec {
     useAndroidPrebuilt = true;
   };
 
+  powerpc64le-multiplatform = rec {
+    config = "powerpc64le-unknown-linux-gnu";
+    arch = "ppc64le";
+    platform = platforms.ppc64le-multiplatform;
+  };
+
+
+
   aarch64-android-prebuilt = rec {
     config = "aarch64-unknown-linux-android";
     sdkVer = "24";

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -11,6 +11,7 @@ rec {
     isi686         = { cpu = cpuTypes.i686; };
     isx86_64       = { cpu = cpuTypes.x86_64; };
     isPowerPC      = { cpu = cpuTypes.powerpc; };
+    isppc64le      = { cpu = cpuTypes.powerpc64le; };
     isx86          = { cpu = { family = "x86"; }; };
     isAarch32      = { cpu = { family = "arm"; bits = 32; }; };
     isAarch64      = { cpu = { family = "arm"; bits = 64; }; };

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -89,7 +89,7 @@ rec {
     mips64el = { bits = 64; significantByte = littleEndian; family = "mips"; };
 
     powerpc  = { bits = 32; significantByte = bigEndian;    family = "power"; };
-
+    powerpc64le  = { bits = 64; significantByte = littleEndian;    family = "power"; };
     riscv32  = { bits = 32; significantByte = littleEndian; family = "riscv"; };
     riscv64  = { bits = 64; significantByte = littleEndian; family = "riscv"; };
 

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -306,6 +306,15 @@ rec {
     };
   };
 
+  ppc64le-multiplatform = {
+    name = "ppc64le-multiplatform";
+    kernelMajor = "2.6";
+    kernelBaseConfig = "ppc64le_defconfig";
+    kernelAutoModules = true;
+    kernelArch = "powerpc";
+    kernelDTB = true;
+  };
+
   aarch64-multiplatform = {
     name = "aarch64-multiplatform";
     kernelMajor = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -178,6 +178,7 @@ stdenv.mkDerivation {
       /**/ if targetPlatform.isAarch64 then endianPrefix + "aarch64"
       else if targetPlatform.isAarch32     then endianPrefix + "arm"
       else if targetPlatform.isx86_64  then "x86-64"
+      else if targetPlatform.isppc64le  then "ppc64le"
       else if targetPlatform.isi686    then "i386"
       else if targetPlatform.isMips    then {
           "mips"     = "btsmipn32"; # n32 variant

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -75,7 +75,7 @@ let version = "7.3.0";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
-      ] else if crossStageStatic then [
+      ] else if crossStageStatic then ([
         "--disable-libssp"
         "--disable-nls"
         "--without-headers"
@@ -88,7 +88,10 @@ let version = "7.3.0";
         # maybe only needed on musl, PATH_MAX
         # https://github.com/richfelker/musl-cross-make/blob/0867cdf300618d1e3e87a0a939fa4427207ad9d7/litecross/Makefile#L62
         "--disable-libmpx"
-      ] else [
+      ] ++ stdenv.lib.optionals ( targetPlatform.config == "powerpc64le-unknown-linux-gnu" )  [
+	"--with-long-double-128"
+	"--enable-softfloat"
+      ]) else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")
         "--enable-__cxa_atexit"

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -59,6 +59,10 @@ stdenv.mkDerivation rec {
   ];
   preConfigure = ''
     configureFlagsArray+=("--syslibdir=$out/lib")
+
+    # musl enforce long double to be 64bits when ppc64le glibc enforce long double to be 128bits
+    # for bootstraping busybox for ppc64le, we need to enforce long double 64bits for musl compilation
+    ${if (stdenv.isppc64le or false) then ''export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -mlong-double-64"'' else ''''}
   '';
 
   configureFlags = [

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -122,7 +122,7 @@ let
       # Utility flags to test the type of platform.
       inherit (hostPlatform)
         isDarwin isLinux isSunOS isHurd isCygwin isFreeBSD isOpenBSD
-        isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian;
+        isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian isppc64le;
       isArm = builtins.trace "stdenv.isArm is deprecated after 18.03" hostPlatform.isArm;
 
       # Whether we should run paxctl to pax-mark binaries.

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -16,5 +16,6 @@ in with (import ../../../lib).systems.examples; {
   x86_64-musl  = make musl64;
   armv6l-musl  = make muslpi;
   aarch64-musl = make aarch64-multiplatform-musl;
+  ppc64le = make powerpc64le-multiplatform;
   riscv64 = make riscv64;
 }


### PR DESCRIPTION
- ppc64le is the architecture used for POWER8 / POWER9 machines
- ppc64le implies a bit of trickery for long long double being 128bits

###### Motivation for this change

- Initial request to add POWER9 architecture support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

