### PR TITLE
xfce4-13.xfce4-panel: fix path to tzdata

### DIFF
--- a/pkgs/desktops/xfce4-13/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-panel/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, makeWrapper, exo, garcon, gtk2, gtk3, gettext, glib-networking, libxfce4ui, libxfce4util, libwnck3, xfconf }:
+{ mkXfceDerivation, makeWrapper, tzdata, exo, garcon, gtk2, gtk3, gettext, glib-networking, libxfce4ui, libxfce4util, libwnck3, xfconf }:
 
 mkXfceDerivation rec {
   category = "xfce";
@@ -17,6 +17,9 @@ mkXfceDerivation rec {
     for f in $(find . -name \*.sh); do
       substituteInPlace $f --replace gettext ${gettext}/bin/gettext
     done
+    substituteInPlace plugins/clock/clock.c \
+       --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
+       --replace "if (!g_file_test (filename, G_FILE_TEST_IS_SYMLINK))" ""
   '';
 
   configureFlags = [ "--enable-gtk3" ];


### PR DESCRIPTION
###### Motivation for this change

This should be part of https://github.com/NixOS/nixpkgs/pull/43522
I did the fix for XFCE 4.12 (https://github.com/NixOS/nixpkgs/pull/43522/files#diff-d5900334ef3a7a897a90b8a3a9eac90c) but forgot for XFCE 4.13

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

