### PR TITLE
antlr: explicitly use python2

### DIFF
--- a/pkgs/development/tools/parsing/antlr/2.7.7.nix
+++ b/pkgs/development/tools/parsing/antlr/2.7.7.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, jdk, python}:
+{ stdenv, fetchurl, jdk, python2 }:
 
 stdenv.mkDerivation {
   name = "antlr-2.7.7";
@@ -7,7 +7,8 @@ stdenv.mkDerivation {
     sha256 = "1ffvcwdw73id0dk6pj2mlxjvbg0662qacx4ylayqcxgg381fnfl5";
   };
   patches = [ ./2.7.7-fixes.patch ];
-  buildInputs = [jdk python];
+  buildInputs = [ jdk ];
+  nativeBuildInputs = [ python2 ];
 
   meta = with stdenv.lib; {
     description = "Powerful parser generator";


### PR DESCRIPTION
Also, put python2 into nativeBuildInputs because Arch lists it in makedepends.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

