### PR TITLE
fix libgpg-error cross build on armv7

### DIFF
--- a/pkgs/development/libraries/libgpg-error/default.nix
+++ b/pkgs/development/libraries/libgpg-error/default.nix
@@ -34,6 +34,8 @@ in stdenv.mkDerivation (rec {
 
   postPatch = ''
     sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure
+  '' + lib.optionalString (stdenv.hostPlatform.isArm && stdenv.buildPlatform != stdenv.hostPlatform ) ''
+    ln -s lock-obj-pub.arm-unknown-linux-gnueabi.h src/syscfg/lock-obj-pub.linux-gnueabihf.h
   '' + lib.optionalString stdenv.hostPlatform.isMusl ''
     ln -s lock-obj-pub.x86_64-pc-linux-musl.h src/syscfg/lock-obj-pub.linux-musl.h
   '';


### PR DESCRIPTION
###### Motivation for this change
libgpg-error fails to cross build for armv7:

    ./gpg-error.h.in:476: error including `./syscfg/lock-obj-pub.linux-gnueabihf.h': No such file or directory

the change in this PR allows it to build.
please say if there is a better way to fix this!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

