### PR TITLE
squashfuse : unstable-2018-02-20 -> 0.1.103

### DIFF
--- a/pkgs/tools/filesystems/squashfuse/default.nix
+++ b/pkgs/tools/filesystems/squashfuse/default.nix
@@ -6,7 +6,7 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   pname = "squashfuse";
-  version = "unstable-2018-02-20";
+  version = "0.1.103";
   name = "${pname}-${version}";
 
   meta = {
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "vasi";
     repo  = "${pname}";
-    rev = "3f4a93f373796e88f7eee3a0c005ef60cb395d30";
+    rev = "540204955134eee44201d50132a5f66a246bcfaf";
     sha256 = "07jv4qjjz9ky3mw3p5prgs19g1bna9dcd7jjdz8083s1wyipdgcq";
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

