### PR TITLE
lib/trivial: remove deprecation warning for `lib.nixpkgsVersion`.

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -105,7 +105,7 @@ rec {
     then lib.strings.fileContents suffixFile
     else "pre-git";
 
-  nixpkgsVersion = builtins.trace "`lib.nixpkgsVersion` is deprecated, use `lib.version` instead!" version;
+  nixpkgsVersion = version;
 
   # Whether we're being called by nix-shell.
   inNixShell = builtins.getEnv "IN_NIX_SHELL" != "";


### PR DESCRIPTION
###### Motivation for this change

Originally introduced in #39416 (1),
however it causes confusion and shouldn't be deprecated (2)(3).

/cc @edolstra

(1) https://github.com/NixOS/nixpkgs/pull/39416#discussion_r183845745
(2) https://github.com/NixOS/nixpkgs/commit/9274ea390348e17f766732e7fbd335e3bc164954#commitcomment-29951594
(3) https://github.com/NixOS/nix/pull/2291

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

