### PR TITLE
consul: 0.9.3 -> 1.2.2

### DIFF
--- a/pkgs/servers/consul/default.nix
+++ b/pkgs/servers/consul/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, consul-ui, fetchFromGitHub }:
+{ stdenv,  buildGoPackage, consul-ui, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "consul-${version}";
-  version = "0.9.3";
+  version = "1.2.2";
   rev = "v${version}";
 
   goPackagePath = "github.com/hashicorp/consul";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     owner = "hashicorp";
     repo = "consul";
     inherit rev;
-    sha256 = "1176frp7kimpycsmz9wrbizf46jgxr8jq7hz5w4q1x90lswvrxv3";
+    sha256 = "1dfmzbqnfazqfp6xr6xvrr3ziy0c46sk90cnfcfs8wwj13lfks3j";
   };
 
   # Keep consul.ui for backward compatability


### PR DESCRIPTION
0.8.3 is ~a year out of date

This doesn't touch the web UI; I'm going to look into  into
packaging the new webUI in the near future. The existing webUI
package fails to build on 18.03 anyhow. (The Consul Web UI has
been completely rewritten between 0.8.3 and 1.2.1)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in 
[`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] T	ested via one or more NixOS test(s) if existing and applicable for the change (look inside 
[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).