### PR TITLE
browsh: init at 1.4.10

### DIFF
--- a/pkgs/applications/networking/browsers/browsh/default.nix
+++ b/pkgs/applications/networking/browsers/browsh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchurl, fetchFromGitHub, go-bindata, ... }:
+{ stdenv, buildGoPackage, fetchurl, fetchFromGitHub, go-bindata }:
 
 let
   version = "1.4.10";

--- a/pkgs/applications/networking/browsers/browsh/default.nix
+++ b/pkgs/applications/networking/browsers/browsh/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, buildGoPackage, fetchurl, fetchFromGitHub, go-bindata, ... }:
+
+let
+  version = "1.4.10";
+
+  # TODO: must build the extension instead of downloading it. But since it's
+  # literally an asset that is indifferent regardless of the platform, this
+  # might be just enough.
+  webext = fetchurl {
+    url = "https://github.com/browsh-org/browsh/releases/download/v${version}/browsh-${version}-an.fx.xpi";
+    sha256 = "0rgwzv1qahqy52q7zz4dklnwx7w4x3gj92ka8n0ypgf9fjjnmqas";
+  };
+
+in buildGoPackage rec {
+  inherit version;
+
+  name = "browsh-${version}";
+
+  goPackagePath = "browsh";
+
+  src = fetchFromGitHub {
+    owner = "browsh-org";
+    repo = "browsh";
+    rev = "v${version}";
+    sha256 = "0lvb20zziknlbgy509ccpvlc21sqjc53xar26blmb6sdl6yqkj0w";
+  };
+
+  buildInputs = [ go-bindata ];
+
+  # embed the web extension in a go file and place it where it's supposed to
+  # be. See
+  # https://github.com/browsh-org/browsh/blob/9abc3aaa3f575ca6ec9a483408d9fdfcf76300fa/interfacer/contrib/xpi2bin.sh
+  preBuild = ''
+    xpiprefix="$(mktemp -d)"
+    cp "${webext}" "$xpiprefix/browsh.xpi"
+    go-bindata \
+      -prefix "$xpiprefix" \
+      -pkg browsh \
+      -o "$NIX_BUILD_TOP/go/src/${goPackagePath}/interfacer/src/browsh/webextension.go" \
+      "$xpiprefix/browsh.xpi"
+
+    sed \
+      -e 's:Asset("/browsh.xpi"):Asset("browsh.xpi"):g' \
+      -i "$NIX_BUILD_TOP/go/src/${goPackagePath}/interfacer/src/browsh/firefox.go"
+  '';
+
+  postBuild = ''
+    mv "$NIX_BUILD_TOP/go/bin/src" "$NIX_BUILD_TOP/go/bin/browsh"
+  '';
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "A fully-modern text-based browser, rendering to TTY and browsers";
+    homepage = https://www.brow.sh/;
+    maintainers = [ maintainers.kalbasit ];
+    license = stdenv.lib.licenses.lgpl21;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+  };
+}

