### PR TITLE
mate-screensaver: 1.20.1 -> 1.21.0

### DIFF
--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-screensaver-${version}";
-  version = "1.20.1";
+  version = "1.21.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1mcr2915wymwjy55m2z0l6b9dszabbv0my0xxsa1fb8xkr4hk4qh";
+    sha256 = "1asfw2x0ha830ilkw97bjdqm2gnjbpb6dd7lb6h43aix7g3lgm7f";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.21.0](https://github.com/mate-desktop/mate-screensaver/blob/master/NEWS).

Fix https://github.com/NixOS/nixpkgs/issues/44523.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).