### PR TITLE
gcc8: 8.1 -> 8.2

### DIFF
--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -38,7 +38,7 @@ assert langGo -> langCC;
 with stdenv.lib;
 with builtins;
 
-let version = "8.1.0";
+let version = "8.2.0";
 
     enableParallelBuilding = true;
 
@@ -127,7 +127,7 @@ stdenv.mkDerivation ({
 
   src = fetchurl {
     url = "mirror://gcc/releases/gcc-${version}/gcc-${version}.tar.xz";
-    sha256 = "0lxil8x0jjx7zbf90cy1rli650akaa6hpk8wk8s62vk2jbwnc60x";
+    sha256 = "10007smilswiiv2ymazr3b6x2i933c0ycxrr529zh4r6p823qv0r";
   };
 
   inherit patches;


### PR DESCRIPTION
https://gcc.gnu.org/gcc-8/changes.html

###### Motivation for this change

Second in 8 series, lots of fixes!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Don't think "WIP" is quite right, but definitely could use some testing.  I don't believe this has any in-tree users (other than the cc-tests), but it'd be good to test on major platforms/configurations, like we did for 8.1.

cc #39866