### PR TITLE
sage: don't override pari

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -8,10 +8,6 @@ let
   # https://trac.sagemath.org/ticket/15980 for tracking of python3 support
   python = nixpkgs.python2.override {
     packageOverrides = self: super: {
-      cypari2 = super.cypari2.override { inherit pari; };
-
-      cysignals = super.cysignals.override { inherit pari; };
-
       # python packages that appear unmaintained and were not accepted into the nixpkgs
       # tree because of that. These packages are only dependencies of the more-or-less
       # deprecated sagenb. However sagenb is still a default dependency and the doctests
@@ -24,7 +20,7 @@ let
       pybrial = self.callPackage ./pybrial.nix {};
 
       sagelib = self.callPackage ./sagelib.nix {
-        inherit flint ecl pari eclib arb;
+        inherit flint ecl arb;
         inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
         linbox = nixpkgs.linbox.override { withSage = true; };
       };
@@ -38,19 +34,19 @@ let
       };
 
       env-locations = self.callPackage ./env-locations.nix {
-        inherit pari_data ecl pari;
+        inherit pari_data ecl;
         inherit singular;
         three = nodePackages_8_x.three;
         mathjax = nodePackages_8_x.mathjax;
       };
 
       sage-env = self.callPackage ./sage-env.nix {
-        inherit sage-src python rWrapper openblas-cblas-pc ecl singular eclib pari palp flint pynac pythonEnv;
+        inherit sage-src python rWrapper openblas-cblas-pc ecl singular palp flint pynac pythonEnv;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
       };
 
       sage-with-env = self.callPackage ./sage-with-env.nix {
-        inherit pari eclib pythonEnv;
+        inherit pythonEnv;
         inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
         three = nodePackages_8_x.three;
@@ -113,8 +109,6 @@ let
   # *not* to confuse with the python package "pynac"
   pynac = nixpkgs.pynac.override { inherit singular flint; };
 
-  eclib = nixpkgs.eclib.override { inherit pari; };
-
   # With openblas (64 bit), the tests fail the same way as when sage is build with
   # openblas instead of openblasCompat. Apparently other packages somehow use flints
   # blas when it is available. Alternative would be to override flint to use
@@ -144,8 +138,6 @@ let
 
   # https://trac.sagemath.org/ticket/22191
   ecl = nixpkgs.ecl_16_1_2;
-
-  pari = nixpkgs.pari.override { withThread = false; };
 in
   python.pkgs.sage-wrapper // {
     doc = python.pkgs.sagedoc;

--- a/pkgs/applications/science/math/sage/patches/pari-no-threads.patch
+++ b/pkgs/applications/science/math/sage/patches/pari-no-threads.patch
@@ -1,0 +1,18 @@
+diff --git a/src/sage/libs/pari/__init__.py b/src/sage/libs/pari/__init__.py
+index e451766474..77eda66097 100644
+--- a/src/sage/libs/pari/__init__.py
++++ b/src/sage/libs/pari/__init__.py
+@@ -205,6 +205,13 @@ def _get_pari_instance():
+     # messages in Sage.
+     P.default("debugmem", 0)
+ 
++    # Make sure pari doesn't use threads, regardless of how it was compiled.
++    # Threads cause some doctest failures (memory issues). Those could probably
++    # be solved without disabling threads. But that would require figuring out
++    # some sensible values for `threadsizemax`. See
++    # https://pari.math.u-bordeaux.fr/dochtml/html/GP_defaults.html
++    P.default("nbthreads", 1)
++
+     return P
+ 
+ pari = _get_pari_instance()

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -56,6 +56,10 @@ stdenv.mkDerivation rec {
     # https://trac.sagemath.org/ticket/25345
     # (upstream patch doesn't apply on 8.2 source)
     ./patches/dochtml-optional.patch
+
+    # work with pari with threads enabled at compile time (disable them at runtime)
+    # https://trac.sagemath.org/ticket/26002
+    ./patches/pari-no-threads.patch
   ];
 
   packageUpgradePatches = [


### PR DESCRIPTION
###### Motivation for this change

Getting pretty close to the goal of no dependency overrides for sage :)

Sage assumes that pari does not use threads. However instead of
disabling them at compile time, we can diable them at runtime instead.
As a result, sage doesn't need its own version of pari anymore. That
means less rebuilds, less complexity and easier debugging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

