### PR TITLE
thunderbird, thunderbird-bin: 52.9.1 -> 60.0 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,595 +1,585 @@
 {
-  version = "52.9.1";
+  version = "60.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ar/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ar/thunderbird-60.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "9384c43cbac7d6b88fa160e22fb21e6f4250276b46d3fc0322dca45a6b5ebacfc39a431b54d34262a32f2a7cc9130b68b6dc4b636a737ecb7132e077592882a5";
+      sha512 = "fd37e00c8b50d1dc932295288ad2865358da2f37f5b170a3a7f75d929e78486165a24f1967defcb4032546a7f712cd6887c7cf47257a4a08685df85f9ecf81bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ast/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ast/thunderbird-60.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "b1d0b26dc21c4487f016c60aa8560ff34c868c6e617040f963ff9e76b859d7d265cf529c0d70fcb736aa946ad50b1a0cae0dd66df1594e102a85cfa489b07358";
+      sha512 = "64a14f40678a64def00597eb1bd7cc0c9759b56da4e72bfe24c3d4e50ef92414bb18346b8ecc9c0a834a063a2a2fe7920b72c2ce59c7cb7ba67442f7e8842b13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/be/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/be/thunderbird-60.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "635ad3d57463eb51830dfb66871258b69bcfcd9ed0c2b38956a25db242905113a6604812a6d6aa1778dde1783595e2b4cb6b3a51f48af6f6740e6613ba78adf7";
+      sha512 = "6368f3693f0f54f4768d27a4b9f82015d4c789180db3d8ea5302053e2ff8d7bc5e50388b00b7b1d534c0145718255c84d43977361f5d8cff5f432a8336436e9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/bg/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/bg/thunderbird-60.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "573f0b63a16f62662958ff1884a2cf76436242f377258f39ea254732aaa4d1f358ee651b2e4f5eb2cd3c20f69ad6b6ea2bc6985fc3d99e23edeb75d3ca55ba27";
+      sha512 = "b881105b39f5a3d66cf77105fb555af692477b387a4fe2c13c9c398968baa705cdf3753665b0e6d28bd8fdb21bc75e439672402dbe1185a9f8289b8236f505ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/bn-BD/thunderbird-52.9.1.tar.bz2";
-      locale = "bn-BD";
-      arch = "linux-x86_64";
-      sha512 = "d277706e699ebdbcc4ccbf8f6d5c4c256b0ed65ad7b604962e8cc2dffa5b06eeffad7dfd5dc5a08b87a25f0e728daa79d2e0ca0ab9ade7136057a3aef203f26f";
-    }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/br/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/br/thunderbird-60.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "11e362e77f4b5ce75823c3aa60fab68969d8b19b6fb9a51027c81ad4e1e4f46c4a5a4e3218361521d076859453523a30cf79ec715abfc59cca31c541f02562ef";
+      sha512 = "c45a3dfb8ae5564071c2e59a623263f995a83f9ac20c84345be47935a337b863be3d334b2e0f40767842e9a53cbb1eb00dd87645cb0b8a737efce15cd81b9336";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ca/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ca/thunderbird-60.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "7eba10d82c0b2bd58d87670c345ac8948c06f1b6a0ac853d40b1993fc101931dc581b3e252ebe0a22948f18738d60714aeabebc8dc1953f0199ccb6b2fa1af47";
+      sha512 = "aec05cd7e9a5f529408bca9691ef68bb384b23b9cd464c9342336b96da0afe20473121128861c20d55bc3c4f5c33f779fe892681270d5b26df6b64aa27c13511";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/cs/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/cs/thunderbird-60.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "2c05465bc32b6703ee930ccc17b7bebeba3e0eda37b959f08812d3a891fe17664862b7e981a37e43e0adf775d7cb929d866ebdbc044ff53ecf6b1066fcc2796b";
+      sha512 = "e0286e388a1b9a273043bfbcfd2bdf9675bede43d6b3f364882a9f7a9bee1fccd76e5ada76aae309f961c3e0bcae6373cb40457a53d48a9ff37c9fb53245f889";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/cy/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/cy/thunderbird-60.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "0cb9735931a29e098e707d27f22f412ba0d0d242799a10658b4ba41abc3ffae5fc2028f4efaf82ef1544f7ddc8efd8401b076945f8b5669231af62fb00cb2019";
+      sha512 = "7f5f28836084132f044b3fcda749dec03fa6234a04eff73a8001f804c98be8df57eba564e864bf09a9938818bb86003d9fcf54cacba2d1efad7a330381e08b0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/da/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/da/thunderbird-60.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "906ae74d45a9915e76fb666a89b00c5378aa9498f29025088eddd3853a93b79ba0eab2d5678908e10f11fc5273dc15ebeee6714a02a70df6ab7bdc0fb7df4917";
+      sha512 = "1b9b63abe185fc91ee2e0dea054bc5e94941bc2cdd59cd85c9997ef9d49eed0c93827265847a480845901af8b37e3547c9301896beb538aef724945bca2ed2b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/de/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/de/thunderbird-60.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "729a833d64df3d1270b07ba2bfdd963efaee4d0bba98d23d4b07f9924878806f59b916af117dd5b866fecba6715bf10b9586e2a34b6de66fce803a76eda07232";
+      sha512 = "e499f327ed9f4536b7bd9659879b28a2282a6a2b9aeb4514b3a70f774d76427283379293d09e95271e54f7c68ab07beaa60e867936b9de8c09b600914d3e4156";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/dsb/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/dsb/thunderbird-60.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "420a61731fb8159104a14b9741166f250d689ca18f15ffb1e408366fd976e723a72b94cc5ed512895e1e0fc58cfcba2dd39c7c898a38cf996fd59a1de7967fd1";
+      sha512 = "d862020f5ae7c50560ba4c58d67af4c0e54622f826934b90887efcff5ae1c97126bbce0bd42f7e1c1215258b92db6a012b184a2106f4beed0d7e8c79b84bae54";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/el/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/el/thunderbird-60.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "7a7cccdf48c9fae667ea33294dbabfd2217cdcf6922a847dd93db3567e9d9d527015124d777e94db5a7c32a9d9f31ecc272978972dd07ada60c8bd3e323b1d12";
+      sha512 = "88b98d3558400370b48f1e133147b8ba57fbb240ad6db1bbd79d7e0266c4a2814fc9cad5521ea8c0296b14857bd09cb4e8e0d86f625fc53d621008729f31e002";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/en-GB/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/en-GB/thunderbird-60.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "a713653bc7da8347d2897ff522c8cb13983fd913ec987a81b9bcb1242dac14c0cd875e7bb5dfda14938953af0a526d24a54d40e1b88e31107498baf00aaeb6c9";
+      sha512 = "02f1eecc4aff0a8691cdf131736c34fa93035d821a645c97213be41a95b4ff00d244411344089e56c24267984bc91d294f1250b1fd7e8c966ee9de9983794427";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/en-US/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/en-US/thunderbird-60.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "98a35a81f77b58e6f5fca79ee5a56330f8184072c118b571245c7f686d2a196e0cca6f4df131bee066651fcf69b83ca076bb9dd68fa71dd766962694df8e43a7";
+      sha512 = "87be28d46f22885c730e89c0a945ed307b23da11e331a5911b21353a53536587f8e95658de591d44a9bdf617dc3d50099f537bebe85680dbf1b3f25c7f18fdfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/es-AR/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/es-AR/thunderbird-60.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "fde54338bcc99c98f9e8e77f30795252459f79037ed996f3bb055e3c650104a3f73878f72bf02c0a0db4d907322f896600e6f057c4a39888708183489f80f579";
+      sha512 = "4d1651de4d4b3d5324ae5b07581634fc82399a2b0f9793d53797224d2f6b1205389bd0672b1c671fb956191312549b446c317ff98f187e1a7248aba901bd2499";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/es-ES/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/es-ES/thunderbird-60.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "08eb3b2c6422429e19e909dec8d7cc0cc2288e7b991e466f32618d2018ab4b9dbd8be78f469315645b5efe866f7014dadd3d5a6e997f6540422d6d8de61bbc39";
+      sha512 = "6abc82968464377cb2c05bc09b1bc978af65d9423dcba78e73e8d0817a2dcc1dde89711acb1d5fd9e3539cd33c6e3813e6b00297f3a23ff1c4250771b40c8522";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/et/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/et/thunderbird-60.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "0a1e8496e256990715c11eadd7d1804336542215e4ac34615145fca02a30ca97f2f92220631bbb0f55cfd1579442064d1c0112665bd6e3a35719faefcdf13ea4";
+      sha512 = "9e4bba499f39ee7a87676627fe3ec6da2dcba6a55e39aec897953abf00ad08216550d0fe94804a5426e2894970ad2db3f391dd09ae2768580ea05ac6a77ddbb1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/eu/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/eu/thunderbird-60.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "8696ed02d5bcfeb12ad1057c6a5e2558f3261189d7147bfa86e1043f13da58d60ae5b48a31f2113e1b699f049c9f06a946998cba766bb5faed9b1ba612ed2ec4";
+      sha512 = "66aaf66011117c2f9e675f22a68317552ed7673c05dd56266e4a8719e853629648de3d88fd44448ac1d9674b0cdf6cbe48925328f633c1bc23cb5a7f005468ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/fi/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/fi/thunderbird-60.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "e60015623faff6c065ff719fbbdcaf81c48f5d9175a61c8a4920e27a51d8495db782b6916ba320717d36807f758bf5826f2f882cacfc25ba0bbb4fe1bddbce6c";
+      sha512 = "8c61206e100182080859c45736d973975ae5e1055fc2df170828dc0715e04be5468ba815995be9d60530ba9600e187aed965a1d94f9887337789c8219e2cca6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/fr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/fr/thunderbird-60.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "e5a276e8f53387f8acd939fbe158d594c7b5d9ebcd6f0a2ea92fede421d1584ef42e49bfcf84efe651d62ca60c311634e9fc4ee429fb38c70f82cfd0e3823fd7";
+      sha512 = "1583081060580dc72d864ca88ae8f114a22db4d4f3177532a4345471bac6ca3a85397b5bd82cc32f85dbfdc4992f788dd15a4dfa9d6fa7b154d3921c0c23fa29";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/fy-NL/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/fy-NL/thunderbird-60.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "1f98eec3b67b2aabde704fb14603df6258c0f996868c57490194b1e672b52b59026a17e2b7e35033b71d95f3d46968ad1eb7e46f35f9799af49781d7746d8b20";
+      sha512 = "59deb0b3e32dc2dbcce96aed6558dee899e290a469ded997bd2b7b6b2832f5f7c358d44f128cc1fac2327e3c19c43400424dccf4a0478bcbfeae3401fbc93882";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ga-IE/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ga-IE/thunderbird-60.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "54c8c9484400749efb129630ab6a107da6ce1a77c8e8c43185fb84f98b13c33edfe512c63d571a5206c3600729eb644a8e8a0c325932d81579c8e8932a51abab";
+      sha512 = "8bba0addc0d9d1000ddaed0702b5db0d797f3ac9fff0f04e645d6fb3747f961c2570ee058e53d4084e3c02cbb8490c2a32781517c57bf7971b8f1d4db0fe871d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/gd/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/gd/thunderbird-60.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "4cd2140b0871ee144ba5996c98a67fc6b8c6f0beecc15a628968716d472e4b93286ad606e9b5a54b294329f83dec85f48f5008c30e1970ec2feb40f0bb0eed98";
+      sha512 = "8e8f5df3aee5f1dbc1e6fd8c761b5d968dd35b9e29a8c04e013a7de08091f65cc2573109f0bfe201048f90a578ea84f1bb05826d7bd8e9fb7dd9110b45623034";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/gl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/gl/thunderbird-60.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "e87fab8d479c847ec7110926ee7ac93668495caddc77bc8a4a3e382ee1aa12488221b6facabbbf74c0aeecdc226705d9cf4edd649a7b3a6410fa98c62ab37fc9";
+      sha512 = "56a56179eddff5da07ce124f17ed08a6a033d7c2c3d139fd5b00afdb86f0c54215525c40f9c6c108384adeafdcc6f8dab87d72b07d88bd38e0c43c89aac4db0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/he/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/he/thunderbird-60.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "26766b3b37c3b13173cb06865185fa08d4e8a1c07c3f8ce958545b21b3ffe473885c6559a6799fc82c426702f1433d783b55c821cb1e30480456dc9352c9f3ef";
+      sha512 = "6880b7ab22b3e642d10edce67458fe30935c87dad60f32ac32b443473e5a208a4df0645b2a18ef26d5ce40053b3a9119eb432e640afca8421c4e93815b28bdf9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/hr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hr/thunderbird-60.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "458500d47e73ccc2d8a370ea63826224cb1a8514a322a9c8b98aff16363e3807a1d4e4e0b007b3eccb8888def285831d1afdfd9004dcbf729779137b28bd9333";
+      sha512 = "14b22f95559f1c9addf04d51dcf857c3cd59f3612743970bf9cbfc99c84a3d0fcb898be7e83858c0848e341039493a5aba4189d24941362327f4ef9982dd739e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/hsb/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hsb/thunderbird-60.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "a612cf7e309437abd521b0964d254c3c980ad096f339da0db803d6bb739d9761796af2460ff989355102b628b4d383db412556dcf897c351ada417089703f2dd";
+      sha512 = "5bbddd6bb288cc03015707bd2ed3ef38ff20c7b93b08907e1b90cd8a22725786a293fedb142f99e18e0cf66fa14529097399e95fd157c434414c8fd61c0ba70b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/hu/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hu/thunderbird-60.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "49790909eb91f8862807fbd213974b906d4ca979646c11c7377c205cd6a7092ad9942900729ee90927261ff969a71773941b29a8be19dd4d8d7a325559f81500";
+      sha512 = "4f751f64b1417022f6c1487e1f3d92edc0ea1cd603850a9f64b35a71a652be1e51dfa17babb66e3447bc5a8bb2693c6e2dae89a736dc2f070b4b6a9500cf9299";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/hy-AM/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hy-AM/thunderbird-60.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "57285eb8916dfd90bb4bae2d791695f3bf2c2c82742f9040d20d8c0f6194adc493f36733a6a2b9d474c036ac25309330f96de17e49938a5f97ea9c369a02daed";
+      sha512 = "c932b56abf6801bfb6ff90978343aea12f67f006ea71882fa7bbb469dd750371330c47581f48aec3ecfca9cfa51f7edfb2aed6a3da874041c2087b5c5ff60abc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/id/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/id/thunderbird-60.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "61313d060dc24b1e685aa434c6beefdd6b114a2ca24f19690e1cc712db75d238610c3a23ffddaa373bcbfd080e0bd53c8e3d05243c7d184535bbf95b5d0df00c";
+      sha512 = "d8a61bb0c1c308d7ef89a9f938fd1c738ce8e66cebfdf4a236636e3c9469705c1012d19c3d3cf8837bdabefed01c744692aec2d749c7ec0adb472bc125e54cdf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/is/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/is/thunderbird-60.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "28968973b8379c91dcb1e6c27127ab55a8044edd0c518defc9c2977ac728928bfd1c75e2e357e3faf71acc3b4bad6e90a1f588742cdb0abf9ace85cd424c288b";
+      sha512 = "1fe98420d0ceda881b50e4dfff667de59b960c1d8a23b5f88140c076fa5bfc8cc01b636a3b9bd46987f87a30ba6cb510eeaeadbf83ada954a5681c3da68cf7a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/it/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/it/thunderbird-60.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "3231f2639940323db9a23c236be5ef8304ce953821971801bbea2d8674c2b54d1ead79041992d17609c6d1a9e86e352af84d76137a7728eb085aa54da0c02d38";
+      sha512 = "79190716416c48bfaf486470a5f31ef881bce0b97e4c780126581a38ff39e6a14ae12487779ed219e55afa2467139b652f54e989b91f4d438685d1fb174f920d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ja/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ja/thunderbird-60.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "542aadd1a658f9e21fdf0bfa32069e5adfba58750fda943389ce4e3230cf063503c78353e739fb6771434b209b6c836f87c94f7831d50f2b41c8dd38dc6da198";
+      sha512 = "c8c9d6a31664df4e7ad9668a73197da100f5c0b9bcd7bc500638f1d1c26e123a91cd370cd574185f0a2700c44564df7a048b6942265294c2326c8d0ae02f8c73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/kab/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/kab/thunderbird-60.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "f97fb7db2e055ccad2310d813a15086494d0815fc3cc48d49928c5642175f9db80b4deec8c4a4f5568417a26e898348ad10ec887b8a8be161586ff3c53ee3ff2";
+      sha512 = "d76f7178edaee6d16045e332ecac4dd31d7eaa3e8688c24cc48cde48df7df9b1bf9bbc0d76a95e8c35923fe1fb743792bcadf8d3f705f76a8acc7d714b8b0bad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ko/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/kk/thunderbird-60.0.tar.bz2";
+      locale = "kk";
+      arch = "linux-x86_64";
+      sha512 = "f3d13ee3665e6345ea8295d616d227ade4be5af166af08b0a2094ae27a69eb82955933967f734e111930d802270f8c5ace57a9f16bc56b920ad9a3081f82acbb";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ko/thunderbird-60.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "1854d0c0365bca930a4480226dd54bee3e6798857e68cea3dfdce94247f298be6933f2ed8a7abd89e87ae063a7a14c9d7ad1998abb0fd07dfe9a2a0b2e63dd71";
+      sha512 = "9ff20db6d945938868b5b9833519a93011d33804f5514f0f347814137f9f8e96b427658f1f086867c0b272ef8fa5c22e92b8093950b534f3ac0224f84bbf2779";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/lt/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/lt/thunderbird-60.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "2979f9059f6dae5abd9ead9bc87052e7a4116d0f0001a3585b70e2a0609c85c1e6a38d547a8a187f9057d68f7a87a4875cc209f00a1dd1011ec7634cf0339aa0";
+      sha512 = "cc0309a724a2b21bd6426af53e5ca6b8168f2e3f1293c16aba954c1484defd0a227a1d93c4d92e946d5327d5ce58fcc37f6848d180426e3cd9673de483676713";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/nb-NO/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ms/thunderbird-60.0.tar.bz2";
+      locale = "ms";
+      arch = "linux-x86_64";
+      sha512 = "59351da7225877be43a1e651afd089facd47675497d8f2c0d6bc1c8a2234058ef9362b30309d65b074c8b98faf19b9d4cf80e83cfec2f8e438fc0a7c6d60f899";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/nb-NO/thunderbird-60.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "e9a61cf7cecf7026bd4aa7574ece60e9738f710a43733d7347a1ebdc460322b975ab86be81919a85faa01f728aab754825062da5642231658daa1a318e919c3b";
+      sha512 = "94c5f139cda0a90bc575f32f6121441dd198455482a89d052227777759f912f26aa53d74a6232e3a78ecf1cd3062cadfb3c7f30e349dd59bb8797825dce825a4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/nl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/nl/thunderbird-60.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "07c3db2e75395059f735a17bd4db3a68ee7fa97fbad3dfafb0aa1371d360a8fd5b693bd6034afde2457e7e13fa6968d78df0f297c55fb8882e10f4311eb03244";
+      sha512 = "f1fd359ab66f349643191efc5f112a4512acfb64cf088b963068e54688c34b4244a8b0d31135200a706122ed797e2d2b09237e96c1076bbf086d660b80d44dbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/nn-NO/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/nn-NO/thunderbird-60.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "1eaad3950f23e1e7a83bea070a8d5c4207b5c2443af11623872a446ab45ee8e2746be9de638828f951a47dd8966426a1d166eb98dc900de39d0a230d438bdd10";
+      sha512 = "819c02852685cdebf0b3c3b86ab4261ac13ae6067f0a9c3610214d4cab05f3a913da58527be7d3fd2d06fbe9de13481c34c679b317fe0659383b31ac1fd19bec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/pa-IN/thunderbird-52.9.1.tar.bz2";
-      locale = "pa-IN";
-      arch = "linux-x86_64";
-      sha512 = "da0b4fca7428104c75650435efa2ab65edc6ca4518ed4b6274195465cbea5d5cf9bbb7f3aa22209f298afab970556f51638bc752ea50edf2a3fd7b562314af61";
-    }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/pl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/pl/thunderbird-60.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "41c14a41b00b0a92ee8bce565ba2fe9a4ca1461ce5a1f54dbb40558bc2d871d07ee5edfbc6c8df1a7aba7e1a957cd11acd509e193b657473b14b745bbf06e3e1";
+      sha512 = "e384e19a68ab56c16266d59abb6b22ad5b7bfef649c2a7537a5822753f856a6e90604e057a7a43b744487294475be6afca2b8484911044422fbf06d01df31e5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/pt-BR/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/pt-BR/thunderbird-60.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "146dcbef8d811cb1c295cc72349f10c8f345bd9b7c95a1347b68681cb5edd02d129f583338c0bf619b37df357fc000212894a6d28a3e833b0626bd1a62b02b3c";
+      sha512 = "edf352970e3292c9f3eb17caf8de07edb924d14500c3dfc6d1864adebcfc174d1639b2d0ca5b4006cd952f9922e09fd220ef50c7ee3f15920d554dbae22eaff4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/pt-PT/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/pt-PT/thunderbird-60.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "aa60bb80a1a4df1800037a6dbde7f8deef9c4f7f1bc3926bbc5f223d4436caa62d5e9ded7eac0d91f766b35d6ae9a40fd2aabcc603e5d2276f1bf598b715b56c";
+      sha512 = "2d91620bce2051d6c30a3b16f21f7c97b99e3ac4a239e22b582b37ce7e6ef4b6861d66e56e7e7f58cd71cd25fcddb5e161e66248d87fc9984e755f229dbd54b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/rm/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/rm/thunderbird-60.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "4e109d618b6c6d9d578b90012a142d8ed8e16a430412c95e0a2567dfe7407f828ea70cf9088a4f9d5d33fe294618f052870630ae521feb0c474e76e6946d1bc0";
+      sha512 = "0ee05046cef873313eea34cb5bc002f9231f015415ba97c23b06e7ed0ef9996e7cb77beab89cc1e312fc74122cbac179af430153b2426d885acef8fb7d1126b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ro/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ro/thunderbird-60.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "0fbbf47332fccf2eea593f12751b5e1ec502dbfbae7e100d56906e2850191129f8fa5a51794f13f6225c2de6c219933e36074970b5b7698fcbcb58cab2abe6cf";
+      sha512 = "c53a2bdfbda8cda335d2a9fe03476090034ebfdbd8a8eb345a9fa5d3c0f1422a0e1c2d95bb5a0b75cf84f8338679068436cc90c857a3547f297f3294d5028b70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ru/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ru/thunderbird-60.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "8d26c8c5248418cbf329c3ea6ff0fa60baf9b12110048327beb15073d2398aa7d31c97acc33d1b6bcc65e38b651d619f5a47007961ac1adb290783ad22c4be64";
+      sha512 = "ffc6c2729291d8d1c7f32cca8933d3d8adbd54e278940ccd7cb844778b8a55123af0bcc9d435480077551de49d1c2200250209311579d2a34a5609a336eb32b3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/si/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/si/thunderbird-60.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "17cfaacbafbaa98cf73f6df074c99c40faf6687576cd44315ce4360bb725d8ab0b2fcdbda08f160441449e779b3d769765063079b3fee8c0b4a366799f0c38c6";
+      sha512 = "9f708d01d6a6492d10ff058bd2425172bb90ff9c2827cf88a4307de0df20c6cdac9d8c135daddbca132fc55e89c68924fddfe9ca8cb49d77ca6c874283c49a8d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/sk/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sk/thunderbird-60.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "d22d8d46f3a3d3206368225b7691cf4c6fa235ec1d2e2476f46c1982d2fe071909d66cb180ef2fdb81ba494e25ce3d4d20a30fa579e27c2e2327b60b5c2f44a3";
+      sha512 = "44e3dd85654dd91ac9b0bd1f1d7f6f74341e3f39be8f01b028353d3425938825877b8f8b0c296ebf269cc5b1e78dbdde18bc49153ada0065dbc1de3079096ad8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/sl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sl/thunderbird-60.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "00a89b3dfd33979d5a7c9f256b57add0d91504a00712effa8ed3a14dae80e92aead5bc5857507810b1b99a77cfea709e07454a3834193677fbefa68db46edd50";
+      sha512 = "2d77bebf1e3a6466fdddf32f21cbb5d28e46f4b70fbd07eec701559a0accb6f78ed9ed8a3b969d0eb3e249907208ffe8ab096e6bb035bdfb8c91e268ba228992";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/sq/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sq/thunderbird-60.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "3bf0024db0d43d26bec31eb40fd7a2fe42d105072663c21a5e7f8f38cd718a555d7796cbc2d28da426db01dcf003cb2c351237e67a0cc9b4b3f3cf7b6c37e522";
+      sha512 = "f705fad8b3a3ec5f760f28205caeb19986cd90084c8db0d921569553aa3cef668443e30594a82a32cb684e4cb2444057d04355b39a2dc02ac2dfc0ad5273bd68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/sr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sr/thunderbird-60.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "f3e6ba6a80976bcdd37539d78829bd16344069082dee68ada14ec1de611a3e65f132431c074107b43fe855e46f15504766c9dda536c7112de081d0c450d8fd04";
+      sha512 = "37dd80ec39ea566e66d8ace889bdf0353ec63682356472a1d0352f556814bee38793a263b285c65e9a68e62b782caf064d7b530b503e1222a490ad81798b2a76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/sv-SE/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sv-SE/thunderbird-60.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "5eb1d2ce97320961c3d70403f8f81a36d0d686cec8cb518065d4ea950d7b2ae1588ef64a6b2276c6f8a0fc59136108a4fa50f44ed890742aea2fb77e14886b2c";
+      sha512 = "3685b1788f7da31032b5b16a974af87d729a05aad8f906f6692d7dd688684c6f745fe766a1c5baaaaecac4d1b417d3e91d78ca082a41704a6f9caff29b64d842";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/ta-LK/thunderbird-52.9.1.tar.bz2";
-      locale = "ta-LK";
-      arch = "linux-x86_64";
-      sha512 = "e59d4e4797aa96a8edfeac79bd9720f4a893c548b66efcef365a92cde1e1f9bbdd4c9046d7483a148e28f9377ca2eebda42683769fb4e02f4a56ce629596280e";
-    }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/tr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/tr/thunderbird-60.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "ca29daa1d9f255e3a5748259fe632382937d51c593412e28cb6d99d7339cf5b9482ebcc0e76120d0988519538e10484187d13134c27335ea708a5a115b9bc2d1";
+      sha512 = "3b1de9eb1371ac686c1d28253bab5b5a3c5ee3b91739bd9e272ed496266fbad01fafe5015f257cd0dc6ef553d47d674bf13e5a53444d030f50572c929d0b3c75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/uk/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/uk/thunderbird-60.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "ff02ebaa4d8d9174387b7ad777e5372361567b077882a9cea84c30dc1e430e76f8cc07e14f7b32c8340c893e6aa395dbc249decd89f6facdb05ed9e2e14d34a2";
+      sha512 = "0cbd6f8ad5f0bf49e62efeed2d52b3c22ec0dc4701d84771465f3650ca2ca2736acb1e9d83fead6ecba4dbbd64eb883bd9cce9ece31b5e1ec28da4a410db196c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/vi/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/vi/thunderbird-60.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "210b9f8f70ac499305e0bb66b9dfa294c4c0f6784520e8238874ea7ade9d6ef58760e3beaeb5f0ab14554fe34618cfbfb023ba5486c8ec12ba57f5e72d3fd069";
+      sha512 = "0e0440d0640b7c50aea0a6a6983779524007897dee8996fbf898d110881920041c99891ba282cdd5bd02060d4f8606e57bf9ebd25531ef9cdb87659aa1150e55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/zh-CN/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/zh-CN/thunderbird-60.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "bc41f53a3c37e2aa7f8d960aa7d2f7b90d25971ce34eb664476c92a4b7db3753c96f22f5b0157a1298ab2b65e03b85b8268ff5fb0fbbce7aa3364fb587a17549";
+      sha512 = "3fd66874bbb9853da447cd4a4495f848d1ead3a1ef1ceca36590082f4ccec8985280d25f42a643b52f955290a4b9649709909080db8b6a592a943ee1ba4bbb44";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-x86_64/zh-TW/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/zh-TW/thunderbird-60.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "b400036ddd90488b7cf67e98b2530e4d4594637f9259f20a92a7a3c62b2f7a60ce390b9907a1b2efa44af29941938faed4e10ff6bda0c67656b8907638578712";
+      sha512 = "8e716f938a146a14c9f5ad8d99da463a6b5ea8d1705c26a575a4e34de89e1e9a36e1a288f60bd67b87a2560fae7646dd9157c4d60e9a35f7e977d20d55756f0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ar/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ar/thunderbird-60.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "1c8f71b60a0b5088d3d8b4576e02727a939a60b821aeb3015f9aa5b65231ca93b14894fb506fe2acbf579ad4686e83cf1e0d3179575a0510d571de146c4bb7f8";
+      sha512 = "2076cd84255a8ad52521a752b8444cafd3490932b69a3ec632d8815a5215d08d4efcbebb888f76b26232eb6edd66c4b9ce2233107de32603d6a7a37b87f3595e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ast/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ast/thunderbird-60.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "3d78cdd28deda66fd42a2981d66c765f6ff4af8a37d166712094a7959541ac6f42fabd240307d2189d7bbe24c2d850bb99d7fbca5ccc9820ef68210c3dead49c";
+      sha512 = "a070d8bf3771ae9a9e09f40888b3c7cf391eef4966bbf437f547eb8a914290d2da918e7a824558aa5a506ce1941fc95ad738bb9ba56cc7418004da6658c42344";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/be/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/be/thunderbird-60.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "d08e59550f24a1303c7591fd0b8028c49613b3f0fbfc9adbdf0100955e35fb2569b5159df7847cc514249b25eaf5fce71e7902fb1c13824a9eabe650fa438e5e";
+      sha512 = "f9c92aec1316decc523e8bb9136004ef74e184f2213c1ae92541416c36c9f3aa1a8adbe9f875b25120597026dd948a1ca68a9e1074643088d2698f8483a04762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/bg/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/bg/thunderbird-60.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "c78340650a7f19d14335cd35cc80938f0e5fbfc94063d600d7dd441b925dc2b6270e85369ac293f0addbbe74e10802dbc69bb76e0cec2a6af8648a5ca0481322";
+      sha512 = "a576991acf9129ab9a365e80b90fca7aef01e66ce3d06dffb8ecdc0ae3d8dc2902470a99a0293a87c9f112fd13658b71a86e6fb045fa7cefb7773de1cdbbe31c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/bn-BD/thunderbird-52.9.1.tar.bz2";
-      locale = "bn-BD";
-      arch = "linux-i686";
-      sha512 = "5909ede1236341f07d00d3dba5d3297b7bc24cb9c08d133851fe5e412638a3b9e00291dc40fd927b73095dcc9a239441b3c71ec7a5ab3210fecbd4e4a5a229dc";
-    }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/br/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/br/thunderbird-60.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "9682db4630a840c676c0b68f010da21a65ae9f81c4373def81effe08c9c2b8759626d54e8923e6bb1381453acbac8942c4ab07f2491d3d3027e91c8fe9275f2d";
+      sha512 = "d63edb38305e2ee76df5c05dda275ee45ba419bfc6776d007fa39dec36d202158f7eacff9611aee44d3681b0db5b200a6706e8034fffcf1ca7d575787240a5ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ca/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ca/thunderbird-60.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "3937ecef0ad33e43bc8822bb22f8c3398d51b37278c195dd9b4f4ed9c5d49e53cfb79c9a0b1c684a72735d44dd7865097b716268e7d6280b70e46b219b87302e";
+      sha512 = "d5ae9f8478c638fb50af671dbd12e95b338333e87b31a7cd42d99e8deb200ec23841ac9b93b0ab26b39306067203d8645976cb99292e3a028149ca549c9d43c0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/cs/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/cs/thunderbird-60.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "88f958ef60ac5b73fd29ccd40d9e2794dc8d57df2c15f426aa32a5d605d6b4702e2350003b394d19ad13fe3215552070947ff0ab2851698162946221b3ff1a88";
+      sha512 = "9284fd6b7757c4ba331f2d2e713c247f7fbdecb7724c1d66df1d1f0c81e3803dea4cee6fc4a905020b00ec5b281a4c959eb56ef401af5b8ec5cbf05252d7ab66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/cy/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/cy/thunderbird-60.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "0301925a7378a706ad12225aad4d10ff15962426c02a294b1e9ea9e1f779c429bd2994c964d4f05048b371b71f0c6c0ab1b37204b242990b931a3a774a05b04f";
+      sha512 = "182e1c8878e53af87b5b83fe00ba5a8fa7c72ee35002e843d3e1cbbcebb1d2e82c37e90a44c411b238b9c843be6594aa75d34deaa576d213c23af4e2e8b0fe23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/da/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/da/thunderbird-60.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "960996c312b862bab9447985e1cc9b1f09a61989e538ac3eac2a95b06496102b5387cfe1e762128f1b521844f4515335f4ad4bd9078771f9c2245159eb39a8ae";
+      sha512 = "10f22a40283a4202c0e6612a27022ffdd3d2c45727cd170ebeaab6678f59f624c6d2520ddf2c9540e98030c6813760b5d56c70882caada0166985f3206fef4c7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/de/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/de/thunderbird-60.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "3ab75cb50218db215a1c7d4c39b6038ea3dd52ebe17b5d3fb0cafc74a02dba143d6e4c0efab7c6c1c494ee83297878d82355bd4639f6aa1625be3af5f0b514a4";
+      sha512 = "42709aa4778e93ebd61ff44d027eb0445028f036c735943d71ad355870d03da6dabb763367123156922aa56fe66d6968ba9c93e7b9a8b58197624f984c36437b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/dsb/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/dsb/thunderbird-60.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "157b25d20020c4159708790e50b09eac2b814a817655540abf878910b53ac2c1040790e8aa115bccd54797a5068954b08daa5c28f70c7ac161eb2be78f82cedc";
+      sha512 = "6b82976526b862c9cae1a056b04f36c6d6cbc4ca91308a1f02a808d88272326c10f34cc77aef00b6f6c1863de42ed9a03328a667e4a0b985ecf837765557f982";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/el/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/el/thunderbird-60.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "52c0be75e9979a08f1335da437cb47fc17cd928fbea5af85283b5d07f07fdb4ac6e2f924d53f7db9e31cc0b9e7659f48f8d6e06a28d609760a0f8e6641bc96e8";
+      sha512 = "4314dc7d8fcffa4c4f498d41657332bc476d79f934b4f46181fac4b6cd93d3161271fcd0575f07139186d502c5b833b53ff26d2f8728c9a73765e551963c45d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/en-GB/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/en-GB/thunderbird-60.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "53e66c5e9c98a6af311732341073b553c577dcfe35178996c7a27ee0cc0dddfc7774a065fdebbfa0a4cd4f6f3f422e9fe67fac07a586342e9dde33b59d6bd17a";
+      sha512 = "0840f23683c8c109ac802415b4216f778d6e1c2487e0e8d179def2a3b56308a7d9888c46a96d8d509f99fa4aa296213e2772bf1e74a97330c5e2bea97dce7c70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/en-US/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/en-US/thunderbird-60.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "69121dd8b2445e6304f4437c06e1b7f423b19d4069290c0709a3356680613964df138c417c3d258bc978d8709b9ada28548b43c93ea9122b64daa046d96a6d78";
+      sha512 = "baf0334ba9803cdb79e1a05a6745f6a87575d52bf86f6169b664903608236eda8ba8965481a58b660fb1edb567c681211f328c3f0b9b298e267b5e572b41f642";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/es-AR/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/es-AR/thunderbird-60.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "e557b6249af266de41863b49a811f4c5c979e88dc15ccce6fe60694b98dfd9f09d8ae7316652626c19e5379f20b27e58f4f1be465f4df896a3aab693cb0ef5b9";
+      sha512 = "c7a7ba5a547cbb7b839191b14a0a78835935cf589f82d3ee28e144032e0d94d9209348a45502b7e2da67314427b23d88fabf61db1ea78e55dda9bd1ef97abe9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/es-ES/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/es-ES/thunderbird-60.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "779d6a4a793f4bca441f8ed8ffbeabf20a7ba8555b0fa36229814db68f98d35dd15855446c7dfb8aa9509b40dd5cbabbb0ad66a604d6205daa9fdb4b1a4b9295";
+      sha512 = "ae3c7211dea682e133f960a147169e0a7b615a0fd4ad2fd28fed3976a395f16ebbe1184c872746e2872a09466ca84646cfdddd270ecb3567725dab24201297d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/et/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/et/thunderbird-60.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "7da30d3e48b520c74562d11719d1988ad94cbdf676f244ffd9527475f696b54f50a1e14905a045b7d5375e1b99ba3d0459acac1e72d22ada24b0e91e74e7c2cc";
+      sha512 = "e08db3e430bc90b5af7fa5d979d694d38de1bcfbb89d68613f5b3abc2abe135ca19071890fcaa5e08e2c42d7486a113345ec24ce5555d963ef2c072a3f4b77ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/eu/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/eu/thunderbird-60.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "d8c50713410ee2fe8896e603cba9e04685c8dd277aba9dc2270a2e0d282a609e1feab44398007e9aa96cc0e43997598c6aa702a231d568dafa7f96a8be548e31";
+      sha512 = "f3e5ab6e80ef67fb7b05e08dcaab138475f4feede719939a055c0c548a719902a1bd9b7c18c4a76d5e7173f5a01a319c56579c41059a1888fd29bd43f78666ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/fi/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/fi/thunderbird-60.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "215394b3f4cab3b44d337adb56308b432c62000a592b9ee3b8e985636a6f3fec9189de64c9aba32ae1753b0ea085dca312b1696844aa658356ca9f96a0b7f255";
+      sha512 = "b034c2fc5f633e4cc5b9f3258d7073439e805371833e7dccea9e8a7c9bc52ea7bb862642eb32bc02cacf2f114ff9b379edc22eb0df52ce676db52f67a3d48672";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/fr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/fr/thunderbird-60.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "041c325d7015725fd81c31a1709017ee3091321187c39f84173fa5fa9c963a111e3a3bd0eb85f63a246c5a101e94d536bd0cf4a5d22b6e6bbd5fc284dcb3c965";
+      sha512 = "bdc4222ef8f15ec73297b0b1382e2e6da638d103e70c0a00adb5f3aff3b4944be1149f4099cde60e7e0daab273775959110e2354834641f6c85ddcc3f1b8303f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/fy-NL/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/fy-NL/thunderbird-60.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "6f18bf01a6ca108f13b02b8cff1175640efd9c945827f28301c859858b47f238db7a5481a495c18ae5fab2639e8e3799441e0690ff52dd03d8772ca41f03c641";
+      sha512 = "d4ccbbed8cd929c385369c7df9b9d031e4e06600cf8d08449d9e60844aad2ccafbb6517327882cecf1e25786a573e2878f15d841851cf30c72646eea7cd028d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ga-IE/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ga-IE/thunderbird-60.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "da5509e03c4ecb8f8ab4e6e5c23218af04f4415eec33f62b5f9a48f5d7bd6cbd4d7c583439ae6fe71f009f4287a9a02b188c37a326e3a0683654c766849d25c5";
+      sha512 = "c89c2ff0a5c06ce0df29300ac2e1ba034b39b021487ddf86e870138dd165459a71dc250a066df1622e4ebec1813b1c315eaeadaad5da6afa522ca2208222f1d7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/gd/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/gd/thunderbird-60.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "56b1ed5fd7f63e68ee8ae7d291ebbca6881ccbb9c0481430dac23851ac4bd23ec98ffb93ba846f58d216094f55781ca2197717dcc21427dc3873f6e992b67032";
+      sha512 = "5f1ab74c7492a6a52b1ddbd38f7b9f85f59bd911cf8a64084d1eb35715f0b9cd45a7650dcfa9771679ac6255eed99dafc0becb8b3e32e315e7d186e118b56afb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/gl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/gl/thunderbird-60.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "5a6bbd8729b1c263bee0e31f544b2137a0166e07d6ebf015573e8da51e91735c467c065ab40e2c330c62a0e9c86d2b2cb302949234d746c7c743f6864f3eabe4";
+      sha512 = "690915f4e182b5ecab32675aa03616a2f51f7a4e795991cdfece82f63f074e2d8057d6e87ebf9f74dcc5acd149b1dc844517bee19de3d959a493cb64b51e6158";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/he/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/he/thunderbird-60.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "90998ad6963a3258a5790caf4d36a34348fcacbbf9ba9ef87a8aa8ad1fde35bf146835434754f9421282ea1e36084660d149f28b75c8d422b84232d420810a35";
+      sha512 = "ea589ef7a9b4897beb23b4595c830fa14e7021472dbab815fb15325e99cf858a28b7265d43df0629d2196c1563a769f36beae1ca048fa3c006cd97d54e923ecf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/hr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hr/thunderbird-60.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "727f2ec4f04b32adc2a2dd1b9e5af6de0963334abeeb4582a68fbacaabf7720251a3d5280fd7b1d8e6660747b5ea9ffc94a658d1d95651b8d3a232b15437fe23";
+      sha512 = "e5b8e4cf40819c9b83339520e832773e3161c9c38c802ca37fe512616f128163bcc2d1e7a40ea6e0bb754973a782f141ed044c4be3a0cb7a39685326a1c3a8e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/hsb/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hsb/thunderbird-60.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "213cfe86cf7025f76dca4af15d42d5d9fd676411d8fd64069f82ef34de7ae3de6208b0ea21c77604e6c19b9c015b9c4fe8de783de625a4345bb69f2a69a6ea3c";
+      sha512 = "81382e35b825b65f95508cf04bdeb1a8709f2cd7b408f3dc068cb75d4c5ec31bdbead8807008c78599bc11043f77437013242f9969333c46e10d9ba4a8e563cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/hu/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hu/thunderbird-60.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "97ad1bc5c2c29e7fac01832d44337c79b05e3ddf6dccbc41caece5c249f9ab46ca0a9ae469d0b5a923ecbd43ec4f910b70af81010d9f9b8f35a9741efbc9bc6f";
+      sha512 = "190794f6fa1ffdbfc2b8516cf0c954a9abf8408aa04c1d9c51e1a601f8a1d3d8fc32e2ca9644bcd1e11e8cfc47982c55995b2daadbbbafcc713b4c6f5c8aa63e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/hy-AM/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hy-AM/thunderbird-60.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "7738216dd50fc7a837080770fee652db2091a156623097f04e038a94c456e334af4939973960593ca915da14573263668b08dc7359e3d5a77ddb6c89c18c7efa";
+      sha512 = "a6cc1ebcf284fb7b4fa0873768713dc569efdb39982f37131499434577ab5515448caaa5fac776987bc008074ac6c04eb29e2f60e21626b06dac2dfd17ee09c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/id/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/id/thunderbird-60.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "bef209d87eff0a4ba061c50c1a20937e6052941e3655d92c17eccd79657542db5a6deb68fbb2b25b2c0d5add872d86f4414b761c4f167c289d58238e21dea59e";
+      sha512 = "4333f727d2e310bb24e6f266b748d757683523d6c3414c68169bc1a7852edad8d76bc3021aea01bc08e7d95c5fe4da16281306236cb6eca6f3e339cd5cc11fa0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/is/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/is/thunderbird-60.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "7f939bdca0369eb70a47d8df6f3e453a9b5472f7f3c78bce73380d6f72ec46c74bceab5087ecd4f4516fd0a405a6c70ebc19295da819e037f553f688df33b213";
+      sha512 = "f26d7117241a090de6675e3a336b5b0c9b5462acc80248d6e41bf43f8c990a761ce36e6d0a4620a1733d06f5bf7cd8511c88f686b9ae0806f23f5a852be3c0d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/it/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/it/thunderbird-60.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "289a0db383c7d5ee0fc064867f8821c7f445facb37387229289a1f507174df7cffb390c19bbfec438a4e20c727769688f64000e0e2fbf17273fa21419c770070";
+      sha512 = "33dfd7890b6c156b907e40c5442795c8549053362d65272bd08a5ddaeda61783ec914d8c917a7b9731885aff766011b9a667307ee01cac79614eb84133bc8675";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ja/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ja/thunderbird-60.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "5b9920d334675cea0d603cf2eac923c55f234af5fab69f0002f3a2ae0afbb0a003e8f228448d5485d14543b65494ae7f5add6b28305bde1fa8a4792102d948d9";
+      sha512 = "4ed858b1a1411472bc2029ce1396b78a00f25cabfc2232f6e3daf0acfe91898df769c2397f908db52759c32efc25a79d9d39efa99891a68e2b7d5b7c13820a23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/kab/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/kab/thunderbird-60.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "6ad1cdef0c168d5a7e4d1e26f01354f12c7249440319132fdc07398a395074916576b7047762c231b05b039fa250c5f2fd4e9f6f85f85d2626fcd4fe58ae64b2";
+      sha512 = "61e8b05c0c952eb493fb5f35b7ce6ee1da586a7a4d25f27224f36b7afae75a0f217717f5afac17b43f763b2f6403f4c50ed01c1d1dc6dd084d24f8821566b552";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ko/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/kk/thunderbird-60.0.tar.bz2";
+      locale = "kk";
+      arch = "linux-i686";
+      sha512 = "507ad5d46263ada1fb9b3d05f2c6d1a00b76f5d25fe9459edafcb2793070b6771ff52b338bc9963c1810a46740ea1e22ed330a5b935bfef72437b572f0214e67";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ko/thunderbird-60.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "090a467a7d8ef9f3ba759684cbea8625624f5481b890bd47098e7bbc94017934457cc2ec0a7225f6486a537860c08f695cef60c3ea4bf32b1937c87a66c66c7a";
+      sha512 = "2550ae6cd5e8ee1fb6fc0b3fd974c1028edf8b292da72b57d6e27fe2e600d6418c6f4ca2c9d5535cbf1f1c67b20713cfef5732beae79ceebe328f44a73023b69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/lt/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/lt/thunderbird-60.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "cd0190ffa07115f584718eb8a6c9e94dbe0c883ae48e5f4d5a86caf8db599d37d8e47d2402bd35625c0fdf752194d86a3bfb6a24f3010f0db2e5fcc5aab823fe";
+      sha512 = "29e47bd8306507fd65d27892863b9cd0b58cff4d2035f7c0d3df8cfb98ddc890e922c0e54e0177b255b6bda70116a72fa630494b7ead05683f928c1a3f6bfed3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/nb-NO/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ms/thunderbird-60.0.tar.bz2";
+      locale = "ms";
+      arch = "linux-i686";
+      sha512 = "fec173bea9f579e605ea3b40510f26d0cd94ae96ca465f2b6b829eb710fd3154ce6b997c3951b12165491b8d57af8371517a23ec73615b3b53e463b6077efe96";
+    }
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/nb-NO/thunderbird-60.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "6efb9bbd8f0fee9ab584d2b78425bf89d4dac2b2e7c1da745b922202691698add874b1b3d61b93a17de6256851667c25e7f13cd62591e7a47102c3ac07f8bc1d";
+      sha512 = "1f15c20580104e6bbfcf07d234ac987e2d35eadeff5437369f62b34acb8b47dd646c365c31e2c5601c675a413cc0d2d73fff6f4a663436b426331d373725aee5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/nl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/nl/thunderbird-60.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "ff2860ebe75ae4d542de0f9d7d7351140097367db16728054a97ae23d74c1c357d02bcbd4e05f0f98364ee80fb6054ae7cfdf60307d43da198b2bba20b17bd6f";
+      sha512 = "5f1b20753423ed3882625309ad91e3a6c0931984b502e395cd56d5701eaa6612ba547d996c608b5d87f521989900eb4f02a419036b4f1c9312f9d763bf68e89d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/nn-NO/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/nn-NO/thunderbird-60.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "96a61cbbeb647820e92c268d2a6ffd1578e56a8517a415689c97548f3d218fb26711cd737d6fd682127f9704a6f4ef11f0722620f8ed44379e08cef3945f727d";
+      sha512 = "2a7964d792058c973940cb99add2862f61e66e6ce0cf6988c6b0395274b8791a09f81730a403748962b56be8a183c5d8e063cc8b7e93e166a1d508c8f274ad16";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/pa-IN/thunderbird-52.9.1.tar.bz2";
-      locale = "pa-IN";
-      arch = "linux-i686";
-      sha512 = "83dbd6b5d49ebbcb7b5fbccb0c120b85adaa6085664416921bd06659deeece1a7d27bcd567a47322e81da4793da62c8b54e4f6a751645e8c7add0c362b473d84";
-    }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/pl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/pl/thunderbird-60.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "dd2bc656bc7ab1e21121eaa9903c63056647c31da6fa55c816c458684235559a2b2d9668e200e73f54e9b7c34bb6d0c905c0a31c6153494e16131f7e0ce9c9ed";
+      sha512 = "49e372e264e902eac027db402d5e53683efcdf67faa41696113f7e963dabb85e6fbb8f58759460bb3fefc67ad52100a1d204884dcbafc39ab08e46059f72124e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/pt-BR/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/pt-BR/thunderbird-60.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "83c09f9b314ff82ff59ced594709eff7a0d55c9a7f1c064917ebc3820946ef69aaf509da79cf447f618b3afaab648e4990797724c671ba850655559190a1647f";
+      sha512 = "201398c2c58e55b9d311f87d445727a0a3c455167febe23a597ec97fe80ca189aff3557d8ac0e1957443251af184542d071229664f0a78de2faf31dcf337d951";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/pt-PT/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/pt-PT/thunderbird-60.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "bf6c986e8b43f725a1541c0ac7c880384be40f2c90ffc87e598c177644bd32b2b07bc56be58c2db4f1aca64c4c6590a30199d9f93b7a5fd2d52a9d916ca309f1";
+      sha512 = "88ba0c8dc4665305c85e00a0f50ff4247abf1a5925436d717c082c4934a6df41f9d45c45ac458598167bfae8633e3fa2c12f938e32480b956b2a61527c677af2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/rm/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/rm/thunderbird-60.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "3f07918c0f7ae7117daccd382220aea3e132fa759c25948883c1d97b936e4302fbe6fe176ca4c109f9a35c580d46a7578561c2d2909364b5e915c66d80308cd1";
+      sha512 = "f121ad8ca5ee662a9b815d547352b21f7cf46bbabcf12f21617f857821e8a2b303a915fb1b3b3676684a0e79b30c9d97ba34a9223794616b4fd79f85f562d264";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ro/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ro/thunderbird-60.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "5c0a230ee4d49e6c5d6234480f288788a0b01bea44f85e29f336c5280cbc507da30e681df26938acf8f7d1b67ddd52fc5082d1019df0474ade399a27f1fdff26";
+      sha512 = "a0bff4872cb8186eb187fb7b366a5469cb2f8bbc5c42296195a104432b91e99b4729515d4808651f61faa585979966be903453a75524001b619350b66a6f2349";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ru/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ru/thunderbird-60.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "43ac720dedc608f49107d29119d699c9c1ab4e7d0f62608e44ba4ae55f9c669d5adacf9e11e7fcdc9e8dcddaf87b1a237202e3a6805a0cbaf803df28ddff13ad";
+      sha512 = "e5eb22490436cb0c1456af5f7019b2b1b77dbdc4b68fb9d0d693a8502acde51027a90335ea4adb1b030cb4557ffdcefc8caec423110fbdc40f0c30bd269e1e45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/si/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/si/thunderbird-60.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "338af5daa9c2ba21c47c0aaa449172c3ce315fb8c1d04e522ed77fc986d539c2c15ebe5bda80688d568fa3671b3e32579b00fa4c834c0950db5773109e7aae7e";
+      sha512 = "830965b9d551665e84646e865e66aeabe6082308278669fce95e005643ba5807a0fc17ec294043f5ce908676a53b88ac64d9234b56571dbbb22b5a5de66aefac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/sk/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sk/thunderbird-60.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "30e69e3c3252f3fc2bf8a9efbc19ece01728a8a79deafc42bcc5dfe92d15174816e510a9324e950cb3135f84bdb6587d00eb31a330b94dd330eab0cf35342724";
+      sha512 = "40fca2d6bc9d2dea9df6ad7c153bcffcd30687c0fcce17b78583501dda379994ad706f28003248ed2cb62b0a3f0d510c203b7d4eca2f071be6f2d670f7f04c76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/sl/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sl/thunderbird-60.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "0bd8ff9143652e5363a7c5e1fca0d0694c3891f83c63b2c3c06d4fac245efed31bdb486cdc41f4c5a615fcb1d1a502e6cbac3bdafa7d6e906f19ae6bd215fdc7";
+      sha512 = "0881ee4832639fe79201260f8c0c755bd2d4bdac7ce5a422a37b9798901815b5b7ee1eefda9d3f82c1d49fbd0c6174ffa3aa5cc850aa260af7133d60b0685ad3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/sq/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sq/thunderbird-60.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "294d17e1b5157fc7e168cf29bed2c9750775f6913375e745a66fdc7d70cf7ed783b7cf731c5090cd38803f60b0839e76ee4f260c248b73b675f4a78e5e301bab";
+      sha512 = "df1d0639030a33ecd4e0e336aff064dc87daf423ce7c8a6a0279f1a92d3cec4406ff0054eec1c911812f0ec6074308c8e66180e1adf919d366a8b6f138a6ef36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/sr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sr/thunderbird-60.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "93f8a5c9e17ae9f577ee9746849fc46158e54d6bd550b5ce20e056707b3c05361f717b40637e1539aecc95f223318dd4311aff34dc511dee8507bf2622cf883d";
+      sha512 = "ce264e4a8b5bc11396832533c1dfcfe43b601d4b4e8dad3d3b03c285732ab6b5fba50b90e28dfd883468cdab06e4f726d46478aa8b9e2b3a244c515288fef0bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/sv-SE/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sv-SE/thunderbird-60.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "3555a2d623ece9921bd6acbff45459da7a51de28494f0915639c76066b3b3bf91279716f2c42b5e5d78d09216a6fe6f5be88ab4dba1d2172852ca51d93a634b6";
+      sha512 = "da5e8ee2e9fc35a605481f7351b0391d8ca056ce7f152a5e46b3b91b539f5e35b1ecb0067cd8fdd26f249393d45e22e61d318c9687d66b52accb59e8b3283e13";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/ta-LK/thunderbird-52.9.1.tar.bz2";
-      locale = "ta-LK";
-      arch = "linux-i686";
-      sha512 = "203bb717b4fa77522dcee2a85cf0c0d8997abc6ac565ad908ab4eba8f7bb37e848fb94a0526c0fd8360569c9cf3c98cb82196e38cd930b11d82cad6cd88d8f5d";
-    }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/tr/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/tr/thunderbird-60.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "214b140e3c18a2fd4b936558f4bb80441bec9d2afc79e0a949365d2e20b3fa1a092aab332b307c674b7a1cd3822e428459992fdfa5f56b534733021e5fcc11c9";
+      sha512 = "546c6ed7113af0c52aaa69630561637789381a5e97f2edea3415d14a88edc25124a64427c3a1e1a75e8c4019468aed0ebf4d6ff56ecf26ed1c64eee6b69ee777";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/uk/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/uk/thunderbird-60.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "28a003f1c5c0135a978187e68779500caff1eed42b4da846cd2d5025835fe80ac6ef9cb0424d4a4bd339680666d9a2ca2526b46ffd9ba6b5b0bb725c5c4a7e71";
+      sha512 = "ce3386e90c77fae05c79d4e30abb723fba507e4655bee6667edca9de048c8854184af5c8775b10f2b7560dc9e6e95bbe7b8db79a345e590211cb56ad313f288a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/vi/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/vi/thunderbird-60.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "e2e79d972802b9c9b6319e147b741814f63dc7c5ecb663461483a5fcec45184c9a245752486f4411d961cf7d4da3ad41aeeb52364605ed78058bf53826fb0667";
+      sha512 = "9bce245422e162e017198782778995ecc1ac1e2760ca91864605e3002042576a9c53519f085f6159e1654a4dff7dddc19f9fd1dda0a9f4cb9b616baeba8845d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/zh-CN/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/zh-CN/thunderbird-60.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "05554421534038c4a02cefc68ee9e116d15aa8b607be06de2be7cb7ef794157f6b01533f5a670d739284632faea10b374ad6912f6c332ca4fd5f0e8d0346efe8";
+      sha512 = "db756f120fc2ecfa3478cf07935b12414f79f746a96b0e30f75496f2cb8a7d880b9f3017b12122f0cdc0f64d10ae738da9c026aa9c533dbdaa6e0f38e5a71ee7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/52.9.1/linux-i686/zh-TW/thunderbird-52.9.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/zh-TW/thunderbird-60.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "e2b3081e08f87891a0559456fc74d8d3647d49cd14176abd5155aa8ca5d1e1394638386c6c27b433e581d539ac76d151e37dd4942df2e8646134a0218ef54e77";
+      sha512 = "b589e9f472681bc9ddb5909197db2acf8b54e610998d00df4731c6a1403c5b865334aef2e072b3c7ac0694175f0e7cda6864809fc6079f95681b508267d90a59";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -6,6 +6,7 @@
 , icu, libpng, jemalloc
 , autoconf213, which, m4
 , writeScript, xidel, common-updater-scripts, coreutils, gnused, gnugrep, curl
