### PR TITLE
Backports: onboard: fix missing typelibs

### DIFF
--- a/pkgs/applications/misc/onboard/default.nix
+++ b/pkgs/applications/misc/onboard/default.nix
@@ -88,6 +88,7 @@ in python3.pkgs.buildPythonApplication rec {
 
   nativeBuildInputs = [
     glibcLocales
+    gobjectIntrospection # populate GI_TYPELIB_PATH
     intltool
     pkgconfig
   ];


### PR DESCRIPTION
###### Motivation for this change

Backports 0009ae3d5e1ad620215c2b8409eeec668de60552

This is to fix #43675.

###### Things done

I have verified that onboard

 * on current tip does not start.
 * starts after applying commit.

* * *

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build onboard

This is trivial to merge, cc @jtojnar 
