### PR TITLE
pythonPackages.reportlab: remove test files that require network for the tests to pass

### DIFF
--- a/pkgs/development/python-modules/reportlab/default.nix
+++ b/pkgs/development/python-modules/reportlab/default.nix
@@ -23,12 +23,17 @@ in buildPythonPackage rec {
   buildInputs = [ ft pillow ];
 
   postPatch = ''
-    rm tests/test_graphics_barcode.py
+    # Remove all the test files that require access to the internet to pass.
+    rm tests/test_lib_utils.py
+    rm tests/test_platypus_general.py
+
+    # Remove the tests that require Vera fonts installed
     rm tests/test_graphics_render.py
   '';
 
   checkPhase = ''
-    LC_ALL="en_US.UTF-8" ${python.interpreter} tests/runAll.py
+    cd tests
+    LC_ALL="en_US.UTF-8" ${python.interpreter} runAll.py
   '';
 
   # See https://bitbucket.org/pypy/compatibility/wiki/reportlab%20toolkit


### PR DESCRIPTION
###### Motivation for this change

This PR removes the tests that require the network to pass.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes #44204 

cc @FRidh @eadwu 