### PR TITLE
pythonPackages.asana: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/development/python-modules/asana/default.nix
+++ b/pkgs/development/python-modules/asana/default.nix
@@ -4,22 +4,21 @@
 
 buildPythonPackage rec {
   pname = "asana";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "asana";
     repo = "python-asana";
     rev = "v${version}";
-    sha256 = "0786y3wxqxxhsb0kkpx4bfzif3dhvv3dmm6vnq58iyj94862kpxf";
+    sha256 = "0vmpy4j1n54gkkg0l8bhw0xf4yby5kqzxnsv07cjc2w38snj5vy1";
   };
 
   checkInputs = [ pytest responses ];
   propagatedBuildInputs = [ requests requests_oauthlib six ];
 
-  patchPhase = ''
-    echo > requirements.txt
-    sed -i "s/requests~=2.9.1/requests >=2.9.1/" setup.py
-    sed -i "s/requests_oauthlib~=0.6.1/requests_oauthlib >=0.6.1/" setup.py
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "requests_oauthlib >= 0.8.0, == 0.8.*" "requests_oauthlib>=0.8.0<2.0"
   '';
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Also fixed the package build from
https://hydra.nixos.org/build/78900949.

`requests_oauthlib` seems to work fine at version 1.0 with `asana`, so
rather than creating our own override for `asana` it's fine to use 1.0
and patch `setup.py`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

