### PR TITLE
gnome3.gdm: fix session chooser (backport to 18.03)

### DIFF
--- a/pkgs/desktops/gnome-3/core/gdm/sessions_dir.patch
+++ b/pkgs/desktops/gnome-3/core/gdm/sessions_dir.patch
@@ -1,8 +1,17 @@
-diff --git a/daemon/gdm-session.c b/daemon/gdm-session.c
-index ff3a1acb..b8705d8f 100644
+--- a/daemon/gdm-launch-environment.c
++++ b/daemon/gdm-launch-environment.c
+@@ -126,7 +126,7 @@
+                 "LC_COLLATE", "LC_MONETARY", "LC_MESSAGES", "LC_PAPER",
+                 "LC_NAME", "LC_ADDRESS", "LC_TELEPHONE", "LC_MEASUREMENT",
+                 "LC_IDENTIFICATION", "LC_ALL", "WINDOWPATH", "XCURSOR_PATH",
+-                "XDG_CONFIG_DIRS", NULL
++                "XDG_CONFIG_DIRS", "GDM_SESSIONS_DIR", NULL
+         };
+         char *system_data_dirs;
+         int i;
 --- a/daemon/gdm-session.c
 +++ b/daemon/gdm-session.c
-@@ -344,6 +344,7 @@ get_system_session_dirs (GdmSession *self)
+@@ -345,12 +345,17 @@
          char **search_dirs;
  
          static const char *x_search_dirs[] = {
@@ -10,8 +19,7 @@ index ff3a1acb..b8705d8f 100644
                  "/etc/X11/sessions/",
                  DMCONFDIR "/Sessions/",
                  DATADIR "/gdm/BuiltInSessions/",
-@@ -351,6 +352,10 @@ get_system_session_dirs (GdmSession *self)
-                 NULL
+                 DATADIR "/xsessions/",
          };
  
 +        if (getenv("GDM_SESSIONS_DIR") != NULL) {
@@ -21,3 +29,24 @@ index ff3a1acb..b8705d8f 100644
          static const char *wayland_search_dir = DATADIR "/wayland-sessions/";
  
          search_array = g_array_new (TRUE, TRUE, sizeof (char *));
+--- a/libgdm/gdm-sessions.c
++++ b/libgdm/gdm-sessions.c
+@@ -217,6 +217,7 @@
+ {
+         int         i;
+         const char *xorg_search_dirs[] = {
++                "/var/empty/",
+                 "/etc/X11/sessions/",
+                 DMCONFDIR "/Sessions/",
+                 DATADIR "/gdm/BuiltInSessions/",
+@@ -224,6 +225,10 @@
+                 NULL
+         };
+ 
++        if (g_getenv("GDM_SESSIONS_DIR") != NULL) {
++                xorg_search_dirs[0] = g_getenv("GDM_SESSIONS_DIR");
++        };
++
+ #ifdef ENABLE_WAYLAND_SUPPORT
+         const char *wayland_search_dirs[] = {
+                 DATADIR "/wayland-sessions/",


### PR DESCRIPTION
###### Motivation for this change

Backport to 18.03 of fix in 300af6677760944a3c27f7bf33a1366c380c3317 for #34101.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

