### PR TITLE
firmware-linux-nonfree: fixed-output derivation

### DIFF
--- a/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-linux-nonfree/default.nix
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "110vxgahyx5dvylqrxsm5cmx4a32cl2zchvm6cgc270jz75fg7wd";
   };
 
-  preInstall = ''
-    mkdir -p $out
-  '';
-
   installFlags = [ "DESTDIR=$(out)" ];
 
   # Firmware blobs do not need fixing and should not be modified
   dontFixup = true;
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "0r2g91hc7csp2fbp2ny4s4rwv0mw2m130gpnisxnhzi05hkwki66";
 
   meta = with stdenv.lib; {
     description = "Binary firmware collection packaged by kernel.org";


### PR DESCRIPTION
###### Motivation for this change

make the derivation fixed-output to avoid rebuild/redownload on each mass-rebuild