### PR TITLE
doitlive: use python3Packages

### DIFF
--- a/pkgs/tools/misc/doitlive/default.nix
+++ b/pkgs/tools/misc/doitlive/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, pythonPackages }:
+{ stdenv, python3Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "doitlive";
   version = "3.0.3";
 
-  src = pythonPackages.fetchPypi {
+  src = python3Packages.fetchPypi {
     inherit pname version;
     sha256 = "19i16ca835rb3gal1sxyvpyilj9a80n6nikf0smlzmxck38x86fj";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ click ];
+  propagatedBuildInputs = with python3Packages; [ click ];
 
   # disable tests (too many failures)
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @mbode 
Not that this was not tested.