### PR TITLE
mustache-go: init at 1.0.1

### DIFF
--- a/pkgs/development/tools/mustache-go/default.nix
+++ b/pkgs/development/tools/mustache-go/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "mustache-go-${version}";
+  version = "1.0.1";
+
+  goPackagePath = "github.com/cbroglie/mustache";
+
+  src = fetchFromGitHub {
+    owner = "cbroglie";
+    repo = "mustache";
+    rev = "v${version}";
+    sha256 = "1aywj4fijsv66n6gjiz3l8g1vg0fqzwbf8dcdcgfsvsdb056p90v";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/cbroglie/mustache;
+    description = "The mustache template language in Go";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.Zimmi48 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14833,6 +14833,8 @@ with pkgs;
 
   mustache-spec = callPackage ../data/documentation/mustache-spec { };
 
+  mustache-go = callPackage ../development/tools/mustache-go { };
+
   myrica = callPackage ../data/fonts/myrica { };
 
   nafees = callPackage ../data/fonts/nafees { };


### PR DESCRIPTION
###### Motivation for this change

AFAIK there was no packaged CLI mustache, only programming languages library.
I choose the go implementation because that was the easiest one to package among the implementations that provided a CLI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

