### PR TITLE
documentation: change git:// links to https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ build daemon as so-called channels. To get channel information via git, add
 [nixpkgs-channels](https://github.com/NixOS/nixpkgs-channels.git) as a remote:
 
 ```
-% git remote add channels git://github.com/NixOS/nixpkgs-channels.git
+% git remote add channels https://github.com/NixOS/nixpkgs-channels.git
 ```
 
 For stability and maximum binary package support, it is recommended to maintain

--- a/doc/quick-start.xml
+++ b/doc/quick-start.xml
@@ -9,7 +9,7 @@
     <para>
      Checkout the Nixpkgs source tree:
 <screen>
-$ git clone git://github.com/NixOS/nixpkgs.git 
+$ git clone https://github.com/NixOS/nixpkgs
 $ cd nixpkgs</screen>
     </para>
    </listitem>

--- a/nixos/doc/manual/configuration/adding-custom-packages.xml
+++ b/nixos/doc/manual/configuration/adding-custom-packages.xml
@@ -14,7 +14,7 @@
 xlink:href="http://nixos.org/nixpkgs/manual">Nixpkgs
   manual</link>. In short, you clone Nixpkgs:
 <screen>
-$ git clone git://github.com/NixOS/nixpkgs.git
+$ git clone https://github.com/NixOS/nixpkgs
 $ cd nixpkgs
 </screen>
   Then you write and test the package as described in the Nixpkgs manual.

--- a/nixos/doc/manual/development/sources.xml
+++ b/nixos/doc/manual/development/sources.xml
@@ -11,9 +11,9 @@
   modify NixOS, however, you should check out the latest sources from Git. This
   is as follows:
 <screen>
-$ git clone git://github.com/NixOS/nixpkgs.git
+$ git clone https://github.com/NixOS/nixpkgs
 $ cd nixpkgs
-$ git remote add channels git://github.com/NixOS/nixpkgs-channels.git
+$ git remote add channels https://github.com/NixOS/nixpkgs-channels
 $ git remote update channels
 </screen>
   This will check out the latest Nixpkgs sources to


### PR DESCRIPTION
###### Motivation for this change

The server is not verified over the git:// transfer protocol. If you
clone a repository over git://, you should check if the latest commit's
hash is correct.

On the other hand, https:// will always verify the server automatically,
using certificate authorities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).