### PR TITLE
antfs-cli: use python3Packages

### DIFF
--- a/pkgs/applications/misc/antfs-cli/default.nix
+++ b/pkgs/applications/misc/antfs-cli/default.nix
@@ -1,7 +1,8 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python3Packages }:
 
-pythonPackages.buildPythonApplication rec {
-  name = "antfs-cli-unstable-2017-02-11";
+python3Packages.buildPythonApplication rec {
+  pname = "antfs-cli";
+  version = "unstable-2017-02-11";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/Tigge/antfs-cli;
@@ -17,5 +18,5 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0v8y64kldfbs809j1g9d75dd1vxq7mfxnp4b45pz8anpxhjf64fy";
   };
 
-  propagatedBuildInputs = [ pythonPackages.openant ];
+  propagatedBuildInputs = [ python3Packages.openant ];
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
