### PR TITLE
pythonPackages.cli-helpers: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, terminaltables
+, tabulate
+, backports_csv
+, wcwidth
+, pytest
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "cli_helpers";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1z5rqm8pznj6bvivm2al8rsxm82rai8hc9bqrgh3ksnbzg2kfy7p";
+  };
+
+  propagatedBuildInputs = [
+    terminaltables
+    tabulate
+    wcwidth
+  ] ++ (lib.optionals isPy27 [ backports_csv ]);
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "Python helpers for common CLI tasks";
+    longDescription = ''
+      CLI Helpers is a Python package that makes it easy to perform common
+      tasks when building command-line apps. It's a helper library for
+      command-line interfaces.
+
+      Libraries like Click and Python Prompt Toolkit are amazing tools that
+      help you create quality apps. CLI Helpers complements these libraries by
+      wrapping up common tasks in simple interfaces.
+
+      CLI Helpers is not focused on your app's design pattern or framework --
+      you can use it on its own or in combination with other libraries. It's
+      lightweight and easy to extend.
+
+      What's included in CLI Helpers?
+
+      - Prettyprinting of tabular data with custom pre-processing
+      - [in progress] config file reading/writing
+
+      Read the documentation at http://cli-helpers.rtfd.io
+    '';
+    homepage = https://cli-helpers.readthedocs.io/en/stable/;
+    license = licenses.bsd3 ;
+    maintainers = [ maintainers.kalbasit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1104,6 +1104,8 @@ in {
 
   cheroot = callPackage ../development/python-modules/cheroot {};
 
+  cli-helpers = callPackage ../development/python-modules/cli-helpers {};
+
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
   circus = callPackage ../development/python-modules/circus {};


### PR DESCRIPTION
###### Motivation for this change

cli-helpers is a required module of mycli v1.17.0. See https://github.com/NixOS/nixpkgs/pull/44571

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

