### PR TITLE
qsstv: init 9.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1565,6 +1565,11 @@
     github = "havvy";
     name = "Ryan Scheel";
   };
+  hax404 = {
+    email = "hax404foogit@hax404.de";
+    github = "hax404";
+    name = "Georg Haas";
+  };
   hbunke = {
     email = "bunke.hendrik@gmail.com";
     github = "hbunke";

--- a/pkgs/applications/misc/qsstv/default.nix
+++ b/pkgs/applications/misc/qsstv/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, qtbase, qmake, makeDesktopItem, openjpeg, pkgconfig, fftw,
+  libpulseaudio, alsaLib, hamlib, libv4l, fftwFloat }:
+
+stdenv.mkDerivation rec {
+  version = "9.2.6";
+  name = "qsstv-${version}";
+
+  src = fetchurl {
+    url = "http://users.telenet.be/on4qz/qsstv/downloads/qsstv_${version}.tar.gz";
+    sha256 = "0sx70yk389fq5djvjwnam6ics5knmg9b5x608bk2sjbfxkila108";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    qmake
+    pkgconfig
+  ];
+
+  buildInputs = [ qtbase openjpeg fftw libpulseaudio alsaLib hamlib libv4l
+                  fftwFloat ];
+
+  desktopItem = makeDesktopItem {
+    name = "QSSTV";
+    exec = "qsstv";
+    icon = "qsstv.png";
+    comment = "Qt-based slow-scan TV and fax";
+    desktopName = "QSSTV";
+    genericName = "qsstv";
+    categories = "Application;HamRadio;";
+  };
+
+  installPhase = ''
+    # Install binary to the right location
+    make install INSTALL_ROOT=$out
+    mv $out/usr/bin $out/
+    rm -r $out/usr
+
+    # Install desktop icon
+    install -D qsstv/icons/qsstv.png $out/share/pixmaps/qsstv.png
+
+    # Install desktop item
+    cp -rv ${desktopItem}/share $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Qt-based slow-scan TV and fax";
+    homepage = http://users.telenet.be/on4qz/;
+    platforms = platforms.linux;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ hax404 ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17956,6 +17956,8 @@ with pkgs;
     qt = qt4;
   };
 
+  qsstv = qt5.callPackage ../applications/misc/qsstv { };
+
   qsyncthingtray = libsForQt5.callPackage ../applications/misc/qsyncthingtray { };
 
   qstopmotion = callPackage ../applications/video/qstopmotion { };


### PR DESCRIPTION
###### Motivation for this change
I want to add this program that is useful for amateur radio operators. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

