### PR TITLE
kicad: 4.0.7 -> 5.0.0

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -1,72 +1,56 @@
-{ stdenv, fetchurl, cmake, libGLU_combined, wxGTK, zlib, libX11, gettext, glew, cairo, curl, openssl, boost, pkgconfig, doxygen }:
+{ wxGTK, lib, stdenv, fetchurl, cmake, libGLU_combined, zlib
+, libX11, gettext, glew, glm, cairo, curl, openssl, boost, pkgconfig
+, doxygen, pcre, libpthreadstubs, libXdmcp
 
+, oceSupport ? true, opencascade
+, ngspiceSupport ? true, libngspice
+, scriptingSupport ? true, swig, python, wxPython
+}:
+
+assert ngspiceSupport -> libngspice != null;
+
+with lib;
 stdenv.mkDerivation rec {
   name = "kicad-${version}";
-  series = "4.0";
-  version = "4.0.7";
+  series = "5.0";
+  version = "5.0.0";
 
-  srcs = [
-    (fetchurl {
-      url = "https://code.launchpad.net/kicad/${series}/${version}/+download/kicad-${version}.tar.xz";
-      sha256 = "1hgxan9321szgyqnkflb0q60yjf4yvbcc4cpwhm0yz89qrvlq1q9";
-    })
+  src = fetchurl {
+    url = "https://launchpad.net/kicad/${series}/${version}/+download/kicad-${version}.tar.xz";
+    sha256 = "17nqjszyvd25wi6550j981whlnb1wxzmlanljdjihiki53j84x9p";
+  };
 
-    (fetchurl {
-      url = "http://downloads.kicad-pcb.org/libraries/kicad-library-${version}.tar.gz";
-      sha256 = "1azb7v1y3l6j329r9gg7f4zlg0wz8nh4s4i5i0l9s4yh9r6i9zmv";
-    })
-
-    (fetchurl {
-      url = "http://downloads.kicad-pcb.org/libraries/kicad-footprints-${version}.tar.gz";
-      sha256 = "08qrz5zzsb5127jlnv24j0sgiryd5nqwg3lfnwi8j9a25agqk13j";
-    })
-  ];
-
-  sourceRoot = "kicad-${version}";
-
-  cmakeFlags = ''
-    -DKICAD_SKIP_BOOST=ON
-    -DKICAD_BUILD_VERSION=${version}
-    -DKICAD_REPO_NAME=stable
+  postPatch = ''
+    substituteInPlace CMakeModules/KiCadVersion.cmake \
+      --replace no-vcs-found ${version}
   '';
 
-  enableParallelBuilding = true; # often fails on Hydra: fatal error: pcb_plot_params_lexer.h: No such file or directory
+  cmakeFlags =
+    optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade}" ]
+    ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON"
+    ++ optionals (scriptingSupport) [
+      "-DKICAD_SCRIPTING=ON"
+      "-DKICAD_SCRIPTING_MODULES=ON"
+      "-DKICAD_SCRIPTING_WXPYTHON=ON"
+      # nix installs wxPython headers in wxPython package, not in wxwidget
+      # as assumed. We explicitely set the header location.
+      "-DCMAKE_CXX_FLAGS=-I${wxPython}/include/wx-3.0"
+    ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake libGLU_combined wxGTK zlib libX11 gettext glew cairo curl openssl boost doxygen ];
-
-  # They say they only support installs to /usr or /usr/local,
-  # so we have to handle this.
-  patchPhase = ''
-    sed -i -e 's,/usr/local/kicad,'$out,g common/gestfich.cpp
-  '';
-
-  postUnpack = ''
-    pushd $(pwd)
-  '';
-
-  postInstall = ''
-    popd
-
-    pushd kicad-library-*
-    cmake -DCMAKE_INSTALL_PREFIX=$out
-    make $MAKE_FLAGS
-    make install
-    popd
-
-    pushd kicad-footprints-*
-    mkdir -p $out/share/kicad/modules
-    cp -R *.pretty $out/share/kicad/modules/
-    popd
-  '';
-
+  # https://www.mail-archive.com/kicad-developers@lists.launchpad.net/msg29840.html
+  nativeBuildInputs = [ (cmake.override {majorVersion = "3.10";}) doxygen  pkgconfig ];
+  buildInputs = [
+    libGLU_combined zlib libX11 wxGTK pcre libXdmcp gettext glew glm libpthreadstubs
+    cairo curl openssl boost
+  ] ++ optional (oceSupport) opencascade
+    ++ optional (ngspiceSupport) libngspice
+    ++ optionals (scriptingSupport) [ swig python wxPython ];
 
   meta = {
     description = "Free Software EDA Suite";
     homepage = http://www.kicad-pcb.org/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [viric];
-    platforms = with stdenv.lib.platforms; linux;
-    hydraPlatforms = []; # 'output limit exceeded' error on hydra
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ berce ];
+    platforms = with platforms; linux;
   };
 }

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -4,7 +4,7 @@
 , wrapGAppsHook
 , oceSupport ? true, opencascade
 , ngspiceSupport ? true, libngspice
