### PR TITLE
gitAndTools.pre-commit: init at 1.10.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -539,6 +539,11 @@
     github = "boothead";
     name = "Ben Ford";
   };
+  borisbabic = {
+    email = "boris.ivan.babic@gmail.com";
+    github = "borisbabic";
+    name = "Boris Babić";
+  };
   bosu = {
     email = "boriss@gmail.com";
     github = "bosu";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -111,6 +111,8 @@ let
 
   hubUnstable = throw "use gitAndTools.hub instead";
 
+  pre-commit = callPackage ./pre-commit { };
+
   qgit = qt5.callPackage ./qgit { };
 
   stgit = callPackage ./stgit {

--- a/pkgs/applications/version-management/git-and-tools/pre-commit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pre-commit/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, python3Packages }:
+with python3Packages; buildPythonApplication rec {
+  pname = "pre_commit";
+  version = "1.10.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kn8h9k9ca330m5n7r4cvxp679y3sc95m1x23a3qhzgam09n7jwr";
+  };
+
+  propagatedBuildInputs = [
+    aspy-yaml
+    cached-property
+    cfgv
+    identify
+    nodeenv
+    six
+    toml
+    virtualenv
+  ];
+
+  # Tests fail due to a missing windll dependency
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A framework for managing and maintaining multi-language pre-commit hooks";
+    homepage = https://pre-commit.com/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ borisbabic ];
+  };
+}

--- a/pkgs/development/python-modules/aspy.yaml/default.nix
+++ b/pkgs/development/python-modules/aspy.yaml/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, pyyaml }:
+
+buildPythonPackage rec {
+  pname = "aspy.yaml";
+  version = "1.1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ajb97kn044ximkzq2090h4yblrhw77540pwiw345cp7mwzy4xqa";
+  };
+
+  propagatedBuildInputs = [ pyyaml ];
+
+  # Tests not included in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A few extensions to pyyaml";
+    homepage = https://github.com/asottile/aspy.yaml;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/cfgv/default.nix
+++ b/pkgs/development/python-modules/cfgv/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "cfgv";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1akm5xdbi5kckgnhhfj6qavjwakm44cwqzhfx2ycgh7mkym1qyfi";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  # Tests not included in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Validate configuration and produce human readable error messages";
+    homepage = https://github.com/asottile/cfgv;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/identify/default.nix
+++ b/pkgs/development/python-modules/identify/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "identify";
+  version = "1.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0hvwfpf6fmgn93abrvj88pi7sbcib32s4c5r99lw67kbziq5x129";
+  };
+
+  # Tests not included in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "File identification library for Python";
+    homepage = https://github.com/chriskuehl/identify;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/nodeenv/default.nix
+++ b/pkgs/development/python-modules/nodeenv/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "nodeenv";
+  version = "1.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vs9nyf9w3655j1vv3abxj4vbig61c0hjmhpfb91gblv32shl15a";
+  };
+
+  # Tests not included in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Node.js virtual environment builder";
+    homepage = https://github.com/ekalinin/nodeenv;
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1520,6 +1520,8 @@ in {
 
   cherrypy = callPackage ../development/python-modules/cherrypy {};
 
+  cfgv = callPackage ../development/python-modules/cfgv { };
+
   cftime = callPackage ../development/python-modules/cftime {};
 
   cjson = callPackage ../development/python-modules/cjson { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -186,6 +186,8 @@ in {
 
   asn1crypto = callPackage ../development/python-modules/asn1crypto { };
 
+  aspy-yaml = callPackage ../development/python-modules/aspy.yaml { };
+
   astral = callPackage ../development/python-modules/astral { };
 
   astropy = callPackage ../development/python-modules/astropy {  };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8428,6 +8428,8 @@ in {
     inherit (pkgs) which;
   };
 
+  nodeenv = callPackage ../development/python-modules/nodeenv { };
+
   nose = buildPythonPackage rec {
     version = "1.3.7";
     name = "nose-${version}";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3046,6 +3046,8 @@ in {
 
   idna-ssl = callPackage ../development/python-modules/idna-ssl { };
 
+  identify = callPackage ../development/python-modules/identify { };
+
   ijson = callPackage ../development/python-modules/ijson {};
 
   imagesize = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Add [pre-commit](https://pre-commit.com/) - a useful tool for managing and sharing git commit hooks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

