### PR TITLE
haproxy: 1.8.9 -> 1.8.13

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -1,6 +1,6 @@
 { useLua ? !stdenv.isDarwin
 , usePcre ? true
-, stdenv, fetchurl, fetchpatch
+, stdenv, fetchurl
 , openssl, zlib, lua5_3 ? null, pcre ? null
 }:
 
@@ -9,25 +9,13 @@ assert usePcre -> pcre != null;
 
 stdenv.mkDerivation rec {
   pname = "haproxy";
-  version = "1.8.9";
+  version = "1.8.13";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://www.haproxy.org/download/${stdenv.lib.versions.majorMinor version}/src/${name}.tar.gz";
-    sha256 = "00miblgwll3mycsgmp3gd3cn4lwsagxzgjxk5i6csnyqgj97fss3";
+    sha256 = "2bf5dafbb5f1530c0e67ab63666565de948591f8e0ee2a1d3c84c45e738220f1";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2018-11469.patch";
-      url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=17514045e5d934dede62116216c1b016fe23dd06";
-      sha256 = "0hzcvghg8qz45n3mrcgsjgvrvicvbvm52cc4hs5jbk1yb50qvls7";
-    })
-  ] ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
-    name = "fix-darwin-no-threads-build.patch";
-    url = "https://git.haproxy.org/?p=haproxy-1.8.git;a=patch;h=fbf09c441a4e72c4a690bc7ef25d3374767fe5c5;hp=3157ef219c493f3b01192f1b809a086a5b119a1e";
-    sha256 = "16ckzb160anf7xih7mmqy59pfz8sdywmyblxnr7lz9xix3jwk55r";
-  });
 
   buildInputs = [ openssl zlib ]
     ++ stdenv.lib.optional useLua lua5_3


### PR DESCRIPTION
The patches previously applied have been included upstream. Upstream
changelog (only MAJOR/MEDIUM):

2018/07/30 : 1.8.13
    - BUG/MEDIUM: h2: don't accept new streams if conn_streams are still in excess
    - BUG/MEDIUM: h2: never leave pending data in the output buffer on close
    - BUG/MEDIUM: h2: make sure the last stream closes the connection after a timeout
    - BUG/MEDIUM: threads: Fix the exit condition of the thread barrier
    - BUG/MEDIUM: stream-int: don't immediately enable reading when the buffer was reportedly full
    - BUG/MEDIUM: stats: don't ask for more data as long as we're responding
    - BUG/MEDIUM: threads/sync: use sched_yield when available
    - BUG/MEDIUM: h2: prevent orphaned streams from blocking a connection forever
    - BUG/MEDIUM: threads: properly fix nbthreads == MAX_THREADS
    - BUG/MEDIUM: threads: unbreak "bind" referencing an incorrect thread number
    - MEDIUM: proxy_protocol: Convert IPs to v6 when protocols are mixed

2018/06/27 : 1.8.12
    - BUG/MAJOR: stick_table: Complete incomplete SEGV fix

2018/06/26 : 1.8.11
    - BUG/MAJOR: Stick-tables crash with segfault when the key is not in the stick-table

2018/06/22 : 1.8.10
    - BUG/MEDIUM: spoe: Flags are not encoded in network order
    - BUG/MEDIUM: contrib/mod_defender: Use network order to encode/decode flags
    - BUG/MEDIUM: contrib/modsecurity: Use network order to encode/decode flags
    - BUG/MEDIUM: cache: don't cache when an Authorization header is present
    - BUG/MEDIUM: dns: Delay the attempt to run a DNS resolution on check failure.
    - BUG/MEDIUM: fd: Only check update_mask against all_threads_mask.
    - BUG/MEDIUM: servers: Add srv_addr default placeholder to the state file
    - BUG/MEDIUM: lua/socket: Length required read doesn't work
    - BUG/MEDIUM: stick-tables: Decrement ref_cnt in table_* converters
    - BUG/MEDIUM: spoe: Return an error when the wrong ACK is received in sync mode
    - BUG/MEDIUM: lua/socket: wrong scheduling for sockets
    - BUG/MAJOR: lua: Dead lock with sockets
    - BUG/MEDIUM: lua/socket: Notification error
    - BUG/MEDIUM: lua/socket: Sheduling error on write: may dead-lock
    - BUG/MEDIUM: lua/socket: Buffer error, may segfault
    - MAJOR: spoe: upgrade the SPOP version to 2.0 and remove the support for 1.0
    - BUG/MEDIUM: threads: handle signal queue only in thread 0
    - BUG/MAJOR: map: fix a segfault when using http-request set-map
    - BUG/MAJOR: ssl: Random crash with cipherlist capture
    - BUG/MAJOR: ssl: OpenSSL context is stored in non-reserved memory slot
    - BUG/MEDIUM: fd: Don't modify the update_mask in fd_dodelete().
    - BUG/MEDIUM: threads: Use the sync point to check active jobs and exit

###### Motivation for this change

New stable upstream version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

