### PR TITLE
rtl_433: 2018-02-23 -> 18.05

### DIFF
--- a/pkgs/applications/misc/rtl_433/default.nix
+++ b/pkgs/applications/misc/rtl_433/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1, rtl-sdr }:
 stdenv.mkDerivation rec {
 
-  version = "2018-02-23";
+  version = "18.05";
   name = "rtl_433-${version}";
 
   src = fetchFromGitHub {
     owner = "merbanan";
     repo = "rtl_433";
-    rev = "51d275c";
-    sha256 = "1j443wmws5xgc18s47bvw3pqljk747izypz52rmlrvs16v96cg2g";
+    rev = "18.05";
+    sha256 = "0vfhnjyrx6w1m8g1hww5vdz4zgdlhcaps9g0397mxlki4sm77wpc";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update from a Feb.18 git-rev to a release 18.05

CC @earldouglas 

###### Things done
Tested with a RTL-SDR USB stick.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

