### PR TITLE
doc: add darwin installCheckTarget example

### DIFF
--- a/doc/platform-notes.xml
+++ b/doc/platform-notes.xml
@@ -29,6 +29,7 @@
       }
     </programlisting>
    </listitem>
+
    <listitem>
     <para>
      On darwin libraries are linked using absolute paths, libraries are
@@ -46,6 +47,37 @@
       }
     </programlisting>
    </listitem>
+
+   <listitem>
+    <para>
+     Even if the libraries are linked using absolute paths and resolved via
+     their <literal>install_name</literal> correctly, tests can sometimes fail
+     to run binaries.  This happens because the <varname>checkPhase</varname>
+     runs before the libraries are installed.
+    </para>
+    <para>
+     This can usually be solved by running the tests after the
+     <varname>installPhase</varname> or alternatively by using
+     <varname>DYLD_LIBRARY_PATH</varname>. More information about this variable
+     can be found in the <citerefentry><refentrytitle>dyld</refentrytitle>
+     <manvolnum>1</manvolnum></citerefentry> manpage.
+    </para>
+<programlisting>
+      dyld: Library not loaded: /nix/store/7hnmbscpayxzxrixrgxvvlifzlxdsdir-jq-1.5-lib/lib/libjq.1.dylib
+      Referenced from: /private/tmp/nix-build-jq-1.5.drv-0/jq-1.5/tests/../jq
+      Reason: image not found
+      ./tests/jqtest: line 5: 75779 Abort trap: 6
+    </programlisting>
+<programlisting>
+      stdenv.mkDerivation {
+        name = "libfoo-1.2.3";
+        # ...
+        doInstallCheck = true;
+        installCheckTarget = "check";
+      }
+    </programlisting>
+   </listitem>
+
    <listitem>
     <para>
      Some packages assume xcode is available and use <command>xcrun</command>


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

