### PR TITLE
bash,texinfo: turn interactive versions into passthrus

### DIFF
--- a/doc/configuration.xml
+++ b/doc/configuration.xml
@@ -480,7 +480,7 @@ cp ${myProfile} $out/etc/profile.d/my-profile.sh
         jq
         nox
         silver-searcher
-        texinfoInteractive
+        texinfo.interactive
       ];
       pathsToLink = [ "/share/man" "/share/doc" "/share/info" "/bin" "/etc" ];
       extraOutputsToInstall = [ "man" "doc" "info" ];
@@ -501,7 +501,7 @@ cp ${myProfile} $out/etc/profile.d/my-profile.sh
     <literal>postBuild</literal> tells Nixpkgs to run a command after building
     the environment. In this case, <literal>install-info</literal> adds the
     installed info pages to <literal>dir</literal> which is GNU info's default
-    root node. Note that <literal>texinfoInteractive</literal> is added to the
+    root node. Note that <literal>texinfo.interactive</literal> is added to the
     environment to give the <literal>install-info</literal> command.
    </para>
   </section>

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -135,7 +135,7 @@ in
 
     environment.shells = mkOption {
       default = [];
-      example = literalExample "[ pkgs.bashInteractive pkgs.zsh ]";
+      example = literalExample "[ pkgs.bash.interactive pkgs.zsh ]";
       description = ''
         A list of permissible login shells for user accounts.
         No need to mention <literal>/bin/sh</literal>
@@ -148,7 +148,7 @@ in
 
   config = {
 
-    system.build.binsh = pkgs.bashInteractive;
+    system.build.binsh = pkgs.bash.interactive;
 
     # Set session variables in the shell as well. This is usually
     # unnecessary, but it allows changes to session variables to take

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -11,7 +11,7 @@ let
     [ config.nix.package
       pkgs.acl
       pkgs.attr
-      pkgs.bashInteractive # bash with ncurses support
+      pkgs.bash.interactive # bash with ncurses support
       pkgs.bzip2
       pkgs.coreutils
       pkgs.cpio

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -122,10 +122,10 @@ let
         type = types.either types.shellPackage types.path;
         default = pkgs.shadow;
         defaultText = "pkgs.shadow";
-        example = literalExample "pkgs.bashInteractive";
+        example = literalExample "pkgs.bash.interactive";
         description = ''
           The path to the user's shell. Can use shell derivations,
-          like <literal>pkgs.bashInteractive</literal>. Don’t
+          like <literal>pkgs.bash.interactive</literal>. Don’t
           forget to enable your shell in
           <literal>programs</literal> if necessary,
           like <code>programs.zsh.enable = true;</code>.

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -79,7 +79,7 @@ let cfg = config.documentation; in
     })
 
     (mkIf cfg.info.enable {
-      environment.systemPackages = [ pkgs.texinfoInteractive ];
+      environment.systemPackages = [ pkgs.texinfo.interactive ];
       environment.pathsToLink = [ "/share/info" ];
       environment.extraOutputsToInstall = [ "info" ] ++ optional cfg.dev.enable "devinfo";
     })

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -204,7 +204,7 @@ in
     # priority to allow user override using both .text and .source.
     environment.etc."inputrc".source = mkOptionDefault ./inputrc;
 
-    users.defaultUserShell = mkDefault pkgs.bashInteractive;
+    users.defaultUserShell = mkDefault pkgs.bash.interactive;
 
     environment.pathsToLink = optionals cfg.enableCompletion [
       "/etc/bash_completion.d"
@@ -219,8 +219,8 @@ in
         "/var/run/current-system/sw/bin/bash"
         "/run/current-system/sw/bin/sh"
         "/var/run/current-system/sw/bin/sh"
-        "${pkgs.bashInteractive}/bin/bash"
-        "${pkgs.bashInteractive}/bin/sh"
+        "${pkgs.bash.interactive}/bin/bash"
+        "${pkgs.bash.interactive}/bin/sh"
       ];
 
   };

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -158,8 +158,8 @@ let
     mkdir -p $out
     cp ${pkgs.kubernetes.src}/cluster/centos/node/bin/mk-docker-opts.sh $out/mk-docker-opts.sh
 
