### PR TITLE
llvm 3.8, 3.9, 4: WIP split out compiler-rt for other versions

### DIFF
--- a/pkgs/development/compilers/llvm/3.8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/3.8/compiler-rt.nix
@@ -1,0 +1,41 @@
+{ stdenv, version, fetch, fetchpatch, cmake, python, llvm, libcxxabi }:
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "compiler-rt-${version}";
+  inherit version;
+  src = fetch "compiler-rt" "0p0y85c7izndbpg2l816z7z7558axq11d5pwkm4h11sdw7d13w0d";
+
+  nativeBuildInputs = [ cmake python llvm ];
+  buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
+
+  configureFlags = [
+    "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  patches = [
+    (fetchpatch {
+      name = "sigaltstack.patch"; # for glibc-2.26
+      url = https://github.com/llvm-mirror/compiler-rt/commit/8a5e425a68d.diff;
+      sha256 = "0h4y5vl74qaa7dl54b1fcyqalvlpd8zban2d1jxfkxpzyi7m8ifi";
+    })
+  ];
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build. I realize that this LLVM isn't used in the stdenv but I want to
+  # keep it consistent with 4.0. We really shouldn't be copying and pasting all this code around...
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's/os_trace(\(.*\)");$/printf(\1\\n");/g' ./lib/sanitizer_common/sanitizer_mac.cc
+  '';
+
+  # Hack around weird upsream RPATH bug
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '';
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/compilers/llvm/3.8/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/default.nix
@@ -17,10 +17,18 @@ let
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv isl version fetch; });
- in {
-    llvm = callPackage ./llvm.nix {
-      inherit compiler-rt_src;
-    };
+    mkExtraBuildCommands = cc: ''
+      rsrc="$out/resource-root"
+      mkdir "$rsrc"
+      ln -s "${cc}/lib/clang/${version}/include" "$rsrc"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+    '' + stdenv.lib.optionalString stdenv.targetPlatform.isLinux ''
+      echo "--gcc-toolchain=${tools.clang-unwrapped.gcc}" >> $out/nix-support/cc-cflags
+    '';
+  in {
+
+    llvm = callPackage ./llvm.nix { };
 
     clang-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
@@ -30,14 +38,23 @@ let
 
     clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
 
-    libstdcxxClang = wrapCCWith {
+    libstdcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
-      extraPackages = [ libstdcxxHook ];
+      extraPackages = [
+        libstdcxxHook
+        targetLlvmLibraries.compiler-rt
+      ];
+      extraBuildCommands = mkExtraBuildCommands cc;
     };
 
-    libcxxClang = wrapCCWith {
+    libcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
-      extraPackages = [ targetLlvmLibraries.libcxx targetLlvmLibraries.libcxxabi ];
+      extraPackages = [
+        targetLlvmLibraries.libcxx
+        targetLlvmLibraries.libcxxabi
+        targetLlvmLibraries.compiler-rt
+      ];
+      extraBuildCommands = mkExtraBuildCommands cc;
     };
 
     lldb = callPackage ./lldb.nix {};
@@ -46,6 +63,8 @@ let
   libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv isl version fetch; });
   in {
+
+    compiler-rt = callPackage ./compiler-rt.nix {};
 
     stdenv = overrideCC stdenv buildLlvmTools.clang;
 

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -19,10 +19,7 @@ let
 
     cmakeFlags = [
       "-DCMAKE_CXX_FLAGS=-std=c++11"
-    ] ++
-    # Maybe with compiler-rt this won't be needed?
-    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
-    (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
+    ];
 
     patches = [ ./purity.patch ];
 
@@ -42,7 +39,6 @@ let
         ln -sv ${llvm}/lib/LLVMgold.so $out/lib
       fi
 
-      ln -sv ${llvm}/lib/clang/${version}/lib $out/lib/clang/${version}/
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/3.9/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/3.9/compiler-rt.nix
@@ -1,0 +1,44 @@
+{ stdenv, version, fetch, fetchpatch, cmake, python, llvm, libcxxabi }:
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "compiler-rt-${version}";
+  inherit version;
+  src = fetch "compiler-rt" "16gc2gdmp5c800qvydrdhsp0bzb97s8wrakl6i8a4lgslnqnf2fk";
+
+  nativeBuildInputs = [ cmake python llvm ];
+  buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
+
+  configureFlags = [
+    "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  patches = [
+    (fetchpatch {
+      name = "sigaltstack.patch"; # for glibc-2.26
+      url = https://github.com/llvm-mirror/compiler-rt/commit/8a5e425a68d.diff;
+      sha256 = "0h4y5vl74qaa7dl54b1fcyqalvlpd8zban2d1jxfkxpzyi7m8ifi";
+    })
+  ];
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build. I realize that this LLVM isn't used in the stdenv but I want to
+  # keep it consistent with 4.0. We really shouldn't be copying and pasting all this code around...
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cmake/config-ix.cmake \
+      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+    substituteInPlace lib/esan/esan_sideline_linux.cpp \
+      --replace 'struct sigaltstack' 'stack_t'
+  '';
+
+  # Hack around weird upsream RPATH bug
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '';
+
+  enableParallelBuilding = true;
+}

