### PR TITLE
openshift: 3.9.0 -> 3.10.0

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -9,15 +9,17 @@
 with lib;
 
 let
-  version = "3.9.0";
+  version = "3.10.0";
   ver = stdenv.lib.elemAt (stdenv.lib.splitString "." version);
   versionMajor = ver 0;
   versionMinor = ver 1;
   versionPatch = ver 2;
-  gitCommit = "191fece";
+  gitCommit = "dd10d17";
   # version is in vendor/k8s.io/kubernetes/pkg/version/base.go
-  k8sversion = "v1.9.1";
-  k8sgitcommit = "a0ce1bc657";
+  k8sversion = "v1.10.0";
+  k8sgitcommit = "b81c8f8";
+  k8sgitMajor = "0";
+  k8sgitMinor = "1";
 in stdenv.mkDerivation rec {
   name = "openshift-origin-${version}";
   inherit version;
@@ -26,7 +28,7 @@ in stdenv.mkDerivation rec {
     owner = "openshift";
     repo = "origin";
     rev = "v${version}";
-    sha256 = "06k0zilfyvll7z34yirraslgpwgah9k6y5i6wgi7f00a79k76k78";
+    sha256 = "13aglz005jl48z17vnggkvr39l5h6jcqgkfyvkaz4c3jakms1hi9";
 };
 
   # go > 1.10
@@ -38,15 +40,15 @@ in stdenv.mkDerivation rec {
   patchPhase = ''
     patchShebangs ./hack
 
-    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+    substituteInPlace pkg/oc/clusterup/docker/host/host.go  \
       --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt findmnt' \
       'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/findmnt'
 
-    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+    substituteInPlace pkg/oc/clusterup/docker/host/host.go  \
       --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mount' \
       'nsenter --mount=/rootfs/proc/1/ns/mnt ${utillinux}/bin/mount'
 
-    substituteInPlace pkg/oc/bootstrap/docker/host/host.go  \
+    substituteInPlace pkg/oc/clusterup/docker/host/host.go  \
       --replace 'nsenter --mount=/rootfs/proc/1/ns/mnt mkdir' \
       'nsenter --mount=/rootfs/proc/1/ns/mnt ${coreutils}/bin/mkdir'
   '';
@@ -61,6 +63,8 @@ in stdenv.mkDerivation rec {
     echo "OS_GIT_COMMIT=${gitCommit}" >> os-version-defs
     echo "KUBE_GIT_VERSION=${k8sversion}" >> os-version-defs
     echo "KUBE_GIT_COMMIT=${k8sgitcommit}" >> os-version-defs
+    echo "KUBE_GIT_MAJOR=${k8sgitMajor}" >> os-version-defs
+    echo "KUBE_GIT_MINOR=${k8sgitMinor}" >> os-version-defs
     export OS_VERSION_FILE="os-version-defs"
     export CC=clang
     make all WHAT='${concatStringsSep " " components}'


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

