### PR TITLE
glusterfs: 3.12.4 -> 3.12.12

### DIFF
--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,10 +15,10 @@ let
     #       The command
     #         find /nix/store/...-glusterfs-.../ -name '*.py' -executable
     #       can help with finding new Python scripts.
-    version = "3.12.4";
+    version = "3.12.12";
     name="${baseName}-${version}";
     url="https://github.com/gluster/glusterfs/archive/v${version}.tar.gz";
-    sha256 = "01gsc3dw491ipl47q733iznddxbg42aa749vkyaq6i6w4d7m157f";
+    sha256 = "1q6rcf9y98w3kvgwdlbhl65phkdl0mfil6y7i3gnpf3d21gfb6nw";
   };
   buildInputs = [
     fuse bison flex_2_5_35 openssl ncurses readline


### PR DESCRIPTION
###### Motivation for this change

Update gluster to latest 3.x version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

