### PR TITLE
cadence: init at 0.9.0

### DIFF
--- a/pkgs/applications/audio/cadence/default.nix
+++ b/pkgs/applications/audio/cadence/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, qtbase
+, makeWrapper
+, jack2Full
+, python3Packages
+, a2jmidid
+}:
+
+ stdenv.mkDerivation rec {
+  version = "0.9.0";
+  name = "cadence";
+
+  src = fetchurl {
+    url = "https://github.com/falkTX/Cadence/archive/v${version}.tar.gz";
+    sha256 = "07z1mnb0bmldb3i31bgw816pnvlvr9gawr51rpx3mhixg5wpiqzb";
+  };
+
+  buildInputs = [
+    makeWrapper
+    pkgconfig
+    qtbase
+  ];
+
+  apps = [
+    "cadence"
+    "cadence-jacksettings"
+    "cadence-pulse2loopback"
+    "claudia"
+    "cadence-aloop-daemon"
+    "cadence-logs"
+    "cadence-render"
+    "catarina"
+    "claudia-launcher"
+    "cadence-pulse2jack"
+    "cadence-session-start"
+    "catia"
+  ];
+
+  makeFlags = ''
+    PREFIX=""
+    DESTDIR=$(out)
+  '';
+
+  propagatedBuildInputs = with python3Packages; [ pyqt5 ];
+
+  postInstall = ''
+    # replace with our own wrappers.
+    for app in $apps; do
+      rm $out/bin/$app
+      makeWrapper ${python3Packages.python.interpreter} $out/bin/$app \
+        --set PYTHONPATH "$PYTHONPATH:$out/share/cadence" \
+        --add-flags "-O $out/share/cadence/src/$app.py"
+    done
+  '';
+
+  meta = {
+    homepage = https://github.com/falkTX/Cadence/;
+    description = "Collection of tools useful for audio production";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ genesis ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15227,6 +15227,8 @@ with pkgs;
 
   avocode = callPackage ../applications/graphics/avocode {};
 
+  cadence =  libsForQt5.callPackage ../applications/audio/cadence { };
+
   milkytracker = callPackage ../applications/audio/milkytracker { };
 
   schismtracker = callPackage ../applications/audio/schismtracker { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

I can't fully test it since i don't have yet a proper jack enabled nixos.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

