### PR TITLE
qstopmotion: 2.3.2 -> 2.4.0

### DIFF
--- a/pkgs/applications/video/qstopmotion/default.nix
+++ b/pkgs/applications/video/qstopmotion/default.nix
@@ -1,20 +1,29 @@
-{ stdenv, fetchurl, qt5, ffmpeg, guvcview
-, cmake, ninja, libxml2, gettext, pkgconfig, libgphoto2, gphoto2, v4l_utils
-, libv4l, pcre }:
+{ stdenv, lib, fetchurl, qt5, ffmpeg, guvcview, cmake, ninja, libxml2
+, gettext, pkgconfig, libgphoto2, gphoto2, v4l_utils, libv4l, pcre
+, qwt, extra-cmake-modules }:
 
 stdenv.mkDerivation rec {
   pname = "qstopmotion";
-  version = "2.3.2";
+  version = "2.4.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/${pname}/Version_2_3_2/${name}-Source.tar.gz";
-    sha256 = "1vbiznwyc05jqg0dpmgxmvf7kdzmlck0i8v2c5d69kgrdnaypcrf";
+    url = "mirror://sourceforge/project/${pname}/Version_2_4_0/${name}-Source.tar.gz";
+    sha256 = "0pbyq6nrr9g3crlsng660768167s0fybvcpzbfc0w9kkhs2jwrr2";
   };
 
-  buildInputs = [ qt5.qtbase ffmpeg guvcview v4l_utils libv4l pcre ];
+  buildInputs = with qt5; [ v4l_utils libv4l pcre qtbase qtmultimedia ffmpeg guvcview
+                            qwt qtquickcontrols qtimageformats qtxmlpatterns ];
 
-  nativeBuildInputs = [ pkgconfig cmake ninja gettext libgphoto2 gphoto2 libxml2 libv4l ];
+  nativeBuildInputs = [ pkgconfig cmake extra-cmake-modules ninja
+                        gettext libgphoto2 gphoto2 libxml2 libv4l ];
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml" \
+                "find_package(Qt5 REQUIRED COMPONENTS Core Widgets Xml Multimedia"
+    grep -rl 'qwt' . | xargs sed -i 's@<qwt/qwt_slider.h>@<qwt_slider.h>@g'
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://www.qstopmotion.org;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18019,7 +18019,7 @@ with pkgs;
 
   qsyncthingtray = libsForQt5.callPackage ../applications/misc/qsyncthingtray { };
 
-  qstopmotion = callPackage ../applications/video/qstopmotion { };
+  qstopmotion = libsForQt5.callPackage ../applications/video/qstopmotion { };
 
   qsynth = libsForQt5.callPackage ../applications/audio/qsynth { };
 


### PR DESCRIPTION
###### Motivation for this change

Version bump.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

