### PR TITLE
caprice32: unstable-2018-02-10 -> unstable-2018-03-05

### DIFF
--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -3,14 +3,14 @@
 stdenv.mkDerivation rec {
 
   repo = "caprice32";
-  version = "unstable-2018-02-10";
-  rev = "53de69543300f81af85df32cbd21bb5c68cab61e";
+  version = "unstable-2018-03-05";
+  rev = "317fe638111e245d67e301f6f295094d3c859a70";
   name = "${repo}-${version}";
 
   src = fetchFromGitHub {
     inherit rev repo;
     owner = "ColinPitrat";
-    sha256 = "12yv56blm49qmshpk4mgc802bs51wv2ra87hmcbf2wxma39c45fy";
+    sha256 = "1bywpmkizixcnr057k8zq9nlw0zhcmwkiriln0krgdcm7d3h9b86";
   };
 
   postPatch = "substituteInPlace cap32.cfg --replace /usr/local $out";


### PR DESCRIPTION
###### Motivation for this change

fix memory leak.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

