### PR TITLE
bazel: fix bash completion, halve build time

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -128,10 +128,10 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     export TMPDIR=/tmp/.bazel-$UID
     ./compile.sh
-    ./output/bazel --output_user_root=$TMPDIR/.bazel build //scripts:bash_completion \
-      --spawn_strategy=standalone \
-      --genrule_strategy=standalone
-    cp bazel-bin/scripts/bazel-complete.bash output/
+    scripts/generate_bash_completion.sh \
+        --bazel=./output/bazel \
+        --output=output/bazel-complete.bash \
+        --prepend=scripts/bazel-complete-template.bash
   '';
 
   # Build the CPP and Java examples to verify that Bazel works.
@@ -149,7 +149,7 @@ stdenv.mkDerivation rec {
     mv output/bazel $out/bin
     wrapProgram "$out/bin/bazel" --set JAVA_HOME "${jdk}"
     mkdir -p $out/share/bash-completion/completions $out/share/zsh/site-functions
-    mv output/bazel-complete.bash $out/share/bash-completion/completions/
+    mv output/bazel-complete.bash $out/share/bash-completion/completions/bazel
     cp scripts/zsh_completion/_bazel $out/share/zsh/site-functions/
   '';
 


### PR DESCRIPTION
This finally fixes the build to avoid having to completely rebuild
bazel from source a second time just to generate the bash completion
script!

It also makes completion actually _work_ for bash users by
correcting the name of the installed script.

###### Motivation for this change
bazel takes forEVER to build

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

