### PR TITLE
Add missing dependencies for swi-prolog

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, jdk, gmp, readline, openssl, libjpeg, unixODBC, zlib
-, libXinerama, libXft, libXpm, libSM, libXt, freetype, pkgconfig
-, fontconfig, makeWrapper ? stdenv.isDarwin
+, libXinerama, libarchive, db, pcre, libedit, libossp_uuid, libXft, libXpm
+, libSM, libXt, freetype, pkgconfig, fontconfig, makeWrapper ? stdenv.isDarwin
 }:
 
 let
@@ -15,7 +15,8 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ jdk gmp readline openssl libjpeg unixODBC libXinerama
-    libXft libXpm libSM libXt zlib freetype pkgconfig fontconfig ]
+    libarchive db pcre libedit libossp_uuid libXft libXpm libSM libXt
+    zlib freetype pkgconfig fontconfig ]
   ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
 
   hardeningDisable = [ "format" ];
@@ -42,6 +43,6 @@ stdenv.mkDerivation {
     license = "LGPL";
 
     platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.peti ];
+    maintainers = [ stdenv.lib.maintainers.peti stdenv.lib.maintainers.meditans ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
In the previous version of this derivation, when the command:

?- check_installation.

was issued in the swipl prompt, five errors were encountered. This patch fixes
that, so that the installation is correctly checked.
This enables the usage of the command pack_install to install prolog libraries,
which otherwise fails for the lack of libarchive.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

