### PR TITLE
fix vlan interface bring up on boot

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -473,9 +473,11 @@ let
               # Remove Dead Interfaces
               ip link show "${n}" >/dev/null 2>&1 && ip link delete "${n}"
               ip link add link "${v.interface}" name "${n}" type vlan id "${toString v.id}"
-              # Try to bring up vlan interface
-              # Note: When master interface is down, we cannot bring vlan interfaces up (#28620)
-              #       Vlan interfaces will be automatically bring up when master is up
+              
+              # We try to bring up the logical VLAN interface. If the master 
+              # interface the logical interface is dependent upon is not up yet we will 
+              # fail to immediately bring up the logical interface. The resulting logical
+              # interface will brought up later when the master interface is up.
               ip link set "${n}" up || true
             '';
             postStop = ''

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -473,6 +473,9 @@ let
               # Remove Dead Interfaces
               ip link show "${n}" >/dev/null 2>&1 && ip link delete "${n}"
               ip link add link "${v.interface}" name "${n}" type vlan id "${toString v.id}"
+              # Try to bring up vlan interface
+              # Note: When master interface is down, we cannot bring vlan interfaces up (#28620)
+              #       Vlan interfaces will be automatically bring up when master is up
               ip link set "${n}" up || true
             '';
             postStop = ''

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -473,7 +473,7 @@ let
               # Remove Dead Interfaces
               ip link show "${n}" >/dev/null 2>&1 && ip link delete "${n}"
               ip link add link "${v.interface}" name "${n}" type vlan id "${toString v.id}"
-              ip link set "${n}" up
+              ip link set "${n}" up || true
             '';
             postStop = ''
               ip link delete "${n}" || true


### PR DESCRIPTION
###### Motivation for this change
fix #28620

When the parent interface of a vlan interface is not up (yet), `ip link` cannot bring the vlan interface up. The vlan interface will be automatically brought up when the parent interface is up later.

