### PR TITLE
fzf: fix invalid symlink on vim-plugins

### DIFF
--- a/pkgs/tools/misc/fzf/default.nix
+++ b/pkgs/tools/misc/fzf/default.nix
@@ -42,8 +42,8 @@ buildGoPackage rec {
     cp $src/bin/fzf-tmux $bin/bin
     mkdir -p $man/share/man
     cp -r $src/man/man1 $man/share/man
-    mkdir -p $out/share/vim-plugins
-    ln -s $out/share/go/src/github.com/junegunn/fzf $out/share/vim-plugins/${name}
+    mkdir -p $out/share/vim-plugins/${name}
+    cp -r $src/plugin $out/share/vim-plugins/${name}
 
     cp -R $src/shell $bin/share/fzf
     cat <<SCRIPT > $bin/bin/fzf-share


### PR DESCRIPTION
###### Motivation for this change

The fzf vim plugin wasn't working because it was making a symlink to a
directory with the full source code of fzf. This directory isn't present
anymore since the commit e95f17e2720e67e2eabd59d7754c814d3e27a0b2 wich
removes it because it isn't so useful for the go packages.


###### Things done

I fixed it by manually copying the plugin/ directory into the out
derivation, which is the only part of the source that contains the vim
plugin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

