### PR TITLE
cfssl: 20170527 -> 1.3.2

### DIFF
--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -2,15 +2,15 @@
 
 buildGoPackage rec {
   name = "cfssl-${version}";
-  version = "20170527";
+  version = "1.3.2";
 
   goPackagePath = "github.com/cloudflare/cfssl";
 
   src = fetchFromGitHub {
     owner = "cloudflare";
     repo = "cfssl";
-    rev = "114dc9691ec7bf3dac49d5953eccf7d91a0e0904";
-    sha256 = "1ijq43mrzrf1gkgj5ssxq7sgy6sd4rl706dzqkq9krqv5f6kwhj1";
+    rev = version;
+    sha256 = "0j2gz2vl2pf7ir7sc7jrwmjnr67hk4qhxw09cjx132jbk337jc9x";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Current cfssl package is more than a year old. Time for a bump :)

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @mbrgm @srhb  