### PR TITLE
oxipng: 1.0.1 -> 2.1.0

### DIFF
--- a/pkgs/tools/graphics/oxipng/default.nix
+++ b/pkgs/tools/graphics/oxipng/default.nix
@@ -1,22 +1,26 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  version = "1.0.1";
+  version = "2.1.0";
   name = "oxipng-${version}";
 
   src = fetchFromGitHub {
     owner = "shssoichiro";
     repo = "oxipng";
     rev = "v${version}";
-    sha256 = "0w39f0dhq9cxk25vy0wh8vicxyckvj1vmglx5va4550i3q0hsrws";
+    sha256 = "13rzkfb025y4i9dj66fgc74whgs90gyw861dccsj16cpfl6kh5z0";
   };
 
-  cargoSha256 = "00nbx6n73yl4ax05pqkmim1vhy0pymgz5la1cc4y18gjbjjj9w4h";
+  cargoSha256 = "0l6ad8rnifd5hkv6x2cr0frdddsfwm1xd1v56imlglsjkgz56cva";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/shssoichiro/oxipng;
     description = "A lossless PNG compression optimizer";
     license = licenses.mit;
+    maintainers = with maintainers; [ dywedir ];
     platforms = platforms.all;
+
+    # macro is_arm_feature_detected! is unstable
+    broken = stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
[Version 2.1.0](https://github.com/shssoichiro/oxipng/blob/master/CHANGELOG.md#version-210)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

