### PR TITLE
xfce4-13.xfce4-session: init at 4.13.0

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -66,7 +66,8 @@ makeScope newScope (self: with self; {
     inherit (gnome3) libsoup;
   };
 
-  xfce4-taskmanager = callPackage ./xfce4-taskmanager { };
+  xfce4-session = callPackage ./xfce4-session { };
+  xinitrc = "${xfce4-session}/etc/xdg/xfce4/xinitrc";
 
   xfce4-settings = callPackage ./xfce4-settings { };
 

--- a/pkgs/desktops/xfce4-13/xfce4-session/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-session/default.nix
@@ -1,0 +1,27 @@
+{ mkXfceDerivation, polkit, exo, libxfce4util, libxfce4ui, xfconf, dbus-glib, dbus, iceauth, gtk3, libwnck3, xorg }:
+
+mkXfceDerivation rec {
+  category = "xfce";
+  pname = "xfce4-session";
+  version = "4.13.0";
+
+  sha256 = "0d6h1kgqq6g084jrxx4jxw98h5g0vwsxqrvk0bmapyxh2sbrg07y";
+
+  buildInputs = [ exo dbus-glib dbus gtk3 libxfce4ui libxfce4util libwnck3 xfconf polkit iceauth ];
+
+  configureFlags = [ "--with-xsession-prefix=$(out)" ];
+
+  NIX_CFLAGS_COMPILE = [ "-I${dbus-glib.dev}/include/dbus-1.0"
+                         "-I${dbus.dev}/include/dbus-1.0"
+                         "-I${dbus.lib}/lib/dbus-1.0/include"
+                       ];
+
+  postPatch = ''
+    substituteInPlace configure.ac.in --replace gio-2.0 gio-unix-2.0
+    substituteInPlace scripts/xflock4 --replace PATH=/bin:/usr/bin "PATH=/run/current-system/sw/bin:$out/bin:${xorg.xset}/bin"
+  '';
+
+  meta =  {
+    description = "Session manager for Xfce";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

