### PR TITLE
vscode-extensions: Script to generate Nix for "latest" version of all installed vscode extensions

### DIFF
--- a/pkgs/misc/vscode-extensions/update_installed_exts.sh
+++ b/pkgs/misc/vscode-extensions/update_installed_exts.sh
@@ -1,0 +1,74 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq unzip
+set -eu -o pipefail
+
+# Helper to just fail with a message and non-zero exit code.
+function fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+# Helper to clean up after ourself if we're killed by SIGINT
+function clean_up() {
+    TDIR="${TMPDIR:-/tmp}"
+    echo "Script killed, cleaning up tmpdirs: $TDIR/vscode_exts_*" >&2
+    rm -Rf "$TDIR/vscode_exts_*"
+}
+
+function get_vsixpkg() {
+    N="$1.$2"
+
+    # Create a tempdir for the extension download
+    EXTTMP=$(mktemp -d -t vscode_exts_XXXXXXXX)
+
+    URL="https://$1.gallery.vsassets.io/_apis/public/gallery/publisher/$1/extension/$2/latest/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+
+    # Quietly but delicately curl down the file, blowing up at the first sign of trouble.
+    curl --silent --show-error --fail -X GET -o "$EXTTMP/$N.zip" "$URL"
+    # Unpack the file we need to stdout then pull out the version
+    VER=$(jq -r '.version' <(unzip -qc "$EXTTMP/$N.zip" "extension/package.json"))
+    # Calculate the SHA
+    SHA=$(nix-hash --flat --base32 --type sha256 "$EXTTMP/$N.zip")
+
+    # Clean up.
+    rm -Rf "$EXTTMP"
+    # I don't like 'rm -Rf' lurking in my scripts but this seems appropriate
+
+    cat <<-EOF
+  {
+    name = "$2";
+    publisher = "$1";
+    version = "$VER";
+    sha256 = "$SHA";
+  }
+EOF
+}
+
+# See if can find our code binary somewhere.
+if [ $# -ne 0 ]; then
+    CODE=$1
+else
+    CODE=$(command -v code)
+fi
+
+if [ -z "$CODE" ]; then
+    # Not much point continuing.
+    fail "VSCode executable not found"
+fi
+
+# Try to be a good citizen and clean up after ourselves if we're killed.
+trap clean_up SIGINT
+
+# Begin the printing of the nix expression that will house the list of extensions.
+printf '{ extensions = [\n'
+
+# Note that we are only looking to update extensions that are already installed.
+for i in $($CODE --list-extensions)
+do
+    OWNER=$(echo "$i" | cut -d. -f1)
+    EXT=$(echo "$i" | cut -d. -f2)
+
+    get_vsixpkg "$OWNER" "$EXT"
+done
+# Close off the nix expression.
+printf '];\n}'


### PR DESCRIPTION
###### Motivation for this change
This is a useful bash script for generating the nix expressions to be used with this expression: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vscode/with-extensions.nix#L18

These extensions are fiddly to update by hand as each package must be inspected individually and then the SHA must also be generated before the list can be updated and then the packages installed.

This script only cares about vscode extensions that you already have installed, any new extensions must be inspected and constructed yourself. If you use the `bbenoist.Nix` extension then you will have to filter that out as this script doesn't force any particular arrangement. The expression to filter the Nix vscode extension is `__filter (e: e.name != "Nix")`.

This is my first PR to nixpkgs so I'm keen to hear if there are better ways of managing this! :+1: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