+, cargo, rustc, llvmPackages
 , enableGTK3 ? false, gtk3, gnome3, wrapGAppsHook, makeWrapper
 , enableCalendar ? true
 , debugBuild ? false
@@ -20,21 +21,15 @@
 
 let
   wrapperTool = if enableGTK3 then wrapGAppsHook else makeWrapper;
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "52.9.1";
+  version = "60.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "0ipvhllvlkcjshf2h938d531wpgnhbvdw1k088iazqamb3vrspxpfb4dhfrxvff995nym0gs7j5wa6bjd36nm4wajlabs5i6r80ms0d";
+    sha512 = "1933csh6swcx1z35lbxfkxlln36mx2mny28rzxz53r480wcvar8zcj77gwb06hzn6j5cvqls7qd5n6a7x43sp7w9ykkf4kf9gmlccya";
   };
-
-  # New sed no longer tolerates this mistake.
-  postPatch = ''
-    for f in mozilla/{js/src,}/configure; do
-      substituteInPlace "$f" --replace '[:space:]*' '[[:space:]]*'
-    done
-  '';
 
   # from firefox, but without sound libraries
   buildInputs =
@@ -50,11 +45,11 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals enableGTK3 [ gtk3 gnome3.defaultIconTheme ];
 
   # from firefox + m4 + wrapperTool
