### PR TITLE
Add gnome wayland support

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -136,19 +136,17 @@ in {
 
     services.xserver.displayManager.extraSessionFilePackages = [ pkgs.gnome3.gnome-session ];
 
-    services.xserver.displayManager.sessionCommands = ''
-      if test "$XDG_CURRENT_DESKTOP" = "GNOME"; then
-          ${concatMapStrings (p: ''
-            if [ -d "${p}/share/gsettings-schemas/${p.name}" ]; then
-              export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${p}/share/gsettings-schemas/${p.name}
-            fi
+    environment.extraInit = ''
+      ${concatMapStrings (p: ''
+        if [ -d "${p}/share/gsettings-schemas/${p.name}" ]; then
+          export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${p}/share/gsettings-schemas/${p.name}
+        fi
 
-            if [ -d "${p}/lib/girepository-1.0" ]; then
-              export GI_TYPELIB_PATH=$GI_TYPELIB_PATH''${GI_TYPELIB_PATH:+:}${p}/lib/girepository-1.0
-              export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${p}/lib
-            fi
-          '') cfg.sessionPath}
-      fi
+        if [ -d "${p}/lib/girepository-1.0" ]; then
+          export GI_TYPELIB_PATH=$GI_TYPELIB_PATH''${GI_TYPELIB_PATH:+:}${p}/lib/girepository-1.0
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${p}/lib
+        fi
+      '') cfg.sessionPath}
     '';
 
     environment.variables.GNOME_SESSION_DEBUG = optionalString cfg.debug "1";

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -78,8 +78,7 @@ let
       # This is required by user units using the session bus.
       ${config.systemd.package}/bin/systemctl --user import-environment DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS
 
-      # Load X defaults.
-      # FIXME: Check XDG_SESSION_TYPE against x11
+      # Load X defaults. This should probably be safe on wayland too.
       ${xorg.xrdb}/bin/xrdb -merge ${xresourcesXft}
       if test -e ~/.Xresources; then
           ${xorg.xrdb}/bin/xrdb -merge ~/.Xresources
@@ -193,6 +192,11 @@ let
 
       ${concatMapStrings (pkg: ''
         ${xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
+      '') cfg.displayManager.extraSessionFilePackages}
+
+      mkdir -p "$out/share/wayland-sessions"
+      ${concatMapStrings (pkg: ''
+        ${xorg.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
       '') cfg.displayManager.extraSessionFilePackages}
     '';
 

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -244,7 +244,10 @@ in
           ''
             xmessage "Hello World!" &
           '';
-        description = "Shell commands executed just before the window or desktop manager is started.";
+        description = ''
+          Shell commands executed just before the window or desktop manager is
+          started. These commands are not currently sourced for Wayland sessions.
+        '';
       };
 
       hiddenUsers = mkOption {

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -59,6 +59,7 @@ let
 
     [Wayland]
     EnableHidpi=${if cfg.enableHidpi then "true" else "false"}
+    SessionDir=${dmcfg.session.desktops}/share/wayland-sessions
 
     ${optionalString cfg.autoLogin.enable ''
     [Autologin]

--- a/nixos/tests/gnome3.nix
+++ b/nixos/tests/gnome3.nix
@@ -16,7 +16,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       services.xserver.displayManager.lightdm.autoLogin.enable = true;
       services.xserver.displayManager.lightdm.autoLogin.user = "alice";
       services.xserver.desktopManager.gnome3.enable = true;
-      services.xserver.desktopManager.default = "gnome";
+      services.xserver.desktopManager.default = "gnome-xorg";
 
       virtualisation.memorySize = 1024;
     };

--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, substituteAll, meson, ninja, pkgconfig, gnome3, glib, gtk, gsettings-desktop-schemas
 , gnome-desktop, dbus, json-glib, libICE, xmlto, docbook_xsl, docbook_xml_dtd_412, python3
-, libxslt, gettext, makeWrapper, systemd, xorg, epoxy }:
+, libxslt, gettext, makeWrapper, systemd, xorg, epoxy, gnugrep, bash }:
 
 stdenv.mkDerivation rec {
   name = "gnome-session-${version}";
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
+      grep = "${gnugrep}/bin/grep";
+      bash = "${bash}/bin/bash";
     })
   ];
 
@@ -37,8 +39,11 @@ stdenv.mkDerivation rec {
     patchShebangs meson_post_install.py
   '';
 
+  # `bin/gnome-session` will reset the environment when run in wayland, we
+  # therefor wrap `libexec/gnome-session-binary` instead which is the actual
+  # binary needing wrapping
   preFixup = ''
-    wrapProgram "$out/bin/gnome-session" \
+    wrapProgram "$out/libexec/gnome-session-binary" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
       --suffix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH" \
       --suffix XDG_DATA_DIRS : "${gnome3.gnome-shell}/share"\

--- a/pkgs/desktops/gnome-3/core/gnome-session/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-session/fix-paths.patch
@@ -1,6 +1,22 @@
 --- a/gnome-session/gnome-session.in
 +++ b/gnome-session/gnome-session.in
-@@ -13,7 +13,7 @@ if [ "x$XDG_SESSION_TYPE" = "xwayland" ] &&
+@@ -3,11 +3,11 @@
+ if [ "x$XDG_SESSION_TYPE" = "xwayland" ] &&
+    [ "x$XDG_SESSION_CLASS" != "xgreeter" ] &&
+    [  -n "$SHELL" ] &&
+-   grep -q "$SHELL" /etc/shells &&
+-   ! (echo "$SHELL" | grep -q "false") &&
+-   ! (echo "$SHELL" | grep -q "nologin"); then
++   @grep@ -q "$SHELL" /etc/shells &&
++   ! (echo "$SHELL" | @grep@ -q "false") &&
++   ! (echo "$SHELL" | @grep@ -q "nologin"); then
+   if [ "$1" != '-l' ]; then
+-    exec bash -c "exec -l '$SHELL' -c '$0 -l $*'"
++    exec @bash@ -c "exec -l '$SHELL' -c '$0 -l $*'"
+   else
+     shift
+   fi
+@@ -13,7 +13,7 @@
    fi
  fi
  


### PR DESCRIPTION
###### Motivation for this change

This adds support for launching gnome wayland sessions from GDM and SDDM, using the upstream session file. See #39871 and #32806 for some more discussion.

Edit: Updated against master now that gnome 3.30 is merged.

###### sessionCommand support

This should work quite well, but one remaining issue is the lack of support for `displayManager.sessionCommands` and therefore also `gnome3.sessionPath`. Some options here:

- We could patch GDM, gnome-session, to run the wrapper for wayland-sessions too, not super happy about it, but might be good as it makes GDM act more like SDDM and LightDM.
- Or we could move sessionCommands into /etc/profile checking for eg. XDG_SESSION_TYPE, but that seems really ugly.

Edit: We landed on simply not supporting `sessionCommands` on wayland for now. 

###### patching gnome-session more? 

6171bc0 might be better expressed by patching `gnome-session` to always look for session files in its own `share/` folder.

###### Writing a test

Edit: `gnome3-gdm` now runs a wayland gnome session (GDM prefers the wayland session and we don't have a good way of telling it otherwise), so I ported it to work with wayland.

cc @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Edit:
- Tested succesfully in a VM (at https://github.com/NixOS/nixpkgs/pull/44497/commits/a6c1ffec1db2b08c8c8188fef4c09cc78cc00621).

- Ran `gnome3`, `gnome3-gdm` and  `sddm` tests succesfully.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

