### PR TITLE
cantata: 2.2.0 -> 2.3.2

### DIFF
--- a/pkgs/applications/audio/cantata/default.nix
+++ b/pkgs/applications/audio/cantata/default.nix
@@ -28,7 +28,7 @@ assert withOnlineServices -> withTaglib;
 assert withReplaygain -> withTaglib;
 
 let
-  version = "2.2.0";
+  version = "2.3.2";
   pname = "cantata";
   fstat = x: fn: "-DENABLE_" + fn + "=" + (if x then "ON" else "OFF");
   fstats = x: map (fstat x);
@@ -42,18 +42,9 @@ in stdenv.mkDerivation rec {
     owner  = "CDrummond";
     repo   = "cantata";
     rev    = "v${version}";
-    sha256 = "1b633chgfs8rya78bzzck5zijna15d1y4nmrz4dcjp862ks5y5q6";
+    sha256 = "11hjday5vj0wzkc8yb5wbs05jwa8mvgxswd5qvhpci0zkl975yzn";
   };
 
-  patches = [
-    # patch is needed for 2.2.0 with qt 5.10 (doesn't harm earlier versions)
-    (fetchpatch {
-      url    = "https://github.com/CDrummond/cantata/commit/4da7a9128f2c5eaf23ae2a5006d300dc4f21fc6a.patch";
-      sha256 = "1z21ax3542z7hm628xv110lmplaspb407jzgfk16xkphww5qyphj";
-      name   = "fix_qt_510.patch";
-    })
-
-  ];
   buildInputs = [ vlc qtbase qtmultimedia qtsvg ]
     ++ stdenv.lib.optionals withTaglib [ taglib taglib_extras ]
     ++ stdenv.lib.optionals withReplaygain [ ffmpeg speex mpg123 ]


### PR DESCRIPTION
Removed merged patch.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

