### PR TITLE
vkquake: 0.97.3 -> 1.00.0

### DIFF
--- a/pkgs/games/quakespasm/vulkan.nix
+++ b/pkgs/games/quakespasm/vulkan.nix
@@ -1,14 +1,14 @@
 { stdenv, SDL2, fetchFromGitHub, makeWrapper, gzip, libvorbis, libmad, vulkan-loader }:
 stdenv.mkDerivation rec {
   name = "vkquake-${version}";
-  majorVersion = "0.97";
-  version = "${majorVersion}.3";
+  majorVersion = "1.00";
+  version = "${majorVersion}.0";
 
   src = fetchFromGitHub {
     owner = "Novum";
     repo = "vkQuake";
     rev = version;
-    sha256 = "11z9k5aw9ip7ggmgjdnaq4g45pxqiy0xhd4jqqmgzpmfdbjk4x13";
+    sha256 = "1h7ac5bh6h6cpvkx5bvp17lv5m24hmdykcdppkivblikpxhml70s";
   };
 
   sourceRoot = "source/Quake";


### PR DESCRIPTION
###### Motivation for this change
update to latest version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


