### PR TITLE
magit-annex: provide `external.git`

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -23,6 +23,10 @@ self:
       "swbuff-x" # required dependency swbuff is missing
     ];
 
+    addBuildDepends = pkg: xs: pkg.overrideAttrs (attrs: {
+      nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ xs;
+    });
+
     dontConfigure = pkg: pkg.override (args: {
       melpaBuild = drv: args.melpaBuild (drv // {
         configureScript = "true";
@@ -120,16 +124,14 @@ self:
       # upstream issue: missing file header
       maxframe = markBroken super.maxframe;
 
-      magit =
+      magit = addBuildDepends
         (super.magit.override {
           # version of magit-popup needs to match magit
           # https://github.com/magit/magit/issues/3286
           inherit (self.melpaPackages) magit-popup;
-        }).overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or []) ++ [ external.git ];
-        });
+        }) [external.git];
+
+      magit-annex = addBuildDepends super.magit-annex [external.git];
 
       # missing OCaml
       merlin = markBroken super.merlin;

--- a/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
@@ -22,6 +22,10 @@ self:
 
     super = imported;
 
+    addBuildDepends = pkg: xs: pkg.overrideAttrs (attrs: {
+      nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ xs;
+    });
+
     dontConfigure = pkg: pkg.override (args: {
       melpaBuild = drv: args.melpaBuild (drv // {
         configureScript = "true";
@@ -140,16 +144,14 @@ self:
       # upstream issue: missing file header
       maxframe = markBroken super.maxframe;
 
-      magit =
+      magit = addBuildDepends
         (super.magit.override {
           # version of magit-popup needs to match magit
           # https://github.com/magit/magit/issues/3286
           inherit (self.melpaStablePackages) magit-popup;
-        }).overrideAttrs (attrs: {
-          # searches for Git at build time
-          nativeBuildInputs =
-            (attrs.nativeBuildInputs or []) ++ [ external.git ];
-        });
+        }) [external.git];
+
+      magit-annex = addBuildDepends super.magit-annex [external.git];
 
       # missing OCaml
       merlin = markBroken super.merlin;


### PR DESCRIPTION
Refactor the code to add the input from the `magit` expression to be reusable.

###### Motivation for this change

#44539 details how the `magit-annex` package broke; this is the same breakage that `magit` experienced---this refactors @ttuegel's solution for that package to be reusable, and adds a similar annotation to `magit-annex`.

###### Things done

Rebuilt `magit` using the refactored expression, which worked fine, and confirmed that the `magit-annex` expression now installs.

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

