### PR TITLE
nixos manual: add missing closing tags

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -370,9 +370,12 @@ inherit (pkgs.nixos {
       <varname>s6-dns</varname>, <varname>s6-networking</varname>,
       <varname>s6-linux-utils</varname> and <varname>s6-portable-utils</varname> respectively.
     </para>
-  </listitem>
-  <listitem>
-    <para>The module option <option>nix.useSandbox</option> is now defaulted to <literal>true</literal>.
+   </listitem>
+   <listitem>
+    <para>
+     The module option <option>nix.useSandbox</option> is now defaulted to <literal>true</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>


### PR DESCRIPTION
###### Motivation for this change

Fix #44190

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

