### PR TITLE
sqldeveloper: 17.4.1.054.0712 -> 18.2.0.183.1748

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, openjdk }:
+{ stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, oraclejdk }:
 
 let
-  version = "17.4.1.054.0712";
+  version = "18.2.0.183.1748";
 
   desktopItem = makeDesktopItem {
     name = "sqldeveloper";
@@ -47,7 +47,7 @@ in
         nix-prefetch-url --type sha256 file:///path/to/${name}
     '';
     # obtained by `sha256sum sqldeveloper-${version}-no-jre.zip`
-    sha256 = "7e92ca94d02489002db291c96f1d67f9b2501a8967ff3457103fcf60c1eb154a";
+    sha256 = "0clz2w4ghqczy9sz6j4qqygk20whdwkca192pd3v0dw09875as0k";
   };
 
   buildInputs = [ makeWrapper unzip ];
@@ -55,7 +55,7 @@ in
   buildCommand = ''
     mkdir -p $out/bin
     echo  >$out/bin/sqldeveloper '#! ${stdenv.shell}'
-    echo >>$out/bin/sqldeveloper 'export JAVA_HOME=${openjdk}/lib/openjdk'
+    echo >>$out/bin/sqldeveloper 'export JAVA_HOME=${oraclejdk}'
     echo >>$out/bin/sqldeveloper 'export JDK_HOME=$JAVA_HOME'
     echo >>$out/bin/sqldeveloper "cd $out/lib/${name}/sqldeveloper/bin"
     echo >>$out/bin/sqldeveloper '${stdenv.shell} sqldeveloper "$@"'


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest available version ATM:
http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html

Additionally switch back to OracleJDK, it is officially supported and
far more stable when working with the software:
https://community.oracle.com/docs/DOC-888316#jive_content_id_22_About_OpenJDK_and_Oracle_JDK

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

