### PR TITLE
tt-rss-plugin-tumblr-gdpr: Init at 1.2

### DIFF
--- a/pkgs/servers/tt-rss/plugin-tumblr-gdpr/default.nix
+++ b/pkgs/servers/tt-rss/plugin-tumblr-gdpr/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
+  name = "tt-rss-plugin-tumblr-gdpr-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "GregThib";
+    repo = "ttrss-tumblr-gdpr";
+    rev = "v${version}";
+    sha256 = "1qqnzysg1d0b169kr9fbgi50yjnvw7lrvgrl2zjx6px6z61jhv4j";
+  };
+
+  installPhase = ''
+    mkdir -p $out/tumblr_gdpr
+
+    cp init.php $out/tumblr_gdpr
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Plugin for TT-RSS to workaround GDPR in Europe";
+    longDescription = ''
+      Plugin for TT-RSS to workaround GDPR in Europe.
+
+      The name of the plugin in TT-RSS is 'tumblr_gdpr'.
+    '';
+    license = licenses.gpl3;
+    homepage = https://github.com/GregThib/ttrss-tumblr-gdpr;
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13346,6 +13346,7 @@ with pkgs;
   torque = callPackage ../servers/computing/torque { };
 
   tt-rss = callPackage ../servers/tt-rss { };
+  tt-rss-plugin-tumblr-gdpr = callPackage ../servers/tt-rss/plugin-tumblr-gdpr { };
 
   searx = callPackage ../servers/web-apps/searx { };
 


### PR DESCRIPTION
###### Motivation for this change

I'd really like to read Tumblr RSS Feeds from the EU.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

