### PR TITLE
rclone-browser: init at 1.2

### DIFF
--- a/pkgs/applications/networking/sync/rclone/browser.nix
+++ b/pkgs/applications/networking/sync/rclone/browser.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub , rclone, qt5,cmake  }:
+{ stdenv, fetchFromGitHub, qt5,cmake  }:
 
 stdenv.mkDerivation rec {
   name = "rclone-browser-${version}";
@@ -10,11 +10,12 @@ stdenv.mkDerivation rec {
     rev = "${version}";
     sha256 = "1ldradd5c606mfkh46y4mhcvf9kbjhamw0gahksp9w43h5dh3ir7";
   };
+  
   buildInputs = [ qt5.qtbase cmake ];
   meta = with stdenv.lib; {
     description = "Graphical Frontend to Rclone written in Qt";
     homepage = https://github.com/mmozeiko/RcloneBrowser;
     license = licenses.unlicense;
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/sync/rclone/browser.nix
+++ b/pkgs/applications/networking/sync/rclone/browser.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/mmozeiko/RcloneBrowser;
     license = licenses.unlicense;
     platforms = platforms.linux;
+    maintainers = [];
   };
 }

--- a/pkgs/applications/networking/sync/rclone/browser.nix
+++ b/pkgs/applications/networking/sync/rclone/browser.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, qt5,cmake  }:
+{ stdenv, fetchFromGitHub, cmake, qtbase }:
 
 stdenv.mkDerivation rec {
   name = "rclone-browser-${version}";
@@ -7,16 +7,19 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mmozeiko";
     repo = "RcloneBrowser";
-    rev = "${version}";
+    rev = version;
     sha256 = "1ldradd5c606mfkh46y4mhcvf9kbjhamw0gahksp9w43h5dh3ir7";
   };
-  
-  buildInputs = [ qt5.qtbase cmake ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtbase ];
+
   meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
     description = "Graphical Frontend to Rclone written in Qt";
-    homepage = https://github.com/mmozeiko/RcloneBrowser;
     license = licenses.unlicense;
     platforms = platforms.linux;
-    maintainers = [];
+    maintainers = with maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/applications/networking/sync/rclone/browser.nix
+++ b/pkgs/applications/networking/sync/rclone/browser.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchFromGitHub , rclone, qt5,cmake  }:
+
+stdenv.mkDerivation rec {
+  name = "rclone-browser-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "mmozeiko";
+    repo = "RcloneBrowser";
+    rev = "${version}";
+    sha256 = "1ldradd5c606mfkh46y4mhcvf9kbjhamw0gahksp9w43h5dh3ir7";
+  };
+  buildInputs = [ qt5.qtbase cmake ];
+  meta = with stdenv.lib; {
+    description = "Graphical Frontend to Rclone written in Qt";
+    homepage = https://github.com/mmozeiko/RcloneBrowser;
+    license = licenses.unlicense;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18129,6 +18129,7 @@ with pkgs;
   };
 
   rclone = callPackage ../applications/networking/sync/rclone { };
+
   rclone-browser = callPackage ../applications/networking/sync/rclone/browser.nix { };
   
   rcs = callPackage ../applications/version-management/rcs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18130,7 +18130,7 @@ with pkgs;
 
   rclone = callPackage ../applications/networking/sync/rclone { };
 
-  rclone-browser = callPackage ../applications/networking/sync/rclone/browser.nix { };
+  rclone-browser = libsForQt5.callPackage ../applications/networking/sync/rclone/browser.nix { };
   
   rcs = callPackage ../applications/version-management/rcs { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18129,7 +18129,8 @@ with pkgs;
   };
 
   rclone = callPackage ../applications/networking/sync/rclone { };
-
+  rclone-browser = callPackage ../applications/networking/sync/rclone/browser.nix { };
+  
   rcs = callPackage ../applications/version-management/rcs { };
 
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };


### PR DESCRIPTION
###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---