### PR TITLE
adb-sync: use python3

### DIFF
--- a/pkgs/development/mobile/adb-sync/default.nix
+++ b/pkgs/development/mobile/adb-sync/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, python, androidsdk, makeWrapper }:
+{ stdenv, fetchgit, python3, androidsdk, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "adb-sync-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1y016bjky5sn58v91jyqfz7vw8qfqnfhb9s9jd32k8y29hy5vy4d";
   };
 
-  buildInputs = [ python androidsdk makeWrapper ];
+  buildInputs = [ python3 androidsdk makeWrapper ];
 
   phases = "installPhase";
 


### PR DESCRIPTION
According to https://github.com/google/adb-sync/pull/2#commitcomment-11399661,
it should work with python2 and python3. Using python3 is prefered in nixpkgs.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @scolobb 
Note that this is completely untested.