### PR TITLE
pythonPackages.fire: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/fire/default.nix
+++ b/pkgs/development/python-modules/fire/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, six, hypothesis, mock
+, python-Levenshtein, pytest }:
+
+buildPythonPackage rec {
+  pname = "fire";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "python-fire";
+    rev = "v${version}";
+    sha256 = "0kdcmzr3sgzjsw5fmvdylgrn8akqjbs433jbgqzp498njl9cc6qx";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ hypothesis mock python-Levenshtein pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+
+  meta = with stdenv.lib; {
+    description = "A library for automatically generating command line interfaces";
+    longDescription = ''
+      Python Fire is a library for automatically generating command line
+      interfaces (CLIs) from absolutely any Python object.
+
+      * Python Fire is a simple way to create a CLI in Python.
+
+      * Python Fire is a helpful tool for developing and debugging
+        Python code.
+
+      * Python Fire helps with exploring existing code or turning other
+        people's code into a CLI.
+
+      * Python Fire makes transitioning between Bash and Python easier.
+
+      * Python Fire makes using a Python REPL easier by setting up the
+        REPL with the modules and variables you'll need already imported
+        and created.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -278,6 +278,8 @@ in {
 
   fido2 = callPackage ../development/python-modules/fido2 {  };
 
+  fire = callPackage ../development/python-modules/fire { };
+
   globus-sdk = callPackage ../development/python-modules/globus-sdk { };
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };


### PR DESCRIPTION
###### Motivation for this change

Useful library.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

