### PR TITLE
mpv: patch shebang for macOS

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -92,7 +92,7 @@ in stdenv.mkDerivation rec {
   };
 
   postPatch = ''
-    patchShebangs ./TOOLS/
+    patchShebangs ./TOOLS/ version.sh
   '';
 
   NIX_LDFLAGS = optionalString x11Support "-lX11 -lXext "
@@ -156,7 +156,8 @@ in stdenv.mkDerivation rec {
       CoreFoundation libiconv Cocoa CoreAudio
     ]);
 
-  enableParallelBuilding = true;
+  # TODO: remove me when I found out where macOS failed
+  enableParallelBuilding = false;
 
   buildPhase = ''
     python3 ${waf} build


### PR DESCRIPTION
###### Motivation for this change

mpv is broken as of: https://github.com/NixOS/nixpkgs/pull/43977
not sure if this works, let's wait for ofBorg....

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

