### PR TITLE
vimNox: drop

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -73,15 +73,6 @@ in stdenv.mkDerivation rec {
 
   src = builtins.getAttr source {
     "default" = common.src; # latest release
-
-    "vim-nox" =
-      {
-        # vim nox branch: client-server without X by uing sockets
-        # REGION AUTO UPDATE: { name="vim-nox"; type="hg"; url="https://code.google.com/r/yukihironakadaira-vim-cmdsrv-nox/"; branch="cmdsrv-nox"; }
-        src = (fetchurl { url = "http://mawercer.de/~nix/repos/vim-nox-hg-2082fc3.tar.bz2"; sha256 = "293164ca1df752b7f975fd3b44766f5a1db752de6c7385753f083499651bd13a"; });
-        name = "vim-nox-hg-2082fc3";
-        # END
-      }.src;
   };
 
   patches = [ ./cflags-prune.diff ] ++ stdenv.lib.optional ftNixSupport ./ft-nix-support.patch;

--- a/pkgs/games/ezquake/default.nix
+++ b/pkgs/games/ezquake/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, curl, expat
 , jansson, libpng, libjpeg, libGLU_combined, libXxf86vm, pcre
-, pkgconfig, SDL2, vimNox }:
+, pkgconfig, SDL2, vim }:
 
 stdenv.mkDerivation rec {
   name = pname + "-" + version;
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    expat curl jansson libpng libjpeg libGLU_combined libXxf86vm pcre SDL2 vimNox
+    expat curl jansson libpng libjpeg libGLU_combined libXxf86vm pcre SDL2 vim
   ];
 
   installPhase = with stdenv.lib; let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18746,11 +18746,6 @@ with pkgs;
     inherit lua;
   });
 
-  vimNox = lowPrio (vim_configurable.override {
-    source = "vim-nox";
-    lua = pkgs.lua5_1; # vimNox source is from 2012, requires older lua
-  });
-
   qpdfview = libsForQt5.callPackage ../applications/misc/qpdfview {};
 
   qtile = callPackage ../applications/window-managers/qtile {


### PR DESCRIPTION
###### Motivation for this change

Close #40876 . `vimNox` is severely outdated (2012) and only used by a single other package, `ezquake`.

---

