### PR TITLE
hwdata: fixed-output derivation

### DIFF
--- a/pkgs/os-specific/linux/hwdata/default.nix
+++ b/pkgs/os-specific/linux/hwdata/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "hwdata-${version}";
   version = "0.313";
 
-  src = fetchurl {
-    url = "https://github.com/vcrhonek/hwdata/archive/v0.313.tar.gz";
-    sha256 = "0x0qk2cim1mv8cl8h8rwqn8mbbs43j04rn06m81b531i182zii17";
+  src = fetchFromGitHub {
+    owner = "vcrhonek";
+    repo = "hwdata";
+    rev = "v${version}";
+    sha256 = "1mmqiy4ams14mdiakz60dm07wfan343hisiiz0dwvh685mjxap8h";
   };
 
   preConfigure = "patchShebangs ./configure";
@@ -14,6 +16,10 @@ stdenv.mkDerivation rec {
   configureFlags = "--datadir=$(prefix)/data";
 
   doCheck = false; # this does build machine-specific checks (e.g. enumerates PCI bus)
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "0lz8pykpfw6aqkpdaqdc3jnny1iqgsqnc0wm61784xxml7zqfdvx";
 
   meta = {
     homepage = https://github.com/vcrhonek/hwdata;


### PR DESCRIPTION
###### Motivation for this change

make the derivation fixed-output to avoid rebuild/redownload on each mass-rebuild