### PR TITLE
redsocks: add self as maintainer

### DIFF
--- a/pkgs/tools/networking/redsocks/default.nix
+++ b/pkgs/tools/networking/redsocks/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     description = "Transparent redirector of any TCP connection to proxy";
     homepage = http://darkk.net.ru/redsocks/;
     license = stdenv.lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ stdenv.lib.maintainers.ekleog ];
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Looks like I had not added myself as maintainer when submitting a PR for this package at first, likely because I thought maintainers had to be committers at the time. Anyway, here it is, at least someone will know if the build fails :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

