### PR TITLE
ams-lv2: use python3

### DIFF
--- a/pkgs/applications/audio/ams-lv2/default.nix
+++ b/pkgs/applications/audio/ams-lv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cairo, fftw, gtkmm2, lv2, lvtk, pkgconfig, python }:
+{ stdenv, fetchFromGitHub, cairo, fftw, gtkmm2, lv2, lvtk, pkgconfig, python3 }:
 
 stdenv.mkDerivation  rec {
   name = "ams-lv2-${version}";
@@ -12,13 +12,13 @@ stdenv.mkDerivation  rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cairo fftw gtkmm2 lv2 lvtk python ];
+  buildInputs = [ cairo fftw gtkmm2 lv2 lvtk ];
 
-  configurePhase = "python waf configure --prefix=$out";
+  configurePhase = "${python3.interpreter} waf configure --prefix=$out";
 
-  buildPhase = "python waf";
+  buildPhase = "${python3.interpreter} waf";
 
-  installPhase = "python waf install";
+  installPhase = "${python3.interpreter} waf install";
 
   meta = with stdenv.lib; {
     description = "An LV2 port of the internal modules found in Alsa Modular Synth";


### PR DESCRIPTION
It is python3-compatible since 1.1.5.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @cillianderoiste 
Note that this was not tested.