### PR TITLE
Add support for user-extensible shellHook to haskell.lib.buildStackProject

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation (args // {
   STACK_PLATFORM_VARIANT="nix";
   STACK_IN_NIX_SHELL=1;
   STACK_IN_NIX_EXTRA_ARGS = extraArgs;
-  shellHook = addStackArgsHook;
+  shellHook = addStackArgsHook + args.shellHook or "";
 
 
   # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.


### PR DESCRIPTION
`haskell.lib.buildStackProject` is overridding shell hook and doesn't append
user-specified shellHook to it, resulting in user's shellHook
never executing.

I believe `shellHook` should be appended after `addStackArgsHook` has been executed, but I can see a case for being executed beforehand too so if that is preferred approach let me know and I'll fix it.

###### Motivation for this change

Ability to add shellHook commands to stack nix environments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Testing:

````
# shell.nix

{ pkgs ? import <nixpkgs> {}
}:

pkgs.haskell.lib.buildStackProject {
  inherit ghc;
  name = "stacktest";
  buildInputs = [
    pkgs-master.glpk
    pkgs-master.pcre
  ];
  
  shellHook = ''
    echo "Hello https://github.com/NixOS/nixpkgs!"
    '';

}
````

Result:

````
$ cd ~/dev/nixpkgs && git co upstream/master && cd - && NIX_PATH=nixpkgs=/path/to/nixpkgs nix-shell
HEAD is now at 9934f0bb51a AgdaStdlib: 0.15 -> 0.16 (#44550)

[nix-shell:~/dev/haskell-test]$ exit

$ cd ~/dev/nixpkgs && git co add-shellhook-support-to-buildstackproject && cd - && NIX_PATH=nixpkgs=/path/to/nixpkgs nix-shell
Previous HEAD position was 9934f0bb51a AgdaStdlib: 0.15 -> 0.16 (#44550)
Switched to branch 'add-shellhook-support-to-buildstackproject'
Hello https://github.com/NixOS/nixpkgs!
````