### PR TITLE
pkgs/tests: Add test for LD_LIBRARY_PATH

### DIFF
--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -22,6 +22,8 @@ with pkgs;
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
+  ld-library-path = callPackage ./ld-library-path {};
+
   macOSSierraShared = callPackage ./macos-sierra-shared {};
 
   cross = callPackage ./cross {};

--- a/pkgs/test/ld-library-path/default.nix
+++ b/pkgs/test/ld-library-path/default.nix
@@ -1,0 +1,88 @@
+{ stdenv }:
+
+# This tests that libraries listed in LD_LIBRARY_PATH take precedence over those listed in RPATH.
+
+let
+  # A simple test library: libgreeting.so which exports a single function getGreeting() returning the good old hello greeting.
+  libgreeting = stdenv.mkDerivation {
+    name = "libgreeting";
+
+    code = ''
+      const char* getGreeting() { return "Hello, world!"; }
+    '';
+
+    unpackPhase = ''
+      echo "$code" > libgreeting.c
+    '';
+
+    installPhase = ''
+      mkdir -p $out/lib
+      $CC -c -fpic libgreeting.c
+      $CC -shared libgreeting.o -o $out/lib/libgreeting.so
+    '';
+  };
+
+  # A variant of libgreeting.so that returns a different message.
+  libgoodbye = libgreeting.overrideAttrs (_: {
+    name = "libgoodbye";
+    code = ''
+      const char* getGreeting() { return "Goodbye, world!"; }
+    '';
+  });
+
+  # A simple consumer of libgreeting.so that just prints the greeting to stdout.
+  testProgram = stdenv.mkDerivation {
+    name = "greeting-test";
+
+    buildInputs = [ libgreeting ];
+
+    code = ''
+      #include <stdio.h>
+
+      extern const char* getGreeting(void);
+
+      int main() {
+        puts(getGreeting());
+      }
+    '';
+
+    unpackPhase = ''
+      echo "$code" > greeting-test.c
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      $CC -c greeting-test.c
+      $CC greeting-test.o -lgreeting -o $out/bin/greeting-test
+
+      # Now test the installed binaries right after compiling them. In particular,
+      # don't do this in installCheckPhase because fixupPhase has been run by then!
+      (
+        export PATH=$out/bin
+        set -x
+
+        # Verify that our unmodified binary works as expected.
+        [ "$(greeting-test)" = "Hello, world!" ]
+
+        # And finally, test that a library in LD_LIBRARY_PATH takes precedence over the linked-in library.
+        [ "$(LD_LIBRARY_PATH=${libgoodbye}/lib greeting-test)" = "Goodbye, world!" ]
+      )
+    '';
+
+  };
+in stdenv.mkDerivation {
+  name = "test-LD_LIBRARY_PATH";
+  nativeBuildInputs = [ testProgram ];
+
+  buildCommand = ''
+    # And for good measure, repeat the tests again from a separate derivation,
+    # as fixupPhase done by the stdenv can (and has!) affect the result.
+
+    [ "$(greeting-test)" = "Hello, world!" ]
+    [ "$(LD_LIBRARY_PATH=${libgoodbye}/lib greeting-test)" = "Goodbye, world!" ]
+
+    touch $out
+  '';
+
+  meta.platforms = stdenv.lib.platforms.linux;
+}


### PR DESCRIPTION
The latest binutils upgrade silently broke this until it was fixed by
https://github.com/NixOS/nixpkgs/pull/43531.

So add a test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