--- a/pkgs/applications/networking/browsers/browsh/deps.nix
+++ b/pkgs/applications/networking/browsers/browsh/deps.nix
@@ -1,0 +1,272 @@
+[
+  {
+    goPackagePath  = "github.com/NYTimes/gziphandler";
+    fetch = {
+      type = "git";
+      url = "https://github.com/NYTimes/gziphandler";
+      rev =  "5032c8878b9dd46cfe8c625c0d9b9f258a560ee8";
+      sha256 = "1avn8xb78xmmc61fjycpc81yrkfi42fna8zgzdqba6v7g8gq8a3x";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "8991bc29aa16c548c550c7ff78260e27b9ab7c73";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev =  "a1dbeea552b7c8df4b542c66073e393de198a800";
+      sha256 = "0nssmn8j0yavs8099gwb69qpd1k9yd2z28bii6i4y61v0grb6bc2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gdamore/encoding";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gdamore/encoding";
+      rev =  "b23993cbb6353f0e6aa98d0ee318a34728f628b9";
+      sha256 = "0d7irqpx2fa9vkxgkhf04yiwazsm10fxh0yk86x5crflhph5fv8a";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gdamore/tcell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gdamore/tcell";
+      rev =  "de7e78efa4a71b3f36c7154989c529dbdf9ae623";
+      sha256 = "1ly3gqkziw01cb7h64k0wc4myzfcsr9hl7xznxd8k2yqzqvmhljz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-errors/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-errors/errors";
+      rev =  "a6af135bd4e28680facf08a3d206b454abc877a4";
+      sha256 = "0rznpknk19rxkr7li6dqs52c26pjazp69lh493l4ny4sxn5922lp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "5ed622c449da6d44c3c8329331ff47a9e5844f71";
+      sha256 = "1yhcwraijdk6lx7f6m9p6i1b3zfh2hq80l1nfpnckfn10gh72aw7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev =  "ef8a98b0bbce4a65b5aa4c368430a80ddc533168";
+      sha256 = "1qalfsc31fra7hcw2lc3s20aj7al62fq3j5fn5kga3mg99b82nyr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lucasb-eyer/go-colorful";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lucasb-eyer/go-colorful";
+      rev =  "c7842319cf3ac2eff253e8b3ebe15fcc56b6414a";
+      sha256 = "00v2x6qchhi6vv09w29kcyr9i0kq4n4daaj3vk1c4nfj2z7xx5hc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev =  "c2353362d570a7bfa228149c62842019201cfb71";
+      sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev =  "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb";
+      sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev =  "f15292f7a699fcc1a38a80977f80a046874ba8ac";
+      sha256 = "0zm3nhdvmj3f8q0vg2sjfw1sm3pwsw0ggz501awz95w99664a8al";
+    };
+  }
+  {
+    goPackagePath  = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev =  "3774a09d95489ccaa16032e0770d08ea77ba6184";
+      sha256 = "0x0gc89vgq38xhgmi2h22bhr73cf2gmk42g89nz89k8dgg9hhr25";
+    };
+  }
+  {
+    goPackagePath  = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev =  "b6ea1ea48f981d0f615a154a45eabb9dd466556d";
+      sha256 = "14179j7pj1h2vx60i68x2m6650ldji4xhanhc702i8a8iy7b49ja";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev =  "c2dbbc24a97911339e01bda0b8cabdbd8f13b602";
+      sha256 = "0v1dsqnk5zmn6ir8jgxijx14s47jvijlqfz3aq435snfrgybd5rz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "816c9085562cd7ee03e7f8188a1cfd942858cded";
+      sha256 = "1ws5crb7c70wdicavl6qr4g03nn6m92zd6wwp9n2ygz5c8rmxh8k";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/shibukawa/configdir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shibukawa/configdir";
+      rev =  "e180dbdc8da04c4fa04272e875ce64949f38bd3e";
+      sha256 = "0vbma9jkwh0ifz8dk2ssgmy7aiaify63lpa0lah7i4dkkxr94c9z";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev =  "787d034dfe70e44075ccc060d346146ef53270ad";
+      sha256 = "0138rjiacl71h7kvhzinviwvy6qa2m6rflpv9lgqv15hnjvhwvg1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev =  "8965335b8c7107321228e3e3702cab9832751bac";
+      sha256 = "177bk7lq40jbgv9p9r80aydpaccfk8ja3a7jjhfwiwk9r1pa4rr2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev =  "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394";
+      sha256 = "132p84i20b9s5r6fs597lsa6648vd415ch7c0d018vm8smzqpd0h";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "3ebe029320b2676d667ae88da602a5f854788a8a";
+      sha256 = "11yxs0wqy70wj106fkz8r923yg4ncnc2mbw33v48zmlg4a1rasgp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev =  "d493c32b69b8c6f2377bf30bc4d70267ffbc0793";
+      sha256 = "1jq46790rkjn6c1887wz98dqjk792ij6wnrifzk1maglmfb061hh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "f35b8ab0b5a2cef36673838d662e249dd9c94686";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ulule/limiter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ulule/limiter";
+      rev =  "af07f8759cbc68c744a15ffbfdabf35f7aff5e3b";
+      sha256 = "1c68vz9r0442lkj206l6k03nssxx3ys8ddg7d2p2brdanfbprzrq";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "a0f8a16cb08c06df97cbdf9c47f4731ba548c33c";
+      sha256 = "1pnvrhi2minkn9mfa9p70b5jnixx8il5yqp08ad1w7kl34c21ma2";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e";
+      sha256 = "0zj8s3q2fznmap1nfr8pv4hz8xqixmkyhr6slq4baf8rvcb4mvbj";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "0605a8320aceb4207a5fb3521281e17ec2075476";
+      sha256 = "1pak7q9ivwxh5bnjk00pkrs9ri9vmbyccvza56fl6138w397h49j";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15469,6 +15469,8 @@ with pkgs;
     inherit (pythonPackages) pyserial pygtk;
   };
 
+  browsh = callPackage ../applications/networking/browsers/browsh { };
+
   chromium = callPackage ../applications/networking/browsers/chromium {
     channel = "stable";
     pulseSupport = config.pulseaudio or true;


### PR DESCRIPTION
###### Motivation for this change

A fully-modern text-based browser, rendering to TTY and browsers. https://www.brow.sh/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes #43283 