### PR TITLE
liblinear: init at 2.20

### DIFF
--- a/pkgs/development/libraries/liblinear/default.nix
+++ b/pkgs/development/libraries/liblinear/default.nix
@@ -1,0 +1,39 @@
+{stdenv, fetchurl}:
+
+stdenv.mkDerivation rec {
+  name = "liblinear-${version}";
+  version = "2.20";
+
+  src = fetchurl {
+    url = "https://www.csie.ntu.edu.tw/~cjlin/liblinear/liblinear-${version}.tar.gz";
+    sha256 = "13q48azqy9pd8jyhk0c2hzj5xav1snbdrj8pp38vwrv2wwhfz7rz";
+  };
+
+  buildPhase = ''
+    make
+    make lib
+  '';
+
+  installPhase = let
+    libSuff = stdenv.hostPlatform.extensions.sharedLibrary;
+  in ''
+    mkdir -p $out/lib $out/bin $out/include
+    cp liblinear.so.3 $out/lib/liblinear.3${libSuff}
+    ln -s $out/lib/liblinear.3${libSuff} $out/lib/liblinear${libSuff}
+    cp train $out/bin/liblinear-train
+    cp predict $out/bin/liblinear-predict
+    cp linear.h $out/include
+  '';
+
+  postFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id liblinear.3.dylib $out/lib/liblinear.3.dylib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A library for large linear classification";
+    homepage = https://www.csie.ntu.edu.tw/~cjlin/liblinear/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.danieldk ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10509,6 +10509,8 @@ with pkgs;
 
   libksi = callPackage ../development/libraries/libksi { };
 
+  liblinear = callPackage ../development/libraries/liblinear { };
+
   libmad = callPackage ../development/libraries/libmad { };
 
   libmatchbox = callPackage ../development/libraries/libmatchbox { };


### PR DESCRIPTION
Since building liblinear is very similar to libsvm, this expression
is largely based on libsvm.

###### Motivation for this change

liblinear is the linear counterpart to libsvm and supports linear SVMs and logistic regression. liblinear is quite a popular library in the machine learning community.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

