### PR TITLE
atom, atom-beta: 1.28.2 -> 1.29.0, refactored build script

### DIFF
--- a/pkgs/applications/editors/atom/default.nix
+++ b/pkgs/applications/editors/atom/default.nix
@@ -1,12 +1,15 @@
 { stdenv, pkgs, fetchurl, makeWrapper, gvfs, atomEnv}:
 
 let
-  common = pname: {version, sha256}: stdenv.mkDerivation rec {
-    name = "${pname}-${version}";
-    inherit version;
+  common = pname: {version, sha256, beta ? null}:
+      let fullVersion = version + stdenv.lib.optionalString (beta != null) "-beta${toString beta}";
+      name = "${pname}-${fullVersion}";
+  in stdenv.mkDerivation {
+    inherit name;
+    version = fullVersion;
 
     src = fetchurl {
-      url = "https://github.com/atom/atom/releases/download/v${version}/atom-amd64.deb";
+      url = "https://github.com/atom/atom/releases/download/v${fullVersion}/atom-amd64.deb";
       name = "${name}.deb";
       inherit sha256;
     };
@@ -61,12 +64,13 @@ let
   };
 in stdenv.lib.mapAttrs common {
   atom = {
-    version = "1.28.2";
-    sha256 = "07lz4lj07dbfz952l3q9vplvg41pxl1cx89gzy8bzzr3ay7kn6za";
+    version = "1.29.0";
+    sha256 = "0f0qpn8aw2qlqk8ah71xvk4vcmwsnsf2f3g4hz0rvaqnhb9ri9fz";
   };
 
   atom-beta = {
-    version = "1.29.0-beta1";
-    sha256 = "121y716pnq4vpjrymr505prskvi5a2lnn8hw79q8b4hf7yz0j6rb";
+    version = "1.30.0";
+    beta = 1;
+    sha256 = "0ygqj81xlwhzmmci0d0rd2q7xfskxd1k7h6db3zvvjdxjcnyqp1z";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

atom-beta: 1.29.0-beta1 -> 1.30.0-beta1

The beta version jump seems like an irregular update, but 1.30.0-beta0
was retired rougly 3 hours after release due to an macOS error:

> Fixed an error about a missing string_decoder module when the Git pane
> is displayed on macOS.

This shouldn't affect the Linux x86_64 version, but latest versions are
always nice.

Also refactored the build script, it now takes the version number as
an extra (optional) argument and creates the version number from that.

Also removed `rec` from the main set because it was no longer needed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

