### PR TITLE
mesa: add patch to include driver path in cache key

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -88,6 +88,7 @@ let self = stdenv.mkDerivation {
   patches = [
     ./symlink-drivers.patch
     ./missing-includes.patch # dev_t needs sys/stat.h, time_t needs time.h, etc.-- fixes build w/musl
+    ./disk_cache-include-dri-driver-path-in-cache-key.patch
   ];
 
   outputs = [ "out" "dev" "drivers" "osmesa" ];

--- a/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/pkgs/development/libraries/mesa/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -1,0 +1,52 @@
+From 9c9df280b318c26aece9873cf77b32e4f95634c1 Mon Sep 17 00:00:00 2001
+From: David McFarland <corngood@gmail.com>
+Date: Mon, 6 Aug 2018 15:52:11 -0300
+Subject: [PATCH] disk_cache: include dri driver path in cache key
+
+This fixes invalid cache hits on NixOS where all shared library
+timestamps in /nix/store are zero.
+---
+ src/util/Makefile.am  | 3 +++
+ src/util/disk_cache.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/util/Makefile.am b/src/util/Makefile.am
+index 07bf052175..aea09f60b3 100644
+--- a/src/util/Makefile.am
++++ b/src/util/Makefile.am
+@@ -30,6 +30,9 @@ noinst_LTLIBRARIES = \
+ 	libmesautil.la \
+ 	libxmlconfig.la
+ 
++AM_CFLAGS = \
++	-DDISK_CACHE_KEY=\"$(drivers)\"
++
+ AM_CPPFLAGS = \
+ 	$(PTHREAD_CFLAGS) \
+ 	-I$(top_srcdir)/include
+diff --git a/src/util/disk_cache.c b/src/util/disk_cache.c
+index 4a762eff20..8086c0be75 100644
+--- a/src/util/disk_cache.c
++++ b/src/util/disk_cache.c
+@@ -388,8 +388,10 @@ disk_cache_create(const char *gpu_name, const char *timestamp,
+ 
+    /* Create driver id keys */
+    size_t ts_size = strlen(timestamp) + 1;
++   size_t key_size = strlen(DISK_CACHE_KEY) + 1;
+    size_t gpu_name_size = strlen(gpu_name) + 1;
+    cache->driver_keys_blob_size += ts_size;
++   cache->driver_keys_blob_size += key_size;
+    cache->driver_keys_blob_size += gpu_name_size;
+ 
+    /* We sometimes store entire structs that contains a pointers in the cache,
+@@ -410,6 +412,7 @@ disk_cache_create(const char *gpu_name, const char *timestamp,
+    uint8_t *drv_key_blob = cache->driver_keys_blob;
+    DRV_KEY_CPY(drv_key_blob, &cache_version, cv_size)
+    DRV_KEY_CPY(drv_key_blob, timestamp, ts_size)
++   DRV_KEY_CPY(drv_key_blob, DISK_CACHE_KEY, key_size)
+    DRV_KEY_CPY(drv_key_blob, gpu_name, gpu_name_size)
+    DRV_KEY_CPY(drv_key_blob, &ptr_size, ptr_size_size)
+    DRV_KEY_CPY(drv_key_blob, &driver_flags, driver_flags_size)
+-- 
+2.18.0
+


### PR DESCRIPTION
###### Motivation for this change

Fixes #44183.  Also see #44383.

Mesa uses shared library mtimes as a key to its shader cache, however everything in /nix/store has the same timestamp, so it may incorrectly use shaders from the wrong version of mesa/llvm.  This has manifested itself as a complete system hang when booting a system on mesa 18.1 after previously using 18.0, or vice-versa.

This change adds the mesa driver store path to the cache key, which should make it sufficiently unique.  I've tried to keep the patch as simple as possible for ease of maintenance, and I've tested it with 18.0 and 18.1.

I also tested booting with mesa 18.0 on my system which is currently using 18.1.  It hangs without the patch, and works normally with it.

I have some ideas about how to upstream this, but it will probably require more intrusive changes which wouldn't be suitable for a nixpkgs patch.

@vcunat 

edit: merged to staging because of mesa dependencies

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

