### PR TITLE
 scrcpy: init at 1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -926,6 +926,11 @@
     github = "deepfire";
     name = "Kosyrev Serge";
   };
+  deltaevo = {
+    email = "deltaduartedavid@gmail.com";
+    github = "DeltaEvo";
+    name = "Duarte David";
+  };
   demin-dmitriy = {
     email = "demindf@gmail.com";
     github = "demin-dmitriy";

--- a/pkgs/development/mobile/scrcpy/default.nix
+++ b/pkgs/development/mobile/scrcpy/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, fetchurl, meson, ninja, pkgconfig, SDL2, libav }:
+
+stdenv.mkDerivation rec {
+  name = "scrcpy-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "Genymobile";
+    repo = "scrcpy";
+    rev = "v${version}";
+    sha256 = "01zw6h6mz2cwqfh9lwypm8pbfx9m9df91l1fq1i0f1d8v49x8wqc";
+  };
+
+  server = fetchurl {
+    url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}.jar";
+    sha256 = "cb39654ed2fda3d30ddff292806950ccc5c394375ea12b974f790c7f38f61f60";
+  };
+
+  mesonFlags = [ "-Dprebuilt_server=${server}" ];
+
+  buildInputs = [ meson ninja pkgconfig SDL2 libav ];
+
+  meta = with stdenv.lib; {
+    description = "Display and control your Android device";
+    homepage = https://github.com/Genymobile/scrcpy;
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ deltaevo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8671,6 +8671,8 @@ with pkgs;
 
   xpwn = callPackage ../development/mobile/xpwn {};
 
+  scrcpy = callPackage ../development/mobile/scrcpy {};
+
   xxdiff = callPackage ../development/tools/misc/xxdiff {
     bison = bison2;
   };


### PR DESCRIPTION
###### Motivation for this change

Add scrcpy https://github.com/Genymobile/scrcpy

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

