### PR TITLE
update: latte-dock 0.7.5 -> 0.8.0

### DIFF
--- a/pkgs/applications/misc/latte-dock/default.nix
+++ b/pkgs/applications/misc/latte-dock/default.nix
@@ -1,28 +1,31 @@
-{ mkDerivation, lib, cmake, xorg, plasma-framework, fetchFromGitHub
-, extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash }:
+{ mkDerivation, lib, cmake, xorg, plasma-framework, fetchurl
+, extra-cmake-modules, karchive, kwindowsystem, qtx11extras, kcrash, knewstuff }:
 
-let version = "0.7.5"; in
+mkDerivation rec {
+  pname = "latte-dock";
+  version = "0.8.0";
+  name = "${pname}-${version}";
 
-mkDerivation {
-  name = "latte-dock-${version}";
-
-  src = fetchFromGitHub {
-    owner = "psifidotos";
-    repo = "Latte-Dock";
-    rev = "v${version}";
-    sha256 = "0fblbx6qk4miag1mhiyns7idsw03p9pj3xc3xxxnb5rpj1fy0ifv";
+  src = fetchurl {
+    url = "https://download.kde.org/stable/${pname}/${name}.tar.xz";
+    sha256 = "1zg9r162r66vcvj5rzgy61mda89sk5yfy96g5p1aahbim0rgbdbs";
+    name = "${name}.tar.xz";
   };
 
   buildInputs = [ plasma-framework xorg.libpthreadstubs xorg.libXdmcp xorg.libSM ];
 
   nativeBuildInputs = [ extra-cmake-modules cmake karchive kwindowsystem
-    qtx11extras kcrash ];
+    qtx11extras kcrash knewstuff ];
+
+
 
   meta = with lib; {
     description = "Dock-style app launcher based on Plasma frameworks";
     homepage = https://github.com/psifidotos/Latte-Dock;
     license = licenses.gpl2;
     platforms = platforms.unix;
-    maintainers = [ maintainers.benley ];
+    maintainers = [ maintainers.benley maintainers.ysndr ];
   };
+
+
 }


### PR DESCRIPTION
###### Motivation for this change
Bringing the new version of latte-dock to nixos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

