### PR TITLE
nix-top: init at 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/tools/package-management/nix-top/default.nix
+++ b/pkgs/tools/package-management/nix-top/default.nix
@@ -33,11 +33,10 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ruby
   ];
-  
+
   installPhase = ''
-    mkdir -p $out/bin $out/libexec/nix-top
-    cp ./nix-top $out/bin/nix-top
-    chmod +x $out/bin/nix-top
+    mkdir -p $out/libexec/nix-top
+    install -D -m755 ./nix-top $out/bin/nix-top
     wrapProgram $out/bin/nix-top \
       --prefix PATH : "$out/libexec/nix-top:${additionalPath}"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/tools/package-management/nix-top/default.nix
+++ b/pkgs/tools/package-management/nix-top/default.nix
@@ -3,25 +3,27 @@
 , fetchFromGitHub
 , ruby
 , makeWrapper
-, procps               # ps
+, getent               # /etc/passwd
 , ncurses              # tput
+, procps               # ps
 , binutils-unwrapped   # strings
+, coreutils
 , findutils
 }:
 
 # No gems used, so mkDerivation is fine.
 let
-  additionalPath = lib.makeBinPath [ncurses procps binutils-unwrapped findutils];
+  additionalPath = lib.makeBinPath [ getent ncurses binutils-unwrapped coreutils findutils ];
 in
 stdenv.mkDerivation rec {
   name = "nix-top-${version}";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "samueldr";
     repo = "nix-top";
     rev = "v${version}";
-    sha256 = "0l50w90hs3kmdk5kb3cwjzkx38104j6n4ssqs6jpnqfc2znagpni";
+    sha256 = "0560a9g8n4p764r3va1nn95iv4bg71g8h0wws1af2p5g553j4zps";
   };
 
   nativeBuildInputs = [
@@ -33,10 +35,13 @@ stdenv.mkDerivation rec {
   ];
   
   installPhase = ''
-    mkdir -p $out/bin/
+    mkdir -p $out/bin $out/libexec/nix-top
     cp ./nix-top $out/bin/nix-top
+    chmod +x $out/bin/nix-top
     wrapProgram $out/bin/nix-top \
-      --prefix PATH : "${additionalPath}"
+      --prefix PATH : "$out/libexec/nix-top:${additionalPath}"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    ln -s /bin/stty $out/libexec/nix-top
   '';
 
   meta = with lib; {
@@ -44,7 +49,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/samueldr/nix-top;
     license = licenses.mit;
     maintainers = with maintainers; [ samueldr ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     inherit version;
   };
 }

--- a/pkgs/tools/package-management/nix-top/default.nix
+++ b/pkgs/tools/package-management/nix-top/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, ruby
+, makeWrapper
+, procps               # ps
+, ncurses              # tput
+, binutils-unwrapped   # strings
+, findutils
+}:
+
+# No gems used, so mkDerivation is fine.
+let
+  additionalPath = lib.makeBinPath [ncurses procps binutils-unwrapped findutils];
+in
+stdenv.mkDerivation rec {
+  name = "nix-top-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "samueldr";
+    repo = "nix-top";
+    rev = "v${version}";
+    sha256 = "0l50w90hs3kmdk5kb3cwjzkx38104j6n4ssqs6jpnqfc2znagpni";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    ruby
+  ];
+  
+  installPhase = ''
+    mkdir -p $out/bin/
+    cp ./nix-top $out/bin/nix-top
+    wrapProgram $out/bin/nix-top \
+      --prefix PATH : "${additionalPath}"
+  '';
+
+  meta = with lib; {
+    description = "Tracks what nix is building";
+    homepage = https://github.com/samueldr/nix-top;
+    license = licenses.mit;
+    maintainers = with maintainers; [ samueldr ];
+    platforms = platforms.linux;
+    inherit version;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21301,6 +21301,8 @@ with pkgs;
 
   nix-template-rpm = callPackage ../build-support/templaterpm { inherit (pythonPackages) python toposort; };
 
+  nix-top = callPackage ../tools/package-management/nix-top { };
+
   nix-repl = callPackage ../tools/package-management/nix-repl { nix = nix1; };
 
   nix-review = callPackage ../tools/package-management/nix-review { };


### PR DESCRIPTION
###### Motivation for this change

Integrate my tool to nixpkgs.

This tool gives an overview of the activity coming from nix builds.

![image](https://user-images.githubusercontent.com/132835/43370188-6da73572-9348-11e8-91a6-d41715846c87.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ⬜ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

