### PR TITLE
lib/trivial: add assertMsg and assertMsgOneOf

### DIFF
--- a/lib/asserts.nix
+++ b/lib/asserts.nix
@@ -1,0 +1,44 @@
+{ lib }:
+
+rec {
+
+  /* Print a trace message if pred is false.
+     Intended to be used to augment asserts with helpful error messages.
+
+     Example:
+       assertMsg false "nope"
+       => false
+       stderr> trace: nope
+
+       assert (assertMsg ("foo" == "bar") "foo is not bar, silly"); ""
+       stderr> trace: foo is not bar, silly
+       stderr> assert failed at …
+
+     Type:
+       assertMsg :: Bool -> String -> Bool
+  */
+  # TODO(Profpatsch): add tests that check stderr
+  assertMsg = pred: msg:
+    if pred
+    then true
+    else builtins.trace msg false;
+
+  /* Specialized `assertMsg` for checking if val is one of the elements
+     of a list. Useful for checking enums.
+
+     Example:
+       let sslLibrary = "libressl"
+       in assertOneOf "sslLibrary" sslLibrary [ "openssl" "bearssl" ]
+       => false
+       stderr> trace: sslLibrary must be one of "openssl", "bearssl", but is: "libressl"
+
+     Type:
+       assertOneOf :: String -> ComparableVal -> List ComparableVal -> Bool
+  */
+  assertOneOf = name: val: xs: assertMsg
+    (lib.elem val xs)
+    "${name} must be one of ${
+      lib.generators.toPretty {} xs}, but is: ${
+        lib.generators.toPretty {} val}";
+
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -60,7 +60,7 @@ let
       boolToString mergeAttrs flip mapNullable inNixShell min max
       importJSON warn info nixpkgsVersion version mod compare
       splitByAndCompare functionArgs setFunctionArgs isFunction
-      assertMsg;
+      assertMsg assertOneOf;
 
     inherit (fixedPoints) fix fix' extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -38,10 +38,11 @@ let
     systems = callLibs ./systems;
 
     # misc
+    asserts = callLibs ./asserts.nix;
     debug = callLibs ./debug.nix;
-
     generators = callLibs ./generators.nix;
     misc = callLibs ./deprecated.nix;
+
     # domain-specific
     fetchers = callLibs ./fetchers.nix;
 
@@ -59,9 +60,7 @@ let
     inherit (trivial) id const concat or and bitAnd bitOr bitXor bitNot
       boolToString mergeAttrs flip mapNullable inNixShell min max
       importJSON warn info nixpkgsVersion version mod compare
-      splitByAndCompare functionArgs setFunctionArgs isFunction
-      assertMsg assertOneOf;
-
+      splitByAndCompare functionArgs setFunctionArgs isFunction;
     inherit (fixedPoints) fix fix' extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;
     inherit (attrsets) attrByPath hasAttrByPath setAttrByPath
