### PR TITLE
pythonPackages.jupyterlab 0.32.1 -> 0.33.7

### DIFF
--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -1,12 +1,12 @@
 { lib, buildPythonPackage, isPy3k, fetchPypi, ipython_genutils, jupyterlab_launcher, notebook }:
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "0.32.1";
+  version = "0.33.7";
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "88290656a2db2e38ef913a257ec283f3b5bd99144ed3d52899c9af7030077554";
+    sha256 = "ab9f7bcbc3b4e107897f368aa0527cdc1b4ccf0c370e218ae03ac1d75fac261c";
   };
 
   propagatedBuildInputs = [
@@ -26,6 +26,6 @@ buildPythonPackage rec {
     description = "Jupyter lab environment notebook server extension.";
     license = with licenses; [ bsd3 ];
     homepage = "http://jupyter.org/";
-    maintainers = with maintainers; [ zimbatm ];
+    maintainers = with maintainers; [ zimbatm costrouc ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

previous jupyterlab 0.32.1 did not build due to requiring
jupyterlab_launcher version between (0.10.0 <-> 0.11.0) now
requires (0.11.2 <-> 0.12.0).

###### Things done

Updated: jupyterlab 0.32.1 -> 0.33.7

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

