### PR TITLE
python-language-server: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -1,17 +1,22 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
+{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder, isPy27
 , configparser, futures, future, jedi, pluggy
 , pytest, mock, pytestcov, coverage
-# The following packages are optional and
-# can be overwritten with null as your liking.
-# This also requires to disable tests.
-, rope ? null
-, mccabe ? null
-, pyflakes ? null
-, pycodestyle ? null
+, # Allow building a limited set of providers, e.g. ["pycodestyle"].
+  providers ? ["*"]
+  # The following packages are optional and
+  # can be overwritten with null as your liking.
 , autopep8 ? null
-, yapf ? null
+, mccabe ? null
+, pycodestyle ? null
 , pydocstyle ? null
+, pyflakes ? null
+, rope ? null
+, yapf ? null
 }:
+
+let
+  withProvider = p: builtins.elem "*" providers || builtins.elem p providers;
+in
 
 buildPythonPackage rec {
   pname = "python-language-server";
@@ -24,22 +29,32 @@ buildPythonPackage rec {
     sha256 = "0glnhnjmsnnh1vs73n9dglknfkhcgp03nkjbpz0phh1jlqrkrwm6";
   };
 
+  # The tests require all the providers, disable otherwise.
+  doCheck = providers == ["*"];
+
   checkInputs = [
     pytest mock pytestcov coverage
     # rope is technically a dependency, but we don't add it by default since we
     # already have jedi, which is the preferred option
     rope
   ];
+
   checkPhase = ''
     HOME=$TEMPDIR pytest
   '';
 
-  propagatedBuildInputs = [
-    jedi pluggy mccabe pyflakes pycodestyle yapf pydocstyle future autopep8
-  ] ++ lib.optional (isPy27) [ configparser ]
-    ++ lib.optional (pythonOlder "3.2") [ futures ];
+  propagatedBuildInputs = [ jedi pluggy future ]
+    ++ stdenv.lib.optional (withProvider "autopep8") autopep8
+    ++ stdenv.lib.optional (withProvider "mccabe") mccabe
+    ++ stdenv.lib.optional (withProvider "pycodestyle") pycodestyle
+    ++ stdenv.lib.optional (withProvider "pydocstyle") pydocstyle
+    ++ stdenv.lib.optional (withProvider "pyflakes") pyflakes
+    ++ stdenv.lib.optional (withProvider "rope") rope
+    ++ stdenv.lib.optional (withProvider "yapf") yapf
+    ++ stdenv.lib.optional isPy27 configparser
+    ++ stdenv.lib.optional (pythonOlder "3.2") futures;
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     homepage = https://github.com/palantir/python-language-server;
     description = "An implementation of the Language Server Protocol for Python";
     license = licenses.mit;

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "python-language-server";
-  version = "0.18.0";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "palantir";
     repo = "python-language-server";
     rev = version;
-    sha256 = "0ig34bc0qm6gdj8xakmm3877lmf8ms7qg0xj8hay9gpgf8cz894s";
+    sha256 = "0glnhnjmsnnh1vs73n9dglknfkhcgp03nkjbpz0phh1jlqrkrwm6";
   };
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

Adding all of the extra dependencies isn't always desirable and
overriding a bunch of inputs is a bit cumbersome and brittle.

eg.

```
python-language-server.override { providers = ["rope"]; }
```

/cc @Mic92 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
