### PR TITLE
biboumi: 7.2 -> 8.3

### DIFF
--- a/pkgs/servers/xmpp/biboumi/catch.patch
+++ b/pkgs/servers/xmpp/biboumi/catch.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -273,27 +273,6 @@ foreach(file ${source_all})
+@@ -303,27 +303,6 @@
  endforeach()
  
  #
@@ -19,7 +19,7 @@
 -ExternalProject_Get_Property(catch SOURCE_DIR)
 -if(NOT EXISTS ${CMAKE_SOURCE_DIR}/tests/catch.hpp)
 -  target_include_directories(test_suite
--    PUBLIC "${SOURCE_DIR}/include/"
+-    PUBLIC "${SOURCE_DIR}/single_include/"
 -    )
 -  add_dependencies(test_suite catch)
 -endif()

--- a/pkgs/servers/xmpp/biboumi/default.nix
+++ b/pkgs/servers/xmpp/biboumi/default.nix
@@ -3,17 +3,17 @@
 
 stdenv.mkDerivation rec {
   name = "biboumi-${version}";
-  version = "7.2";
+  version = "8.3";
 
   src = fetchurl {
     url = "https://git.louiz.org/biboumi/snapshot/biboumi-${version}.tar.xz";
-    sha256 = "0gyr2lp2imrjm5hvijcq0s7k9fzkirfl70cprjy9r4yvq6mg1jvd";
+    sha256 = "0896f52nh8vd0idkdznv3gj6wqh1nqhjbwv0m560f0h62f01vm7k";
   };
 
   louiz_catch = fetchgit {
     url = https://lab.louiz.org/louiz/Catch.git;
-    rev = "35f510545d55a831372d3113747bf1314ff4f2ef";
-    sha256 = "1l5b32sgr9zc2hlfr445hwwxv18sh3cn5q1xmvf588z6jyf88g2g";
+    rev = "0a34cc201ef28bf25c88b0062f331369596cb7b7"; # v2.2.1
+    sha256 = "0ad0sjhmzx61a763d2ali4vkj8aa1sbknnldks7xlf4gy83jfrbl";
   };
 
   patches = [ ./catch.patch ];


### PR DESCRIPTION
###### Motivation for this change

Version 8.3 was released on 2018-06-01, see [here](https://lab.louiz.org/louiz/biboumi/blob/8.3/CHANGELOG.rst) for a changelog.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

If you can contact me on IRC, this package works.