### PR TITLE
idrisPackages: add quantities library

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1689,6 +1689,11 @@
     github = "imalsogreg";
     name = "Greg Hale";
   };
+  imuli = {
+    email = "i@imu.li";
+    github = "imuli";
+    name = "Imuli";
+  };
   infinisil = {
     email = "infinisil@icloud.com";
     github = "infinisil";

--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -153,6 +153,8 @@
 
     protobuf = callPackage ./protobuf.nix {};
 
+    quantities = callPackage ./quantities.nix {};
+
     rationals = callPackage ./rationals.nix {};
 
     recursion_schemes = callPackage ./recursion_schemes.nix {};

--- a/pkgs/development/idris-modules/quantities.nix
+++ b/pkgs/development/idris-modules/quantities.nix
@@ -1,0 +1,22 @@
+{ build-idris-package
+, fetchFromGitHub
+, lib
+}:
+build-idris-package  {
+  name = "quantities";
+  version = "2018-04-17";
+
+  src = fetchFromGitHub {
+    owner = "timjb";
+    repo = "quantities";
+    rev = "76bb872bd89122043083351993140ae26eb91ead";
+    sha256 = "0fv12kdi9089b4kkr6inhqvs2s8x62nv5vqj76wzk8hy0lrzylzj";
+  };
+
+  meta = {
+    description = "Type-safe physical computations and unit conversions in Idris";
+    homepage = https://github.com/timjb/quantities;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ imuli ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

I was surprised it was not present amongst the other Idris packages.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
