### PR TITLE
linux-kernel: Removes bcm2835_mmal_v4l2_camera_driver patch

### DIFF
--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -48,17 +48,6 @@ rec {
     };
   };
 
-  # https://patchwork.kernel.org/patch/9626797/
-  # Should be included in 4.17, so this patch can be dropped when 4.16 becomes obsolete.
-  bcm2835_mmal_v4l2_camera_driver = rec {
-    name = "bcm2835_mmal_v4l2_camera_driver";
-    patch = fetchpatch {
-      name = name + ".patch";
-      url = https://patchwork.kernel.org/patch/9626797/raw/;
-      sha256 = "0iwb0yxsf95zv4qxkvlvhqfmzx0rk13g9clvxsharvwkb4w5lwa0";
-    };
-  };
-
   # https://github.com/NixOS/nixpkgs/issues/42755
   xen-netfront_fix_mismatched_rtnl_unlock = rec {
     name = "xen-netfront_fix_mismatched_rtnl_unlock";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13838,7 +13838,6 @@ with pkgs;
         # when adding a new linux version
         # kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
-        kernelPatches.bcm2835_mmal_v4l2_camera_driver # Only needed for 4.16!
       ];
   };
 


### PR DESCRIPTION
The patch was only required for kernel 4.16.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

