### PR TITLE
osquery: do not rebuild at each nixpkgs commit

### DIFF
--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   # this is what `osquery --help` will show as the version.
   OSQUERY_BUILD_VERSION = version;
-  OSQUERY_PLATFORM = "nixos;${stdenv.lib.version}";
+  OSQUERY_PLATFORM = "NixOS;";
 
   src = fetchFromGitHub {
     owner = "facebook";


### PR DESCRIPTION
###### Motivation for this change

Includging `stdenv.lib.version` triggers a rebuild at each nixpkgs commit. It also makes osquery a permanent false positive in nox-review.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

