### PR TITLE
tldr: add support for darwin

### DIFF
--- a/pkgs/tools/misc/tldr/default.nix
+++ b/pkgs/tools/misc/tldr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, clang, curl, libzip, pkgconfig }:
+{ stdenv, fetchFromGitHub, curl, libzip, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "tldr-${version}";
@@ -11,13 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "10ylpiqc06p0qpma72vwksd7hd107s0vlx9c6s9rz4vc3i274lb6";
   };
 
-  buildInputs = [ curl clang libzip ];
+  buildInputs = [ curl libzip ];
   nativeBuildInputs = [ pkgconfig ];
 
-  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
-    substituteInPlace Makefile --replace "gcc" "$CC"
-    substituteInPlace Makefile --replace "gcc" "$CC"
-  '';
+  makeFlags = ["CC=cc" "LD=cc" "CFLAGS="];
 
   installFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/tools/misc/tldr/default.nix
+++ b/pkgs/tools/misc/tldr/default.nix
@@ -14,6 +14,11 @@ stdenv.mkDerivation rec {
   buildInputs = [ curl clang libzip ];
   nativeBuildInputs = [ pkgconfig ];
 
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace Makefile --replace "gcc" "$CC"
+    substituteInPlace Makefile --replace "gcc" "$CC"
+  '';
+
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
@@ -24,7 +29,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://tldr-pages.github.io;
     license = licenses.mit;
-    maintainers = with maintainers; [ taeer ];
-    platforms = platforms.linux;
+    maintainers = with maintainers; [ taeer carlosdagos ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Adds darwin support for `tldr`. Also fixes warning due to git being missing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

