### PR TITLE
beam-packages: default erlangR19 -> erlangR20

### DIFF
--- a/pkgs/development/tools/erlang/cuter/default.nix
+++ b/pkgs/development/tools/erlang/cuter/default.nix
@@ -1,5 +1,5 @@
 { stdenv, autoreconfHook, which, writeText, makeWrapper, fetchFromGitHub, erlang
-, beamPackages, z3, python27 }:
+, beamPackages, z3, python }:
 
 stdenv.mkDerivation rec {
   name = "cuter-${version}";
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
     addToSearchPath ERL_LIBS "$1/lib/erlang/lib/"
   '';
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = with beamPackages; [ python27.pkgs.setuptools erlang z3.python python27 makeWrapper which ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper which ];
+  buildInputs = [ python python.pkgs.setuptools z3.python erlang ];
 
   buildFlags = "PWD=$(out)/lib/erlang/lib/cuter-${version} cuter_target";
   configurePhase = ''
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
     cp -r * "$out/lib/erlang/lib/cuter-${version}"
     cp cuter "$out/bin/cuter"
     wrapProgram $out/bin/cuter \
-      --prefix PATH : "${python27}/bin" \
-      --suffix PYTHONPATH : "${z3}/lib/python2.7/site-packages" \
+      --prefix PATH : "${python}/bin" \
+      --suffix PYTHONPATH : "${z3}/${python.sitePackages}" \
       --suffix ERL_LIBS : "$out/lib/erlang/lib"
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7309,9 +7309,10 @@ with pkgs;
   inherit (beam.packages.erlang)
     rebar rebar3-open rebar3
     hexRegistrySnapshot fetchHex beamPackages
-    hex2nix cuter;
+    hex2nix;
 
   inherit (beam.packages.erlangR18) relxExe;
+  inherit (beam.packages.erlangR19) cuter;
 
   groovy = callPackage ../development/interpreters/groovy { };
 

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -6,12 +6,12 @@ rec {
   # Each
   interpreters = rec {
 
-    # R19 is the default version.
-    erlang = erlangR19; # The main switch to change default Erlang version.
-    erlang_odbc = erlangR19_odbc;
-    erlang_javac = erlangR19_javac;
-    erlang_odbc_javac = erlangR19_odbc_javac;
-    erlang_nox = erlangR19_nox;
+    # R20 is the default version.
+    erlang = erlangR20; # The main switch to change default Erlang version.
+    erlang_odbc = erlangR20_odbc;
+    erlang_javac = erlangR20_javac;
+    erlang_odbc_javac = erlangR20_odbc_javac;
+    erlang_nox = erlangR20_nox;
 
     # These are standard Erlang versions, using the generic builder.
     erlangR18 = lib.callErlang ../development/interpreters/erlang/R18.nix {


### PR DESCRIPTION
###### Motivation for this change

This is probably a bit overdue by now.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

