### PR TITLE
gscrabble: init at unstable-2019-03-11

### DIFF
--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, buildPythonApplication, fetchFromGitHub
+, gtk3, wrapGAppsHook, gst_all_1, gobject-introspection
+, python3Packages, gnome3, hicolor-icon-theme }:
+
+buildPythonApplication rec {
+  pname = "gscrabble";
+  version = "unstable-2019-03-11";
+
+  src = fetchFromGitHub {
+    owner = "RaaH";
+    repo = "gscrabble";
+    rev = "4b6e4e151a4cd4a4f66a5be2c8616becac3f2a29";
+    sha256 = "0a89kqh04x52q7qyv1rfa7xif0pdw3zc0dw5a24msala919g90q2";
+  };
+
+  doCheck = false;
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = with gst_all_1; [
+    gst-plugins-base gst-plugins-good gst-plugins-ugly gst-plugins-bad
+    hicolor-icon-theme gnome3.adwaita-icon-theme gtk3 gobject-introspection
+  ];
+
+  propagatedBuildInputs = with python3Packages; [ gst-python pygobject3 ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PYTHONPATH : "$out/share/GScrabble/modules"
+      )
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Golden Scrabble crossword puzzle game";
+    homepage = https://github.com/RaaH/gscrabble/;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.genesis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20911,6 +20911,8 @@ in
 
   gogui = callPackage ../games/gogui {};
 
+  gscrabble = python3Packages.callPackage ../games/gscrabble {};
+
   gshogi = python3Packages.callPackage ../games/gshogi {};
 
   gtetrinet = callPackage ../games/gtetrinet {


### PR DESCRIPTION
###### Motivation for this change

i had to restore gnome3.gnome-icon-theme-symbolic , some review about it needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

