### PR TITLE
stog: 0.17.0 -> 0.18.0

### DIFF
--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocf, ptime,
-  uutf, uri, ppx_blob, xtmpl, ocaml_lwt, higlo, camlp4, omd
+{ stdenv, fetchFromGitLab, ocaml, findlib, ocf, ptime,
+  uutf, uri, ppx_blob, xtmpl, ocaml_lwt, higlo, omd
 }:
 
 stdenv.mkDerivation rec {
   name = "stog-${version}";
-  version = "0.17.0";
-  src = fetchFromGitHub {
+  version = "0.18.0";
+  src = fetchFromGitLab {
+    domain = "framagit.org";
     owner = "zoggy";
     repo = "stog";
-    rev = "release-${version}";
-    sha256 = "06fnl3im0rycn05w39adfmm7w4s8l3jrj43h8f8h3b56grh21x0d";
+    rev = version;
+    sha256 = "154gl3ljxqlw8wz1vmsyv8180igrl5bjq0wir7ybrnzq2cdflkv0";
   };
 
-  buildInputs = [ ocaml camlp4 uutf ];
+  buildInputs = [ ocaml uutf ];
   propagatedBuildInputs = [ findlib omd ppx_blob ocf ptime uri xtmpl ocaml_lwt higlo ];
 
   createFindlibDestdir = true;
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "XML documents and web site compiler";
-    homepage = https://zoggy.github.io/stog/;
+    homepage = https://www.good-eris.net/stog;
     license = licenses.lgpl3;
     platforms = ocaml.meta.platforms or [];
     maintainers = with maintainers; [ regnat ];

--- a/pkgs/development/ocaml-modules/asn1-combinators/default.nix
+++ b/pkgs/development/ocaml-modules/asn1-combinators/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, fetchFromGitHub, ocaml, findlib
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild
 , cstruct, zarith, ounit, result, topkg, ptime
 }:
 
@@ -10,15 +10,13 @@ let param =
   } else {
     version = "0.1.3";
     sha256 = "0hpn049i46sdnv2i6m7r6m6ch0jz8argybh71wykbvcqdby08zxj";
-  propagatedBuildInputs = [ ];
+    propagatedBuildInputs = [ ];
   };
 in
 
-buildOcaml rec {
-  name = "asn1-combinators";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-asn1-combinators-${version}";
   inherit (param) version;
-
-  minimumSupportedOcamlVersion = "4.01";
 
   src = fetchFromGitHub {
     owner  = "mirleft";
@@ -27,7 +25,7 @@ buildOcaml rec {
     inherit (param) sha256;
   };
 
-  buildInputs = [ ocaml findlib ounit topkg ];
+  buildInputs = [ ocaml findlib ocamlbuild ounit topkg ];
   propagatedBuildInputs = [ result cstruct zarith ] ++ param.propagatedBuildInputs;
 
   buildPhase = "${topkg.run} build --tests true";

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, buildOcaml, ocaml, findlib, ocamlbuild, topkg, result, js_of_ocaml }:
+{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, result, js_of_ocaml }:
 
-buildOcaml rec {
-  version = "0.8.3";
-  name = "ptime";
+stdenv.mkDerivation rec {
+  version = "0.8.4";
+  name = "ocaml${ocaml.version}-ptime-${version}";
 
   src = fetchurl {
     url = "http://erratique.ch/software/ptime/releases/ptime-${version}.tbz";
-    sha256 = "18jimskgnd9izg7kn6zk6sk35adgjm605dkv13plwslbb90kqr44";
+    sha256 = "0z2snhda8bg136xkw2msw6k2dz84vb49p8bgzrxfs8mawdlk0kkg";
   };
 
   unpackCmd = "tar -xf $curSrc";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -689,9 +689,7 @@ let
 
     ssl = callPackage ../development/ocaml-modules/ssl { };
 
-    stog = callPackage ../applications/misc/stog {
-      ocaml_lwt = lwt2;
-    };
+    stog = callPackage ../applications/misc/stog { };
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

