### PR TITLE
Fix gi vte haskell pkg

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -4742,7 +4742,6 @@ dont-distribute-packages:
   gi-gtkosxapplication:                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-notify:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-poppler:                                     [ i686-linux, x86_64-linux, x86_64-darwin ]
-  gi-vte:                                         [ i686-linux, x86_64-linux, x86_64-darwin ]
   gi-wnck:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   giak:                                           [ i686-linux, x86_64-linux, x86_64-darwin ]
   Gifcurry:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change

The [gi-vte](https://hackage.haskell.org/package/gi-vte) Haskell package does not compile in master:

https://hydra.nixos.org/job/nixpkgs/haskell-updates/haskellPackages.gi-vte.x86_64-linux

gi-vte depends on the gi-gtk Haskell package, as well as the VTE system library.  The gi-gtk Haskell packge depends on the GTK system library.  Currently, gi-gtk is being compiled against the GTK system library from Gnome 3.  However, gi-vte is being compiled against the VTE system library from Gnome 2.

This PR does the following three things:

1. Change the gi-vte package to depend the VTE system library from Gnome 3 in `hackage-packages.nix`.

2. Add a dependency on the GTK system library for gi-vte.  I'm not sure exactly why this is necessary, but gi-vte wouldn't build without it.

3. Remove the gi-vte package from `dont-distribute-packages` in `configuration-hackage2nix.yaml`.

Eventually, I'd like to add a new Haskell [package](https://hackage.haskell.org/package/termonad) to nixpkgs that depends on gi-vte, so I would like gi-vte to be compiling in master.  I'd like to get this in before the 18.09 release.

However, I think the `hackage-packages.nix` file (and maybe even the `configuration-hackge2nix.yaml`) is being auto-generated, so please let me know if there is some other file I should actually be editing.  Also, for my future reference, is there an explanation somewhere of how the Haskell-related nixpkg files work?  Like, which files I should edit and send PRs to?

Pinging the nixpkgs Haskell maintainers: @peti @ryantm @basvandijk (please let me know if it is not appropriate to do this)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (**there are currently no packages that depend on gi-vte**)
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (**there are no binary files produced by gi-vte**)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

