### PR TITLE
scrcpy: init at v1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2264,6 +2264,11 @@
     github = "luispedro";
     name = "Luis Pedro Coelho";
   };
+  lukeadams = {
+    email = "luke.adams@belljar.io";
+    github = "lukeadams";
+    name = "Luke Adams";
+  };
   lukego = {
     email = "luke@snabb.co";
     github = "lukego";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -926,6 +926,11 @@
     github = "deepfire";
     name = "Kosyrev Serge";
   };
+  deltaevo = {
+    email = "deltaduartedavid@gmail.com";
+    github = "DeltaEvo";
+    name = "Duarte David";
+  };
   demin-dmitriy = {
     email = "demindf@gmail.com";
     github = "demin-dmitriy";

--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchurl, fetchFromGitHub, makeWrapper
+, meson
+, ninja
+, pkgconfig
+
+, platformTools
+, ffmpeg
+, SDL2
+}:
+
+let
+  version = "1.2";
+  prebuilt_server = fetchurl {
+    url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}.jar";
+    sha256 = "0q0zyqw7y33r9ybjp8ay6yac7ifca1lq14pjvw6x78zxs976affb";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "scrcpy-${version}";
+  inherit version;
+  src = fetchFromGitHub {
+    owner = "Genymobile";
+    repo = "scrcpy";
+    rev = "v${version}";
+    sha256 = "01zw6h6mz2cwqfh9lwypm8pbfx9m9df91l1fq1i0f1d8v49x8wqc";
+  };
+
+  nativeBuildInputs = [ makeWrapper meson ninja pkgconfig ];
+
+  buildInputs = [ ffmpeg SDL2 ];
+
+  # Manually install the server jar to prevent Meson from "fixing" it
+  preConfigure = ''
+    echo -n > server/meson.build
+  '';
+
+  postInstall = ''
+    mkdir -p "$out/share/scrcpy"
+    ln -s "${prebuilt_server}" "$out/share/scrcpy/scrcpy-server.jar"
+
+    # runtime dep on `adb` to push the server
+    wrapProgram "$out/bin/scrcpy" --prefix PATH : "${platformTools}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Display and control Android devices over USB or TCP/IP";
+    homepage = https://github.com/Genymobile/scrcpy;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ deltaevo lukeadams ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5012,6 +5012,10 @@ with pkgs;
     inherit (darwin.apple_sdk.libs) utmp;
   };
 
+  scrcpy = callPackage ../misc/scrcpy {
+    inherit (androidenv) platformTools;
+  };
+
   screen-message = callPackage ../tools/X11/screen-message { };
 
   screencloud = callPackage ../applications/graphics/screencloud {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

