### PR TITLE
nixos/nix-daemon: default `nix.useSandbox` to `true`.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -370,7 +370,9 @@ inherit (pkgs.nixos {
       <varname>s6-dns</varname>, <varname>s6-networking</varname>,
       <varname>s6-linux-utils</varname> and <varname>s6-portable-utils</varname> respectively.
     </para>
-   </listitem>
+  </listitem>
+  <listitem>
+    <para>The module option <option>nix.useSandbox</option> is now defaulted to <literal>true</literal>.
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -127,16 +127,16 @@ in
 
       useSandbox = mkOption {
         type = types.either types.bool (types.enum ["relaxed"]);
-        default = false;
+        default = true;
         description = "
           If set, Nix will perform builds in a sandboxed environment that it
           will set up automatically for each build. This prevents impurities
           in builds by disallowing access to dependencies outside of the Nix
           store by using network and mount namespaces in a chroot environment.
-          This isn't enabled by default for possible performance impacts due to
-          the initial setup time of a sandbox for each build. It doesn't affect
-          derivation hashes, so changing this option will not trigger a rebuild
-          of packages.
+          This is enabled by default even though it has a possible performance
+          impact due to the initial setup time of a sandbox for each build. It
+          doesn't affect derivation hashes, so changing this option will not
+          trigger a rebuild of packages.
         ";
       };
 


### PR DESCRIPTION
###### Motivation for this change

After some discussions on IRC we thought that enabling sanboxing per default might be a good idea. The initial concern was the comment about a performance penalty when using sandboxing. The penalty is supposedly only significant during the startup of build. IMHO the gained level of security does warrant the extra bit of slowness.

Please leave you opinions here.

There was a recent rephrasing of the `description` of said option with f098e60ecfe9f2d7b1d51a58e00a09656099b342. It would be great to know if that also originated from thoughts of enabling it. (CC @LnL7 @bbarker)

CC those people involved in the discussion on IRC: @manveru @cleverca22 

CC some of the people that might know more about the impact: @edolstra @LnL7 @grahamc