### PR TITLE
glpk: adopt error recovery patch

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -12,8 +12,6 @@ let
 
       cysignals = super.cysignals.override { inherit pari; };
 
-      cvxopt = super.cvxopt.override { inherit glpk; };
-
       # python packages that appear unmaintained and were not accepted into the nixpkgs
       # tree because of that. These packages are only dependencies of the more-or-less
       # deprecated sagenb. However sagenb is still a default dependency and the doctests
@@ -26,7 +24,7 @@ let
       pybrial = self.callPackage ./pybrial.nix {};
 
       sagelib = self.callPackage ./sagelib.nix {
-        inherit flint ecl pari glpk eclib ntl arb;
+        inherit flint ecl pari eclib ntl arb;
         inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
         linbox = nixpkgs.linbox.override { withSage = true; };
       };
@@ -47,7 +45,7 @@ let
       };
 
       sage-env = self.callPackage ./sage-env.nix {
-        inherit sage-src python rWrapper openblas-cblas-pc glpk ecl singular eclib pari palp flint pynac pythonEnv giac ntl;
+        inherit sage-src python rWrapper openblas-cblas-pc ecl singular eclib pari palp flint pynac pythonEnv giac ntl;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
       };
 
@@ -175,37 +173,6 @@ let
       url = "mirror://sageupstream/pari/pari-${version}.tar.gz";
       sha256 = "19gbsm8jqq3hraanbmsvzkbh88iwlqbckzbnga3y76r7k42akn7m";
     };
-  });
-
-  # https://trac.sagemath.org/ticket/24824
-  glpk = nixpkgs.glpk.overrideAttrs (attrs: rec {
-    version = "4.63";
-    name = "glpk-${version}";
-    src = fetchurl {
-      url = "mirror://gnu/glpk/${name}.tar.gz";
-      sha256 = "1xp7nclmp8inp20968bvvfcwmz3mz03sbm0v3yjz8aqwlpqjfkci";
-    };
-    patches = (attrs.patches or []) ++ [
-      # Alternatively patch sage with debians
-      # https://sources.debian.org/data/main/s/sagemath/8.1-7/debian/patches/t-version-glpk-4.60-extra-hack-fixes.patch
-      # The header of that debian patch contains a good description of the issue. The gist of it:
-      # > If GLPK in Sage causes one error, and this is caught by Sage and recovered from, then
-      # > later (because upstream GLPK does not clear the "error" flag) Sage will append
-      # > all subsequent terminal output of GLPK into the error_message string but not
-      # > actually forward it to the user's terminal. This breaks some doctests.
-      (fetchpatch {
-        name = "error_recovery.patch";
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/error_recovery.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-        sha256 = "0z99z9gd31apb6x5n5n26411qzx0ma3s6dnznc4x61x86bhq31qf";
-      })
-
-      # Allow setting a exact verbosity level (OFF|ERR|ON|ALL|DBG)
-      (fetchpatch {
-        name = "exact_verbosity.patch";
-        url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/glp_exact_verbosity.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-        sha256 = "15gm5i2alqla3m463i1qq6jx6c0ns6lip7njvbhp37pgxg4s9hx8";
-      })
-    ];
   });
 in
   python.pkgs.sage-wrapper // {

--- a/pkgs/development/libraries/glpk/default.nix
+++ b/pkgs/development/libraries/glpk/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 # Excerpt from glpk's INSTALL file:
 # This feature allows the exact simplex solver to use the GNU MP
 # bignum library. If it is disabled, the exact simplex solver uses the
@@ -28,6 +29,24 @@ stdenv.mkDerivation rec {
     "--with-gmp"
   ];
 
+  patches = [
+    # GLPK makes it possible to customize its message printing behaviour. Sage
+    # does that and needs to differentiate between printing regular messages and
+    # printing errors. Unfortunately there is no way to tell and glpk upstream
+    # rejected this patch. All it does is set the variable pointing to the error
+    # file back to NULL before glpk calls abort(). In sage's case, abort won't
+    # actually be called because the error handler jumps out of the function.
+    # This shouldn't affect everybody else, since glpk just calls abort()
+    # immediately afterwards anyways.
+    # See the sage trac ticket for more details:
+    # https://trac.sagemath.org/ticket/20710#comment:18
+    (fetchpatch {
+      name = "error_recovery.patch";
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/glpk/patches/error_recovery.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "0z99z9gd31apb6x5n5n26411qzx0ma3s6dnznc4x61x86bhq31qf";
+    })
+  ];
+
   doCheck = true;
 
   meta = {
@@ -43,7 +62,7 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnu.org/software/glpk/;
     license = stdenv.lib.licenses.gpl3Plus;
 
-    maintainers = with stdenv.lib.maintainers; [ bjg ];
+    maintainers = with stdenv.lib.maintainers; [ bjg timokau ];
     platforms = stdenv.lib.platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This makes it possible to use "vanilla" glpk for sage and **shouldn't affect anything else**.

Unfortunately the github handle of the maintainer isn't listed in `maintainer-list.nix` and the maintainer hasn't been active in nixpkgs since 2010 anyways.

Details: https://trac.sagemath.org/ticket/20710#comment:18

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

