### PR TITLE
quakespasm: 0.92.1 -> 0.93.1

### DIFF
--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -1,12 +1,12 @@
 { stdenv, SDL, fetchurl, gzip, libvorbis, libmad }:
 stdenv.mkDerivation rec {
   name = "quakespasm-${version}";
-  majorVersion = "0.92";
+  majorVersion = "0.93";
   version = "${majorVersion}.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/quakespasm/quakespasm-${version}.tgz";
-    sha256 = "0vhycjg97sn4cd85ph6qz68rplzrm4apijdkrlj9mycnqjv5l100";
+    sha256 = "1bimv18f6rzhyjz78yvw2vqr5n0kdqbcqmq7cb3m951xgsxfcgpd";
   };
 
   sourceRoot = "${name}/Quake";


### PR DESCRIPTION
###### Motivation for this change
update to latest version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

