### PR TITLE
libgit2: 0.26.0 -> 0.26.6, 0.27.3 -> 0.27.4

### DIFF
--- a/pkgs/development/libraries/git2/0.27.nix
+++ b/pkgs/development/libraries/git2/0.27.nix
@@ -4,14 +4,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.27.3";
+  version = "0.27.4";
   name = "libgit2-${version}";
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "044dzwgl8zf1i1mk2g1z07hzxz46gma9sh63x09hswhw8j6zqx61";
+    sha256 = "1cmc8ldhpyp62pswb7dmjjya3ng0ssaggcsxs1labvp6xyxjvp6s";
   };
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];

--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation (rec {
   name = "libgit2-${version}";
-  version = "0.26.0";
+  version = "0.26.6";
   # keep the version in sync with pythonPackages.pygit2 and gnome3.libgit2-glib
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "0zrrmfkfhd2xb4879z5khjb6xsdklrm01f1lscrs2ks68v25fk78";
+    sha256 = "17pjvprmdrx4h6bb1hhc98w9qi6ki7yl57f090n9kbhswxqfs7s3";
   };
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];


### PR DESCRIPTION
Security, misc fixes.

Unsure about the 0.26.x bump, wanted to at least see it's build-okay.

Have not tested the many dependencies.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---