### PR TITLE
pythonPackages.fluent-logger: init at 0.9.3

### DIFF
--- a/pkgs/development/python-modules/fluent-logger/default.nix
+++ b/pkgs/development/python-modules/fluent-logger/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, msgpack }:
+
+buildPythonPackage rec {
+  pname = "fluent-logger";
+  version = "0.9.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "09vii0iclfq6vhz37xyybksq9m3538hkr7z40sz2dlpf2rkg98mg";
+  };
+
+  propagatedBuildInputs = [ msgpack ];
+  
+  # Tests fail because absent in package
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A structured logger for Fluentd (Python)";
+    homepage = https://github.com/fluent/fluent-logger-python;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2546,6 +2546,8 @@ in {
     };
   };
 
+  fluent-logger = callPackage ../development/python-modules/fluent-logger {};
+
   python-forecastio = callPackage ../development/python-modules/python-forecastio { };
 
   fpdf = callPackage ../development/python-modules/fpdf { };


### PR DESCRIPTION
###### Motivation for this change
Add fluent-logger package to pythonPackages

###### Things done
Added pypi fluent-logger package to `pythonPackages.nix`

- [x] Tested using sandboxing - Built on platform(s)
   - [x] NixOS
   - [x] macOS

References:
https://github.com/fluent/fluent-logger-python
https://pypi.org/project/fluent-logger/
