### PR TITLE
pius: introduce perl as buildInput

### DIFF
--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, pythonPackages, gnupg }:
+{ fetchFromGitHub, stdenv, pythonPackages, gnupg, perl }:
 
 let version = "2.2.4"; in
 pythonPackages.buildPythonApplication {
@@ -17,6 +17,8 @@ pythonPackages.buildPythonApplication {
       sed -i "$file" -E -e's|/usr/bin/gpg2?|${gnupg}/bin/gpg|g'
     done
   '';
+
+  buildInputs = [ perl ];
 
   meta = {
     homepage = https://www.phildev.net/pius/;


### PR DESCRIPTION
Otherwise, `pius-party-worksheet` would be unusable.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

