### PR TITLE
duply: 1.9.2 -> 2.1

### DIFF
--- a/pkgs/tools/backup/duply/default.nix
+++ b/pkgs/tools/backup/duply/default.nix
@@ -2,12 +2,13 @@
 , gnugrep, txt2man, makeWrapper, which
 }:
 
-stdenv.mkDerivation {
-  name = "duply-1.9.2";
+stdenv.mkDerivation rec {
+  name = "duply-${version}";
+  version = "2.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/ftplicity/duply%20%28simple%20duplicity%29/1.9.x/duply_1.9.2.tgz";
-    sha256 = "1ay50rsr90dcnjncjclzfckqmxxnizmi4jhb5rsybfn0xdj0kz1b";
+    url = "mirror://sourceforge/project/ftplicity/duply%20%28simple%20duplicity%29/2.1.x/duply_${version}.tgz";
+    sha256 = "0i5j7h7h6ssrwhll0sfhymisshg54kx7j45zcqffzjxa0ylvzlm8";
   };
 
   buildInputs = [ txt2man makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

