### PR TITLE
Cassandra version bumps

### DIFF
--- a/pkgs/servers/nosql/cassandra/2.1.nix
+++ b/pkgs/servers/nosql/cassandra/2.1.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "2.1.19";
-  sha256 = "1qlc62j3hf5831yrrbydn3z19zrn6bpirarinys6bmhshr7mhpyr";
+  version = "2.1.20";
+  sha256 = "0ik7a4jg3s3xnyrj1sa0rvbh066fv1y2202l7cv6nbca72pgyl6a";
 })

--- a/pkgs/servers/nosql/cassandra/2.2.nix
+++ b/pkgs/servers/nosql/cassandra/2.2.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "2.2.11";
-  sha256 = "0r39mm5ibdn9dqv11n4x33vcb5247r6fl6r07l6frqp6i36ilvl6";
+  version = "2.2.13";
+  sha256 = "19jryhjkh5jsgp6jlz2v28vwm5dks8i7mshsv3s2fpnl6147paaq";
 })

--- a/pkgs/servers/nosql/cassandra/3.0.nix
+++ b/pkgs/servers/nosql/cassandra/3.0.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "3.0.15";
-  sha256 = "1n92wpp5gm41r4agjwjw9ymnnn114pmaqf04c1dx3fksk100wd5g";
+  version = "3.0.17";
+  sha256 = "0568r5xdy78pl29zby5g4m9qngf29cb9222sc1q1wisapb7zkl2p";
 })

--- a/pkgs/servers/nosql/cassandra/3.11.nix
+++ b/pkgs/servers/nosql/cassandra/3.11.nix
@@ -1,6 +1,6 @@
 { callPackage, ... } @ args:
 
 callPackage ./generic.nix (args // {
-  version = "3.11.2";
-  sha256 = "0867i3irsji3qkjpp2s171xmjf2r8yhwzhs24ka8hljxv457f8p9";
+  version = "3.11.3";
+  sha256 = "1fp2sm8v7dpp7iym39c7dh1fmi25x462amgzizl93c21rdq0cbnq";
 })


### PR DESCRIPTION
###### Motivation for this change

New Cassandra versions available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Executed tests from #31410 for all versions.
---

