### PR TITLE
idrisPackages.graphviz: fix homepage

### DIFF
--- a/pkgs/development/idris-modules/graphviz.nix
+++ b/pkgs/development/idris-modules/graphviz.nix
@@ -22,7 +22,7 @@ build-idris-package  {
 
   meta = {
     description = "Parser and library for graphviz dot files";
-    homepage = https://github.com/mgttlinger/idris-graphviz;
+    homepage = https://gitlab.com/mgttlinger/idris-graphviz;
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.brainrape ];
   };


### PR DESCRIPTION
###### Motivation for this change
I went to the website supplied and couldn't find anything - then read the source and figured out that it was supposed to be on gitlab rather than on github.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---