### PR TITLE
plasma-nm: fix path to mobile broadband provider file

### DIFF
--- a/pkgs/desktops/plasma-5/plasma-nm/0001-mobile-broadband-provider-info-path.patch
+++ b/pkgs/desktops/plasma-5/plasma-nm/0001-mobile-broadband-provider-info-path.patch
@@ -16,7 +16,7 @@ index 568cb34..98a5992 100644
  #include <KLocale>
  
 -const QString MobileProviders::ProvidersFile = "/usr/share/mobile-broadband-provider-info/serviceproviders.xml";
-+const QString MobileProviders::ProvidersFile = "@mobile-broadband-provider-info@/share/mobile-broadband-provider-info/serviceproviders.xml";
++const QString MobileProviders::ProvidersFile = "@mobile_broadband_provider_info@/share/mobile-broadband-provider-info/serviceproviders.xml";
  
  bool localeAwareCompare(const QString & one, const QString & two) {
      return one.localeAwareCompare(two) < 0;

--- a/pkgs/desktops/plasma-5/plasma-nm/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-nm/default.nix
@@ -21,7 +21,7 @@ mkDerivation {
   patches = [
     (substituteAll {
       src = ./0001-mobile-broadband-provider-info-path.patch;
-      inherit mobile-broadband-provider-info;
+      mobile_broadband_provider_info = mobile-broadband-provider-info;
     })
     (substituteAll {
       src = ./0002-openvpn-binary-path.patch;


### PR DESCRIPTION
When creating a new mobile broadband connection
with the plasma network manager connection editor,
it tries to find a file containing provider
information somewhere in /usr/share/... .
The build recipe contains a patch to fix the lookup path
such that it finds the file in the corresponding package,
probably added due to
https://github.com/NixOS/nixpkgs/issues/9389 .
The actual lookup path is injected into
the patch file with substituteAll.

With commit a31d98f3120e0f676303b7fc3e84424e6b325290 ,
the variable name used in subsituteAll changed from
mobile_broadband_provider_info to mobile-broadband-provider-info
(underscores in package names turned into dashes).
Apparently, substituteAll can't handle dashes in variable names.
Consequently, the variable name was no longer resolved.
plasma-nm failed to create new mobile broadband connections;
the connection creator silently exited and logged the error
> plasma-nm: Error opening providers file "@mobile-broadband-provider-info@/share/mobile-broadband-provider-info/serviceproviders.xml"

This commit keeps the dashes in package names, but it
restores the underscores in the variable used by substituteAll,
thereby ensuring the variable gets resolved properly.

###### Motivation for this change

Restore ability to create mobile broadband connections with the plasma network manager frontend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS: on 18.03
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): there are none
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ttuegel (sorry, you are the last one who touched this according to git log ... there is no maintainer given in the build recipe)