### PR TITLE
stdenv/build-support: support .tbz and .txz tarballs

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -836,9 +836,10 @@ passthru = {
         These can optionally be compressed using <command>gzip</command>
         (<filename>.tar.gz</filename>, <filename>.tgz</filename> or
         <filename>.tar.Z</filename>), <command>bzip2</command>
-        (<filename>.tar.bz2</filename> or <filename>.tbz2</filename>) or
-        <command>xz</command> (<filename>.tar.xz</filename> or
-        <filename>.tar.lzma</filename>).
+        (<filename>.tar.bz2</filename>, <filename>.tbz2</filename> or
+        <filename>.tbz</filename>) or <command>xz</command>
+        (<filename>.tar.xz</filename>, <filename>.tar.lzma</filename> or
+        <filename>.txz</filename>).
        </para>
       </listitem>
      </varlistentry>

--- a/pkgs/build-support/release/functions.sh
+++ b/pkgs/build-support/release/functions.sh
@@ -1,7 +1,7 @@
 findTarball() {
     local suffix i
     if [ -d "$1/tarballs/" ]; then
-        for suffix in tar.gz tgz tar.bz2 tbz2 tar.xz tar.lzma; do
+        for suffix in tar.gz tgz tar.bz2 tbz2 tbz tar.xz txz tar.lzma; do
             for i in $1/tarballs/*.$suffix; do echo $i; break; done
         done | sort | head -1
         return

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -801,11 +801,11 @@ _defaultUnpack() {
     else
 
         case "$fn" in
-            *.tar.xz | *.tar.lzma)
+            *.tar.xz | *.tar.lzma | *.txz)
                 # Don't rely on tar knowing about .xz.
                 xz -d < "$fn" | tar xf -
                 ;;
-            *.tar | *.tar.* | *.tgz | *.tbz2)
+            *.tar | *.tar.* | *.tgz | *.tbz2 | *.tbz)
                 # GNU tar can automatically select the decompression method
                 # (info "(tar) gzip").
                 tar xf "$fn"


### PR DESCRIPTION
###### Motivation for this change

Ocaml packages often use these extensions; tbz in general seems more common
than .tbz2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

