### PR TITLE
tex-gyre: remove unused displayName argument

### DIFF
--- a/pkgs/data/fonts/tex-gyre/default.nix
+++ b/pkgs/data/fonts/tex-gyre/default.nix
@@ -34,56 +34,48 @@ let
   };
 in stdenv.lib.mapAttrs mkVariant {
   adventor = {
-    displayName = "Adventor";
     version = "2_501";
     sha256 = "0qjg3x0adfppyx3x33cm07ww9i9sl88xaq07m7wfip8rmyp567fn";
     outputHash = "117h6f02m1r54b4f1a98q5kkjchl5pv9ibm1jla6xrzhk2pchb27";
     abbreviation = "qag";
   };
   bonum = {
-    displayName = "Bonum";
     version = "2.004";
     sha256 = "0qbrs98knx4h0b297c5n3vav4mkal1a95ai2dzmdc10pghfzl8vv";
     outputHash = "0bid8gzwz50ylmm8jyqf9s4nfvy6cp1x34wbyrh4gyk1ki6hf3z1";
     abbreviation = "qbk";
   };
   chorus = {
-    displayName = "Chorus";
     version = "2.003";
     sha256 = "1b0zak27fzmapwbf2jasvsd95vhnqyc92n985d1lc1ivwja1zgfa";
     outputHash = "0fqifd45c1ys6y98b66lmldfbv7wjb2414fs9swicv4n7xvl3cp1";
     abbreviation = "qzc";
   };
   cursor = {
-    displayName = "Cursor";
     version = "2.004";
     sha256 = "0ck3jm33bk2xsxp5d2irzd3j24zb49f0gnjvd1nikg1ivk8w85ng";
     outputHash = "0i76835xqlkrnlx303mx63m0f4899j056c2ag2fl6p9qk8s4rskp";
     abbreviation = "qcr";
   };
   heros = {
-    displayName = "Heros";
     version = "2.004";
     sha256 = "1fj2srxxf6ap913y5yd3dn4jzg828j7381gifs39nm5lnzmgw78y";
     outputHash = "16y76ab46fxm9k8wfmwx4w0cl96yrmjywz587lyr08s0agp1v3kf";
     abbreviation = "qhv";
   };
   pagella = {
-    displayName = "Pagella";
     version ="2_501";
     sha256 = "1kccaxs3vk93la2pz4nv05hx1x3diyla49cz4l33zifdcp2zgg9d";
     outputHash = "1nnjsgplimh29502pkd19rvfg93x31svxxmx4x7h51njrx1j8qa8";
     abbreviation = "qpl";
   };
   schola = {
-    displayName = "Schola";
     version = "2.005";
     sha256 = "05z3gk4mm0sa7wwjcv31j2xlzqhwhcncpamn0kn9y0221cdknyp8";
     outputHash = "1yqq1ngcylhldrh1v35l439k72szq9m4gx6g0wh235fk65chb2bm";
     abbreviation = "qcs";
   };
   termes = {
-    displayName = "Termes";
     version = "2.004";
     sha256 = "1aq3yqbgkc3z20dkcqyhicsyq0afbgg4l397z96sd8a16jyz2x8k";
     outputHash = "1igw821m601h8937pix6yish4d8fxmz3h4j9hripf41bxsiafzzg";


### PR DESCRIPTION
### Motivation

Fixes evaluation of `tex-gyre`.


### Testing

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

