### PR TITLE
smarty3-i18n: Init at 1.0

### DIFF
--- a/pkgs/development/libraries/smarty3-i18n/default.nix
+++ b/pkgs/development/libraries/smarty3-i18n/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
+  name = "smarty-i18n-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "kikimosha";
+    repo = "smarty3-i18n";
+    rev = "${version}";
+    sha256 = "0rjxq4wka73ayna3hb5dxc5pgc8bw8p5fy507yc6cv2pl4h4nji2";
+  };
+
+  installPhase = ''
+    mkdir $out
+    cp block.t.php $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "gettext for the smarty3 framework";
+    license = licenses.lgpl21;
+    homepage = https://github.com/kikimosha/smarty3-i18n;
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5186,6 +5186,7 @@ with pkgs;
   };
 
   smarty3 = callPackage ../development/libraries/smarty3 { };
+  smarty3-i18n = callPackage ../development/libraries/smarty3-i18n { };
 
   smbldaptools = callPackage ../tools/networking/smbldaptools {
     inherit (perlPackages) perlldap CryptSmbHash DigestSHA1;


### PR DESCRIPTION
###### Motivation for this change

This is the last depdendency for adding FusionDirectory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

