### PR TITLE
xfce4-13.xfce4-whiskermenu-plugin: init at 2.2.0

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -76,5 +76,7 @@ makeScope newScope (self: with self; {
 
   xfce4-volumed-pulse = callPackage ./xfce4-volumed-pulse { };
 
+  xfce4-whiskermenu-plugin = callPackage ./xfce4-whiskermenu-plugin { };
+
   xfwm4 = callPackage ./xfwm4 { };
 })

--- a/pkgs/desktops/xfce4-13/xfce4-whiskermenu-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-whiskermenu-plugin/default.nix
@@ -1,0 +1,18 @@
+{ mkXfceDerivation, dbus-glib, gtk3, cmake, exo, garcon, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-whiskermenu-plugin";
+  version = "2.2.0";
+  rev = "v${version}";
+  sha256 = "1d35xxkdzw8pl3d5ps226mmrrjk0hqczsbvl5smh7l7jbwfambjm";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ dbus-glib exo garcon gtk3 libxfce4ui libxfce4util xfce4-panel xfconf ];
+
+  postInstall = ''
+    substituteInPlace $out/bin/xfce4-popup-whiskermenu \
+      --replace $out/bin/xfce4-panel ${xfce4-panel.out}/bin/xfce4-panel
+  '';
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

