### PR TITLE
jq: fix darwin build

### DIFF
--- a/pkgs/development/tools/jq/default.nix
+++ b/pkgs/development/tools/jq/default.nix
@@ -34,12 +34,15 @@ stdenv.mkDerivation rec {
     "--datadir=\${doc}/share"
     "--mandir=\${man}/share/man"
     ]
-  # jq is linked to libjq:
+    # jq is linked to libjq:
     ++ stdenv.lib.optional (!stdenv.isDarwin) "LDFLAGS=-Wl,-rpath,\\\${libdir}";
 
-  installCheckPhase = "$bin/bin/jq --help >/dev/null";
   doInstallCheck = true;
-  doCheck = true;
+  installCheckTarget = "check";
+
+  postInstallCheck = ''
+    $bin/bin/jq --help >/dev/null
+  '';
 
   meta = with stdenv.lib; {
     description = ''A lightweight and flexible command-line JSON processor'';


### PR DESCRIPTION
###### Motivation for this change

One of the tests failed on my builder but not locally because of some kind of timezone issue, hopefully this isn't also a problem on hydra.

/cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

