### PR TITLE
afflib: use python3

### DIFF
--- a/pkgs/development/libraries/afflib/default.nix
+++ b/pkgs/development/libraries/afflib/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, zlib, curl, expat, fuse, openssl
-, autoreconfHook, python
+, autoreconfHook, python3
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ zlib curl expat fuse openssl python ];
+  buildInputs = [ zlib curl expat fuse openssl python3 ];
 
   meta = {
     homepage = http://afflib.sourceforge.net/;


### PR DESCRIPTION
Python3 is supported since 3.7.14.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @7c6f434c 
Note that this was not tested.