### PR TITLE
raspberrypifw: fix cross 'builds'

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, dpkg }:
 
 stdenv.mkDerivation rec {
   name = "raspberrypi-wireless-firmware-${version}";
@@ -20,11 +20,12 @@ stdenv.mkDerivation rec {
   # Firmware blobs do not need fixing and should not be modified
   dontFixup = true;
 
+
   # Unpack the debian package
+  nativeBuildInputs = [ dpkg ];
   unpackCmd = ''
     if ! [[ "$curSrc" =~ \.deb$ ]]; then return 1; fi
-    ar -xf "$curSrc"
-    tar -xf data.tar.xz
+    dpkg -x "$curSrc" .
   '';
 
   installPhase = ''
@@ -38,6 +39,10 @@ stdenv.mkDerivation rec {
     # Bluetooth firmware
     cp broadcom/*.hcd "$out/lib/firmware/brcm"
   '';
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "1gwzasl5w5nc0awqv3w2081ns63wd1yds0xh0dg95dc6brnqhhf8";
 
   meta = with stdenv.lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3 and Zero W";


### PR DESCRIPTION
###### Motivation for this change
unprefixed `ar` is not found when cross compiling. the change in this PR allows it to build 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

