### PR TITLE
mpich2: cleanup derivation, rename to mpich

### DIFF
--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, gfortran
-, slurm, openssh, hwloc
+,  openssh, hwloc
 } :
 
 stdenv.mkDerivation  rec {
@@ -16,7 +16,9 @@ stdenv.mkDerivation  rec {
     "--enable-sharedlib"
   ];
 
-  buildInputs = [ perl gfortran slurm openssh hwloc ];
+  enableParallelBuilding = true;
+
+  buildInputs = [ perl gfortran openssh hwloc ];
 
   doCheck = true;
 
@@ -26,8 +28,12 @@ stdenv.mkDerivation  rec {
       echo "fix rpath: $entry"
       patchelf --set-rpath "$out/lib" $entry
     done
-  '';
 
+    # Ensure the default compilers are the ones mpich was built with
+    sed -i 's:CC="gcc":CC=${stdenv.cc}/bin/gcc:' $out/bin/mpicc
+    sed -i 's:CXX="g++":CXX=${stdenv.cc}/bin/g++:' $out/bin/mpicxx
+    sed -i 's:FC="gfortran":FC=${gfortran}/bin/gfortran:' $out/bin/mpifort
+  '';
 
   meta = with stdenv.lib; {
     description = "Implementation of the Message Passing Interface (MPI) standard";

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation  rec {
       fullName = "MPICH license (permissive)";
     };
     maintainers = [ maintainers.markuskowa ];
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -171,6 +171,7 @@ mapAliases ({
   mlt-qt5 = libsForQt5.mlt;  # added 2015-12-19
   mobile_broadband_provider_info = mobile-broadband-provider-info; # added 2018-02-25
   module_init_tools = kmod; # added 2016-04-22
+  mpich2 = mpich;  # added 2018-08-06
   msf = metasploit; # added 2018-04-25
   mssys = ms-sys; # added 2015-12-13
   multipath_tools = multipath-tools;  # added 2016-01-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11071,9 +11071,7 @@ with pkgs;
 
   libmpc = callPackage ../development/libraries/libmpc { };
 
-  mpich2 = callPackage ../development/libraries/mpich2 {
-    gfortran = gfortran5;
-  };
+  mpich = callPackage ../development/libraries/mpich { };
 
   mstpd = callPackage ../os-specific/linux/mstpd { };
 


### PR DESCRIPTION
###### Motivation for this change
Some cleanup of the derivation (see below).
The official name of the package was changed from mpich2 to mpich in 2012 (https://www.mpich.org/about/overview/)

###### Things done
* mpich2 -> mpich (added alias)
* remove `slurm` dependency (not needed)
* use most recent `gfortran`
* turn `enableParallelBulding` on
* ensure mpi[cc,cxx,fort] uses default compilers it was built with

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

