### PR TITLE
appimagekit: init at 20180727

### DIFF
--- a/pkgs/tools/package-management/appimagekit/default.nix
+++ b/pkgs/tools/package-management/appimagekit/default.nix
@@ -1,0 +1,112 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, cmake, autoconf, automake, libtool
+, wget, xxd, desktop-file-utils
+, glib, zlib, cairo, openssl, fuse, xz, squashfuse, inotify-tools, libarchive
+, squashfsTools
+, gtest
+}:
+
+let
+
+  appimagekit_src = fetchFromGitHub {
+    owner = "AppImage";
+    repo = "AppImageKit";
+    rev = "b0859501df61cde198b54a317c03b41dbafc98b1";
+    sha256 = "0qqg79jw9w9rs8c2w3lla4kz62ihafrf7jm370pp1dl8y2i81jzg";
+  };
+
+  # squashfuse adapted to nix from cmake experession in "${appimagekit_src}/cmake/dependencies.cmake"
+  appimagekit_squashfuse = squashfuse.overrideAttrs (attrs: rec {
+    name = "squashfuse-${version}";
+    version = "20161009";
+
+    src = fetchFromGitHub {
+      owner = "vasi";
+      repo  = "squashfuse";
+      rev   = "1f980303b89c779eabfd0a0fdd36d6a7a311bf92";
+      sha256 = "0lrw9ff8k15l34wjwyllw3i35hl0cms97jj2hpnr2q8ipgxpb5q5";
+    };
+
+    patches = [
+      "${appimagekit_src}/squashfuse.patch"
+      "${appimagekit_src}/squashfuse_dlopen.patch"
+    ];
+
+    postPatch = ''
+      cp -v ${appimagekit_src}/squashfuse_dlopen.[hc] .
+    '';
+
+    preConfigure = ''
+      sed -i "/PKG_CHECK_MODULES.*/,/,:./d" configure
+      sed -i "s/typedef off_t sqfs_off_t/typedef int64_t sqfs_off_t/g" common.h
+    '';
+
+    configureFlags = [
+      "--disable-demo" "--disable-high-level" "--without-lzo" "--without-lz4"
+    ];
+
+    postConfigure = ''
+      sed -i "s|XZ_LIBS = -llzma |XZ_LIBS = -Bstatic -llzma/|g" Makefile
+    '';
+
+    # only static libs and header files
+    installPhase = ''
+      mkdir -p $out/lib $out/include
+      cp -v ./.libs/*.a $out/lib
+      cp -v ./*.h $out/include
+    '';
+  });
+
+in stdenv.mkDerivation rec {
+  name = "appimagekit-20180727";
+
+  src = appimagekit_src;
+
+  patches = [ ./nix.patch ];
+
+  nativeBuildInputs = [
+    pkgconfig cmake autoconf automake libtool wget xxd
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    glib zlib cairo openssl fuse
+    xz inotify-tools libarchive
+    squashfsTools
+  ];
+
+  preConfigure = ''
+    export HOME=$(pwd)
+  '';
+
+  cmakeFlags = [
+    "-DUSE_SYSTEM_XZ=ON"
+    "-DUSE_SYSTEM_SQUASHFUSE=ON"
+    "-DSQUASHFUSE=${appimagekit_squashfuse}"
+    "-DUSE_SYSTEM_INOTIFY_TOOLS=ON"
+    "-DUSE_SYSTEM_LIBARCHIVE=ON"
+    "-DUSE_SYSTEM_GTEST=ON"
+    "-DUSE_SYSTEM_MKSQUASHFS=ON"
+    "-DBUILD_TESTING=${if doCheck then "ON" else "OFF"}"
+  ];
+
+  checkInputs = [ gtest ];
+  doCheck = false; # fails 1 out of 4 tests, I'm too lazy to debug why
+
+  # for debugging
+  passthru = {
+    squashfuse = appimagekit_squashfuse;
+  };
+
+  meta = with stdenv.lib; {
+    description = "A tool to package desktop applications as AppImages";
+    longDescription = ''
+      AppImageKit is an implementation of the AppImage format that
+      provides tools such as appimagetool and appimaged for handling
+      AppImages.
+    '';
+    license = licenses.mit;
+    homepage = src.meta.homepage;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/package-management/appimagekit/nix.patch
+++ b/pkgs/tools/package-management/appimagekit/nix.patch
@@ -1,0 +1,174 @@
+diff --git a/cmake/dependencies.cmake b/cmake/dependencies.cmake
+index ea133a3..916606c 100644
+--- a/cmake/dependencies.cmake
++++ b/cmake/dependencies.cmake
+@@ -224,21 +224,23 @@ if(NOT USE_SYSTEM_XZ)
+         LIBRARY_DIRS <INSTALL_DIR>/lib/
+         LIBRARIES "<INSTALL_DIR>/lib/liblzma.a"
+         INCLUDE_DIRS "<SOURCE_DIR>/src/liblzma/api/"
+     )
+ else()
+     message(STATUS "Using system xz")
+ 
+     import_pkgconfig_target(TARGET_NAME xz PKGCONFIG_TARGET liblzma STATIC)
+ endif()
+ 
++set(USE_SYSTEM_SQUASHFUSE OFF CACHE BOOL "Use system squashfuse instead of building our own")
+ 
++if(NOT USE_SYSTEM_SQUASHFUSE)
+ # as distros don't provide suitable squashfuse and squashfs-tools, those dependencies are bundled in, can, and should
+ # be used from this repository
+ # TODO: implement out-of-source builds for squashfuse, as for the other dependencies
+ configure_file(
+     ${CMAKE_CURRENT_SOURCE_DIR}/src/patch-squashfuse.sh.in
+     ${CMAKE_CURRENT_BINARY_DIR}/patch-squashfuse.sh
+     @ONLY
+ )
+ 
+ ExternalProject_Add(squashfuse-EXTERNAL
+@@ -259,20 +261,34 @@ ExternalProject_Add(squashfuse-EXTERNAL
+     BUILD_IN_SOURCE ON
+     INSTALL_COMMAND ${MAKE} install
+ )
+ 
+ import_external_project(
+     TARGET_NAME squashfuse
+     EXT_PROJECT_NAME squashfuse-EXTERNAL
+     LIBRARIES "<SOURCE_DIR>/.libs/libsquashfuse.a;<SOURCE_DIR>/.libs/libsquashfuse_ll.a;<SOURCE_DIR>/.libs/libfuseprivate.a"
+     INCLUDE_DIRS "<SOURCE_DIR>"
+ )
++else()
++    message(STATUS "Using system squashfsfuse from ${SQUASHFUSE}")
++
++    add_library(squashfuse INTERFACE IMPORTED GLOBAL)
++
++    set(squashfuse_INCLUDE_DIRS "${SQUASHFUSE}/include")
++    set(squashfuse_LIBRARIES "${SQUASHFUSE}/lib/libsquashfuse.a;${SQUASHFUSE}/lib/libsquashfuse_ll.a;${SQUASHFUSE}/lib/libfuseprivate.a")
++
++    set_property(
++      TARGET squashfuse
++      PROPERTY INTERFACE_LINK_LIBRARIES ${squashfuse_LIBRARIES}
++    )
++    include_directories(${squashfuse_INCLUDE_DIRS})
++endif()
+ 
+ 
+ set(USE_SYSTEM_INOTIFY_TOOLS OFF CACHE BOOL "Use system libinotifytools instead of building our own")
+ 
+ if(NOT USE_SYSTEM_INOTIFY_TOOLS)
+     message(STATUS "Downloading and building inotify-tools")
+ 
+     # TODO: build out of source
+     ExternalProject_Add(inotify-tools-EXTERNAL
+         URL https://github.com/downloads/rvoicilas/inotify-tools/inotify-tools-3.14.tar.gz
+@@ -345,20 +361,23 @@ if(NOT USE_SYSTEM_GTEST)
+             INCLUDE_DIRS "<INSTALL_DIR>/include/"
+         )
+     else()
+         message(STATUS "Using system GTest")
+ 
+         import_find_pkg_target(gtest GTest GTEST)
+     endif()
+ endif()
+ 
+ 
++set(USE_SYSTEM_MKSQUASHFS OFF CACHE BOOL "Use system mksquashfs instead of downloading and building our own")
++
++if(NOT USE_SYSTEM_MKSQUASHFS)
+ # TODO: allow using system wide mksquashfs
+ set(mksquashfs_cflags "-DXZ_SUPPORT ${CFLAGS}")
+ 
+ if(xz_LIBRARIES MATCHES "\\.a$")
+     set(mksquashfs_ldflags "${xz_LIBRARIES}")
+ else()
+     set(mksquashfs_ldflags "-l${xz_LIBRARIES}")
+ endif()
+ 
+ if(xz_INCLUDE_DIRS)
+@@ -385,20 +404,25 @@ ExternalProject_Add(mksquashfs
+     INSTALL_COMMAND ${MAKE} -C squashfs-tools/ install INSTALL_DIR=<INSTALL_DIR>
+ )
+ 
+ ExternalProject_Get_Property(mksquashfs INSTALL_DIR)
+ set(mksquashfs_INSTALL_DIR "${INSTALL_DIR}")
+ mark_as_advanced(mksquashfs_INSTALL_DIR)
+ 
+ # for later use when packaging as an AppImage
+ set(mksquashfs_BINARY "${mksquashfs_INSTALL_DIR}/mksquashfs")
+ mark_as_advanced(mksquashfs_BINARY)
++else()
++    message(STATUS "Using system mksquashfs")
++
++    set(mksquashfs_BINARY "mksquashfs")
++endif()
+ 
+ 
+ #### build dependency configuration ####
+ 
+ # only have to build custom xz when not using system libxz
+ if(TARGET xz-EXTERNAL)
+     if(TARGET squashfuse-EXTERNAL)
+         ExternalProject_Add_StepDependencies(squashfuse-EXTERNAL configure xz-EXTERNAL)
+     endif()
+     if(TARGET mksquashfs)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3f25442..974ed0e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -197,27 +197,27 @@ target_include_directories(digest_md5
+ 
+ target_link_libraries(digest_md5
+     PRIVATE
+     libglib
+ )
+ 
+ 
+ # install binaries
+ if(AUXILIARY_FILES_DESTINATION)
+     install(
+-        PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
++        PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/runtime
+         DESTINATION ${AUXILIARY_FILES_DESTINATION}
+         COMPONENT applications
+     )
+ else()
+     install(
+-        PROGRAMS ${mksquashfs_INSTALL_DIR}/mksquashfs ${CMAKE_CURRENT_BINARY_DIR}/runtime
++        PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/runtime
+         DESTINATION bin
+         COMPONENT applications
+     )
+ endif()
+ 
+ install(
+     TARGETS AppRun appimagetool digest validate
+     RUNTIME DESTINATION bin COMPONENT applications
+     LIBRARY DESTINATION lib COMPONENT applications
+     ARCHIVE DESTINATION lib/static COMPONENT applications
+diff --git a/src/shared.c b/src/shared.c
+index cf5fd5c..4f48dbc 100644
+--- a/src/shared.c
++++ b/src/shared.c
+@@ -34,21 +34,21 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <dirent.h>
+ #include <errno.h>
+ 
+ #include <glib.h>
+ #include <glib/gprintf.h>
+ #include <glib/gstdio.h>
+ #include <gio/gio.h>
+ 
+-#include "squashfuse.h"
++#include <squashfuse.h>
+ #include <squashfs_fs.h>
+ #include "getsection.h"
+ #include "elf.h"
+ 
+ #include "xdg-basedir.h"
+ 
+ // own header
+ #include "shared.h"
+ 
+ #if HAVE_LIBARCHIVE3 == 1 // CentOS

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -508,6 +508,8 @@ with pkgs;
 
   appimage-run = callPackage ../tools/package-management/appimage-run {};
 
+  appimagekit = callPackage ../tools/package-management/appimagekit {};
+
   apt-cacher-ng = callPackage ../servers/http/apt-cacher-ng { };
 
   apt-offline = callPackage ../tools/misc/apt-offline { };


### PR DESCRIPTION
###### Motivation for this change

@matthewbauer mentioned in https://github.com/matthewbauer/nix-bundle/blob/master/appimagetool.nix that he couldn't build it via nix, I thought I'd give it a try myself. Took quite some work, indeed.

###### Things done

- [X] It builds.
- But I have not tested that the runtime works outside of NixOS, it's likely to need some more patching.

But I feel it's better to contribute this now, as opposed to fermenting this patch in my local branch till I feel like continuing this.