### PR TITLE
[rdy]iproute: allow to load ebpf programs

### DIFF
--- a/pkgs/os-specific/linux/iproute/default.nix
+++ b/pkgs/os-specific/linux/iproute/default.nix
@@ -1,4 +1,6 @@
-{ fetchurl, stdenv, config, flex, bash, bison, db, iptables, pkgconfig }:
+{ fetchurl, stdenv, config, flex, bash, bison, db, iptables, pkgconfig
+, libelf
+}:
 
 stdenv.mkDerivation rec {
   name = "iproute2-${version}";
@@ -35,7 +37,7 @@ stdenv.mkDerivation rec {
     "CONFDIR=$(out)/etc/iproute2"
   ];
 
-  buildInputs = [ db iptables ];
+  buildInputs = [ db iptables libelf ];
   nativeBuildInputs = [ bison flex pkgconfig ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
...via passing libelf as a buildinput.

###### Motivation for this change
I want to attach some filters to my interfaces  via tc
```
IF="enp4s0"
sudo tc qdisc add dev "$IF" clsact
sudo tc filter add dev "$IF" ingress bpf obj test_ebpf_tc.o section action direct-action
```
but this failed with 
```
No ELF library support compiled in.
Unable to load program
```

###### Things done
just passed libelf as a buildinput then iproute's ./configure scripts picks it up.

I can make it optional if need be.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

