### PR TITLE
emacs: make a number of melpa packages work again

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -163,6 +163,11 @@ self:
             (attrs.nativeBuildInputs or []) ++ [ external.git ];
          }));
 
+      # tries to write to $HOME
+      php-auto-yasnippets = super.php-auto-yasnippets.overrideAttrs (attrs: {
+        HOME = "/tmp";
+      });
+
       # upstream issue: mismatched filename
       processing-snippets = markBroken super.processing-snippets;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -81,6 +81,11 @@ self:
           (attrs.nativeBuildInputs or []) ++ [ external.git ];
       });
 
+      # missing dependencies
+      evil-search-highlight-persist = super.evil-search-highlight-persist.overrideAttrs (attrs: {
+        packageRequires = with self; [ evil highlight ];
+      });
+
       # missing OCaml
       flycheck-ocaml = markBroken super.flycheck-ocaml;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -75,6 +75,12 @@ self:
         inherit (self.melpaPackages) ess ctable popup;
       };
 
+      evil-magit = super.evil-magit.overrideAttrs (attrs: {
+        # searches for Git at build time
+        nativeBuildInputs =
+          (attrs.nativeBuildInputs or []) ++ [ external.git ];
+      });
+
       # missing OCaml
       flycheck-ocaml = markBroken super.flycheck-ocaml;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -52,10 +52,6 @@ self:
       # part of a larger package
       caml = dontConfigure super.caml;
 
-      # part of a larger package
-      # upstream issue: missing package version
-      cmake-mode = markBroken (dontConfigure super.cmake-mode);
-
       # Expects bash to be at /bin/bash
       company-rtags = markBroken super.company-rtags;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -55,9 +55,6 @@ self:
       # Expects bash to be at /bin/bash
       company-rtags = markBroken super.company-rtags;
 
-      # upstream issue: missing file header
-      connection = markBroken super.connection;
-
       easy-kill-extras = super.easy-kill-extras.override {
         inherit (self.melpaPackages) easy-kill;
       };

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -58,9 +58,6 @@ self:
       # upstream issue: missing file header
       connection = markBroken super.connection;
 
-      # upstream issue: missing file header
-      dictionary = markBroken super.dictionary;
-
       easy-kill-extras = super.easy-kill-extras.override {
         inherit (self.melpaPackages) easy-kill;
       };

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -172,9 +172,6 @@ self:
             (attrs.nativeBuildInputs or []) ++ [ external.git ];
          }));
 
-      # upstream issue: truncated file
-      powershell = markBroken super.powershell;
-
       # upstream issue: mismatched filename
       processing-snippets = markBroken super.processing-snippets;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -127,9 +127,6 @@ self:
       jsfmt = markBroken super.jsfmt;
 
       # upstream issue: missing file header
-      link = markBroken super.link;
-
-      # upstream issue: missing file header
       maxframe = markBroken super.maxframe;
 
       magit =

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -143,6 +143,12 @@ self:
             (attrs.nativeBuildInputs or []) ++ [ external.git ];
         });
 
+      magit-gitflow = super.magit-gitflow.overrideAttrs (attrs: {
+        # searches for Git at build time
+        nativeBuildInputs =
+          (attrs.nativeBuildInputs or []) ++ [ external.git ];
+      });
+
       # missing OCaml
       merlin = markBroken super.merlin;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -115,6 +115,11 @@ self:
       # upstream issue: missing file header
       initsplit = super.initsplit;
 
+      # tries to write a log file to $HOME
+      insert-shebang = super.insert-shebang.overrideAttrs (attrs: {
+        HOME = "/tmp";
+      });
+
       # Expects bash to be at /bin/bash
       ivy-rtags = markBroken super.ivy-rtags;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -134,6 +134,12 @@ self:
             (attrs.nativeBuildInputs or []) ++ [ external.git ];
         });
 
+      magit-annex = super.magit-annex.overrideAttrs (attrs: {
+        # searches for Git at build time
+        nativeBuildInputs =
+          (attrs.nativeBuildInputs or []) ++ [ external.git ];
+      });
+
       magit-gitflow = super.magit-gitflow.overrideAttrs (attrs: {
         # searches for Git at build time
         nativeBuildInputs =


### PR DESCRIPTION
###### Motivation for this change

Fixes #44539

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Cc: @chaoflow @lovek323 @peti @the-kenny @jwiegley