### PR TITLE
treewide: All configureFlags are lists 

### DIFF
--- a/doc/old/cross.txt
+++ b/doc/old/cross.txt
@@ -64,7 +64,7 @@ stdenv.mkDerivation {
     sha256 = "1ian3kwh2vg6hr3ymrv48s04gijs539vzrq62xr76bxbhbwnz2np";
   };
   inherit noSysDirs;
-  configureFlags = "--target=arm-linux";
+  configureFlags = [ "--target=arm-linux" ];
 }
 ---
 

--- a/pkgs/applications/audio/lingot/default.nix
+++ b/pkgs/applications/audio/lingot/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool gtk2 alsaLib libglade ];
 
-  configureFlags = "--disable-jack";
+  configureFlags = [ "--disable-jack" ];
 
   meta = {
     description = "Not a Guitar-Only tuner";

--- a/pkgs/applications/audio/mhwaveedit/default.nix
+++ b/pkgs/applications/audio/mhwaveedit/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation  rec {
      pkgconfig libpulseaudio makeWrapper
   ];
 
-  configureFlags = "--with-default-ladspa-path=${ladspaPlugins}/lib/ladspa";
+  configureFlags = [ "--with-default-ladspa-path=${ladspaPlugins}/lib/ladspa" ];
 
   postInstall = ''
     wrapProgram $out/bin/mhwaveedit \

--- a/pkgs/applications/audio/puredata/default.nix
+++ b/pkgs/applications/audio/puredata/default.nix
@@ -15,13 +15,12 @@ stdenv.mkDerivation  rec {
 
   buildInputs = [ alsaLib libjack2 fftw ];
 
-  configureFlags = ''
-    --enable-alsa
-    --enable-jack
-    --enable-fftw
-    --disable-portaudio
-
-  '';
+  configureFlags = [
+    "--enable-alsa"
+    "--enable-jack"
+    "--enable-fftw"
+    "--disable-portaudio"
+  ];
 
   # https://github.com/pure-data/pure-data/issues/188
   # --disable-oss

--- a/pkgs/applications/audio/schismtracker/default.nix
+++ b/pkgs/applications/audio/schismtracker/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     export ac_cv_prog_ac_ct_WINDRES=
   '';
 
-  configureFlags = "--enable-dependency-tracking";
+  configureFlags = [ "--enable-dependency-tracking" ];
 
   buildInputs = [ alsaLib python SDL ];
 

--- a/pkgs/applications/audio/transcode/default.nix
+++ b/pkgs/applications/audio/transcode/default.nix
@@ -10,9 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flac lame zlib libjpeg libvorbis libtheora libxml2 lzo
                   libdvdread pkgconfig x264 libmpeg2 xvidcore ];
-  configureFlags = "--disable-ffmpeg --disable-libavcodec --disable-libavformat
-    --enable-lzo --enable-ogg --enable-vorbis --enable-theora --enable-libxml2
-    --enable-x264 --enable-libmpeg2 --enable-xvid";
+  configureFlags = [
+    "--disable-ffmpeg" "--disable-libavcodec" "--disable-libavformat"
+    "--enable-lzo" "--enable-ogg" "--enable-vorbis" "--enable-theora" "--enable-libxml2"
+    "--enable-x264" "--enable-libmpeg2" "--enable-xvid"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/editors/elvis/default.nix
+++ b/pkgs/applications/editors/elvis/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  configureFlags = "--ioctl=termios";
+  configureFlags = [ "--ioctl=termios" ];
 
   meta = {
     homepage = http://elvis.vi-editor.org/;

--- a/pkgs/applications/editors/emacs-modes/bbdb/default.nix
+++ b/pkgs/applications/editors/emacs-modes/bbdb/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   patches = [ ./install-infodir.patch ];
 
   buildInputs = [emacs texinfo ctags];
-  configureFlags = "--with-package-dir=$$out/share/emacs/site-lisp";
+  configureFlags = [ "--with-package-dir=$$out/share/emacs/site-lisp" ];
   preInstall = "mkdir -p $out/info";
   installTargets = "install-pkg texinfo";
   postInstall = ''

--- a/pkgs/applications/editors/emacs-modes/maude/default.nix
+++ b/pkgs/applications/editors/emacs-modes/maude/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [emacs];
-  configureFlags = "--with-lispdir=$$out/share/emacs/site-lisp";
+  configureFlags = [ "--with-lispdir=$$out/share/emacs/site-lisp" ];
 
   meta = {
     description = "Emacs mode for the programming language Maude";

--- a/pkgs/applications/editors/gobby/default.nix
+++ b/pkgs/applications/editors/gobby/default.nix
@@ -18,9 +18,6 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtkmm2 gsasl gtksourceview libxmlxx libinf intltool ]
     ++ stdenv.lib.optional gnomeSupport gnome_vfs;
-  
-  configureFlags = ''
-  '';
 
   meta = with stdenv.lib; {
     homepage = http://gobby.0x539.de/;

--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -32,11 +32,11 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "info" ];
 
-  configureFlags = ''
-    --sysconfdir=/etc
-    ${optionalString (!enableNls) "--disable-nls"}
-    ${optionalString enableTiny "--enable-tiny"}
-  '';
+  configureFlags = [
+    "--sysconfdir=/etc"
+    (stdenv.lib.enableFeature enableNls "nls")
+    (stdenv.lib.enableFeature enableTiny "tiny")
+  ];
 
   postInstall = ''
     cp ${nixSyntaxHighlight}/nix.nanorc $out/share/nano/

--- a/pkgs/applications/graphics/dia/default.nix
+++ b/pkgs/applications/graphics/dia/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     NOCONFIGURE=1 ./autogen.sh # autoreconfHook is not enough
   '';
-  configureFlags = stdenv.lib.optionalString withGNOME "--enable-gnome";
+  configureFlags = stdenv.lib.optional withGNOME "--enable-gnome";
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/graphics/xara/default.nix
+++ b/pkgs/applications/graphics/xara/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ automake pkgconfig gettext perl zip ];
   buildInputs = [ wxGTK gtk2 libxml2 freetype pango ];
 
-  configureFlags = "--disable-svnversion";
+  configureFlags = [ "--disable-svnversion" ];
 
   patches = map fetchurl (import ./debian-patches.nix);
 

--- a/pkgs/applications/misc/cgminer/default.nix
+++ b/pkgs/applications/misc/cgminer/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     xorg.libX11 xorg.libXext xorg.libXinerama jansson
   ];
   configureScript = "./autogen.sh";
-  configureFlags = "--enable-scrypt --enable-opencl";
+  configureFlags = [ "--enable-scrypt" "--enable-opencl" ];
   NIX_LDFLAGS = "-lgcc_s -lX11 -lXext -lXinerama";
 
   preConfigure = ''

--- a/pkgs/applications/misc/fetchmail/default.nix
+++ b/pkgs/applications/misc/fetchmail/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ openssl ];
 
