### PR TITLE
ocamlPackages.{core,async_kernel,async_extra,incremental_kernel}: update

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -370,8 +370,9 @@ rec {
   };
 
   async_extra = janePackage {
+    version = "0.11.1";
     name = "async_extra";
-    hash = "1qac95zlvq34fh2wbwbw0vdzxnba6si8lkal7n09y2lzpwvsifx3";
+    hash = "0dmplvqf41820rm5i0l9bx1xmmdlq8zsszi36y2rkjna8991f7s2";
     propagatedBuildInputs = [ async_rpc_kernel async_unix ];
     meta.description = "Jane Street's asynchronous execution library (extra)";
   };

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -341,8 +341,9 @@ rec {
   };
 
   async_kernel = janePackage {
+    version = "0.11.1";
     name = "async_kernel";
-    hash = "1drxawih7vhhb1mhd291698ly7yb38qzif82jk1adqcvwdb547af";
+    hash = "1ssv0gqbdns6by1wdjrrs35cj1c1n1qcfkxs8hj04b7x89wzvf1q";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Jane Street Capital's asynchronous execution library (core)";
   };

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -299,9 +299,9 @@ rec {
   };
 
   core = janePackage {
-    version = "0.11.1";
+    version = "0.11.2";
     name = "core";
-    hash = "0wa2dsfk5m5wlhz915664y9h08idijj5s41hyg8n54dhihvxw2ci";
+    hash = "0vpsvd75lxb09il2rnzyib9mlr51v1hzqdc9fdxgx353pb5agh8a";
     propagatedBuildInputs = [ core_kernel spawn ];
     meta.description = "Jane Street's standard library overlay";
   };

--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -550,8 +550,9 @@ rec {
   };
 
   incremental_kernel = janePackage {
+    version = "0.11.1";
     name = "incremental_kernel";
-    hash = "02arw8blpmnzlw5jlvavyvpgh3s9q0j9mhi2byz0x8cxknqvvasg";
+    hash = "1qp9dqncx2h0np0rndqaic4dna8f1dlkqnbjfcdhcim5dp2vg4x6";
     propagatedBuildInputs = [ core_kernel ];
     meta.description = "Library for incremental computations depending only on core_kernel";
   };


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.07.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

