### PR TITLE
ocamlPackages.sequence: 0.10 -> 1.1

### DIFF
--- a/pkgs/development/ocaml-modules/sequence/default.nix
+++ b/pkgs/development/ocaml-modules/sequence/default.nix
@@ -1,6 +1,10 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, ounit }:
+{ stdenv, fetchFromGitHub, ocaml, findlib, jbuilder, qtest, result }:
 
-let version = "0.10"; in
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "sequence is not available for OCaml ${ocaml.version}"
+else
+
+let version = "1.1"; in
 
 stdenv.mkDerivation {
   name = "ocaml${ocaml.version}-sequence-${version}";
@@ -9,19 +13,16 @@ stdenv.mkDerivation {
     owner = "c-cube";
     repo = "sequence";
     rev = version;
-    sha256 = "0pl8pv758wn8bm555i8f0fvfn2pw88w1bmzjrzrv01092d85wx1g";
+    sha256 = "08j37nldw47syq3yw4mzhhvya43knl0d7biddp0q9hwbaxhzgi44";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild qtest ounit ];
-
-  configureFlags = [
-    "--enable-tests"
-  ];
+  buildInputs = [ ocaml findlib jbuilder qtest ];
+  propagatedBuildInputs = [ result ];
 
   doCheck = true;
-  checkTarget = "test";
+  checkPhase = "jbuilder runtest";
 
-  createFindlibDestdir = true;
+  inherit (jbuilder) installPhase;
 
   meta = {
     homepage = https://github.com/c-cube/sequence;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.07.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

