### PR TITLE
astroid: 0.11.1 -> 0.13

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,22 +1,44 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, webkitgtk24x-gtk3
-, libsass, notmuch, boost, wrapGAppsHook, glib-networking }:
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, webkitgtk
+, libsass, notmuch, boost, wrapGAppsHook, glib-networking, protobuf, vim_configurable
+, makeWrapper, python3, python3Packages
+, vim ? vim_configurable.override {
+                    features = "normal";
+                    gui = "auto";
+                  }
+}:
 
 stdenv.mkDerivation rec {
   name = "astroid-${version}";
-  version = "0.11.1";
+  version = "0.13";
 
   src = fetchFromGitHub {
     owner = "astroidmail";
     repo = "astroid";
     rev = "v${version}";
-    sha256 = "1z48rvlzwi7bq7j55rnb0gg1a4k486yj910z2cxz1p46lxk332j1";
+    sha256 = "105x5g44hng3fi03h67j3an53088148jbq8726nmcp0zs0cy9gac";
   };
 
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ gnome3.gtkmm gmime3 webkitgtk24x-gtk3 libsass gnome3.libpeas
-                  notmuch boost gnome3.gsettings-desktop-schemas
-                  glib-networking ];
+  buildInputs = [ gnome3.gtkmm gmime3 webkitgtk libsass gnome3.libpeas
+                  python3 python3Packages.pygobject3
+                  notmuch boost gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme
+                  glib-networking protobuf ] ++ (if vim == null then [] else [ vim ]);
+
+  patches = [
+    # TODO: remove when https://github.com/astroidmail/astroid/pull/531
+    #       is released
+    ./run_tests.diff
+  ];
+
+  postPatch = ''
+    sed -i "s~gvim ~${vim}/bin/vim -g ~g" src/config.cc
+    sed -i "s~ -geom 10x10~~g" src/config.cc
+  '';
+
+  postInstall = ''
+    wrapProgram "$out/bin/astroid" --set CHARSET=en_us.UTF-8
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://astroidmail.github.io/;

--- a/pkgs/applications/networking/mailreaders/astroid/run_tests.diff
+++ b/pkgs/applications/networking/mailreaders/astroid/run_tests.diff
@@ -1,0 +1,10 @@
+diff --git a/tests/run_test.sh b/tests/run_test.sh
+index f2ea7d7..927c61d 100755
+--- a/tests/run_test.sh
++++ b/tests/run_test.sh
+@@ -1,4 +1,4 @@
+-#! /bin/bash
++#! /usr/bin/env bash
+ #
+ # Set up environment and run test specified on command line
+ 


### PR DESCRIPTION
Couple of things were updated to make this work.

1. webkitgtk24x-gtk3 that is marked unsafe has been replaced with
   webkitgtk (2.20.*) as astroid has recently indicated that [>= 2.20
   is
   acceptable](https://github.com/astroidmail/astroid/commit/48ce7e3010d2ee99ccba18798b4f5333867bd1a2)
2. protobuf built input was added to satisfy requirements
3. astroid was not functional at all without proper icons so gnome3.defaultIconTheme
   were added to buildInputs
4. By default, astroid will use `gvim` as a setting for the embedded
   editor, however that didn't work well with nixpkgs. vim is now
   bundled with astroid by default. This setting can be overridden
   by the user in astroid's config file.

###### Motivation for this change

Astroid 0.11.1 is outdated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

