### PR TITLE
jetbrains.editors: 2018.1.x -> 2018.2 (upgrade using the script)

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -328,12 +328,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1kv1d5y2ph36aq91sq08lbz8hvfp765xi7m0hdwkhqdi2wkrpnkc"; /* updated by script */
+      sha256 = "0azjrbxpwank09i7riflbkgrgm23f0q6hgisca6d14ldcbr933aj"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -276,12 +276,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2018.1.5"; /* updated by script */
+    version = "2018.1.6"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "0bhajghwh5r5mdv3lbnq0xlr6669hid5kyzlsxnsfzc2z737zwc5"; /* updated by script */
+      sha256 = "14y3rlka21rwirlfnd6akpgz4rzplsxkzqrlgk4ccn5w4rm78z6a"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -289,12 +289,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2018.1.6"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jdk.tar.gz";
-      sha256 = "1jcamms12qwj80j89cws63d26yj2lhbifrjp5gb6s6mran46ylx2"; /* updated by script */
+      sha256 = "1xq97dcf7xcs8fsrjsqqrzxf2gnrll8bbqkzrpg85bqxap0hvb45"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -366,15 +366,15 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "0pjmr6g4wcqgxci4f3a4n6x1dqyabhzw886l7faj33nwdk9i2gv3"; /* updated by script */
+      sha256 = "0la83cqf3aknrc62ddpij0gg50rws5l2g4iasyrvfhn4wnmj6n4q"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
-    update-channel = "RubyMine 2018.1";
+    update-channel = "RubyMine 2018.2";
   };
 
   webstorm = buildWebStorm rec {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -367,12 +367,12 @@ in
 
   webstorm = buildWebStorm rec {
     name = "webstorm-${version}";
-    version = "2018.1.5"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "Professional IDE for Web and JavaScript development";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz";
-      sha256 = "1mqms8gzmsaqvwzfk821vj1z1cxdgjw5nnwq63mag6rly04h60n6"; /* updated by script */
+      sha256 = "024schngx26ik8cvmkijfzzmpkajckl2dbyz31ajnmixpn07pwi6"; /* updated by script */
     };
     wmClass = "jetbrains-webstorm";
     update-channel = "WebStorm Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -263,12 +263,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2018.1.5"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "08k7idgsv6qla11fbf2rl1v83y0p23sm40a85ii7a4a0n0jpw8np"; /* updated by script */
+      sha256 = "0z7a06892c3hcq5zxvkfnyf0ablwq51710x1f12v6r297l4mfra0"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -354,12 +354,12 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2018.1.3"; /* updated by script */
+    version = "2018.1.4"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "033rjsx6zjrfbl89i513ms14iw53ip56h4bkilrij32hshb7c2c5"; /* updated by script */
+      sha256 = "0pjmr6g4wcqgxci4f3a4n6x1dqyabhzw886l7faj33nwdk9i2gv3"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
     update-channel = "RubyMine 2018.1";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -237,12 +237,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2018.1.6"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "1xf77bld2zhdvdvfb4bw8f5dmgbrdyh0i0l0h1if0a0p8agl0qgq"; /* updated by script */
+      sha256 = "08kjlmldnd6rnk8m12klfp9vbkbvcsgaknpi55r248nzglnbx9gz"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion Release"; # channel's id as in http://www.jetbrains.com/updates/updates.xml

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -237,12 +237,12 @@ in
 
   clion = buildClion rec {
     name = "clion-${version}";
-    version = "2018.1.5"; /* updated by script */
+    version = "2018.1.6"; /* updated by script */
     description  = "C/C++ IDE. New. Intelligent. Cross-platform";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/cpp/CLion-${version}.tar.gz";
-      sha256 = "0hd58i531schyjlm99vff9bi5gjskdbsljd367k9zafjfh53z91l"; /* updated by script */
+      sha256 = "1xf77bld2zhdvdvfb4bw8f5dmgbrdyh0i0l0h1if0a0p8agl0qgq"; /* updated by script */
     };
     wmClass = "jetbrains-clion";
     update-channel = "CLion Release"; # channel's id as in http://www.jetbrains.com/updates/updates.xml

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -341,15 +341,15 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "2018.1.2"; /* updated by script */
+    version = "2018.1.3"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-${version}.tar.gz";
-      sha256 = "1jsj0g4mv7fci3jgwx9skaz2m40g3ray2n17djaln08731rls5cc"; /* updated by script */
+      sha256 = "00wskr60mjipyp44wrpc3pn6awc92djn7rwhc08nrar3zv0j4mgg"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
-    update-channel = "Rider 2018.1.2";
+    update-channel = "Rider 2018.1.3";
   };
 
   ruby-mine = buildRubyMine rec {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -250,12 +250,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.1.5"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "1m0qckq645jw7cj40m5vfgr212b8hji539skavch2j5s5fbqy3ln"; /* updated by script */
+      sha256 = "0jqkqiml7v1m9hkcjwmx866vrn5myxcg4zqzyghviyx5i7jrvx3c"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip 2018.1";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -315,12 +315,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "0frzasqh3jx7wcip4dnwdl9ap2g1nkx7anapwd416cxv4jj3r5ch"; /* updated by script */
+      sha256 = "0a5dsr2piw0vgm9lvc2k18sdnvii55xdyi90z95hzg5syhsm1a94"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -314,15 +314,15 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2018.1.6"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "0v07sfg7ywawk6wb52zhr3753hscpxw3m53ppgw4n50dcdwx0kdn"; /* updated by script */
+      sha256 = "15czwk15c1gnf7xrgm423xafsw55083dd6g15g69zs0l9psrss31"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
-    update-channel = "PhpStorm 2018.1";
+    update-channel = "PhpStorm 2018.2";
   };
 
   pycharm-community = buildPycharm rec {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -289,12 +289,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2018.1.5"; /* updated by script */
+    version = "2018.1.6"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jdk.tar.gz";
-      sha256 = "046wyvk2f7vbh4zam1bbri4yxzb34q43rjpk6i6npxrb25jv6clx"; /* updated by script */
+      sha256 = "1jcamms12qwj80j89cws63d26yj2lhbifrjp5gb6s6mran46ylx2"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -276,12 +276,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2018.1.6"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "14y3rlka21rwirlfnd6akpgz4rzplsxkzqrlgk4ccn5w4rm78z6a"; /* updated by script */
+      sha256 = "0r5fsai77w74vhfs449yff56pi4vynl8w25amn23k6hddlqxph2s"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA Release";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -262,15 +262,15 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2018.1.5"; /* updated by script */
+    version = "2018.2"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "0jqkqiml7v1m9hkcjwmx866vrn5myxcg4zqzyghviyx5i7jrvx3c"; /* updated by script */
+      sha256 = "1byf46vni8s6qf3wlsnscxipgndl6ic48nizwiaqasnhhszqssxs"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
-    update-channel = "DataGrip 2018.1";
+    update-channel = "DataGrip 2018.2";
   };
 
   goland = buildGoland rec {

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -263,12 +263,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2018.1.4"; /* updated by script */
+    version = "2018.1.5"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "1ipib91443sb27snnqik8rm3bm9w6gb5niildbd538lhc9agc9xb"; /* updated by script */
+      sha256 = "08k7idgsv6qla11fbf2rl1v83y0p23sm40a85ii7a4a0n0jpw8np"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand Release";


### PR DESCRIPTION
###### Motivation for this change
New release in the 2018 series. New features.

###### Things done

This goes beyond https://github.com/NixOS/nixpkgs/pull/44064 in that it fixes the clion build so that clion actually builds.

I've only tested idea-ultimate and clion packages. In case of clion, ~~I looked into patching the bundled gdb, but could not make it work. Does not really matter, it did not work before, and llvm debugger or gdb from users profile can be used instead. The furthest I got with the bundled gdb is~~

```
clion-2018.2/bin/gdb/linux/lib/python3.6 clion-2018.2/bin/gdb/linux/bin/gdb
Fatal Python error: Py_Initialize: Unable to get the locale encoding
zipimport.ZipImportError: can't decompress data; zlib not available

Current thread 0x00007fca468ae740 (most recent call first):
Aborted

PYTHONHOME=clion-2018.2/bin/gdb/linux/lib/python3.6 clion-2018.2/bin/gdb/linux/bin/gdb
Fatal Python error: Py_Initialize: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007ff2fd02e740 (most recent call first):
Aborted
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

