### PR TITLE
pythonPackages.sabyenc: init at 2.3.3

### DIFF
--- a/pkgs/development/python-modules/sabyenc/default.nix
+++ b/pkgs/development/python-modules/sabyenc/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "sabyenc";
+  version = "3.3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fpvd5mckf1kbn0bhc5ybm08y41ps7sc5f9khz08qyjbikbcww85";
+  };
+
+  # tests are not included in pypi distribution
+  doCheck = false;
+
+  meta = {
+    description = "Python yEnc package optimized for use within SABnzbd";
+    homepage = "https://github.com/sabnzbd/sabyenc/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.georgewhewell ];
+  };
+
+}

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchFromGitHub, python2, par2cmdline, unzip, unrar, p7zip, makeWrapper}:
 
 let
-  pythonEnv = python2.withPackages(ps: with ps; [ cryptography cheetah yenc ]);
+  pythonEnv = python2.withPackages(ps: with ps; [ cryptography cheetah yenc sabyenc ]);
   path = stdenv.lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
   version = "2.3.3";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -470,6 +470,8 @@ in {
 
   rx = callPackage ../development/python-modules/rx { };
 
+  sabyenc = callPackage ../development/python-modules/sabyenc { };
+
   salmon-mail = callPackage ../development/python-modules/salmon-mail { };
 
   seekpath = callPackage ../development/python-modules/seekpath { };


### PR DESCRIPTION
###### Motivation for this change
sabnzbd has started complaining about missing sabyenc module (which apparently offers better performance), so package it and add to sabnzbd dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

