### PR TITLE
cargo-asm: init at 0.1.16

### DIFF
--- a/pkgs/development/tools/rust/cargo-asm/default.nix
+++ b/pkgs/development/tools/rust/cargo-asm/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "cargo-asm-${version}";
+  version = "0.1.16";
+
+  src = fetchFromGitHub {
+    owner = "gnzlbg";
+    repo = "cargo-asm";
+    rev = "7d0ece74657edb002bd8530227b829b31fd19dcd";
+    sha256 = "0mzbh5zw5imlaagm5zjbjk9kqdnglm398rxkqisd22h6569ppqpc";
+  };
+
+  cargoSha256 = "1m2j6i8hc8isdlj77gv9m6sk6q0x3bvzpva2k16g27i1ngy1989b";
+
+  # Test checks against machine code output, which fails with some
+  # LLVM/compiler versions.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Display the assembly or LLVM-IR generated for Rust source code";
+    homepage = https://github.com/gnzlbg/cargo-asm;
+    license = licenses.mit;
+    maintainers = [ maintainers.danieldk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7088,6 +7088,7 @@ with pkgs;
   cargo-release = callPackage ../tools/package-management/cargo-release { };
   cargo-tree = callPackage ../tools/package-management/cargo-tree { };
 
+  cargo-asm = callPackage ../development/tools/rust/cargo-asm { };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
 
   rainicorn = callPackage ../development/tools/rust/rainicorn { };


### PR DESCRIPTION
###### Motivation for this change

cargo-asm is a utility and Cargo subcommand for showing assembly/LLVM-IR of invidual Rust functions and methods.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

