### PR TITLE
unixODBCDrivers.msodbcsql17: init at 17.2.0.1

### DIFF
--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql55, mariadb, sqlite, zlib, libxml2, dpkg, lib, openssl, kerberos, curl, libuuid }:
+{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql55, mariadb, sqlite, zlib, libxml2, dpkg, lib, openssl, kerberos, curl, libuuid, autoPatchelfHook }:
 
 # I haven't done any parameter tweaking.. So the defaults provided here might be bad
 
@@ -133,19 +133,18 @@
       sha256 = "1966ymbbk0jsacqwzi3dmhxv2n8hfgnpjsx3hr3n7s9d88chgpx5";
     };
 
-    buildInputs = [ unixODBC dpkg];
+    nativeBuildInputs = [ autoPatchelfHook ];
+    buildInputs = [ unixODBC dpkg openssl kerberos curl libuuid stdenv.cc.cc ];
 
     unpackPhase = "dpkg -x $src ./";
     buildPhase = "";
 
     installPhase = ''
       mkdir -p $out
-      mkdir -p $out/libshim
-      ln -s ${lib.makeLibraryPath [openssl]}/libssl.so.1.0.0 $out/libshim/libssl.so.1.0.2
-      ln -s ${lib.makeLibraryPath [openssl]}/libcrypto.so.1.0.0 $out/libshim/libcrypto.so.1.0.2
+      mkdir -p $out/lib
+      ln -s ${lib.makeLibraryPath [openssl]}/libssl.so.1.0.0 $out/lib/libssl.so.1.0.2
+      ln -s ${lib.makeLibraryPath [openssl]}/libcrypto.so.1.0.0 $out/lib/libcrypto.so.1.0.2
       cp -r opt/microsoft/msodbcsql${versionMajor}/lib64 opt/microsoft/msodbcsql${versionMajor}/share $out/
-      patchelf --set-rpath ${lib.makeLibraryPath [ openssl unixODBC kerberos curl libuuid stdenv.cc.cc]}:$out/libshim \
-        $out/lib64/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}
     '';
 
     passthru = {

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -142,8 +142,8 @@
     installPhase = ''
       mkdir -p $out
       mkdir -p $out/lib
-      ln -s ${lib.makeLibraryPath [openssl]}/libssl.so.1.0.0 $out/lib/libssl.so.1.0.2
-      ln -s ${lib.makeLibraryPath [openssl]}/libcrypto.so.1.0.0 $out/lib/libcrypto.so.1.0.2
+      ln -s ${lib.getLib openssl}/lib/libssl.so.1.0.0 $out/lib/libssl.so.1.0.2
+      ln -s ${lib.getLib openssl}/lib/libcrypto.so.1.0.0 $out/lib/libcrypto.so.1.0.2
       cp -r opt/microsoft/msodbcsql${versionMajor}/lib64 opt/microsoft/msodbcsql${versionMajor}/share $out/
     '';
 

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql55, mariadb, sqlite, zlib, libxml2 }:
+{ fetchurl, stdenv, unixODBC, cmake, postgresql, mysql55, mariadb, sqlite, zlib, libxml2, dpkg, lib, openssl, kerberos, curl, libuuid }:
 
 # I haven't done any parameter tweaking.. So the defaults provided here might be bad
 
@@ -117,6 +117,48 @@
       license = licenses.bsd2;
       platforms = platforms.linux;
       maintainers = with maintainers; [ vlstill ];
+    };
+  };
+
+  msodbcsql17 = stdenv.mkDerivation rec {
+    name = "msodbcsql17-${version}";
+    version = "${versionMajor}.${versionMinor}.${versionAdditional}-1";
+
+    versionMajor = "17";
+    versionMinor = "2";
+    versionAdditional = "0.1";
+
+    src = fetchurl {
+      url = "https://packages.microsoft.com/debian/9/prod/pool/main/m/msodbcsql17/msodbcsql${versionMajor}_${version}_amd64.deb";
+      sha256 = "1966ymbbk0jsacqwzi3dmhxv2n8hfgnpjsx3hr3n7s9d88chgpx5";
+    };
+
+    buildInputs = [ unixODBC dpkg];
+
+    unpackPhase = "dpkg -x $src ./";
+    buildPhase = "";
+
+    installPhase = ''
+      mkdir -p $out
+      mkdir -p $out/libshim
+      ln -s ${lib.makeLibraryPath [openssl]}/libssl.so.1.0.0 $out/libshim/libssl.so.1.0.2
+      ln -s ${lib.makeLibraryPath [openssl]}/libcrypto.so.1.0.0 $out/libshim/libcrypto.so.1.0.2
+      cp -r opt/microsoft/msodbcsql${versionMajor}/lib64 opt/microsoft/msodbcsql${versionMajor}/share $out/
+      patchelf --set-rpath ${lib.makeLibraryPath [ openssl unixODBC kerberos curl libuuid stdenv.cc.cc]}:$out/libshim \
+        $out/lib64/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}
+    '';
+
+    passthru = {
+      fancyName = "ODBC Driver 17 for SQL Server";
+      driver = "lib/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}";
+    };
+
+    meta = with stdenv.lib; {
+      description = "ODBC Driver 17 for SQL Server";
+      homepage = https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-2017;
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ spencerjanssen ];
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This patch adds Microsoft's ODBC driver for SQL Server.  I have tested it on NixOS against SQL Server 2008 and it has worked quite reliably in that scenario.

I'm new to packaging binaries with Nix and would appreciate feedback.  The 'libshim' symlinks in particular I'm not sure about -- the driver is linked against specific names of libssl and libcrypto and I couldn't find another way to provide or fake those names.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

