### PR TITLE
python.pkgs.pytest-flake8: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/pytest-flake8/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-flake8";
-  version = "1.0.1";
+  version = "1.0.2";
 
   # although pytest is a runtime dependency, do not add it as
   # propagatedBuildInputs in order to allow packages depend on another version
@@ -12,15 +12,12 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0s5fdivrmhjf6ybr6m2qb1h8hndv2jh2ir29qv36lhy9b7sc9kg5";
+    sha256 = "c740ad6aa19e3958947d2118f70bed218caf1d2097039fb7318573a2a72f89a1";
   };
 
   checkPhase = ''
-    pytest . -k "not test_mtime_caching"
+    pytest .
   '';
-
-  # https://github.com/tholo/pytest-flake8/issues/49
-  doCheck = false;
 
   meta = {
     description = "py.test plugin for efficiently checking PEP8 compliance";


### PR DESCRIPTION
###### Motivation for this change
Enable tests again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

