### PR TITLE
pythonPackages.contextvars: 2.2 -> 2.3

### DIFF
--- a/pkgs/development/python-modules/contextvars/default.nix
+++ b/pkgs/development/python-modules/contextvars/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "contextvars";
-  version = "2.2";
+  version = "2.3";
   disabled = !isPy36;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "046b385nfzkjh0wqmd268p2jkgn9fg6hz40npq7j1w3c8aqzhwvx";
+    sha256 = "09fnni8cyxm070bfv9ay030qbyk0dfds5nq77s0p38h33hp08h93";
   };
 
   propagatedBuildInputs = [ immutables ];


### PR DESCRIPTION
###### Motivation for this change

This fixes the build of this package, which was previously broken because pythonPackages.immutables was upgraded, and this package expressed a dependency on a specific version of "immutables". The only change in this new version is to depend on the new version of immutables.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

