### PR TITLE
release/metrics: drop requiredSystemFeatures

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -4,7 +4,7 @@ with pkgs;
 
 runCommand "nixpkgs-metrics"
   { buildInputs = [ nix time ];
-    requiredSystemFeatures = [ "benchmark" ];
+    # requiredSystemFeatures = [ "benchmark" ]; # TODO: a 1-job machine for this on Hydra?
   }
   ''
     export NIX_DB_DIR=$TMPDIR


### PR DESCRIPTION
Lack of a "benchmark" machine on Hydra prevents it from building, and that blocks channels.

/cc @grahamc, @domenkozar.  This is just a quick fix.  I could set up a spare [core2duo machine](https://github.com/orgs/NixOS/teams/nix-core/discussions/4) for this later, for example.