### PR TITLE
haskell: re-enable aarch64, disable parallel builds on that arch.

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -169,6 +169,5 @@ stdenv.mkDerivation rec {
   };
 
   meta.license = stdenv.lib.licenses.bsd3;
-  # AArch64 should work in theory but eventually some builds start segfaulting
-  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin" "armv7l-linux" /* "aarch64-linux" */];
+  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin" "armv7l-linux" "aarch64-linux"];
 }

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -87,7 +87,8 @@ stdenv.mkDerivation rec {
     sha256 = "1z05vkpaj54xdypmaml50hgsdpw29dhbs2r7magx0cm199iw73mv";
   };
 
-  enableParallelBuilding = true;
+  # https://ghc.haskell.org/trac/ghc/ticket/15449
+  enableParallelBuilding = !buildPlatform.isAarch64;
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -85,7 +85,8 @@ stdenv.mkDerivation (rec {
     sha256 = "1mk046vb561j75saz05rghhbkps46ym5aci4264dwc2qk3dayixf";
   };
 
-  enableParallelBuilding = true;
+  # https://ghc.haskell.org/trac/ghc/ticket/15449
+  enableParallelBuilding = !buildPlatform.isAarch64;
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -85,7 +85,8 @@ stdenv.mkDerivation (rec {
     sha256 = "1jrkqrqdv2z9i9s1xaxhci34c9rjvlgr40y34bxsfj0hj1r28409";
   };
 
-  enableParallelBuilding = true;
+  # https://ghc.haskell.org/trac/ghc/ticket/15449
+  enableParallelBuilding = !buildPlatform.isAarch64;
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -117,7 +117,9 @@ let
   # We cannot enable -j<n> parallelism for libraries because GHC is far more
   # likely to generate a non-determistic library ID in that case. Further
   # details are at <https://github.com/peti/ghc-library-id-bug>.
-  enableParallelBuilding = (versionOlder "7.8" ghc.version && !hasActiveLibrary) || versionOlder "8.0.1" ghc.version;
+  #
+  # Currently disabled for aarch64. See https://ghc.haskell.org/trac/ghc/ticket/15449.
+  enableParallelBuilding = ((versionOlder "7.8" ghc.version && !hasActiveLibrary) || versionOlder "8.0.1" ghc.version) && !(buildPlatform.isAarch64);
 
   crossCabalFlags = [
     "--with-ghc=${ghc.targetPrefix}ghc"


### PR DESCRIPTION
Attempt to work around unreliable Haskell builds on `aarch64`. See
https://ghc.haskell.org/trac/ghc/ticket/15449

###### Motivation for this change

`ghc843` builds fine on `aarch64-linux` if you disable parallel builds, and the resulting binary is also capable of building many Haskell packages without issues (again, *if* parallel builds are disabled).

The only drawback to this fix is that `ghc` itself takes a *very* long time to build (~24h on my Jetson TX1).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