-  configureFlags = "--with-ssl=${openssl.dev}";
+  configureFlags = [ "--with-ssl=${openssl.dev}" ];
 
   meta = {
     homepage = http://www.fetchmail.info/;

--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace "/usr/bin/file" "${file}/bin/file"
   '';
 
-  configureFlags = "--disable-pycompile";
+  configureFlags = [ "--disable-pycompile" ];
 
   meta = {
     homepage = https://fontmanager.github.io/;

--- a/pkgs/applications/misc/gksu/default.nix
+++ b/pkgs/applications/misc/gksu/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     sed -i -e 's|/usr/bin/x-terminal-emulator|-l gnome-terminal|g' gksu.desktop
   '';
 
-  configureFlags = "--disable-nautilus-extension";
+  configureFlags = [ "--disable-nautilus-extension" ];
 
   meta = {
     description = "A graphical frontend for libgksu";

--- a/pkgs/applications/misc/jigdo/default.nix
+++ b/pkgs/applications/misc/jigdo/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ db gtk2 bzip2 ];
 
-  configureFlags = "--without-libdb";
+  configureFlags = [ "--without-libdb" ];
 
   meta = {
     description = "Download utility that can fetch files from several sources simultaneously";

--- a/pkgs/applications/misc/lilyterm/default.nix
+++ b/pkgs/applications/misc/lilyterm/default.nix
@@ -40,10 +40,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = "sh autogen.sh";
 
-  configureFlags = ''
-    --enable-nls
-    --enable-safe-mode
-  '';
+  configureFlags = [
+    "--enable-nls"
+    "--enable-safe-mode"
+  ];
 
   meta = with stdenv.lib; {
     description = "A fast, lightweight terminal emulator";

--- a/pkgs/applications/misc/notify-osd/default.nix
+++ b/pkgs/applications/misc/notify-osd/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     gnome3.gsettings-desktop-schemas
   ];
 
-  configureFlags = "--libexecdir=$(out)/bin";
+  configureFlags = [ "--libexecdir=$(out)/bin" ];
 
   preFixup = ''
     wrapProgram "$out/bin/notify-osd" \

--- a/pkgs/applications/misc/taskjuggler/2.x/default.nix
+++ b/pkgs/applications/misc/taskjuggler/2.x/default.nix
@@ -44,12 +44,12 @@ stdenv.mkDerivation rec {
     HOME=$TMPDIR
   '';
 
-  configureFlags = "
-    --without-arts --disable-docs
-    --x-includes=${libX11.dev}/include
-    --x-libraries=${libX11.out}/lib
-    --with-qt-dir=${qt3}
-  ";
+  configureFlags = [
+    "--without-arts" "--disable-docs"
+    "--x-includes=${libX11.dev}/include"
+    "--x-libraries=${libX11.out}/lib"
+    "--with-qt-dir=${qt3}"
+  ];
 
   preInstall = ''
     mkdir -p $out/share/emacs/site-lisp/

--- a/pkgs/applications/misc/wordnet/default.nix
+++ b/pkgs/applications/misc/wordnet/default.nix
@@ -17,8 +17,10 @@ stdenv.mkDerivation rec {
   '';
 
   # Needs the path to `tclConfig.sh' and `tkConfig.sh'.
-  configureFlags = "--with-tcl=" + tcl + "/lib " +
-                   "--with-tk="  + tk  + "/lib";
+  configureFlags = [
+    "--with-tcl=${tcl}/lib"
+    "--with-tk=${tk}/lib"
+  ];
 
   postInstall = ''
     wrapProgram $out/bin/wishwn --set TK_LIBRARY "${tk}/lib/${tk.libPrefix}"

--- a/pkgs/applications/networking/browsers/dillo/default.nix
+++ b/pkgs/applications/networking/browsers/dillo/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = with stdenv.lib;
   [ perl fltk openssl libjpeg libpng libXcursor libXi libXinerama ];
 
-  configureFlags =  "--enable-ssl";
+  configureFlags = [ "--enable-ssl" ];
 
   meta = with stdenv.lib; {
     homepage = https://www.dillo.org/;

--- a/pkgs/applications/networking/ids/daq/default.nix
+++ b/pkgs/applications/networking/ids/daq/default.nix
@@ -11,7 +11,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flex bison libpcap libdnet libnfnetlink libnetfilter_queue];
 
-  configureFlags = "--enable-nfq-module=yes --with-dnet-includes=${libdnet}/includes --with-dnet-libraries=${libdnet}/lib";
+  configureFlags = [
+    "--enable-nfq-module=yes"
+    "--with-dnet-includes=${libdnet}/includes"
+    "--with-dnet-libraries=${libdnet}/lib"
+  ];
 
   meta = {
     description = "Data AcQuisition library (DAQ), for packet I/O";

--- a/pkgs/applications/networking/ids/snort/default.nix
+++ b/pkgs/applications/networking/ids/snort/default.nix
@@ -14,7 +14,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = "--disable-static-daq --enable-control-socket --with-daq-includes=${daq}/includes --with-daq-libraries=${daq}/lib"; 
+  configureFlags = [
+    "--disable-static-daq"
+    "--enable-control-socket"
+    "--with-daq-includes=${daq}/includes"
+    "--with-daq-libraries=${daq}/lib"
+  ]; 
 
   postInstall = ''
     wrapProgram $out/bin/snort --add-flags "--daq-dir ${daq}/lib/daq --dynamic-preprocessor-lib-dir $out/lib/snort_dynamicpreprocessor/ --dynamic-engine-lib-dir $out/lib/snort_dynamicengine"

--- a/pkgs/applications/networking/instant-messengers/amsn/default.nix
+++ b/pkgs/applications/networking/instant-messengers/amsn/default.nix
@@ -7,7 +7,11 @@ stdenv.mkDerivation {
     sha256 = "0b8ir7spxnsz8f7kvr9f1k91nsy8cb65q6jv2l55b04fl20x4z7r";
   };
 
-  configureFlags = "--with-tcl=${tcl}/lib --with-tk=${tk}/lib --enable-static";
+  configureFlags = [
+    "--with-tcl=${tcl}/lib"
+    "--with-tk=${tk}/lib"
+    "--enable-static"
+  ];
 
   buildInputs = [which tcl tk xlibsWrapper libpng libjpeg makeWrapper];
 

--- a/pkgs/applications/networking/instant-messengers/mcabber/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mcabber/default.nix
@@ -14,7 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ncurses glib loudmouth libotr gpgme ];
 
-  configureFlags = "--with-openssl=${openssl.dev} --enable-modules --enable-otr";
+  configureFlags = [
+    "--with-openssl=${openssl.dev}"
+    "--enable-modules"
+    "--enable-otr"
+  ];
 
   doCheck = true;
 

--- a/pkgs/applications/networking/instant-messengers/silc-client/default.nix
+++ b/pkgs/applications/networking/instant-messengers/silc-client/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = "--with-ncurses=${ncurses.dev}";
+  configureFlags = [ "--with-ncurses=${ncurses.dev}" ];
 
   preConfigure = stdenv.lib.optionalString enablePlugin ''
     configureFlags="$configureFlags --with-silc-plugin=$out/lib/irssi"

--- a/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/gabble/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   checkInputs = [ dbus.daemon ];
 
-  configureFlags = "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";
+  configureFlags = [ "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt" ];
 
   enableParallelBuilding = true;
   doCheck = true;

--- a/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/logger/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     dbus telepathy-glib.python
   ];
 
-  configureFlags = "--enable-call";
+  configureFlags = [ "--enable-call" ];
 
   preFixup = ''
     wrapProgram "$out/libexec/telepathy-logger" \

--- a/pkgs/applications/networking/instant-messengers/telepathy/salut/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telepathy/salut/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ libxslt pkgconfigUpstream ];
 
-  configureFlags = "--disable-avahi-tests";
+  configureFlags = [ "--disable-avahi-tests" ];
 
   meta = with stdenv.lib; {
     description = "Link-local XMPP connection manager for Telepathy";

--- a/pkgs/applications/networking/newsreaders/slrn/default.nix
+++ b/pkgs/applications/networking/newsreaders/slrn/default.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation {
       -e "s|/bin/rm|rm|"
   '';
 
-  configureFlags = "--with-slang=${slang.dev} --with-ssl=${openssl.dev}";
+  configureFlags = [
+    "--with-slang=${slang.dev}"
+    "--with-ssl=${openssl.dev}"
+  ];
 
   buildInputs = [ slang ncurses openssl ];
 

--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -24,10 +24,13 @@ stdenv.mkDerivation rec {
     ++ optional withTcl tcl
     ++ optional withCyrus cyrus_sasl;
 
-  configureFlags = optionalString withPerl "--enable-perl "
-    + optionalString withPython "--enable-python "
-    + optionalString withTcl "--enable-tcl --with-tcl=${tcl}/lib "
-    + optionalString withCyrus "--enable-cyrus ";
+  configureFlags = [
+    (stdenv.lib.enableFeature withPerl "perl")
+    (stdenv.lib.enableFeature withPython "python")
+    (stdenv.lib.enableFeature withTcl "tcl")
+    (stdenv.lib.withFeatureAs withTcl "tcl" "${tcl}/lib")
+    (stdenv.lib.enableFeature withCyrus "cyrus")
+  ];
 
   meta = with stdenv.lib; {
     description = "Advanced IRC bouncer";

--- a/pkgs/applications/office/gnucash/2.4.nix
+++ b/pkgs/applications/office/gnucash/2.4.nix
@@ -27,7 +27,13 @@ stdenv.mkDerivation rec {
   ];
   propagatedUserEnvPkgs = [ gconf ];
 
-  configureFlags = "CFLAGS=-O3 CXXFLAGS=-O3 --disable-dbi --enable-ofx --enable-aqbanking";
+  configureFlags = [
+    "CFLAGS=-O3"
+    "CXXFLAGS=-O3"
+    "--disable-dbi"
+    "--enable-ofx"
+    "--enable-aqbanking"
+  ];
 
   postInstall = ''
     # Auto-updaters don't make sense in Nix.

--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
     sha256 = "26cceb7fa97dc7eee7181a79a6251a85b1f1464dcaaaf7624829f7439c5f7d3f";
   };
 
-  configureFlags = "--disable-component";
+  configureFlags = [ "--disable-component" ];
 
   prePatch = ''
     substituteInPlace doc/C/gnumeric.xml \

--- a/pkgs/applications/office/ledger/2.6.3.nix
+++ b/pkgs/applications/office/ledger/2.6.3.nix
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ emacs gmp pcre expat ];
 
-  configureFlags = "CPPFLAGS=-DNDEBUG CFLAGS=-O3 CXXFLAGS=-O3";
+  configureFlags = [
+    "CPPFLAGS=-DNDEBUG"
+    "CFLAGS=-O3"
+    "CXXFLAGS=-O3"
+  ];
 
   doCheck = true;
 

--- a/pkgs/applications/science/biology/ncbi-tools/default.nix
+++ b/pkgs/applications/science/biology/ncbi-tools/default.nix
@@ -15,7 +15,12 @@ stdenv.mkDerivation rec {
     sha256 = "1b2v0dcdqn3bysgdkj57sxmd6s0hc9wpnxssviz399g6plhxggbr";
   };
 
-  configureFlags = "--without-debug --with-bin-release --with-dll --without-static";
+  configureFlags = [ 
+    "--without-debug"
+    "--with-bin-release"
+    "--with-dll"
+    "--without-static"
+  ];
   buildInputs = [ cpio ];
 
   meta = {

--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -17,14 +17,14 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ perl procps fftw.dev ];
   buildInputs = [ libyaml gfortran libxc openblas gsl fftw.out netcdf arpack ];
 
-  configureFlags = ''
-    --with-yaml-prefix=${libyaml}
-    --with-blas=-lopenblas
-    --with-lapack=-lopenblas
-    --with-fftw-prefix=${fftwAll}
-    --with-gsl-prefix=${gsl}
-    --with-libxc-prefix=${libxc}
-  '';
+  configureFlags = [
+    "--with-yaml-prefix=${libyaml}"
+    "--with-blas=-lopenblas"
+    "--with-lapack=-lopenblas"
+    "--with-fftw-prefix=${fftwAll}"
+    "--with-gsl-prefix=${gsl}"
+    "--with-libxc-prefix=${libxc}"
+  ];
 
   doCheck = false;
   checkTarget = "check-short";

--- a/pkgs/applications/science/electronics/geda/default.nix
+++ b/pkgs/applications/science/electronics/geda/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "08dpa506xk4gjbbi8vnxcb640wq4ihlgmhzlssl52nhvxwx7gx5v";
   };
 
-  configureFlags = "--disable-update-xdg-database";
+  configureFlags = [
+    "--disable-update-xdg-database" 
+  ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ guile gtk2 flex gawk perl ];
 

--- a/pkgs/applications/science/electronics/xcircuit/default.nix
+++ b/pkgs/applications/science/electronics/xcircuit/default.nix
@@ -17,7 +17,11 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook automake pkgconfig ];
   hardeningDisable = [ "format" ];
 
-  configureFlags = "--with-tcl=${tcl}/lib --with-tk=${tk}/lib --with-ngspice=${getBin ngspice}/bin/ngspice";
+  configureFlags = [
+    "--with-tcl=${tcl}/lib"
+    "--with-tk=${tk}/lib"
+    "--with-ngspice=${getBin ngspice}/bin/ngspice"
+  ];
 
   buildInputs = with xorg; [ cairo ghostscript libSM libXt libICE libX11 libXpm tcl tk zlib ];
 

--- a/pkgs/applications/science/logic/eprover/default.nix
+++ b/pkgs/applications/science/logic/eprover/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     sed -e 's/ *CC *= *gcc$//' -i Makefile.vars
   '';
-  configureFlags = "--exec-prefix=$(out) --man-prefix=$(out)/share/man";
+  configureFlags = [
+    "--exec-prefix=$(out)"
+    "--man-prefix=$(out)/share/man"
+  ];
 
   meta = with stdenv.lib; {
     description = "Automated theorem prover for full first-order logic with equality";

--- a/pkgs/applications/science/logic/hol/default.nix
+++ b/pkgs/applications/science/logic/hol/default.nix
@@ -15,7 +15,7 @@ in
 
 let
   polymlEnableShared = with pkgs; lib.overrideDerivation polyml (attrs: {
-    configureFlags = "--enable-shared";
+    configureFlags = [ "--enable-shared" ];
   });
 in
 

--- a/pkgs/applications/science/math/cbc/default.nix
+++ b/pkgs/applications/science/math/cbc/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     sha256 = "1w8axdzm05xf5y13c31w7rc5z6ywxqxiwafnxcq3p195kgj0915a";
   };
 
-  configureFlags = "-C";
+  configureFlags = [ "-C" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/science/math/ginac/default.nix
+++ b/pkgs/applications/science/math/ginac/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "patchShebangs ginsh";
 
-  configureFlags = "--disable-rpath";
+  configureFlags = [ "--disable-rpath" ];
 
   meta = with stdenv.lib; {
     description = "GiNaC is Not a CAS";

--- a/pkgs/applications/science/math/scilab/default.nix
+++ b/pkgs/applications/science/math/scilab/default.nix
@@ -29,35 +29,29 @@ stdenv.mkDerivation rec {
 /*
   --with-atlas-library=DIR  Atlas library files are in DIR and we use Atlas
 */
-  configureFlags = ""
-  # use gcc C compiler and gnu Fortran compiler (g77 or gfortran)
-  + " --with-gcc --with-g77"
-  # use Xaw3d widgets given with Scilab
-  + (lib.optionalString (!withXaw3d) " --with-local-xaw")
-  # do not compile with PVM library
-  + " --without-pvm"
-  # compile with GTK
-  + (if withGtk then "
-       --with-gtk --with-gtk2
-    " else "
-       --without-gtk --without-gtk2
-    ")
-  # compile with TCL/TK
-  + (lib.optionalString withTk "
-       --with-tk
-       --with-tcl-library=${tcl}/lib
-       --with-tcl-include=${tcl}/include
-       --with-tk-library=${tk}/lib
-       --with-tk-include=${tk}/include
-    ")
-  # do not use Gtk widgets
-  + " --without-gtk --without-gtk2"
-  # compile with ocaml
-  + (if withOCaml then " --with-ocaml" else " --without-ocaml")
-  # do not compile Java interface
-  + " --without-java"
-  # use the X Window System
-  + lib.optionalString withX "--with-x"
+  configureFlags = [
+    # use gcc C compiler and gnu Fortran compiler (g77 or gfortran)
+    "--with-gcc" "--with-g77"
+    # do not compile with PVM library
+    "--without-pvm"
+    # compile with GTK
+    (stdenv.lib.enableFeature withGtk "gtk")
+    (stdenv.lib.enableFeature withGtk "gtk2")
+    # compile with ocaml
+    (stdenv.lib.withFeature withOCaml "ocaml")
+    # do not compile Java interface
+    "--without-java"
+    # use the X Window System
+    (stdenv.lib.withFeature withX "x")
+    # compile with TCL/TK
+  ] ++ lib.optionals withTk [
+    "--with-tk"
+    "--with-tcl-library=${tcl}/lib"
+    "--with-tcl-include=${tcl}/include"
+    "--with-tk-library=${tk}/lib"
+    "--with-tk-include=${tk}/include"
+  ]    # use Xaw3d widgets given with Scilab
+    ++ lib.optional (!withXaw3d) "--with-local-xaw"
   ;
 
   makeFlags = "all";

--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = "--disable-server";
+  configureFlags = [ "--disable-server" ];
 
   meta = {
     description = "Free software for distributed and grid computing";

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   preCheck = stdenv.lib.optional doCheck ''
     export TCLLIBPATH="${tcllib}/lib/tcllib${tcllib.version}"
   '';
-  configureFlags = if withJson then  "--json" else  "";
+  configureFlags = stdenv.lib.optional withJson "--json";
 
   preBuild=''
     export USER=nonexistent-but-specified-user

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -42,17 +42,19 @@ let
     # https://gcc.gnu.org/gcc-5/porting_to.html
     CPPFLAGS = "-P";
 
-    configureFlags = ''
-      ${if bdbSupport then "--with-berkeley-db" else "--without-berkeley-db"}
-      ${if httpServer then "--with-apxs=${apacheHttpd.dev}/bin/apxs" else "--without-apxs"}
-      ${if pythonBindings || perlBindings then "--with-swig=${swig}" else "--without-swig"}
-      ${if javahlBindings then "--enable-javahl --with-jdk=${jdk}" else ""}
-      --disable-keychain
-      ${if saslSupport then "--with-sasl=${sasl}" else "--without-sasl"}
-      ${if httpSupport then "--with-serf=${serf}" else "--without-serf"}
-      --with-zlib=${zlib.dev}
-      --with-sqlite=${sqlite.dev}
-    '';
+    configureFlags = [
+      (stdenv.lib.withFeature bdbSupport "berkeley-db")
+      (stdenv.lib.withFeatureAs httpServer "apxs" "${apacheHttpd.dev}/bin/apxs")
+      (stdenv.lib.withFeatureAs (pythonBindings || perlBindings) "swig" swig)
+      (stdenv.lib.withFeatureAs saslSupport "sasl" sasl)
+      (stdenv.lib.withFeatureAs httpSupport "serf" serf)
+      "--disable-keychain"
+      "--with-zlib=${zlib.dev}"
+      "--with-sqlite=${sqlite.dev}"
+    ] ++ stdenv.lib.optionals javahlBindings [
+      "--enable-javahl"
+      "--with-jdk=${jdk}"
+    ];
 
     preBuild = ''
       makeFlagsArray=(APACHE_LIBEXECDIR=$out/modules)

--- a/pkgs/applications/video/kino/default.nix
+++ b/pkgs/applications/video/kino/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
   buildInputs = [ gtk2 libglade libxml2 libraw1394 libsamplerate libdv
       pkgconfig perl perlXMLParser libavc1394 libiec61883 intltool libXv gettext libX11 glib cairo ffmpeg libv4l ]; # TODOoptional packages 
 
-  configureFlags = "--enable-local-ffmpeg=no";
+  configureFlags = [ "--enable-local-ffmpeg=no" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/applications/video/xawtv/default.nix
+++ b/pkgs/applications/video/xawtv/default.nix
@@ -12,8 +12,9 @@ stdenv.mkDerivation rec {
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -I${linux}/lib/modules/${linux.modDirVersion}/build"
   '';
 
-  configureFlags="--prefix=";
-  NIX_LDFLAGS="-lgcc_s";
+  configureFlags= [ "--prefix=" ];
+
+  NIX_LDFLAGS = "-lgcc_s";
 
   makeFlags = "SUID_ROOT= DESTDIR=\$(out) PREFIX=";
 

--- a/pkgs/applications/video/xine-ui/default.nix
+++ b/pkgs/applications/video/xine-ui/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''sed -e '/curl\/types\.h/d' -i src/xitk/download.c'';
 
-  configureFlags = "--with-readline=${readline.dev}";
+  configureFlags = [ "--with-readline=${readline.dev}" ];
   
   LIRC_CFLAGS="-I${lirc}/include";
   LIRC_LIBS="-L ${lirc}/lib -llirc_client";

--- a/pkgs/applications/virtualization/singularity/default.nix
+++ b/pkgs/applications/virtualization/singularity/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  configureFlags = "--localstatedir=/var";
+  configureFlags = [ "--localstatedir=/var" ];
   installFlags = "CONTAINER_MOUNTDIR=dummy CONTAINER_FINALDIR=dummy CONTAINER_OVERLAY=dummy SESSIONDIR=dummy";
 
   fixupPhase = ''

--- a/pkgs/data/icons/tango-icon-theme/default.nix
+++ b/pkgs/data/icons/tango-icon-theme/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ intltool iconnamingutils imagemagick librsvg ];
 
-  configureFlags = "--enable-png-creation";
+  configureFlags = [ "--enable-png-creation" ];
 
   postInstall = '''${gtk.out}/bin/gtk-update-icon-cache' "$out/share/icons/Tango" '';
 

--- a/pkgs/desktops/gnome-2/desktop/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gnome-control-center/default.nix
@@ -18,5 +18,5 @@ stdenv.mkDerivation {
                   libgnomeui librsvg gnome_menus gnome-desktop gnome_panel metacity gnome-settings-daemon
                   libSM docbook_xml_dtd_412
   ];
-  configureFlags = "--disable-scrollkeeper";
+  configureFlags = [ "--disable-scrollkeeper" ];
 }

--- a/pkgs/desktops/gnome-2/desktop/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gnome-desktop/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "17bkng6ay37n3492lr9wpb49kms6gh554rn9gbjs27zygvvfrjsm";
   };
 
-  configureFlags = "--disable-scrollkeeper";
+  configureFlags = [ "--disable-scrollkeeper" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ python libxml2Python libxslt which libX11 gtk
                   intltool GConf gnome-doc-utils ];

--- a/pkgs/desktops/gnome-2/desktop/libgweather/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/libgweather/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/libgweather/2.30/${name}.tar.bz2";
     sha256 = "0k16lpdyy8as8wgc5dqpy5b8i9i4mrl77qx8db23fgs2c533fddq";
   };
-  configureFlags = "--with-zoneinfo-dir=${stdenv.glibc}/share/zoneinfo";
+  configureFlags = [ "--with-zoneinfo-dir=${stdenv.glibc}/share/zoneinfo" ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libxml2 gtk intltool GConf libsoup libtasn1 nettle gmp ];
 }

--- a/pkgs/desktops/gnome-2/desktop/scrollkeeper/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/scrollkeeper/default.nix
@@ -15,5 +15,5 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ perl perlXMLParser libxml2 libxslt gettext];
-  configureFlags = "--with-xml-catalog=${docbook_xml_dtd_42}/xml/dtd/docbook/catalog.xml";
+  configureFlags = [ "--with-xml-catalog=${docbook_xml_dtd_42}/xml/dtd/docbook/catalog.xml" ];
 }

--- a/pkgs/desktops/gnome-2/desktop/vte/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/vte/default.nix
@@ -32,9 +32,9 @@ in stdenv.mkDerivation rec {
   buildInputs = [ intltool glib gtk ncurses ] ++
                 stdenv.lib.optionals pythonSupport [python pygtk];
 
-  configureFlags = ''
-    ${if pythonSupport then "--enable-python" else "--disable-python"}
-  '';
+  configureFlags = [
+    (stdenv.lib.enableFeature pythonSupport "python")
+  ];
 
   postInstall = stdenv.lib.optionalString pythonSupport ''
     cd $(toPythonPath $out)/gtk-2.0

--- a/pkgs/desktops/gnome-2/desktop/zenity/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/zenity/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
     sha256 = "1b0qxb07wif0ds1pl8xk3fq9p874j89rf718lii4ndh7382bwf48";
   };
 
-  configureFlags = "--disable-scrollkeeper";
+  configureFlags = [ "--disable-scrollkeeper" ];
   buildInputs = [ gtk libglade libxml2 libxslt libX11 docbook_xml_dtd_412 ];
 
   nativeBuildInputs = [ pkgconfig intltool gnome-doc-utils which ];

--- a/pkgs/desktops/gnome-3/core/folks/default.nix
+++ b/pkgs/desktops/gnome-3/core/folks/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
                   vala libsecret libxml2 libsoup nspr nss intltool db ];
   nativeBuildInputs = [ pkgconfig ];
 
-  configureFlags = "--disable-fatal-warnings";
+  configureFlags = [ "--disable-fatal-warnings" ];
 
   NIX_CFLAGS_COMPILE = ["-I${nss.dev}/include/nss"
                         "-I${dbus-glib.dev}/include/dbus-1.0" "-I${dbus.dev}/include/dbus-1.0"];

--- a/pkgs/desktops/gnome-3/core/rest/default.nix
+++ b/pkgs/desktops/gnome-3/core/rest/default.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib libsoup gobjectIntrospection];
 
-  configureFlags = "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt";
+  configureFlags = [ "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt" ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     mate.mate-settings-daemon
   ];
 
-  configureFlags = "--disable-update-mimedb";
+  configureFlags = [ "--disable-update-mimedb" ];
 
   meta = with stdenv.lib; {
     description = "Utilities to configure the MATE desktop";

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     mate.mate-menus
   ];
 
-  configureFlags = "--without-console-kit";
+  configureFlags = [ "--without-console-kit" ];
 
   makeFlags = "DBUS_SESSION_SERVICE_DIR=$(out)/etc";
 

--- a/pkgs/desktops/mate/mate-system-monitor/default.nix
+++ b/pkgs/desktops/mate/mate-system-monitor/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  configureFlags = "--enable-systemd";
+  configureFlags = [ "--enable-systemd" ];
 
   meta = with stdenv.lib; {
     description = "System monitor for the MATE desktop";

--- a/pkgs/development/compilers/opa/default.nix
+++ b/pkgs/development/compilers/opa/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
 
-  configureFlags = "-ocamlfind ${ocamlPackages.findlib}/bin/ocamlfind ";
+  configureFlags = [ "-ocamlfind ${ocamlPackages.findlib}/bin/ocamlfind" ];
 
   buildInputs = [ which perl jdk openssl coreutils zlib ncurses
     makeWrapper gcc binutils gnumake nodejs

--- a/pkgs/development/compilers/opendylan/default.nix
+++ b/pkgs/development/compilers/opendylan/default.nix
@@ -24,7 +24,9 @@ stdenv.mkDerivation {
     ./autogen.sh
   '';
 
-  configureFlags = if stdenv.system == "i686-linux" then "--with-mps=$(TMPDIR)/mps" else "--with-gc=${boehmgc.out}";
+  configureFlags = [
+    (if stdenv.system == "i686-linux" then "--with-mps=$(TMPDIR)/mps" else "--with-gc=${boehmgc.out}")
+  ];
   buildPhase = "make 3-stage-bootstrap";
 
   postInstall = "wrapProgram $out/bin/dylan-compiler --suffix PATH : ${gcc}/bin";

--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -20,7 +20,11 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = "--with-world --enable-gmp --enable-shared";
+  configureFlags = [
+    "--with-world"
+    "--enable-gmp"
+    "--enable-shared"
+  ];
 
   buildFlags = "world";
 

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sed -e 's@/usr/bin/file@${file}/bin/file@g' -i configure
   '';
 
-  configureFlags = "--with-openssl=${openssl.dev}";
+  configureFlags = [ "--with-openssl=${openssl.dev}" ];
 
   preConfigure = ''
     export PGHEADER="${postgresql}/include/libpq-fe.h";

--- a/pkgs/development/compilers/yap/default.nix
+++ b/pkgs/development/compilers/yap/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ readline gmp zlib ];
 
-  configureFlags = "--enable-tabling=yes";
+  configureFlags = [ "--enable-tabling=yes" ];
 
   NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
 

--- a/pkgs/development/coq-modules/coquelicot/default.nix
+++ b/pkgs/development/coq-modules/coquelicot/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   buildInputs = [ coq ];
   propagatedBuildInputs = [ ssreflect ];
 
-  configureFlags = "--libdir=$out/lib/coq/${coq.coq-version}/user-contrib/Coquelicot";
+  configureFlags = [ "--libdir=$out/lib/coq/${coq.coq-version}/user-contrib/Coquelicot" ];
   buildPhase = "./remake";
   installPhase = "./remake install";
 

--- a/pkgs/development/interpreters/clisp/default.nix
+++ b/pkgs/development/interpreters/clisp/default.nix
@@ -67,15 +67,15 @@ stdenv.mkDerivation rec {
     substituteInPlace modules/bindings/glibc/linux.lisp --replace "(def-c-type __swblk_t)" ""
   '';
 
-  configureFlags = "builddir"
-  + stdenv.lib.optionalString (!dllSupport) " --without-dynamic-modules"
-  + stdenv.lib.optionalString (readline != null) " --with-readline"
+  configureFlags = [ "builddir" ]
+  ++ stdenv.lib.optional (!dllSupport) "--without-dynamic-modules"
+  ++ stdenv.lib.optional (readline != null) "--with-readline"
   # --with-dynamic-ffi can only exist with --with-ffcall - foreign.d does not compile otherwise
-  + stdenv.lib.optionalString (ffcallAvailable && (libffi != null)) " --with-dynamic-ffi"
-  + stdenv.lib.optionalString ffcallAvailable " --with-ffcall"
-  + stdenv.lib.optionalString (!ffcallAvailable) " --without-ffcall"
-  + stdenv.lib.concatMapStrings (x: " --with-module=" + x) withModules
-  + stdenv.lib.optionalString threadSupport " --with-threads=POSIX_THREADS";
+  ++ stdenv.lib.optional (ffcallAvailable && (libffi != null)) "--with-dynamic-ffi"
+  ++ stdenv.lib.optional ffcallAvailable "--with-ffcall"
+  ++ stdenv.lib.optional (!ffcallAvailable) "--without-ffcall"
+  ++ builtins.map (x: "--with-module=" + x) withModules
+  ++ stdenv.lib.optional threadSupport "--with-threads=POSIX_THREADS";
 
   preBuild = ''
     sed -e '/avcall.h/a\#include "config.h"' -i src/foreign.d

--- a/pkgs/development/interpreters/clisp/hg.nix
+++ b/pkgs/development/interpreters/clisp/hg.nix
@@ -62,15 +62,15 @@ stdenv.mkDerivation rec {
     substituteInPlace modules/bindings/glibc/linux.lisp --replace "(def-c-type __swblk_t)" ""
   '';
 
-  configureFlags = "builddir"
-  + stdenv.lib.optionalString (!dllSupport) " --without-dynamic-modules"
-  + stdenv.lib.optionalString (readline != null) " --with-readline"
+  configureFlags = [ "builddir" ]
+  ++ stdenv.lib.optional (!dllSupport) "--without-dynamic-modules"
+  ++ stdenv.lib.optional (readline != null) "--with-readline"
   # --with-dynamic-ffi can only exist with --with-ffcall - foreign.d does not compile otherwise
-  + stdenv.lib.optionalString (ffcallAvailable && (libffi != null)) " --with-dynamic-ffi"
-  + stdenv.lib.optionalString ffcallAvailable " --with-ffcall"
-  + stdenv.lib.optionalString (!ffcallAvailable) " --without-ffcall"
-  + stdenv.lib.concatMapStrings (x: " --with-module=" + x) withModules
-  + stdenv.lib.optionalString threadSupport " --with-threads=POSIX_THREADS";
+  ++ stdenv.lib.optional (ffcallAvailable && (libffi != null)) "--with-dynamic-ffi"
+  ++ stdenv.lib.optional ffcallAvailable "--with-ffcall"
+  ++ stdenv.lib.optional (!ffcallAvailable) "--without-ffcall"
+  ++ builtins.map (x: " --with-module=" + x) withModules
+  ++ stdenv.lib.optional threadSupport "--with-threads=POSIX_THREADS";
 
   preBuild = ''
     sed -e '/avcall.h/a\#include "config.h"' -i src/foreign.d

--- a/pkgs/development/interpreters/scsh/default.nix
+++ b/pkgs/development/interpreters/scsh/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ scheme48 ];
-  configureFlags = ''--with-scheme48=${scheme48}'';
+  configureFlags = [ "--with-scheme48=${scheme48}" ];
 
   meta = with stdenv.lib; {
     description = "A Scheme shell";

--- a/pkgs/development/libraries/aalib/default.nix
+++ b/pkgs/development/libraries/aalib/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ ncurses ];
 
-  configureFlags = "--without-x --with-ncurses=${ncurses.dev}";
+  configureFlags = [ "--without-x" "--with-ncurses=${ncurses.dev}" ];
 
   postInstall = ''
     mkdir -p $dev/bin

--- a/pkgs/development/libraries/agg/default.nix
+++ b/pkgs/development/libraries/agg/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sh autogen.sh
   '';
 
-  configureFlags = "--x-includes=${libX11.dev}/include --x-libraries=${libX11.out}/lib --enable-examples=no";
+  configureFlags = [ "--x-includes=${libX11.dev}/include" "--x-libraries=${libX11.out}/lib" "--enable-examples=no" ];
 
   # libtool --tag=CXX --mode=link g++ -g -O2 libexamples.la ../src/platform/X11/libaggplatformX11.la ../src/libagg.la -o alpha_mask2 alpha_mask2.o
   # libtool: error: cannot find the library 'libexamples.la'

--- a/pkgs/development/libraries/arb/git.nix
+++ b/pkgs/development/libraries/arb/git.nix
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
     rev = "10bc615ce5999caf4723444b2b1219b74781d8a4";
     sha256 = "1xb40x3hv9nh76aizhskj5gdhalgn7r95a7zji2nn4ih3lmh40hl";
   };
-  buildInputs = [mpir gmp mpfr flint];
-  configureFlags = "--with-gmp=${gmp} --with-mpir=${mpir} --with-mpfr=${mpfr} --with-flint=${flint}";
+  buildInputs = [ mpir gmp mpfr flint ];
+  configureFlags = [ "--with-gmp=${gmp}" "--with-mpir=${mpir}" "--with-mpfr=${mpfr}" "--with-flint=${flint}" ];
   meta = {
     inherit version;
     description = ''A library for arbitrary-precision interval arithmetic'';

--- a/pkgs/development/libraries/beecrypt/default.nix
+++ b/pkgs/development/libraries/beecrypt/default.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation {
     url = mirror://sourceforge/beecrypt/beecrypt-4.2.1.tar.gz;
     sha256 = "0pf5k1c4nsj77jfq5ip0ra1gzx2q47xaa0s008fnn6hd11b1yvr8";
   };
-  buildInputs = [m4];
-  configureFlags = "--disable-optimized --enable-static";
+  buildInputs = [ m4 ];
+  configureFlags = [ "--disable-optimized" "--enable-static" ];
 
   meta = {
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/buddy/default.nix
+++ b/pkgs/development/libraries/buddy/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bison ];
   patches = [ ./gcc-4.3.3-fixes.patch ];
-  configureFlags = "CFLAGS=-O3 CXXFLAGS=-O3";
+  configureFlags = [ "CFLAGS=-O3" "CXXFLAGS=-O3" ];
   doCheck = true;
 
   meta = {

--- a/pkgs/development/libraries/classads/default.nix
+++ b/pkgs/development/libraries/classads/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ pcre ];
 
-  configureFlags = ''                                                  
-    --enable-namespace --enable-flexible-member
-  '';
+  configureFlags = [
+    "--enable-namespace" "--enable-flexible-member"
+  ];
   
   meta = {
     homepage = http://www.cs.wisc.edu/condor/classad/;

--- a/pkgs/development/libraries/clearsilver/default.nix
+++ b/pkgs/development/libraries/clearsilver/default.nix
@@ -10,7 +10,14 @@ stdenv.mkDerivation rec {
 
   PYTHON_SITE = "$(out)/site-packages";
 
-  configureFlags = "--with-python=${python}/bin/python --disable-apache --disable-perl --disable-ruby --disable-java --disable-csharp";
+  configureFlags = [
+    "--with-python=${python}/bin/python"
+    "--disable-apache"
+    "--disable-perl"
+    "--disable-ruby"
+    "--disable-java"
+    "--disable-csharp"
+  ];
 
   preInstall = ''
     mkdir -p $out

--- a/pkgs/development/libraries/cloog-ppl/default.nix
+++ b/pkgs/development/libraries/cloog-ppl/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-ppl-version.patch ];
 
-  configureFlags = "--with-ppl=${ppl}";
+  configureFlags = [ "--with-ppl=${ppl}" ];
 
   preAutoreconf = ''
     touch NEWS ChangeLog AUTHORS

--- a/pkgs/development/libraries/cwiid/default.nix
+++ b/pkgs/development/libraries/cwiid/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = "--without-python";
+  configureFlags = [ "--without-python" ];
 
   prePatch = ''
     sed -i -e '/$(LDCONFIG)/d' common/include/lib.mak.in

--- a/pkgs/development/libraries/dbus-cplusplus/default.nix
+++ b/pkgs/development/libraries/dbus-cplusplus/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ dbus glib expat ];
 
-  configureFlags = "--disable-ecore";
+  configureFlags = [ "--disable-ecore" ];
 
   meta = with stdenv.lib; {
     homepage = http://dbus-cplusplus.sourceforge.net;

--- a/pkgs/development/libraries/fflas-ffpack/1.nix
+++ b/pkgs/development/libraries/fflas-ffpack/1.nix
@@ -9,7 +9,11 @@ stdenv.mkDerivation rec {
   };
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ givaro_3_7 openblas gmpxx];
-  configureFlags = "--with-blas=-lopenblas --with-gmp=${gmpxx.dev} --with-givaro=${givaro_3_7}";
+  configureFlags = [
+    "--with-blas=-lopenblas"
+    "--with-gmp=${gmpxx.dev}"
+    "--with-givaro=${givaro_3_7}"
+  ];
   meta = {
     inherit version;
     description = ''Finite Field Linear Algebra Subroutines'';

--- a/pkgs/development/libraries/gamin/default.nix
+++ b/pkgs/development/libraries/gamin/default.nix
@@ -14,7 +14,11 @@ stdenv.mkDerivation (rec {
 
   # `_GNU_SOURCE' is needed, e.g., to get `struct ucred' from
   # <sys/socket.h> with Glibc 2.9.
-  configureFlags = "--disable-debug --with-python=${python} CPPFLAGS=-D_GNU_SOURCE";
+  configureFlags = [
+    "--disable-debug"
+    "--with-python=${python}"
+    "CPPFLAGS=-D_GNU_SOURCE"
+  ];
 
   patches = [ ./deadlock.patch ]
     ++ map fetchurl (import ./debian-patches.nix)

--- a/pkgs/development/libraries/gegl/3.0.nix
+++ b/pkgs/development/libraries/gegl/3.0.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   # needs fonts otherwise  don't know how to pass them
-  configureFlags = "--disable-docs";
+  configureFlags = [ "--disable-docs" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/gegl/default.nix
+++ b/pkgs/development/libraries/gegl/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   })];
 
   # needs fonts otherwise  don't know how to pass them
-  configureFlags = "--disable-docs";
+  configureFlags = [ "--disable-docs" ];
 
   buildInputs = [ babl libpng cairo libjpeg librsvg pango gtk2 bzip2 intltool libintl ]
     ++ stdenv.lib.optional stdenv.isDarwin OpenGL;

--- a/pkgs/development/libraries/gmp/4.3.2.nix
+++ b/pkgs/development/libraries/gmp/4.3.2.nix
@@ -27,8 +27,12 @@ let self = stdenv.mkDerivation rec {
     then "ln -sf configfsf.guess config.guess"
     else ''echo "Darwin host is `./config.guess`."'';
 
-  configureFlags = (if cxx then "--enable-cxx" else "--disable-cxx") +
-    stdenv.lib.optionalString stdenv.isDarwin " ac_cv_build=x86_64-apple-darwin13.4.0 ac_cv_host=x86_64-apple-darwin13.4.0";
+  configureFlags = [
+    (stdenv.lib.enableFeature cxx "cxx")
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "ac_cv_build=x86_64-apple-darwin13.4.0"
+    "ac_cv_host=x86_64-apple-darwin13.4.0"
+  ];
 
   # The test t-lucnum_ui fails (on Linux/x86_64) when built with GCC 4.8.
   # Newer versions of GMP don't have that issue anymore.

--- a/pkgs/development/libraries/gmp/5.1.x.nix
+++ b/pkgs/development/libraries/gmp/5.1.x.nix
@@ -20,18 +20,17 @@ let self = stdenv.mkDerivation rec {
 
   patches = if stdenv.isDarwin then [ ./need-size-t.patch ] else null;
 
-  configureFlags =
+  configureFlags = [
+    "--with-pic"
+    (stdenv.lib.enableFeature cxx "cxx")
     # Build a "fat binary", with routines for several sub-architectures
     # (x86), except on Solaris where some tests crash with "Memory fault".
     # See <http://hydra.nixos.org/build/2760931>, for instance.
     #
     # no darwin because gmp uses ASM that clang doesn't like
-    optional (!stdenv.isSunOS) "--enable-fat"
-    ++ (if cxx then [ "--enable-cxx"  ]
-               else [ "--disable-cxx" ])
-    ++ optional (cxx && stdenv.isDarwin) "CPPFLAGS=-fexceptions"
-    ++ optional stdenv.isDarwin "ABI=64"
-    ++ optional stdenv.is64bit "--with-pic"
+    (stdenv.lib.enableFeature (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "fat")
+  ] ++ optional (cxx && stdenv.isDarwin) "CPPFLAGS=-fexceptions"
+    ++ optional (stdenv.isDarwin && stdenv.is64bit) "ABI=64"
     ;
 
   # The config.guess in GMP tries to runtime-detect various

--- a/pkgs/development/libraries/gmp/6.x.nix
+++ b/pkgs/development/libraries/gmp/6.x.nix
@@ -21,18 +21,17 @@ let self = stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ m4 ];
 
-  configureFlags =
+  configureFlags = [
+    "--with-pic"
+    (stdenv.lib.enableFeature cxx "cxx")
     # Build a "fat binary", with routines for several sub-architectures
     # (x86), except on Solaris where some tests crash with "Memory fault".
     # See <http://hydra.nixos.org/build/2760931>, for instance.
     #
     # no darwin because gmp uses ASM that clang doesn't like
-    optional (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "--enable-fat"
-    ++ (if cxx then [ "--enable-cxx"  ]
-               else [ "--disable-cxx" ])
-    ++ optional (cxx && stdenv.isDarwin) "CPPFLAGS=-fexceptions"
+    (stdenv.lib.enableFeature (!stdenv.isSunOS && stdenv.hostPlatform.isx86) "fat")
+  ] ++ optional (cxx && stdenv.isDarwin) "CPPFLAGS=-fexceptions"
     ++ optional (stdenv.isDarwin && stdenv.is64bit) "ABI=64"
-    ++ optional stdenv.is64bit "--with-pic"
     ++ optional (with stdenv.hostPlatform; useAndroidPrebuilt || useiOSPrebuilt) "--disable-assembly"
     ;
 

--- a/pkgs/development/libraries/gsasl/default.nix
+++ b/pkgs/development/libraries/gsasl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libidn kerberos ];
 
-  configureFlags = "--with-gssapi-impl=mit";
+  configureFlags = [ "--with-gssapi-impl=mit" ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/gstreamer/legacy/gst-ffmpeg/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gst-ffmpeg/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   # Upstream strongly recommends against using --with-system-ffmpeg,
   # but we do it anyway because we're so hardcore (and we don't want
   # multiple copies of ffmpeg).
-  configureFlags = stdenv.lib.optionalString (!useInternalFfmpeg) "--with-system-ffmpeg";
+  configureFlags = stdenv.lib.optional (!useInternalFfmpeg) "--with-system-ffmpeg";
 
   buildInputs =
     [ pkgconfig bzip2 gst-plugins-base orc ]

--- a/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/legacy/gstreamer/default.nix
@@ -26,9 +26,13 @@ stdenv.mkDerivation rec {
     patch -p1 < ${./darwin.patch}
   '';
 
-  configureFlags = ''
-    --disable-examples --enable-failing-tests --localstatedir=/var --disable-gtk-doc --disable-docbook
-  '';
+  configureFlags = [
+    "--disable-examples"
+    "--enable-failing-tests"
+    "--localstatedir=/var"
+    "--disable-gtk-doc"
+    "--disable-docbook"
+  ];
 
   postInstall = ''
     # Hm, apparently --disable-gtk-doc is ignored...

--- a/pkgs/development/libraries/icu/base.nix
+++ b/pkgs/development/libraries/icu/base.nix
@@ -36,9 +36,9 @@ let
       sed -e 's/LDFLAGSICUDT=-nodefaultlibs -nostdlib/LDFLAGSICUDT=/' -i config/mh-linux
     '';
 
-    configureFlags = "--disable-debug" +
-      stdenv.lib.optionalString (stdenv.isFreeBSD || stdenv.isDarwin) " --enable-rpath" +
-      stdenv.lib.optionalString (buildPlatform != hostPlatform) " --with-cross-build=${nativeBuildRoot}";
+    configureFlags = [ "--disable-debug" ]
+      ++ stdenv.lib.optional (stdenv.isFreeBSD || stdenv.isDarwin) "--enable-rpath"
+      ++ stdenv.lib.optional (buildPlatform != hostPlatform) "--with-cross-build=${nativeBuildRoot}";
 
     enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/ilixi/default.nix
+++ b/pkgs/development/libraries/ilixi/default.nix
@@ -14,9 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ directfb libsigcxx libxml2 fontconfig ];
 
-  configureFlags = ''
-    --enable-log-debug --enable-debug --enable-trace --with-examples
-  '';
+  configureFlags = [
+    "--enable-log-debug"
+    "--enable-debug"
+    "--enable-trace"
+    "--with-examples"
+  ];
 
   meta = with stdenv.lib; {
     description = "Lightweight C++ GUI toolkit for embedded Linux systems";

--- a/pkgs/development/libraries/imlib/default.nix
+++ b/pkgs/development/libraries/imlib/default.nix
@@ -7,10 +7,11 @@ stdenv.mkDerivation {
     sha256 = "0ggjxyvgp4pxc0b88v40xj9daz90518ydnycw7qax011gxpr12d3";
   };
 
-  configureFlags = "
-    --disable-shm
-    --x-includes=${libX11.dev}/include
-    --x-libraries=${libX11.out}/lib";
+  configureFlags = [
+    "--disable-shm"
+    "--x-includes=${libX11.dev}/include"
+    "--x-libraries=${libX11.out}/lib"
+  ];
 
   buildInputs = [libjpeg libXext libX11 xextproto libtiff libungif libpng];
 

--- a/pkgs/development/libraries/jasper/default.nix
+++ b/pkgs/development/libraries/jasper/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ libjpeg ];
 
-  configureFlags = "--enable-shared";
+  configureFlags = [ "--enable-shared" ];
 
   outputs = [ "bin" "dev" "out" "man" ];
 

--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib zlib libpng cmake gnumake3 ];
 
-  configureFlags = "-v";
+  configureFlags = [ "-v" ];
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libagar/libagar_test.nix
+++ b/pkgs/development/libraries/libagar/libagar_test.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     cat configure.in | ${bsdbuild}/bin/mkconfigure > configure
   '';
 
-  configureFlags = "--with-agar=${libagar}";
+  configureFlags = [ "--with-agar=${libagar}" ];
 
   buildInputs = [ perl bsdbuild libagar libjpeg libpng openssl ];
 

--- a/pkgs/development/libraries/libantlr3c/default.nix
+++ b/pkgs/development/libraries/libantlr3c/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
     sha256 ="0lpbnb4dq4azmsvlhp6khq1gy42kyqyjv8gww74g5lm2y6blm4fa";
   };
 
-  configureFlags = if stdenv.is64bit then "--enable-64bit" else "";
+  configureFlags = stdenv.lib.optional stdenv.is64bit "--enable-64bit";
 
   meta = with stdenv.lib; {
     description = "C runtime libraries of ANTLR v3";

--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional withAlsa alsaLib;
 
-  configureFlags = "--disable-oss";
+  configureFlags = [ "--disable-oss" ];
 
   patchFlags = "-p0";
   patches = stdenv.lib.optional stdenv.isDarwin

--- a/pkgs/development/libraries/libcdr/default.nix
+++ b/pkgs/development/libraries/libcdr/default.nix
@@ -18,8 +18,7 @@ stdenv.mkDerivation rec {
     sed -i 's,^CPPFLAGS.*,\0 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED,' src/lib/Makefile.in
   '';
 
-  configureFlags = if stdenv.cc.isClang
-    then [ "--disable-werror" ] else null;
+  configureFlags = stdenv.lib.optional stdenv.cc.isClang "--disable-werror";
 
   CXXFLAGS="--std=gnu++0x"; # For c++11 constants in lcms2.h
 

--- a/pkgs/development/libraries/libcmis/default.nix
+++ b/pkgs/development/libraries/libcmis/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ boost libxml2 curl ];
-  configureFlags = "--without-man --with-boost=${boost.dev} --disable-werror --disable-tests";
+  configureFlags = [ "--without-man" "--with-boost=${boost.dev}" "--disable-werror" "--disable-tests" ];
 
   # Cppcheck cannot find all the include files (use --check-config for details)
   doCheck = false;

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -27,10 +27,12 @@ stdenv.mkDerivation rec {
    ] ++ stdenv.lib.optionals gtkSupport [ glib gtk3 ]
      ++ stdenv.lib.optionals videoSupport [ ffmpeg libmpeg2 ];
 
-  configureFlags = "--disable-ltdl-install "
-    + "--with-ltdl-include=${libtool}/include "
-    + "--with-ltdl-lib=${libtool.lib}/lib "
-    + "--enable-xpdf";
+  configureFlags = [
+    "--disable-ltdl-install"
+    "--with-ltdl-include=${libtool}/include"
+    "--with-ltdl-lib=${libtool.lib}/lib"
+    "--enable-xpdf"
+  ];
 
   # Checks need to be run after "make install", otherwise plug-ins are not in
   # the search path, etc.

--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -7,7 +7,6 @@
 , libintl }:
 
 let
-  edf = flag: feature: (if flag then "--with-" else "--without-") + feature;
   optional = cond: elem: assert cond -> elem != null; if cond then [elem] else [];
 
 in stdenv.mkDerivation rec {
@@ -28,14 +27,14 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ gnutls ];
 
-  configureFlags = ''
-    ${if documentation then "--enable-gtk-doc" else "--disable-gtk-doc"}
-    ${edf gtkWidgets "inftextgtk"}
-    ${edf gtkWidgets "infgtk"}
-    ${edf daemon "infinoted"}
-    ${edf daemon "libdaemon"}
-    ${edf avahiSupport "avahi"}
-  '';
+  configureFlags = [
+    (stdenv.lib.enableFeature documentation "gtk-doc")
+    (stdenv.lib.withFeature gtkWidgets "inftextgtk")
+    (stdenv.lib.withFeature gtkWidgets "infgtk")
+    (stdenv.lib.withFeature daemon "infinoted")
+    (stdenv.lib.withFeature daemon "libdaemon")
+    (stdenv.lib.withFeature avahiSupport "avahi")
+  ];
 
   passthru = {
     inherit version;

--- a/pkgs/development/libraries/libmp3splt/default.nix
+++ b/pkgs/development/libraries/libmp3splt/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ libtool ];
   buildInputs = [ libmad libid3tag ];
 
-  configureFlags = "--disable-pcre";
+  configureFlags = [ "--disable-pcre" ];
 
   meta = with stdenv.lib; {
     homepage    = https://sourceforge.net/projects/mp3splt/;

--- a/pkgs/development/libraries/liboping/default.nix
+++ b/pkgs/development/libraries/liboping/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses perl ];
 
-  configureFlags = stdenv.lib.optionalString (perl == null) "--with-perl-bindings=no";
+  configureFlags = stdenv.lib.optional (perl == null) "--with-perl-bindings=no";
 
   meta = with stdenv.lib; {
     description = "C library to generate ICMP echo requests (a.k.a. ping packets)";

--- a/pkgs/development/libraries/libpng/12.nix
+++ b/pkgs/development/libraries/libpng/12.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   passthru = { inherit zlib; };
 
-  configureFlags = "--enable-static";
+  configureFlags = [ "--enable-static" ];
 
   postInstall = ''mv "$out/bin" "$dev/bin"'';
 

--- a/pkgs/development/libraries/libpqxx/default.nix
+++ b/pkgs/development/libraries/libpqxx/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  configureFlags = "--enable-shared";
+  configureFlags = [ "--enable-shared" ];
 
   meta = {
     description = "A C++ library to access PostgreSQL databases";

--- a/pkgs/development/libraries/librsync/0.9.nix
+++ b/pkgs/development/libraries/librsync/0.9.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  configureFlags = if stdenv.isCygwin then "--enable-static" else "--enable-shared";
+  configureFlags = [
+    (stdenv.lib.enableFeature stdenv.isCygwin    "static")
+    (stdenv.lib.enableFeature (!stdenv.isCygwin) "shared")
+  ];
 
   dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
 

--- a/pkgs/development/libraries/libspatialite/default.nix
+++ b/pkgs/development/libraries/libspatialite/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libxml2 sqlite zlib proj geos libiconv ];
 
-  configureFlags = "--disable-freexl";
+  configureFlags = [ "--disable-freexl" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -32,12 +32,13 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ zlib findXMLCatalogs ] ++ lib.optional icuSupport icu;
 
-  configureFlags =
-       lib.optional pythonSupport "--with-python=${python}"
-    ++ lib.optional icuSupport    "--with-icu"
-    ++ [ "--exec_prefix=$dev" ]
-    ++ lib.optional enableStatic "--enable-static"
-    ++ lib.optional (!enableShared) "--disable-shared";
+  configureFlags = [
+    "--exec_prefix=$dev"
+    (lib.enableFeature enableStatic "static")
+    (lib.enableFeature enableShared "shared")
+    (lib.withFeature icuSupport "icu")
+    (lib.withFeatureAs pythonSupport "python" python)
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libzmf/default.nix
+++ b/pkgs/development/libraries/libzmf/default.nix
@@ -10,9 +10,9 @@ stdenv.mkDerivation rec {
     sha256 = "08mg5kmkjrmqrd8j5rkzw9vdqlvibhb1ynp6bmfxnzq5rcq1l197";
   };
 
-  buildInputs = [boost icu libpng librevenge zlib cppunit];
-  nativeBuildInputs = [doxygen pkgconfig];
-  configureFlags = " --disable-werror ";
+  buildInputs = [ boost icu libpng librevenge zlib cppunit ];
+  nativeBuildInputs = [ doxygen pkgconfig ];
+  configureFlags = [ "--disable-werror" ];
 
   meta = {
     inherit version;

--- a/pkgs/development/libraries/loudmouth/default.nix
+++ b/pkgs/development/libraries/loudmouth/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   patches = [
   ];
 
-  configureFlags = "--with-ssl=openssl";
+  configureFlags = [ "--with-ssl=openssl" ];
 
   propagatedBuildInputs = [ openssl libidn glib zlib ];
 

--- a/pkgs/development/libraries/neon/0.29.nix
+++ b/pkgs/development/libraries/neon/0.29.nix
@@ -28,13 +28,12 @@ stdenv.mkDerivation rec {
   buildInputs = [libxml2 openssl]
     ++ stdenv.lib.optional compressionSupport zlib;
 
-  configureFlags = ''
-    ${if shared then "--enable-shared" else "--disable-shared"}
-    ${if static then "--enable-static" else "--disable-static"}
-    ${if compressionSupport then "--with-zlib" else "--without-zlib"}
-    ${if sslSupport then "--with-ssl" else "--without-ssl"}
-    --enable-shared
-  '';
+  configureFlags = [
+    (stdenv.lib.enableFeature shared "shared")
+    (stdenv.lib.enableFeature static "static")
+    (stdenv.lib.withFeature compressionSupport "zlib")
+    (stdenv.lib.withFeature sslSupport "ssl")
+  ];
 
   passthru = {inherit compressionSupport sslSupport;};
 

--- a/pkgs/development/libraries/neon/default.nix
+++ b/pkgs/development/libraries/neon/default.nix
@@ -28,13 +28,12 @@ stdenv.mkDerivation rec {
   buildInputs = [libxml2 openssl]
     ++ stdenv.lib.optional compressionSupport zlib;
 
-  configureFlags = ''
-    ${if shared then "--enable-shared" else "--disable-shared"}
-    ${if static then "--enable-static" else "--disable-static"}
-    ${if compressionSupport then "--with-zlib" else "--without-zlib"}
-    ${if sslSupport then "--with-ssl" else "--without-ssl"}
-    --enable-shared
-  '';
+  configureFlags = [
+    (stdenv.lib.enableFeature shared "shared")
+    (stdenv.lib.enableFeature static "static")
+    (stdenv.lib.withFeature compressionSupport "zlib")
+    (stdenv.lib.withFeature sslSupport "ssl")
+  ];
 
   passthru = {inherit compressionSupport sslSupport;};
 

--- a/pkgs/development/libraries/nlopt/default.nix
+++ b/pkgs/development/libraries/nlopt/default.nix
@@ -10,11 +10,18 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ octave ];
 
-  configureFlags = "--with-cxx --enable-shared --with-pic --without-guile --without-python
-  --without-matlab " +
-    stdenv.lib.optionalString (octave != null) ("--with-octave " +
-        "M_INSTALL_DIR=$(out)/${octave.sitePath}/m " +
-        "OCT_INSTALL_DIR=$(out)/${octave.sitePath}/oct ");
+  configureFlags = [
+    "--with-cxx"
+    "--enable-shared"
+    "--with-pic"
+    "--without-guile"
+    "--without-python"
+    "--without-matlab"
+  ] ++ stdenv.lib.optionals (octave != null) [
+    "--with-octave"
+    "M_INSTALL_DIR=$(out)/${octave.sitePath}/m"
+    "OCT_INSTALL_DIR=$(out)/${octave.sitePath}/oct"
+  ];
 
   meta = {
     homepage = http://ab-initio.mit.edu/nlopt/;

--- a/pkgs/development/libraries/ntrack/default.nix
+++ b/pkgs/development/libraries/ntrack/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig python ];
 
-  configureFlags = "--without-gobject CFLAGS=--std=gnu99";
+  configureFlags = [ "--without-gobject" "CFLAGS=--std=gnu99" ];
 
   # Remove this patch after version 016
   patches = [ ./libnl-fix.patch ];

--- a/pkgs/development/libraries/openwsman/default.nix
+++ b/pkgs/development/libraries/openwsman/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cmakeFlags="$cmakeFlags -DPACKAGE_ARCHITECTURE=$(uname -m)";
   '';
 
-  configureFlags = "--disable-more-warnings";
+  configureFlags = [ "--disable-more-warnings" ];
 
   meta = with stdenv.lib; {
     description  = "Openwsman server implementation and client API with bindings";

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -6,7 +6,7 @@
 , buildMultimedia ? stdenv.isLinux, alsaLib, gstreamer, gst-plugins-base
 , buildWebkit ? (stdenv.isLinux || stdenv.isDarwin)
 , flashplayerFix ? false, gdk_pixbuf
-, gtkStyle ? true, gtk2
+, gtkStyle ? stdenv.hostPlatform == stdenv.buildPlatform, gtk2
 , gnomeStyle ? false, libgnomeui, GConf, gnome_vfs
 , developerBuild ? false
 , docs ? false
@@ -139,37 +139,40 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
 
-  ${if stdenv.hostPlatform == stdenv.buildPlatform then null else "configurePlatforms"} = [];
+  configurePlatforms = [];
   configureFlags = let
+    mk = cond: name: "-${lib.optionalString cond "no-"}${name}";
     platformFlag =
       if stdenv.hostPlatform != stdenv.buildPlatform
       then "-xplatform"
       else "-platform";
-    in (if stdenv.hostPlatform == stdenv.buildPlatform then ''
-      -v -no-separate-debug-info -release -fast -confirm-license -opensource
+  in (if stdenv.hostPlatform != stdenv.buildPlatform then [
+    # I've not tried any case other than i686-pc-mingw32.
+    # -nomake tools: it fails linking some asian language symbols
+    # -no-svg: it fails to build on mingw64
+    "-static" "-release" "-confirm-license" "-opensource"
+    "-no-opengl" "-no-phonon"
+    "-no-svg"
+    "-make" "qmake" "-make" "libs" "-nomake" "tools"
+  ] else [
+    "-v" "-no-separate-debug-info" "-release" "-fast" "-confirm-license" "-opensource"
 
-      -${if stdenv.isFreeBSD then "no-" else ""}opengl -xrender -xrandr -xinerama -xcursor -xinput -xfixes -fontconfig
-      -qdbus -${if cups == null then "no-" else ""}cups -glib -dbus-linked -openssl-linked
+    (mk (!stdenv.isFreeBSD) "opengl") "-xrender" "-xrandr" "-xinerama" "-xcursor" "-xinput" "-xfixes" "-fontconfig"
+    "-qdbus" (mk (cups != null) "cups") "-glib" "-dbus-linked" "-openssl-linked"
 
-      ${if mysql != null then "-plugin" else "-no"}-sql-mysql -system-sqlite
+    "-${if mysql != null then "plugin" else "no"}-sql-mysql" "-system-sqlite"
 
-      -exceptions -xmlpatterns
+    "-exceptions" "-xmlpatterns"
 
-      -make libs -make tools -make translations
-      -${if demos then "" else "no"}make demos
-      -${if examples then "" else "no"}make examples
-      -${if docs then "" else "no"}make docs
-
-      -no-phonon ${if buildWebkit then "" else "-no"}-webkit ${if buildMultimedia then "" else "-no"}-multimedia -audio-backend
-      ${if developerBuild then "-developer-build" else ""}
-    '' else ''
-      -static -release -confirm-license -opensource
-      -no-opengl -no-phonon
-      -no-svg
-      -make qmake -make libs -nomake tools
-      -nomake demos -nomake examples -nomake docs
-    '') + lib.optionalString stdenv.hostPlatform.isDarwin "${platformFlag} unsupported/macx-clang-libc++"
-        + lib.optionalString stdenv.hostPlatform.isMinGW  "${platformFlag} win32-g++-4.6";
+    "-make" "libs" "-make" "tools" "-make" "translations"
+    "-no-phonon" (mk buildWebkit "webkit") (mk buildMultimedia "multimedia") "-audio-backend"
+  ]) ++ [
+    (mk demos "make") "demos"
+    (mk examples "make") "examples"
+    (mk docs "make") "docs"
+  ] ++ lib.optional developerBuild "-developer-build"
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ platformFlag "unsupported/macx-clang-libc++" ]
+    ++ lib.optionals stdenv.hostPlatform.isWindows [ platformFlag "win32-g++-4.6" ];
 
   propagatedBuildInputs =
     [ libXrender libXrandr libXinerama libXcursor libXext libXfixes libXv libXi
@@ -219,7 +222,7 @@ stdenv.mkDerivation rec {
     cp bin/qmake* $out/bin
   '';
 
-  dontStrip = if stdenv.hostPlatform == stdenv.buildPlatform then null else true;
+  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
 
   meta = {
     homepage    = http://qt-project.org/;

--- a/pkgs/development/libraries/rarian/default.nix
+++ b/pkgs/development/libraries/rarian/default.nix
@@ -12,7 +12,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ perl perlXMLParser libxml2 libxslt];
-  configureFlags = "--with-xml-catalog=${docbook_xml_dtd_42}/xml/dtd/docbook/docbook.cat";
+  configureFlags = [ "--with-xml-catalog=${docbook_xml_dtd_42}/xml/dtd/docbook/docbook.cat" ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/readosm/default.nix
+++ b/pkgs/development/libraries/readosm/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ expat zlib geos libspatialite ];
 
-  configureFlags = "--disable-freexl";
+  configureFlags = [ "--disable-freexl" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/science/biology/htslib/default.nix
+++ b/pkgs/development/libraries/science/biology/htslib/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib bzip2 lzma curl ];
 
-  configureFlags = "--enable-libcurl"; # optional but strongly recommended
+  configureFlags = [ "--enable-libcurl" ]; # optional but strongly recommended
 
   installFlags = "prefix=$(out)";
 

--- a/pkgs/development/libraries/science/math/liblbfgs/default.nix
+++ b/pkgs/development/libraries/science/math/liblbfgs/default.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation {
   name = "liblbfgs-1.10";
 
-  configureFlags = "--enable-sse2";
+  configureFlags = [ "--enable-sse2" ];
   src = fetchurl {
     url = https://github.com/downloads/chokkan/liblbfgs/liblbfgs-1.10.tar.gz;
     sha256 = "1kv8d289rbz38wrpswx5dkhr2yh4fg4h6sszkp3fawxm09sann21";

--- a/pkgs/development/libraries/snack/default.nix
+++ b/pkgs/development/libraries/snack/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     sha256 = "07p89jv9qnjqkszws9sssq93ayvwpdnkcxrvyicbm4mb8x2pdzjb";
   };
 
-  configureFlags = "--with-tcl=${tcl}/lib --with-tk=${tk}/lib";
+  configureFlags = [ "--with-tcl=${tcl}/lib" "--with-tk=${tk}/lib" ];
 
   postUnpack = ''sourceRoot="$sourceRoot/unix"'';
 

--- a/pkgs/development/libraries/spatialite-tools/default.nix
+++ b/pkgs/development/libraries/spatialite-tools/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ sqlite expat zlib proj geos libspatialite readosm ];
 
-  configureFlags = "--disable-freexl";
+  configureFlags = [ "--disable-freexl" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/sword/default.nix
+++ b/pkgs/development/libraries/sword/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = "--without-conf --enable-tests=no CXXFLAGS=-Wno-unused-but-set-variable";
+  configureFlags = [ "--without-conf" "--enable-tests=no CXXFLAGS=-Wno-unused-but-set-variable" ];
 
   meta = with stdenv.lib; {
     description = "A software framework that allows research manipulation of Biblical texts";

--- a/pkgs/development/libraries/thrift/default.nix
+++ b/pkgs/development/libraries/thrift/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   # TODO: package boost-test, so we can run the test suite. (Currently it fails
   # to find libboost_unit_test_framework.a.)
-  configureFlags = "--enable-tests=no";
+  configureFlags = [ "--enable-tests=no" ];
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/tix/default.nix
+++ b/pkgs/development/libraries/tix/default.nix
@@ -34,13 +34,13 @@ stdenv.mkDerivation rec {
       ln -s $i private_headers/generic;
     done;
     '';
-  configureFlags = ''
-      --with-tclinclude=${tcl}/include
-      --with-tclconfig=.
-      --with-tkinclude=${tk.dev}/include
-      --with-tkconfig=.
-      --libdir=''${prefix}/lib
-    '';
+  configureFlags = [
+    "--with-tclinclude=${tcl}/include"
+    "--with-tclconfig=."
+    "--with-tkinclude=${tk.dev}/include"
+    "--with-tkconfig=."
+    "--libdir=\${prefix}/lib"
+  ];
 
   meta = with stdenv.lib; {
     description = "A widget library for Tcl/Tk";

--- a/pkgs/development/libraries/vapoursynth-mvtools/default.nix
+++ b/pkgs/development/libraries/vapoursynth-mvtools/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     yasm vapoursynth fftwFloat
   ];
 
-  configureFlags = "--libdir=$(out)/lib/vapoursynth";
+  configureFlags = [ "--libdir=$(out)/lib/vapoursynth" ];
 
   meta = with stdenv.lib; {
     description = "A set of filters for motion estimation and compensation";

--- a/pkgs/development/libraries/wayland/1.9.nix
+++ b/pkgs/development/libraries/wayland/1.9.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1yhy62vkbq8j8c9zaa6yzvn75cd99kfa8n2zfdwl80x019r711ww";
   };
 
-  configureFlags = "--with-scanner --disable-documentation";
+  configureFlags = [ "--with-scanner" "--disable-documentation" ];
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/misc/avr/binutils/default.nix
+++ b/pkgs/development/misc/avr/binutils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     url = "mirror://gnu/binutils/binutils-${version}.tar.bz2";
     sha256 = "028cklfqaab24glva1ks2aqa1zxa6w6xmc8q34zs1sb7h22dxspg";
   };
-  configureFlags = "--target=avr --enable-languages=c,c++";
+  configureFlags = [ "--target=avr" "--enable-languages=c,c++" ];
 
   meta = with stdenv.lib; {
     description = "the GNU Binutils for AVR microcontrollers";

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   disableIda = "--disable-ida --disable-fsi-benchmark";
 
-  configureFlags = "--enable-everything ${disableIda} --with-llvm-config=${llvm_38}/bin/llvm-config";
+  configureFlags = [ "--enable-everything ${disableIda}" "--with-llvm-config=${llvm_38}/bin/llvm-config" ];
 
   BAPBUILDFLAGS = "-j $(NIX_BUILD_CORES)";
 

--- a/pkgs/development/ocaml-modules/fileutils/default.nix
+++ b/pkgs/development/ocaml-modules/fileutils/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ounit ];
 
-  configureFlags = "--enable-tests";
+  configureFlags = [ "--enable-tests" ];
   doCheck = true;
   checkTarget = "test";
 

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml findlib gtk2 libgnomecanvas libglade gtksourceview camlp4 ];
 
-  configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib";
+  configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
   buildFlags = "world";
 
   preInstall = ''

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml findlib gtk2 libgnomecanvas libglade gtksourceview ];
 
-  configureFlags = "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib";
+  configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
   buildFlags = "world";
 
   preInstall = ''

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   ocaml_sqlite3 tree uutf makeWrapper camlp4 pgocaml camlzip ]
   ++ (param.buildInputs or []);
 
-  configureFlags = "--root $(out) --prefix /";
+  configureFlags = [ "--root $(out) --prefix /" ];
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   buildInputs = [ ocaml findlib ocamlbuild ounit ];
 
-  configureFlags = "--enable-tests";
+  configureFlags = [ "--enable-tests" ];
 
   doCheck = true;
   checkPhase = "ocaml setup.ml -test";

--- a/pkgs/development/python-modules/pygobject/default.nix
+++ b/pkgs/development/python-modules/pygobject/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     ./pygobject-2.28.6-gio-types-2.32.patch
   ];
 
-  configureFlags = "--disable-introspection";
+  configureFlags = [ "--disable-introspection" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib ];

--- a/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
+++ b/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
@@ -13,7 +13,7 @@ python2Packages.buildPythonApplication {
   nativeBuildInputs = [ intltool pkgconfig ];
   buildInputs = [ libxslt ];
 
-  configureFlags = "--disable-scrollkeeper";
+  configureFlags = [ "--disable-scrollkeeper" ];
 
   preBuild = ''
     substituteInPlace xml2po/xml2po/Makefile --replace '-e "s+^#!.*python.*+#!$(PYTHON)+"' '-e "s\"^#!.*python.*\"#!$(PYTHON)\""'

--- a/pkgs/development/tools/misc/avrdude/default.nix
+++ b/pkgs/development/tools/misc/avrdude/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "15m1w1qad3dj7r8n5ng1qqcaiyx1gyd6hnc3p2apgjllccdp77qg";
   };
 
-  configureFlags = stdenv.lib.optionalString docSupport "--enable-doc";
+  configureFlags = stdenv.lib.optionals docSupport "--enable-doc";
 
   buildInputs = [ yacc flex libusb libelf libftdi1 readline ]
     ++ stdenv.lib.optionals docSupport [ texLive texinfo texi2html ];

--- a/pkgs/development/tools/misc/cscope/default.nix
+++ b/pkgs/development/tools/misc/cscope/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1byk29rcpyygrnr03h5j3y8j0aqxldd9dr5ihi9q982sy28x12a8";
   };
 
-  configureFlags = "--with-ncurses=${ncurses.dev}";
+  configureFlags = [ "--with-ncurses=${ncurses.dev}" ];
 
   buildInputs = [ ncurses ];
   nativeBuildInputs = stdenv.lib.optional emacsSupport emacs;

--- a/pkgs/development/tools/misc/ddd/default.nix
+++ b/pkgs/development/tools/misc/ddd/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
     sha256 = "0p5nx387857w3v2jbgvps2p6mlm0chajcdw5sfrddcglsxkwvmis";
   };
   buildInputs = [motif ncurses libX11 libXt];
-  configureFlags = "--with-x";
+  configureFlags = [ "--with-x" ];
 
   patches = [ ./gcc44.patch ];
 

--- a/pkgs/development/tools/misc/dialog/default.nix
+++ b/pkgs/development/tools/misc/dialog/default.nix
@@ -1,11 +1,8 @@
 { stdenv, fetchurl, ncurses
 , withLibrary ? false, libtool
 , unicodeSupport ? true
+, enableShared ? !stdenv.isDarwin
 }:
-
-let optStr = stdenv.lib.optionalString;
-    buildShared = !stdenv.isDarwin;
-in
 
 assert withLibrary -> libtool != null;
 assert unicodeSupport -> ncurses.unicode && ncurses != null;
@@ -24,14 +21,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
-  configureFlags = ''
-    --disable-rpath-hacks
-    ${optStr withLibrary "--with-libtool"}
-    --with-libtool-opts=${optStr buildShared "-shared"}
-    --with-ncurses${optStr unicodeSupport "w"}
-  '';
+  configureFlags = [
+    "--disable-rpath-hacks"
+    (stdenv.lib.withFeature withLibrary "libtool")
+    "--with-ncurses${stdenv.lib.optionalString unicodeSupport "w"}"
+    "--with-libtool-opts=${stdenv.lib.optionalString enableShared "-shared"}"
+  ];
 
-  installTargets = "install${optStr withLibrary "-full"}";
+  installTargets = "install${stdenv.lib.optionalString withLibrary "-full"}";
 
   meta = {
     homepage = http://invisible-island.net/dialog/dialog.html;

--- a/pkgs/development/tools/misc/elfutils/default.nix
+++ b/pkgs/development/tools/misc/elfutils/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   #
   # I wrote this testing for the nanonote.
 
-  buildPhase = if stdenv.hostPlatform == stdenv.buildPlatform then null else ''
+  buildPhase = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     pushd libebl
     make
     popd
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  installPhase = if stdenv.hostPlatform == stdenv.buildPlatform then null else ''
+  installPhase = stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
     pushd libelf
     make install
     popd

--- a/pkgs/development/tools/misc/gnum4/default.nix
+++ b/pkgs/development/tools/misc/gnum4/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  configureFlags = "--with-syscmd-shell=${stdenv.shell}";
+  configureFlags = [ "--with-syscmd-shell=${stdenv.shell}" ];
 
   # Upstream is aware of it; it may be in the next release.
   patches = [ ./s_isdir.patch ] ++ stdenv.lib.optional hostPlatform.isDarwin stdenv.secure-format-patch;

--- a/pkgs/development/tools/misc/srecord/default.nix
+++ b/pkgs/development/tools/misc/srecord/default.nix
@@ -10,8 +10,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost libtool groff ghostscript libgcrypt ];
 
-  configureFlags = stdenv.lib.optionalString
-    (libgcrypt == null) "--without-gcrypt";
+  configureFlags = [
+    (stdenv.lib.optional (libgcrypt == null) "--without-gcrypt")
+  ];
 
   meta = with stdenv.lib; {
     description = "Collection of powerful tools for manipulating EPROM load files";

--- a/pkgs/development/tools/misc/swig/2.x.nix
+++ b/pkgs/development/tools/misc/swig/2.x.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ pcre ];
 
-  configureFlags = "--without-tcl";
+  configureFlags = [ "--without-tcl" ];
 
   postPatch = ''
     # Disable ccache documentation as it need yodl

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoconf automake libtool bison ];
   buildInputs = [ pcre ];
 
-  configureFlags = "--without-tcl";
+  configureFlags = [ "--without-tcl" ];
 
   postPatch = ''
     # Disable ccache documentation as it need yodl

--- a/pkgs/development/tools/misc/swig/default.nix
+++ b/pkgs/development/tools/misc/swig/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   # 'make check' uses boost and tcl
   buildInputs = stdenv.lib.optionals doCheck [ boost tcl ];
 
-  configureFlags = "--disable-ccache";
+  configureFlags = [ "--disable-ccache" ];
 
   meta = {
     description = "Interface compiler that connects C/C++ code to higher-level languages";

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison ];
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = stdenv.lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    export ac_cv_func_malloc_0_nonnull=yes
-    export ac_cv_func_realloc_0_nonnull=yes
-  '';
+  preConfigure = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
 
   postConfigure = stdenv.lib.optionalString (stdenv.isDarwin || stdenv.isCygwin) ''
     sed -i Makefile -e 's/-no-undefined//;'

--- a/pkgs/games/exult/default.nix
+++ b/pkgs/games/exult/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0a03a2l3ji6h48n106d4w55l8v6lni1axniafnvvv5c5n3nz5bgd";
   };
 
-  configureFlags = "--disable-tools";
+  configureFlags = [ "--disable-tools" ];
 
   patches =
     [ # Arch Linux patch set.

--- a/pkgs/games/gltron/default.nix
+++ b/pkgs/games/gltron/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   '';
 
   # The build fails, unless we disable the default -Wall -Werror
-  configureFlags = "--disable-warn";
+  configureFlags = [ "--disable-warn" ];
 
   buildInputs = [ SDL libGLU_combined zlib libpng libvorbis libmikmod SDL_sound ];
 

--- a/pkgs/games/typespeed/default.nix
+++ b/pkgs/games/typespeed/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
 
   patches = [ ./typespeed-config-in-home.patch ];
 
-  configureFlags = "--datadir=\${out}/share/";
-  makeFlags = ["CC=cc"];
+  configureFlags = [ "--datadir=\${out}/share/" ];
+  makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 
   meta = with stdenv.lib; {
     description = "A curses based typing game";

--- a/pkgs/misc/drivers/xwiimote/default.nix
+++ b/pkgs/misc/drivers/xwiimote/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ udev ncurses bluez ];
 
-  configureFlags = "--with-doxygen=no";
+  configureFlags = [ "--with-doxygen=no" ];
 
   meta = {
     homepage = http://dvdhrm.github.io/xwiimote;

--- a/pkgs/misc/emulators/atari800/default.nix
+++ b/pkgs/misc/emulators/atari800/default.nix
@@ -13,7 +13,15 @@ stdenv.mkDerivation rec{
 
   buildInputs = [ unzip zlib SDL readline libGLU_combined libX11 ];
 
-  configureFlags = "--target=default --with-video=sdl --with-sound=sdl --with-readline --with-opengl --with-x --enable-riodevice";
+  configureFlags = [
+    "--target=default"
+    "--with-video=sdl"
+    "--with-sound=sdl"
+    "--with-readline"
+    "--with-opengl"
+    "--with-x"
+    "--enable-riodevice"
+  ];
 
   preConfigure = "cd src";
 

--- a/pkgs/misc/emulators/vice/default.nix
+++ b/pkgs/misc/emulators/vice/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison flex perl libpng giflib libjpeg alsaLib readline libGLU_combined
     pkgconfig gtk2 SDL autoreconfHook libXaw ];
   dontDisableStatic = true;
-  configureFlags = "--enable-fullscreen --enable-gnomeui";
+  configureFlags = [ "--enable-fullscreen --enable-gnomeui" ];
 
   desktopItem = makeDesktopItem {
     name = "vice";

--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -3,7 +3,7 @@
   # flex 2.6.3 causes: undefined reference to `yywrap'
   pkgconfig, fontforge, makeWrapper, flex_2_6_1, bison,
   supportFlags,
-  buildScript ? null, configureFlags ? ""
+  buildScript ? null, configureFlags ? []
 }:
 
 with import ./util.nix { inherit lib; };

--- a/pkgs/misc/jackaudio/jack1.nix
+++ b/pkgs/misc/jackaudio/jack1.nix
@@ -22,9 +22,9 @@ stdenv.mkDerivation rec {
     sha256 = "0i6l25dmfk2ji2lrakqq9icnwjxklgcjzzk65dmsff91z2zva5rm";
   };
   
-  configureFlags = ''
-    ${if (optLibffado != null) then "--enable-firewire" else ""}
-  '';
+  configureFlags = [
+    (stdenv.lib.enableFeature (optLibffado != null) "firewire")
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ optAlsaLib optDb optLibffado optCelt ];

--- a/pkgs/misc/screensavers/vlock/default.nix
+++ b/pkgs/misc/screensavers/vlock/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   patches = [ ./eintr.patch ];
 
-  configureFlags = "VLOCK_GROUP=root ROOT_GROUP=root";
+  configureFlags = [ "VLOCK_GROUP=root" "ROOT_GROUP=root" ];
 
   buildInputs = [ pam ];
 

--- a/pkgs/os-specific/linux/alsa-firmware/default.nix
+++ b/pkgs/os-specific/linux/alsa-firmware/default.nix
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "0gfcyj5anckjn030wcxx5v2xk2s219nyf99s9m833275b5wz2piw";
   };
 
-  configureFlags = ''
-    --with-hotplug-dir=$(out)/lib/firmware
-  '';
+  configureFlags = [
+    "--with-hotplug-dir=$(out)/lib/firmware"
+  ];
 
   dontStrip = true;
 

--- a/pkgs/os-specific/linux/alsa-oss/default.nix
+++ b/pkgs/os-specific/linux/alsa-oss/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ alsaLib ncurses libsamplerate ];
   nativeBuildInputs = [ gettext ];
 
-  configureFlags = "--disable-xmlto";
+  configureFlags = [ "--disable-xmlto" ];
 
   installFlags = "ASOUND_STATE_DIR=$(TMPDIR)/dummy";
 

--- a/pkgs/os-specific/linux/alsa-utils/default.nix
+++ b/pkgs/os-specific/linux/alsa-utils/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gettext ];
   buildInputs = [ alsaLib ncurses libsamplerate fftw ];
 
-  configureFlags = "--disable-xmlto --with-udev-rules-dir=$(out)/lib/udev/rules.d";
+  configureFlags = [ "--disable-xmlto" "--with-udev-rules-dir=$(out)/lib/udev/rules.d" ];
 
   installFlags = "ASOUND_STATE_DIR=$(TMPDIR)/dummy";
 

--- a/pkgs/os-specific/linux/drbd/default.nix
+++ b/pkgs/os-specific/linux/drbd/default.nix
@@ -12,7 +12,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flex perl ];
 
-  configureFlags = "--without-distro --without-pacemaker --localstatedir=/var --sysconfdir=/etc";
+  configureFlags = [
+    "--without-distro"
+    "--without-pacemaker"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+  ];
 
   preConfigure =
     ''

--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = "patchShebangs ./configure";
 
-  configureFlags = "--datadir=$(prefix)/data";
+  configureFlags = [ "--datadir=$(prefix)/data" ];
 
   doCheck = false; # this does build machine-specific checks (e.g. enumerates PCI bus)
 

--- a/pkgs/os-specific/linux/ipsec-tools/default.nix
+++ b/pkgs/os-specific/linux/ipsec-tools/default.nix
@@ -28,19 +28,19 @@ stdenv.mkDerivation rec {
   # fix build with newer gcc versions
   preConfigure = ''substituteInPlace configure --replace "-Werror" "" '';
 
-  configureFlags = ''
-    --sysconfdir=/etc --localstatedir=/var
-    --with-kernel-headers=${linuxHeaders}/include
-    --disable-security-context
-    --enable-adminport
-    --enable-dpd
-    --enable-frag
-    --enable-gssapi
-    --enable-hybrid
-    --enable-natt
-    --enable-shared
-    --enable-stats
-  '';
+  configureFlags = [
+    "--sysconfdir=/etc --localstatedir=/var"
+    "--with-kernel-headers=${linuxHeaders}/include"
+    "--disable-security-context"
+    "--enable-adminport"
+    "--enable-dpd"
+    "--enable-frag"
+    "--enable-gssapi"
+    "--enable-hybrid"
+    "--enable-natt"
+    "--enable-shared"
+    "--enable-stats"
+  ];
 
   meta = {
     homepage = http://ipsec-tools.sourceforge.net/;

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
     export NIX_LDFLAGS="$NIX_LDFLAGS -lmnl -lnftnl"
   '';
 
-  configureFlags = ''
-    --enable-devel
-    --enable-shared
-  '';
+  configureFlags = [
+    "--enable-devel"
+    "--enable-shared"
+  ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/os-specific/linux/pm-utils/default.nix
+++ b/pkgs/os-specific/linux/pm-utils/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "02qc6zaf7ams6qcc470fwb6jvr4abv3lrlx16clqpn36501rkn4f";
   };
 
-  configureFlags = "--sysconfdir=/etc";
+  configureFlags = [ "--sysconfdir=/etc" ];
 
   preConfigure =
     ''

--- a/pkgs/os-specific/linux/pmount/default.nix
+++ b/pkgs/os-specific/linux/pmount/default.nix
@@ -18,13 +18,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ intltool utillinux ];
 
-  configureFlags = ""
-  + " --with-media-dir=${mediaDir}"
-  + " --with-lock-dir=${lockDir}"
-  + " --with-whitelist=${whiteList}"
-  + " --with-mount-prog=${utillinux}/bin/mount"
-  + " --with-umount-prog=${utillinux}/bin/umount"
-  + " --with-mount-ntfs3g=${ntfs3g}/sbin/mount.ntfs-3g";
+  configureFlags = [
+    "--with-media-dir=${mediaDir}"
+    "--with-lock-dir=${lockDir}"
+    "--with-whitelist=${whiteList}"
+    "--with-mount-prog=${utillinux}/bin/mount"
+    "--with-umount-prog=${utillinux}/bin/umount"
+    "--with-mount-ntfs3g=${ntfs3g}/sbin/mount.ntfs-3g"
+  ];
 
   postConfigure = ''
     # etc/Mafile.am is hardcoded and it does not respect the --prefix option.

--- a/pkgs/os-specific/linux/udisks/1-default.nix
+++ b/pkgs/os-specific/linux/udisks/1-default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
 
-  configureFlags = "--localstatedir=/var --enable-lvm2";
+  configureFlags = [ "--localstatedir=/var" "--enable-lvm2" ];
 
   meta = {
     homepage = http://www.freedesktop.org/wiki/Software/udisks;

--- a/pkgs/os-specific/linux/util-linux/default.nix
+++ b/pkgs/os-specific/linux/util-linux/default.nix
@@ -28,10 +28,6 @@ in stdenv.mkDerivation rec {
       --replace "/bin/umount" "$out/bin/umount"
   '';
 
-  preConfigure = lib.optionalString (systemd != null) ''
-    configureFlags+=" --with-systemd --with-systemdsystemunitdir=$bin/lib/systemd/system/"
-  '';
-
   # !!! It would be better to obtain the path to the mount helpers
   # (/sbin/mount.*) through an environment variable, but that's
   # somewhat risky because we have to consider that mount can setuid
@@ -43,8 +39,11 @@ in stdenv.mkDerivation rec {
     "--disable-use-tty-group"
     "--enable-fs-paths-default=/run/wrappers/bin:/var/run/current-system/sw/bin:/sbin"
     "--disable-makeinstall-setuid" "--disable-makeinstall-chown"
-  ] ++ lib.optional (ncurses == null) "--without-ncurses"
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
+    (lib.withFeature (ncurses != null) "ncurses")
+    (lib.withFeature (systemd != null) "systemd")
+    (lib.withFeatureAs (systemd != null)
+       "systemdsystemunitdir" "$bin/lib/systemd/system/")
+  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
        "scanf_cv_type_modifier=ms"
   ;
 

--- a/pkgs/os-specific/windows/cygwin-setup/default.nix
+++ b/pkgs/os-specific/windows/cygwin-setup/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     });
   in map mkStatic [ zlib bzip2 lzma libgcrypt ];
 
-  configureFlags = "--disable-shared";
+  configureFlags = [ "--disable-shared" ];
 
   dontDisableStatic = true;
 

--- a/pkgs/servers/dict/libmaa.nix
+++ b/pkgs/servers/dict/libmaa.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ libtool ];
-  # configureFlags = "--datadir=/var/run/current-system/share/dictd";
+  # configureFlags = [ "--datadir=/var/run/current-system/share/dictd" ];
 
   meta = with stdenv.lib; {
     description = "Dict protocol server and client";

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -47,26 +47,32 @@ stdenv.mkDerivation rec {
     configureFlags="$configureFlags --includedir=$dev/include"
   '';
 
-  configureFlags = ''
-    --with-apr=${apr.dev}
-    --with-apr-util=${aprutil.dev}
-    --with-z=${zlib.dev}
-    --with-pcre=${pcre.dev}
-    --disable-maintainer-mode
-    --disable-debugger-mode
-    --enable-mods-shared=all
-    --enable-mpms-shared=all
-    --enable-cern-meta
-    --enable-imagemap
-    --enable-cgi
-    ${optionalString brotliSupport "--enable-brotli --with-brotli=${brotli}"}
-    ${optionalString proxySupport "--enable-proxy"}
-    ${optionalString sslSupport "--enable-ssl"}
-    ${optionalString http2Support "--enable-http2 --with-nghttp2"}
-    ${optionalString luaSupport "--enable-lua --with-lua=${lua5}"}
-    ${optionalString libxml2Support "--with-libxml2=${libxml2.dev}/include/libxml2"}
-    --docdir=$(doc)/share/doc
-  '';
+  configureFlags = [
+    "--with-apr=${apr.dev}"
+    "--with-apr-util=${aprutil.dev}"
+    "--with-z=${zlib.dev}"
+    "--with-pcre=${pcre.dev}"
+    "--disable-maintainer-mode"
+    "--disable-debugger-mode"
+    "--enable-mods-shared=all"
+    "--enable-mpms-shared=all"
+    "--enable-cern-meta"
+    "--enable-imagemap"
+    "--enable-cgi"
+    (stdenv.lib.enableFeature proxySupport "proxy")
+    (stdenv.lib.enableFeature sslSupport "ssl")
+    (stdenv.lib.withFeatureAs libxml2Support "libxml2" "${libxml2.dev}/include/libxml2")
+    "--docdir=$(doc)/share/doc"
+
+    (stdenv.lib.enableFeature brotliSupport "brotli")
+    (stdenv.lib.withFeatureAs brotliSupport "brotli" brotli)
+
+    (stdenv.lib.enableFeature http2Support "http2")
+    (stdenv.lib.withFeature http2Support "nghttp2")
+
+    (stdenv.lib.enableFeature luaSupport "lua")
+    (stdenv.lib.withFeatureAs luaSupport "lua" lua5)
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/http/apache-modules/tomcat-connectors/default.nix
+++ b/pkgs/servers/http/apache-modules/tomcat-connectors/default.nix
@@ -8,7 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "11khipjpy3y84j1pp7yyx76y64jccvyhh3klwzqxylff49vjc2fc";
   };
 
-  configureFlags = "--with-apxs=${apacheHttpd.dev}/bin/apxs --with-java-home=${jdk}";
+  configureFlags = [
+    "--with-apxs=${apacheHttpd.dev}/bin/apxs"
+    "--with-java-home=${jdk}"
+  ];
 
   setSourceRoot = ''
     sourceRoot=$(echo */native)

--- a/pkgs/servers/http/couchdb/default.nix
+++ b/pkgs/servers/http/couchdb/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
 
   If you wish to ignore this error pass --enable-js-trunk to ./configure.
   */
-  configureFlags = ''
-    --enable-js-trunk
-  '';
+  configureFlags = [
+    "--enable-js-trunk"
+  ];
 
   meta = with stdenv.lib; {
     description = "A database that uses JSON for documents, JavaScript for MapReduce queries, and regular HTTP for an API";

--- a/pkgs/servers/http/pshs/default.nix
+++ b/pkgs/servers/http/pshs/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libevent file qrencode miniupnpc ];
 
   # SSL requires libevent at 2.1 with ssl support
-  configureFlags = "--disable-ssl";
+  configureFlags = [ "--disable-ssl" ];
 
   meta = {
     description = "Pretty small HTTP server - a command-line tool to share files";

--- a/pkgs/servers/http/yaws/default.nix
+++ b/pkgs/servers/http/yaws/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     cd $name
   '';
 
-  configureFlags = "--with-extrainclude=${pam}/include/security";
+  configureFlags = [ "--with-extrainclude=${pam}/include/security" ];
 
   buildInputs = [ erlang pam perl ];
 

--- a/pkgs/servers/irc/ircd-hybrid/default.nix
+++ b/pkgs/servers/irc/ircd-hybrid/default.nix
@@ -10,8 +10,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl zlib ];
 
-  configureFlags =
-    "--with-nicklen=100 --with-topiclen=360 --enable-openssl=${openssl.dev}";
+  configureFlags = [
+    "--with-nicklen=100"
+    "--with-topiclen=360"
+    "--enable-openssl=${openssl.dev}"
+  ];
 
   postInstall = "echo postinstall; mkdir -p \${out}/ ; rm -rf \${out}/logs ; ln -s /home/ircd \${out}/logs;";
 

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -13,9 +13,13 @@ stdenv.mkDerivation rec {
 
   patches = [ ./fix-var-prefix.patch ];
 
-  configureFlags = "--without-permcheck --with-cgi-ext=.cgi --with-var-prefix=/var/lib/mailman";
+  configureFlags = [
+    "--without-permcheck"
+    "--with-cgi-ext=.cgi"
+    "--with-var-prefix=/var/lib/mailman"
+  ];
 
-  installTargets = "doinstall";         # Leave out the 'update' target that's implied by 'install'.
+  installTargets = "doinstall"; # Leave out the 'update' target that's implied by 'install'.
 
   makeFlags = [ "DIRSETGID=:" ];
 

--- a/pkgs/servers/mail/petidomo/default.nix
+++ b/pkgs/servers/mail/petidomo/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flex bison ];
 
-  configureFlags = "--with-mta=${sendmailPath}";
+  configureFlags = [ "--with-mta=${sendmailPath}" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/servers/monitoring/zabbix/2.0.nix
+++ b/pkgs/servers/monitoring/zabbix/2.0.nix
@@ -77,7 +77,7 @@ in
 
     inherit src preConfigure;
 
-    configureFlags = "--enable-agent";
+    configureFlags = [ "--enable-agent" ];
 
     meta = with stdenv.lib; {
       inherit branch;

--- a/pkgs/servers/monitoring/zabbix/2.2.nix
+++ b/pkgs/servers/monitoring/zabbix/2.2.nix
@@ -89,7 +89,7 @@ in
 
     inherit src preConfigure;
 
-    configureFlags = "--enable-agent";
+    configureFlags = [ "--enable-agent" ];
 
     meta = with stdenv.lib; {
       inherit branch;

--- a/pkgs/servers/monitoring/zabbix/default.nix
+++ b/pkgs/servers/monitoring/zabbix/default.nix
@@ -27,7 +27,12 @@ in
 
     inherit src preConfigure;
 
-    configureFlags = "--enable-agent --enable-server --with-pgsql --with-libcurl";
+    configureFlags = [
+      "--enable-agent"
+      "--enable-server"
+      "--with-pgsql"
+      "--with-libcurl"
+    ];
 
   nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ postgresql curl openssl zlib ];
@@ -56,7 +61,7 @@ in
 
     inherit src preConfigure;
 
-    configureFlags = "--enable-agent";
+    configureFlags = [ "--enable-agent" ];
 
     meta = with stdenv.lib; {
       description = "An enterprise-class open source distributed monitoring solution (client-side agent)";

--- a/pkgs/servers/news/leafnode/default.nix
+++ b/pkgs/servers/news/leafnode/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "096w4gxj08m3vwmyv4sxpmbl8dn6mzqfmrhc32jgyca6qzlrdin8";
   };
 
-  configureFlags = "--enable-runas-user=nobody";
+  configureFlags = [ "--enable-runas-user=nobody" ];
 
   prePatch = ''
     substituteInPlace Makefile.in --replace 02770 0770

--- a/pkgs/servers/shairport-sync/default.nix
+++ b/pkgs/servers/shairport-sync/default.nix
@@ -27,11 +27,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = ''
-    --with-alsa --with-pipe --with-pulseaudio --with-stdout
-    --with-avahi --with-ssl=openssl --with-soxr
-    --without-configfiles --without-initscript
-  '';
+  configureFlags = [
+    "--with-alsa" "--with-pipe" "--with-pulseaudio" "--with-stdout"
+    "--with-avahi" "--with-ssl=openssl" "--with-soxr"
+    "--without-configfiles" "--without-initscript"
+  ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/servers/sql/postgresql/psqlodbc/default.nix
+++ b/pkgs/servers/sql/postgresql/psqlodbc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libiodbc postgresql openssl ];
 
-  configureFlags = "--with-iodbc=${libiodbc}";
+  configureFlags = [ "--with-iodbc=${libiodbc}" ];
 
   meta = with stdenv.lib; {
     homepage = http://psqlodbc.projects.postgresql.org/;

--- a/pkgs/servers/sql/virtuoso/6.x.nix
+++ b/pkgs/servers/sql/virtuoso/6.x.nix
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
 
   CPP = "${stdenv.cc}/bin/gcc -E";
 
-  configureFlags = "
-    --enable-shared --disable-all-vads --with-readline=${readline.dev}
-    --disable-hslookup --disable-wbxml2 --without-iodbc
-    --enable-openssl=${openssl.dev}
-    ";
+  configureFlags = [
+    "--enable-shared" "--disable-all-vads" "--with-readline=${readline.dev}"
+    "--disable-hslookup" "--disable-wbxml2" "--without-iodbc"
+    "--enable-openssl=${openssl.dev}"
+  ];
 
   postInstall = ''
     echo Moving documentation

--- a/pkgs/servers/sql/virtuoso/7.x.nix
+++ b/pkgs/servers/sql/virtuoso/7.x.nix
@@ -12,11 +12,11 @@ stdenv.mkDerivation rec {
 
   CPP = "${stdenv.cc}/bin/gcc -E";
 
-  configureFlags = "
-    --enable-shared --disable-all-vads --with-readline=${readline.dev}
-    --disable-hslookup --disable-wbxml2 --without-iodbc
-    --enable-openssl=${openssl.dev}
-    ";
+  configureFlags = [
+    "--enable-shared" "--disable-all-vads" "--with-readline=${readline.dev}"
+    "--disable-hslookup" "--disable-wbxml2" "--without-iodbc"
+    "--enable-openssl=${openssl.dev}"
+  ];
 
   postInstall=''
     echo Moving documentation

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -171,7 +171,7 @@ let
       sha256 = "0m60f5bd0caambrk8ksknb5dks7wzsg7g7xaf0j21jxmx8rq9h5j";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -183,7 +183,7 @@ let
       sha256 = "02advcv9lyxpvrjv8bjh1b797lzg6jvhipclz49z8r8y98g4l0n6";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -195,7 +195,7 @@ let
       sha256 = "19dd9znam1ah72jmdh7i6ny2ss2r6m21z9v0l43xvikw48zmwvyi";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -207,7 +207,7 @@ let
       sha256 = "152wigpph5wvl4k9m3l4mchxxisgsnzlx033mn5iqrpkc6f72cl7";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -219,7 +219,7 @@ let
       sha256 = "0xw0pdnzj5jljsbbhakc6q9ha2qnca1jr81zk7w70yl9bw83b54p";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -243,7 +243,7 @@ let
       sha256 = "1x246dfnxnmflzf0qzy62k8jdpkb6jkgspcjgbk8jcq9lw99npah";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -255,7 +255,7 @@ let
       sha256 = "10cl4gm38dw68jzln99ijix730y7cbx8np096gmpjjwff1i73h13";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -267,7 +267,7 @@ let
       sha256 = "073jmhf0sr2j1l8da97pzsqj805f7mf9r2gy92j4diljmi8sm1il";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -279,7 +279,7 @@ let
       sha256 = "1fqzckxdzjv4802iad2fdrkpaxl4w0hhs9lxlkyraq2kq9ik7a32";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -291,7 +291,7 @@ let
       sha256 = "0cfbxdp5m12cm7jsh3my0lym9328cgm7fa9faz2hqj05wbxnmhaa";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -303,7 +303,7 @@ let
       sha256 = "0pyjmc0ha288d4i4j0si4dh3ncf3jiwwjljvddrb0k8v4xiyljqv";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -315,7 +315,7 @@ let
       sha256 = "1hb3iav089albp4sdgnlh50k47cdjif9p4axm0kkjvs8jyi5a53n";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -327,7 +327,7 @@ let
       sha256 = "1kmn9jbck3vghz6rj3bhc3h0w6gh0qiaqm90cjkqsz1x9r2dgq7b";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -339,7 +339,7 @@ let
       sha256 = "13plbifkvfvdfym6gjbgy9wx2xbdxi9hfrl1k22xayy02135wgxs";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -351,7 +351,7 @@ let
       sha256 = "1256z0jhcf5gbh1d03593qdwnag708rxqa032izmfb5dmmlhbsn6";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -363,7 +363,7 @@ let
       sha256 = "0ai1v4n61k8j9x2a1knvfbl2xjxk3xxmqaq3p9vpqrspc69k31kf";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -375,7 +375,7 @@ let
       sha256 = "0dd6vfiagjc4zmvlskrbjz85jfqhf060cpys8j0y1qpcbsrkwdhp";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -387,7 +387,7 @@ let
       sha256 = "1s2bbhizzgbbbn5wqs3vw53n619cclxksljvm759h9p1prqdwrdw";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -399,7 +399,7 @@ let
       sha256 = "0yzza0l4zwyy7accr1s8ab7fjqkpwggqydbm2vc19scdby5xz7g1";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -411,7 +411,7 @@ let
       sha256 = "1pyjll4adch3z5cg663s6vhi02k8m6488f0mrasg81ssvg9jinzx";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -423,7 +423,7 @@ let
       sha256 = "0rx8q02rkx673a7skkpnvfkg28i8gmqzgf25s9yi0lar915sn92q";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -435,7 +435,7 @@ let
       sha256 = "0rdc3xdz12pnv951538q6wilx8mrdndpkphpbblszsv7nc8cw61b";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -447,7 +447,7 @@ let
       sha256 = "1dldxlh54zq1yzfnrh83j5vm0k4ijprrs5yl18gm3n9j1z0q2cws";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -459,7 +459,7 @@ let
       sha256 = "0q2ybxs8wvylvw95j6x9i800rismsmx4b587alwbfqiw6biy63z4";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -471,7 +471,7 @@ let
       sha256 = "19cq7iq0pfad0nc2v28n681fdq3fcw1l1hzaq0wpkgpx7bc1zjsk";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -483,7 +483,7 @@ let
       sha256 = "148793fqwzrc3bmh2vlw5fdiwjc2n7vs25cic35gfp452czk489p";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 
@@ -495,7 +495,7 @@ let
       sha256 = "150pq6n8n984fah34n3k133kggn9v0c5k07igv29sxp1wi07krxq";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -507,7 +507,7 @@ let
       sha256 = "13qghgr1zzpv64m0p42195k1kc77pksiv059fdvijz1n6kdplpxx";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -519,7 +519,7 @@ let
       sha256 = "0nkym3n48b4v36y4s927bbkjnsmicajarnf6vlp7wxp0as304i74";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf fontutil mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf fontutil mkfontdir mkfontscale ;};
 
@@ -531,7 +531,7 @@ let
       sha256 = "0yayf1qlv7irf58nngddz2f1q04qkpr5jwp4aja2j5gyvzl32hl2";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -543,7 +543,7 @@ let
       sha256 = "1xfgcx4gsgik5mkgkca31fj3w72jw9iw76qyrajrsz1lp8ka6hr0";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -567,7 +567,7 @@ let
       sha256 = "1q6jcqrffg9q5f5raivzwx9ffvf7r11g6g0b125na1bhpz5ly7s8";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -591,7 +591,7 @@ let
       sha256 = "181n1bgq8vxfxqicmy1jpm1hnr6gwn1kdhl6hr4frjigs1ikpldb";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ bdftopcf mkfontdir ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit bdftopcf mkfontdir ;};
 
@@ -603,7 +603,7 @@ let
       sha256 = "0jp3zc0qfdaqfkgzrb44vi9vi0a8ygb35wp082yz7rvvxhmg9sya";
     };
     nativeBuildInputs = [ pkgconfig ];
-    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = "--with-fontrootdir=$(out)/lib/X11/fonts";
+    buildInputs = [ mkfontdir mkfontscale ]; configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
     meta.platforms = stdenv.lib.platforms.unix;
   }) // {inherit mkfontdir mkfontscale ;};
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -178,7 +178,7 @@ while (<>) {
     }
 
     if ($isFont) {
-        $extraAttrs{$pkg} = " configureFlags = \"--with-fontrootdir=\$(out)/lib/X11/fonts\"; ";
+        $extraAttrs{$pkg} = " configureFlags = [ \"--with-fontrootdir=\$(out)/lib/X11/fonts\" ]; ";
     }
 
     sub process {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -77,7 +77,7 @@ in
 
   libxcb = attrs : attrs // {
     nativeBuildInputs = attrs.nativeBuildInputs ++ [ args.python ];
-    configureFlags = "--enable-xkb --enable-xinput";
+    configureFlags = [ "--enable-xkb" "--enable-xinput" ];
     outputs = [ "out" "dev" "man" "doc" ];
   };
 
@@ -147,7 +147,7 @@ in
   # See https://bugs.freedesktop.org/show_bug.cgi?id=47792
   # Once the bug is fixed upstream, this can be removed.
   luit = attrs: attrs // {
-    configureFlags = "--disable-selective-werror";
+    configureFlags = [ "--disable-selective-werror" ];
   };
 
   compositeproto = attrs: attrs // {
@@ -408,7 +408,7 @@ in
   };
 
   xkbcomp = attrs: attrs // {
-    configureFlags = "--with-xkb-config-root=${xorg.xkeyboardconfig}/share/X11/xkb";
+    configureFlags = [ "--with-xkb-config-root=${xorg.xkeyboardconfig}/share/X11/xkb" ];
   };
 
   xkeyboardconfig = attrs: attrs // {
@@ -597,7 +597,7 @@ in
 
   xcursorthemes = attrs: attrs // {
     buildInputs = attrs.buildInputs ++ [xorg.xcursorgen];
-    configureFlags = "--with-cursordir=$(out)/share/icons";
+    configureFlags = [ "--with-cursordir=$(out)/share/icons" ];
   };
 
   xinit = attrs: attrs // {
@@ -627,7 +627,7 @@ in
     };
     buildInputs = attrs.buildInputs ++ [xorg.libXfixes xorg.libXScrnSaver xorg.pixman];
     nativeBuildInputs = attrs.nativeBuildInputs ++ [args.autoreconfHook xorg.utilmacros];
-    configureFlags = "--with-default-dri=3 --enable-tools";
+    configureFlags = [ "--with-default-dri=3" "--enable-tools" ];
 
     meta = attrs.meta // {
       platforms = ["i686-linux" "x86_64-linux"];
@@ -672,7 +672,7 @@ in
   };
 
   xrdb = attrs: attrs // {
-    configureFlags = "--with-cpp=${args.mcpp}/bin/mcpp";
+    configureFlags = [ "--with-cpp=${args.mcpp}/bin/mcpp" ];
   };
 
   sessreg = attrs: attrs // {

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -34,9 +34,9 @@ rec {
   makeStaticBinaries = stdenv: stdenv //
     { mkDerivation = args: stdenv.mkDerivation (args // {
         NIX_CFLAGS_LINK = "-static";
-        configureFlags =
-          toString args.configureFlags or ""
-          + " --disable-shared"; # brrr...
+        configureFlags = (args.configureFlags or []) ++ [
+            "--disable-shared" # brrr...
+          ];
       });
       isStatic = true;
     };
@@ -47,9 +47,10 @@ rec {
   makeStaticLibraries = stdenv: stdenv //
     { mkDerivation = args: stdenv.mkDerivation (args // {
         dontDisableStatic = true;
-        configureFlags =
-          toString args.configureFlags or ""
-          + " --enable-static --disable-shared";
+        configureFlags = (args.configureFlags or []) ++ [
+          "--enable-static"
+          "--disable-shared"
+        ];
       });
     };
 

--- a/pkgs/tools/backup/partimage/default.nix
+++ b/pkgs/tools/backup/partimage/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     url = mirror://sourceforge/partimage/partimage-0.6.9.tar.bz2;
     sha256 = "0db6xiphk6xnlpbxraiy31c5xzj0ql6k4rfkmqzh665yyj0nqfkm";
   };
-  configureFlags = "--with-ssl-headers=${openssl.dev}/include/openssl";
+  configureFlags = [ "--with-ssl-headers=${openssl.dev}/include/openssl" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [bzip2 zlib newt newt openssl slang

--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./isdir.patch ./fix-sysconfdir.patch ];
 
-  configureFlags = "--sysconfdir=/etc";
+  configureFlags = [ "--sysconfdir=/etc" ];
 
   makeFlags = ["sbindir=$(out)/sbin" "ssbindir=$(out)/sbin"];
 

--- a/pkgs/tools/filesystems/nixpart/0.4/lvm2.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/lvm2.nix
@@ -12,8 +12,13 @@ stdenv.mkDerivation {
     sha256 = "0nr833bl0q4zq52drjxmmpf7bs6kqxwa5kahwwxm9411khkxz0vc";
   };
 
-  configureFlags =
-    "--disable-readline --enable-udev_rules --enable-udev_sync --enable-pkgconfig --enable-applib";
+  configureFlags = [
+    "--disable-readline"
+    "--enable-udev_rules"
+    "--enable-udev_sync"
+    "--enable-pkgconfig"
+    "--enable-applib"
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ systemd ];

--- a/pkgs/tools/graphics/editres/default.nix
+++ b/pkgs/tools/graphics/editres/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libXt libXaw libXres utilmacros ];
 
-  configureFlags = "--with-appdefaultdir=$(out)/share/X11/app-defaults/editres";
+  configureFlags = [ "--with-appdefaultdir=$(out)/share/X11/app-defaults/editres" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/tools/graphics/ggobi/default.nix
+++ b/pkgs/tools/graphics/ggobi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libxml2 gtk2 ];
 
-  configureFlags = "--with-all-plugins";
+  configureFlags = [ "--with-all-plugins" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/tools/graphics/plotutils/default.nix
+++ b/pkgs/tools/graphics/plotutils/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     make -C libplot xmi.h
   '';
 
-  configureFlags = "--enable-libplotter"; # required for pstoedit
+  configureFlags = [ "--enable-libplotter" ]; # required for pstoedit
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/tools/inputmethods/keyfuzz/default.nix
+++ b/pkgs/tools/inputmethods/keyfuzz/default.nix
@@ -17,5 +17,5 @@ stdenv.mkDerivation rec {
     sha256 = "0xv9ymivp8fnyc5xcyh1vamxnx90bzw66wlld813fvm6q2gsiknk";
   };
 
-  configureFlags = "--without-initdir --disable-lynx";
+  configureFlags = [ "--without-initdir" "--disable-lynx" ];
 }

--- a/pkgs/tools/misc/most/default.nix
+++ b/pkgs/tools/misc/most/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
       -e "s|/bin/rm|rm|"
   '';
 
-  configureFlags = "--with-slang=${slang.dev}";
+  configureFlags = [ "--with-slang=${slang.dev}" ];
 
   buildInputs = [ slang ncurses ];
 

--- a/pkgs/tools/misc/urjtag/default.nix
+++ b/pkgs/tools/misc/urjtag/default.nix
@@ -21,12 +21,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ gettext autoconf automake libtool bison flex which
     subversion makeWrapper readline libftdi libusb python3 ];
 
-  configureFlags = ''
-    ${if svfSupport then "--enable-svf" else "--disable-svf"}
-    ${if bsdlSupport then "--enable-bsdl" else "--disable-bsdl"}
-    ${if staplSupport then "--enable-stapl" else "--disable-stapl"}
-    ${if jedecSupport then "--enable-jedec-exp" else "--disable-jedec-exp"}
-  '';
+  configureFlags = [
+    (stdenv.lib.enableFeature svfSupport   "svf")
+    (stdenv.lib.enableFeature bsdlSupport  "bsdl")
+    (stdenv.lib.enableFeature staplSupport "stapl")
+    (stdenv.lib.enableFeature jedecSupport "jedec-exp")
+  ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/tools/misc/xburst-tools/default.nix
+++ b/pkgs/tools/misc/xburst-tools/default.nix
@@ -18,9 +18,10 @@ stdenv.mkDerivation {
     sh autogen.sh
   '';
 
-  configureFlags = if gccCross != null then
-    "--enable-firmware CROSS_COMPILE=${gccCross.targetPrefix}"
-    else "";
+  configureFlags = stdenv.lib.optionals (gccCross != null) [
+    "--enable-firmware"
+    "CROSS_COMPILE=${gccCross.targetPrefix}"
+  ];
 
   hardeningDisable = [ "pic" "stackprotector" ];
 

--- a/pkgs/tools/networking/argus-clients/default.nix
+++ b/pkgs/tools/networking/argus-clients/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     done
     '';
 
-  configureFlags = "--with-perl=${perl}/bin/perl";
+  configureFlags = [ "--with-perl=${perl}/bin/perl" ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libpcap bison cyrus_sasl tcp_wrappers flex ];

--- a/pkgs/tools/networking/cadaver/default.nix
+++ b/pkgs/tools/networking/cadaver/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = "--with-ssl";
+  configureFlags = [ "--with-ssl" ];
 
   buildInputs = [ openssl ];
 

--- a/pkgs/tools/networking/infiniband-diags/default.nix
+++ b/pkgs/tools/networking/infiniband-diags/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  configureFlags = "--with-perl-installdir=\${out}/lib/perl5/site_perl --sbindir=\${out}/bin";
+  configureFlags = [ "--with-perl-installdir=\${out}/lib/perl5/site_perl" "--sbindir=\${out}/bin" ];
 
   postInstall = ''
     rmdir $out/var/run $out/var

--- a/pkgs/tools/networking/mtr/default.nix
+++ b/pkgs/tools/networking/mtr/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile.in --replace ' install-exec-hook' ""
   '';
 
-  configureFlags = stdenv.lib.optionalString (!withGtk) "--without-gtk";
+  configureFlags = stdenv.lib.optional (!withGtk) "--without-gtk";
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 

--- a/pkgs/tools/networking/p2p/amule/default.nix
+++ b/pkgs/tools/networking/p2p/amule/default.nix
@@ -8,10 +8,7 @@
 assert httpServer -> libpng != null;
 assert client -> libX11 != null;
 with stdenv;
-let
-  # Enable/Disable Feature
-  edf = enabled: flag: if enabled then "--enable-" + flag else "--disable-" + flag;
-in
+
 mkDerivation rec {
   name = "aMule-2.3.2";
 
@@ -27,15 +24,15 @@ mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  configureFlags = ''
-    --with-crypto-prefix=${cryptopp}
-    --disable-debug
-    --enable-optimize
-    ${edf monolithic "monolithic"}
-    ${edf daemon "amule-daemon"}
-    ${edf client "amule-gui"}
-    ${edf httpServer "webserver"}
-  '';
+  configureFlags = [
+    "--with-crypto-prefix=${cryptopp}"
+    "--disable-debug"
+    "--enable-optimize"
+    (stdenv.lib.enableFeature monolithic "monolithic")
+    (stdenv.lib.enableFeature daemon "amule-daemon")
+    (stdenv.lib.enableFeature client "amule-gui")
+    (stdenv.lib.enableFeature httpServer "webserver")
+  ];
 
   postConfigure = ''
     sed -i "src/libs/ec/file_generator.pl"     \

--- a/pkgs/tools/networking/reaver-wps/default.nix
+++ b/pkgs/tools/networking/reaver-wps/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     sourceRoot=$(echo */src)
   '';
 
-  configureFlags = "--sysconfdir=${confdir}";
+  configureFlags = [ "--sysconfdir=${confdir}" ];
 
   installPhase = ''
     mkdir -p $out/{bin,etc}

--- a/pkgs/tools/networking/ssmtp/default.nix
+++ b/pkgs/tools/networking/ssmtp/default.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation {
   # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858781
   patches = [ ./ssmtp_support_AuthPassFile_parameter.patch ];
 
-  configureFlags = "--sysconfdir=/etc ${if tlsSupport then "--enable-ssl" else ""}";
+  configureFlags = [
+    "--sysconfdir=/etc"
+    (stdenv.lib.enableFeature tlsSupport "ssl")
+  ];
 
   postConfigure =
     ''

--- a/pkgs/tools/networking/trickle/default.nix
+++ b/pkgs/tools/networking/trickle/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   LDFLAGS = "-levent";
 
-  configureFlags = "--with-libevent";
+  configureFlags = [ "--with-libevent" ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/tools/networking/vtun/default.nix
+++ b/pkgs/tools/networking/vtun/default.nix
@@ -20,10 +20,11 @@ stdenv.mkDerivation rec {
   '';
   buildInputs = [ lzo openssl zlib yacc flex ];
 
-  configureFlags = ''
-    --with-lzo-headers=${lzo}/include/lzo
-    --with-ssl-headers=${openssl.dev}/include/openssl
-    --with-blowfish-headers=${openssl.dev}/include/openssl'';
+  configureFlags = [
+    "--with-lzo-headers=${lzo}/include/lzo"
+    "--with-ssl-headers=${openssl.dev}/include/openssl"
+    "--with-blowfish-headers=${openssl.dev}/include/openssl"
+  ];
 
   meta = with stdenv.lib; {
       description = "Virtual Tunnels over TCP/IP with traffic shaping, compression and encryption";

--- a/pkgs/tools/networking/webalizer/default.nix
+++ b/pkgs/tools/networking/webalizer/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, zlib, libpng, gd, geoip, db}:
+{ stdenv, fetchurl, zlib, libpng, gd, geoip, db }:
 
 stdenv.mkDerivation {
   name = "webalizer-2.23-05";
@@ -16,7 +16,12 @@ stdenv.mkDerivation {
 
   buildInputs = [zlib libpng gd geoip db]; 
 
-  configureFlags = "--enable-dns --enable-geoip --disable-static --enable-shared";
+  configureFlags = [
+    "--enable-dns"
+    "--enable-geoip"
+    "--disable-static"
+    "--enable-shared"
+  ];
 
   meta = {
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -34,8 +34,9 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional (libpsl != null) libpsl
     ++ stdenv.lib.optional stdenv.isDarwin perl;
 
-  configureFlags =
-    if openssl != null then "--with-ssl=openssl" else "--without-ssl";
+  configureFlags = [ 
+    (stdenv.lib.withFeatureAs (openssl != null) "ssl" openssl)
+  ];
 
   doCheck = false;
 

--- a/pkgs/tools/security/fwknop/default.nix
+++ b/pkgs/tools/security/fwknop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, lib
+{ stdenv, fetchFromGitHub, autoreconfHook
 , libpcap, texinfo
 , iptables
 , gnupgSupport ? true, gnupg, gpgme # Increases dependencies!
@@ -23,21 +23,18 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional gnupgSupport [ gnupg gpgme.dev ]
     ++ stdenv.lib.optional wgetSupport [ wget ];
 
-  configureFlags = ''
-    --sysconfdir=/etc
-    --localstatedir=/run
-    --with-iptables=${iptables}/sbin/iptables
-    ${lib.optionalString (!buildServer) "--disable-server"}
-    ${lib.optionalString (!buildClient) "--disable-client"}
-    ${lib.optionalString gnupgSupport ''
-      --with-gpgme
-      --with-gpgme-prefix=${gpgme.dev}
-      --with-gpg=${gnupg}
-    ''}
-    ${lib.optionalString wgetSupport ''
-      --with-wget=${wget}/bin/wget
-    ''}
-  '';
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/run"
+    "--with-iptables=${iptables}/sbin/iptables"
+    (stdenv.lib.enableFeature buildServer "server")
+    (stdenv.lib.enableFeature buildClient "client")
+    (stdenv.lib.withFeatureAs wgetSupport wget "${wget}/bin/wget")
+  ] ++ stdenv.lib.optionalString gnupgSupport [
+    "--with-gpgme"
+    "--with-gpgme-prefix=${gpgme.dev}"
+    "--with-gpg=${gnupg}"
+  ];
 
   # Temporary hack to copy the example configuration files into the nix-store,
   # this'll probably be helpful until there's a NixOS module for that (feel free

--- a/pkgs/tools/security/modsecurity/default.nix
+++ b/pkgs/tools/security/modsecurity/default.nix
@@ -22,17 +22,17 @@ stdenv.mkDerivation rec {
   buildInputs = [  curl apacheHttpd pcre apr aprutil libxml2 ] ++
     optional luaSupport lua5;
 
-  configureFlags = ''
-    --enable-standalone-module
-    --enable-static
-    --with-curl=${curl.dev}
-    --with-apxs=${apacheHttpd.dev}/bin/apxs
-    --with-pcre=${pcre.dev}
-    --with-apr=${apr.dev}
-    --with-apu=${aprutil.dev}/bin/apu-1-config
-    --with-libxml=${libxml2.dev}
-    --with-lua=${luaValue}
-  '';
+  configureFlags = [
+    "--enable-standalone-module"
+    "--enable-static"
+    "--with-curl=${curl.dev}"
+    "--with-apxs=${apacheHttpd.dev}/bin/apxs"
+    "--with-pcre=${pcre.dev}"
+    "--with-apr=${apr.dev}"
+    "--with-apu=${aprutil.dev}/bin/apu-1-config"
+    "--with-libxml=${libxml2.dev}"
+    "--with-lua=${luaValue}"
+  ];
 
   outputs = ["out" "nginx"];
   # by default modsecurity's install script copies compiled output to httpd's modules folder

--- a/pkgs/tools/security/super/default.nix
+++ b/pkgs/tools/security/super/default.nix
@@ -24,7 +24,10 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-D_GNU_SOURCE";
 
-  configureFlags = "--sysconfdir=/etc --localstatedir=/var";
+  configureFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+  ];
 
   installFlags = "sysconfdir=$(out)/etc localstatedir=$(TMPDIR)";
 

--- a/pkgs/tools/security/yara/default.nix
+++ b/pkgs/tools/security/yara/default.nix
@@ -41,11 +41,11 @@ stdenv.mkDerivation rec {
 
   preConfigure = "./bootstrap.sh";
 
-  configureFlags = ""
-    + stdenv.lib.optionalString withCrypto "--with-crypto "
-    + stdenv.lib.optionalString enableMagic "--enable-magic "
-    + stdenv.lib.optionalString enableCuckoo "--enable-cuckoo "
-  ;
+  configureFlags = [
+    (stdenv.lib.withFeature withCrypto "crypto")
+    (stdenv.lib.enableFeature enableMagic "magic")
+    (stdenv.lib.enableFeature enableCuckoo "cuckoo")
+  ];
 
   meta = with stdenv.lib; {
     description = "The pattern matching swiss knife for malware researchers";

--- a/pkgs/tools/text/catdoc/default.nix
+++ b/pkgs/tools/text/catdoc/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = "--disable-wordview";
+  configureFlags = [ "--disable-wordview" ];
 
   meta = with stdenv.lib; {
     description = "MS-Word/Excel/PowerPoint to text converter";

--- a/pkgs/tools/typesetting/xmlroff/default.nix
+++ b/pkgs/tools/typesetting/xmlroff/default.nix
@@ -26,7 +26,10 @@ stdenv.mkDerivation rec {
 
   configureScript = "./autogen.sh";
 
-  configureFlags = "--disable-pangoxsl --disable-gp";
+  configureFlags = [
+    "--disable-pangoxsl"
+    "--disable-gp"
+  ];
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -109,7 +109,7 @@ let
   imagick = buildPecl {
     name = "imagick-3.4.3";
     sha256 = "0z2nc92xfc5axa9f2dy95rmsd2c81q8cs1pm4anh0a50x9g5ng0z";
-    configureFlags = "--with-imagick=${pkgs.imagemagick.dev}";
+    configureFlags = [ "--with-imagick=${pkgs.imagemagick.dev}" ];
     nativeBuildInputs = [ pkgs.pkgconfig ];
     buildInputs = [ pkgs.pcre ];
   };
@@ -120,7 +120,7 @@ let
 
     sha256 = "04c35rj0cvq5ygn2jgmyvqcb0k8d03v4k642b6i37zgv7x15pbic";
 
-    configureFlags = "--with-zlib-dir=${pkgs.zlib.dev}";
+    configureFlags = [ "--with-zlib-dir=${pkgs.zlib.dev}" ];
 
     makeFlags = [ "CFLAGS=-fgnu89-inline" ];
   };


### PR DESCRIPTION
###### Motivation for this change

I have one more commit to enforce this, but not sure whether that's appropriate for 18.09.

I also sprinkled in `{enable,with}Feature{,As}` to make some things more concise.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @aneeshusa 