### PR TITLE
antibody: 3.5.1 -> 3.6.1

### DIFF
--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -2,16 +2,16 @@
 
 buildGoPackage rec {
   name = "antibody-${version}";
-  version = "3.5.1";
+  version = "3.6.1";
   rev = "v${version}";
-  
+
   goPackagePath = "github.com/getantibody/antibody";
 
   src = fetchFromGitHub {
     inherit rev;
     owner  = "getantibody";
     repo   = "antibody";
-    sha256 = "0bqq59vnnm80jiqlhn7wfyzj96nkv8k9zp8i4sgcj8gvk1zq2lbc";
+    sha256 = "1xlaf3440hs1ffa23ja0fc185sj0rxjv0808ib8li3rq2qfkd0k8";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

