### PR TITLE
exiv2: bugfix updates

### DIFF
--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -46,9 +46,10 @@ stdenv.mkDerivation rec {
   ];
   propagatedBuildInputs = [ zlib expat ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.exiv2.org/;
     description = "A library and command-line utility to manage image metadata";
-    platforms = stdenv.lib.platforms.all;
+    platforms = platforms.all;
+    license = licenses.gpl2;
   };
 }

--- a/pkgs/development/libraries/exiv2/default.nix
+++ b/pkgs/development/libraries/exiv2/default.nix
@@ -1,11 +1,15 @@
-{ stdenv, fetchurl, fetchpatch, zlib, expat, gettext }:
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, zlib, expat, gettext
+, autoconf }:
 
 stdenv.mkDerivation rec {
-  name = "exiv2-0.26";
+  name = "exiv2-0.26.2018.06.09";
 
-  src = fetchurl {
-    url = "http://www.exiv2.org/builds/${name}-trunk.tar.gz";
-    sha256 = "1yza317qxd8yshvqnay164imm0ks7cvij8y8j86p1gqi1153qpn7";
+    #url = "http://www.exiv2.org/builds/${name}-trunk.tar.gz";
+  src = fetchFromGitHub rec {
+    owner = "exiv2";
+    repo  = "exiv2";
+    rev = "4aa57ad";
+    sha256 = "1kblpxbi4wlb0l57xmr7g23zn9adjmfswhs6kcwmd7skwi2yivcd";
   };
 
   patches = [
@@ -16,20 +20,30 @@ stdenv.mkDerivation rec {
           + "/sha512/${sha512}/${patchname}";
       sha512 = "3f9242dbd4bfa9dcdf8c9820243b13dc14990373a800c4ebb6cf7eac5653cfef"
              + "e6f2c47a94fbee4ed24f0d8c2842729d721f6100a2b215e0f663c89bfefe9e32";
-     })
-     (fetchpatch {
-       # many CVEs - see https://github.com/Exiv2/exiv2/pull/120
-       url = "https://patch-diff.githubusercontent.com/raw/Exiv2/exiv2/pull/120.patch";
-       sha256 = "1szl22xmh12hibzaqf2zi8zl377x841m52x4jm5lziw6j8g81sj8";
-       excludes = [ "test/bugfixes-test.sh" ];
-     })
+    })
+    # Two backports from master, submitted as https://github.com/Exiv2/exiv2/pull/398
+    (fetchpatch {
+      name = "CVE-2018-12264.diff";
+      url = "https://github.com/vcunat/exiv2/commit/fd18e853.diff";
+      sha256 = "0y7ahh45lpaiazjnfllndfaa5pyixh6z4kcn2ywp7qy4ra7qpwdr";
+    })
+    (fetchpatch {
+      name = "CVE-2018-12265.diff";
+      url = "https://github.com/vcunat/exiv2/commit/9ed1671bd4.diff";
+      sha256 = "1cn446pfcgsh1bn9vxikkkcy1cqq7ghz2w291h1094ydqg6w7q6w";
+    })
   ];
 
   postPatch = "patchShebangs ./src/svn_version.sh";
 
+  preConfigure = "make config"; # needed because not using tarball
+
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ gettext ];
+  nativeBuildInputs = [
+    gettext
+    autoconf # needed because not using tarball
+  ];
   propagatedBuildInputs = [ zlib expat ];
 
   meta = {


### PR DESCRIPTION
- use upstream branch with backports
- backport two fixes missing from it yet

###### Motivation for this change
I wasn't aware of work #44464 and took a different approach.  I'm not too sure which is better, so let me open another PR at least for reference :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] negligible impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

