### PR TITLE
Feature/brother ql

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3134,6 +3134,11 @@
     github = "pneumaticat";
     name = "Kevin Liu";
   };
+  poelzi = {
+    email = "nixos@poelzi.org";
+    github = "poelzi";
+    name = "Daniel Poelzleithner";
+  };
   polyrod = {
     email = "dc1mdp@gmail.com";
     github = "polyrod";

--- a/pkgs/development/python-modules/brother_ql/default.nix
+++ b/pkgs/development/python-modules/brother_ql/default.nix
@@ -14,9 +14,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ future packbits pillow pyusb ];
 
   meta = with stdenv.lib; {
-    description = ''Python package for the raster language protocol of the Brother QL series\
-                   label printers (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800,\
-                   QL-820NWB, QL-1050 and more)'';
+    description = "Python package for the raster language protocol of the Brother QL series label printers";
+    long_description = ''Python package for the raster language protocol of the Brother QL series label printers
+     (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800, QL-820NWB, QL-1050 and more)'';
     homepage = https://github.com/pklaus/brother_ql;
     license = licenses.gpl3;
     maintainers = with maintainers; [ poelzi ];

--- a/pkgs/development/python-modules/brother_ql/default.nix
+++ b/pkgs/development/python-modules/brother_ql/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, future, packbits, pillow, pyusb
+, pytest, mock }:
+
+buildPythonPackage rec {
+  pname = "brother_ql";
+  version = "0.8.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d77fdfdf0ab61ca45b9599fc3270fe98faa16d992e4ce098c66ac7f722787b87";
+  };
+
+  propagatedBuildInputs = [ future packbits pillow pyusb ];
+
+  meta = with stdenv.lib; {
+    description = "Python package for the raster language protocol of the Brother QL series label printers (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800, QL-820NWB, QL-1050 and more)";
+    homepage = https://github.com/pklaus/brother_ql;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/brother_ql/default.nix
+++ b/pkgs/development/python-modules/brother_ql/default.nix
@@ -14,9 +14,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ future packbits pillow pyusb ];
 
   meta = with stdenv.lib; {
-    description = "Python package for the raster language protocol of the Brother QL series label printers (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800, QL-820NWB, QL-1050 and more)";
+    description = ''Python package for the raster language protocol of the Brother QL series\
+                   label printers (QL-500, QL-550, QL-570, QL-700, QL-710W, QL-720NW, QL-800,\
+                   QL-820NWB, QL-1050 and more)'';
     homepage = https://github.com/pklaus/brother_ql;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ poelzi ];
   };
 }

--- a/pkgs/development/python-modules/packbits/default.nix
+++ b/pkgs/development/python-modules/packbits/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, pyparsing, six, pytest, pretend }:
+
+buildPythonPackage rec {
+  pname = "packbits";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bc6b370bb34e04ac8cfa835e06c0484380affc6d593adb8009dd6c0f7bfff034";
+  };
+
+  meta = with stdenv.lib; {
+    description = "PackBits encoder/decoder for Python";
+    homepage = https://github.com/psd-tools/packbits;
+    license = [ licenses.bsd2 ];
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/packbits/default.nix
+++ b/pkgs/development/python-modules/packbits/default.nix
@@ -14,6 +14,6 @@ buildPythonPackage rec {
     description = "PackBits encoder/decoder for Python";
     homepage = https://github.com/psd-tools/packbits;
     license = [ licenses.bsd2 ];
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ poelzi ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -340,6 +340,8 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
+  packbits = callPackage ../development/python-modules/packbits { };
+
   pdf2image = callPackage ../development/python-modules/pdf2image { };
 
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -232,6 +232,8 @@ in {
 
   breathe = callPackage ../development/python-modules/breathe { };
 
+  brother_ql = callPackage ../development/python-modules/brother_ql { };
+
   browsermob-proxy = disabledIf isPy3k (callPackage ../development/python-modules/browsermob-proxy {});
 
   bugseverywhere = callPackage ../applications/version-management/bugseverywhere {};


### PR DESCRIPTION
###### Motivation for this change

Allows to print label with the Brother QL printer line. Tested and works with a QL-800 printer on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

