### PR TITLE
intel2200BGFirmware: fixed-output derivation

### DIFF
--- a/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/intel2200BGFirmware/default.nix
@@ -1,35 +1,25 @@
-{ stdenv, fetchurl }:
+{ lib, fetchzip }:
 
 let version = "3.1"; in
 
-stdenv.mkDerivation {
+fetchzip {
   name = "intel2200BGFirmware-${version}";
+  url = "https://src.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
+  sha256 = "0zjyjndyc401pn5x5lgypxdal21n82ymi3vbb2ja1b89yszj432b";
 
-  src = fetchurl {
-    url = "https://src.fedoraproject.org/repo/pkgs/ipw2200-firmware/ipw2200-fw-${version}.tgz/eaba788643c7cc7483dd67ace70f6e99/ipw2200-fw-${version}.tgz";
-    sha256 = "c6818c11c18cc030d55ff83f64b2bad8feef485e7742f84f94a61d811a6258bd";
-  };
-
-  phases = [ "unpackPhase" "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/lib/firmware
-    for fw in \
-      ipw2200-bss.fw \
-      ipw2200-ibss.fw \
-      ipw2200-sniffer.fw
-    do
-      cp -f $fw $out/lib/firmware/$fw
-    done
-    mkdir -p $out/share/doc/intel2200BGFirmware
-    cp -f LICENSE.ipw2200-fw $out/share/doc/intel2200BGFirmware/LICENSE
+  postFetch = ''
+    tar -xzvf $downloadedFile --strip-components=1
+    install -D -m644 ipw2200-bss.fw     $out/lib/firmware/ipw2200-bss.fw
+    install -D -m644 ipw2200-ibss.fw    $out/lib/firmware/ipw2200-ibss.fw
+    install -D -m644 ipw2200-sniffer.fw $out/lib/firmware/ipw2200-sniffer.fw
+    install -D -m644 LICENSE.ipw2200-fw $out/share/doc/intel2200BGFirmware/LICENSE
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Firmware for Intel 2200BG cards";
     homepage = http://ipw2200.sourceforge.net/firmware.php;
-    license = stdenv.lib.licenses.unfreeRedistributableFirmware;
+    license = licenses.unfreeRedistributableFirmware;
     maintainers = with maintainers; [ sternenseemann ];
-    platforms = with platforms; linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

make the derivation fixed-output to avoid rebuild/redownload on each mass-rebuild
