### PR TITLE
tensorflow: workaround tensorboard collision due to upstream pip hack

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -61,6 +61,15 @@ in buildPythonPackage rec {
   # bleach) Hence we disable dependency checking for now.
   installFlags = lib.optional isPy36 "--no-dependencies";
 
+
+  # Upstream has a pip hack that results in bin/tensorboard being in both tensorflow
+  # and the propageted input tensorflow-tensorboard which causes environment collisions.
+  #
+  # https://github.com/tensorflow/tensorflow/blob/v1.7.1/tensorflow/tools/pip_package/setup.py#L79
+  postInstall = ''
+    rm $out/bin/tensorboard
+  '';
+
   # Note that we need to run *after* the fixup phase because the
   # libraries are loaded at runtime. If we run in preFixup then
   # patchelf --shrink-rpath will remove the cuda libraries.


### PR DESCRIPTION
###### Motivation for this change

Fails to work with `python.withPackages`
```
nix-build -E 'with import ./. { }; python.withPackages (p: with p; [tensorflow])'
```
```
building '/nix/store/zj8adg9ri2jfmr0xg86rlk0i9nk0sw85-python-2.7.15-env.drv'...
collision between `/nix/store/z9a2y31akz53df8g9d6f5klr7kdzgmvb-python2.7-tensorflow-tensorboard-1.7.0/bin/.tensorboard-wrapped' and `/nix/store/wmxg0d5zw88a9m8zk1pmza3ga05npgzc-python2.7-tensorflow-1.7.1/bin/.tensorboard-wrapped'
builder for '/nix/store/zj8adg9ri2jfmr0xg86rlk0i9nk0sw85-python-2.7.15-env.drv' failed with exit code 25
error: build of '/nix/store/zj8adg9ri2jfmr0xg86rlk0i9nk0sw85-python-2.7.15-env.drv' failed
```
issue is upstream lists the command tensorboard as a utility from `tensorflow` despite it being provided by `tensorboard `to stop pip for deleting it.  This causes the python.withPackages collisions between the two.  The work around is to just delete it from `tensorflow` as a `postFixup` step.

https://github.com/NixOS/nixpkgs/issues/31492#issuecomment-409428739
https://github.com/NixOS/nixpkgs/issues/31492#issuecomment-409841317

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

