### PR TITLE
zsh-command-time: disable exec flag

### DIFF
--- a/pkgs/shells/zsh/zsh-command-time/default.nix
+++ b/pkgs/shells/zsh/zsh-command-time/default.nix
@@ -18,8 +18,10 @@ stdenv.mkDerivation rec {
     sha256 = "1bvyjgz6bhgg1nwr56r50p6fblgah6yiql55pgm5abnn2h876fjq";
   };
 
+  phases = [ "installPhase" ];
+
   installPhase = ''
-    install -D $src/command-time.plugin.zsh --target-directory=$out/share/zsh-command-time
+    install -Dm444 $src/command-time.plugin.zsh --target-directory=$out/share/zsh-command-time
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
ZSH plugins command-time - disable executable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

