### PR TITLE
Fetch spotify from snapcraft

### DIFF
--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -1,13 +1,18 @@
-{ fetchurl, stdenv, dpkg, xorg, alsaLib, makeWrapper, openssl, freetype
+{ fetchurl, stdenv, squashfsTools, xorg, alsaLib, makeWrapper, openssl, freetype
 , glib, pango, cairo, atk, gdk_pixbuf, gtk2, cups, nspr, nss, libpng
 , libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg_0_10, curl, zlib, gnome3 }:
 
 let
-  # Please update the stable branch!
-  # Latest version number can be found at:
-  # http://repository-origin.spotify.com/pool/non-free/s/spotify-client/
-  # Be careful not to pick the testing version.
-  version = "1.0.80.480.g51b03ac3-13";
+  # "rev" decides what is actually being downloaded
+  version = "1.0.80.474.gef6b503e-7";
+  # To get the latest stable revision:
+  # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=stable' | jq '.download_url,.version,.last_updated'
+  # To get general information:
+  # curl -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/spotify' | jq '.'
+  # More exapmles of api usage:
+  # https://github.com/canonical-websites/snapcraft.io/blob/master/webapp/publisher/snaps/views.py
+  rev = "16";
+
 
   deps = [
     alsaLib
@@ -49,12 +54,20 @@ in
 stdenv.mkDerivation {
   name = "spotify-${version}";
 
+  # fetch from snapcraft instead of the debian repository most repos fetch from.
+  # That is a bit more cumbersome. But the debian repository only keeps the last
+  # two versions, while snapcraft should provide versions indefinately:
+  # https://forum.snapcraft.io/t/how-can-a-developer-remove-her-his-app-from-snap-store/512
+
+  # This is the next-best thing, since we're not allowed to re-distribute
+  # spotify ourselves:
+  # https://community.spotify.com/t5/Desktop-Linux/Redistribute-Spotify-on-Linux-Distributions/td-p/1695334
   src = fetchurl {
-    url = "https://repository-origin.spotify.com/pool/non-free/s/spotify-client/spotify-client_${version}_amd64.deb";
-    sha256 = "e32f4816ae79dbfa0c14086e76df3bc83d526402aac1dbba534127fc00fe50ea";
+    url = "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_${rev}.snap";
+    sha512 = "45b7ab574b30fb368e0b6f4dd60addbfd1ddc02173b4f98b31c524eed49073432352a361e75959ce8e2f752231e93c79ca1b538c4bd295c935d1e2e0585d147f";
   };
 
-  buildInputs = [ dpkg makeWrapper ];
+  buildInputs = [ squashfsTools makeWrapper ];
 
   doConfigure = false;
   doBuild = false;
@@ -63,7 +76,23 @@ stdenv.mkDerivation {
 
   unpackPhase = ''
     runHook preUnpack
-    dpkg-deb -x $src .
+    unsquashfs "$src" '/usr/share/spotify' '/usr/bin/spotify' '/meta/snap.yaml'
+    cd squashfs-root
+    if ! grep -q 'grade: stable' meta/snap.yaml; then
+      # Unfortunately this check is not reliable: At the moment (2018-07-26) the
+      # latest version in the "edge" channel is also marked as stable.
+      echo "The snap package is marked as unstable:"
+      grep 'grade: ' meta/snap.yaml
+      echo "You probably chose the wrong revision."
+      exit 1
+    fi
+    if ! grep -q '${version}' meta/snap.yaml; then
+      echo "Package version differs from version found in snap metadata:"
+      grep 'version: ' meta/snap.yaml
+      echo "While the nix package specifies: ${version}."
+      echo "You probably chose the wrong revision or forgot to update the nix version."
+      exit 1
+    fi
     runHook postUnpack
   '';
 
@@ -74,6 +103,8 @@ stdenv.mkDerivation {
       libdir=$out/lib/spotify
       mkdir -p $libdir
       mv ./usr/* $out/
+
+      cp meta/snap.yaml $out
 
       # Work around Spotify referring to a specific minor version of
       # OpenSSL.

--- a/pkgs/applications/audio/spotify/update.sh
+++ b/pkgs/applications/audio/spotify/update.sh
@@ -1,0 +1,49 @@
+channel="stable" # stable/candidate/edge
+nixpkgs="$(git rev-parse --show-toplevel)"
+spotify_nix="$nixpkgs/pkgs/applications/audio/spotify/default.nix"
+
+
+
+# create bash array from snap info
+snap_info=($(
+	curl -H 'X-Ubuntu-Series: 16' \
+		"https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=$channel" \
+	| jq --raw-output \
+		'.revision,.download_sha512,.version,.last_updated'
+))
+
+revision="${snap_info[0]}"
+sha512="${snap_info[1]}"
+version="${snap_info[2]}"
+last_updated="${snap_info[3]}"
+
+# find the last commited version
+version_pre=$(
+	git  grep 'version\s*=' HEAD "$spotify_nix" \
+	| sed -Ene 's/.*"(.*)".*/\1/p'
+)
+
+if [[ "$version_pre" = "$version" ]]; then
+	echo "Spotify is already up ot date"
+	exit 0
+fi
+
+echo "Updating from ${version_pre} to ${version}, released on ${last_updated}"
+
+# search-andreplace revision, hash and version
+sed --regexp-extended \
+	-e 's/rev\s*=\s*"[0-9]+"\s*;/rev = "'"${revision}"'";/' \
+	-e 's/sha512\s*=\s*".{128}"\s*;/sha512 = "'"${sha512}"'";/' \
+	-e 's/version\s*=\s*".*"\s*;/version = "'"${version}"'";/' \
+	-i "$spotify_nix" 
+
+if ! nix-build -A spotify "$nixpkgs"; then
+	echo "The updated spotify failed to build."
+	exit 1
+fi
+
+git add "$spotify_nix"
+# show diff for review
+git diff HEAD
+# prepare commit message, but allow edit
+git commit --edit --message "spotify: $version_pre -> $version"


### PR DESCRIPTION
###### Motivation for this change

Spotify is currently fetched from a [debian repository](http://repository.spotify.com/pool/non-free/s/spotify-client/) hosted on their own server. The big problem with that is that they only keep a couple of versions around. That leads to failures when trying to build older versions. Unfortunately we are [not allowed](https://community.spotify.com/t5/Desktop-Linux/Redistribute-Spotify-on-Linux-Distributions/td-p/1695334) to keep old versions and re-distribute them.

In december 2017, spotify released a "snap" package on snapcraft. That has the significant advantage that the server is not controlled by spotify and snapcraft does not automatically delete old versions and [does not even allow](https://forum.snapcraft.io/t/how-can-a-developer-remove-her-his-app-from-snap-store/512) spotify to remove them. The oldest version currently available on snapcraft is `1.0.59.395`, while the oldest version available on the debian repository is `1.0.72.117`.


###### Disadvantages of this approach

- the snap contains all the dependencies at is ~160mb, while the debian package is ~90 mb. The installed versions have the same size.

- the upgrade process is a bit more complex, since the snap url's are based on the snap_id (which doesn't change) and the revision. The revision takes the place of the version and is a simple increasing integer. It does not indicate weather or not the version is stable or what spotify version it responds to. Because of that I included update instructions and even a fully automated update script.

- currently the versions on snapcraft and the debian repo don't quite match up. Snapcraft has `1.0.80.474`, while the repository has `1.0.80.480`. Both of these were released on the same day however and are probably pretty much identical. Who knows what that last version number signifies. Since the snap version is at least as "official" as the debian version, I assume that version is just as up-to-date.


###### Advantages of this approach

- the spotify package doesn't break anymore


The advantages far outweight the disadvantages in my opinion. I've already been bitten by this at least twice. I wasn't able to rebuild my configuration anymore and had to remove spotify from my system packages.

Maintainers @edolstra @ftrvxmtrx @sheenobu  @laMudri

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

