### PR TITLE
citrix_receiver: allow custom certs and hooks for the installation

### DIFF
--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -156,7 +156,7 @@ let
         '';
       };
 
-      phases = [ "unpackPhase" "installPhase" ];
+      dontBuild = true;
 
       sourceRoot = ".";
 
@@ -203,6 +203,8 @@ let
       };
 
       installPhase = ''
+        runHook preInstall
+
         export ICAInstDir="$out/opt/citrix-icaclient"
 
         sed -i \
@@ -262,13 +264,15 @@ let
 
         # We introduce a dependency on the source file so that it need not be redownloaded everytime
         echo $src >> "$out/share/nix_dependencies.pin"
+
+        runHook postInstall
       '';
 
       meta = with stdenv.lib; {
         license     = stdenv.lib.licenses.unfree;
         inherit homepage;
         description = "Citrix Receiver";
-        maintainers = with maintainers; [ obadz a1russell ];
+        maintainers = with maintainers; [ obadz a1russell ma27 ];
         platforms   = platforms.linux;
       };
     };

--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -39,50 +39,6 @@ let
   });
 
   versionInfo = {
-    "13.4.0" = rec {
-      major     = "13";
-      minor     = "4";
-      patch     = "0";
-      x64hash   = "133brs0sq6d0mgr19rc6ig1n9ahm3ryi23v5nrgqfh0hgxqcrrjb";
-      x86hash   = "0r7jfl5yqv1s2npy8l9gsn0gbb82f6raa092ppkc8xy5pni5sh7l";
-      x64suffix = "10109380";
-      x86suffix = x64suffix;
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/legacy-receiver-for-linux/receiver-for-linux-latest-13-4.html;
-    };
-
-    "13.5.0" = rec {
-      major     = "13";
-      minor     = "5";
-      patch     = "0";
-      x64hash   = "1r24mhkpcc0z95n597p07fz92pd1b8qqzp2z6w07rmb9wb8mpd4x";
-      x86hash   = "0pwxshlryzhkl86cj9ryybm54alhzjx0gpp67fnvdn5r64wy1nd1";
-      x64suffix = "10185126";
-      x86suffix = x64suffix;
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/legacy-receiver-for-linux/receiver-for-linux-latest-13-5.html;
-    };
-
-    "13.6.0" = rec {
-      major     = "13";
-      minor     = "6";
-      patch     = "0";
-      x64hash   = "6e423be41d5bb8186bcca3fbb4ede54dc3f00b8d2aeb216ae4aabffef9310d34";
-      x86hash   = "0ba3eba208b37844904d540b3011075ed5cecf429a0ab6c6cd52f2d0fd841ad2";
-      x64suffix = "10243651";
-      x86suffix = x64suffix;
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/legacy-receiver-for-linux/receiver-for-linux-136.html;
-    };
-
-    "13.7.0" = {
-      major     = "13";
-      minor     = "7";
-      patch     = "0";
-      x64hash   = "18fb374b9fb8e249b79178500dddca7a1f275411c6537e7695da5dcf19c5ba91";
-      x86hash   = "4c68723b0327cf6f12da824056fce2b7853c38e6163a48c9d222b93dd8da75b6";
-      x64suffix = "10276927";
-      x86suffix = "10276925";
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/legacy-receiver-for-linux/receiver-for-linux-137.html;
-    };
-
     "13.8.0" = {
       major     = "13";
       minor     = "8";

--- a/pkgs/applications/networking/remote/citrix-receiver/wrapper.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/wrapper.nix
@@ -1,0 +1,19 @@
+{ citrix_receiver, extraCerts ? [], symlinkJoin }:
+
+let
+
+  mkCertCopy = certPath:
+    "cp ${certPath} $out/opt/citrix-icaclient/keystore/cacerts/";
+
+in
+
+if builtins.length extraCerts == 0 then citrix_receiver else symlinkJoin {
+  name = "citrix-with-extra-certs-${citrix_receiver.version}";
+  paths = [ citrix_receiver ];
+
+  postBuild = ''
+    ${builtins.concatStringsSep "\n" (map mkCertCopy extraCerts)}
+
+    sed -i -E "s,-icaroot (.+citrix-icaclient),-icaroot $out/opt/citrix-icaclient," $out/bin/wfica
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1740,10 +1740,6 @@ with pkgs;
   citrix_receiver_unwrapped_13_9_1  = citrix_receiver_unwrapped.override { version = "13.9.1";  };
   citrix_receiver_unwrapped_13_9_0  = citrix_receiver_unwrapped.override { version = "13.9.0";  };
   citrix_receiver_unwrapped_13_8_0  = citrix_receiver_unwrapped.override { version = "13.8.0";  };
-  citrix_receiver_unwrapped_13_7_0  = citrix_receiver_unwrapped.override { version = "13.7.0";  };
-  citrix_receiver_unwrapped_13_6_0  = citrix_receiver_unwrapped.override { version = "13.6.0";  };
-  citrix_receiver_unwrapped_13_5_0  = citrix_receiver_unwrapped.override { version = "13.5.0";  };
-  citrix_receiver_unwrapped_13_4_0  = citrix_receiver_unwrapped.override { version = "13.4.0";  };
 
   citrix_receiver = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
     citrix_receiver = citrix_receiver_unwrapped;
@@ -1759,18 +1755,6 @@ with pkgs;
   };
   citrix_receiver_13_8_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
     citrix_receiver = citrix_receiver_unwrapped_13_8_0;
-  };
-  citrix_receiver_13_7_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
-    citrix_receiver = citrix_receiver_unwrapped_13_7_0;
-  };
-  citrix_receiver_13_6_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
-    citrix_receiver = citrix_receiver_unwrapped_13_6_0;
-  };
-  citrix_receiver_13_5_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
-    citrix_receiver = citrix_receiver_unwrapped_13_5_0;
-  };
-  citrix_receiver_13_4_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
-    citrix_receiver = citrix_receiver_unwrapped_13_4_0;
   };
 
   citra = libsForQt5.callPackage ../misc/emulators/citra { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1735,15 +1735,43 @@ with pkgs;
 
   circleci-cli = callPackage ../development/tools/misc/circleci-cli { };
 
-  citrix_receiver = callPackage ../applications/networking/remote/citrix-receiver { };
-  citrix_receiver_13_10_0 = citrix_receiver.override { version = "13.10.0"; };
-  citrix_receiver_13_9_1  = citrix_receiver.override { version = "13.9.1";  };
-  citrix_receiver_13_9_0  = citrix_receiver.override { version = "13.9.0";  };
-  citrix_receiver_13_8_0  = citrix_receiver.override { version = "13.8.0";  };
-  citrix_receiver_13_7_0  = citrix_receiver.override { version = "13.7.0";  };
-  citrix_receiver_13_6_0  = citrix_receiver.override { version = "13.6.0";  };
-  citrix_receiver_13_5_0  = citrix_receiver.override { version = "13.5.0";  };
-  citrix_receiver_13_4_0  = citrix_receiver.override { version = "13.4.0";  };
+  citrix_receiver_unwrapped = callPackage ../applications/networking/remote/citrix-receiver { };
+  citrix_receiver_unwrapped_13_10_0 = citrix_receiver_unwrapped.override { version = "13.10.0"; };
+  citrix_receiver_unwrapped_13_9_1  = citrix_receiver_unwrapped.override { version = "13.9.1";  };
+  citrix_receiver_unwrapped_13_9_0  = citrix_receiver_unwrapped.override { version = "13.9.0";  };
+  citrix_receiver_unwrapped_13_8_0  = citrix_receiver_unwrapped.override { version = "13.8.0";  };
+  citrix_receiver_unwrapped_13_7_0  = citrix_receiver_unwrapped.override { version = "13.7.0";  };
+  citrix_receiver_unwrapped_13_6_0  = citrix_receiver_unwrapped.override { version = "13.6.0";  };
+  citrix_receiver_unwrapped_13_5_0  = citrix_receiver_unwrapped.override { version = "13.5.0";  };
+  citrix_receiver_unwrapped_13_4_0  = citrix_receiver_unwrapped.override { version = "13.4.0";  };
+
+  citrix_receiver = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped;
+  };
+  citrix_receiver_13_10_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_10_0;
+  };
+  citrix_receiver_13_9_1 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_9_1;
+  };
+  citrix_receiver_13_9_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_9_0;
+  };
+  citrix_receiver_13_8_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_8_0;
+  };
+  citrix_receiver_13_7_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_7_0;
+  };
+  citrix_receiver_13_6_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_6_0;
+  };
+  citrix_receiver_13_5_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_5_0;
+  };
+  citrix_receiver_13_4_0 = callPackage ../applications/networking/remote/citrix-receiver/wrapper.nix {
+    citrix_receiver = citrix_receiver_unwrapped_13_4_0;
+  };
 
   citra = libsForQt5.callPackage ../misc/emulators/citra { };
 


### PR DESCRIPTION
###### Motivation for this change

Sometimes it's required to modify some parts of the Citrix build on
their own which is why `{pre,post}Install` hooks can be quite helpful.

Additionally some corporate clients use their own certificates that
aren't stored as trusted ones in the `cacert` package with all of the
trusted certs by Mozilla.

Now it's possible to add custom certs like this:

``` nix
with import <nixpkgs> { config.allowUnfree = true; };

let path = ../../Downloads/custom-corporate-cert.pem; in
citrix_receiver.override {
  extraCerts = [ path ];
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

