### PR TITLE
mpv: add lcms2 support

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -21,6 +21,7 @@
 , sdl2Support        ? true,  SDL2          ? null
 , alsaSupport        ? true,  alsaLib       ? null
 , screenSaverSupport ? true,  libXScrnSaver ? null
+, cmsSupport         ? true,  lcms2         ? null
 , vdpauSupport       ? true,  libvdpau      ? null
 , dvdreadSupport     ? true,  libdvdread    ? null
 , dvdnavSupport      ? true,  libdvdnav     ? null
@@ -53,6 +54,7 @@ assert xvSupport          -> x11Support && available libXv;
 assert sdl2Support        -> available SDL2;
 assert alsaSupport        -> available alsaLib;
 assert screenSaverSupport -> available libXScrnSaver;
+assert cmsSupport         -> available lcms2;
 assert vdpauSupport       -> available libvdpau;
 assert dvdreadSupport     -> available libdvdread;
 assert dvdnavSupport      -> available libdvdnav;
@@ -136,6 +138,7 @@ in stdenv.mkDerivation rec {
     ++ optional pulseSupport       libpulseaudio
     ++ optional rubberbandSupport  rubberband
     ++ optional screenSaverSupport libXScrnSaver
+    ++ optional cmsSupport        lcms2
     ++ optional vdpauSupport       libvdpau
     ++ optional speexSupport       speex
     ++ optional bs2bSupport        libbs2b


### PR DESCRIPTION
###### Motivation for this change

The mpv package is missing icc/color profile support which I (and hopefully others) would like to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

