### PR TITLE
vim-configurable: fix python support

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -112,12 +112,9 @@ in stdenv.mkDerivation rec {
     "--enable-luainterp"
   ]
   ++ stdenv.lib.optionals pythonSupport [
-    "--enable-python${if isPython3 then "3" else ""}"
-  ]
-  ++ stdenv.lib.optionals (pythonSupport && stdenv.isDarwin) [  # Why only for Darwin?
-    "--enable-python${if isPython3 then "3" else ""}interp=yes" # Duplicate?
+    "--enable-python${if isPython3 then "3" else ""}interp=yes"
     "--with-python${if isPython3 then "3" else ""}-config-dir=${python}/lib"
-    "--disable-python${if isPython3 then "" else "3"}interp"
+    "--disable-python${if (!isPython3) then "3" else ""}interp"
   ]
   ++ stdenv.lib.optional nlsSupport          "--enable-nls"
   ++ stdenv.lib.optional perlSupport         "--enable-perlinterp"


### PR DESCRIPTION
###### Motivation for this change

This seems to be a regression since https://github.com/NixOS/nixpkgs/pull/43886, python support currently only works on darwin.


/cc @FRidh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


```diff
 VIM - Vi IMproved 8.1 (2018 May 18, compiled Jan  1 1970 00:00:01)
 Included patches: 1-146
 Compiled by nixbld
 Huge version without GUI.  Features included (+) or not (-):
-+comments          +libcall           -python            +viminfo
++comments          +libcall           +python            +viminfo
 +conceal           +linebreak         -python3           +vreplace
```