### PR TITLE
treewide: Remove stdenv.isCross

### DIFF
--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isDarwin gettext
     ++ stdenv.lib.optional enableCapabilities libcap;
 
-  preConfigure = stdenv.lib.optionalString stdenv.isCross ''
+  preConfigure = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     # This is intentional: gpg-error-config is a shell script that will work during the build
     mkdir -p "$NIX_BUILD_TOP"/bin
     ln -s ${libgpgerror.dev}/bin/gpg-error-config "$NIX_BUILD_TOP/bin"

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,7 +1,6 @@
-{ lib, python3Packages, stdenv, targetPlatform, writeTextDir, substituteAll }: let
-  targetPrefix = lib.optionalString stdenv.isCross
-                   (targetPlatform.config + "-");
-in python3Packages.buildPythonApplication rec {
+{ lib, python3Packages, stdenv, targetPlatform, writeTextDir, substituteAll }:
+
+python3Packages.buildPythonApplication rec {
   version = "0.46.1";
   pname = "meson";
 
@@ -48,10 +47,10 @@ in python3Packages.buildPythonApplication rec {
 
   crossFile = writeTextDir "cross-file.conf" ''
     [binaries]
-    c = '${targetPrefix}cc'
-    cpp = '${targetPrefix}c++'
-    ar = '${targetPrefix}ar'
-    strip = '${targetPrefix}strip'
+    c = '${stdenv.cc.targetPrefix}cc'
+    cpp = '${stdenv.cc.targetPrefix}c++'
+    ar = '${stdenv.cc.bintools.targetPrefix}ar'
+    strip = '${stdenv.cc.bintools.targetPrefix}strip'
     pkgconfig = 'pkg-config'
 
     [properties]
@@ -69,7 +68,9 @@ in python3Packages.buildPythonApplication rec {
   # checkInputs = [ ninja pkgconfig ];
   # checkPhase = "python ./run_project_tests.py";
 
-  inherit (stdenv) cc isCross;
+  inherit (stdenv) cc;
+
+  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
 
   meta = with lib; {
     homepage = http://mesonbuild.com;

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional (!stdenv.hostPlatform.isMusl) libidn;
 
   # ninfod probably could build on cross, but the Makefile doesn't pass --host etc to the sub configure...
-  buildFlags = "man all" + stdenv.lib.optionalString (!stdenv.isCross) " ninfod";
+  buildFlags = "man all" + stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) " ninfod";
 
   installPhase =
     ''

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -141,8 +141,6 @@ let
       inherit overrides;
 
       inherit cc;
-
-      isCross = targetPlatform != buildPlatform;
     }
 
     # Propagate any extra attributes.  For instance, we use this to

--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -11,7 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "0319q59kb8g324wnj7xzbr7vvlx5bcs13lr34j0zb3kqlyjq2fy9";
   };
 
-  configureFlags = "CPPFLAGS=-DNDEBUG CFLAGS=-O3 CXXFLAGS=-O3" + stdenv.lib.optionalString stdenv.isCross " CXX=${stdenv.cc.targetPrefix}c++";
+  configureFlags = [
+    "CPPFLAGS=-DNDEBUG"
+    "CFLAGS=-O3"
+    "CXXFLAGS=-O3"
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+    "CXX=${stdenv.cc.targetPrefix}c++";
 
   setupHook = ./lzip-setup-hook.sh;
 


### PR DESCRIPTION
###### Motivation for this change

I *want* cross-specific overrides to be verbose, so I rather not have this shorthand. This makes the syntactic overhead more proportional to the maintenance cost. Hopefully this pushes people towards fewer conditionals and more abstractions.

I'd like this to get in 18.09. `stdenv.isCross` was made just in time for 18.03, so if we are to remove it I wouldn't like it to be around for another stable cycle.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

