### PR TITLE
reaper: init at 5.93

### DIFF
--- a/pkgs/applications/audio/reaper/default.nix
+++ b/pkgs/applications/audio/reaper/default.nix
@@ -1,0 +1,81 @@
+{ stdenv, fetchurl, autoPatchelfHook, makeWrapper
+, alsaLib, xorg
+, fetchFromGitHub, pkgconfig, gnome3
+, gnome2, gdk_pixbuf, cairo, glib, freetype
+, libpulseaudio
+}:
+
+let
+  libSwell = stdenv.mkDerivation {
+    name = "libSwell";
+
+    src = fetchFromGitHub {
+      owner = "justinfrankel";
+      repo = "WDL";
+      rev = "e87f5bdee7327b63398366fde6ec0a3f08bf600d";
+      sha256 = "147idjqc6nc23w9krl8a9w571k5jx190z3id6ir6cr8zsx0lakdb";
+    };
+
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [ gnome3.gtk ];
+
+    buildPhase = ''
+      cd WDL/swell
+      make
+    '';
+
+    installPhase = ''
+      mv libSwell.so $out
+    '';
+  };
+
+in stdenv.mkDerivation rec {
+  name = "reaper-${version}";
+  version = "5.93";
+
+  src = fetchurl {
+    url = "https://www.reaper.fm/files/${stdenv.lib.versions.major version}.x/reaper${builtins.replaceStrings ["."] [""] version}_linux_x86_64.tar.xz";
+    sha256 = "17ciysyqp4by0yy08avk7z16inrmfwrmzh5l1r6fdni0y4ax65iq";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
+
+  buildInputs = [
+    alsaLib
+    stdenv.cc.cc.lib
+
+    xorg.libX11
+    xorg.libXi
+
+    gnome3.gtk
+    gdk_pixbuf
+    gnome2.pango
+    cairo
+    glib
+    freetype
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    ./install-reaper.sh --install $out/opt
+    rm $out/opt/REAPER/uninstall-reaper.sh
+
+    cp ${libSwell.out} $out/opt/REAPER/libSwell.so
+
+    wrapProgram $out/opt/REAPER/reaper5 \
+      --prefix LD_LIBRARY_PATH : ${libpulseaudio}/lib
+
+    mkdir $out/bin
+    ln -s $out/opt/REAPER/reaper5 $out/bin/
+    ln -s $out/opt/REAPER/reamote-server $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Digital audio workstation";
+    homepage = https://www.reaper.fm/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ jfrankenau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18117,6 +18117,8 @@ with pkgs;
     tcl = tcl-8_5;
   };
 
+  reaper = callPackage ../applications/audio/reaper { };
+
   recode = callPackage ../tools/text/recode { };
 
   rednotebook = python3Packages.callPackage ../applications/editors/rednotebook { };


### PR DESCRIPTION
###### Motivation for this change

Linux native builds of [REAPER](https://www.reaper.fm/) are now available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The UI is hideous. I've got to see if this is the case on other Linux distributions as well.