### PR TITLE
golangci-lint: init at 1.9.2

### DIFF
--- a/pkgs/development/tools/golangci-lint/default.nix
+++ b/pkgs/development/tools/golangci-lint/default.nix
@@ -1,0 +1,24 @@
+{ buildGoPackage, fetchFromGitHub, lib }:
+
+buildGoPackage rec {
+  name = "golangci-lint-${version}";
+  version = "1.9.2";
+  goPackagePath = "github.com/golangci/golangci-lint";
+
+  subPackages = [ "cmd/golangci-lint" ];
+
+  src = fetchFromGitHub {
+    owner = "golangci";
+    repo = "golangci-lint";
+    rev = "v${version}";
+    sha256 = "0r05j6ayk5778fkd5r1sgcwq675ra0vq82lqs125g70291ryha08";
+  };
+
+  meta = with lib; {
+    description = "Linters Runner for Go. 5x faster than gometalinter. Nice colored output.";
+    homepage = https://golangci.com/;
+    license = licenses.agpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.manveru ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14205,6 +14205,8 @@ with pkgs;
 
   golint = callPackage ../development/tools/golint { };
 
+  golangci-lint = callPackage ../development/tools/golangci-lint { };
+
   godef = callPackage ../development/tools/godef { };
 
   goimports = callPackage ../development/tools/goimports { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