-  nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python wrapperTool ];
+  nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python wrapperTool cargo rustc ];
 
   configureFlags =
     [ # from firefox, but without sound libraries (alsa, libvpx, pulseaudio)
-      "--enable-application=mail"
+      "--enable-application=comm/mail"
       "--disable-alsa"
       "--disable-pulseaudio"
 
@@ -66,6 +61,7 @@ in stdenv.mkDerivation rec {
       "--with-system-libevent"
       "--with-system-png" # needs APNG support
       "--with-system-icu"
+      "--enable-rust-simd"
       "--enable-system-ffi"
       "--enable-system-hunspell"
       "--enable-system-pixman"
@@ -79,18 +75,29 @@ in stdenv.mkDerivation rec {
       "--enable-jemalloc"
       "--disable-gconf"
       "--enable-default-toolkit=cairo-gtk${if enableGTK3 then "3" else "2"}"
+      "--enable-js-shell"
     ]
       ++ lib.optional enableCalendar "--enable-calendar"
       ++ (if debugBuild then [ "--enable-debug" "--enable-profiling"]
                         else [ "--disable-debug" "--enable-release"
                                "--disable-debug-symbols"
                                "--enable-optimize" "--enable-strip" ])
-      ++ lib.optional enableOfficialBranding "--enable-official-branding";
+      ++ lib.optional enableOfficialBranding "--enable-official-branding"
+      ++ lib.optionals (lib.versionAtLeast version "56" && !stdenv.hostPlatform.isi686) [
+        # on i686-linux: --with-libclang-path is not available in this configuration
+        "--with-libclang-path=${llvmPackages.libclang}/lib"
+        "--with-clang-path=${llvmPackages.clang}/bin/clang"
+      ];
 
   enableParallelBuilding = true;
 
   preConfigure =
     ''
+      cxxLib=$( echo -n ${gcc}/include/c++/* )
+      archLib=$cxxLib/$( ${gcc}/bin/gcc -dumpmachine )
+  
+      test -f layout/style/ServoBindings.toml && sed -i -e '/"-DRUST_BINDGEN"/ a , "-cxx-isystem", "'$cxxLib'", "-isystem", "'$archLib'"' layout/style/ServoBindings.toml
+
       configureScript="$(realpath ./configure)"
       mkdir ../objdir
       cd ../objdir
@@ -106,14 +113,14 @@ in stdenv.mkDerivation rec {
   postInstall =
     ''
       # For grsecurity kernels
-      paxmark m $out/lib/thunderbird-[0-9]*/thunderbird
+      paxmark m $out/lib/thunderbird/thunderbird
 
       # TODO: Move to a dev output?
       rm -rf $out/include $out/lib/thunderbird-devel-* $out/share/idl
 
       # $binary is a symlink to $target.
       # We wrap $target by replacing the $binary symlink.
-      local target="$out/lib/thunderbird-${version}/thunderbird"
+      local target="$out/lib/thunderbird/thunderbird"
       local binary="$out/bin/thunderbird"
 
       # Wrap correctly, this is needed to
@@ -139,7 +146,7 @@ in stdenv.mkDerivation rec {
           name = "thunderbird";
           exec = "thunderbird %U";
           desktopName = "Thunderbird";
-          icon = "$out/lib/thunderbird-${version}/chrome/icons/default/default256.png";
+          icon = "$out/lib/thunderbird/chrome/icons/default/default256.png";
           genericName = "Mail Reader";
           categories = "Application;Network";
           mimeType = stdenv.lib.concatStringsSep ";" [
@@ -163,8 +170,8 @@ in stdenv.mkDerivation rec {
     # Fix notifications. LibXUL uses dlopen for this, unfortunately; see #18712.
     ''
       patchelf --set-rpath "${lib.getLib libnotify
-        }/lib:$(patchelf --print-rpath "$out"/lib/thunderbird-*/libxul.so)" \
-          "$out"/lib/thunderbird-*/libxul.so
+        }/lib:$(patchelf --print-rpath "$out"/lib/thunderbird*/libxul.so)" \
+          "$out"/lib/thunderbird*/libxul.so
     '';
 
   doInstallCheck = true;


### PR DESCRIPTION
###### Motivation for this change

- various improvements and fixes

https://www.thunderbird.net/en-US/thunderbird/60.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

