### PR TITLE
python3.pkgs.cheroot: fix build

### DIFF
--- a/pkgs/development/python-modules/cheroot/default.nix
+++ b/pkgs/development/python-modules/cheroot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage
+{ stdenv, fetchPypi, buildPythonPackage, fetchpatch
 , more-itertools, six
 , pytest, pytestcov, portend
 , backports_unittest-mock
@@ -13,9 +13,15 @@ buildPythonPackage rec {
     sha256 = "8e3ac15e1efffc81425a693e99b3c09d7ea4bf947255d8d4c38e2cf76f3a4d25";
   };
 
-  propagatedBuildInputs = [ more-itertools six ];
+  patches = fetchpatch {
+    name = "cheroot-fix-setup-python3.patch";
+    url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/cheroot-fix-setup-python3.patch?h=packages/python-cheroot";
+    sha256 = "1rlgz0qln536y00mfqlf0i9hz3f53id73wh47cg5q2vcsw1w2bpc";
+  };
 
-  checkInputs = [ pytest pytestcov portend backports_unittest-mock backports_functools_lru_cache ];
+  propagatedBuildInputs = [ more-itertools six backports_functools_lru_cache ];
+
+  checkInputs = [ pytest pytestcov portend backports_unittest-mock ];
 
 # Disable testmon, it needs pytest-testmon, which we do not currently have in nikpkgs,
 # and is only used to skip some tests that are already known to work.


### PR DESCRIPTION
###### Motivation for this change
`python3.pkgs.backports_functools_lru_cache` is `null`,
so we cannot require this for python3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

