### PR TITLE
megatools: v2017-10-26 -> v1.10.2

### DIFF
--- a/pkgs/tools/networking/megatools/default.nix
+++ b/pkgs/tools/networking/megatools/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "megatools-${version}";
-  version = "2017-10-26";
+  version = "1.10.2";
 
   src = fetchFromGitHub {
     owner = "megous";
     repo = "megatools";
-    rev = "35dfba3262f620b4701ec1975293463957e20f26";
-    sha256 = "0xphgv78j731rmhxic4fwzdr7vq5px921qifrw1y40b93nhy4d5n";
+    rev = "${version}";
+    sha256 = "001hw8j36ld03wwaphq3xdaazf2dpl36h84k8xmk524x8vlia8lk";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

