### PR TITLE
photon: init at 1.0.7

### DIFF
--- a/pkgs/tools/networking/photon/default.nix
+++ b/pkgs/tools/networking/photon/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, pythonPackages, fetchurl, makeWrapper }:
+
+with pythonPackages;
+buildPythonApplication rec {
+  pname = "photon";
+  version = "1.0.7";
+
+  src = fetchurl {
+    url = "https://github.com/s0md3v/Photon/archive/v${version}.tar.gz";
+    sha256 = "0c5l1sbkkagfxmh8v7yvi6z58mhqbwjyr7fczb5qwxm7la42ah9y";
+  };
+
+  patches = [ ./destdir.patch ];
+  postPatch = ''
+       substituteInPlace photon.py --replace DESTDIR $out/share/photon 
+  '';
+
+  dontBuild = true;
+  doCheck = false;
+  propagatedBuildInputs = [
+    requests
+    urllib3
+  ];
+
+  installPhase = ''
+    mkdir -p "$out"/{bin,share/photon}
+    cp -R photon.py core plugins $out/share/photon
+ 
+    makeWrapper ${python.interpreter} $out/bin/photon \
+      --set PYTHONPATH "$PYTHONPATH:$out/share/photon" \
+      --add-flags "-O $out/share/photon/photon.py"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "a lightning fast web crawler which extracts URLs, files, intel & endpoints from a target";
+    homepage = https://github.com/s0md3v/Photon;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ genesis ];
+  };
+}

--- a/pkgs/tools/networking/photon/destdir.patch
+++ b/pkgs/tools/networking/photon/destdir.patch
@@ -1,0 +1,20 @@
+diff --git a/photon.py.old b/photon.py
+index 92498e4..f7e2c3d 100644
+--- a/photon.py.old
++++ b/photon.py
+@@ -185,7 +185,7 @@ if args.user_agent:
+     user_agents = args.user_agent.split(',')
+ else:
+     user_agents = []
+-    with open(os.getcwd() + '/core/user-agents.txt', 'r') as uas:
++    with open('DESTDIR/core/user-agents.txt', 'r') as uas:
+         for agent in uas:
+             user_agents.append(agent.strip('\n'))
+ 
+@@ -534,4 +534,4 @@ if args.export:
+ if not colors: # if colors are disabled
+     print ('%s Results saved in %s directory' % (good, output_dir))
+ else:
+-    print ('%s Results saved in \033[;1m%s\033[0m directory' % (good, output_dir))
+\ No newline at end of file
++    print ('%s Results saved in \033[;1m%s\033[0m directory' % (good, output_dir))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1438,6 +1438,8 @@ with pkgs;
 
   pbzx = callPackage ../tools/compression/pbzx { };
 
+  photon = callPackage ../tools/networking/photon { };
+
   playerctl = callPackage ../tools/audio/playerctl { };
 
   ps_mem = callPackage ../tools/system/ps_mem { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

