### PR TITLE
elixir: init 1.7.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -44,25 +44,30 @@ let
         # BEAM-based languages.
         elixir = elixir_1_6;
 
+        elixir_1_7 = lib.callElixir ../interpreters/elixir/1.7.nix {
+          inherit rebar erlang;
+          debugInfo = true;
+        };
+
         elixir_1_6 = lib.callElixir ../interpreters/elixir/1.6.nix {
-                       inherit rebar erlang;
-                       debugInfo = true;
-                     };
+          inherit rebar erlang;
+          debugInfo = true;
+        };
 
         elixir_1_5 = lib.callElixir ../interpreters/elixir/1.5.nix {
-                       inherit rebar erlang;
-                       debugInfo = true;
-                     };
+          inherit rebar erlang;
+          debugInfo = true;
+        };
 
         elixir_1_4 = lib.callElixir ../interpreters/elixir/1.4.nix {
-                       inherit rebar erlang;
-                       debugInfo = true;
-                     };
+          inherit rebar erlang;
+          debugInfo = true;
+        };
 
         elixir_1_3 = lib.callElixir ../interpreters/elixir/1.3.nix {
-                       inherit rebar erlang;
-                       debugInfo = true;
-                     };
+          inherit rebar erlang;
+          debugInfo = true;
+        };
 
         lfe = lfe_1_2;
         lfe_1_2 = lib.callLFE ../interpreters/lfe/1.2.nix { inherit erlang buildRebar3 buildHex; };

--- a/pkgs/development/interpreters/elixir/1.7.nix
+++ b/pkgs/development/interpreters/elixir/1.7.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+
+mkDerivation rec {
+  version = "1.7.0";
+  sha256 = "082924fngc6ypbkn1ghdwf199radk00daf4q09mm04h81jy4nmxm";
+  minimumOTPVersion = "18";
+}

--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -37,7 +37,7 @@ in
 
     preBuild = ''
       # The build process uses ./rebar. Link it to the nixpkgs rebar
-      rm -v rebar
+      rm -vf rebar
       ln -s ${rebar}/bin/rebar rebar
 
       substituteInPlace Makefile \

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -61,7 +61,7 @@ rec {
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlangR19.elixir`.
-    inherit (packages.erlang) elixir elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
+    inherit (packages.erlang) elixir elixir_1_7 elixir_1_6 elixir_1_5 elixir_1_4 elixir_1_3;
 
     inherit (packages.erlang) lfe lfe_1_2;
   };


### PR DESCRIPTION
###### Motivation for this change

https://elixir-lang.org/blog/2018/07/25/elixir-v1-7-0-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
