### PR TITLE
simp_le: use python3Packages

### DIFF
--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -12,7 +12,9 @@ let
         '';
       });
 
-      pythonPackages = (super.python.override {
+      # Override certifi so that it accepts fake certificate for Let's Encrypt
+      # Need to override the attribute used by simp_le, which is python3Packages
+      python3Packages = (super.python3.override {
         packageOverrides = lib.const (pysuper: {
           certifi = pysuper.certifi.overridePythonAttrs (attrs: {
             postPatch = (attrs.postPatch or "") + ''

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, pythonPackages, bash }:
+{ stdenv, python3Packages, bash }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "simp_le-client";
   version = "0.9.0";
 
-  src = pythonPackages.fetchPypi {
+  src = python3Packages.fetchPypi {
     inherit pname version;
     sha256 = "1yxfznd78zkg2f657v520zj5w4dvq5n594d0kpm4lra8xnpg4zcv";
   };
@@ -22,7 +22,7 @@ pythonPackages.buildPythonApplication rec {
     $out/bin/simp_le --test
   '';
 
-  propagatedBuildInputs = with pythonPackages; [ acme setuptools_scm josepy idna ];
+  propagatedBuildInputs = with python3Packages; [ acme setuptools_scm josepy idna ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/zenhack/simp_le;


### PR DESCRIPTION
###### Motivation for this change
#18185 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

