### PR TITLE
altcoins.mist: 0.10.0 -> 0.11.1

### DIFF
--- a/pkgs/applications/altcoins/mist.nix
+++ b/pkgs/applications/altcoins/mist.nix
@@ -1,8 +1,8 @@
-{ stdenv, makeWrapper, fetchurl, unzip, atomEnv, makeDesktopItem, buildFHSUserEnv }:
+{ stdenv, makeWrapper, fetchurl, unzip, atomEnv, makeDesktopItem, buildFHSUserEnv, gtk2 }:
 
 let
-  version = "0.10.0";
-  name = "mist-${version}";
+  version = "0.11.1";
+  name = "mist";
 
   throwSystem = throw "Unsupported system: ${stdenv.system}";
 
@@ -31,11 +31,11 @@ let
     src = {
       i686-linux = fetchurl {
         url = "https://github.com/ethereum/mist/releases/download/v${version}/Mist-linux32-${urlVersion}.zip";
-        sha256 = "01hvxlm9w522pwvsjdy18gsrapkfjr7d1jjl4bqjjysxnjaaj2lk";
+        sha256 = "1ffzp9aa0g6w3d5pzp69fljk3sd51cbqdgxa1x16vj106sqm0gj7";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/ethereum/mist/releases/download/v${version}/Mist-linux64-${urlVersion}.zip";
-        sha256 = "01k17j7fdfhxfd26njdsiwap0xnka2536k9ydk32czd8db7ya9zi";
+        sha256 = "0yx4x72l8gk68yh9saki48zgqx8k92xnkm79dc651wdpd5c25cz3";
       };
     }.${stdenv.system} or throwSystem;
 
@@ -50,13 +50,14 @@ let
       ln -s ${desktopItem}/share/applications/* $out/share/applications
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${atomEnv.libPath}:$out/lib/mist" \
+        --set-rpath "${atomEnv.libPath}:${gtk2}/lib:$out/lib/mist" \
         $out/lib/mist/mist
     '';
   });
 in
 buildFHSUserEnv {
-  inherit name meta;
+  name = "mist";
+  inherit meta;
 
   targetPkgs = pkgs: with pkgs; [
      mist


### PR DESCRIPTION
###### Motivation for this change

Update the Mist browser to the latest version and fix an issue similar to #43297

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

