### PR TITLE
flatpak: Don't hardcode flatpak binary path in launchers

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -24,6 +24,7 @@ in stdenv.mkDerivation rec {
     })
     # patch taken from gtk_doc
     ./respect-xml-catalog-files-var.patch
+    ./use-flatpak-from-path.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/flatpak/use-flatpak-from-path.patch
+++ b/pkgs/development/libraries/flatpak/use-flatpak-from-path.patch
@@ -1,0 +1,48 @@
+--- a/common/flatpak-dir.c
++++ b/common/flatpak-dir.c
+@@ -5467,7 +5467,7 @@ export_desktop_file (const char   *app,
+ 
+       new_exec = g_string_new ("");
+       g_string_append_printf (new_exec,
+-                              FLATPAK_BINDIR "/flatpak run --branch=%s --arch=%s",
++                              "flatpak run --branch=%s --arch=%s",
+                               escaped_branch,
+                               escaped_arch);
+ 
+@@ -6644,8 +6644,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
+                                        error))
+         return FALSE;
+ 
+-      bin_data = g_strdup_printf ("#!/bin/sh\nexec %s/flatpak run --branch=%s --arch=%s %s \"$@\"\n",
+-                                  FLATPAK_BINDIR, escaped_branch, escaped_arch, escaped_app);
++      bin_data = g_strdup_printf ("#!/bin/sh\nexec flatpak run --branch=%s --arch=%s %s \"$@\"\n",
++                                  escaped_branch, escaped_arch, escaped_app);
+       if (!g_file_replace_contents (wrapper, bin_data, strlen (bin_data), NULL, FALSE,
+                                     G_FILE_CREATE_REPLACE_DESTINATION, NULL, cancellable, error))
+         return FALSE;
+diff --git a/tests/test-bundle.sh b/tests/test-bundle.sh
+index 6937b041..01f8add7 100755
+--- a/tests/test-bundle.sh
++++ b/tests/test-bundle.sh
+@@ -59,7 +59,7 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/files
+ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/export
+ assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
+ # Ensure Exec key is rewritten
+-assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=master --arch=$ARCH --command=hello.sh org.test.Hello$"
++assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=flatpak run --branch=master --arch=$ARCH --command=hello.sh org.test.Hello$"
+ assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
+ assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png
+ 
+diff --git a/tests/test-run.sh b/tests/test-run.sh
+index 9d83d82e..234e4ec6 100755
+--- a/tests/test-run.sh
++++ b/tests/test-run.sh
+@@ -42,7 +42,7 @@ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/files
+ assert_has_dir $FL_DIR/app/org.test.Hello/$ARCH/master/active/export
+ assert_has_file $FL_DIR/exports/share/applications/org.test.Hello.desktop
+ # Ensure Exec key is rewritten
+-assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=.*/flatpak run --branch=master --arch=$ARCH --command=hello.sh org.test.Hello$"
++assert_file_has_content $FL_DIR/exports/share/applications/org.test.Hello.desktop "^Exec=flatpak run --branch=master --arch=$ARCH --command=hello.sh org.test.Hello$"
+ assert_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/org.test.Hello.png
+ assert_not_has_file $FL_DIR/exports/share/icons/hicolor/64x64/apps/dont-export.png
+ assert_has_file $FL_DIR/exports/share/icons/HighContrast/64x64/apps/org.test.Hello.png


### PR DESCRIPTION
###### Motivation for this change

The hardcoded flatpak path broke all installed applications when flatpak is
updated.

fixes: https://github.com/NixOS/nixpkgs/issues/43581

Some tests that were expecting `Exec=.*/flatpak` in the .desktop files needed patching.

cc @jtojnar @xeji 


###### Things done

I've run the `nixos.tests.flatpak` test and I'm not getting any failures, but the return code isn't `0` for some reason. Not sure if that's a regression or not (the tests takes forever).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

