### PR TITLE
prototypejs: Init at 1.7.3.0

### DIFF
--- a/pkgs/development/libraries/prototypejs/default.nix
+++ b/pkgs/development/libraries/prototypejs/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, ... }:
+let
+  version = "1.7.3.0";
+in fetchurl {
+  name = "prototype-${version}.js";
+  url = "https://ajax.googleapis.com/ajax/libs/prototype/${version}/prototype.js";
+  sha256 = "0q43vvrsb22h4jvavs1gk3v4ps61yx9k85b5n6q9mxivhmxprg26";
+
+  meta = with stdenv.lib; {
+    description = "A foundation for ambitious web user interfaces";
+    longDescription = ''
+      Prototype takes the complexity out of client-side web
+      programming. Built to solve real-world problems, it adds
+      useful extensions to the browser scripting environment
+      and provides elegant APIs around the clumsy interfaces
+      of Ajax and the Document Object Model.
+    '';
+    homepage = http://prototypejs.org/;
+    downloadPage = http://prototypejs.org/download/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4684,6 +4684,8 @@ with pkgs;
 
   proot = callPackage ../tools/system/proot { };
 
+  prototypejs = callPackage ../development/libraries/prototypejs { };
+
   proxychains = callPackage ../tools/networking/proxychains { };
 
   proxytunnel = callPackage ../tools/misc/proxytunnel { };


### PR DESCRIPTION
###### Motivation for this change

I'm currently packaging [FusionDirectory](https://www.fusiondirectory.org/), and this is a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

