### PR TITLE
xfce4-13.xfce4-pulseaudio-plugin: init at 0.4.1

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -62,6 +62,8 @@ makeScope newScope (self: with self; {
 
   xfce4-power-manager = callPackage ./xfce4-power-manager { };
 
+  xfce4-pulseaudio-plugin = callPackage ./xfce4-pulseaudio-plugin { };
+
   xfce4-screenshooter = callPackage ./xfce4-screenshooter {
     inherit (gnome3) libsoup;
   };

--- a/pkgs/desktops/xfce4-13/xfce4-pulseaudio-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-pulseaudio-plugin/default.nix
@@ -1,0 +1,19 @@
+{ mkXfceDerivation, automakeAddFlags, dbus-glib, dbus, gtk3, libpulseaudio
+, libnotify, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-pulseaudio-plugin";
+  version = "0.4.1";
+  sha256 = "1c8krpg3l6ki00ldd9hifc4bddysdm0w3x5w43fkr31j0zrscvfp";
+
+  nativeBuildInputs = [ automakeAddFlags ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${dbus-glib.dev}/include/dbus-1.0" "-I${dbus.dev}/include/dbus-1.0" ];
+
+  postPatch = ''
+    substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
+  '';
+
+  buildInputs = [ gtk3 libnotify libpulseaudio libxfce4ui libxfce4util xfce4-panel xfconf ];
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

