### PR TITLE
ansible-lint: explicitly use python2Packages

### DIFF
--- a/pkgs/development/tools/ansible-lint/default.nix
+++ b/pkgs/development/tools/ansible-lint/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, ansible }:
+{ stdenv, fetchFromGitHub, python2Packages, ansible }:
 
-pythonPackages.buildPythonPackage rec {
+python2Packages.buildPythonPackage rec {
   pname = "ansible-lint";
   version = "3.4.20";
 
@@ -11,9 +11,9 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "0wgczijrg5azn2f63hjbkas1w0f5hbvxnk3ia53w69mybk0gy044";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ pyyaml six ] ++ [ ansible ];
+  propagatedBuildInputs = with python2Packages; [ pyyaml six ] ++ [ ansible ];
 
-  checkInputs = [ pythonPackages.nose ];
+  checkInputs = [ python2Packages.nose ];
 
   postPatch = ''
     patchShebangs bin/ansible-lint


### PR DESCRIPTION
The README tells us to use `pip2`. I infer that this package is not python3-compatible.
Also, the build fails when using `python3Packages`.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @sengaya 