-, scriptingSupport ? true, swig, python, pythonPackages
+, swig, python, pythonPackages
 }:
 
 assert ngspiceSupport -> libngspice != null;
@@ -25,17 +25,15 @@ stdenv.mkDerivation rec {
       --replace no-vcs-found ${version}
   '';
 
-  cmakeFlags =
-    optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade}" ]
-    ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON"
-    ++ optionals (scriptingSupport) [
-      "-DKICAD_SCRIPTING=ON"
-      "-DKICAD_SCRIPTING_MODULES=ON"
-      "-DKICAD_SCRIPTING_WXPYTHON=ON"
-      # nix installs wxPython headers in wxPython package, not in wxwidget
-      # as assumed. We explicitely set the header location.
-      "-DCMAKE_CXX_FLAGS=-I${pythonPackages.wxPython}/include/wx-3.0"
-    ];
+  cmakeFlags = [
+    "-DKICAD_SCRIPTING=ON"
+    "-DKICAD_SCRIPTING_MODULES=ON"
+    "-DKICAD_SCRIPTING_WXPYTHON=ON"
+    # nix installs wxPython headers in wxPython package, not in wxwidget
+    # as assumed. We explicitely set the header location.
+    "-DCMAKE_CXX_FLAGS=-I${pythonPackages.wxPython}/include/wx-3.0"
+  ] ++ optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade}" ]
+    ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON";
 
   nativeBuildInputs = [
     # https://www.mail-archive.com/kicad-developers@lists.launchpad.net/msg29840.html
@@ -51,9 +49,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libGLU_combined zlib libX11 wxGTK pcre libXdmcp gettext glew glm libpthreadstubs
     cairo curl openssl boost
+    swig python
   ] ++ optional (oceSupport) opencascade
-    ++ optional (ngspiceSupport) libngspice
-    ++ optionals (scriptingSupport) [ swig python ];
+    ++ optional (ngspiceSupport) libngspice;
 
   # this breaks other applications in kicad
   dontWrapGApps = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20744,6 +20744,7 @@ with pkgs;
 
   kicad = callPackage ../applications/science/electronics/kicad {
     wxGTK = wxGTK30;
+    inherit (pythonPackages) wxPython;
     boost = boost160;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11829,7 +11829,7 @@ with pkgs;
   sofia_sip = callPackage ../development/libraries/sofia-sip { };
 
   soil = callPackage ../development/libraries/soil { };
-  
+
   sonic = callPackage ../development/libraries/sonic { };
 
   soprano = callPackage ../development/libraries/soprano { };
@@ -20744,7 +20744,6 @@ with pkgs;
 
   kicad = callPackage ../applications/science/electronics/kicad {
     wxGTK = wxGTK30;
-    inherit (pythonPackages) wxPython;
     boost = boost160;
   };
 
@@ -20909,7 +20908,7 @@ with pkgs;
   spyder = pythonPackages.spyder;
 
   openspace = callPackage ../applications/science/astronomy/openspace { };
-  
+
   stellarium = libsForQt5.callPackage ../applications/science/astronomy/stellarium { };
 
   tulip = callPackage ../applications/science/misc/tulip {


### PR DESCRIPTION
###### Motivation for this change

Just a regular update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

