### PR TITLE
crispy-doom: init at 5.2

### DIFF
--- a/pkgs/games/crispy-doom/default.nix
+++ b/pkgs/games/crispy-doom/default.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation rec {
     longDescription = "Crispy Doom is a limit-removing enhanced-resolution Doom source port based on Chocolate Doom. Its name means that 640x400 looks \"crisp\" and is also a slight reference to its origin.";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;
-    hydraPlatforms = stdenv.lib.platforms.linux; # darwin times out
     maintainers = with stdenv.lib.maintainers; [ neonfuz ];
   };
 }

--- a/pkgs/games/crispy-doom/default.nix
+++ b/pkgs/games/crispy-doom/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, autoreconfHook, pkgconfig, SDL2, SDL2_mixer, SDL2_net, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "crispy-doom-5.2";
+  src = fetchurl {
+    url = "https://github.com/fabiangreffrath/crispy-doom/archive/${name}.tar.gz";
+    sha256 = "0arj2pn66ygzdlws80irdhald9sj0wr7cbckfs69z34ij21zzfgz";
+  };
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ SDL2 SDL2_mixer SDL2_net ];
+  patchPhase = ''
+    sed -e 's#/games#/bin#g' -i src{,/setup}/Makefile.am
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = {
+    homepage = http://fabiangreffrath.github.io/crispy-doom;
+    description = "A limit-removing enhanced-resolution Doom source port based on Chocolate Doom";
+    longDescription = "Crispy Doom is a limit-removing enhanced-resolution Doom source port based on Chocolate Doom. Its name means that 640x400 looks \"crisp\" and is also a slight reference to its origin.";
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = stdenv.lib.platforms.unix;
+    hydraPlatforms = stdenv.lib.platforms.linux; # darwin times out
+    maintainers = with stdenv.lib.maintainers; [ neonfuz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19483,6 +19483,8 @@ with pkgs;
 
   chocolateDoom = callPackage ../games/chocolate-doom { };
 
+  crispyDoom = callPackage ../games/crispy-doom { };
+
   ckan = callPackage ../games/ckan { };
 
   cockatrice = libsForQt5.callPackage ../games/cockatrice {  };


### PR DESCRIPTION
###### Motivation for this change
Crispy doom is enhanced version of chocolate doom (which in turn is a sourceport of doom). Some of it's features are optionally doubling the original resolution from 320x200 to 640x400, removing or raising static limits set by the original game, and adding compatibility for the "Doom Classic" WADs shipped with the "Doom 3: BFG Edition", especially the "No Rest For The Living" episode shipped in the NERVE.WAD file.

Nixos already has chocolate doom so the port was pretty straight-forward from that. Some people would probably enjoy the features of this sourceport, the more the merrier IMO.

Also, there is a comment remaining from chocolate-doom that hydra darwin times out, I don't know if this is still true but I left the comment because this package is similar to chocolate doom so it's probably true. Someone might want to re-test this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

