### PR TITLE
Nginx modules

### DIFF
--- a/pkgs/development/libraries/msgpuck/default.nix
+++ b/pkgs/development/libraries/msgpuck/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  name = "msgpuck-${version}";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "rtsisyk";
+    repo = "msgpuck";
+    rev = "${version}";
+    sha256 = "0cjq86kncn3lv65vig9cqkqqv2p296ymcjjbviw0j1s85cfflps0";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  meta = with stdenv.lib; {
+     description = ''A simple and efficient MsgPack binary serialization library in a self-contained header file'';
+     homepage = https://github.com/rtsisyk/msgpuck;
+     license = licenses.bsd2;
+     platforms = platforms.linux;
+     maintainers = with maintainers; [ izorkin ];
+ };
+}

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -224,6 +224,16 @@
     };
   };
 
+  upstream-tarantool = {
+    src = fetchFromGitHub {
+      owner = "tarantool";
+      repo = "nginx_upstream_module";
+      rev = "v2.7";
+      sha256 = "05dwj0caj910p7kan2qjvm6x2x601igryhny2xzr47hhsk5q1cnx";
+    };
+    inputs = [ pkgs.msgpuck.dev pkgs.yajl ];
+  };
+
   vts = {
     src = fetchFromGitHub {
       owner = "vozlt";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -161,6 +161,15 @@
     inputs = [ pkgs.pam ];
   };
 
+  push-stream ={
+    src = fetchFromGitHub {
+      owner = "wandenberg";
+      repo = "nginx-push-stream-module";
+      rev = "0.5.4";
+      sha256 = "0izn7lqrp2zfl738aqa9i8c5lba97wkhcnqg8qbw3ipp5cysb2hr";
+    };
+  };
+
   rtmp ={
     src = fetchFromGitHub {
       owner = "arut";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -214,4 +214,13 @@
       sha256 = "1cjisxw1wykll683nw09k0i1nvzslp4dr59x58cvarpk43paim2y";
     };
   };
+
+  vts = {
+    src = fetchFromGitHub {
+      owner = "vozlt";
+      repo = "nginx-module-vts";
+      rev = "v0.1.18";
+      sha256 = "1jq2s9k7hah3b317hfn9y3g1q4g4x58k209psrfsqs718a9sw8c7";
+    };
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8341,6 +8341,8 @@ with pkgs;
 
   msgpack-tools = callPackage ../development/tools/msgpack-tools { };
 
+  msgpuck = callPackage ../development/libraries/msgpuck { };
+
   msitools = callPackage ../development/tools/misc/msitools { };
 
   multi-ghc-travis = haskell.lib.justStaticExecutables haskellPackages.multi-ghc-travis;


### PR DESCRIPTION
###### Motivation for this change
Add nginx modules - vts, push-stream, upstream-tarantool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

