### PR TITLE
shotcut: 18.06.02 -> 18.08

### DIFF
--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchFromGitHub, SDL2, frei0r, gettext, mlt, jack1, pkgconfig, qtbase
 , qtmultimedia, qtwebkit, qtx11extras, qtwebsockets, qtquickcontrols
 , qtgraphicaleffects, libmlt
-, qmake, makeWrapper, fetchpatch, qttools }:
+, qmake, makeWrapper, qttools }:
 
 assert stdenv.lib.versionAtLeast libmlt.version "6.8.0";
 assert stdenv.lib.versionAtLeast mlt.version "6.8.0";
 
 stdenv.mkDerivation rec {
   name = "shotcut-${version}";
-  version = "18.06.02";
+  version = "18.08";
 
   src = fetchFromGitHub {
     owner = "mltframework";
     repo = "shotcut";
     rev = "v${version}";
-    sha256 = "1pqpgsb8ix1akq326chf46vvl5h02dwmdskskf2n6impygsy4x7v";
+    sha256 = "1p2s4avm3bl5ippmgfzkkbb2w0xs4vhk2wbcd22g7bh1zq9w190n";
   };
 
   enableParallelBuilding = true;
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   ];
 
   NIX_CFLAGS_COMPILE = "-I${libmlt}/include/mlt++ -I${libmlt}/include/mlt";
-  qmakeFlags = [ "QMAKE_LRELEASE=${stdenv.lib.getDev qttools}/bin/lrelease" ];
+  qmakeFlags = [ "QMAKE_LRELEASE=${stdenv.lib.getDev qttools}/bin/lrelease" "SHOTCUT_VERSION=${version}" ];
 
   prePatch = ''
     sed 's_shotcutPath, "qmelt"_"${mlt}/bin/melt"_' -i src/jobs/meltjob.cpp
@@ -34,12 +34,6 @@ stdenv.mkDerivation rec {
     NICE=$(type -P nice)
     sed "s_/usr/bin/nice_''${NICE}_" -i src/jobs/meltjob.cpp src/jobs/ffmpegjob.cpp
   '';
-
-  patches = [ (fetchpatch {
-    url = https://github.com/mltframework/shotcut/commit/f304b7403cc7beb57b1610afd9c5c8173749e80b.patch;
-    name = "qt511.patch";
-    sha256 = "1ynvyjchcb33a33x4w1ddnah2gyzmnm125ailgg6xy60lqsnsmp9";
-    } ) ];
 
   postInstall = ''
     mkdir -p $out/share/shotcut


### PR DESCRIPTION
and fix SHOTCUT_VERSION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

