### PR TITLE
WIP: treewide: Always prefix compilers

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation rec {
     ++ (with darwin.apple_sdk.frameworks; optionals stdenv.isDarwin [ Cocoa OpenGL ])
     ;
 
-  configurePlatforms = [ ];
   configureFlags = with stdenv.lib; [
     "--enable-freetype"
     (if fontconfigSupport then "--enable-fontconfig" else "--disable-fontconfig")

--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -12,7 +12,6 @@ let
       sha256 = "03s1zsprz5p6gjgwwqcf7b6cvzwwid6l8k7bamx9i0f1iwkgdm0j";
     };
     
-    configurePlatforms = [];
     configureFlags = [
       "--arch=${hostPlatform.parsed.cpu.name}"
     ] ++ stdenv.lib.optionals stdenv.hostPlatform.isAarch32 [

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -143,13 +143,7 @@ stdenv.mkDerivation {
       wrap ld-solaris ${./ld-solaris-wrapper.sh}
     '')
 
-    + ''
-      # Create a symlink to as (the assembler).
-      if [ -e $ldPath/${inPrefix}as ]; then
-        ln -s $ldPath/${inPrefix}as $out/bin/${targetPrefix}as
-      fi
-
-    '' + (if !useMacosReexportHack then ''
+    + (if !useMacosReexportHack then ''
       wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${inPrefix}ld}
     '' else ''
       ldInner="${targetPrefix}ld-reexport-delegate"

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation {
   shell = getBin shell + shell.shellPath or "";
   gnugrep_bin = if nativeTools then "" else gnugrep;
 
-  inherit targetPrefix infixSalt;
+  inherit inPrefix targetPrefix infixSalt;
 
   outputs = [ "out" ] ++ optionals propagateDoc [ "man" "info" ];
 

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -59,11 +59,13 @@ for cmd in \
     ar as ld nm objcopy objdump readelf ranlib strip strings size windres
 do
     if
-        PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
+        # We prefer wrapped to unwrapped. `command -v`'s error codes by dumb
+        # luck have the convenient semantics.
+        cmd_path=$(PATH=$_PATH command -v "@inPrefix@${cmd}" "@targetPrefix@${cmd}" | tail -n 1)
     then
         upper_case="$(echo "$cmd" | tr "[:lower:]" "[:upper:]")"
-        export "${role_pre}${upper_case}=@targetPrefix@${cmd}";
-        export "${upper_case}${role_post}=@targetPrefix@${cmd}";
+        export "${role_pre}${upper_case}=${cmd_path}";
+        export "${upper_case}${role_post}=${cmd_path}";
     fi
 done
 
@@ -72,5 +74,5 @@ done
 export NIX_HARDENING_ENABLE
 
 # No local scope in sourced file
-unset -v role_pre role_post cmd upper_case
+unset -v role_pre role_post cmd cmd_path upper_case
 set +u

--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -26,7 +26,7 @@ for var in "${var_templates_bool[@]}"; do
 done
 
 # `-B@out@/bin' forces cc to use ld-wrapper.sh when calling ld.
-NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/bin/ $NIX_@infixSalt@_CFLAGS_COMPILE"
+NIX_@infixSalt@_CFLAGS_COMPILE="-B@out@/libexec/ $NIX_@infixSalt@_CFLAGS_COMPILE"
 
 # Export and assign separately in order that a failing $(..) will fail
 # the script.

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -109,10 +109,10 @@ fi
 
 export NIX_${role_pre}CC=@out@
 
-export ${role_pre}CC=@named_cc@
-export ${role_pre}CXX=@named_cxx@
-export CC${role_post}=@named_cc@
-export CXX${role_post}=@named_cxx@
+export ${role_pre}CC=@out@/bin/@named_cc@
+export ${role_pre}CXX=@out@/bin/@named_cxx@
+export CC${role_post}=@out@/bin/@named_cc@
+export CXX${role_post}=@out@/bin/@named_cxx@
 
 # If unset, assume the default hardening flags.
 : ${NIX_HARDENING_ENABLE="fortify stackprotector pic strictoverflow format relro bindnow"}

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -150,8 +150,8 @@ let version = "4.8.5";
           "--enable-nls"
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
-    stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = stdenv.lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
@@ -161,7 +161,7 @@ in
 assert x11Support -> (filter (x: x == null) ([ gtk2 libart_lgpl ] ++ xlibs)) == [];
 
 stdenv.mkDerivation ({
-  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -421,6 +421,9 @@ stdenv.mkDerivation ({
     inherit langC langCC langObjC langObjCpp langFortran langGo version;
     isGNU = true;
     hardeningUnsupportedFlags = [ "stackprotector" ];
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
   };
 
   inherit enableParallelBuilding enableMultilib;

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -263,8 +263,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -115,6 +115,7 @@ let version = "4.8.5";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -123,8 +124,9 @@ let version = "4.8.5";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -286,8 +286,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -120,6 +120,7 @@ let version = "4.9.4";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -128,8 +129,9 @@ let version = "4.9.4";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -158,8 +158,8 @@ let version = "4.9.4";
           "--enable-nls"
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
-    stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
@@ -169,7 +169,7 @@ in
 assert x11Support -> (filter (x: x == null) ([ gtk2 libart_lgpl ] ++ xlibs)) == [];
 
 stdenv.mkDerivation ({
-  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -439,8 +439,12 @@ stdenv.mkDerivation ({
       "-Wl,${libpthreadCross.TARGET_LDFLAGS}"
     ]);
 
-  passthru =
-    { inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true; };
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true;
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
+  };
 
   inherit enableParallelBuilding enableMultilib;
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -144,8 +144,8 @@ let version = "5.5.0";
           "--enable-nls"
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
-    stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = stdenv.lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
@@ -155,7 +155,7 @@ in
 assert x11Support -> (filter (x: x == null) ([ gtk2 libart_lgpl ] ++ xlibs)) == [];
 
 stdenv.mkDerivation ({
-  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -438,8 +438,12 @@ stdenv.mkDerivation ({
       "-Wl,${libpthreadCross.TARGET_LDFLAGS}"
     ]);
 
-  passthru =
-    { inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true; };
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true;
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
+  };
 
   inherit enableParallelBuilding enableMultilib;
 

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -288,8 +288,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -106,6 +106,7 @@ let version = "5.5.0";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -114,8 +115,9 @@ let version = "5.5.0";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -147,8 +147,8 @@ let version = "6.4.0";
           "--enable-nls"
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
-    stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = stdenv.lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
@@ -158,7 +158,7 @@ in
 assert x11Support -> (filter (x: x == null) ([ gtk2 libart_lgpl ] ++ xlibs)) == [];
 
 stdenv.mkDerivation ({
-  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -296,8 +296,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -104,6 +104,7 @@ let version = "6.4.0";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -112,11 +113,9 @@ let version = "6.4.0";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
-        # maybe only needed on musl, PATH_MAX
-        # https://github.com/richfelker/musl-cross-make/blob/0867cdf300618d1e3e87a0a939fa4427207ad9d7/litecross/Makefile#L62
-        "--disable-libmpx"
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -446,8 +446,12 @@ stdenv.mkDerivation ({
       "-Wl,${libpthreadCross.TARGET_LDFLAGS}"
     ]);
 
-  passthru =
-    { inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true; };
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true;
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
+  };
 
   inherit enableParallelBuilding enableMultilib;
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -75,6 +75,7 @@ let version = "7.3.0";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -83,11 +84,9 @@ let version = "7.3.0";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
-        # maybe only needed on musl, PATH_MAX
-        # https://github.com/richfelker/musl-cross-make/blob/0867cdf300618d1e3e87a0a939fa4427207ad9d7/litecross/Makefile#L62
-        "--disable-libmpx"
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -118,15 +118,15 @@ let version = "7.3.0";
           "--enable-nls"
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
-    stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "${targetPlatform.config}${stageNameAddon}-" else "";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = stdenv.lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
 in
 
 stdenv.mkDerivation ({
-  name = crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -264,8 +264,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -391,8 +391,12 @@ stdenv.mkDerivation ({
       "-Wl,${libpthreadCross.TARGET_LDFLAGS}"
     ]);
 
-  passthru =
-    { inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true; };
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true;
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
+  };
 
   inherit enableParallelBuilding enableMultilib;
 

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -380,8 +380,12 @@ stdenv.mkDerivation ({
       "-Wl,${libpthreadCross.TARGET_LDFLAGS}"
     ]);
 
-  passthru =
-    { inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true; };
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true;
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
+  };
 
   inherit enableParallelBuilding enableMultilib;
 

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -113,15 +113,15 @@ let version = "8.2.0";
           "--enable-nls"
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
-    stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
+    stageNameAddon = if crossStageStatic then "stage-static" else "stage-final";
+    crossNameAddon = stdenv.lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
 in
 
 stdenv.mkDerivation ({
-  name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -70,6 +70,7 @@ let version = "8.2.0";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -78,11 +79,9 @@ let version = "8.2.0";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
-        # maybe only needed on musl, PATH_MAX
-        # https://github.com/richfelker/musl-cross-make/blob/0867cdf300618d1e3e87a0a939fa4427207ad9d7/litecross/Makefile#L62
-        "--disable-libmpx"
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -256,8 +256,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -224,8 +224,7 @@ stdenv.mkDerivation ({
 
   dontDisableStatic = true;
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags =
     # Basic dependencies

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -107,14 +107,14 @@ let version = "7-20170409";
           "--disable-decimal-float" # No final libdecnumber (it may work only in 386)
         ]));
     stageNameAddon = if crossStageStatic then "-stage-static" else "-stage-final";
-    crossNameAddon = if targetPlatform != hostPlatform then "-${targetPlatform.config}" + stageNameAddon else "";
+    crossNameAddon = stdenv.lib.optionalString (targetPlatform != hostPlatform) "${stageNameAddon}-";
 
     bootstrap = targetPlatform == hostPlatform;
 
 in
 
 stdenv.mkDerivation ({
-  name = "${name}${if stripped then "" else "-debug"}-${version}" + crossNameAddon;
+  name = targetPlatform.config + "-" + crossNameAddon + "${name}${if stripped then "" else "-debug"}-${version}";
 
   builder = ../builder.sh;
 

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -68,6 +68,7 @@ let version = "7-20170409";
         "--enable-sjlj-exceptions"
         "--enable-threads=win32"
         "--disable-win32-registry"
+        "--disable-libmpx" # requires libc
       ] else if crossStageStatic then [
         "--disable-libssp"
         "--disable-nls"
@@ -76,8 +77,9 @@ let version = "7-20170409";
         "--disable-libgomp"
         "--disable-libquadmath"
         "--disable-shared"
-        "--disable-libatomic"  # libatomic requires libc
-        "--disable-decimal-float" # libdecnumber requires libc
+        "--disable-libatomic" # requires libc
+        "--disable-decimal-float" # requires libc
+        "--disable-libmpx" # requires libc
       ] else [
         (if crossDarwin then "--with-sysroot=${getLib libcCross}/share/sysroot"
          else                "--with-headers=${getDev libcCross}/include")

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -349,8 +349,12 @@ stdenv.mkDerivation ({
       "-Wl,${libpthreadCross.TARGET_LDFLAGS}"
     ]);
 
-  passthru =
-    { inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true; };
+  passthru = {
+    inherit langC langCC langObjC langObjCpp langFortran langGo version; isGNU = true;
+
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = targetPlatform.config + "-";
+  };
 
   inherit enableParallelBuilding enableMultilib;
 

--- a/pkgs/development/compilers/ghc/7.10.3-binary.nix
+++ b/pkgs/development/compilers/ghc/7.10.3-binary.nix
@@ -101,7 +101,6 @@ stdenv.mkDerivation rec {
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
     '';
 
-  configurePlatforms = [ ];
   configureFlags = [
     "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
     "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"

--- a/pkgs/development/compilers/ghc/8.2.1-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.1-binary.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation rec {
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
     '';
 
-  configurePlatforms = [ ];
   configureFlags = [
     "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
     "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"

--- a/pkgs/development/compilers/llvm/3.4/clang.nix
+++ b/pkgs/development/compilers/llvm/3.4/clang.nix
@@ -43,6 +43,8 @@ stdenv.mkDerivation {
     # actually be a gcc
     gcc = stdenv.cc.cc;
     hardeningUnsupportedFlags = [ "stackprotector" ];
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = "";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/3.5/clang.nix
+++ b/pkgs/development/compilers/llvm/3.5/clang.nix
@@ -43,6 +43,8 @@ in stdenv.mkDerivation {
 
   passthru = {
     isClang = true;
+    # Prefix for binaries. Customarily ends with a dash separator.
+    targetPrefix = "";
   } // stdenv.lib.optionalAttrs stdenv.isLinux {
     inherit gcc;
   };

--- a/pkgs/development/compilers/llvm/3.7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.7/clang/default.nix
@@ -46,6 +46,8 @@ let
       lib = self; # compatibility with gcc, so that `stdenv.cc.cc.lib` works on both
       isClang = true;
       inherit llvm;
+      # Prefix for binaries. Customarily ends with a dash separator.
+      targetPrefix = "";
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/3.8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.8/clang/default.nix
@@ -64,6 +64,8 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      # Prefix for binaries. Customarily ends with a dash separator.
+      targetPrefix = "";
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/3.9/clang/default.nix
+++ b/pkgs/development/compilers/llvm/3.9/clang/default.nix
@@ -65,6 +65,8 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      # Prefix for binaries. Customarily ends with a dash separator.
+      targetPrefix = "";
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/4/clang/default.nix
+++ b/pkgs/development/compilers/llvm/4/clang/default.nix
@@ -78,6 +78,8 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      # Prefix for binaries. Customarily ends with a dash separator.
+      targetPrefix = "";
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/5/clang/default.nix
+++ b/pkgs/development/compilers/llvm/5/clang/default.nix
@@ -74,6 +74,8 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      # Prefix for binaries. Customarily ends with a dash separator.
+      targetPrefix = "";
     } // stdenv.lib.optionalAttrs stdenv.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/llvm/6/clang/default.nix
+++ b/pkgs/development/compilers/llvm/6/clang/default.nix
@@ -74,6 +74,8 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
+      # Prefix for binaries. Customarily ends with a dash separator.
+      targetPrefix = "";
     } // stdenv.lib.optionalAttrs stdenv.targetPlatform.isLinux {
       inherit gcc;
     };

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -161,7 +161,6 @@ stdenv.mkDerivation {
 
   inherit doCheck;
 
-  configurePlatforms = [];
 
   # https://github.com/NixOS/nixpkgs/pull/21742#issuecomment-272305764
   # https://github.com/rust-lang/rust/issues/30181

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -333,7 +333,6 @@ stdenv.mkDerivation ({
   '';
 
   # Cabal takes flags like `--configure-option=--host=...` instead
-  configurePlatforms = [];
   inherit configureFlags;
 
   configurePhase = ''

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -69,7 +69,7 @@ let
     configureFlags =
       (if crossCompiling
        then [ "-Dlibpth=\"\"" "-Dglibpth=\"\"" ]
-       else [ "-de" "-Dcc=cc" ])
+       else [ "-de" "-Dcc=${stdenv.cc.targetPrefix}cc" ])
       ++ [
         "-Uinstallusrbinperl"
         "-Dinstallstyle=lib/perl5"

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -132,7 +132,6 @@ stdenv.mkDerivation {
     ++ optional enableNumpy python.pkgs.numpy;
 
   configureScript = "./bootstrap.sh";
-  configurePlatforms = [];
   configureFlags = [
     "--includedir=$(dev)/include"
     "--libdir=$(out)/lib"

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -251,7 +251,6 @@ stdenv.mkDerivation rec {
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
   '';
 
-  configurePlatforms = [];
   configureFlags = [
     "--target_os=${hostPlatform.parsed.kernel.name}"
     "--arch=${hostPlatform.parsed.cpu.name}"

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation rec {
     ++ optional (reqMin "1.0") "doc" ; # just dev-doc
   setOutputFlags = false; # doesn't accept all and stores configureFlags in libs!
 
-  configurePlatforms = [];
   configureFlags = [
       "--arch=${hostPlatform.parsed.cpu.name}"
       "--target_os=${hostPlatform.parsed.kernel.name}"

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation ({
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ bison ];
-  buildInputs = lib.optionals withGd [ gd libpng ];
+  buildInputs = [ linuxHeaders ] ++ lib.optionals withGd [ gd libpng ];
 
   # Needed to install share/zoneinfo/zone.tab.  Set to impure /bin/sh to
   # prevent a retained dependency on the bootstrap tools in the stdenv-linux

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -51,7 +51,6 @@ let
       substituteInPlace ./configure --replace "#! /bin/sh" "#!${bash}/bin/sh"
     '';
 
-    configurePlatforms = [];
     configureFlags = assert stdenv.lib.all (x: x!=null) buildInputs; [
       "--arch=${hostPlatform.parsed.cpu.name}"
       "--target_os=${hostPlatform.parsed.kernel.name}"

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ];
   setOutputFlags = false;
 
-  configurePlatforms = [];
   configureFlags = [
     (enableFeature (vp8EncoderSupport || vp8DecoderSupport) "vp8")
     (enableFeature vp8EncoderSupport "vp8-encoder")

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -76,7 +76,6 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ];
   setOutputFlags = false;
 
-  configurePlatforms = [];
   configureFlags = [
     (enableFeature (vp8EncoderSupport || vp8DecoderSupport) "vp8")
     (enableFeature vp8EncoderSupport "vp8-encoder")

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -56,9 +56,6 @@ let
           throw "Not sure what configuration to use for ${hostPlatform.config}"
       );
 
-    # TODO(@Ericson2314): Make unconditional on mass rebuild
-    ${if buildPlatform != hostPlatform then "configurePlatforms" else null} = [];
-
     preConfigure = ''
       patchShebangs Configure
     '';

--- a/pkgs/development/libraries/qt-3/default.nix
+++ b/pkgs/development/libraries/qt-3/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  configurePlatforms = [];
   configureFlags = let
     mk = cond: name: "-${stdenv.lib.optionalString cond "no-"}${name}";
   in [

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -139,7 +139,6 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
 
-  configurePlatforms = [];
   configureFlags = let
     mk = cond: name: "-${lib.optionalString cond "no-"}${name}";
     platformFlag =

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (!hostPlatform.isDarwin) "-static-libgcc";
 
   dontStrip = hostPlatform != buildPlatform && static;
-  configurePlatforms = [];
 
   installFlags = stdenv.lib.optionals (hostPlatform.libc == "msvcrt") [
     "BINARY_PATH=$(out)/bin"

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -117,7 +117,6 @@ stdenv.mkDerivation rec {
 
   # This isn't an autoconf configure script; triples are passed via
   # CMAKE_SYSTEM_NAME, etc.
-  configurePlatforms = [ ];
 
   doCheck = false; # fails
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -100,8 +100,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags = [
     "--enable-targets=all" "--enable-64-bit-bfd"

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -56,8 +56,7 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-Wno-format-nonliteral";
 
-  # TODO(@Ericson2314): Always pass "--target" and always prefix.
-  configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+  configurePlatforms = [ "build" "host" "target" ];
 
   configureFlags = with stdenv.lib; [
     "--enable-targets=all" "--enable-64-bit-bfd"

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -76,8 +76,7 @@ let
 
     enableParallelBuilding = true;
 
-    # TODO(@Ericson2314): Always pass "--target" and always targetPrefix.
-    configurePlatforms = [ "build" "host" ] ++ stdenv.lib.optional (targetPlatform != hostPlatform) "target";
+    configurePlatforms = [ "build" "host" "target" ];
 
     postPatch = ''
       sed -i -e 's/addStandardLibraryDirectories = true/addStandardLibraryDirectories = false/' cctools/ld64/src/ld/Options.cpp

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -1,12 +1,12 @@
 { stdenvNoCC, lib, buildPackages
-, hostPlatform
-, fetchurl, perl
+, buildPlatform, hostPlatform
+, fetchurl, fetchpatch, perl
 }:
 
 assert hostPlatform.isLinux;
 
 let
-  common = { version, sha256, patches ? null }: stdenvNoCC.mkDerivation {
+  common = { version, sha256, patches ? [] }: stdenvNoCC.mkDerivation {
     name = "linux-headers-${version}";
 
     src = fetchurl {
@@ -23,16 +23,35 @@ let
 
     extraIncludeDirs = lib.optional hostPlatform.isPowerPC ["ppc"];
 
-    # "patches" array defaults to 'null' to avoid changing hash
-    # and causing mass rebuild
     inherit patches;
 
-    buildPhase = ''
-      make mrproper headers_check SHELL=bash
+    hardeningDisable = lib.optional buildPlatform.isDarwin "format";
+
+    makeFlags = [
+      "SHELL=bash"
+      # Avoid use of runtime build->host compilers for checks
+      "cc-version:=9999"
+      "cc-fullversion:=999999"
+      # `$(..)` expanded by make alone
+      "HOSTCC:=$(BUILD_CC)"
+      "HOSTCXX:=$(BUILD_CXX)"
+    ];
+
+    # Skip clean on darwin, case-sensitivity issues.
+    buildPhase = lib.optionalString (!buildPlatform.isDarwin) ''
+      make mrproper $makeFlags
+    '' + ''
+      make headers_install $makeFlags
+    '';
+
+    # doCheck = !buildPlatform.isDarwin;
+
+    checkPhase = ''
+      make headers_check $makeFlags
     '';
 
     installPhase = ''
-      make INSTALL_HDR_PATH=$out headers_install
+      make headers_install INSTALL_HDR_PATH=$out $makeFlags
 
       # Some builds (e.g. KVM) want a kernel.release.
       mkdir -p $out/include/config
@@ -50,5 +69,13 @@ in {
   linuxHeaders = common {
     version = "4.15";
     sha256 = "0sd7l9n9h7vf9c6gd6ciji28hawda60yj0llh17my06m0s4lf9js";
+    patches = [
+       ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
+       ./no-dynamic-cc-version-check.patch # so we can use `stdenvNoCC`, see `makeFlags` above
+       #(fetchpatch { # For building on non-ELF platforms
+       #  url = https://github.com/richfelker/musl-cross-make/blame/master/patches/linux-4.4.10/0001-archscripts.diff;
+       #  sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
+       #})
+    ];
   };
 }

--- a/pkgs/os-specific/linux/kernel-headers/no-dynamic-cc-version-check.patch
+++ b/pkgs/os-specific/linux/kernel-headers/no-dynamic-cc-version-check.patch
@@ -1,0 +1,16 @@
+diff --git a/scripts/Kbuild.include b/scripts/Kbuild.include
+index 065324a8046f..d09c67194549 100644
+--- a/scripts/Kbuild.include
++++ b/scripts/Kbuild.include
+@@ -216,11 +216,8 @@ cc-disable-warning = $(call try-run-cached,\
+ cc-name = $(call shell-cached,$(CC) -v 2>&1 | grep -q "clang version" && echo clang || echo gcc)
+ 
+ # cc-version
+-cc-version = $(call shell-cached,$(CONFIG_SHELL) $(srctree)/scripts/gcc-version.sh $(CC))
+ 
+ # cc-fullversion
+-cc-fullversion = $(call shell-cached,$(CONFIG_SHELL) \
+-	$(srctree)/scripts/gcc-version.sh -p $(CC))
+ 
+ # cc-ifversion
+ # Usage:  EXTRA_CFLAGS += $(call cc-ifversion, -lt, 0402, -O1)

--- a/pkgs/os-specific/linux/kernel-headers/no-relocs.patch
+++ b/pkgs/os-specific/linux/kernel-headers/no-relocs.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index fad55160dcb9..a48c8331cbb2 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -239,7 +239,7 @@ ifdef CONFIG_RETPOLINE
+ endif
+ 
+ archscripts: scripts_basic
+-	$(Q)$(MAKE) $(build)=arch/x86/tools relocs
++	$(Q)$(MAKE) $(build)=arch/x86/tools
+ 
+ ###
+ # Syscall table generation

--- a/pkgs/os-specific/linux/paxctl/default.nix
+++ b/pkgs/os-specific/linux/paxctl/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   preBuild = ''
-    sed "s|--owner 0 --group 0||g" -i Makefile
+    sed -i Makefile \
+      -e 's|--owner 0 --group 0||g' \
+      -e '/CC:=gcc/d'
   '';
 
   makeFlags = [

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
 
   # configure script is not autotools-based, doesn't support these options
-  configurePlatforms = [ ];
 
   doCheck = false; # fails
 


### PR DESCRIPTION
###### Motivation for this change

The goal is to bring the native and cross code paths closer together by always prefixing compilers. This makes it easier to catch programs that hard-code `gcc` or `clang`.

This also includes:

  - Two patches to help with darwin -> linux cross compilation; since they're fine patches and the same override-`gcc` fix is needed.
  - Making the wrapper env vars define `CC`, `LD`, and friends use full paths instead of names, generally good for robustness.

The whole thing I plan to merge after 18.09, but maybe those 2 bits can go in first.

Fixes #21471

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

