### PR TITLE
capitaine-cursors: init at r2.1

### DIFF
--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub
+, inkscape, xcursorgen }:
+
+stdenv.mkDerivation rec {
+  name = "capitaine-cursors-${version}";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "keeferrourke";
+    repo = "capitaine-cursors";
+    rev = "r${version}";
+    sha256 = "0ljvq1dqscp5gyf23qszn2ax80bxkqw2vx5zh3qln9vnzfascirb";
+  };
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  buildInputs  =[
+    inkscape
+    xcursorgen
+  ];
+
+  buildPhase = ''
+    # https://github.com/NixOS/nixpkgs/blob/master/pkgs/data/fonts/emojione/default.nix#L16
+    HOME="$NIX_BUILD_ROOT" ./build.sh
+  '';
+
+  installPhase = ''
+    install -dm 0755 $out/share/icons
+    cp -pr dist $out/share/icons/capitaine-cursors
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      An x-cursor theme inspired by macOS and based on KDE Breeze
+    '';
+    homepage = https://github.com/keeferrourke/capitaine-cursors;
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [
+      eadwu
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14611,6 +14611,8 @@ with pkgs;
 
   cantarell-fonts = callPackage ../data/fonts/cantarell-fonts { };
 
+  capitaine-cursors = callPackage ../data/icons/capitaine-cursors { };
+
   carlito = callPackage ../data/fonts/carlito {};
 
   comfortaa = callPackage ../data/fonts/comfortaa {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

