### PR TITLE
run-scaled: init at 2018-06-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3683,6 +3683,11 @@
     github = "s-na";
     name = "S. Nordin Abouzahra";
   };
+  snaar = {
+    email = "snaar@snaar.net";
+    github = "snaar";
+    name = "Serguei Narojnyi";
+  };
   snyh = {
     email = "snyh@snyh.org";
     github = "snyh";

--- a/pkgs/tools/X11/run-scaled/default.nix
+++ b/pkgs/tools/X11/run-scaled/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/kaueraal/run_scaled;
     maintainers = [ maintainers.snaar ];
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/X11/run-scaled/default.nix
+++ b/pkgs/tools/X11/run-scaled/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, makeWrapper, bc, xorgserver, xpra, xrandr }:
+
+stdenv.mkDerivation rec {
+  version = "git-2018-06-03";
+  name = "run-scaled-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "kaueraal";
+    repo   = "run_scaled";
+    rev    = "fa71b3c17e627a96ff707ad69f1def5361f2245c";
+    sha256 = "1ma4ax7ydq4xvyzrc4zapihmf7v3d9zl9mbi8bgpps7nlgz544ys";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp run_scaled $out/bin
+    wrapProgram $out/bin/run_scaled --prefix PATH ":" \
+      ${stdenv.lib.makeBinPath [ bc xorgserver xpra xrandr ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Run an X application scaled via xpra";
+    homepage = https://github.com/kaueraal/run_scaled;
+    maintainers = [ maintainers.snaar ];
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21551,6 +21551,8 @@ with pkgs;
 
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
+  run-scaled = callPackage ../tools/X11/run-scaled { };
+
   runit = callPackage ../tools/system/runit { };
 
   refind = callPackage ../tools/bootloaders/refind { };


### PR DESCRIPTION
###### Motivation for this change
Run an X application scaled via xpra.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

