### PR TITLE
matterbridge: 1.7.1 -> 1.11.0

### DIFF
--- a/pkgs/servers/matterbridge/default.nix
+++ b/pkgs/servers/matterbridge/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "matterbridge-${version}";
-  version = "1.7.1";
+  version = "1.11.0";
 
   goPackagePath = "github.com/42wim/matterbridge";
 
   src = fetchurl {
     url = "https://github.com/42wim/matterbridge/archive/v${version}.tar.gz";
-    sha256 = "0ajc7xswmwhc2xn937sv3b76s8hblfn9x9rj5825hi3d3s8zqq88";
+    sha256 = "1fjpgdaq4mfgf36gzk3hhmlbpfn44b7xll2rdpy69y460jrjfg6k";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Simple version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

