### PR TITLE
certmgr: init at 1.6.1

### DIFF
--- a/pkgs/tools/security/certmgr/default.nix
+++ b/pkgs/tools/security/certmgr/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  version = "1.6.1";
+  name = "certmgr-${version}";
+
+  goPackagePath = "github.com/cloudflare/certmgr/";
+
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = "certmgr";
+    rev = "v${version}";
+    sha256 = "1ky2pw1wxrb2fxfygg50h0mid5l023x6xz9zj5754a023d01qqr2";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://cfssl.org/;
+    description = "Cloudflare's certificate manager";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ johanot srhb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1696,6 +1696,8 @@ with pkgs;
   ceph = callPackage ../tools/filesystems/ceph { boost = boost165; };
   ceph-dev = ceph;
 
+  certmgr = callPackage ../tools/security/certmgr { };
+
   cfdg = callPackage ../tools/graphics/cfdg {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
###### Motivation for this change

Certmgr is a Cloudflare client intended for interacting with cfssl. 

Based on declarative specification, it can request new, and monitor existing, x509 certificates on any host and renew them automatically when required. 

Certmgr can be used interactively on the cmdline to query and manage certficates, or it can be run as a daemon that continuously watches selected certificates. I will follow up soon with a nixos module for configuring the certmgr-daemon in particular.

As agreed with @srhb, I've added both of us as package maintainers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
