### PR TITLE
llvm-packages: fix manpages on darwin

### DIFF
--- a/pkgs/development/compilers/llvm/4/default.nix
+++ b/pkgs/development/compilers/llvm/4/default.nix
@@ -1,5 +1,5 @@
-{ lowPrio, newScope, stdenv, cmake, libstdcxxHook
-, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
+{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -16,25 +16,28 @@ let
   compiler-rt_src = fetch "compiler-rt" "0h5lpv1z554szi4r4blbskhwrkd78ir50v3ng8xvk1s86fa7gj53";
   clang-tools-extra_src = fetch "clang-tools-extra" "1dhmp7ccfpr42bmvk3kp37ngjpf3a9m5d4kkpsn7d00hzi7fdl9m";
 
-  # Add man output without introducing extra dependencies.
-  overrideManOutput = drv:
-    let drv-manpages = drv.override { enableManpages = true; }; in
-    drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
-
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
   in {
 
-    llvm = overrideManOutput (callPackage ./llvm.nix {
+    llvm = callPackage ./llvm.nix {
       inherit compiler-rt_src;
-    });
-    clang-unwrapped = overrideManOutput (callPackage ./clang {
+    };
+    clang-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
+    };
+
+    llvm-manpages = lowPrio (tools.llvm.override {
+      enableManpages = true;
+      python = pkgs.python;  # don't use python-boot
+    });
+
+    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+      enableManpages = true;
+      python = pkgs.python;  # don't use python-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
-    llvm-manpages = lowPrio tools.llvm.man;
-    clang-manpages = lowPrio tools.clang-unwrapped.man;
 
     clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
 
@@ -54,7 +57,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
   in {
 
     stdenv = overrideCC stdenv buildLlvmTools.clang;

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -13,7 +13,7 @@
 , compiler-rt_src
 , debugVersion ? false
 , enableManpages ? false
-, enableSharedLibraries ? true
+, enableSharedLibraries ? !enableManpages
 }:
 
 let

--- a/pkgs/development/compilers/llvm/5/default.nix
+++ b/pkgs/development/compilers/llvm/5/default.nix
@@ -1,5 +1,5 @@
-{ lowPrio, newScope, stdenv, cmake, libstdcxxHook
-, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
+{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -15,13 +15,8 @@ let
 
   clang-tools-extra_src = fetch "clang-tools-extra" "018b3fiwah8f8br5i26qmzh6sjvzchpn358sn8v079m49f2jldm3";
 
-  # Add man output without introducing extra dependencies.
-  overrideManOutput = drv:
-    let drv-manpages = drv.override { enableManpages = true; }; in
-    drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
-
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -33,15 +28,23 @@ let
     '';
   in {
 
-    llvm = overrideManOutput (callPackage ./llvm.nix { });
+    llvm = callPackage ./llvm.nix { };
 
-    clang-unwrapped = overrideManOutput (callPackage ./clang {
+    clang-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
+    };
+
+    llvm-manpages = lowPrio (tools.llvm.override {
+      enableManpages = true;
+      python = pkgs.python;  # don't use python-boot
+    });
+
+    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+      enableManpages = true;
+      python = pkgs.python;  # don't use python-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
-    llvm-manpages = lowPrio tools.llvm.man;
-    clang-manpages = lowPrio tools.clang-unwrapped.man;
 
     clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
 
@@ -70,7 +73,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix {};

--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -12,7 +12,7 @@
 , libcxxabi
 , debugVersion ? false
 , enableManpages ? false
-, enableSharedLibraries ? true
+, enableSharedLibraries ? !enableManpages
 }:
 
 let

--- a/pkgs/development/compilers/llvm/6/default.nix
+++ b/pkgs/development/compilers/llvm/6/default.nix
@@ -1,5 +1,5 @@
-{ lowPrio, newScope, stdenv, cmake, libstdcxxHook
-, libxml2, python2, isl, fetchurl, overrideCC, wrapCCWith
+{ lowPrio, newScope, pkgs, stdenv, cmake, libstdcxxHook
+, libxml2, python, isl, fetchurl, overrideCC, wrapCCWith
 , buildLlvmTools # tools, but from the previous stage, for cross
 , targetLlvmLibraries # libraries, but from the next stage, for cross
 }:
@@ -15,13 +15,8 @@ let
 
   clang-tools-extra_src = fetch "clang-tools-extra" "1w8ml7fyn4vyxmy59n2qm4r1k1kgwgwkaldp6m45fdv4g0kkfbhd";
 
-  # Add man output without introducing extra dependencies.
-  overrideManOutput = drv:
-    let drv-manpages = drv.override { enableManpages = true; }; in
-    drv // { man = drv-manpages.out; /*outputs = drv.outputs ++ ["man"];*/ };
-
   tools = stdenv.lib.makeExtensible (tools: let
-    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+    callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
     mkExtraBuildCommands = cc: ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
@@ -33,15 +28,23 @@ let
     '';
   in {
 
-    llvm = overrideManOutput (callPackage ./llvm.nix { });
+    llvm = callPackage ./llvm.nix { };
 
-    clang-unwrapped = overrideManOutput (callPackage ./clang {
+    clang-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
+    };
+
+    llvm-manpages = lowPrio (tools.llvm.override {
+      enableManpages = true;
+      python = pkgs.python;  # don't use python-boot
+    });
+
+    clang-manpages = lowPrio (tools.clang-unwrapped.override {
+      enableManpages = true;
+      python = pkgs.python;  # don't use python-boot
     });
 
     libclang = tools.clang-unwrapped.lib;
-    llvm-manpages = lowPrio tools.llvm.man;
-    clang-manpages = lowPrio tools.clang-unwrapped.man;
 
     clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
 
@@ -70,7 +73,7 @@ let
   });
 
   libraries = stdenv.lib.makeExtensible (libraries: let
-    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python2 isl release_version version fetch; });
+    callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });
   in {
 
     compiler-rt = callPackage ./compiler-rt.nix {};

--- a/pkgs/development/interpreters/python/cpython/2.7/boot.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/boot.nix
@@ -75,6 +75,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru.pkgs = builtins.throw "python-boot does not support packages, this package is only intended for bootstrapping." {};
+
   meta = {
     homepage = http://python.org;
     description = "A high-level dynamically-typed programming language";

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -339,15 +339,7 @@ in rec {
 
       llvmPackages_5 = super.llvmPackages_5 // (let
         tools = super.llvmPackages_5.tools.extend (_: super: {
-          # Build man pages with final stdenv not before
-          llvm = lib.extendDerivation
-            true
-            { inherit (super.llvm) man; }
-            llvmPackages_5.llvm;
-          clang-unwrapped = lib.extendDerivation
-            true
-            { inherit (super.clang-unwrapped) man; }
-            llvmPackages_5.clang-unwrapped;
+          inherit (llvmPackages_5) llvm clang-unwrapped;
         });
         libraries = super.llvmPackages_5.libraries.extend (_: _: {
           inherit (llvmPackages_5) compiler-rt libcxx libcxxabi;
@@ -384,9 +376,8 @@ in rec {
     initialPath = import ../common-path.nix { inherit pkgs; };
     shell       = "${pkgs.bash}/bin/bash";
 
-    # Hack to avoid man pages in stdenv, building bootstrap python
     cc = pkgs.llvmPackages.libcxxClang.override {
-      cc = builtins.removeAttrs pkgs.llvmPackages.clang-unwrapped [ "man" ];
+      cc = pkgs.llvmPackages.clang-unwrapped;
     };
 
     extraNativeBuildInputs = [];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6213,6 +6213,7 @@ with pkgs;
   };
 
   clang = llvmPackages.clang;
+  clang-manpages = llvmPackages.clang-manpages;
 
   clang-sierraHack = clang.override {
     name = "clang-wrapper-with-reexport-hack";
@@ -6845,6 +6846,7 @@ with pkgs;
   lldb_6 = llvmPackages_6.lldb;
 
   llvm = llvmPackages.llvm;
+  llvm-manpages = llvmPackages.llvm-manpages;
 
   llvm_6  = llvmPackages_6.llvm;
   llvm_5  = llvmPackages_5.llvm;
@@ -11866,7 +11868,7 @@ with pkgs;
   sofia_sip = callPackage ../development/libraries/sofia-sip { };
 
   soil = callPackage ../development/libraries/soil { };
-  
+
   sonic = callPackage ../development/libraries/sonic { };
 
   soprano = callPackage ../development/libraries/soprano { };
@@ -20941,7 +20943,7 @@ with pkgs;
   spyder = pythonPackages.spyder;
 
   openspace = callPackage ../applications/science/astronomy/openspace { };
-  
+
   stellarium = libsForQt5.callPackage ../applications/science/astronomy/stellarium { };
 
   tulip = callPackage ../applications/science/misc/tulip {


### PR DESCRIPTION
###### Motivation for this change

Fixes manpages and removes `.man` attribute.

/cc @Ericson2314 @jwiegley

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

