### PR TITLE
protonmail-bridge: init at 1.0.5-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2174,6 +2174,11 @@
     github = "nathanielbaxter";
     name = "Nathaniel Baxter";
   };
+  lightdiscord = {
+    email = "arnaud@lightdiscord.me";
+    github = "lightdiscord";
+    name = "Arnaud Pascal";
+  };
   lihop = {
     email = "nixos@leroy.geek.nz";
     github = "lihop";

--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -1,0 +1,83 @@
+{ stdenv, fetchurl, lib, qtbase, qtmultimedia, qtsvg, qtdeclarative, qttools, full,
+  libsecret, libGL, libpulseaudio, glib, makeWrapper, makeDesktopItem }:
+
+let
+  version = "1.0.5-1";
+
+  description = ''
+    An application that runs on your computer in the background and seamlessly encrypts
+    and decrypts your mail as it enters and leaves your computer
+  '';
+
+  desktopItem = makeDesktopItem {
+    name = "Desktop-Bridge";
+    exec = "Desktop-Bridge";
+    icon = "desktop-bridge";
+    comment = stdenv.lib.replaceStrings ["\n"] [" "] description;
+    desktopName = "ProtonMail Bridge";
+    genericName = "ProtonMail Bridge for Linux";
+    categories = "Utility;Security;Network;Email";
+  };
+in stdenv.mkDerivation rec {
+  name = "protonmail-bridge-${version}";
+
+  src = fetchurl {
+    url = "https://protonmail.com/download/protonmail-bridge_${version}_amd64.deb";
+    sha256 = "1fsf4l5c9ii370fgy721a71h34g7vjfddscal3jblb4mm3ywzxfl";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  sourceRoot = ".";
+
+  unpackCmd = ''
+    ar p "$src" data.tar.xz | tar xJ
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib,share}
+    mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
+
+    cp -r usr/lib/protonmail/bridge/Desktop-Bridge{,.sh} $out/lib
+    cp usr/share/icons/protonmail/Desktop-Bridge.svg $out/share/icons/hicolor/scalable/apps/desktop-bridge.svg
+    cp ${desktopItem}/share/applications/* $out/share/applications
+
+    ln -s $out/lib/Desktop-Bridge $out/bin/Desktop-Bridge
+  '';
+
+  postFixup = let
+    rpath = lib.makeLibraryPath [
+      stdenv.cc.cc.lib
+      qtbase
+      qtmultimedia
+      qtsvg
+      qtdeclarative
+      qttools
+      libGL
+      libsecret
+      libpulseaudio
+      glib
+    ];
+
+    qtPath = prefix: "${full}/${prefix}";
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${rpath}" \
+      $out/lib/Desktop-Bridge
+
+    wrapProgram $out/lib/Desktop-Bridge \
+      --set QT_PLUGIN_PATH "${qtPath qtbase.qtPluginPrefix}" \
+      --set QML_IMPORT_PATH "${qtPath qtbase.qtQmlPrefix}" \
+      --set QML2_IMPORT_PATH "${qtPath qtbase.qtQmlPrefix}" \
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.protonmail.com/bridge;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ lightdiscord ];
+
+    inherit description;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17920,6 +17920,8 @@ with pkgs;
     python = python3;
   };
 
+  protonmail-bridge = libsForQt5.callPackage ../applications/networking/protonmail-bridge { };
+
   psi = callPackage ../applications/networking/instant-messengers/psi { };
 
   psi-plus = callPackage ../applications/networking/instant-messengers/psi-plus { };


### PR DESCRIPTION
###### Motivation for this change

Add a new package to nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

