### PR TITLE
pmdk: init at 1.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4577,4 +4577,9 @@
     github = "zzamboni";
     name = "Diego Zamboni";
   };
+  barakb = {
+    email = "barak.bar@gmail.com";
+    github =  "barakb";
+    name = "Barak Bar Orion";
+  };
 }

--- a/pkgs/development/libraries/pmdk/default.nix
+++ b/pkgs/development/libraries/pmdk/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoconf, automake, doxygen, graphviz, pandoc
+}:
+
+stdenv.mkDerivation rec {
+       version = "1.4.1"; 
+       name="pmdk-${version}";
+       src = fetchFromGitHub {
+           owner = "pmem";
+           repo = "pmdk";
+           rev = version;
+           sha256 = "0ylif2ws1zz5dcfgidmm7nyhmvshclcas22gyx7zhyrkq2zs5npc";
+       };
+
+       nativeBuildInputs = [
+          pkgconfig
+          autoconf
+          automake
+          doxygen
+          graphviz
+          pandoc
+       ];
+       
+       buildFlags = [ "EXTRA_CFLAGS=-Wno-error" ];
+
+       preBuild = ''
+            substituteInPlace Makefile --replace /usr /
+            makeFlagsArray=(INSTALL=install prefix=$out)
+           '';
+
+       meta = {
+            description = "Persistent memory programming";
+            homepage = https://pmem.io/pmdk;
+            license = licenses.bsd3;
+            platforms = platforms.unix;
+            maintainers = [ maintainers.barakb ];
+	    };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22179,4 +22179,7 @@ with pkgs;
   powershell = callPackage ../shells/powershell { };
 
   doing = callPackage ../applications/misc/doing  { };
+  
+  pmdk = callPackage ../development/libraries/pmdk { };
+
 }


### PR DESCRIPTION
pmdk is a persistent Memory Development Kit

###### Motivation for this change
PMDK package is missing from Nix repostitory

###### Things done
Add Nix package that fetch PMDK from git and build it.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [x ] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