-    # bashInteractive needed for `compgen`
-    makeWrapper ${pkgs.bashInteractive}/bin/bash $out/mk-docker-opts --add-flags "$out/mk-docker-opts.sh"
+    # bash.interactive needed for `compgen`
+    makeWrapper ${pkgs.bash.interactive}/bin/bash $out/mk-docker-opts --add-flags "$out/mk-docker-opts.sh"
   '';
 in {
 

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -6,7 +6,7 @@ let
 
   bootStage2 = pkgs.substituteAll {
     src = ./stage-2-init.sh;
-    shellDebug = "${pkgs.bashInteractive}/bin/bash";
+    shellDebug = "${pkgs.bash.interactive}/bin/bash";
     shell = "${pkgs.bash}/bin/bash";
     isExecutable = true;
     inherit (config.nix) readOnlyStore;

--- a/pkgs/applications/misc/finalterm/default.nix
+++ b/pkgs/applications/misc/finalterm/default.nix
@@ -2,7 +2,7 @@
 , pkgconfig, cmake, libxml2, vala_0_26, intltool, libmx, gnome3, gtk3, gtk-doc
 , keybinder3, clutter-gtk, libnotify
 , libxkbcommon, xorg, udev
-, bashInteractive
+, bash
 }:
 
 with stdenv.lib;
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     substituteInPlace data/org.gnome.finalterm.gschema.xml \
-      --replace "/bin/bash" "${bashInteractive}/bin/bash"
+      --replace "/bin/bash" "${bash.interactive}/bin/bash"
 
     cmakeFlagsArray=(
       -DMINIMAL_FLAGS=ON

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -39,7 +39,7 @@ let
   # builds.
   basePkgs = with pkgs;
     [ (if isMultiBuild then glibc_multi else glibc)
-      (toString gcc.cc.lib) bashInteractive coreutils less shadow su
+      (toString gcc.cc.lib) bash.interactive coreutils less shadow su
       gawk diffutils findutils gnused gnugrep
       gnutar gzip bzip2 xz glibcLocales
     ];

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -14,7 +14,7 @@ rec {
   bash = buildImage {
     name = "bash";
     tag = "latest";
-    contents = pkgs.bashInteractive;
+    contents = pkgs.bash.interactive;
   };
 
   # 2. service example, layered on another image

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -187,7 +187,7 @@ rec {
       export PATH=/bin:/usr/bin:${coreutils}/bin
       echo "Starting interactive shell..."
       echo "(To run the original builder: \$origBuilder \$origArgs)"
-      exec ${busybox}/bin/setsid ${bashInteractive}/bin/bash < /dev/${qemuSerialDevice} &> /dev/${qemuSerialDevice}
+      exec ${busybox}/bin/setsid ${bash.interactive}/bin/bash < /dev/${qemuSerialDevice} &> /dev/${qemuSerialDevice}
     fi
   '';
 

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ xz.bin ]
     ++ optionals stdenv.isSunOS [ libiconv gawk ]
-    ++ optionals interactive [ ncurses procps ];
+    ++ optional interactive ncurses;
 
   configureFlags = [ "PERL=${buildPackages.perl}/bin/perl" ]
     ++ stdenv.lib.optional stdenv.isSunOS "AWK=${gawk}/bin/awk";
@@ -32,6 +32,8 @@ stdenv.mkDerivation rec {
     installFlags="TEXMF=$out/texmf-dist";
     installTargets="install install-tex";
   '';
+
+  checkInputs = [ procps ];
 
   doCheck = interactive
     && !stdenv.isDarwin

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -1,9 +1,12 @@
 { version, sha256 }:
 
+let self =
 { stdenv, buildPackages, fetchurl, perl, xz
 
 # we are a dependency of gcc, this simplifies bootstraping
 , interactive ? false, ncurses, procps
+
+, callPackage
 }:
 
 with stdenv.lib;
@@ -39,6 +42,12 @@ stdenv.mkDerivation rec {
     && !stdenv.isDarwin
     && !stdenv.isSunOS; # flaky
 
+  passthru = {
+    interactive = callPackage self {
+      interactive = true;
+    };
+  };
+
   meta = {
     homepage = http://www.gnu.org/software/texinfo/;
     description = "The GNU documentation system";
@@ -63,4 +72,4 @@ stdenv.mkDerivation rec {
     '';
     branch = version;
   };
-}
+}; in self

--- a/pkgs/misc/my-env/default.nix
+++ b/pkgs/misc/my-env/default.nix
@@ -60,7 +60,7 @@
 { mkDerivation, substituteAll, pkgs }:
     { stdenv ? pkgs.stdenv, name, buildInputs ? []
     , propagatedBuildInputs ? [], gcc ? stdenv.cc, extraCmds ? ""
-    , cleanupCmds ? "", shell ? "${pkgs.bashInteractive}/bin/bash --norc"}:
+    , cleanupCmds ? "", shell ? "${pkgs.bash.interactive}/bin/bash --norc"}:
 
 mkDerivation {
   inherit buildInputs propagatedBuildInputs;

--- a/pkgs/servers/x11/xquartz/default.nix
+++ b/pkgs/servers/x11/xquartz/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, buildEnv, makeFontsConf, gnused, writeScript, xorg, bashInteractive, xterm, makeWrapper, ruby
+{ stdenv, lib, buildEnv, makeFontsConf, gnused, writeScript, xorg, bash, xterm, makeWrapper, ruby
 , quartz-wm, fontconfig, xlsfonts, xfontsel
 , ttf_bitstream_vera, freefont_ttf, liberation_ttf
-, shell ? "${bashInteractive}/bin/bash"
+, shell ? "${bash.interactive}/bin/bash"
 }:
 
 # ------------

--- a/pkgs/shells/bash/4.4.nix
+++ b/pkgs/shells/bash/4.4.nix
@@ -1,3 +1,4 @@
+let self =
 { stdenv, buildPackages
 , fetchurl, binutils ? null, bison, autoconf
 , buildPlatform, hostPlatform
@@ -5,6 +6,8 @@
 # patch for cygwin requires readline support
 , interactive ? stdenv.isCygwin, readline70 ? null
 , withDocs ? false, texinfo ? null
+
+, callPackage
 }:
 
 with stdenv.lib;
@@ -127,6 +130,10 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
+    interactive = callPackage self {
+      interactive = true;
+      withDocs = true;
+    };
     shellPath = "/bin/bash";
   };
-}
+}; in self

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -25,7 +25,7 @@
 , enableAlternatives   ? false
 , enableCopyArtifacts  ? false
 
-, bashInteractive, bash-completion
+, bash, bash-completion
 }:
 
 assert enableAcoustid    -> pythonPackages.pyacoustid     != null;
