### PR TITLE
grafana: 5.2.1 -> 5.2.2

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchurl, fetchFromGitHub, phantomjs2 }:
 
 buildGoPackage rec {
-  version = "5.2.1";
+  version = "5.2.2";
   name = "grafana-${version}";
   goPackagePath = "github.com/grafana/grafana";
 
@@ -9,12 +9,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "0gv7g6ddcmdkjd1xp9dg2kq7askzaw1vkmcii21glqb74k2jfg74";
+    sha256 = "17w8ljq4p1sxcdpsiz4221gwhi3ykggpisnx1wdw22g2160q9sdj";
   };
 
   srcStatic = fetchurl {
     url = "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "0j69a9cjvkknq19aa2l634b48zy1lwmv2p676hzc856zgq3h6m9m";
+    sha256 = "1frbk13sww3sw09mpkijii1kf7m19hqg58ps8gvs4dvxg12bbv3l";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
New [patch release](https://github.com/grafana/grafana/releases/tag/v5.2.2) with bug fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
```
$ nix path-info -S /nix/store/5isq75lafy5486ysy2kahqh4av00k5lj-grafana-5.2.1-bin                                               
/nix/store/5isq75lafy5486ysy2kahqh4av00k5lj-grafana-5.2.1-bin	  608157216

$ nix path-info -S /nix/store/krzpwrhw9q73wfsw0vrm7rkvynj9c3sp-grafana-5.2.2-bin                           
/nix/store/krzpwrhw9q73wfsw0vrm7rkvynj9c3sp-grafana-5.2.2-bin	  608160336
```
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---