### PR TITLE
cups-filters: fix the build with poppler-0.67.0

### DIFF
--- a/pkgs/misc/cups/filters.nix
+++ b/pkgs/misc/cups/filters.nix
@@ -2,6 +2,7 @@
 , libjpeg, libpng, perl, ijs, qpdf, dbus, avahi
 , makeWrapper, coreutils, gnused, bc, gawk, gnugrep, which, ghostscript
 , mupdf
+, fetchpatch
 }:
 
 let
@@ -15,6 +16,16 @@ in stdenv.mkDerivation rec {
     url = "https://openprinting.org/download/cups-filters/${name}.tar.xz";
     sha256 = "0sjkmclcb1r77015wllsyz26272br3s17v6b1q2xwb2nm2gnwx9k";
   };
+
+  patches = [
+    # This patch fixes cups-filters when compiled with poppler-0.67.0.
+    # Issue: https://github.com/OpenPrinting/cups-filters/pull/50
+    # PR: https://github.com/OpenPrinting/cups-filters/pull/51
+    (fetchpatch {
+      url = "https://github.com/OpenPrinting/cups-filters/commit/219de01c61f3b1ec146abf142d0dfc8c560cc58e.patch";
+      sha256 = "0f0lql3rbm2g8mxrpigfyi8fb4i2g4av20g417jzdilp60jq0ny8";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change

Apply the patch from https://github.com/OpenPrinting/cups-filters/pull/51 to fix the build of cups-filter originally broken by 7d016502d88a89bebb2fd8728a5bb40702a7feba.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes #44282