### PR TITLE
elasticsearch6: refactor plugins

### DIFF
--- a/pkgs/servers/search/elasticsearch/plugins-6.x.nix
+++ b/pkgs/servers/search/elasticsearch/plugins-6.x.nix
@@ -1,0 +1,41 @@
+{ pkgs, stdenv, fetchurl, unzip, elasticsearch6-oss, elk6Version }:
+
+with pkgs.lib;
+
+let
+  esPlugin = a@{
+    pluginName,
+    installPhase ? ''
+      mkdir -p $out/config
+      mkdir -p $out/plugins
+      ES_HOME=$out ${elasticsearch6-oss}/bin/elasticsearch-plugin install --batch -v file://$src
+    '',
+    ...
+  }:
+    stdenv.mkDerivation (a // {
+      inherit installPhase;
+      unpackPhase = "true";
+      buildInputs = [ unzip ];
+      meta = a.meta // {
+        platforms = elasticsearch6-oss.meta.platforms;
+        maintainers = (a.meta.maintainers or []) ++ [ maintainers.offline ];
+      };
+    });
+in {
+
+  discovery-ec2 = esPlugin {
+    name = "elasticsearch-discovery-ec2-${version}";
+    pluginName = "discovery-ec2";
+    version = "${elk6Version}";
+    src = pkgs.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/discovery-ec2/discovery-ec2-${elk6Version}.zip";
+      sha256 = "1i7ksy69132sr84h51lamgq967yz3a3dw0b54nckxpqwad9pcpj0";
+    };
+    meta = {
+      homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/discovery-ec2;
+      description = "The EC2 discovery plugin uses the AWS API for unicast discovery.";
+      license = licenses.asl20;
+    };
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2274,6 +2274,10 @@ with pkgs;
     callPackage ../servers/search/elasticsearch/plugins.nix { }
   );
 
+  elasticsearch6Plugins = recurseIntoAttrs (
+    callPackage ../servers/search/elasticsearch/plugins-6.x.nix { }
+  );
+
   embree2 = callPackage ../development/libraries/embree/2.x.nix { };
 
   emem = callPackage ../applications/misc/emem { };


### PR DESCRIPTION
The plugins command didn't actually work with elasticsearch6 so
I have added a new derivation for elasticsearch6 plugins. This
also means there won't be problems with versions of plugins that
only work for ES5 and not ES6.

Unfortunately it is down to the user to use the elasticsearch6Plugins
packages when setting up an elasticsearch server but I couldn't
think of a way around this.

Currently there is only 1 plugin, the discovery ec2 plugin since
this is the one I am using.

###### Motivation for this change

elasticsearchPlugins doesn't work with ES 6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

