### PR TITLE
nix: Put config builder into pkgs

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -24,49 +24,7 @@ let
 
   nixbldUsers = map makeNixBuildUser (range 1 cfg.nrBuildUsers);
 
-  nixConf =
-    let
-      # In Nix < 2.0, If we're using sandbox for builds, then provide
-      # /bin/sh in the sandbox as a bind-mount to bash. This means we
-      # also need to include the entire closure of bash. Nix >= 2.0
-      # provides a /bin/sh by default.
-      sh = pkgs.runtimeShell;
-      binshDeps = pkgs.writeReferencesToFile sh;
-    in
-      pkgs.runCommand "nix.conf" { extraOptions = cfg.extraOptions; } (''
-        ${optionalString (!isNix20) ''
-          extraPaths=$(for i in $(cat ${binshDeps}); do if test -d $i; then echo $i; fi; done)
-        ''}
-        cat > $out <<END
-        # WARNING: this file is generated from the nix.* options in
-        # your NixOS configuration, typically
-        # /etc/nixos/configuration.nix.  Do not edit it!
-        build-users-group = nixbld
-        ${if isNix20 then "max-jobs" else "build-max-jobs"} = ${toString (cfg.maxJobs)}
-        ${if isNix20 then "cores" else "build-cores"} = ${toString (cfg.buildCores)}
-        ${if isNix20 then "sandbox" else "build-use-sandbox"} = ${if (builtins.isBool cfg.useSandbox) then boolToString cfg.useSandbox else cfg.useSandbox}
-        ${if isNix20 then "extra-sandbox-paths" else "build-sandbox-paths"} = ${toString cfg.sandboxPaths} ${optionalString (!isNix20) "/bin/sh=${sh} $(echo $extraPaths)"}
-        ${if isNix20 then "substituters" else "binary-caches"} = ${toString cfg.binaryCaches}
-        ${if isNix20 then "trusted-substituters" else "trusted-binary-caches"} = ${toString cfg.trustedBinaryCaches}
-        ${if isNix20 then "trusted-public-keys" else "binary-cache-public-keys"} = ${toString cfg.binaryCachePublicKeys}
-        auto-optimise-store = ${boolToString cfg.autoOptimiseStore}
-        ${if isNix20 then ''
-          require-sigs = ${if cfg.requireSignedBinaryCaches then "true" else "false"}
-        '' else ''
-          signed-binary-caches = ${if cfg.requireSignedBinaryCaches then "*" else ""}
-        ''}
-        trusted-users = ${toString cfg.trustedUsers}
-        allowed-users = ${toString cfg.allowedUsers}
-        ${optionalString (isNix20 && !cfg.distributedBuilds) ''
-          builders =
-        ''}
-        $extraOptions
-        END
-      '' + optionalString cfg.checkConfig ''
-        echo "Checking that Nix can read nix.conf..."
-        ln -s $out ./nix.conf
-        NIX_CONF_DIR=$PWD ${cfg.package}/bin/nix show-config >/dev/null
-      '');
+  nixConf = pkgs.nixConfig.override { nix = cfg.package; } { inherit cfg; };
 
 in
 

--- a/pkgs/tools/package-management/nix/config.nix
+++ b/pkgs/tools/package-management/nix/config.nix
@@ -1,0 +1,69 @@
+{ runtimeShell, writeReferencesToFile, runCommand
+, nix, lib
+}:
+
+{ cfg }:
+/* Accepts these values from the NixOS nix.* options. Refer to the
+  configuration.nix man page or https://nixos.org/nixos/options.html#nix. for futher details
+  - extraOptions
+  - maxJobs
+  - buildCores
+  - useSandbox
+  - sandboxPaths
+  - binaryCaches
+  - trustedBinaryCaches
+  - binaryCachePublicKeys
+  - autoOptimiseStore
+  - requireSignedBinaryCaches
+  - trustedUsers
+  - allowedUsers
+  - distributedBuilds
+  - checkConfig
+*/
+
+with lib;
+
+let
+  # In Nix < 2.0, If we're using sandbox for builds, then provide
+  # /bin/sh in the sandbox as a bind-mount to bash. This means we
+  # also need to include the entire closure of bash. Nix >= 2.0
+  # provides a /bin/sh by default.
+  sh = runtimeShell;
+  binshDeps = writeReferencesToFile sh;
+
+  isNix20 = versionAtLeast (getVersion nix.out) "2.0pre";
+in
+  runCommand "nix.conf" { extraOptions = cfg.extraOptions; } (''
+    ${optionalString (!isNix20) ''
+      extraPaths=$(for i in $(cat ${binshDeps}); do if test -d $i; then echo $i; fi; done)
+    ''}
+    cat > $out <<END
+    # WARNING: this file is generated from the nix.* options in
+    # your NixOS configuration, typically
+    # /etc/nixos/configuration.nix.  Do not edit it!
+    build-users-group = nixbld
+    ${if isNix20 then "max-jobs" else "build-max-jobs"} = ${toString cfg.maxJobs}
+    ${if isNix20 then "cores" else "build-cores"} = ${toString cfg.buildCores}
+    ${if isNix20 then "sandbox" else "build-use-sandbox"} = ${if (builtins.isBool cfg.useSandbox) then boolToString cfg.useSandbox else cfg.useSandbox}
+    ${if isNix20 then "extra-sandbox-paths" else "build-sandbox-paths"} = ${toString cfg.sandboxPaths} ${optionalString (!isNix20) "/bin/sh=${sh} $(echo $extraPaths)"}
+    ${if isNix20 then "substituters" else "binary-caches"} = ${toString cfg.binaryCaches}
+    ${if isNix20 then "trusted-substituters" else "trusted-binary-caches"} = ${toString cfg.trustedBinaryCaches}
+    ${if isNix20 then "trusted-public-keys" else "binary-cache-public-keys"} = ${toString cfg.binaryCachePublicKeys}
+    auto-optimise-store = ${boolToString cfg.autoOptimiseStore}
+    ${if isNix20 then ''
+      require-sigs = ${if cfg.requireSignedBinaryCaches then "true" else "false"}
+    '' else ''
+      signed-binary-caches = ${if cfg.requireSignedBinaryCaches then "*" else ""}
+    ''}
+    trusted-users = ${toString cfg.trustedUsers}
+    allowed-users = ${toString cfg.allowedUsers}
+    ${optionalString (isNix20 && !cfg.distributedBuilds) ''
+      builders =
+    ''}
+    $extraOptions
+    END
+  '' + optionalString cfg.checkConfig ''
+    echo "Checking that Nix can read nix.conf..."
+    ln -s $out ./nix.conf
+    NIX_CONF_DIR=$PWD ${nix}/bin/nix show-config >/dev/null
+  '')

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21331,6 +21331,8 @@ with pkgs;
     nixStable
     nixUnstable;
 
+  nixConfig = callPackage ../tools/package-management/nix/config.nix { };
+
   nixops = callPackage ../tools/package-management/nixops { };
 
   nixopsUnstable = lowPrio (callPackage ../tools/package-management/nixops/unstable.nix { });


### PR DESCRIPTION
This is such that even people not using NixOS can use it to generate the
nix.conf file. See https://github.com/NixOS/nixpkgs/issues/35662

This doesn't change the semantics in any way, and in fact, `config.system.build.etc` is exactly the same derivation before and after this change.

Ping @FRidh @7c6f434c @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

