### PR TITLE
cc-wrapper: dont inconditionnally include glibc

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -16,6 +16,9 @@ var_templates_bool=(
 
 accumulateRoles
 
+cppInclude="$1"
+noLibc="$2"
+
 # We need to mangle names for hygiene, but also take parameters/overrides
 # from the environment.
 for var in "${var_templates_list[@]}"; do
@@ -31,7 +34,7 @@ NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
 # Export and assign separately in order that a failing $(..) will fail
 # the script.
 
-if [ -e @out@/nix-support/libc-cflags ]; then
+if [ -e @out@/nix-support/libc-cflags ] && ([ $cppInclude -ne 0 ]); then
     NIX_@infixSalt@_CFLAGS_COMPILE="$(< @out@/nix-support/libc-cflags) $NIX_@infixSalt@_CFLAGS_COMPILE"
 fi
 

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -27,7 +27,7 @@
 }:
 
 { name
-, withLinuxHeaders ? false
+, withLinuxHeaders ? true
 , profilingLibraries ? false
 , installLocales ? false
 , withGd ? false


### PR DESCRIPTION
... headers even when using -nostdinc or -nolibc (clang attribute)

###### Motivation for this change
Even with nostdinc/nolibc flags wrapper-cc will look in glibc include directories see  https://github.com/NixOS/nixpkgs/issues/44530

Upon compiling glibcLocales, I have a problem though:
```
checking for alloca... yes
checking for stdlib.h... (cached) yes
checking whether the C++ compiler supports thread_local... no
running configure fragment for sysdeps/unix/sysv/linux/x86_64/64
running configure fragment for sysdeps/unix/sysv/linux/x86_64
running configure fragment for sysdeps/unix/sysv/linux
checking for unistd.h... (cached) yes
checking installed Linux kernel header files... missing or too old!
configure: error: GNU libc requires kernel header files from
Linux 3.2.0 or later to be installed before configuring.
The kernel header files are found usually in /usr/include/asm and
/usr/include/linux; make sure these directories use files from
Linux 3.2.0 or later.  This check uses <linux/version.h>, so
make sure that file was built correctly when installing the kernel header
files.  To use kernel headers not from /usr/include/linux, use the
configure option --with-headers.
gcc -I.. -I../.. -I../modes -I../asn1 -I../evp -I../../include  -fPIC -DOPENSSL_PIC -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -Wa,--noexecstack -m64 -DL_ENDIAN -O3 -Wall -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DRC4_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DWHIRLPOOL_ASM -DGHASH_ASM -DECP_NISTZ256_ASM   -c -o e_aes.o e_aes.c
checking for sys/param.h... yes
note: keeping build directory '/tmp/nix-build-glibc-locales-2.27.drv-0'
builder for '/nix/store/a9n3c7vxj95jp1l8qzfgh5zcn6vxmn71-glibc-locales-2.27.drv' failed with exit code 1
note: keeping build directory '/tmp/nix-build-openssl-1.0.2o.drv-0'
note: keeping build directory '/tmp/nix-build-ghc-8.2.1-binary.drv-0'
cannot build derivation '/nix/store/hhvvpx581bvxsng70l7c8xzqscsgdwri-ShellCheck-0.5.0.drv': 1 dependencies couldn't be built
note: keeping build directory '/tmp/nix-build-bash-interactive-4.4-p23.drv-0'
error: build of '/nix/store/a4122g7iwdy52qr1qb33pvsa3gdhnbjr-bash-interactive-4.4-p23.drv', '/nix/store/hhvvpx581bvxsng70l7c8xzqscsgdwri-ShellCheck-0.5.0.drv' failed

```
I tried in a nix-shell with the same result
```
configure flags: --disable-static --prefix=/nix/store/64x91npllljy88insldhgvdnlmh36dda-glibc-locales-2.27 --prefix=/nix/store/64x91npllljy88insldhgvdnlmh36dda-glibc-locales-2.27 --disable-static --prefix=/nix/store/64x91npllljy88insldhgvdnlmh36dda-glibc-locales-2.27 -C --enable-add-ons --enable-obsolete-nsl --enable-obsolete-rpc --sysconfdir=/etc --enable-stackguard-randomization --without-headers --disable-profile
...
running configure fragment for sysdeps/unix/sysv/linux
checking installed Linux kernel header files... missing or too old!
configure: error: GNU libc requires kernel header files from
Linux 3.2.0 or later to be installed before configuring.
The kernel header files are found usually in /usr/include/asm and
/usr/include/linux; make sure these directories use files from
Linux 3.2.0 or later.  This check uses <linux/version.h>, so
make sure that file was built correctly when installing the kernel header
files.  To use kernel headers not from /usr/include/linux, use the
configure option --with-headers.

```
Looking at the log, it seems that glibc compiles with nostdinc

```
configure:28: gcc -c -g -O2  -nostdinc -isystem /nix/store/qqcha3j759fl1wj840z0b0hdhkbg061a-gcc-7.3.0/lib/gcc/x86_64-unknown-linux-gnu/7.3.0/include -isystem /nix/store/qqcha3j759fl1wj840z0b0hdhkbg061a-gcc-7.3.0/lib/gcc/x86_64-unknown-linux-gnu/7.3.0/include-fixed -isystem no conftest.c >&5
conftest.c:25:10: fatal error: linux/version.h: No such file or directory
 #include <linux/version.h>
          ^~~~~~~~~~~~~~~~~
```
and that my change make it really effective thus calling configure `--without-headers` fail ?
My guess is that glibc should always be compiled with `withLinuxHeaders` to prevent this (which is not the case for glibLocales) but I could be wrong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

