### PR TITLE
xfce4-13.xfce4-netload-plugin: init at 1.3.1

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -56,6 +56,8 @@ makeScope newScope (self: with self; {
 
   xfce4-mixer = callPackage ./xfce4-mixer { };
 
+  xfce4-netload-plugin = callPackage ./xfce4-netload-plugin { };
+
   xfce4-notifyd = callPackage ./xfce4-notifyd { };
 
   xfce4-panel = callPackage ./xfce4-panel { };

--- a/pkgs/desktops/xfce4-13/xfce4-netload-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-netload-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-netload-plugin";
+  version = "1.3.1";
+  rev = "version-${version}";
+  sha256 = "0nm8advafw4jpc9p1qszyfqa56194sz51z216rdh4c6ilcrrpy1h";
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

