### PR TITLE
nixos/activation: Identifies the snippet that failed

### DIFF
--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -8,7 +8,12 @@ let
   addAttributeName = mapAttrs (a: v: v // {
     text = ''
       #### Activation script snippet ${a}:
+      _localstatus=0
       ${v.text}
+
+      if (( _localstatus > 0 )); then
+        printf "Activation script snippet '%s' failed (%s)\n" "${a}" "$_localstatus"
+      fi
     '';
   });
 
@@ -71,7 +76,7 @@ in
             done
 
             _status=0
-            trap "_status=1" ERR
+            trap "_status=1 _localstatus=\$?" ERR
 
             # Ensure a consistent umask.
             umask 0022


### PR DESCRIPTION
This allows a developer to better identify in which snippet the
failure happened. Furthermore, users seeking help will have more
information available about the failure.

###### Motivation for this change

[Talked about the idea briefly earlier today on #nixos](https://logs.nix.samueldr.com/nixos/2018-08-05#1533486659-1533488029;)

***EDIT** Removed a misleading request for comments, see later comment form myself*

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

