### PR TITLE
*diag: use python3 and toPythonApplication

### DIFF
--- a/pkgs/development/python-modules/actdiag/default.nix
+++ b/pkgs/development/python-modules/actdiag/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, pep8, nose, unittest2, docutils, blockdiag  }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
+, pep8, nose, unittest2, docutils, blockdiag, reportlab }:
 
 buildPythonPackage rec {
   pname = "actdiag";
@@ -10,13 +10,17 @@ buildPythonPackage rec {
     sha256 = "983071777d9941093aaef3be1f67c198a8ac8d2bba264cdd1f337ca415ab46af";
   };
 
+  patches = fetchpatch {
+    name = "drop_test_pep8.py.patch";
+    url = https://bitbucket.org/blockdiag/actdiag/commits/c1f2ed5947a1e93291f5860e4e30cee098bd635d/raw;
+    sha256 = "1zxzwb0fvwlc8xgs45fx65341sjhb3h6l2p6rdj6i127vg1hsxb4";
+  };
+
   buildInputs = [ pep8 nose unittest2 docutils ];
 
   propagatedBuildInputs = [ blockdiag ];
 
-  # One test fails:
-  #   UnicodeEncodeError: 'ascii' codec can't encode character u'\u3042' in position 0: ordinal not in range(128)
-  doCheck = false;
+  checkInputs = [ reportlab ];
 
   meta = with stdenv.lib; {
     description = "Generate activity-diagram image from spec-text file (similar to Graphviz)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -429,7 +429,7 @@ with pkgs;
 
   acpica-tools = callPackage ../tools/system/acpica-tools { };
 
-  actdiag = pythonPackages.actdiag;
+  actdiag = with python3.pkgs; toPythonApplication actdiag;
 
   actkbd = callPackage ../tools/system/actkbd { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -905,7 +905,7 @@ with pkgs;
 
   blobfuse = callPackage ../tools/filesystems/blobfuse { };
 
-  blockdiag = pythonPackages.blockdiag;
+  blockdiag = with python3Packages; toPythonApplication blockdiag;
 
   blsd = callPackage ../tools/misc/blsd {
     libgit2 = libgit2_0_27;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5074,7 +5074,7 @@ with pkgs;
 
   setserial = callPackage ../tools/system/setserial { };
 
-  seqdiag = pythonPackages.seqdiag;
+  seqdiag = with python3Packages; toPythonApplication seqdiag;
 
   screenfetch = callPackage ../tools/misc/screenfetch { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4242,7 +4242,7 @@ with pkgs;
 
   nssmdns = callPackage ../tools/networking/nss-mdns { };
 
-  nwdiag = pythonPackages.nwdiag;
+  nwdiag = with python3Packages; toPythonApplication nwdiag;
 
   nylon = callPackage ../tools/networking/nylon { };
 


### PR DESCRIPTION
###### Motivation for this change
~Actdiag is only an application, not a Python module.~
This makes the actdiag package use python3 instead of python2 (https://github.com/NixOS/nixpkgs/issues/18185).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @bjornfor 