### PR TITLE
opencollada: include pcre.h (KhronosGroup/OpenCOLLADA#570)

### DIFF
--- a/pkgs/development/libraries/opencollada/default.nix
+++ b/pkgs/development/libraries/opencollada/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patchPhase = lib.optionalString stdenv.isDarwin ''
+  patchPhase = ''
+    patch -p1 < ${./pcre.patch}
+  '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp \
       --replace math.h cmath
   '';

--- a/pkgs/development/libraries/opencollada/pcre.patch
+++ b/pkgs/development/libraries/opencollada/pcre.patch
@@ -1,0 +1,14 @@
+diff --git a/COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h b/COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h
+index 22f2598b..269c50ca 100644
+--- a/COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h
++++ b/COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h
+@@ -13,8 +13,7 @@
+ 
+ #include "COLLADABUPrerequisites.h"
+ 
+-struct real_pcre;
+-typedef struct real_pcre pcre;
++#include "pcre.h"
+ 
+ 
+ namespace COLLADABU


### PR DESCRIPTION
###### Motivation for this change
Fixes build (or at least on nixOS)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