@@ -80,7 +80,7 @@ let
   allPlugins = pluginsWithoutDeps ++ attrNames optionalPlugins;
   allEnabledPlugins = pluginsWithoutDeps ++ enabledOptionalPlugins;
 
-  testShell = "${bashInteractive}/bin/bash --norc";
+  testShell = "${bash.interactive}/bin/bash --norc";
   completion = "${bash-completion}/share/bash-completion/bash_completion";
 
   # This is a stripped down beets for testing of the external plugins.

--- a/pkgs/tools/misc/papis/default.nix
+++ b/pkgs/tools/misc/papis/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, bashInteractive
+{ lib, fetchFromGitHub, bash
 , python3, vim
 }:
 
@@ -44,7 +44,7 @@ in python.pkgs.buildPythonApplication rec {
 
     export HOME=$(pwd)/check-phase
     make test
-    SH=${bashInteractive}/bin/bash make test-non-pythonic
+    SH=${bash.interactive}/bin/bash make test-non-pythonic
   '';
 
   meta = {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -278,6 +278,7 @@ mapAliases ({
   tex-gyre-pagella-math = tex-gyre-math.pagella; # added 2018-04-03
   tex-gyre-schola-math = tex-gyre-math.schola; # added 2018-04-03
   tex-gyre-termes-math = tex-gyre-math.termes; # added 2018-04-03
+  texinfoInteractive = lib.hiPrio texinfo.interactive; # added 2018-03-25
   tftp_hpa = tftp-hpa; # added 2015-04-03
   trang = jing-trang; # added 2018-04-25
   transmission_gtk = transmission-gtk; # added 2018-01-06

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -34,7 +34,7 @@ in
 
 mapAliases ({
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = lib.hiPrio bash.interactive;
+  bashInteractive = bash.interactive;
 
   PPSSPP = ppsspp; # added 2017-10-01
   QmidiNet = qmidinet;  # added 2016-05-22

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -278,7 +278,7 @@ mapAliases ({
   tex-gyre-pagella-math = tex-gyre-math.pagella; # added 2018-04-03
   tex-gyre-schola-math = tex-gyre-math.schola; # added 2018-04-03
   tex-gyre-termes-math = tex-gyre-math.termes; # added 2018-04-03
-  texinfoInteractive = lib.hiPrio texinfo.interactive; # added 2018-03-25
+  texinfoInteractive = texinfo.interactive; # added 2018-03-25
   tftp_hpa = tftp-hpa; # added 2015-04-03
   trang = jing-trang; # added 2018-04-25
   transmission_gtk = transmission-gtk; # added 2018-01-06

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -33,6 +33,9 @@ in
   ### Deprecated aliases - for backward compatibility
 
 mapAliases ({
+  # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
+  bashInteractive = lib.hiPrio bash.interactive;
+
   PPSSPP = ppsspp; # added 2017-10-01
   QmidiNet = qmidinet;  # added 2016-05-22
   accounts-qt = libsForQt5.accounts-qt; # added 2015-12-19

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6148,13 +6148,7 @@ with pkgs;
   runtimeShell = "${runtimeShellPackage}/bin/bash";
   runtimeShellPackage = bash;
 
-  bash = lowPrio (callPackage ../shells/bash/4.4.nix { });
-
-  # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = callPackage ../shells/bash/4.4.nix {
-    interactive = true;
-    withDocs = true;
-  };
+  bash = callPackage ../shells/bash/4.4.nix { };
 
   bash-completion = callPackage ../shells/bash/bash-completion { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8614,9 +8614,6 @@ with pkgs;
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.2.nix { };
   texinfo6 = callPackage ../development/tools/misc/texinfo/6.5.nix { };
   texinfo = texinfo6;
-  texinfoInteractive = appendToName "interactive" (
-    texinfo.override { interactive = true; }
-  );
 
   texi2html = callPackage ../development/tools/misc/texi2html { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8974,7 +8974,7 @@ in {
       rev = "b730f880cfe85a8547f569355a21706f27ebfa78";
       sha256 = "0hh9j5zd2kc0804d2jmf1q3w5xm9l9s69hhgysbncrv5fw0414lh";
     };
-    buildInputs = with pkgs; [ bashInteractive ]; # needed for bash-completion helper
+    buildInputs = with pkgs; [ bash.interactive ]; # needed for bash-completion helper
     propagatedBuildInputs = with self; [ urlgrabber m2crypto pyyaml lxml ];
     postInstall = ''
       ln -s $out/bin/osc-wrapper.py $out/bin/osc


### PR DESCRIPTION
###### Motivation for this change

This patchset is a part of a bigger patchset (that needs a bit more work) that adds `getInteractive` to the lib (or maybe not, that is a subject to change) and then uses that to build user-facing environments. I.e. you, as a user, won't need to ask yourself "Do I need specify Y or YInteractive here?" after applying that patchset, you just say "Y" and it will then select the appropriate one for every instance. E.g. `bash` in FHS environments and NixOS shells will be automatically referenced as `bash.interactive`.

###### Notes

- b51ef9ece59be09c466d84b5387e5534d1458d3a is related, but unrelated (it's actually a piece of `doCheck` patchset), bundled here for simplicity.

- I do `let self =` thing here instead of pushing `self` attr from `all-packages.nix` because both `bash` and `texinfo` are used in `stdenv` stages. Doing this the other way like, e.g. python does, needs some really ugly changes to stdenv.

###### Things done

- [X] Writing from a system with that patchset applied. It worked before rebasing onto master.