### PR TITLE
mesa: 18.1.5->18.1.2 [revert]

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -63,7 +63,7 @@ let
 in
 
 let
-  version = "18.1.4";
+  version = "18.1.2";
   branch  = head (splitString "." version);
 in
 
@@ -77,7 +77,7 @@ let self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "12zm9hc3v4wnzhqyrvf2kfnz55idzdn82hs3ry940l45bn5lhq9h";
+    sha256 = "1ydivzm4c2k53b65lvm11d62z140xlmd7viw63bl5cm5idjg02q7";
   };
 
   prePatch = "patchShebangs .";

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -63,7 +63,7 @@ let
 in
 
 let
-  version = "18.1.5";
+  version = "18.1.4";
   branch  = head (splitString "." version);
 in
 
@@ -77,7 +77,7 @@ let self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "69dbe6f1a6660386f5beb85d4fcf003ee23023ed7b9a603de84e9a37e8d98dea";
+    sha256 = "12zm9hc3v4wnzhqyrvf2kfnz55idzdn82hs3ry940l45bn5lhq9h";
   };
 
   prePatch = "patchShebangs .";


### PR DESCRIPTION
###### Motivation for this change
Holy hell, did this ever take debugging. So after `nixos-unstable-small` was finally unstuck, I eagerly rebased my branch and went onto rebuilding. Just to find that Xorg was segfaulting whenever I got past sddm and into an actual session. See sample log excerpt below.

I took to bisecting the nixpkgs tree, with eternal rebuilds, and eventually isolated the problem: mesa. I know this seems obvious in retrospect, but seeing `radeonsi` in the trace had me thinking the kernel might be at fault, what with all the new AMDGPU code being merged and me running a fancy Vega card.

Anyway, I tried 18.1.5, found that it did not fix it, and so I reverted that and the bump to 18.1.4 as well. 18.1.2 seems to run fine for me. Let's wait for another release before updating mesa maybe.

```
Aug 01 23:58:15 cryptbreaker X[1230]: (EE)
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) Backtrace:
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 0: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/bin/X (OsSigHandler+0x29) [0x59e609]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 1: /nix/store/v7hg431d55q30gy7hqlpiji3jnvi8gs3-glibc-2.27/lib/libpthread.so.0 (funlockfile+0x50) [0x7f19a6505f5f]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 2: /run/opengl-driver/lib/dri/radeonsi_dri.so (_mesa_add_parameter+0x223) [0x7f199f104e73]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 3: /run/opengl-driver/lib/dri/radeonsi_dri.so (deserialize_glsl_program+0x5ee) [0x7f199f24e13e]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 4: /run/opengl-driver/lib/dri/radeonsi_dri.so (_Z34shader_cache_read_program_metadataP10gl_contextP17gl_shader_program+0x357) [0x7f199f24f447]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 5: /run/opengl-driver/lib/dri/radeonsi_dri.so (_Z12link_shadersP10gl_contextP17gl_shader_program+0x9d) [0x7f199f1b68ed]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 6: /run/opengl-driver/lib/dri/radeonsi_dri.so (_mesa_glsl_link_shader+0x1ae) [0x7f199f0fd1ce]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 7: /run/opengl-driver/lib/dri/radeonsi_dri.so (link_program_error+0x9d) [0x7f199f01e1fd]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 8: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/lib/xorg/modules/libglamoregl.so (glamor_link_glsl_prog+0xa2) [0x7f19984a8a72]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 9: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/lib/xorg/modules/libglamoregl.so (glamor_build_program+0x4c8) [0x7f19984b6468]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 10: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/lib/xorg/modules/libglamoregl.so (glamor_setup_program_render+0x22b) [0x7f19984b6a0b]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 11: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/lib/xorg/modules/libglamoregl.so (glamor_composite_glyphs+0xb69) [0x7f19984aaf69]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 12: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/bin/X (damageGlyphs+0x3d9) [0x51fae9]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 13: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/bin/X (ProcRenderCompositeGlyphs+0x4fe) [0x51530e]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 14: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/bin/X (Dispatch+0x308) [0x439ae8]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 15: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/bin/X (dix_main+0x3d8) [0x43dab8]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 16: /nix/store/v7hg431d55q30gy7hqlpiji3jnvi8gs3-glibc-2.27/lib/libc.so.6 (__libc_start_main+0xee) [0x7f19a56b7b8e]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) 17: /nix/store/329mvdd6q6xiyq2dp6karcg0yx18n246-xorg-server-1.19.6/bin/X (_start+0x2a) [0x4277da]
Aug 01 23:58:15 cryptbreaker X[1230]: (EE)
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) Segmentation fault at address 0x7f1a0e0e8454
Aug 01 23:58:15 cryptbreaker X[1230]: (EE)
Aug 01 23:58:15 cryptbreaker X[1230]: Fatal server error:
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) Caught signal 11 (Segmentation fault). Server aborting
Aug 01 23:58:15 cryptbreaker X[1230]: (EE)
Aug 01 23:58:15 cryptbreaker X[1230]: Please consult the The X.Org Foundation support
Aug 01 23:58:15 cryptbreaker X[1230]:          at http://wiki.x.org
Aug 01 23:58:15 cryptbreaker X[1230]:  for help.
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) Please also check the log file at "/dev/null" for additional information.
Aug 01 23:58:15 cryptbreaker X[1230]: (EE)
Aug 01 23:58:15 cryptbreaker X[1230]: (II) AIGLX: Suspending AIGLX clients for VT switch
Aug 01 23:58:15 cryptbreaker X[1230]: (EE) Server terminated with error (1). Closing log file.
```

###### Things done

I've reverted two commits that bump mesa to 18.1.4 and then to 18.1.5

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

