### PR TITLE
Update skarnet packages & add ssl support to s6-networking

### DIFF
--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.6.0.1";
+  version = "2.6.4.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/skalibs";
     rev = "refs/tags/v${version}";
-    sha256 = "0skdv3wff1i78hb0y771apw0cak5rzxbwbh6l922snfm01z9k1ws";
+    sha256 = "13icrwxxb7k3cj37dl07h0apk6lwyrg1qrwjwh4l82i8f32bnjz2";
   };
 
   outputs = [ "lib" "dev" "doc" "out" ];

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.3.0.3";
+  version = "2.5.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/execline";
     rev = "refs/tags/v${version}";
-    sha256 = "1q0izb8ajzxl36fjpy4rn63sz01055r9s33fga99jprdmkkfzz6x";
+    sha256 = "19vd8252g5bmzm4i9gybpj7i2mhsflcgfl4ns5k3g1vv7f69i1dn";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.2.0.1";
+  version = "2.3.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-dns";
     rev = "refs/tags/v${version}";
-    sha256 = "10qvkh608nsx8gqs3pj4pb8aivwpshbmjw2766grgmrb35d31brl";
+    sha256 = "1hczdg3dzi9z6f0wicm2qa2239fiax915zp66xspdz6qd23nqrxb";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "0.3.0.0";
+  version = "0.4.0.1";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-rc";
     rev = "refs/tags/v${version}";
-    sha256 = "174a3l92nkhxrx8gq36xmb5a7krj40iz1xdiii25nxwjfiw5ynfb";
+    sha256 = "10gkkdbvkb4s2yshx425v9diwm7vvbl320a2bm0c3wz71xr94wsw";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.6.1.1";
+  version = "2.7.1.1";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6";
     rev = "refs/tags/v${version}";
-    sha256 = "162hng8xcwjp8pr4d78zq3f82lm9c6ldbcfll0mjsmnxdds5hrsg";
+    sha256 = "0dncw3h9wc4cgc9q8zjwicgbcqcn6722yhk8g9bvrhs7h4fkfqav";
   };
 
   # NOTE lib: cannot split lib from bin at the moment,


### PR DESCRIPTION
This should leave all skarnet packages in nixpkgs at their currently latest versions.
`s6-networking` gets `libressl` as additional input, so that it creates two new binaries, `s6-tlsclient` and `s6-tlsserver`.

cc other maintainer @pmahoney 