### PR TITLE
scriptaculous: Init at 1.9.0

### DIFF
--- a/pkgs/development/libraries/scriptaculous/default.nix
+++ b/pkgs/development/libraries/scriptaculous/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, unzip, ... }: stdenv.mkDerivation rec {
+  name = "scriptaculous-${version}";
+  version = "1.9.0";
+
+  src = fetchurl {
+    url = "https://script.aculo.us/dist/scriptaculous-js-${version}.zip";
+    sha256 = "1xpnk3cq8n07lxd69k5jxh48s21zh41ihq10z4a6lcnk238rp8qz";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    mkdir $out
+    cp src/*.js $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A set of JavaScript libraries to enhance the user interface of web sites";
+    longDescription = ''
+      script.aculo.us provides you with
+      easy-to-use, cross-browser user
+      interface JavaScript libraries to make
+      your web sites and web applications fly.
+    '';
+    homepage = https://script.aculo.us/;
+    downloadPage = https://script.aculo.us/dist/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5050,6 +5050,8 @@ with pkgs;
 
   scfbuild = python2.pkgs.callPackage ../tools/misc/scfbuild { };
 
+  scriptaculous = callPackage ../development/libraries/scriptaculous { };
+
   scrot = callPackage ../tools/graphics/scrot { };
 
   scrypt = callPackage ../tools/security/scrypt { };


### PR DESCRIPTION
###### Motivation for this change

I'm currently packaging [FusionDirectory](https://www.fusiondirectory.org/), and this is a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

