### PR TITLE
xfce4-13.xfce4-cpufreq-plugin: init at 1.2.0

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -46,6 +46,8 @@ makeScope newScope (self: with self; {
 
   xfce4-battery-plugin = callPackage ./xfce4-battery-plugin { };
 
+  xfce4-cpufreq-plugin = callPackage ./xfce4-cpufreq-plugin { };
+
   xfce4-dev-tools = callPackage ./xfce4-dev-tools {
     mkXfceDerivation = mkXfceDerivation.override {
       xfce4-dev-tools = null;

--- a/pkgs/desktops/xfce4-13/xfce4-cpufreq-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-cpufreq-plugin/default.nix
@@ -1,0 +1,10 @@
+{ mkXfceDerivation, gtk3, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-cpufreq-plugin";
+  version = "1.2.0";
+  sha256 = "0zhs7b7py1njczmpnib4532fwpnd3vnpqfhss2r136cfgy72kp6g";
+
+  buildInputs = [ gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

