### PR TITLE
android-simg2img: init at 1.1.3

### DIFF
--- a/pkgs/tools/filesystems/android-simg2img/default.nix
+++ b/pkgs/tools/filesystems/android-simg2img/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "android-simg2img-${version}";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "anestisb";
+    repo  = "android-simg2img";
+    rev   = "02777ee356ecc38efcd480f8da535755d598cc30";
+    sha256 = "119gl9i61g2wr07hzv6mi1ihql6yd6pwq94ki2pgcpfbamv8f6si";
+  };
+
+  buildInputs = [ zlib ];
+
+  installPhase = ''
+      PREFIX="$out" make install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool to convert Android sparse images to raw images";
+    longDescription = ''
+      Tool to convert Android sparse images to raw images.
+      Since image tools are not part of Android SDK, this standalone port of AOSP libsparse aims to avoid complex building chains.
+    '';
+    homepage = https://github.com/anestisb/android-simg2img;
+    license = licenses.asl20;
+    maintainers = [ maintainers.alexchapman ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -744,6 +744,8 @@ with pkgs;
 
   inherit (androidenv) androidndk;
 
+  android-simg2img = callPackage ../tools/filesystems/android-simg2img { };
+
   androidsdk = androidenv.androidsdk_8_0;
 
   androidsdk_extras = self.androidenv.androidsdk_8_0_extras;


### PR DESCRIPTION
###### Motivation for this change
I needed simg2img!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

