### PR TITLE
Revert "nixos: rename system.{stateVersion,defaultChannel} -> system.nixos.\1"

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -70,7 +70,7 @@
     <listitem>
      <para>
       <link xlink:href="https://github.com/NixOS/nixpkgs/compare/bdf161ed8d21...6b63c4616790">
-      Bump the <literal>system.nixos.defaultChannel</literal> attribute in
+      Bump the <literal>system.defaultChannel</literal> attribute in
       <literal>nixos/modules/misc/version.nix</literal> </link>
      </para>
     </listitem>

--- a/nixos/doc/manual/release-notes/rl-1509.xml
+++ b/nixos/doc/manual/release-notes/rl-1509.xml
@@ -433,9 +433,9 @@ system.autoUpgrade.enable = true;
      default. If you have existing systems with such host keys and want to
      continue to use them, please set
 <programlisting>
-system.nixos.stateVersion = "14.12";
+system.stateVersion = "14.12";
 </programlisting>
-     The new option <option>system.nixos.stateVersion</option> ensures that
+     The new option <option>system.stateVersion</option> ensures that
      certain configuration changes that could break existing systems (such as
      the <command>sshd</command> host key setting) will maintain compatibility
      with the specified NixOS release. NixOps sets the state version of

--- a/nixos/modules/installer/cd-dvd/installation-cd-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-base.nix
@@ -32,5 +32,5 @@ with lib;
   # Allow the user to log in as root without a password.
   users.users.root.initialHashedPassword = "";
 
-  system.nixos.stateVersion = mkDefault "18.03";
+  system.stateVersion = mkDefault "18.03";
 }

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -628,7 +628,7 @@ $bootLoaderConfig
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.nixos.stateVersion = "${\(qw(@release@))}"; # Did you read the comment?
+  system.stateVersion = "${\(qw(@release@))}"; # Did you read the comment?
 
 }
 EOF

--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -21,5 +21,5 @@ with lib;
   services.xserver.videoDrivers = mkOverride 40 [ "virtualbox" "vmware" "cirrus" "vesa" "modesetting" ];
 
   powerManagement.enable = false;
-  system.nixos.stateVersion = mkDefault "18.03";
+  system.stateVersion = mkDefault "18.03";
 }

