### PR TITLE
exiv2: include recent Debian security patches

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch, zlib, expat, gettext }:
+{ stdenv, fetchurl, fetchpatch, runCommand, zlib, expat, gettext }:
 
 stdenv.mkDerivation rec {
   name = "exiv2-0.26";
@@ -17,13 +17,31 @@ stdenv.mkDerivation rec {
       sha512 = "3f9242dbd4bfa9dcdf8c9820243b13dc14990373a800c4ebb6cf7eac5653cfef"
              + "e6f2c47a94fbee4ed24f0d8c2842729d721f6100a2b215e0f663c89bfefe9e32";
      })
-     (fetchpatch {
-       # many CVEs - see https://github.com/Exiv2/exiv2/pull/120
-       url = "https://patch-diff.githubusercontent.com/raw/Exiv2/exiv2/pull/120.patch";
-       sha256 = "1szl22xmh12hibzaqf2zi8zl377x841m52x4jm5lziw6j8g81sj8";
-       excludes = [ "test/bugfixes-test.sh" ];
-     })
-  ];
+    (fetchpatch {
+      # many CVEs - see https://github.com/Exiv2/exiv2/pull/120
+      url = "https://patch-diff.githubusercontent.com/raw/Exiv2/exiv2/pull/120.patch";
+      sha256 = "1szl22xmh12hibzaqf2zi8zl377x841m52x4jm5lziw6j8g81sj8";
+      excludes = [ "test/bugfixes-test.sh" ];
+    })
+  ] ++
+  (let
+    debian = fetchurl {
+      url = http://http.debian.net/debian/pool/main/e/exiv2/exiv2_0.25-4.debian.tar.xz;
+      sha256 = "0dp9y0d8pbsys5r4j1xyhn5liv6x0p4gncf90bcgnsp5shipzsr1";
+    };
+    patches = runCommand "exiv2-debian-patches" {} ''
+      mkdir $out
+      tar xf ${debian} -C $out --strip-components=2 debian/patches
+    '';
+  in [
+    "${patches}/CVE-2018-10998.patch"
+    "${patches}/CVE-2018-11531_1_of_3.patch"
+    "${patches}/CVE-2018-11531_2_of_3.patch"
+    "${patches}/CVE-2018-11531_3_of_3.patch"
+    "${patches}/CVE-2018-12264.patch"
+    "${patches}/CVE-2018-12265_prereq.patch"
+    "${patches}/CVE-2018-12265.patch"
+  ]);
 
   postPatch = "patchShebangs ./src/svn_version.sh";
 
@@ -32,9 +50,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gettext ];
   propagatedBuildInputs = [ zlib expat ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.exiv2.org/;
     description = "A library and command-line utility to manage image metadata";
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
+    license = licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This patchset contains patches against:

* CVE-2018-10998
* CVE-2018-11531
* CVE-2018-12264
* CVE-2018-12265

Also adding GPL2 license.

Re #44457 (vulnerability roundup 46 - master)
Re #43716 (add missing licenses)

Please cherry pick to 18.03 if build on master is successful.

Re #44458 (vulnerability roundup 46 - 18.03)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions: Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of some pkgs that depend on this change: `darktable`, `digikam`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): 34613256 -> 34613688
- [x] Fits CONTRIBUTING.md

