### PR TITLE
xfce4-13.xfce4-xkb-plugin: init at 0.8.1

### DIFF
--- a/pkgs/desktops/xfce4-13/default.nix
+++ b/pkgs/desktops/xfce4-13/default.nix
@@ -84,5 +84,7 @@ makeScope newScope (self: with self; {
 
   xfce4-whiskermenu-plugin = callPackage ./xfce4-whiskermenu-plugin { };
 
+  xfce4-xkb-plugin = callPackage ./xfce4-xkb-plugin { };
+
   xfwm4 = callPackage ./xfwm4 { };
 })

--- a/pkgs/desktops/xfce4-13/xfce4-xkb-plugin/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-xkb-plugin/default.nix
@@ -1,0 +1,11 @@
+{ mkXfceDerivation, gtk3, librsvg, libwnck3, libxklavier, garcon, libxfce4ui, libxfce4util, xfce4-panel, xfconf }:
+
+mkXfceDerivation rec {
+  category = "panel-plugins";
+  pname = "xfce4-xkb-plugin";
+  version = "0.8.1";
+  rev = version;
+  sha256 = "1gyky4raynp2ggdnq0g96c6646fjm679fzipcsmf1q0aymr8d5ky";
+
+  buildInputs = [ garcon gtk3 librsvg libxfce4ui libxfce4util libxklavier libwnck3 xfce4-panel xfconf ];
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

