### PR TITLE
trellis: init 2018.08.01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3197,6 +3197,11 @@
     email = "patrick.callahan@latitudeengineering.com";
     name = "Patrick Callahan";
   };
+  q3k = {
+    email = "q3k@q3k.org";
+    github = "q3k";
+    name = "Serge Bazanski";
+  };
   qknight = {
     email = "js@lastlog.de";
     github = "qknight";

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -12,8 +12,6 @@ stdenv.mkDerivation rec {
   name = "trellis-${version}";
   version = "2018.08.01";
 
-  blah = trellisdb;
-
   buildInputs = [
     (boost.override { python = python3; enablePython = true; })
   ];

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -14,9 +14,12 @@ stdenv.mkDerivation rec {
 
   blah = trellisdb;
 
+  buildInputs = [
+    (boost.override { python = python3; enablePython = true; })
+  ];
+
   nativeBuildInputs = [
     cmake python3
-    (boost.override { python = python3; enablePython = true; })
   ];
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, python3, cmake, boost }:
+
+let
+  trellisdb = fetchFromGitHub {
+    owner = "SymbiFlow";
+    repo  = "prjtrellis-db";
+    rev   = "06b429ddb7fd8ec1e3f2b35de2e94b4853cf2835";
+    sha256 = "07bsgw5x3gq0jcn9j4g7q9xvibvz6j2arjnvgyrxnrg30ri9q173";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "trellis-${version}";
+  version = "2018.08.01";
+
+  blah = trellisdb;
+
+  nativeBuildInputs = [
+    cmake python3
+    (boost.override { python = python3; enablePython = true; })
+  ];
+
+  src = fetchFromGitHub {
+    owner  = "SymbiFlow";
+    repo   = "prjtrellis";
+    rev    = "fff9532fe59bf9e38b44f029ce4a06c607a9ee78";
+    sha256 = "0ycw9fjf6428sf5x8x5szn8fha79610nf7nn8kmibgmz9868yv30";
+  };
+
+  preConfigure = ''
+    source environment.sh
+    cp -RT "${trellisdb}" database
+    cd libtrellis
+  '';
+
+  meta = {
+    description = "Documentation and tools for Lattice ECP5 FPGAs";
+    longDescription = ''
+      Project Trellis documents the Lattice ECP5 architecture
+      to enable development of open-source tools. Its goal is
+      to provide sufficient information to develop a free and
+      open Verilog to bitstream toolchain for these devices.
+    '';
+    homepage = https://github.com/SymbiFlow/prjtrellis;
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ q3k ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8620,6 +8620,8 @@ with pkgs;
 
   travis = callPackage ../development/tools/misc/travis { };
 
+  trellis = callPackage ../development/tools/trellis { };
+
   tweak = callPackage ../applications/editors/tweak { };
 
   uhd = callPackage ../development/tools/misc/uhd { };


### PR DESCRIPTION
###### Motivation for this change

This adds a package for Project Trellis, a prerequisite for the open-source verilog-to-bistream flow for Lattice ECP5 FPGAs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

