### PR TITLE
New dask-jobqueue 0.3.0, docrep 0.2.3. Updated distributed 1.15.1 -> 1.22.1

### DIFF
--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -30,6 +30,5 @@ buildPythonPackage rec {
     description = "Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm, or SGE.*";
     homepage = https://github.com/dask/dask-jobqueue;
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ costrouc ];
   };
 }

--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, dask
+, distributed
+, docrep
+}:
+
+buildPythonPackage rec {
+  pname = "dask-jobqueue";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fc1bca08781dea9007bd7407f72921b94c524e2489f21c23f56a2d685e72911";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ dask distributed docrep ];
+
+  checkPhase = ''
+    py.test dask_jobqueue
+  '';
+
+  # tests required slurm, sge, schedulers to be available
+  doCheck = false;
+
+  meta = {
+    description = "Easy deployment of Dask Distributed on job queuing systems such as PBS, Slurm, or SGE.*";
+    homepage = https://github.com/dask/dask-jobqueue;
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/docrep/default.nix
+++ b/pkgs/development/python-modules/docrep/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "docrep";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7d195b6dfcf4efe5cb65402b6c6f6d7e6db77ce255887fae32c9a8288a022659";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  # tests not packaged with PyPi download
+  doCheck = false;
+
+  meta = {
+    description = "Python package for docstring repetition";
+    homepage = https://github.com/Chilipp/docrep;
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/docrep/default.nix
+++ b/pkgs/development/python-modules/docrep/default.nix
@@ -28,6 +28,5 @@ buildPythonPackage rec {
     description = "Python package for docstring repetition";
     homepage = https://github.com/Chilipp/docrep;
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ costrouc ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -272,6 +272,8 @@ in {
 
   distorm3 = callPackage ../development/python-modules/distorm3 { };
 
+  docrep = callPackage ../development/python-modules/docrep { };
+
   dogtail = callPackage ../development/python-modules/dogtail { };
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
@@ -1970,6 +1972,8 @@ in {
 
   dask = callPackage ../development/python-modules/dask { };
 
+  dask-jobqueue = callPackage ../development/python-modules/dask-jobqueue { };
+
   datrie = callPackage ../development/python-modules/datrie { };
 
   heapdict = callPackage ../development/python-modules/heapdict { };
@@ -1979,17 +1983,17 @@ in {
   distributed = buildPythonPackage rec {
 
     name = "distributed-${version}";
-    version = "1.15.1";
+    version = "1.22.1";
 
     src = pkgs.fetchurl {
       url = "mirror://pypi/d/distributed/${name}.tar.gz";
-      sha256 = "037a07sdf2ch1d360nqwqz3b4ld8msydng7mw4i5s902v7xr05l6";
+      sha256 = "eefdd511912a001077bf1e00e2c3989dcfa853d68d14a8cd5b688c6175389e3a";
     };
 
     buildInputs = with self; [ pytest docutils ];
     propagatedBuildInputs = with self; [
-      dask six boto3 s3fs tblib locket msgpack-python click cloudpickle tornado
-      psutil botocore zict lz4 sortedcollections sortedcontainers
+      dask six boto3 s3fs tblib locket msgpack click cloudpickle tornado
+      psutil botocore zict lz4 sortedcollections sortedcontainers pyyaml
     ] ++ (if !isPy3k then [ singledispatch ] else []);
 
     # py.test not picking up local config file, even when running


### PR DESCRIPTION
###### motivation

Adding python package `dask-jobqueue`. `dask-jobqueue` has required
dependencies of new package `docrep` and updated version of
`distributed`.

The newest release of `distributed` has a change in
dependencies. `msgpack-python` (depreciated) -> `msgpack` and `pyyaml`
is a new dependency.

###### Things done

Added python package `dask-distributed` 0.3.0 and `docrep` 0.2.3.
Update python package `distributed` 1.15.1 -> 1.22.1

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

