### PR TITLE
citrix_receiver: document installation pitfalls and `extraCerts`

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -705,4 +705,52 @@ overrides = super: self: rec {
 </programlisting>
   </para>
  </section>
+ <section xml:id="sec-citrix">
+  <title>Citrix Receiver</title>
+
+  <para>
+   The <link xlink:href="https://www.citrix.com/products/receiver/">Citrix Receiver</link> is a remote
+   desktop viewer which provides access to
+   <link xlink:href="https://www.citrix.com/products/xenapp-xendesktop/">XenDesktop</link> installations.
+  </para>
+
+  <section xml:id="sec-citrix-base">
+   <title>Basic usage</title>
+   <para>
+    The tarball archive needs to be downloaded manually as the licenses agreements of the vendor
+    need to be accepted first. This is available at the
+    <link xlink:href="https://www.citrix.com/downloads/citrix-receiver/">download page at citrix.com</link>.
+    Then run <literal>nix-prefetch-url file://$PWD/linuxx64-$version.tar.gz</literal>.
+    With the archive available in the store the package can be built and installed with Nix.
+   </para>
+
+   <para>
+    <emphasis>Note: it's recommended to install <literal>Citrix Receiver</literal> using
+    <literal>nix-env -i</literal> or globally to ensure that the <literal>.desktop</literal> files
+    are installed properly into <literal>$XDG_CONFIG_DIRS</literal>. Otherwise it won't
+    be possible to open <literal>.ica</literal> files
+    automatically from the browser to start a Citrix connection.</emphasis>
+   </para>
+  </section>
+  <section xml:id="sec-citrix-custom-certs">
+   <title>Custom certificates</title>
+   <para>
+    The <literal>Citrix Receiver</literal> in <literal>nixpkgs</literal> trusts several certificates
+    <link xlink:href="https://curl.haxx.se/docs/caextract.html">from the Mozilla database</link> by default.
+    However several companies using Citrix might require their own corporate certificate. On distros with imperative
+    packaging these certs can be stored easily in
+    <link xlink:href="https://developer-docs.citrix.com/projects/receiver-for-linux-command-reference/en/13.7/"><literal>$ICAROOT</literal></link>,
+    however this directory is a store path in <literal>nixpkgs</literal>. In order to work around this issue the package provides a simple
+    mechanism to add custom certificates without rebuilding the entire package using <literal>symlinkJoin</literal>:
+
+<programlisting>
+<![CDATA[with import <nixpkgs> { config.allowUnfree = true; };
+let extraCerts = [ ./custom-cert-1.pem ./custom-cert-2.pem /* ... */ ]; in
+citrix_receiver.override {
+  inherit extraCerts;
+}]]>
+</programlisting>
+   </para>
+  </section>
+ </section>
 </chapter>


### PR DESCRIPTION
###### Motivation for this change

Since #44522 it's possible to specify custom certificates for the Citrix
receiver. As it took me some time to create a proper setup Citrix can
behave fairly unexpected.

I mostly covered two aspects:

* Don't install Citrix with `nix run`: when `citrix.desktop` is linked
  to $XDG_CONFIG_DIRS, it's possible to start a session directly from the
  browser when loading `.ica` files which makes the usage *way* easier.

* It's possible to add custom certificates using the Citrix wrapper. A
  new store path with the original derivation and the certificates will be
  created and therefore no rebuild of the package is needed when adding
  new certs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

