### PR TITLE
ocamlPackages.jingoo: 1.2.7 -> 1.2.18

### DIFF
--- a/pkgs/development/ocaml-modules/jingoo/default.nix
+++ b/pkgs/development/ocaml-modules/jingoo/default.nix
@@ -1,18 +1,24 @@
-{stdenv, buildOcaml, fetchurl, batteries, pcre}:
+{ stdenv, fetchFromGitHub, ocaml, findlib, ounit, pcre, uutf }:
 
-buildOcaml rec {
-  name = "jingoo";
-  version = "1.2.7";
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "jingoo is not available for OCaml ${ocaml.version}"
+else
 
-  src = fetchurl {
-    url = "https://github.com/tategakibunko/jingoo/archive/v${version}.tar.gz";
-    sha256 = "8ffc5723d77b323a12761981d048c046af77db47543a4b1076573aa5f4003009";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-jingoo-${version}";
+  version = "1.2.18";
+
+  src = fetchFromGitHub {
+    owner = "tategakibunko";
+    repo = "jingoo";
+    rev = "v${version}";
+    sha256 = "0gciiysrjy5r4yiisc41k4h0p530yawzqnr364xg8fdkk444fgkn";
   };
 
-  propagatedBuildInputs = [ batteries pcre ];
+  buildInputs = [ ocaml findlib ];
+  propagatedBuildInputs = [ pcre uutf ];
 
-  preInstall = "mkdir -p $out/bin";
-  installFlags = "BINDIR=$(out)/bin";
+  createFindlibDestdir = true;
 
   meta = with stdenv.lib; {
     homepage = https://github.com/tategakibunko/jingoo;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml ≥ 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

