### PR TITLE
Add pkgs.overrideWithScope

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -169,6 +169,71 @@
    </note>
   </section>
 
+  <section xml:id="sec-pkg-overrideWithScope">
+   <title>&lt;pkg&gt;.override</title>
+
+   <para>
+    The function <varname>overrideWithScope</varname> is usually available for all the
+    derivations in the nixpkgs expression (<varname>pkgs</varname>).
+   </para>
+
+   <para>
+    It is used to override the arguments passed to a function, by extracting the
+    arguments from a larger set, similar to the default argument provided by the
+    <varname>callPackage</varname> function.
+   </para>
+
+   <para>
+    This function is useful to deeply override a package within a set of
+    packages, such as making compilation stages or to build packages which rely
+    on having the same interpreter (i-e: python, haskell, emacs, …).
+   </para>
+
+   <para>
+    Example usages:
+<programlisting>pkgs.foo.overrideWithScope pkgs.fooDependencies</programlisting>
+<programlisting>import pkgs.path { overlays = [
+  (self: super: {
+    # The interpreter would be overriden in the following packages too.
+    myInterpreterPackages = super.lib.mapAttrs (n: v: v.overrideWithScope self.myInterpreterPackages) {
+      interpreter = super.interpreter.overrideDerivation (prev: { ... });
+      inherit (super) foo bar baz qux;
+    };
+  })
+  (self: super: {
+    # baz changes would be visible by all packages within myInterpreterPackages set.
+    myInterpreterPackages = super.myInterpreterPackages // {
+      baz = super.myInterpreterPackages.baz.override { ... };
+    };
+  })
+  ]};</programlisting>
+   </para>
+
+   <para>
+    In the first example, <varname>pkgs.foo</varname> is the result of a
+    function call with some default arguments, usually a derivation. Using
+    <varname>pkgs.foo.overrideWithScope</varname> will call the same function
+    with the given new arguments. This is similar to how
+    <varname>pkgs.foo.override</varname> would behave, except that
+    <varname>overrideWithScope</varname> will not raise an error if an argument
+    is given, but not expected by the package.
+   </para>
+
+   <para>
+    In the second example, two overlays are added. The first overlay create a
+    custom version of an interpreter, and replaces it in all packages included
+    in the <varname>myInterpreterPackages</varname> set, as well as replacing
+    <varname>foo</varname> in <varname>myInterpreterPackages.bar</varname>. The
+    second overlay replaces <varname>baz</varname> in all packages under
+    <varname>myInterpreterPackages</varname>, such as
+    <varname>myInterpreterPackages.qux</varname>. Note, the second overlay did
+    not had a re-use <varname>overrideWithScope</varname> as the argument of it
+    in the first overlay is the fix-point result of
+    <varname>myInterpreterSet</varname>, which includes the custom
+    <varname>baz</varname>.
+   </para>
+  </section>
+
   <section xml:id="sec-lib-makeOverridable">
    <title>lib.makeOverridable</title>
 


### PR DESCRIPTION
Add `pkgs.overrideWithScope`. This function is similar to `pkgs.override`, except that it filters the arguments like `callPackage` does.

While this might seems like a small addition, this is actually a really really big change for the future of Nixpkgs. This function can help us simplify a lot the manipulation of `emacsPackages`, `pythonPackages`, `haskellPackages`, `linuxPackages`, ... This can also help us rewrite the bootstrapping done before all-packages and move it within `all-packages.nix`. and on a simpler note, this will help solving the #43755 as explained in #43828.

The reason which makes this function is a revolution for the implementation of package sets is that it make it simple to ""recursively"" (dependencies of dependencies of dependencies) and conherently override the input of a set of packages with a simple function, which does not appear in future overlay.

To make it clearer, here is a set of overlay:

```nix
import <nixpkgs> { overlays = [
  # Add an interpreter and its package set.
  (self: super: 
  let interpreterPackages = withSet: {
      foo = super.lib.callPackageWith withSet ./pkgs/interpreter/foo { /* interpreter libxml */ };
      bar = super.lib.callPackageWith withSet ./pkgs/interpreter/bar { /* interpreter foo */ };
      baz = super.lib.callPackageWith withSet ./pkgs/interpreter/baz { /* interpreter foo bar qt */ };
      qux = super.lib.callPackageWith withSet ./pkgs/interpreter/qux { /* interpreter bar baz */ };
    };
  in
  rec {
    interpreter27 = super.callPackage ./pkgs/interpreter_27.nix {};
    interpreter35 = super.callPackage ./pkgs/interpreter_35.nix {};
    interpreter27Packages = let withSet = self // { interpreter = interpreter27; } // self.interpreter27Packages; in
      super.lib.mapAttrs (n: v: v.overrideWithScope withSet) (interpreterPackages withSet);
    interpreter35Packages = let withSet = self // { interpreter = interpreter35; } // self.interpreter35Packages; in
      super.lib.mapAttrs (n: v: v.overrideWithScope withSet) (interpreterPackages withSet);
  })
  # Change a package dependency. Like any ordinary package, as opposed as today.
  (self: super: {
    interpreter27Packages = super.interpreter27Packages // {
      # Will change foo within bar, baz, qux (as expected).
      foo = super.interpreter27Packages.foo.override { libxml = null; };
    };
  })
  # Duplicate a package set with a custom interpreter.
  (self: super: {
    interpreter27ProfilePackages = let withSet = self // self.interpreter27ProfilePackages; in
      super.lib.mapAttrs (n: v: v.overrideWithScope withSet) (super.interpreter27Packages // {
      interpreter = super.interpreter27.override { withProfiler = true; };
    });
  })
]; }
```

What is important to note, is that:
 - Changing a package within an existing attribute set, except for the attribute set manipulation, is like any ordinary package.
 - Creating a forked configuration (with a profiler for example), is as simple as changing the interpreter in a new set which is isolated with `overrideWithScope`.

To make it simple, `pkgs.overrideWithScope` make it possible to leverage the Nixpkgs fix-point without the burden of writing too many `pkgs.override` by hand (which need to have no-more than the expected set of arguments).

As it leverage the Nixpkgs fix-point, there is no need to unwrap the function to override packages within a given set, like is done with package sets today (Haskell being infamous due to the stacking of multiple fix-points).

Ideally, we would want to have the `pkgs.overrideWithScope` evaluated before the resolution of the arguments of a given package, which would not be possible until we add some post-processing of all packages at the end of Nixpkgs fix-point. This enforces that we have to provide the `withSet` argument to the interpreter set, and implies that we cannot have a raw set of packages which lives independently of a given interpreter version. (Note, one could cheat by providing a fake version of missing packages `interpreter = null; libxml = null; qt = null; `)

Another issue, which already exists but is made explicit here, is that `self // self.interpreterPackages` is inefficient in terms of memory because attribute sets are not lazy.  This does not worry me much as this is a fixable issue in Nixpkgs, as long as the expression is strictly used as argument of `callPackagesWith` and `overrideWithScope`

Other suggestions:
 - Renaming `overrideWithScope` to `overrideWith`.
 - Replacing `override` by `overrideWithScope`.
