### PR TITLE
cddlib: 0.94i -> 0.94j

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -118,6 +118,13 @@ stdenv.mkDerivation rec {
       url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/sagemath-lcalc-c++11.patch?h=packages/sagemath&id=0e31ae526ab7c6b5c0bfacb3f8b1c4fd490035aa";
       sha256 = "0p5wnvbx65i7cp0bjyaqgp4rly8xgnk12pqwaq3dqby0j2bk6ijb";
     })
+
+    # cddlib 0.94i -> 0.94j
+    (fetchpatch {
+      name = "cddlib-0.94j.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?id=2ab1546b3e21d1d0ab3b4fcd58576848b3a2d888";
+      sha256 = "1c5gnasq7y9xxj762bn79bis0zi8d9bgg7jzlf64ifixsrc5cymb";
+    })
   ];
 
   patches = nixPatches ++ packageUpgradePatches ++ [

--- a/pkgs/development/libraries/cddlib/default.nix
+++ b/pkgs/development/libraries/cddlib/default.nix
@@ -1,55 +1,33 @@
 { stdenv
-, fetchurl
-, fetchpatch
+, fetchFromGitHub
 , gmp
 , autoreconfHook
+, texlive
 }:
 
 stdenv.mkDerivation rec {
   name = "cddlib-${version}";
-  version = "0.94i";
-  src = let
-    fileVersion = stdenv.lib.replaceStrings ["."] [""] version;
-  in fetchurl {
-    # Might switch to github in the future, see
-    # https://trac.sagemath.org/ticket/21952#comment:20
-    urls = [
-      "http://archive.ubuntu.com/ubuntu/pool/universe/c/cddlib/cddlib_${fileVersion}.orig.tar.gz"
-      "ftp://ftp.math.ethz.ch/users/fukudak/cdd/cddlib-${fileVersion}.tar.gz"
-    ];
-    sha256 = "00zdgiqb91vx6gd2103h3ijij0llspsxc6zz3iw2bll39fvkl4xq";
+  version = "0.94j";
+  src = fetchFromGitHub {
+    owner = "cddlib";
+    repo = "cddlib";
+    rev = "${version}";
+    sha256 = "1z03ljy3rrr0qq5gq54vynnif6fn0xhn05g90nnv0dpyc3ps8lzp";
   };
   buildInputs = [gmp];
   nativeBuildInputs = [
     autoreconfHook
+    texlive.combined.scheme-small # for building the documentation
   ];
-  # compute reduced H and V representation of polytope
-  # this patch is included by most distributions (Debian, Conda, ArchLinux, SageMath)
-  # proposed upstream (no answer yet): https://github.com/cddlib/cddlib/pull/3
-  both_reps_c = (fetchurl {
-    name = "cdd_both_reps.c";
-    url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/cddlib/files/cdd_both_reps.c?id=56bd759df1d0c750a065b8c845e93d5dfa6b549d";
-    sha256 = "0r9yc5bgiz8i72c6vsn2y2mjk5581iw94gji9v7lg16kzzgrk9x0";
-  });
-  preAutoreconf = ''
-    # Required by sage.geometry.polyhedron
-    cp ${both_reps_c} src/cdd_both_reps.c
-    cp ${both_reps_c} src-gmp/cdd_both_reps.c
-  '';
-  patches = [
-    # add the cdd_both_reps binary
-    (fetchpatch {
-      name = "add-cdd_both_reps-binary.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-libs/cddlib/files/cddlib-094h-add-cdd_both_reps-binary.patch?id=78e3a61a68c916450aa4e5ceecd20041583af901";
-      sha256 = "162ni2fr7dpbdkz0b5nizxq7qr5k1i1d75g0smiylpzfb0hb761a";
-    })
-  ];
-  meta = {
+  # No actual checks yet (2018-05-05), but maybe one day.
+  # Requested here: https://github.com/cddlib/cddlib/issues/25
+  doCheck = true;
+  meta = with stdenv.lib; {
     inherit version;
     description = ''An implementation of the Double Description Method for generating all vertices of a convex polyhedron'';
-    license = stdenv.lib.licenses.gpl2Plus ;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [raskin timokau];
+    platforms = platforms.linux;
     homepage = https://www.inf.ethz.ch/personal/fukudak/cdd_home/index.html;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

cddlib was autotoolized, incorporated equivalents to the sage patches
and moved to GitHub.

The build is simplified, I added myself as a maintainer and asked for tests upstream.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

