### PR TITLE
smarty3: Init at 3.1.32

### DIFF
--- a/pkgs/development/libraries/smarty3/default.nix
+++ b/pkgs/development/libraries/smarty3/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
+  name = "smarty3-${version}";
+  version = "3.1.32";
+
+  src = fetchFromGitHub {
+    owner = "smarty-php";
+    repo = "smarty";
+    rev = "v${version}";
+    sha256 = "1rfa5pzr23db1bivpivljgmgpn99m6ksgli64kmii5cmpvxi00y2";
+  };
+
+  installPhase = ''
+    mkdir $out
+    cp -r libs/* $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Smarty 3 template engine";
+    longDescription = ''
+      Smarty is a template engine for PHP, facilitating the
+      separation of presentation (HTML/CSS) from application
+      logic. This implies that PHP code is application
+      logic, and is separated from the presentation.
+    '';
+    homepage = https://www.smarty.net;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5171,6 +5171,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;
   };
 
+  smarty3 = callPackage ../development/libraries/smarty3 { };
+
   smbldaptools = callPackage ../tools/networking/smbldaptools {
     inherit (perlPackages) perlldap CryptSmbHash DigestSHA1;
   };


### PR DESCRIPTION
###### Motivation for this change

I'm currently packaging [FusionDirectory](https://www.fusiondirectory.org/), and this is a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

