### PR TITLE
openmolcas: init at 20180529

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -1,0 +1,72 @@
+{ stdenv, pkgs, fetchFromGitLab, cmake, gfortran, perl
+, openblas, hdf5-cpp, python3, texlive
+, armadillo, openmpi, globalarrays, openssh
+, makeWrapper
+} :
+
+let
+  version = "20180529";
+  gitLabRev = "b6b9ceffccae0dd7f14c099468334fee0b1071fc";
+
+  python = python3.withPackages (ps : with ps; [ six pyparsing ]);
+
+in stdenv.mkDerivation {
+  name = "openmolcas-${version}";
+
+  src = fetchFromGitLab {
+    owner = "Molcas";
+    repo = "OpenMolcas";
+    rev = gitLabRev;
+    sha256 = "1wbjjdv07lg1x4kdnf28anyrjgy33gdgrd5d7zi1c97nz7vhdjaz";
+  };
+
+  nativeBuildInputs = [ perl cmake texlive.combined.scheme-minimal makeWrapper ];
+  buildInputs = [
+    gfortran
+    openblas
+    hdf5-cpp
+    python
+    armadillo
+    openmpi
+    globalarrays
+    openssh
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DOPENMP=ON"
+    "-DGA=ON"
+    "-DMPI=ON"
+    "-DLINALG=OpenBLAS"
+    "-DTOOLS=ON"
+    "-DHDF5=ON"
+    "-DFDE=ON"
+    "-DOPENBLASROOT=${openblas}"
+  ];
+
+  GAROOT=globalarrays;
+
+  postConfigure = ''
+    # The Makefile will install pymolcas during the build grrr.
+    mkdir -p $out/bin
+    export PATH=$PATH:$out/bin
+  '';
+
+  postFixup = ''
+    # Wrong store path in shebang (no Python pkgs), force re-patching
+    sed -i "1s:/.*:/usr/bin/env python:" $out/bin/pymolcas
+    patchShebangs $out/bin
+
+    wrapProgram $out/bin/pymolcas --set MOLCAS $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Advanced quantum chemistry software package";
+    homepage = https://gitlab.com/Molcas/OpenMolcas;
+    maintainers = [ maintainers.markuskowa ];
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/development/libraries/globalarrays/default.nix
+++ b/pkgs/development/libraries/globalarrays/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, pkgs, fetchFromGitHub, automake, autoconf, libtool
+, openblas, gfortran, openssh, openmpi
+} :
+
+let
+  version = "5.7";
+
+in stdenv.mkDerivation {
+  name = "globalarrays-${version}";
+
+  src = fetchFromGitHub {
+    owner = "GlobalArrays";
+    repo = "ga";
+    rev = "v${version}";
+    sha256 = "07i2idaas7pq3in5mdqq5ndvxln5q87nyfgk3vzw85r72c4fq5jh";
+  };
+
+  nativeBuildInputs = [ automake autoconf libtool ];
+  buildInputs = [ openmpi openblas gfortran openssh ];
+
+  preConfigure = ''
+    autoreconf -ivf
+    configureFlagsArray+=( "--enable-i8" \
+                           "--with-mpi" \
+                           "--with-mpi3" \
+                           "--enable-eispack" \
+                           "--enable-underscoring" \
+                           "--with-blas8=${openblas}/lib -lopenblas" )
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Global Arrays Programming Models";
+    homepage = http://hpc.pnl.gov/globalarrays/;
+    maintainers = [ maintainers.markuskowa ];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1314,6 +1314,8 @@ with pkgs;
 
   glide = callPackage ../development/tools/glide { };
 
+  globalarrays = callPackage ../development/libraries/globalarrays { };
+
   glock = callPackage ../development/tools/glock { };
 
   glslviewer = callPackage ../development/tools/glslviewer {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20278,6 +20278,8 @@ with pkgs;
 
   octopus = callPackage ../applications/science/chemistry/octopus { openblas=openblasCompat; };
 
+  openmolcas = callPackage ../applications/science/chemistry/openmolcas { };
+
   pymol = callPackage ../applications/science/chemistry/pymol { };
 
   ### SCIENCE/GEOMETRY


### PR DESCRIPTION
###### Motivation for this change
Openmolcas is an advanced electronic structure program packages.

###### Things done
* `globalarrays` package (required by `openmolcas`)
* `openmolcas` package

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

