### PR TITLE
pythonPackages.pymysql: 0.6.6 -> 0.9.2; move to python-modules.

### DIFF
--- a/pkgs/development/python-modules/pymysql/default.nix
+++ b/pkgs/development/python-modules/pymysql/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, cryptography
+, unittest2
+}:
+
+buildPythonPackage rec {
+  pname = "PyMySQL";
+  version = "0.9.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gvi63f1zq1bbd30x28kqyx351hal1yc323ckp0mihainb5n1iwy";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  buildInputs = [ unittest2 ];
+
+  # Wants to connect to MySQL
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pure Python MySQL Client";
+    homepage = https://github.com/PyMySQL/PyMySQL;
+    license = licenses.mit;
+    maintainers = [ maintainers.fridh maintainers.kalbasit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -352,6 +352,8 @@ in {
 
   plantuml = callPackage ../tools/misc/plantuml { };
 
+  pymysql = callPackage ../development/python-modules/pymysql { };
+
   Pmw = callPackage ../development/python-modules/Pmw { };
 
   py_stringmatching = callPackage ../development/python-modules/py_stringmatching { };
@@ -8093,25 +8095,6 @@ in {
       homepage = https://pythonhosted.org/Pympler/;
       license = licenses.asl20;
     };
-  };
-
-  pymysql = buildPythonPackage rec {
-    name = "pymysql-${version}";
-    version = "0.6.6";
-    src = pkgs.fetchgit {
-      url = https://github.com/PyMySQL/PyMySQL.git;
-      rev = "refs/tags/pymysql-${version}";
-      sha256 = "0kpw11rxpyyhs9b139hxhbnx9n5kzjjw10wgwvhnf9m3mv7j4n71";
-    };
-
-    buildInputs = with self; [ unittest2 ];
-
-    checkPhase = ''
-      ${python.interpreter} runtests.py
-    '';
-
-    # Wants to connect to MySQL
-    doCheck = false;
   };
 
   pymysqlsa = self.buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Updating pymysql required by mycli. See https://github.com/NixOS/nixpkgs/pull/44571.

I also moved the package to the new location under `//pkgs/development/python-modules/pymysql`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

