### PR TITLE
cc-wrapper: propagate man and info to propagated-build-inputs

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -262,8 +262,8 @@ stdenv.mkDerivation {
       ##
 
       mkdir -p $man/nix-support $info/nix-support
-      printWords ${cc.man or ""}  > $man/nix-support/propagated-user-env-packages
-      printWords ${cc.info or ""}  > $info/nix-support/propagated-user-env-packages
+      printWords ${cc.man or ""}  >> $man/nix-support/propagated-build-inputs
+      printWords ${cc.info or ""}  >> $info/nix-support/propagated-build-inputs
     ''
 
     + ''


### PR DESCRIPTION
Should fix #43547.