### PR TITLE
Fix lesspipe dependency backport to 18.03

### DIFF
--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchFromGitHub, perl, file }:
+{ stdenv, lib, fetchFromGitHub, makeWrapper, perl, file, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "lesspipe-${version}";
   version = "1.82";
 
-  buildInputs = [ perl ];
+  buildInputs = [ makeWrapper perl ];
   preConfigure = "patchShebangs .";
+  preFixupPhases = ["wrapWithDepsPhase"];
 
   src = fetchFromGitHub {
     owner = "wofr06";
@@ -13,6 +14,10 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "0vb7bpap8vy003ha10hc7hxl17y47sgdnrjpihgqxkn8k0bfqbbq";
   };
+
+  wrapWithDepsPhase = ''
+    wrapProgram $out/bin/lesspipe.sh --prefix PATH ":" ${lib.makeBinPath [ file ncurses ]}
+  '';
 
   meta = with stdenv.lib; {
     description = "A preprocessor for less";

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perl }:
+{ stdenv, fetchFromGitHub, perl, file }:
 
 stdenv.mkDerivation rec {
   name = "lesspipe-${version}";

--- a/pkgs/tools/misc/lesspipe/default.nix
+++ b/pkgs/tools/misc/lesspipe/default.nix
@@ -1,12 +1,11 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, perl, file, ncurses }:
+{ stdenv, fetchFromGitHub, substituteAll, perl, file, ncurses }:
 
 stdenv.mkDerivation rec {
   name = "lesspipe-${version}";
   version = "1.82";
 
-  buildInputs = [ makeWrapper perl ];
+  buildInputs = [ perl ];
   preConfigure = "patchShebangs .";
-  preFixupPhases = ["wrapWithDepsPhase"];
 
   src = fetchFromGitHub {
     owner = "wofr06";
@@ -15,9 +14,13 @@ stdenv.mkDerivation rec {
     sha256 = "0vb7bpap8vy003ha10hc7hxl17y47sgdnrjpihgqxkn8k0bfqbbq";
   };
 
-  wrapWithDepsPhase = ''
-    wrapProgram $out/bin/lesspipe.sh --prefix PATH ":" ${lib.makeBinPath [ file ncurses ]}
-  '';
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      file = "${file}/bin/file";
+      tput = "${ncurses}/bin/tput";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A preprocessor for less";

--- a/pkgs/tools/misc/lesspipe/fix-paths.patch
+++ b/pkgs/tools/misc/lesspipe/fix-paths.patch
@@ -1,0 +1,22 @@
+--- a/lesspipe.sh.in
++++ b/lesspipe.sh.in
+@@ -48,8 +48,8 @@ if [[ "$LESS_ADVANCED_PREPROCESSOR" = '' ]]; then
+ fi
+ 
+ filecmd() {
+-  file -L -s "$@"
+-  file -L -s -i "$@" 2> /dev/null | sed -n 's/.*charset=/;/p' | tr a-z A-Z
++  @file@ -L -s "$@"
++  @file@ -L -s -i "$@" 2> /dev/null | sed -n 's/.*charset=/;/p' | tr a-z A-Z
+ }
+ 
+ sep=:						# file name separator
+@@ -546,7 +546,7 @@ isfinal() {
+ 
+   # color requires -r or -R when calling less
+   typeset COLOR
+-  if [[ $(tput colors) -ge 8 && ("$LESS" = *-*r* || "$LESS" = *-*R*) ]]; then
++  if [[ $(@tput@ colors) -ge 8 && ("$LESS" = *-*r* || "$LESS" = *-*R*) ]]; then
+     COLOR="--color=always"
+   fi
+ 


### PR DESCRIPTION
###### Motivation for this change
Backport of #43985. Adding explicit dependency on file and ncurses.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

