### PR TITLE
Workaround for issue #44254 (Steam cannot connect to friends network)

### DIFF
--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -181,7 +181,7 @@ in buildFHSUserEnv rec {
     # Workaround for issue #44254 (Steam cannot connect to friends network)
     # https://github.com/NixOS/nixpkgs/issues/44254
     test -z ''${TZ+x} &&
-    new_TZ="$(readlink -f /etc/localtime | grep -o '(?<=/zoneinfo/).*$' -P)" &&
+    new_TZ="$(readlink -f /etc/localtime | grep -P -o '(?<=/zoneinfo/).*$')" &&
     export TZ="$new_TZ"
 
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -180,11 +180,12 @@ in buildFHSUserEnv rec {
   profile = ''
     # Workaround for issue #44254 (Steam cannot connect to friends network)
     # https://github.com/NixOS/nixpkgs/issues/44254
-    test -z ''${TZ+x} &&
-    new_TZ="$(readlink -f /etc/localtime | grep -P -o '(?<=/zoneinfo/).*$')" &&
-    export TZ="$new_TZ"
-    # Above, the use of intermediate variable `new_TZ` is necessary to ensure
-    # that `TZ` is left alone if the grep fails.
+    if [ -z ''${TZ+x} ]; then
+      new_TZ="$(readlink -f /etc/localtime | grep -P -o '(?<=/zoneinfo/).*$')"
+      if [ $? -eq 0 ]; then
+        export TZ="$new_TZ"
+      fi
+    fi
 
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}
   '' + extraProfile;

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -183,6 +183,8 @@ in buildFHSUserEnv rec {
     test -z ''${TZ+x} &&
     new_TZ="$(readlink -f /etc/localtime | grep -P -o '(?<=/zoneinfo/).*$')" &&
     export TZ="$new_TZ"
+    # Above, the use of intermediate variable `new_TZ` is necessary to ensure
+    # that `TZ` is left alone if the grep fails.
 
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}
   '' + extraProfile;

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -178,6 +178,12 @@ in buildFHSUserEnv rec {
   '';
 
   profile = ''
+    # Workaround for issue #44254 (Steam cannot connect to friends network)
+    # https://github.com/NixOS/nixpkgs/issues/44254
+    test -z ''${TZ+x} &&
+    new_TZ="$(readlink -f /etc/localtime | grep -o '(?<=/zoneinfo/).*$' -P)" &&
+    export TZ="$new_TZ"
+
     export STEAM_RUNTIME=${if nativeOnly then "0" else "/steamrt"}
   '' + extraProfile;
 


### PR DESCRIPTION
###### Motivation for this change

When /etc/localtime is a valid symlink but doesn't point directly to a zoneinfo file, Steam has trouble connecting to friends network. I've reported this upstream, maybe they'll fix it. But for now, there's this workaround.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

