### PR TITLE
apt-offline: 1.3 -> 1.8.1

### DIFF
--- a/pkgs/tools/misc/apt-offline/default.nix
+++ b/pkgs/tools/misc/apt-offline/default.nix
@@ -1,15 +1,14 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchFromGitHub, python3Packages }:
 
-pythonPackages.buildPythonApplication rec {
-  version = "1.3";
-  name = "apt-offline-${version}";
+python3Packages.buildPythonApplication rec {
+  version = "1.8.1";
+  pname = "apt-offline";
 
-  src = fetchurl {
-    #url = "https://alioth.debian.org/frs/download.php/file/3855/${name}.tar.gz";
-    # The above URL has two problems: it requires one to be logged in, and it
-    # uses a CA that curl doesn't know about.  Instead, we use this mirror:
-    url = "http://www.falsifian.org/a/cFi5/${name}.tar.gz";
-    sha256 = "1sp7ai2abzhbg9y84700qziybphvpzl2nk3mz1d1asivzyjvxlxy";
+  src = fetchFromGitHub {
+    owner = "rickysarraf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0k79d1d8jiwg1s684r05njmk1dz8gsb8a9bl4agz7m31snc11j84";
   };
 
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/18185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @falsifian 
Note that this was not tested.