### PR TITLE
gwyddion, ripser: fix derivation name

### DIFF
--- a/pkgs/applications/science/chemistry/gwyddion/default.nix
+++ b/pkgs/applications/science/chemistry/gwyddion/default.nix
@@ -2,11 +2,11 @@
 
 with stdenv.lib;
 
+let version = "2.48"; in
 stdenv.mkDerivation {
   name = "gwyddion-${version}";
-  version = "2.48";
   src = fetchurl {
-    url = "http://sourceforge.net/projects/gwyddion/files/gwyddion/2.48/gwyddion-2.48.tar.xz";
+    url = "http://sourceforge.net/projects/gwyddion/files/gwyddion/${version}/gwyddion-${version}.tar.xz";
     sha256 = "119iw58ac2wn4cas6js8m7r1n4gmmkga6b1y711xzcyjp9hshgwx";
   };
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/science/math/ripser/default.nix
+++ b/pkgs/applications/science/math/ripser/default.nix
@@ -13,10 +13,10 @@ assert useGoogleHashmap -> sparsehash != null;
 
 let
   inherit (stdenv.lib) optional;
+  version = "1.0";
 in
 stdenv.mkDerivation {
   name = "ripser-${version}";
-  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "Ripser";


### PR DESCRIPTION
###### Motivation for this change
the version attribute was pulled from stdenv.lib and was wrong as a result. Furthermore, since stdenv.lib.version changes with each commit, this triggers a rebuild of these derivations on each commit (and always with nox-review).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

