### PR TITLE
tinyproxy: init at 1.8.4

### DIFF
--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub, automake, autoreconfHook, asciidoc, libxml2, libxslt }:
+
+stdenv.mkDerivation rec{
+  name = "tinyproxy-${version}";
+  version = "1.8.4";
+
+  src = fetchFromGitHub {
+    sha256 = "043mfqin5bsba9igm1lqbkp2spibk4j3niyjqc868cnzgx60709c";
+    rev = "${version}";
+    repo = "tinyproxy";
+    owner = "tinyproxy";
+  };
+
+  nativeBuildInputs = [ autoreconfHook asciidoc libxml2 libxslt ];
+
+  # -z flag is not supported in darwin
+  preAutoreconf = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace configure.ac --replace \
+          'LDFLAGS="-Wl,-z,defs $LDFLAGS"' \
+          'LDFLAGS="-Wl, $LDFLAGS"'
+  '';
+
+  # See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=154624
+  postConfigure = ''
+    substituteInPlace docs/man5/Makefile --replace \
+          "-f manpage" \
+          "-f manpage \\
+           -L"
+    substituteInPlace docs/man8/Makefile --replace \
+          "-f manpage" \
+          "-f manpage \\
+           -L"
+  '';
+
+  configureFlags = [
+    "--disable-debug"      # Turn off debugging
+    "--enable-xtinyproxy"  # Compile in support for the XTinyproxy header, which is sent to any web server in your domain.
+    "--enable-filter"      # Allows Tinyproxy to filter out certain domains and URLs.
+    "--enable-upstream"    # Enable support for proxying connections through another proxy server.
+    "--enable-transparent" # Allow Tinyproxy to be used as a transparent proxy daemon.
+    "--enable-reverse"     # Enable reverse proxying.
+  ] ++
+  # See: https://github.com/tinyproxy/tinyproxy/issues/1
+  stdenv.lib.optional stdenv.isDarwin "--disable-regexcheck";
+
+  meta = with stdenv.lib; {
+    homepage = https://tinyproxy.github.io/;
+    description = "A light-weight HTTP/HTTPS proxy daemon for POSIX operating systems";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = [ maintainers.carlosdagos ];
+  };
+}

--- a/pkgs/tools/networking/tinyproxy/default.nix
+++ b/pkgs/tools/networking/tinyproxy/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, automake, autoreconfHook, asciidoc, libxml2, libxslt }:
+{ stdenv, fetchFromGitHub, automake, autoreconfHook, asciidoc, libxml2,
+  libxslt, docbook_xsl }:
 
 stdenv.mkDerivation rec{
   name = "tinyproxy-${version}";
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec{
     owner = "tinyproxy";
   };
 
-  nativeBuildInputs = [ autoreconfHook asciidoc libxml2 libxslt ];
+  nativeBuildInputs = [ autoreconfHook asciidoc libxml2 libxslt docbook_xsl ];
 
   # -z flag is not supported in darwin
   preAutoreconf = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -24,11 +25,13 @@ stdenv.mkDerivation rec{
   postConfigure = ''
     substituteInPlace docs/man5/Makefile --replace \
           "-f manpage" \
-          "-f manpage \\
+          "--xsltproc-opts=--nonet \\
+           -f manpage \\
            -L"
     substituteInPlace docs/man8/Makefile --replace \
           "-f manpage" \
-          "-f manpage \\
+          "--xsltproc-opts=--nonet \\
+           -f manpage \\
            -L"
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5448,6 +5448,8 @@ with pkgs;
 
   tiny8086 = callPackage ../applications/virtualization/8086tiny { };
 
+  tinyproxy = callPackage ../tools/networking/tinyproxy {};
+
   tio = callPackage ../tools/misc/tio { };
 
   tldr = callPackage ../tools/misc/tldr { };


### PR DESCRIPTION
###### Motivation for this change

Tinyproxy is great 😄 

This _should_ compile for all platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).