### PR TITLE
Nginx modules

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -233,6 +233,15 @@
     };
   };
 
+  sysguard = {
+    src = fetchFromGitHub {
+      owner = "vozlt";
+      repo = "nginx-module-sysguard";
+      rev = "e512897f5aba4f79ccaeeebb51138f1704a58608";
+      sha256 = "19c6w6wscbq9phnx7vzbdf4ay6p2ys0g7kp2rmc9d4fb53phrhfx";
+    };
+  };
+
   upstream-check = {
     src = fetchFromGitHub {
       owner = "yaoweibin";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -94,6 +94,16 @@
     '';
   };
 
+  lua-upstream = {
+    src = fetchFromGitHub {
+      owner = "openresty";
+      repo = "lua-upstream-nginx-module";
+      rev = "v0.07";
+      sha256 = "1gqccg8airli3i9103zv1zfwbjm27h235qjabfbfqk503rjamkpk";
+    };
+    inputs = [ pkgs.luajit ];
+  };
+
   modsecurity = {
     src = "${pkgs.modsecurity_standalone.nginx}/nginx/modsecurity";
     inputs = [ pkgs.curl pkgs.apr pkgs.aprutil pkgs.apacheHttpd pkgs.yajl ];

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -215,6 +215,15 @@
     };
   };
 
+  sts = {
+    src = fetchFromGitHub {
+      owner = "vozlt";
+      repo = "nginx-module-sts";
+      rev = "v0.1.1";
+      sha256 = "0nvb29641x1i7mdbydcny4qwlvdpws38xscxirajd2x7nnfdflrk";
+    };
+  };
+
   upstream-check = {
     src = fetchFromGitHub {
       owner = "yaoweibin";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -261,6 +261,15 @@
     inputs = [ pkgs.msgpuck.dev pkgs.yajl ];
   };
 
+  url = {
+    src = fetchFromGitHub {
+      owner = "vozlt";
+      repo = "nginx-module-url";
+      rev = "9299816ca6bc395625c3683fbd2aa7b916bfe91e";
+      sha256 = "0mk1gjmfnry6hgdsnlavww9bn7223idw50jlkhh5k00q5509w4ip";
+    };
+  };
+
   vts = {
     src = fetchFromGitHub {
       owner = "vozlt";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -215,6 +215,15 @@
     };
   };
 
+  stream-sts = {
+    src = fetchFromGitHub {
+      owner = "vozlt";
+      repo = "nginx-module-stream-sts";
+      rev = "v0.1.1";
+      sha256 = "1jdj1kik6l3rl9nyx61xkqk7hmqbncy0rrqjz3dmjqsz92y8zaya";
+    };
+  };
+
   sts = {
     src = fetchFromGitHub {
       owner = "vozlt";


### PR DESCRIPTION
###### Motivation for this change
Add nginx modules - sts, stream-sts, sysguard, url and lua-upstream. Module lua-upstream need module lua.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

