### PR TITLE
Use LLVM 6 with llvm-hs, don't run tests on Darwin.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -264,11 +264,13 @@ self: super: builtins.intersectAttrs super {
       }
     );
 
-  llvm-hs = super.llvm-hs.override { llvm-config = pkgs.llvm; };
-  llvm-hs_6_3_0 = super.llvm-hs_6_3_0.override {
-    llvm-config = pkgs.llvm_6;
-    llvm-hs-pure = super.llvm-hs-pure_6_2_1;
-  };
+  llvm-hs =
+      let dontCheckDarwin = if pkgs.stdenv.isDarwin
+                            then dontCheck
+                            else pkgs.lib.id;
+      in dontCheckDarwin (super.llvm-hs.override {
+        llvm-config = pkgs.llvm_6;
+      });
 
   # Needs help finding LLVM.
   spaceprobe = addBuildTool super.spaceprobe self.llvmPackages.llvm;


### PR DESCRIPTION
###### Motivation for this change

Fixes llvm-hs.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
