### PR TITLE
Plasma Wayland

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -11,7 +11,7 @@
   kcoreaddons, kcrash, kdeclarative, kdecoration, kglobalaccel, ki18n,
   kiconthemes, kidletime, kinit, kio, knewstuff, knotifications, kpackage,
   kscreenlocker, kservice, kwayland, kwidgetsaddons, kwindowsystem, kxmlgui,
-  plasma-framework, qtsensors, libcap
+  plasma-framework, qtsensors, libcap, libdrm
 }:
 
 mkDerivation {
@@ -27,7 +27,7 @@ mkDerivation {
     kcoreaddons kcrash kdeclarative kdecoration kglobalaccel ki18n kiconthemes
     kidletime kinit kio knewstuff knotifications kpackage kscreenlocker kservice
     kwayland kwidgetsaddons kwindowsystem kxmlgui plasma-framework
-    libcap
+    libcap libdrm
   ];
   outputs = [ "bin" "dev" "out" ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
+++ b/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
@@ -907,10 +907,10 @@ index dd9e304d..49d456e9 100644
 -    }
  fi
  
- kstartupconfig5
+-kstartupconfig5
++@CMAKE_INSTALL_FULL_BINDIR@/kstartupconfig5
  returncode=$?
--if test $returncode -ne 0; then
-+if ! @CMAKE_INSTALL_FULL_BINDIR@/kstartupconfig5; then
+ if test $returncode -ne 0; then
      exit 1
  fi
 -[ -r $configDir/startupconfig ] && . $configDir/startupconfig


### PR DESCRIPTION
###### Motivation for this change
Adds support for starting Plasma under Wayland. However, it still requires the following patch to get it shown in SDDM:
```
diff --git a/nixos/modules/services/x11/display-managers/sddm.nix b/nixos/modules/services/x11/display-managers/sddm.nix
index 426b899586f..66e481bc6f5 100644
--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -58,6 +58,8 @@ let
 
     [Wayland]
     EnableHidpi=${if cfg.enableHidpi then "true" else "false"}
+    SessionCommand=${lib.getBin pkgs.sddm}/share/sddm/scripts/wayland-session
+    SessionDir=/etc/wayland
 
     ${optionalString cfg.autoLogin.enable ''
     [Autologin]
@@ -262,10 +264,21 @@ in
       home = "/var/lib/sddm";
       group = "sddm";
       uid = config.ids.uids.sddm;
+      extraGroups = [ "video" ];
     };
 
     environment.etc."sddm.conf".source = cfgFile;
 
+    environment.etc."wayland/plasma-wayland.desktop".text = ''
+      [Desktop Entry]
+      Encoding=UTF-8
+      Type=Application
+      Exec=/run/current-system/sw/bin/dbus-run-session ${lib.getBin pkgs.plasma-workspace}/bin/startplasmacompositor
+      TryExec=${lib.getBin pkgs.plasma-workspace}/bin/startplasmacompositor
+      DesktopNames=KDE
+      Name=Plasma-wayland
+    '';
+
     users.groups.sddm.gid = config.ids.gids.sddm;
 
     environment.systemPackages = [ sddm ];
```

CC @worldofpeace @adisbladis @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

