### PR TITLE
lbdb: 0.46 -> 0.47

### DIFF
--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "0.46";
+  version = "0.47";
 in
 with stdenv.lib;
 with perlPackages;
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   name = "lbdb-${version}";
   src = fetchurl {
     url = "http://www.spinnaker.de/lbdb/download/lbdb_${version}.tar.gz";
-    sha256 = "16fx02xk98k3friigq2lcgk535xagp3kfnmngni5kw61f7yj6gxi";
+    sha256 = "06zgj03q75gc6ri4cw3jdmi01f22anwchlv2kw4zp9nbm5swv36b";
   };
 
   buildInputs = [ goobook makeWrapper perl ConvertASN1 perlldap AuthenSASL ]


### PR DESCRIPTION
###### Motivation for this change
Update to latest upstream version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

