### PR TITLE
Add Home option to Hoogle Server

### DIFF
--- a/nixos/modules/services/development/hoogle.nix
+++ b/nixos/modules/services/development/hoogle.nix
@@ -47,8 +47,6 @@ in {
       type = types.string;
       description = "Url for hoogle logo";
       default = "https://hoogle.haskell.org";
-      defaultText = "https://hoogle.haskell.org";
-
     };
 
   };

--- a/nixos/modules/services/development/hoogle.nix
+++ b/nixos/modules/services/development/hoogle.nix
@@ -43,6 +43,14 @@ in {
       defaultText = "pkgs.haskellPackages";
     };
 
+    home = mkOption {
+      type = types.string;
+      description = "Url for hoogle logo";
+      default = "https://hoogle.haskell.org";
+      defaultText = "https://hoogle.haskell.org";
+
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -53,7 +61,7 @@ in {
 
       serviceConfig = {
         Restart = "always";
-        ExecStart = ''${hoogleEnv}/bin/hoogle server --local -p ${toString cfg.port}'';
+        ExecStart = ''${hoogleEnv}/bin/hoogle server --local --port ${toString cfg.port} --home ${cfg.home}'';
 
         User = "nobody";
         Group = "nogroup";

--- a/nixos/modules/services/development/hoogle.nix
+++ b/nixos/modules/services/development/hoogle.nix
@@ -44,7 +44,7 @@ in {
     };
 
     home = mkOption {
-      type = types.string;
+      type = types.str;
       description = "Url for hoogle logo";
       default = "https://hoogle.haskell.org";
     };


### PR DESCRIPTION
###### Motivation for this change

Its confusing to click on the hoogle logo and end up on a different hoogle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

