### PR TITLE
crystal: 0.25.0 -> 0.25.1; mint 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -3,25 +3,25 @@
 
 stdenv.mkDerivation rec {
   name = "crystal-${version}";
-  version = "0.25.0";
+  version = "0.25.1";
 
   src = fetchurl {
     url = "https://github.com/crystal-lang/crystal/archive/${version}.tar.gz";
-    sha256 = "1pnx21ky6cqfyv6df4mmjnyd1yh1bvcqkdzq6f0mk0yrkcl57k3q";
+    sha256 = "1ikzly6vs28ilqvqm4kxzhqs8mp6l4l344rhak63dav7vv97nnlv";
   };
 
-  prebuiltName = "crystal-0.25.0-1";
+  prebuiltName = "crystal-0.25.1-1";
   prebuiltSrc = let arch = {
     "x86_64-linux" = "linux-x86_64";
     "i686-linux" = "linux-i686";
     "x86_64-darwin" = "darwin-x86_64";
   }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
   in fetchurl {
-    url = "https://github.com/crystal-lang/crystal/releases/download/0.25.0/${prebuiltName}-${arch}.tar.gz";
+    url = "https://github.com/crystal-lang/crystal/releases/download/0.25.1/${prebuiltName}-${arch}.tar.gz";
     sha256 = {
-      "x86_64-linux" = "1q006086pbbvhmscbjzzgbdq1jkppd4p4kl9z9fn9j6np8fhi8ms";
-      "i686-linux" = "074ndm9n0mzsa7dkl3chhf234l85msm99yjksa5980lyqynyrw1d";
-      "x86_64-darwin" = "006f2j5984dkp5lsq8kns5mkxbhj50syjvzqk9z931pxl92wc7iy";
+      "x86_64-linux" = "0zjmbvbhi11p7s99jmvb3pac6zzsr792bxcfanrx503fjxxafgll";
+      "i686-linux" = "0i0hgsq7xa53594blqw5qi6jrqja18spifmalg7df2mj3h13h3pz";
+      "x86_64-darwin" = "1h369hzis1cigxbb6fgpahyq4d13gfgjc6adf300zc38yh8rvyy0";
     }."${stdenv.system}";
   };
 

--- a/pkgs/development/compilers/mint/crystal2nix.cr
+++ b/pkgs/development/compilers/mint/crystal2nix.cr
@@ -7,7 +7,7 @@ end
 
 class ShardLock
   YAML.mapping(
-    version: String,
+    version: Float32,
     shards: Hash(String, Hash(String, String))
   )
 end

--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -28,13 +28,13 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  version = "0.1.0";
+  version = "0.2.0";
   name = "mint-${version}";
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
-    rev = "0.1.0";
-    sha256 = "0n9lnkm2k8lv3wcw0jc7bcpgvcjyp3a8cywn0w7ipb22q8cl0n96";
+    rev = "0.2.0";
+    sha256 = "1ds9zrvbmnfy744i9ri6v4w37aw7ccmdxzxmy8l97h045hzz9cp3";
   };
 
   buildInputs = [ crystal zlib openssl duktape ];

--- a/pkgs/development/compilers/mint/shards.nix
+++ b/pkgs/development/compilers/mint/shards.nix
@@ -2,8 +2,8 @@
   admiral = {
     owner = "jwaldrip";
     repo = "admiral.cr";
-    rev = "v1.6.1";
-    sha256 = "0y30b9b9rkz43afd3b9l24hs0r170qyc07r05kvydbv89376c53i";
+    rev = "v1.7.2";
+    sha256 = "1j2cr4p3d44848v0gfl97p9kw2dslscnb1piyb7b3374iy345i0k";
   };
   ameba = {
     owner = "veelenga";
@@ -14,8 +14,14 @@
   baked_file_system = {
     owner = "schovi";
     repo = "baked_file_system";
-    rev = "e1447549d5ac0560720fae62179b2f2c62c9bfd1";
-    sha256 = "1fi6zag1a6h4xwrfizy01dls3hhraqw0cmpwj7rjv1qcddjgig5z";
+    rev = "24dbaf2180b872c0f0fc777b34e3759108959e6e";
+    sha256 = "01p7hzsvms9cywdgs0rcs6mxdi94491wk55823fw2vxv24hvxnvk";
+  };
+  diff = {
+    owner = "MakeNowJust";
+    repo = "crystal-diff";
+    rev = "51962dc36f9bbb1b926d557f7cb8993a6c73cc63";
+    sha256 = "1nwnsxm8srfw8jg0yfi2v19x6j3dadx62hq0xpxra40qcqz9dbnp";
   };
   duktape = {
     owner = "jessedoyle";
@@ -23,11 +29,17 @@
     rev = "v0.14.1";
     sha256 = "0fkay3qspzych050xl8xjkrphmxpzaj0dcf9jl22xwz8cx1l89f1";
   };
+  exception_page = {
+    owner = "crystal-loot";
+    repo = "exception_page";
+    rev = "v0.1.1";
+    sha256 = "0pimjm64p21cjhp0jhcgdmbgisx7amk8hhbkcprkbr44bj6rv9ay";
+  };
   kemal = {
     owner = "kemalcr";
     repo = "kemal";
-    rev = "a5870e7d24e5ec75c956bcf3e4423f55a2c4ff78";
-    sha256 = "1f2bm4xmfg6zqs3a8744pbk1vx964flf17g1mj01yslfcnzxywal";
+    rev = "09bb1fcd4073a374b3a61c99e48e05a866b23c08";
+    sha256 = "0yyb59i897gr8cqjbf48d6s0znq68ibpxarxkxkgrqk7lbvrqqr7";
   };
   kilt = {
     owner = "jeromegn";


### PR DESCRIPTION
###### Motivation for this change

Crystal upgrade is needed because of bugs in File handling (among others). See https://github.com/crystal-lang/crystal/releases/tag/0.25.1 for details. Those bugs prevented kemal to compile, which is used by Mint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

