### PR TITLE
strelka: init 2.9.5

### DIFF
--- a/pkgs/applications/science/biology/strelka/default.nix
+++ b/pkgs/applications/science/biology/strelka/default.nix
@@ -1,0 +1,37 @@
+{stdenv, fetchFromGitHub, cmake, zlib, python2}:
+
+stdenv.mkDerivation rec {
+  name = "strelka-${version}";
+  version = "2.9.5";
+
+  src = fetchFromGitHub {
+    owner = "Illumina";
+    repo = "strelka";
+    rev = "v${version}";
+    sha256 = "0x4a6nkx1jnyag9svghsdjz1fz6q7qx5pn77wphdfnk81f9yspf8";
+  };
+
+  buildInputs = [ cmake zlib python2 ];
+
+  preConfigure = ''
+    sed -i 's|/usr/bin/env python|${python2}/bin/python|' src/python/lib/makeRunScript.py
+    patchShebangs .
+  '';
+
+  postFixup = ''
+    pushd $out/lib/python/pyflow
+    sed -i 's|/bin/bash|${stdenv.shell}|' pyflowTaskWrapper.py
+    rm pyflowTaskWrapper.pyc
+    echo "import pyflowTaskWrapper" | python2
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Germline and small variant caller";
+    license = licenses.gpl3;
+    homepage = https://github.com/Illumina/strelka;
+    maintainers = with maintainers; [ jbedo ];
+    platforms = [ "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20393,6 +20393,8 @@ with pkgs;
 
   star = callPackage ../applications/science/biology/star { };
 
+  strelka = callPackage ../applications/science/biology/strelka { };
+
   varscan = callPackage ../applications/science/biology/varscan { };
 
   hmmer = callPackage ../applications/science/biology/hmmer { };


### PR DESCRIPTION
###### Motivation for this change

Strelka init at version 2.9.5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

