### PR TITLE
tengine: init init at v2.2.2

### DIFF
--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -60,7 +60,10 @@ stdenv.mkDerivation rec {
     ++ optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
     ++ map (mod: "--add-module=${mod.src}") modules;
 
-  NIX_CFLAGS_COMPILE = [ "-I${libxml2.dev}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
+  NIX_CFLAGS_COMPILE = [
+    "-I${libxml2.dev}/include/libxml2"
+    "-Wno-error=implicit-fallthrough"
+  ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
 
   preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
 

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -1,0 +1,82 @@
+{ stdenv, fetchurl, openssl, zlib, pcre, libxml2, libxslt
+, gd, geoip
+, withDebug ? false
+, withMail ? false
+, withIPv6 ? true
+, modules ? []
+, ...
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "2.2.2";
+  name = "tengine-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/alibaba/tengine/archive/${name}.tar.gz";
+    sha256 = "1vq73wsldvj7rc61ag85pvnaacrrq9rs0pfqv71z5iyvb5r3bxc2";
+  };
+
+  buildInputs =
+    [ openssl zlib pcre libxml2 libxslt gd geoip ]
+    ++ concatMap (mod: mod.inputs or []) modules;
+
+  configureFlags = [
+    "--with-http_ssl_module"
+    "--with-http_v2_module"
+    "--with-http_realip_module"
+    "--with-http_addition_module"
+    "--with-http_xslt_module"
+    "--with-http_geoip_module"
+    "--with-http_sub_module"
+    "--with-http_dav_module"
+    "--with-http_flv_module"
+    "--with-http_mp4_module"
+    "--with-http_gunzip_module"
+    "--with-http_gzip_static_module"
+    "--with-http_auth_request_module"
+    "--with-http_concat_module"
+    "--with-http_random_index_module"
+    "--with-http_secure_link_module"
+    "--with-http_degradation_module"
+    "--with-http_stub_status_module"
+    "--with-http_sysguard_module"
+    "--with-threads"
+    "--with-pcre-jit"
+    "--with-http_slice_module"
+  ] ++ optional withDebug [
+    "--with-debug"
+  ] ++ optional withMail [
+    "--with-mail"
+    "--with-mail_ssl_module"
+  ] ++ optional (withMail != true) [
+    "--without-mail_pop3_module"
+    "--without-mail_imap_module"
+    "--without-mail_smtp_module"
+  ] ++ optional withIPv6 [
+    "--with-ipv6"
+  ] ++ optional (gd != null) "--with-http_image_filter_module"
+    ++ optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
+    ++ map (mod: "--add-module=${mod.src}") modules;
+
+  NIX_CFLAGS_COMPILE = [ "-I${libxml2.dev}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
+
+  preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
+
+  hardeningEnable = optional (!stdenv.isDarwin) "pie";
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    mv $out/sbin $out/bin
+  '';
+
+  meta = {
+    description = "A web server based on Nginx and has many advanced features, originated by Taobao.";
+    homepage    = https://tengine.taobao.org;
+    license     = licenses.bsd2;
+    platforms   = platforms.all;
+    maintainers = with maintainers; [ izorkin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19955,8 +19955,7 @@ with pkgs;
   teeworlds = callPackage ../games/teeworlds { };
 
   tengine = callPackage ../servers/http/tengine {
-    stdenv = overrideCC stdenv gcc6;
-    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.modsecurity-nginx];
+    modules = with nginxModules; [ rtmp dav moreheaders modsecurity-nginx ];
   };
 
   tennix = callPackage ../games/tennix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19954,6 +19954,11 @@ with pkgs;
 
   teeworlds = callPackage ../games/teeworlds { };
 
+  tengine = callPackage ../servers/http/tengine {
+    stdenv = overrideCC stdenv gcc6;
+    modules = [ nginxModules.rtmp nginxModules.dav nginxModules.moreheaders nginxModules.modsecurity-nginx];
+  };
+
   tennix = callPackage ../games/tennix { };
 
   terraria-server = callPackage ../games/terraria-server { };


### PR DESCRIPTION
###### Motivation for this change
Add web server tengine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

