### PR TITLE
haproxy: use getaddrinfo() on Linux

### DIFF
--- a/pkgs/tools/networking/haproxy/default.nix
+++ b/pkgs/tools/networking/haproxy/default.nix
@@ -51,7 +51,8 @@ stdenv.mkDerivation rec {
     "USE_LUA=yes"
     "LUA_LIB=${lua5_3}/lib"
     "LUA_INC=${lua5_3}/include"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc";
+  ] ++ stdenv.lib.optional stdenv.isDarwin "CC=cc"
+    ++ stdenv.lib.optional stdenv.isLinux "USE_GETADDRINFO=1";
 
   meta = {
     description = "Reliable, high performance TCP/HTTP load balancer";


### PR DESCRIPTION
As per project's README:

> Recent systems can resolve IPv6 host names using getaddrinfo(). This
> primitive is not present in all libcs and does not work in all of
> them either. Support in glibc was broken before 2.3. Some embedded
> libs may not properly work either, thus, support is disabled by
> default, meaning that some host names which only resolve as IPv6
> addresses will not resolve and configs might emit an error during
> parsing. If you know that your OS libc has reliable support for
> getaddrinfo(), you can add USE_GETADDRINFO=1 on the make command
> line to enable it. This is the recommended option for most Linux
> distro packagers since it's working fine on all recent mainstream
> distros. It is automatically enabled on Solaris 8 and above, as it's
> known to work.

Without this option, it is not possible for HAProxy to solve IPv6-only
names. This option is enabled in Debian builds without any notable
adverse effect.

###### Motivation for this change

Make HAProxy able to use DNS features with IPv6-only hosts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

