### PR TITLE
mycli: 1.6.0 -> 1.17.0

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, terminaltables
+, tabulate
+, backports_csv
+, wcwidth
+, pytest
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "cli_helpers";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z5rqm8pznj6bvivm2al8rsxm82rai8hc9bqrgh3ksnbzg2kfy7p";
+  };
+
+  propagatedBuildInputs = [
+    terminaltables
+    tabulate
+    wcwidth
+  ] ++ (lib.optionals isPy27 [ backports_csv ]);
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Python helpers for common CLI tasks";
+    longDescription = ''
+      CLI Helpers is a Python package that makes it easy to perform common
+      tasks when building command-line apps. It's a helper library for
+      command-line interfaces.
+
+      Libraries like Click and Python Prompt Toolkit are amazing tools that
+      help you create quality apps. CLI Helpers complements these libraries by
+      wrapping up common tasks in simple interfaces.
+
+      CLI Helpers is not focused on your app's design pattern or framework --
+      you can use it on its own or in combination with other libraries. It's
+      lightweight and easy to extend.
+
+      What's included in CLI Helpers?
+
+      - Prettyprinting of tabular data with custom pre-processing
+      - [in progress] config file reading/writing
+
+      Read the documentation at http://cli-helpers.rtfd.io
+    '';
+    homepage = https://cli-helpers.readthedocs.io/en/stable/;
+    license = licenses.bsd3 ;
+    maintainers = [ maintainers.kalbasit ];
+  };
+}

--- a/pkgs/development/python-modules/pymysql/default.nix
+++ b/pkgs/development/python-modules/pymysql/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "PyMySQL";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gvi63f1zq1bbd30x28kqyx351hal1yc323ckp0mihainb5n1iwy";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  # Wants to connect to MySQL
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pure Python MySQL Client";
+    homepage = https://github.com/PyMySQL/PyMySQL;
+    license = licenses.mit;
+    maintainers = [ maintainers.kalbasit ];
+  };
+}

--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -1,28 +1,31 @@
 { lib
-, python
+, python3
+, glibcLocales
 }:
 
-with python.pkgs;
+with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "mycli";
-  version = "1.6.0";
+  version = "1.17.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0qg4b62kizyb16kk0cvpk70bfs3gg4q4hj2b15nnc7a3gqqfp67j";
+    sha256 = "11d3ssjifms6bid77jk06zl5wl3srihijmv5kggxa0w2l59y8h9m";
   };
 
   propagatedBuildInputs = [
-    pymysql configobj sqlparse prompt_toolkit pygments click pycrypto
+    pymysql configobj sqlparse prompt_toolkit pygments click pycrypto cli-helpers
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "==" ">="
-  '';
+  checkInputs = [ pytest mock glibcLocales ];
 
-  # No tests in archive. Newer versions do include tests
-  doCheck = false;
+  checkPhase = ''
+    export HOME=.
+    export LC_ALL="en_US.UTF-8"
+
+    py.test
+  '';
 
   meta = {
     inherit version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -352,6 +352,8 @@ in {
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  pymysql = callPackage ../development/python-modules/pymysql { };
+
   Pmw = callPackage ../development/python-modules/Pmw { };
 
   py_stringmatching = callPackage ../development/python-modules/py_stringmatching { };
@@ -8095,25 +8097,6 @@ in {
       homepage = https://pythonhosted.org/Pympler/;
       license = licenses.asl20;
     };
-  };
-
-  pymysql = buildPythonPackage rec {
-    name = "pymysql-${version}";
-    version = "0.6.6";
-    src = pkgs.fetchgit {
-      url = https://github.com/PyMySQL/PyMySQL.git;
-      rev = "refs/tags/pymysql-${version}";
-      sha256 = "0kpw11rxpyyhs9b139hxhbnx9n5kzjjw10wgwvhnf9m3mv7j4n71";
-    };
-
-    buildInputs = with self; [ unittest2 ];
-
-    checkPhase = ''
-      ${python.interpreter} runtests.py
-    '';
-
-    # Wants to connect to MySQL
-    doCheck = false;
   };
 
   pymysqlsa = self.buildPythonPackage rec {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1104,6 +1104,8 @@ in {
 
   cheroot = callPackage ../development/python-modules/cheroot {};
 
+  cli-helpers = callPackage ../development/python-modules/cli-helpers {};
+
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
   circus = callPackage ../development/python-modules/circus {};


### PR DESCRIPTION
###### Motivation for this change

I'm getting errors when using mycli 1.6.0, not getting errors after the update.

```python
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/nix/store/7sbvn0wgv7hsnxpss1jba723kx5nz6d4-python-2.7.15/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/nix/store/7sbvn0wgv7hsnxpss1jba723kx5nz6d4-python-2.7.15/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/nix/store/8gs9jrpz8g9hmj4cz1326mr8k39y9nyw-python2.7-prompt_toolkit-1.0.15/lib/python2.7/site-packages/prompt_toolkit/interface.py", line 865, in run
    completions = list(buffer.completer.get_completions(document, complete_event))
  File "/nix/store/rsvy8bnpdninfzm9x3vk8l7a7vsgmzns-mycli-1.6.0/lib/python2.7/site-packages/mycli/sqlcompleter.py", line 255, in get_completions
    suggestions = suggest_type(document.text, document.text_before_cursor)
  File "/nix/store/rsvy8bnpdninfzm9x3vk8l7a7vsgmzns-mycli-1.6.0/lib/python2.7/site-packages/mycli/packages/completion_engine.py", line 85, in suggest_type
    full_text, identifier)
  File "/nix/store/rsvy8bnpdninfzm9x3vk8l7a7vsgmzns-mycli-1.6.0/lib/python2.7/site-packages/mycli/packages/completion_engine.py", line 134, in suggest_based_on_last_token
    token_v = token.value.lower()
AttributeError: 'tuple' object has no attribute 'value'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

closes kalbasit/system#32