### PR TITLE
pg_journal: init at 0.2.0 & fixed some PostgreSQL plugins related issues

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -24,6 +24,10 @@ let
         # configured package. Note that this does require every plugin to have
         # postgresql in its arguments but every plugin already needs this.
         map (plugin: plugin.override { postgresql = pg; }) cfg.extraPlugins;
+      # We include /bin to ensure the $out/bin directory is created which is
+      # needed because we'll be removing files from that directory in postBuild
+      # below.
+      pathsToLink = ["/" "/bin"];
       buildInputs = [ pkgs.makeWrapper ];
       postBuild =
         ''

--- a/pkgs/servers/sql/postgresql/pg_journal/default.nix
+++ b/pkgs/servers/sql/postgresql/pg_journal/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, postgresql, systemd, openssl }:
+
+# # To enable on NixOS:
+# config.services.postgresql = {
+#   extraPlugins = [ pkgs.pg_journal ];
+#   extraConfig = "shared_preload_libraries = 'pg_journal'";
+# }
+
+stdenv.mkDerivation rec {
+  name = "pg_journal-${version}";
+  version = "0.2.0";
+
+  buildInputs = [ postgresql pkgconfig systemd.dev openssl.dev ];
+
+  src = fetchFromGitHub {
+    owner  = "intgr";
+    repo   = "pg_journal";
+    rev    = "e3847a1ff34c0aa8e7d16646bf921f69433b39ae";
+    sha256 = "0kgqw75hnm7dx9haiv26gwa8h73c39276pqkmnryn3fg469hl8wb";
+  };
+
+  patches = [
+    # See: https://github.com/intgr/pg_journal/issues/1
+    (fetchpatch {
+      url = https://github.com/gosuai/pg_journal/commit/a8e534ee1089c35bc073113358166ce2fd9e2c99.patch;
+      sha256 = "1bgc1jzhkvwc86gvf5s8qfzlr9xiqdrdbi9zgppd1zb0i4ndmqcp";
+    })
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp pg_journal.so $out/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Log PostgreSQL messages to systemd journal";
+    homepage    = https://github.com/intgr/pg_journal;
+    maintainers = with maintainers; [ basvandijk ];
+    license     = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/pgjwt/default.nix
+++ b/pkgs/servers/sql/postgresql/pgjwt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, postgresql }:
 stdenv.mkDerivation rec {
   name = "pgjwt-${version}";
   version = "unstable-2017-04-24";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     rev = "546a2911027b716586e241be7fd4c6f1785237cd";
     sha256 = "1riz0xvwb6y02j0fljbr9hcbqb2jqs4njlivmavy9ysbcrrv1vrf";
   };
-  dontBuild = true;
+  buildInputs = [ postgresql ];
   installPhase = ''
     mkdir -p $out/bin  # current postgresql extension mechanism in nixos requires bin directory
     mkdir -p $out/share/extension

--- a/pkgs/servers/sql/postgresql/pgjwt/default.nix
+++ b/pkgs/servers/sql/postgresql/pgjwt/default.nix
@@ -10,7 +10,6 @@ stdenv.mkDerivation rec {
   };
   buildInputs = [ postgresql ];
   installPhase = ''
-    mkdir -p $out/bin  # current postgresql extension mechanism in nixos requires bin directory
     mkdir -p $out/share/extension
     cp pg*sql *.control $out/share/extension
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2974,6 +2974,8 @@ with pkgs;
 
   pg_cron = callPackage ../servers/sql/postgresql/pg_cron {};
 
+  pg_journal = callPackage ../servers/sql/postgresql/pg_journal {};
+
   pgtap = callPackage ../servers/sql/postgresql/pgtap {};
 
   pg_topn = callPackage ../servers/sql/postgresql/topn {};


### PR DESCRIPTION
###### Motivation for this change

Triggered by [Discourse: Q: Services logging to stderr preferred over logging to syslog?](https://discourse.nixos.org/t/q-services-logging-to-stderr-preferred-over-logging-to-syslog/588) I packaged the [`pg_journal`](https://github.com/intgr/pg_journal) plugin that logs PostgreSQL messages to the systemd journal.

###### Things done

* packaged `pg_journal` at version 0.2.0 (including some patches)

* fixed some PostgreSQL plugins related issues.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ocharles as maintainer of the `postgresql` package. Ollie, what do you think?