### PR TITLE
javacard-devkit: init at 2.2.2

### DIFF
--- a/pkgs/development/compilers/javacard-devkit/default.nix
+++ b/pkgs/development/compilers/javacard-devkit/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, requireFile, unzip, makeWrapper, oraclejdk8, autoPatchelfHook
+, pcsclite
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "javacard-devkit";
+  version = "2.2.2";
+  uscoreVersion = builtins.replaceStrings ["."] ["_"] version;
+
+  src = requireFile {
+    name = "java_card_kit-${uscoreVersion}-linux.zip";
+    url = "http://www.oracle.com/technetwork/java/javasebusiness/downloads/"
+        + "java-archive-downloads-javame-419430.html#java_card_kit-2.2.2-oth-JPR";
+    sha256 = "1rzkw8izqq73ifvyp937wnjjc40a40drc4zsm0l1s6jyv3d7agb2";
+  };
+
+  nativeBuildInputs = [ unzip oraclejdk8 makeWrapper autoPatchelfHook ];
+  buildInputs = [ pcsclite ];
+
+  zipPrefix = "java_card_kit-${uscoreVersion}";
+
+  sourceRoot = ".";
+  unpackCmd = ''
+    unzip -p "$curSrc" "$zipPrefix/$zipPrefix-rr-bin-linux-do.zip" | jar x
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/share/$pname"
+    cp -rt "$out/share/$pname" api_export_files
+    cp -rt "$out" lib
+
+    for i in bin/*; do
+      case "$i" in
+        *.so) install -vD "$i" "$out/libexec/$pname/$(basename "$i")";;
+        *) target="$out/bin/$(basename "$i")"
+           install -vD "$i" "$target"
+           wrapProgram "$target" \
+             --set JAVA_HOME "$JAVA_HOME" \
+             --prefix CLASSPATH : "$out/share/$pname/api_export_files"
+           ;;
+      esac
+    done
+
+    makeWrapper "$JAVA_HOME/bin/javac" "$out/bin/javacardc" \
+      --prefix CLASSPATH : "$out/lib/api.jar"
+  '';
+
+  meta = {
+    description = "Official development kit by Oracle for programming for the Java Card platform";
+    longDescription = ''
+      This Java Card SDK is the official SDK made available by Oracle for programming for the Java Card platform.
+
+      Instructions for usage:
+
+      First, compile your '.java' (NixOS-specific: you should not need to set the class path -- if you need, it's a bug):
+          javacardc -source 1.5 -target 1.5 [MyJavaFile].java
+      Then, convert the '.class' file into a '.cap':
+          converter -applet [AppletAID] [MyApplet] [myPackage] [PackageAID] [Version]
+      For more details, please refer to the documentation by Oracle
+    '';
+    homepage = http://www.oracle.com/technetwork/java/embedded/javacard/overview/index.html;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.ekleog ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6787,6 +6787,8 @@ with pkgs;
   oraclejdk10distro = packageType: _:
       (callPackage ../development/compilers/oraclejdk/jdk10-linux.nix { inherit packageType; });
 
+  javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };
+
   jikes = callPackage ../development/compilers/jikes { };
 
   julia_04 = callPackage ../development/compilers/julia {


### PR DESCRIPTION
Oracle has already released 3.0.5, but versions after 2.2.2 appear to be Windows-only.

This derivation will override `javac` in order to give it the paths required for JavaCard programming.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

