### PR TITLE
tmuxPlugins: add fzf-tmux-url to the list of plugins

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -100,6 +100,15 @@ in rec {
     dependencies = [ pkgs.fpp ];
   };
 
+  fzf-tmux-url = buildTmuxPluginFrom2Nix {
+    pluginName = "fzf-tmux-url";
+    src = fetchgit {
+      url = "https://github.com/wfxr/tmux-fzf-url";
+      rev = "ecd518eec1067234598c01e655b048ff9d06ef2f";
+      sha256 = "0png8hdv91y2nivq5vdii2192mb2qcrkwwn69lzxrdnbfa27qrgv";
+    };
+  };
+
   logging = buildTmuxPluginFrom2Nix {
     pluginName = "logging";
     src = fetchgit {


### PR DESCRIPTION
###### Motivation for this change

Pretty nice Tmux plugin that I use: https://github.com/wfxr/tmux-fzf-url

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

