### PR TITLE
tt-rss-theme-feedly: Init at 1.4.0

### DIFF
--- a/pkgs/servers/tt-rss/theme-feedly/default.nix
+++ b/pkgs/servers/tt-rss/theme-feedly/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }: stdenv.mkDerivation rec {
+  name = "tt-rss-theme-feedly-${version}";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "levito";
+    repo = "tt-rss-feedly-theme";
+    rev = "v${version}";
+    sha256 = "1n5vci84l0wxsd2k90m2x3j8d7y9kz5fqc6fk6y7r568p1cakg9b";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir $out
+
+    cp -ra feedly feedly.css $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Feedly theme for Tiny Tiny RSS";
+    license = licenses.wtfpl;
+    homepage = https://github.com/levito/tt-rss-feedly-theme;
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13348,6 +13348,7 @@ with pkgs;
 
   tt-rss = callPackage ../servers/tt-rss { };
   tt-rss-plugin-tumblr-gdpr = callPackage ../servers/tt-rss/plugin-tumblr-gdpr { };
+  tt-rss-theme-feedly = callPackage ../servers/tt-rss/theme-feedly { };
 
   searx = callPackage ../servers/web-apps/searx { };
 


### PR DESCRIPTION
###### Motivation for this change

I use the theme every day because the default one looks crappy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