--- a/pkgs/development/compilers/llvm/3.9/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/default.nix
@@ -17,10 +17,18 @@ let
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv isl version fetch; });
+    mkExtraBuildCommands = cc: ''
+      rsrc="$out/resource-root"
+      mkdir "$rsrc"
+      ln -s "${cc}/lib/clang/${version}/include" "$rsrc"
+      ln -s "${targetLlvmLibraries.compiler-rt.out}/lib" "$rsrc/lib"
+      echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
+    '' + stdenv.lib.optionalString stdenv.targetPlatform.isLinux ''
+      echo "--gcc-toolchain=${tools.clang-unwrapped.gcc}" >> $out/nix-support/cc-cflags
+    '';
   in {
-    llvm = callPackage ./llvm.nix {
-      inherit compiler-rt_src;
-    };
+
+    llvm = callPackage ./llvm.nix { };
 
     clang-unwrapped = callPackage ./clang {
       inherit clang-tools-extra_src;
@@ -30,14 +38,23 @@ let
 
     clang = if stdenv.cc.isGNU then tools.libstdcxxClang else tools.libcxxClang;
 
-    libstdcxxClang = wrapCCWith {
+    libstdcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
-      extraPackages = [ libstdcxxHook ];
+      extraPackages = [
+        libstdcxxHook
+        targetLlvmLibraries.compiler-rt
+      ];
+      extraBuildCommands = mkExtraBuildCommands cc;
     };
 
-    libcxxClang = wrapCCWith {
+    libcxxClang = wrapCCWith rec {
       cc = tools.clang-unwrapped;
-      extraPackages = [ targetLlvmLibraries.libcxx targetLlvmLibraries.libcxxabi ];
+      extraPackages = [
+        targetLlvmLibraries.libcxx
+        targetLlvmLibraries.libcxxabi
+        targetLlvmLibraries.compiler-rt
+      ];
+      extraBuildCommands = mkExtraBuildCommands cc;
     };
 
     lldb = callPackage ./lldb.nix {};
@@ -46,6 +63,8 @@ let
   libraries = stdenv.lib.makeExtensible (libraries: let
     callPackage = newScope (libraries // buildLlvmTools // { inherit stdenv isl version fetch; });
   in {
+
+    compiler-rt = callPackage ./compiler-rt.nix {};
 
     stdenv = overrideCC stdenv buildLlvmTools.clang;
 

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -11,7 +11,6 @@
 , ncurses
 , version
 , zlib
-, compiler-rt_src
 , debugVersion ? false
 , enableSharedLibraries ? (buildPlatform == hostPlatform)
 , buildPackages
@@ -34,8 +33,6 @@ in stdenv.mkDerivation rec {
     unpackFile ${src}
     mv llvm-${version}.src llvm
     sourceRoot=$PWD/llvm
-    unpackFile ${compiler-rt_src}
-    mv compiler-rt-* $sourceRoot/projects/compiler-rt
   '';
 
   outputs = [ "out" ] ++ stdenv.lib.optional enableSharedLibraries "lib";
@@ -73,16 +70,7 @@ in stdenv.mkDerivation rec {
       sha256 = "11sq86spw41v72f676igksapdlsgh7fiqp5qkkmgfj0ndqcn9skf";
     }}
   ''
-  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
-  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
-  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
-  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
-  # a flag and turn the flag off during the stdenv build. I realize that this LLVM isn't used in the stdenv but I want to
-  # keep it consistent with 4.0. We really shouldn't be copying and pasting all this code around...
   + stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace ./projects/compiler-rt/cmake/config-ix.cmake \
-      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
-
     substituteInPlace CMakeLists.txt \
       --replace 'set(CMAKE_INSTALL_NAME_DIR "@rpath")' "set(CMAKE_INSTALL_NAME_DIR "$lib/lib")" \
       --replace 'set(CMAKE_INSTALL_RPATH "@executable_path/../lib")' ""
@@ -91,20 +79,6 @@ in stdenv.mkDerivation rec {
   + stdenv.lib.optionalString (enableSharedLibraries) ''
     substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
     patch -p1 < ./llvm-outputs.patch
-  ''
-  + ''
-    (
-      cd projects/compiler-rt
-      patch -p1 < ${
-        fetchpatch {
-          name = "sigaltstack.patch"; # for glibc-2.26
-          url = https://github.com/llvm-mirror/compiler-rt/commit/8a5e425a68d.diff;
-          sha256 = "0h4y5vl74qaa7dl54b1fcyqalvlpd8zban2d1jxfkxpzyi7m8ifi";
-        }
-      }
-      substituteInPlace lib/esan/esan_sideline_linux.cpp \
-        --replace 'struct sigaltstack' 'stack_t'
-    )
   '';
 
   # hacky fix: created binaries need to be run before installation

--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -30,10 +30,7 @@ let
       "-DSPHINX_OUTPUT_MAN=ON"
       "-DSPHINX_OUTPUT_HTML=OFF"
       "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
-    ]
-    # Maybe with compiler-rt this won't be needed?
-    ++ stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}"
-    ++ stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include";
+    ];
 
     patches = [ ./purity.patch ];
 
@@ -56,7 +53,6 @@ let
         ln -sv ${llvm}/lib/LLVMgold.so $out/lib
       fi
 
-      ln -sv ${llvm}/lib/clang/${release_version}/lib $out/lib/clang/${release_version}/
       ln -sv $out/bin/clang $out/bin/cpp
 
       # Move libclang to 'lib' output

--- a/pkgs/development/compilers/llvm/4/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/4/compiler-rt.nix
@@ -1,0 +1,43 @@
+{ stdenv, version, fetch, fetchpatch, cmake, python, llvm, libcxxabi }:
+with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "compiler-rt-${version}";
+  inherit version;
+  src = fetch "compiler-rt" "0h5lpv1z554szi4r4blbskhwrkd78ir50v3ng8xvk1s86fa7gj53";
+
+  nativeBuildInputs = [ cmake python llvm ];
+  buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
+
+  configureFlags = [
+    "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  patches = optionals (stdenv.hostPlatform.libc == "glibc") [
+    (fetchpatch {
+      name = "sigaltstack.patch"; # for glibc-2.26
+      url = https://github.com/llvm-mirror/compiler-rt/commit/8a5e425a68d.diff;
+      sha256 = "0h4y5vl74qaa7dl54b1fcyqalvlpd8zban2d1jxfkxpzyi7m8ifi";
+    })
+  ] ++ optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch;
+
+  # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
+  # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
+  # can build this. If we didn't do it, basically the entire nixpkgs on Darwin would have an unfree dependency and we'd
+  # get no binary cache for the entire platform. If you really find yourself wanting the TSAN, make this controllable by
+  # a flag and turn the flag off during the stdenv build.
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace cmake/config-ix.cmake \
+      --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+    substituteInPlace lib/esan/esan_sideline_linux.cpp \
+      --replace 'struct sigaltstack' 'stack_t'
+  '';
+
+  # Hack around weird upsream RPATH bug
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s "$out/lib"/*/* "$out/lib"
+  '';
+
+  enableParallelBuilding = true;
+}


### PR DESCRIPTION
###### Motivation for this change

This is good for build parallelism and cross compilation.

6 was already done, 5 is is Darwin's stdenv so holding off to avoid mass
rebuild, <3.9 is too old for separate compiler-rt.

###### Things done

There are some build failures to track down, however. I'm opening this so others can possibly assist.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

