### PR TITLE
bukubrow: Init at 2.4.0

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -7,7 +7,7 @@
 , trezor-bridge, bluejeans, djview4, adobe-reader
 , google_talk_plugin, fribid, gnome3/*.gnome-shell*/
 , esteidfirefoxplugin
-, browserpass, chrome-gnome-shell, uget-integrator, plasma-browser-integration
+, browserpass, chrome-gnome-shell, uget-integrator, plasma-browser-integration, bukubrow
 , udev
 , kerberos
 }:
@@ -61,6 +61,7 @@ let
       nativeMessagingHosts =
         ([ ]
           ++ lib.optional (cfg.enableBrowserpass or false) (lib.getBin browserpass)
+          ++ lib.optional (cfg.enableBukubrow or false) bukubrow
           ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
           ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
           ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma-browser-integration

--- a/pkgs/tools/networking/bukubrow/default.nix
+++ b/pkgs/tools/networking/bukubrow/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, rustPlatform, fetchFromGitHub, sqlite }:
+
+rustPlatform.buildRustPackage rec {
+  name = "bukubrow-${version}";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "SamHH";
+    repo = "bukubrow";
+    rev = version;
+    sha256 = "1wrwav7am73bmgbpwh1pi0b8k7vhydqvw91hmmhnvbjhrhbns7s5";
+  };
+  sourceRoot = "source/binary";
+
+  cargoSha256 = "19d1pgk8nm5jsfd696bqayi5s8ivv9gi6jdb00d10ddjxz234gs7";
+
+  buildInputs = [ sqlite ];
+
+  postInstall = ''
+    mkdir -p $out/etc $out/lib/mozilla/native-messaging-hosts
+
+    host_file="$out/bin/bukubrow"
+    sed -e "s!%%replace%%!$host_file!" browser-hosts/firefox.json > "$out/etc/firefox-host.json"
+    sed -e "s!%%replace%%!$host_file!" browser-hosts/chrome.json > "$out/etc/chrome-host.json"
+
+    ln -s $out/etc/firefox-host.json $out/lib/mozilla/native-messaging-hosts/com.samhh.bukubrow.json
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bukubrow is a WebExtension for Buku, a command-line bookmark manager";
+    homepage = https://github.com/SamHH/bukubrow;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -940,6 +940,8 @@ with pkgs;
 
   buildah = callPackage ../development/tools/buildah { };
 
+  bukubrow = callPackage ../tools/networking/bukubrow { };
+
   burpsuite = callPackage ../tools/networking/burpsuite {};
 
   c3d = callPackage ../applications/graphics/c3d {
@@ -11842,7 +11844,7 @@ with pkgs;
   sofia_sip = callPackage ../development/libraries/sofia-sip { };
 
   soil = callPackage ../development/libraries/soil { };
-  
+
   sonic = callPackage ../development/libraries/sonic { };
 
   soprano = callPackage ../development/libraries/soprano { };
@@ -20919,7 +20921,7 @@ with pkgs;
   spyder = pythonPackages.spyder;
 
   openspace = callPackage ../applications/science/astronomy/openspace { };
-  
+
   stellarium = libsForQt5.callPackage ../applications/science/astronomy/stellarium { };
 
   tulip = callPackage ../applications/science/misc/tulip {


### PR DESCRIPTION
###### Motivation for this change
This adds https://github.com/SamHH/bukubrow, a web extension for the bookmark manager [buku](https://github.com/jarun/Buku), which is usually invoked from the CLI.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