--- a/nixos/modules/misc/version.nix
+++ b/nixos/modules/misc/version.nix
@@ -12,29 +12,29 @@ in
 
 {
 
-  options.system.nixos = {
+  options.system = {
 
-    version = mkOption {
+    nixos.version = mkOption {
       internal = true;
       type = types.str;
       description = "The full NixOS version (e.g. <literal>16.03.1160.f2d4ee1</literal>).";
     };
 
-    release = mkOption {
+    nixos.release = mkOption {
       readOnly = true;
       type = types.str;
       default = trivial.release;
       description = "The NixOS release (e.g. <literal>16.03</literal>).";
     };
 
-    versionSuffix = mkOption {
+    nixos.versionSuffix = mkOption {
       internal = true;
       type = types.str;
       default = trivial.versionSuffix;
       description = "The NixOS version suffix (e.g. <literal>1160.f2d4ee1</literal>).";
     };
 
-    revision = mkOption {
+    nixos.revision = mkOption {
       internal = true;
       type = types.str;
       default = if pathIsDirectory gitRepo then commitIdFromGitRepo gitRepo
@@ -43,7 +43,7 @@ in
       description = "The Git revision from which this NixOS configuration was built.";
     };
 
-    codeName = mkOption {
+    nixos.codeName = mkOption {
       readOnly = true;
       type = types.str;
       description = "The NixOS release code name (e.g. <literal>Emu</literal>).";
@@ -76,8 +76,8 @@ in
 
   config = {
 
-    warnings = lib.optional (options.system.nixos.stateVersion.highestPrio > 1000)
-      "You don't have `system.nixos.stateVersion` explicitly set. Expect things to break.";
+    warnings = lib.optional (options.system.stateVersion.highestPrio > 1000)
+      "You don't have `system.stateVersion` explicitly set. Expect things to break.";
 
     system.nixos = {
       # These defaults are set here rather than up there so that

--- a/nixos/modules/programs/shell.nix
+++ b/nixos/modules/programs/shell.nix
@@ -34,7 +34,7 @@ with lib;
 
           # Subscribe the root user to the NixOS channel by default.
           if [ "$USER" = root -a ! -e "$HOME/.nix-channels" ]; then
-              echo "${config.system.nixos.defaultChannel} nixos" > "$HOME/.nix-channels"
+              echo "${config.system.defaultChannel} nixos" > "$HOME/.nix-channels"
           fi
 
           # Create the per-user garbage collector roots directory.

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -4,6 +4,11 @@ with lib;
 
 {
   imports = [
+    # !!! These were renamed the other way, but got reverted later.
+    # !!! Drop these before 18.09 is released.
+    (mkRenamedOptionModule [ "system" "nixos" "stateVersion" ] [ "system" "stateVersion" ])
+    (mkRenamedOptionModule [ "system" "nixos" "defaultChannel" ] [ "system" "defaultChannel" ])
+
     (mkRenamedOptionModule [ "dysnomia" ] [ "services" "dysnomia" ])
     (mkRenamedOptionModule [ "environment" "x11Packages" ] [ "environment" "systemPackages" ])
     (mkRenamedOptionModule [ "environment" "enableBashCompletion" ] [ "programs" "bash" "enableCompletion" ])

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -222,8 +222,6 @@ with lib;
     (mkRenamedOptionModule [ "system" "nixosVersionSuffix" ] [ "system" "nixos" "versionSuffix" ])
     (mkRenamedOptionModule [ "system" "nixosRevision" ] [ "system" "nixos" "revision" ])
     (mkRenamedOptionModule [ "system" "nixosLabel" ] [ "system" "nixos" "label" ])
-    (mkRenamedOptionModule [ "system" "stateVersion" ] [ "system" "nixos" "stateVersion" ])
-    (mkRenamedOptionModule [ "system" "defaultChannel" ] [ "system" "nixos" "defaultChannel" ])
 
     # Users
     (mkAliasOptionModule [ "users" "extraUsers" ] [ "users" "users" ])

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -218,7 +218,7 @@ in
   config = mkIf config.services.mysql.enable {
 
     services.mysql.dataDir =
-      mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then "/var/lib/mysql"
+      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/mysql"
                  else "/var/mysql");
 
     users.users.mysql = {

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -146,7 +146,7 @@ in
       };
       superUser = mkOption {
         type = types.str;
-        default= if versionAtLeast config.system.nixos.stateVersion "17.09" then "postgres" else "root";
+        default= if versionAtLeast config.system.stateVersion "17.09" then "postgres" else "root";
         internal = true;
         description = ''
           NixOS traditionally used 'root' as superuser, most other distros use 'postgres'.
@@ -165,14 +165,14 @@ in
 
     services.postgresql.package =
       # Note: when changing the default, make it conditional on
-      # ‘system.nixos.stateVersion’ to maintain compatibility with existing
+      # ‘system.stateVersion’ to maintain compatibility with existing
       # systems!
-      mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then pkgs.postgresql96
-            else if versionAtLeast config.system.nixos.stateVersion "16.03" then pkgs.postgresql95
+      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then pkgs.postgresql96
+            else if versionAtLeast config.system.stateVersion "16.03" then pkgs.postgresql95
             else pkgs.postgresql94);
 
     services.postgresql.dataDir =
-      mkDefault (if versionAtLeast config.system.nixos.stateVersion "17.09" then "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
+      mkDefault (if versionAtLeast config.system.stateVersion "17.09" then "/var/lib/postgresql/${config.services.postgresql.package.psqlSchema}"
                  else "/var/db/postgresql");
 
     services.postgresql.authentication = mkAfter

--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -342,7 +342,7 @@ in {
       };
       database_type = mkOption {
         type = types.enum [ "sqlite3" "psycopg2" ];
-        default = if versionAtLeast config.system.nixos.stateVersion "18.03"
+        default = if versionAtLeast config.system.stateVersion "18.03"
           then "psycopg2"
           else "sqlite3";
         description = ''

--- a/nixos/modules/services/network-filesystems/ipfs.nix
+++ b/nixos/modules/services/network-filesystems/ipfs.nix
@@ -14,7 +14,7 @@ let
     (optionalString (cfg.defaultMode == "norouting") "--routing=none")
   ] ++ cfg.extraFlags);
 
-  defaultDataDir = if versionAtLeast config.system.nixos.stateVersion "17.09" then
+  defaultDataDir = if versionAtLeast config.system.stateVersion "17.09" then
     "/var/lib/ipfs" else
     "/var/lib/ipfs/.ipfs";
 

--- a/nixos/modules/services/networking/radicale.nix
+++ b/nixos/modules/services/networking/radicale.nix
@@ -9,7 +9,7 @@ let
   confFile = pkgs.writeText "radicale.conf" cfg.config;
 
   # This enables us to default to version 2 while still not breaking configurations of people with version 1
-  defaultPackage = if versionAtLeast config.system.nixos.stateVersion "17.09" then {
+  defaultPackage = if versionAtLeast config.system.stateVersion "17.09" then {
     pkg = pkgs.radicale2;
     text = "pkgs.radicale2";
   } else {
@@ -35,7 +35,7 @@ in
       defaultText = defaultPackage.text;
       description = ''
         Radicale package to use. This defaults to version 1.x if
-        <literal>system.nixos.stateVersion &lt; 17.09</literal> and version 2.x
+        <literal>system.stateVersion &lt; 17.09</literal> and version 2.x
         otherwise.
       '';
     };

--- a/nixos/modules/services/web-servers/caddy.nix
+++ b/nixos/modules/services/web-servers/caddy.nix
@@ -66,7 +66,7 @@ in {
       description = "Caddy web server";
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
-      environment = mkIf (versionAtLeast config.system.nixos.stateVersion "17.09")
+      environment = mkIf (versionAtLeast config.system.stateVersion "17.09")
         { CADDYPATH = cfg.dataDir; };
       serviceConfig = {
         ExecStart = ''

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -127,7 +127,7 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
     services.xserver.displayManager.job.logToJournal = true;
 
     # set default stateVersion to avoid warnings during eval
-    system.nixos.stateVersion = mkDefault "18.03";
+    system.stateVersion = mkDefault "18.03";
   };
 
 }

--- a/nixos/modules/virtualisation/amazon-options.nix
+++ b/nixos/modules/virtualisation/amazon-options.nix
@@ -3,7 +3,7 @@
   options = {
     ec2 = {
       hvm = lib.mkOption {
-        default = lib.versionAtLeast config.system.nixos.stateVersion "17.03";
+        default = lib.versionAtLeast config.system.stateVersion "17.03";
         internal = true;
         description = ''
           Whether the EC2 instance is a HVM instance.

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -607,7 +607,7 @@ in
                   { services.postgresql.enable = true;
                     services.postgresql.package = pkgs.postgresql96;
 
-                    system.nixos.stateVersion = "17.03";
+                    system.stateVersion = "17.03";
                   };
               };
           }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -198,7 +198,7 @@ in rec {
         modules = singleton ({ ... }:
           { fileSystems."/".device  = mkDefault "/dev/sda1";
             boot.loader.grub.device = mkDefault "/dev/sda";
-            system.nixos.stateVersion = mkDefault "18.03";
+            system.stateVersion = mkDefault "18.03";
           });
       }).config.system.build.toplevel;
       preferLocalBuild = true;

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -18,7 +18,7 @@ import ./make-test.nix ({ pkgs, ...} : {
           inherit (config.nixpkgs.localSystem) system;
           modules = lib.singleton {
             containers.foo.config = {
-              system.nixos.stateVersion = "18.03";
+              system.stateVersion = "18.03";
             };
           };
         };

--- a/nixos/tests/containers-ipv4.nix
+++ b/nixos/tests/containers-ipv4.nix
@@ -21,7 +21,7 @@ import ./make-test.nix ({ pkgs, ...} : {
               services.httpd.adminAddr = "foo@example.org";
               networking.firewall.allowedTCPPorts = [ 80 ];
               networking.firewall.allowPing = true;
-              system.nixos.stateVersion = "18.03";
+              system.stateVersion = "18.03";
             };
         };
 

--- a/nixos/tests/radicale.nix
+++ b/nixos/tests/radicale.nix
@@ -43,7 +43,7 @@ in
             });
           })
         ];
-        system.nixos.stateVersion = "17.03";
+        system.stateVersion = "17.03";
       };
       radicale1_export = lib.recursiveUpdate radicale1 {
         services.radicale.extraArgs = [
@@ -54,7 +54,7 @@ in
         services.radicale.extraArgs = [ "--verify-storage" ];
       };
       radicale2 = lib.recursiveUpdate (common args) {
-        system.nixos.stateVersion = "17.09";
+        system.stateVersion = "17.09";
       };
     };
 


### PR DESCRIPTION
This reverts commit 095fe5b43def40279a243e663c662b02caac5318.

Pointless renames considered harmful. All they do is force people to spend extra work updating their configs for no benefit, and hinder the ability to switch between unstable and stable versions of NixOS.
    
Like, what was the value of having the "nixos." there? I mean, by definition anything in a NixOS module has something to do with NixOS...