### PR TITLE
global-platform-pro: init at 0.3.10-rc11

### DIFF
--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -46,13 +46,14 @@ stdenv.mkDerivation rec {
     name = "${name}-deps";
     inherit src patches;
     nativeBuildInputs = [ jdk maven ];
-    buildPhase = ''
+    installPhase = ''
+      # Download the dependencies
       while ! mvn package "-Dmaven.repo.local=$out/.m2" -Dmaven.wagon.rto=5000; do
         echo "timeout, restart maven to continue downloading"
       done
-    '';
-    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''
+
+      # And keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files
+      # with lastModified timestamps inside
       find "$out/.m2" -type f \
         -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' \
         -delete

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -3,7 +3,7 @@
 # TODO: This is quite a bit of duplicated logic with gephi. Factor it out?
 stdenv.mkDerivation rec {
   pname = "global-platform-pro";
-  version = "0.3.10-rc11";
+  version = "0.3.10-rc11"; # Waiting for release https://github.com/martinpaljak/GlobalPlatformPro/issues/128
   describeVersion = "v0.3.10-rc11-0-g8923747"; # git describe --tags --always --long --dirty
   name = "${pname}-${version}";
 
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   # run. As `fetchFromGitHub` doesn't fetch a full-fledged git repository,
   # this command can only fail at build-time. As a consequence, we include the
   # `describeVersion` variable defined above here.
+  #
+  # See upstream issue https://github.com/martinpaljak/GlobalPlatformPro/issues/129
   patches = [ (writeText "${name}-version.patch" ''
     diff --git a/pom.xml b/pom.xml
     index 1e5a82d..1aa01fe 100644

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, jdk, maven, writeText, makeWrapper, jre_headless, pcsclite }:
 
-# TODO: This is quite a bit of duplicated logic with gephy. Factor it out?
+# TODO: This is quite a bit of duplicated logic with gephi. Factor it out?
 stdenv.mkDerivation rec {
   pname = "global-platform-pro";
   version = "0.3.10-rc11";

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -2,94 +2,94 @@
 
 # TODO: This is quite a bit of duplicated logic with gephy. Factor it out?
 stdenv.mkDerivation rec {
-    pname = "global-platform-pro";
-    version = "0.3.10-rc11";
-    describeVersion = "v0.3.10-rc11-0-g8923747"; # git describe --tags --always --long --dirty
-    name = "${pname}-${version}";
+  pname = "global-platform-pro";
+  version = "0.3.10-rc11";
+  describeVersion = "v0.3.10-rc11-0-g8923747"; # git describe --tags --always --long --dirty
+  name = "${pname}-${version}";
 
-    src = fetchFromGitHub {
-        owner = "martinpaljak";
-        repo = "GlobalPlatformPro";
-        rev = "v${version}";
-        sha256 = "0rk81x2y7vx1caxm6wa59fjrfxmjn7s8yxaxm764p8m2qxk3m4y2";
-    };
+  src = fetchFromGitHub {
+    owner = "martinpaljak";
+    repo = "GlobalPlatformPro";
+    rev = "v${version}";
+    sha256 = "0rk81x2y7vx1caxm6wa59fjrfxmjn7s8yxaxm764p8m2qxk3m4y2";
+  };
 
-    # This patch hardcodes the return of a git command the build system tries to
-    # run. As `fetchFromGitHub` doesn't fetch a full-fledged git repository,
-    # this command can only fail at build-time. As a consequence, we include the
-    # `describeVersion` variable defined above here.
-    patches = [ (writeText "${name}-version.patch" ''
-        diff --git a/pom.xml b/pom.xml
-        index 1e5a82d..1aa01fe 100644
-        --- a/pom.xml
-        +++ b/pom.xml
-        @@ -121,14 +121,10 @@
-                             </execution>
-                         </executions>
-                         <configuration>
-        -                    <executable>git</executable>
-        +                    <executable>echo</executable>
-                             <outputFile>target/generated-resources/pro/javacard/gp/pro_version.txt</outputFile>
-                             <arguments>
-        -                        <argument>describe</argument>
-        -                        <argument>--tags</argument>
-        -                        <argument>--always</argument>
-        -                        <argument>--long</argument>
-        -                        <argument>--dirty</argument>
-        +                        <argument>${describeVersion}</argument>
-                             </arguments>
-                         </configuration>
-                     </plugin>
-    '') ];
+  # This patch hardcodes the return of a git command the build system tries to
+  # run. As `fetchFromGitHub` doesn't fetch a full-fledged git repository,
+  # this command can only fail at build-time. As a consequence, we include the
+  # `describeVersion` variable defined above here.
+  patches = [ (writeText "${name}-version.patch" ''
+    diff --git a/pom.xml b/pom.xml
+    index 1e5a82d..1aa01fe 100644
+    --- a/pom.xml
+    +++ b/pom.xml
+    @@ -121,14 +121,10 @@
+                         </execution>
+                     </executions>
+                     <configuration>
+    -                    <executable>git</executable>
+    +                    <executable>echo</executable>
+                         <outputFile>target/generated-resources/pro/javacard/gp/pro_version.txt</outputFile>
+                         <arguments>
+    -                        <argument>describe</argument>
+    -                        <argument>--tags</argument>
+    -                        <argument>--always</argument>
+    -                        <argument>--long</argument>
+    -                        <argument>--dirty</argument>
+    +                        <argument>${describeVersion}</argument>
+                         </arguments>
+                     </configuration>
+                 </plugin>
+  '') ];
 
-    deps = stdenv.mkDerivation {
-        name = "${name}-deps";
-        inherit src patches;
-        nativeBuildInputs = [ jdk maven ];
-        buildPhase = ''
-            while ! mvn package "-Dmaven.repo.local=$out/.m2" -Dmaven.wagon.rto=5000; do
-                echo "timeout, restart maven to continue downloading"
-            done
-        '';
-        # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-        installPhase = ''
-            find "$out/.m2" -type f \
-                -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' \
-                -delete
-        '';
-        outputHashAlgo = "sha256";
-        outputHashMode = "recursive";
-        outputHash = "15bbi7z9v601all9vr2azh8nk8rpz2vd91yvvw8id6birnbhn3if";
-    };
-
-    nativeBuildInputs = [ jdk maven makeWrapper ];
-
+  deps = stdenv.mkDerivation {
+    name = "${name}-deps";
+    inherit src patches;
+    nativeBuildInputs = [ jdk maven ];
     buildPhase = ''
-        cp -dpR "${deps}/.m2" ./
-        chmod -R +w .m2
-        mvn package --offline -Dmaven.repo.local="$(pwd)/.m2"
+      while ! mvn package "-Dmaven.repo.local=$out/.m2" -Dmaven.wagon.rto=5000; do
+        echo "timeout, restart maven to continue downloading"
+      done
     '';
-
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
     installPhase = ''
-        mkdir -p "$out/lib/java" "$out/share/java"
-        cp -R target/apidocs "$out/doc"
-        cp target/gp.jar "$out/share/java"
-        makeWrapper "${jre_headless}/bin/java" "$out/bin/gp" \
-            --add-flags "-jar '$out/share/java/gp.jar'" \
-            --prefix LD_LIBRARY_PATH : "${pcsclite.out}/lib"
+      find "$out/.m2" -type f \
+        -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' \
+        -delete
     '';
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "15bbi7z9v601all9vr2azh8nk8rpz2vd91yvvw8id6birnbhn3if";
+  };
 
-    meta = with stdenv.lib; {
-        description = "Command-line utility for managing applets and keys on Java Cards";
-        longDescription = ''
-            This command-line utility can be used to manage applets and keys
-            on Java Cards. It is made available as the `gp` executable.
+  nativeBuildInputs = [ jdk maven makeWrapper ];
 
-            The executable requires the PC/SC daemon running for correct execution.
-            If you run NixOS, it can be enabled with `services.pcscd.enable = true;`.
-        '';
-        homepage = https://github.com/martinpaljak/GlobalPlatformPro;
-        license = with licenses; [ lgpl3 ];
-        platforms = platforms.all;
-    };
+  buildPhase = ''
+    cp -dpR "${deps}/.m2" ./
+    chmod -R +w .m2
+    mvn package --offline -Dmaven.repo.local="$(pwd)/.m2"
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib/java" "$out/share/java"
+    cp -R target/apidocs "$out/doc"
+    cp target/gp.jar "$out/share/java"
+    makeWrapper "${jre_headless}/bin/java" "$out/bin/gp" \
+      --add-flags "-jar '$out/share/java/gp.jar'" \
+      --prefix LD_LIBRARY_PATH : "${pcsclite.out}/lib"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Command-line utility for managing applets and keys on Java Cards";
+    longDescription = ''
+      This command-line utility can be used to manage applets and keys
+      on Java Cards. It is made available as the `gp` executable.
+
+      The executable requires the PC/SC daemon running for correct execution.
+      If you run NixOS, it can be enabled with `services.pcscd.enable = true;`.
+    '';
+    homepage = https://github.com/martinpaljak/GlobalPlatformPro;
+    license = with licenses; [ lgpl3 ];
+    platforms = platforms.all;
+  };
 }

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, fetchFromGitHub, jdk, maven, writeText, makeWrapper, jre_headless, pcsclite }:
+
+# TODO: This is quite a bit of duplicated logic with gephy. Factor it out?
+stdenv.mkDerivation rec {
+    pname = "global-platform-pro";
+    version = "0.3.10-rc11";
+    describeVersion = "v0.3.10-rc11-0-g8923747"; # git describe --tags --always --long --dirty
+    name = "${pname}-${version}";
+
+    src = fetchFromGitHub {
+        owner = "martinpaljak";
+        repo = "GlobalPlatformPro";
+        rev = "v${version}";
+        sha256 = "0rk81x2y7vx1caxm6wa59fjrfxmjn7s8yxaxm764p8m2qxk3m4y2";
+    };
+
+    patches = [ (writeText "${name}-version.patch" ''
+        diff --git a/pom.xml b/pom.xml
+        index 1e5a82d..1aa01fe 100644
+        --- a/pom.xml
+        +++ b/pom.xml
+        @@ -121,14 +121,10 @@
+                             </execution>
+                         </executions>
+                         <configuration>
+        -                    <executable>git</executable>
+        +                    <executable>echo</executable>
+                             <outputFile>target/generated-resources/pro/javacard/gp/pro_version.txt</outputFile>
+                             <arguments>
+        -                        <argument>describe</argument>
+        -                        <argument>--tags</argument>
+        -                        <argument>--always</argument>
+        -                        <argument>--long</argument>
+        -                        <argument>--dirty</argument>
+        +                        <argument>${describeVersion}</argument>
+                             </arguments>
+                         </configuration>
+                     </plugin>
+    '') ];
+
+    deps = stdenv.mkDerivation {
+        name = "${name}-deps";
+        inherit src patches;
+        nativeBuildInputs = [ jdk maven ];
+        buildPhase = ''
+            while mvn package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+                echo "timeout, restart maven to continue downloading"
+            done
+        '';
+        # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+        installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
+        outputHashAlgo = "sha256";
+        outputHashMode = "recursive";
+        outputHash = "15bbi7z9v601all9vr2azh8nk8rpz2vd91yvvw8id6birnbhn3if";
+    };
+
+    nativeBuildInputs = [ jdk maven makeWrapper ];
+
+    buildPhase = ''
+        mvn package --offline -Dmaven.repo.local=$( \
+            cp -dpR ${deps}/.m2 ./ && \
+            chmod +w -R .m2 && \
+            pwd \
+        )/.m2
+    '';
+
+    installPhase = ''
+        mkdir -p $out/lib/java $out/share/java
+        cp -R target/apidocs $out/doc
+        cp target/gp.jar $out/share/java
+        makeWrapper ${jre_headless}/bin/java $out/bin/gp \
+            --add-flags "-jar $out/share/java/gp.jar" \
+            --prefix LD_LIBRARY_PATH : "${pcsclite.out}/lib"
+    '';
+
+    meta = with stdenv.lib; {
+        description = "Command-line utility for managing applets and keys on Java Cards";
+        longDescription = ''
+            This command-line utility can be used to manage applets and keys
+            on Java Cards. It is made available as the `gp` executable.
+
+            The executable requires the PC/SC daemon running for correct execution.
+            If you run NixOS, it can be enabled with `services.pcscd.enable = true;`.
+        '';
+        homepage = https://github.com/martinpaljak/GlobalPlatformPro;
+        license = with licenses; [ lgpl3 ];
+        platforms = platforms.all;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -180,6 +180,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  global-platform-pro = callPackage ../development/tools/global-platform-pro/default.nix { };
+
   graph-easy = callPackage ../tools/graphics/graph-easy { };
 
   packer = callPackage ../development/tools/packer { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

