### PR TITLE
ccemux: init at 1.1.0

### DIFF
--- a/pkgs/misc/emulators/ccemux/default.nix
+++ b/pkgs/misc/emulators/ccemux/default.nix
@@ -1,0 +1,66 @@
+{ stdenv, fetchurl, fetchFromGitHub, makeDesktopItem, makeWrapper, jre
+, useCCTweaked ? true
+}:
+
+let
+  version = "1.1.0";
+  rev = "a12239148332ca7a0b1c44a93e1585452d3631c9";
+
+  baseUrl = "https://emux.cc/versions/${stdenv.lib.substring 0 8 rev}/CCEmuX";
+  jar =
+    if useCCTweaked
+    then fetchurl {
+      url = "${baseUrl}-cct.jar";
+      sha256 = "1i767v3wnb8jsh7ciqqvw548pka1b8vl18k1rdv5dn21la6n0r1d";
+    }
+    else fetchurl {
+      url = "${baseUrl}-cc.jar";
+      sha256 = "0x9hs814ln193cwybd565mcj6vhnii4wirkiz9na7vcas0y5vmmq";
+    };
+
+  desktopIcon = fetchurl {
+    url = "https://github.com/CCEmuX/CCEmuX/raw/${rev}/src/main/resources/img/icon.png";
+    sha256 = "1vmb6rg9k2y99j8xqfgbsvfgfi3g985rmqwrd7w3y54ffr2r99c2";
+  };
+  desktopItem =  makeDesktopItem {
+    name = "CCEmuX";
+    exec = "ccemux";
+    icon = "${desktopIcon}";
+    comment = "A modular ComputerCraft emulator";
+    desktopName = "CCEmuX";
+    genericName = "ComputerCraft Emulator";
+    categories = "Application;Emulator;";
+  };
+in
+
+stdenv.mkDerivation rec {
+  name = "ccemux-${version}";
+
+  src = jar;
+  unpackPhase = "true";
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ jre ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/ccemux}
+    cp -r ${desktopItem}/share/applications $out/share/applications
+
+    install -D ${src} $out/share/ccemux/ccemux.jar
+    install -D ${desktopIcon} $out/share/pixmaps/ccemux.png
+
+    makeWrapper ${jre}/bin/java $out/bin/ccemux \
+      --add-flags "-jar $out/share/ccemux/ccemux.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A modular ComputerCraft emulator";
+    homepage = https://github.com/CCEmuX/CCEmuX;
+    license = licenses.mit;
+    maintainers = with maintainers; [ CrazedProgrammer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21117,6 +21117,8 @@ with pkgs;
 
   calaos_installer = libsForQt5.callPackage ../misc/calaos/installer {};
 
+  ccemux = callPackage ../misc/emulators/ccemux { };
+
   click = callPackage ../applications/networking/cluster/click { };
 
   cups = callPackage ../misc/cups {


### PR DESCRIPTION
###### Motivation for this change
Adds [CCEmuX](https://github.com/CCEmuX/CCEmuX), a modular [ComputerCraft](http://www.computercraft.info/) emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

