### PR TITLE
arb: 2.13.0 -> 2.14.0

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -129,6 +129,13 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch/?id=2ab1546b3e21d1d0ab3b4fcd58576848b3a2d888";
       sha256 = "1c5gnasq7y9xxj762bn79bis0zi8d9bgg7jzlf64ifixsrc5cymb";
     })
+
+    # arb 2.13.0 -> 2.14.0
+    (fetchpatch {
+      name = "arb-2.14.0.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id2=8.4.beta0&id=8bef4fd2876a61969b516fe4eb3b8ad7cc076c5e";
+      sha256 = "00p3hfsfn3w2vxgd9fjd23mz7xfxjfravf8ysjxkyd657jbkpjmk";
+    })
   ];
 
   patches = nixPatches ++ packageUpgradePatches ++ [

--- a/pkgs/development/libraries/arb/default.nix
+++ b/pkgs/development/libraries/arb/default.nix
@@ -2,12 +2,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "arb";
-  version = "2.13.0";
+  version = "2.14.0";
   src = fetchFromGitHub {
     owner = "fredrik-johansson";
     repo = "${pname}";
     rev = "${version}";
-    sha256 = "1fl9gmxf6c1cphk5r8jbys5pywj2rfm705kv0055i0aqc6hrv303";
+    sha256 = "1ndxg7h4xvccjgp5l9z2f8b66dsff6fhf86bn5n7f75a1ksd7554";
   };
   buildInputs = [mpir gmp mpfr flint];
   configureFlags = [
@@ -17,19 +17,11 @@ stdenv.mkDerivation rec {
     "--with-flint=${flint}"
   ];
   doCheck = true;
-  patches = [
-    # https://github.com/fredrik-johansson/arb/pull/210, included in next release
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/fredrik-johansson/arb/pull/210.patch";
-      name = "return-exact-zero-where-possible.patch";
-      sha256 = "01j9npnpmwh4dla9i05qdn606hy34gy9bz7c9bbsqm7az3n7pxjg";
-    })
-  ];
-  meta = {
+  meta = with stdenv.lib; {
     inherit version;
     description = ''A library for arbitrary-precision interval arithmetic'';
     license = stdenv.lib.licenses.lgpl21Plus;
-    maintainers = [stdenv.lib.maintainers.raskin];
+    maintainers = with maintainers; [ raskin timokau ];
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Sage upstream ticket by the author: https://trac.sagemath.org/ticket/25966

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

