### PR TITLE
tmux-plugins: fix the fzf-tmux-url derivation

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -3,13 +3,14 @@
 let
   rtpPath = "share/tmux-plugins";
 
-  addRtp = path: pluginName: attrs: derivation:
-    derivation // { rtp = "${derivation}/${path}/${builtins.replaceStrings ["-"] ["_"] pluginName}.tmux"; } // {
+  addRtp = path: rtpFilePath: attrs: derivation:
+    derivation // { rtp = "${derivation}/${path}/${rtpFilePath}"; } // {
       overrideAttrs = f: buildTmuxPlugin (attrs // f attrs);
     };
 
   buildTmuxPlugin = a@{
     pluginName,
+    rtpFilePath ? (builtins.replaceStrings ["-"] ["_"] pluginName) + ".tmux",
     namePrefix ? "tmuxplugin-",
     src,
     unpackPhase ? "",
@@ -22,7 +23,7 @@ let
     dependencies ? [],
     ...
   }:
-    addRtp "${rtpPath}/${path}" pluginName a (stdenv.mkDerivation (a // {
+    addRtp "${rtpPath}/${path}" rtpFilePath a (stdenv.mkDerivation (a // {
       name = namePrefix + pluginName;
 
       inherit pluginName unpackPhase configurePhase buildPhase addonInfo preInstall postInstall;
@@ -102,6 +103,7 @@ in rec {
 
   fzf-tmux-url = buildTmuxPluginFrom2Nix {
     pluginName = "fzf-tmux-url";
+    rtpFilePath = "fzf-url.tmux";
     src = fetchgit {
       url = "https://github.com/wfxr/tmux-fzf-url";
       rev = "ecd518eec1067234598c01e655b048ff9d06ef2f";


### PR DESCRIPTION
###### Motivation for this change

The current `buildTmuxPluginFrom2Nix` computes the path of rtp by replacing dashes with an underscore in the plugin name and assume it's at the root of the plugin repo. This PR adds a new parameter to `buildTmuxPluginFrom2Nix` called `rtpFilePath` to allow plugins to specify a custom path for the rtp (relative to the plugin $out). This path for fzf-tmux-url is `fzf-url.tmux` 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
$ nix repl .
Welcome to Nix version 2.0.4. Type :? for help.

Loading '.'...
Added 9270 variables.

nix-repl> p = tmuxPlugins.fzf-tmux-url

nix-repl> p.rtp
"/nix/store/k3v0vvfkw9kkirf0k5gdiz8kqvrj8i3i-tmuxplugin-fzf-tmux-url/share/tmux-plugins/fzf-tmux-url/fzf-url.tmux"

$ stat /nix/store/k3v0vvfkw9kkirf0k5gdiz8kqvrj8i3i-tmuxplugin-fzf-tmux-url/share/tmux-plugins/fzf-tmux-url/fzf-url.tmux
  File: /nix/store/k3v0vvfkw9kkirf0k5gdiz8kqvrj8i3i-tmuxplugin-fzf-tmux-url/share/tmux-plugins/fzf-tmux-url/fzf-url.tmux
  Size: 612             Blocks: 8          IO Block: 4096   regular file
Device: 1bh/27d Inode: 11909887    Links: 7
Access: (0555/-r-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2018-08-05 00:12:57.245965835 -0700
Modify: 1969-12-31 16:00:01.000000000 -0800
Change: 2018-08-06 11:14:51.614312143 -0700
 Birth: -
```