### PR TITLE
php*Packages.oci8: init at 2.1.8

### DIFF
--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -52,6 +52,9 @@ in stdenv.mkDerivation rec {
     install -Dm644 *.jar $out/share/java
     install -Dm644 sdk/include/* $out/include
     install -Dm644 sdk/demo/* $out/share/${name}/demo
+
+    # PECL::oci8 will not build without this
+    ln -s $out/lib/libclntsh.so.12.1 $out/lib/libclntsh.so
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -160,6 +160,13 @@ let
     buildInputs = with pkgs; [ cyrus_sasl zlib ];
   };
 
+  oci8 = buildPecl rec {
+    name = "oci8-2.1.8";
+    sha256 = "1bp6fss2f2qmd5bdk7x22j8vx5qivrdhz4x7csf29vjgj6gvchxy";
+    buildInputs = [ pkgs.re2c pkgs.oracle-instantclient ];
+    configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient}/lib" ];
+  };
+
   pcs = buildPecl rec {
     name = "pcs-1.3.3";
 


### PR DESCRIPTION
added the pecl oci8 library for php
had to make an adjustment to the oracle instantclient to make it compile

###### Motivation for this change
the php pecl oci8 library was missing from nixpkgs

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