@@ -118,6 +117,8 @@ let
       unknownModule mkOption;
     inherit (types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;
+    inherit (asserts)
+      assertMsg assertOneOf;
     inherit (debug) addErrorContextToAttrs traceIf traceVal traceValFn
       traceXMLVal traceXMLValMarked traceSeq traceSeqN traceValSeq
       traceValSeqFn traceValSeqN traceValSeqNFn traceShowVal

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -59,7 +59,8 @@ let
     inherit (trivial) id const concat or and bitAnd bitOr bitXor bitNot
       boolToString mergeAttrs flip mapNullable inNixShell min max
       importJSON warn info nixpkgsVersion version mod compare
-      splitByAndCompare functionArgs setFunctionArgs isFunction;
+      splitByAndCompare functionArgs setFunctionArgs isFunction
+      assertMsg;
 
     inherit (fixedPoints) fix fix' extends composeExtensions
       makeExtensible makeExtensibleWithCustomName;

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -509,7 +509,7 @@ rec {
        => 3
   */
   last = list:
-    assert assertMsg (list != []) "lists.last: list must not be empty!";
+    assert lib.assertMsg (list != []) "lists.last: list must not be empty!";
     elemAt list (length list - 1);
 
   /* Return all elements but the last
@@ -519,7 +519,7 @@ rec {
        => [ 1 2 ]
   */
   init = list:
-    assert assertMsg (list != []) "lists.init: list must not be empty!";
+    assert lib.assertMsg (list != []) "lists.init: list must not be empty!";
     take (length list - 1) list;
 
 

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -509,7 +509,8 @@ rec {
        => 3
   */
   last = list:
-    assert list != []; elemAt list (length list - 1);
+    assert assertMsg (list != []) "lists.last: list must not be empty!";
+    elemAt list (length list - 1);
 
   /* Return all elements but the last
 
@@ -517,7 +518,9 @@ rec {
        init [ 1 2 3 ]
        => [ 1 2 ]
   */
-  init = list: assert list != []; take (length list - 1) list;
+  init = list:
+    assert assertMsg (list != []) "lists.init: list must not be empty!";
+    take (length list - 1) list;
 
 
   /* return the image of the cross product of some lists by a function

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -401,7 +401,7 @@ rec {
       components = splitString "/" url;
       filename = lib.last components;
       name = builtins.head (splitString sep filename);
-    in assert name !=  filename; name;
+    in assert name != filename; name;
 
   /* Create an --{enable,disable}-<feat> string that can be passed to
      standard GNU Autoconf scripts.
@@ -459,7 +459,10 @@ rec {
       strw = lib.stringLength str;
       reqWidth = width - (lib.stringLength filler);
     in
-      assert strw <= width;
+      assert lib.assertMsg (strw <= width)
+        "fixedWidthString: requested string length (${
+          toString width}) must not be shorter than actual length (${
+            toString strw})";
       if strw == width then str else filler + fixedWidthString reqWidth filler str;
 
   /* Format a number adding leading zeroes up to fixed width.

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -203,11 +203,29 @@ rec {
      Type:
        assertMsg :: Bool -> String -> Bool
   */
+  # TODO(Profpatsch): add tests that check stderr
   assertMsg = pred: msg:
     if pred
     then true
     else builtins.trace msg false;
 
+  /* Specialized `assertMsg` for checking if val is one of the elements
+     of a list. Useful for checking enums.
+
+     Example:
+       let sslLibrary = "libressl"
+       in assertOneOf "sslLibrary" sslLibrary [ "openssl" "bearssl" ]
+       => false
+       stderr> trace: sslLibrary must be one of "openssl", "bearssl", but is: "libressl"
+
+     Type:
+       assertOneOf :: String -> ComparableVal -> List ComparableVal -> Bool
+  */
+  assertOneOf = name: val: xs: assertMsg
+    (lib.elem val xs)
+    "${name} must be one of ${
+      lib.generators.toPretty {} xs}, but is: ${
+        lib.generators.toPretty {} val}";
 
   ## Function annotations
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -171,7 +171,7 @@ rec {
     builtins.fromJSON (builtins.readFile path);
 
 
-  ## Warnings and asserts
+  ## Warnings
 
   /* See https://github.com/NixOS/nix/issues/749. Eventually we'd like these
      to expand to Nix builtins that carry metadata so that Nix can filter out
@@ -188,44 +188,6 @@ rec {
   warn = msg: builtins.trace "WARNING: ${msg}";
   info = msg: builtins.trace "INFO: ${msg}";
 
-  /* Print a trace message if pred is false.
-     Intended to be used to augment asserts with helpful error messages.
-
-     Example:
-       assertMsg false "nope"
-       => false
-       stderr> trace: nope
-
-       assert (assertMsg ("foo" == "bar") "foo is not bar, silly"); ""
-       stderr> trace: foo is not bar, silly
-       stderr> assert failed at …
-
-     Type:
-       assertMsg :: Bool -> String -> Bool
-  */
-  # TODO(Profpatsch): add tests that check stderr
-  assertMsg = pred: msg:
-    if pred
-    then true
-    else builtins.trace msg false;
-
-  /* Specialized `assertMsg` for checking if val is one of the elements
-     of a list. Useful for checking enums.
-
-     Example:
-       let sslLibrary = "libressl"
-       in assertOneOf "sslLibrary" sslLibrary [ "openssl" "bearssl" ]
-       => false
-       stderr> trace: sslLibrary must be one of "openssl", "bearssl", but is: "libressl"
-
-     Type:
-       assertOneOf :: String -> ComparableVal -> List ComparableVal -> Bool
-  */
-  assertOneOf = name: val: xs: assertMsg
-    (lib.elem val xs)
-    "${name} must be one of ${
-      lib.generators.toPretty {} xs}, but is: ${
-        lib.generators.toPretty {} val}";
 
   ## Function annotations
 

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -188,6 +188,26 @@ rec {
   warn = msg: builtins.trace "WARNING: ${msg}";
   info = msg: builtins.trace "INFO: ${msg}";
 
+  /* Print a trace message if pred is false.
+     Intended to be used to augment asserts with helpful error messages.
+
+     Example:
+       assertMsg false "nope"
+       => false
+       stderr> trace: nope
+
+       assert (assertMsg ("foo" == "bar") "foo is not bar, silly"); ""
+       stderr> trace: foo is not bar, silly
+       stderr> assert failed at …
+
+     Type:
+       assertMsg :: Bool -> String -> Bool
+  */
+  assertMsg = pred: msg:
+    if pred
+    then true
+    else builtins.trace msg false;
+
 
   ## Function annotations
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -119,7 +119,9 @@ rec {
       let
         betweenDesc = lowest: highest:
           "${toString lowest} and ${toString highest} (both inclusive)";
-        between = lowest: highest: assert lowest <= highest;
+        between = lowest: highest:
+          assert lib.assertMsg (lowest <= highest)
+            "ints.between: lowest must be smaller than highest";
           addCheck int (x: x >= lowest && x <= highest) // {
             name = "intBetween";
             description = "integer between ${betweenDesc lowest highest}";
@@ -439,7 +441,9 @@ rec {
     # Either value of type `finalType` or `coercedType`, the latter is
     # converted to `finalType` using `coerceFunc`.
     coercedTo = coercedType: coerceFunc: finalType:
-      assert coercedType.getSubModules == null;
+      assert assertMsg (coercedType.getSubModules == null)
+        "coercedTo: coercedType must not have submodules (it’s a ${
+          coercedType.description})";
       mkOptionType rec {
         name = "coercedTo";
         description = "${finalType.description} or ${coercedType.description} convertible to it";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -441,7 +441,7 @@ rec {
     # Either value of type `finalType` or `coercedType`, the latter is
     # converted to `finalType` using `coerceFunc`.
     coercedTo = coercedType: coerceFunc: finalType:
-      assert assertMsg (coercedType.getSubModules == null)
+      assert lib.assertMsg (coercedType.getSubModules == null)
         "coercedTo: coercedType must not have submodules (it’s a ${
           coercedType.description})";
       mkOptionType rec {

--- a/pkgs/applications/misc/lilyterm/default.nix
+++ b/pkgs/applications/misc/lilyterm/default.nix
@@ -1,13 +1,12 @@
-{ stdenv, fetchurl, fetchFromGitHub
+{ stdenv, lib, fetchurl, fetchFromGitHub
 , pkgconfig
 , autoconf, automake, intltool, gettext
 , gtk, vte
 
-# "stable" or "git"
 , flavour ? "stable"
 }:
 
-assert flavour == "stable" || flavour == "git";
+assert lib.assertOneOf "flavour" flavour [ "stable"  "git" ];
 
 let
   stuff =

--- a/pkgs/applications/science/math/ripser/default.nix
+++ b/pkgs/applications/science/math/ripser/default.nix
@@ -8,7 +8,8 @@
 
 with stdenv.lib;
 
-assert elem fileFormat ["lowerTriangularCsv" "upperTriangularCsv" "dipha"];
+assert assertOneOf "fileFormat" fileFormat
+  ["lowerTriangularCsv" "upperTriangularCsv" "dipha"];
 assert useGoogleHashmap -> sparsehash != null;
 
 let


### PR DESCRIPTION
This is a cute little trick to make nix print an error message if an assertion fails.
It was lingering in my local repo for quite some time.