### PR TITLE
k3b: separate wrapper derivation to easily override cdrtools (e.g. with cdrkit)

### DIFF
--- a/pkgs/applications/kde/k3b.nix
+++ b/pkgs/applications/kde/k3b.nix
@@ -1,5 +1,5 @@
 { mkDerivation, lib
-, extra-cmake-modules, kdoctools, makeWrapper, shared-mime-info
+, extra-cmake-modules, kdoctools, makeWrapper, shared-mime-info, symlinkJoin
 , qtwebkit
 , libkcddb, karchive, kcmutils, kfilemetadata, knewstuff, knotifyconfig, solid, kxmlgui
 , flac, lame, libmad, libmpcdec, libvorbis
@@ -8,41 +8,51 @@
 , ffmpeg, libmusicbrainz3, normalize, sox, transcode, kinit
 }:
 
-mkDerivation {
-  name = "k3b";
-  meta = with lib; {
-    license = with licenses; [ gpl2Plus ];
-    maintainers = with maintainers; [ sander phreedom ];
-    platforms = platforms.linux;
+let
+
+  unwrapped = mkDerivation {
+    name = "k3b";
+    meta = with lib; {
+      license = with licenses; [ gpl2Plus ];
+      maintainers = with maintainers; [ sander phreedom ];
+      platforms = platforms.linux;
+    };
+    nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+    buildInputs = [
+      # qt
+      qtwebkit
+      # kde
+      libkcddb karchive kcmutils kfilemetadata knewstuff knotifyconfig solid kxmlgui
+      # formats
+      flac lame libmad libmpcdec libvorbis
+      # sound utilities
+      libsamplerate libsndfile taglib
+      # cd/dvd
+      cdparanoia libdvdcss libdvdread
+      # others
+      ffmpeg libmusicbrainz3 shared-mime-info
+    ];
+    propagatedUserEnvPkgs = [ (lib.getBin kinit) ];
   };
-  nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
-  buildInputs = [
-    # qt
-    qtwebkit
-    # kde
-    libkcddb karchive kcmutils kfilemetadata knewstuff knotifyconfig solid kxmlgui
-    # formats
-    flac lame libmad libmpcdec libvorbis
-    # sound utilities
-    libsamplerate libsndfile taglib
-    # cd/dvd
-    cdparanoia libdvdcss libdvdread
-    # others
-    ffmpeg libmusicbrainz3 shared-mime-info
+
+  binPath = lib.makeBinPath ( lib.remove null [
+    cdrdao cdrtools dvdplusrwtools libburn normalize sox transcode
+    vcdimager flac
+  ]);
+
+  libraryPath = lib.makeLibraryPath [
+    cdparanoia
   ];
-  propagatedUserEnvPkgs = [ (lib.getBin kinit) ];
-  postFixup =
-    let
-      binPath = lib.makeBinPath [
-        cdrdao cdrtools dvdplusrwtools libburn normalize sox transcode
-        vcdimager flac
-      ];
-      libraryPath = lib.makeLibraryPath [
-        cdparanoia
-      ];
-    in ''
-      wrapProgram "$out/bin/k3b"     \
-        --prefix PATH : "${binPath}" \
-        --prefix LD_LIBRARY_PATH : ${libraryPath}
-    '';
+
+in
+
+symlinkJoin {
+  inherit (unwrapped) name meta;
+  paths = [ unwrapped ];
+  nativeBuildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram "$out/bin/k3b"     \
+      --prefix PATH : "${binPath}" \
+      --prefix LD_LIBRARY_PATH : ${libraryPath}
+  '';
 }


### PR DESCRIPTION
This commit replaces the dependency on
cdrtools with a dependency on cdrkit.
The change affects the PATH seen by k3b (set by a wrapper);
k3b finds the required binaries by itself.

Advantage of cdrkit:
Based on experiment (by committer),
it permits writing optical media without superuser privileges.

Advantage of cdrtools:
It seems well supported and allows writing blu-ray media
(at least that's what the k3b feature list claims).

This commit should fix
https://github.com/NixOS/nixpkgs/issues/19154 .

###### Motivation for this change

Writing optical media should work without superuser privileges.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): k3b fails with same error that also occurs without this commit, which is probably due to NixOS 18.03 environment: `qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Phreedom @svanderburg