### PR TITLE
Add MATE to list of desktop managers in manual

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -26,6 +26,7 @@
 <xref linkend="opt-services.xserver.desktopManager.plasma5.enable"/> = true;
 <xref linkend="opt-services.xserver.desktopManager.xfce.enable"/> = true;
 <xref linkend="opt-services.xserver.desktopManager.gnome3.enable"/> = true;
+<xref linkend="opt-services.xserver.desktopManager.mate.enable"/> = true;
 <xref linkend="opt-services.xserver.windowManager.xmonad.enable"/> = true;
 <xref linkend="opt-services.xserver.windowManager.twm.enable"/> = true;
 <xref linkend="opt-services.xserver.windowManager.icewm.enable"/> = true;


### PR DESCRIPTION
###### Motivation for this change

NixOS supports the MATE desktop environment, per https://discourse.nixos.org/t/mate-desktop-environment/608.  But MATE is not in the manual's list of desktop managers.

###### Things done

Added MATE to the manual's list of desktop managers.

---

