### PR TITLE
cataclysm-dda-git: fix desktop launcher installation

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -74,7 +74,7 @@ let
 
     installXDGAppLauncher = ''
       launcher="$out/share/applications/cataclysm-dda.desktop"
-      install -D -m 444 data/xdg/com.cataclysmdda.cataclysm-dda.desktop -T "$launcher"
+      install -D -m 444 data/xdg/*cataclysm-dda.desktop -T "$launcher"
       sed -i "$launcher" -e "s,\(Exec=\)\(cataclysm-tiles\),\1$out/bin/\2,"
       install -D -m 444 data/xdg/cataclysm-dda.svg -t $out/share/icons/hicolor/scalable/apps
     '';


### PR DESCRIPTION
###### Motivation for this change

Recent upstream changed the launcher's file name:
https://github.com/CleverRaven/Cataclysm-DDA/pull/24559

Although the current nixpkgs version 2018-07-15 is not affected by the above change, I would like to fix it in advance.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

