### PR TITLE
ocamlPackages.sqlexpr: 0.5.5 -> 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/estring/default.nix
+++ b/pkgs/development/ocaml-modules/estring/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, buildOcaml, fetchurl }:
+{ stdenv, buildOcaml, ocaml, fetchurl }:
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "estring is not available for OCaml ${ocaml.version}"
+else
 
 buildOcaml rec {
   name = "estring";

--- a/pkgs/development/ocaml-modules/sqlexpr/default.nix
+++ b/pkgs/development/ocaml-modules/sqlexpr/default.nix
@@ -1,19 +1,32 @@
-{ stdenv, buildOcaml, fetchurl, batteries, csv, ocaml_lwt, ocaml_sqlite3, estring }:
+{ stdenv, fetchurl, ocaml, findlib, jbuilder, ocaml_lwt
+, lwt_ppx, ocaml-migrate-parsetree, ppx_tools_versioned, csv, ocaml_sqlite3
+}:
 
-buildOcaml rec {
-  name = "sqlexpr";
-  version = "0.5.5";
+stdenv.mkDerivation rec {
+  version = "0.9.0";
+  name = "ocaml${ocaml.version}-sqlexpr-${version}";
 
   src = fetchurl {
-    url = "https://forge.ocamlcore.org/frs/download.php/1203/ocaml-sqlexpr-${version}.tar.gz";
-    sha256 = "02pi0xxr3xzalwpvcaq96k57wz2vxj20l2mga1a4d2ddvhran8kr";
+  url = "https://github.com/mfp/ocaml-sqlexpr/releases/download/${version}/ocaml-sqlexpr-${version}.tar.gz";
+  sha256 = "0z0bkzi1mh0m39alzr2ds7hjpfxffx6azpfsj2wpaxrg64ks8ypd";
   };
 
-  propagatedBuildInputs = [ batteries csv ocaml_lwt ocaml_sqlite3 estring ];
+  buildInputs = [ ocaml findlib jbuilder lwt_ppx ocaml-migrate-parsetree ppx_tools_versioned ];
 
-  meta = with stdenv.lib; {
-    homepage = https://github.com/mfp/ocaml-sqlexpr;
+  propagatedBuildInputs = [ ocaml_lwt csv ocaml_sqlite3 ];
+
+  buildPhase = "dune build -p sqlexpr";
+
+  doCheck = true;
+  checkPhase = "dune runtest -p sqlexpr";
+
+  inherit (jbuilder) installPhase;
+
+  meta = {
     description = "Type-safe, convenient SQLite database access";
-    license = licenses.lgpl21;
+    homepage = "https://github.com/mfp/ocaml-sqlexpr";
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/sqlexpr/ppx.nix
+++ b/pkgs/development/ocaml-modules/sqlexpr/ppx.nix
@@ -1,0 +1,15 @@
+{ stdenv, ocaml, findlib, jbuilder, sqlexpr, ounit
+, ppx_core, ppx_tools_versioned, re, lwt_ppx
+}:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ppx_sqlexpr-${version}";
+  inherit (sqlexpr) version src installPhase meta;
+
+  buildInputs = [ ocaml findlib jbuilder sqlexpr ounit ppx_core ppx_tools_versioned re lwt_ppx ];
+
+  buildPhase = "dune build -p ppx_sqlexpr";
+
+  doCheck = true;
+  checkPhase = "dune runtest -p ppx_sqlexpr";
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -644,6 +644,8 @@ let
 
     ppx_import = callPackage ../development/ocaml-modules/ppx_import {};
 
+    ppx_sqlexpr = callPackage ../development/ocaml-modules/sqlexpr/ppx.nix {};
+
     ppx_tools =
       if lib.versionAtLeast ocaml.version "4.02"
       then callPackage ../development/ocaml-modules/ppx_tools {}


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml ≥ 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

