### PR TITLE
Bring back functionTo to prevent evalutation errors while merging

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -149,6 +149,9 @@ checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-long-list.ni
 # Check loaOf with many merges of lists.
 checkConfigOutput "1 2 3 4 5 6 7 8 9 10" config.result ./loaOf-with-many-list-merges.nix
 
+# Check the merge behaviour of the functionTo type.
+checkConfigOutput "a b" config.result ./functionTo.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/functionTo.nix
+++ b/lib/tests/modules/functionTo.nix
@@ -1,0 +1,29 @@
+{ lib, config, ... }:
+
+with lib;
+
+{
+  options = {
+    selector = mkOption {
+      default = _pkgs : [];
+      type = with types; functionTo (listOf str);
+      description = ''
+        Some descriptive text
+      '';
+    };
+
+    result = mkOption {
+      type = types.str;
+      default = toString (config.selector {
+        a = "a";
+        b = "b";
+        c = "c";
+      });
+    };
+  };
+
+  config = lib.mkMerge [
+    { selector = pkgs: [ pkgs.a ]; }
+    { selector = pkgs: [ pkgs.b ]; }
+  ];
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -349,6 +349,16 @@ rec {
       functor = (defaultFunctor name) // { wrapped = elemType; };
     };
 
+    functionTo = elemType: mkOptionType {
+      name = "function that evaluates to a(n) ${elemType.name}";
+      check = isFunction;
+      merge = loc: defs:
+        fnArgs: elemType.merge loc (map (fn: { inherit (fn) file; value = fn.value fnArgs; }) defs);
+      getSubOptions = elemType.getSubOptions;
+      getSubModules = elemType.getSubModules;
+      substSubModules = m: functionTo (elemType.substSubModules m);
+    };
+
     # A submodule (like typed attribute set). See NixOS manual.
     submodule = opts:
       let

--- a/nixos/modules/services/development/hoogle.nix
+++ b/nixos/modules/services/development/hoogle.nix
@@ -25,6 +25,7 @@ in {
     };
 
     packages = mkOption {
+      type = with types; functionTo (listOf package);
       default = hp: [];
       defaultText = "hp: []";
       example = "hp: with hp; [ text lens ]";

--- a/nixos/modules/services/misc/gitit.nix
+++ b/nixos/modules/services/misc/gitit.nix
@@ -42,6 +42,7 @@ let
       };
 
       extraPackages = mkOption {
+        type = with types; functionTo (listOf package);
         default = self: [];
         example = literalExample ''
           haskellPackages: [

--- a/nixos/modules/services/misc/ihaskell.nix
+++ b/nixos/modules/services/misc/ihaskell.nix
@@ -20,6 +20,7 @@ in
       };
 
       extraPackages = mkOption {
+        type = with types; functionTo (listOf package);
         default = self: [];
         example = literalExample ''
           haskellPackages: [

--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -66,6 +66,7 @@ in
       };
 
       plugins = mkOption {
+        type = with types; functionTo (listOf package);
         default = plugins: [];
         defaultText = "plugins: []";
         example = literalExample "plugins: [ m3d-fio ]";

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -28,6 +28,7 @@ in
       };
 
       extraPackages = mkOption {
+        type = with types; functionTo (listOf package);
         default = self: [];
         defaultText = "self: []";
         example = literalExample ''


### PR DESCRIPTION
###### Motivation for this change

This is an alternative for https://github.com/NixOS/nixpkgs/pull/44601 as suggested by @oxij .

This is used to type options like: `services.xserver.windowManager.xmonad.extraPackages` that specify functions that take an attribute set containing packages / plugins and return a list containing a selection of the values in this set. 

The reason we need a dedicated type for this is to define the correct merge behaviour. Without the `functionTo` type merging multiple function option definitions results in an evaluation error.
The `functionTo` merges definitions by returning a new function that applies the functions of all the definitions to the given input and merges the results.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

