### PR TITLE
doc: Fixes mentions of mention-bot.

### DIFF
--- a/doc/reviewing-contributions.xml
+++ b/doc/reviewing-contributions.xml
@@ -103,8 +103,9 @@
     <itemizedlist>
      <listitem>
       <para>
-       mention-bot usually notifies GitHub users based on the submitted changes,
-       but it can happen that it misses some of the package maintainers.
+       <link xlink:href="https://help.github.com/articles/about-codeowners/">CODEOWNERS</link>
+       will make GitHub notify users based on the submitted changes, but it can
+       happen that it misses some of the package maintainers.
       </para>
      </listitem>
     </itemizedlist>
@@ -376,8 +377,9 @@ $ nix-shell -p nox --run "nox-review -k pr PRNUMBER"
     <itemizedlist>
      <listitem>
       <para>
-       Mention-bot notify GitHub users based on the submitted changes, but it
-       can happen that it miss some of the package maintainers.
+       <link xlink:href="https://help.github.com/articles/about-codeowners/">CODEOWNERS</link>
+       will make GitHub notify users based on the submitted changes, but it can
+       happen that it misses some of the package maintainers.
       </para>
      </listitem>
     </itemizedlist>


### PR DESCRIPTION
Its last mention was on 2017-09-25. Close to a year.

The CODEOWNERS feature of github, though, fills in the gap in a more
appropriate manner (IMHO).

*I have let `make` auto-format only the parts I changed*

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

