### PR TITLE
halide: init at 2018_02_15

### DIFF
--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -1,0 +1,64 @@
+{ llvmPackages, lib, fetchFromGitHub, cmake
+, libpng, libjpeg, mesa_noglu, eigen3_3, openblas
+}:
+
+let
+  version = "2018_02_15";
+
+in llvmPackages.stdenv.mkDerivation {
+
+  name = "halide-${builtins.replaceStrings ["_"] ["."] version}";
+
+  src = fetchFromGitHub {
+    owner = "halide";
+    repo = "Halide";
+    rev = "release_${version}";
+    sha256 = "14lmpbxydx7ii0pxds6rgq5vw4i6yfjsq0bai1l5wwpv1rnwmbxd";
+  };
+
+  patches = [ ./nix.patch ];
+
+  # clang fails to compile intermediate code because
+  # of unused "--gcc-toolchain" option
+  postPatch = ''
+    sed -i "s/-Werror//" src/CMakeLists.txt
+  '';
+
+  cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" ];
+
+  # To handle the lack of 'local' RPATH; required, as they call one of
+  # their built binaries requiring their libs, in the build process.
+  preBuild = ''
+    export LD_LIBRARY_PATH="$(pwd)/lib:$LD_LIBRARY_PATH"
+  '';
+
+  enableParallelBuilding = true;
+
+  # Note: only openblas and not atlas part of this Nix expression
+  # see pkgs/development/libraries/science/math/liblapack/3.5.0.nix
+  # to get a hint howto setup atlas instead of openblas
+  buildInputs = [ llvmPackages.llvm libpng libjpeg mesa_noglu eigen3_3 openblas ];
+
+  nativeBuildInputs = [ cmake ];
+
+  # No install target for cmake available.
+  # Calling install target in Makefile causes complete rebuild
+  # and the library rpath is broken, because libncursesw.so.6 is missing.
+  # Another way is using "make halide_archive", but the tarball is not easy
+  # to disassemble.
+  installPhase = ''
+    find
+    mkdir -p "$out/lib" "$out/bin"
+    cp bin/HalideTrace* "$out/bin"
+    cp lib/libHalide.so "$out/lib"
+    cp -r include "$out"
+  '';
+
+  meta = with lib; {
+    description = "C++ based language for image processing and computational photography";
+    homepage = "https://halide-lang.org";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ck3d ];
+  };
+}

--- a/pkgs/development/compilers/halide/nix.patch
+++ b/pkgs/development/compilers/halide/nix.patch
@@ -1,0 +1,55 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 40a685b7e..c452efd09 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,10 +49,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+ set(LLVM_VERSION "${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR}")
+
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-as${CMAKE_EXECUTABLE_SUFFIX}" LLVM_AS)
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}" LLVM_NM)
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}" CLANG)
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-config${CMAKE_EXECUTABLE_SUFFIX}" LLVM_CONFIG)
++find_program(LLVM_AS llvm-as HINTS ${LLVM_TOOLS_BINARY_DIR})
++find_program(LLVM_NM llvm-nm HINTS ${LLVM_TOOLS_BINARY_DIR})
++find_program(CLANG clang HINTS ${LLVM_TOOLS_BINARY_DIR})
++find_program(LLVM_CONFIG llvm-config HINTS ${LLVM_TOOLS_BINARY_DIR})
+
+ # LLVM doesn't appear to expose --system-libs via its CMake interface,
+ # so we must shell out to llvm-config to find this info
+diff --git a/apps/linear_algebra/CMakeLists.txt b/apps/linear_algebra/CMakeLists.txt
+index 132c80e6a..36ce865f2 100644
+--- a/apps/linear_algebra/CMakeLists.txt
++++ b/apps/linear_algebra/CMakeLists.txt
+@@ -26,7 +26,7 @@ if (CBLAS_FOUND)
+   #  Atlas requires also linking against its provided libcblas for cblas symbols
+   set(ATLAS_EXTRA_LIBS cblas) # XXX fragile
+   set(OpenBLAS_EXTRA_LIBS)
+-  set(BLAS_VENDORS OpenBLAS ATLAS)
++  set(BLAS_VENDORS OpenBLAS)
+
+   # TODO
+   # there are more vendors we could add here that support the cblas interface
+@@ -41,6 +41,7 @@ if (CBLAS_FOUND)
+       message(STATUS " ${BLAS_VENDOR}: Missing")
+     else()
+       message(STATUS " ${BLAS_VENDOR}: Found")
++      set(BLAS_LIBRARIES "${BLAS_LIBRARIES}" CACHE FILEPATH "BLAS library to use")
+       list(APPEND BLAS_VENDORS ${NAME})
+     endif()
+   endforeach()
+diff --git a/apps/linear_algebra/tests/CMakeLists.txt b/apps/linear_algebra/tests/CMakeLists.txt
+index 4b95eb3bb..1daa97437 100644
+--- a/apps/linear_algebra/tests/CMakeLists.txt
++++ b/apps/linear_algebra/tests/CMakeLists.txt
+@@ -19,6 +19,6 @@ target_compile_options(test_halide_blas PRIVATE -Wno-unused-variable)
+ target_link_libraries(test_halide_blas
+   PRIVATE
+    halide_blas
+-   cblas # XXX fragile
++   ${BLAS_LIBRARIES}
+    Halide
+ )
+--
+2.15.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2995,6 +2995,8 @@ with pkgs;
 
   halibut = callPackage ../tools/typesetting/halibut { };
 
+  halide = callPackage ../development/compilers/halide {};
+
   hardinfo = callPackage ../tools/system/hardinfo { };
 
   hdapsd = callPackage ../os-specific/linux/hdapsd { };


### PR DESCRIPTION
###### Motivation for this change
Halide is  a LLVM/C++ based language for image processing and computational photography.

Thanks to @ck3d for providing the derivation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

