### PR TITLE
php: Enable mysqlnd as default

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -17,7 +17,7 @@ let
   , ldapSupport ? config.php.ldap or true
   , mhashSupport ? config.php.mhash or true
   , mysqlSupport ? (config.php.mysql or true) && (!php7)
-  , mysqlndSupport ? config.php.mysqlnd or false
+  , mysqlndSupport ? config.php.mysqlnd or true
   , mysqliSupport ? config.php.mysqli or true
   , pdo_mysqlSupport ? config.php.pdo_mysql or true
   , libxml2Support ? config.php.libxml2 or true


### PR DESCRIPTION
###### Motivation for this change

MySQL Native Driver was implemented by PHP back in 5.3.0 and has been
default in most distributions for a very long time.

The option was added in 41cd4f2459d63c5ad19a227c3dd5d7704df6161c and I don't see any reason why it would default to false.

Overview of mysqlnd by PHP: https://secure.php.net/manual/en/mysqlnd.overview.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @globin @FRidh @adisbladis @srhb @elitak @talyz 