### PR TITLE
xtrigger: init at v0.002

### DIFF
--- a/pkgs/tools/X11/xtrigger/default.nix
+++ b/pkgs/tools/X11/xtrigger/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, libX11 }:
+
+stdenv.mkDerivation rec {
+  name = "xtrigger-${version}";
+  version = "0.002";
+
+  src = fetchurl {
+    url = "https://github.com/tgharib/xtrigger/archive/${version}.tar.gz";
+    sha256 = "5bb866b45c592a96787ba950cb63b28f1dc45afc6cc941b1994c2798e1e68d57";
+  };
+
+  buildInputs = [ libX11 ];
+  installFlags = [ "DESTDIR=$(out)" ]; 
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "/usr" "/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An X window monitor and automater";
+    longDescription = "xtrigger monitors windows created by xserver and executes a command once a window 'event' is triggered.";
+    homepage = https://github.com/richard-dp/xtrigger/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.taha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5858,6 +5858,8 @@ with pkgs;
 
   xsensors = callPackage ../os-specific/linux/xsensors { };
 
+  xtrigger = callPackage ../tools/X11/xtrigger {};
+
   xcruiser = callPackage ../applications/misc/xcruiser { };
 
   xxkb = callPackage ../applications/misc/xxkb { };


### PR DESCRIPTION
###### Motivation for this change

Added xtrigger window-monitor to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

