### PR TITLE
Init libbraiding and libhomfly

### DIFF
--- a/pkgs/development/libraries/science/math/libbraiding/default.nix
+++ b/pkgs/development/libraries/science/math/libbraiding/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.0";
+  name = "libbraiding-${version}";
+
+  src = fetchFromGitHub {
+    owner = "miguelmarco";
+    repo = "libbraiding";
+    rev = version;
+    sha256 = "0l68rikfr7k2l547gb3pp3g8cj5zzxwipm79xrb5r8ffj466ydxg";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  # no tests included for now (2018-08-05), but can't hurt to activate
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/miguelmarco/libbraiding/;
+    description = "C++ library for computations on braid groups";
+    longDescription = ''
+      A library to compute several properties of braids, including centralizer and conjugacy check.
+    '';
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/science/math/libhomfly/default.nix
+++ b/pkgs/development/libraries/science/math/libhomfly/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, boehmgc
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.02r5";
+  name = "llibhomfly-${version}";
+
+  src = fetchFromGitHub {
+    owner = "miguelmarco";
+    repo = "libhomfly";
+    rev = version;
+    sha256 = "1szv8iwlhvmy3saigi15xz8vgch92p2lbsm6440v5s8vxj455bvd";
+  };
+
+  buildInputs = [
+    boehmgc
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/miguelmarco/libhomfly/;
+    description = "Library to compute the homfly polynomial of knots and links";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20500,6 +20500,7 @@ with pkgs;
 
   jags = callPackage ../applications/science/math/jags { };
 
+  libbraiding = callPackage ../development/libraries/science/math/libbraiding { };
 
   # We have essentially 4 permutations of liblapack: version 3.4.1 or 3.5.0,
   # and with or without atlas as a dependency. The default `liblapack` is 3.4.1

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20502,6 +20502,8 @@ with pkgs;
 
   libbraiding = callPackage ../development/libraries/science/math/libbraiding { };
 
+  libhomfly = callPackage ../development/libraries/science/math/libhomfly { };
+
   # We have essentially 4 permutations of liblapack: version 3.4.1 or 3.5.0,
   # and with or without atlas as a dependency. The default `liblapack` is 3.4.1
   # with atlas. Atlas, when built with liblapack as a dependency, uses 3.5.0


### PR DESCRIPTION
###### Motivation for this change

sage 8.4 will need these two packages as dependencies. Sage upstream discussion: https://trac.sagemath.org/ticket/25705.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

