### PR TITLE
gobby5: fix build

### DIFF
--- a/nixos/modules/services/editors/infinoted.nix
+++ b/nixos/modules/services/editors/infinoted.nix
@@ -10,8 +10,8 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = pkgs.libinfinity.override { daemon = true; };
-      defaultText = "pkgs.libinfinity.override { daemon = true; }";
+      default = pkgs.libinfinity;
+      defaultText = "pkgs.libinfinity";
       description = ''
         Package providing infinoted
       '';
@@ -119,7 +119,7 @@ in {
     users.groups = optional (cfg.group == "infinoted")
       { name = "infinoted";
       };
-  
+
     systemd.services.infinoted =
       { description = "Gobby Dedicated Server";
 
@@ -129,7 +129,7 @@ in {
         serviceConfig = {
           Type = "simple";
           Restart = "always";
-          ExecStart = "${cfg.package}/bin/infinoted-${versions.majorMinor cfg.package.version} --config-file=/var/lib/infinoted/infinoted.conf";
+          ExecStart = "${cfg.package.infinoted} --config-file=/var/lib/infinoted/infinoted.conf";
           User = cfg.user;
           Group = cfg.group;
           PermissionsStartOnly = true;

--- a/pkgs/applications/editors/gobby/default.nix
+++ b/pkgs/applications/editors/gobby/default.nix
@@ -1,26 +1,22 @@
 { avahiSupport ? false # build support for Avahi in libinfinity
-, gnomeSupport ? false # build support for Gnome(gnome-vfs)
-, stdenv, fetchurl, pkgconfig
-, gtkmm2, gsasl, gtksourceview, libxmlxx, libinfinity, intltool
-, gnome_vfs ? null}:
+, stdenv, fetchurl, fetchFromGitHub, autoconf, automake, pkgconfig, wrapGAppsHook
+, gtkmm3, gsasl, gtksourceview3, libxmlxx, libinfinity, intltool, itstool, gnome3 }:
 
 let
   libinf = libinfinity.override { gtkWidgets = true; inherit avahiSupport; };
-  
 in stdenv.mkDerivation rec {
-
-  name = "gobby-0.5.0";
-  src = fetchurl {
-    url = "http://releases.0x539.de/gobby/${name}.tar.gz";
-    sha256 = "165x0r668ma5blziisvbr8qig3jw9hf7i6w8r7wwvz3wsac3bswc";
+  name = "gobby-unstable-2018-04-03";
+  src = fetchFromGitHub {
+    owner = "gobby";
+    repo = "gobby";
+    rev = "ea4df27c9b6b885434797b0071ce198b23f9f63b";
+    sha256 = "0q7lq64yn16lxvj4jphs8y9194h0xppj8k7y9x8b276krraak2az";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtkmm2 gsasl gtksourceview libxmlxx libinf intltool ]
-    ++ stdenv.lib.optional gnomeSupport gnome_vfs;
-  
-  configureFlags = ''
-  '';
+  nativeBuildInputs = [ autoconf automake pkgconfig intltool itstool gnome3.yelp-tools wrapGAppsHook ];
+  buildInputs = [ gtkmm3 gsasl gtksourceview3 libxmlxx libinf ];
+
+  preConfigure = "./autogen.sh";
 
   meta = with stdenv.lib; {
     homepage = http://gobby.0x539.de/;

--- a/pkgs/development/libraries/libinfinity/default.nix
+++ b/pkgs/development/libraries/libinfinity/default.nix
@@ -1,52 +1,53 @@
 { gtkWidgets ? false # build GTK widgets for libinfinity
-, daemon ? false # build infinote daemon
-, documentation ? false # build documentation
 , avahiSupport ? false # build support for Avahi in libinfinity
 , stdenv, fetchurl, pkgconfig, glib, libxml2, gnutls, gsasl
-, gtk2 ? null, gtkdoc ? null, avahi ? null, libdaemon ? null, libidn, gss
+, gobjectIntrospection
+, gtk3 ? null, gtk-doc, docbook_xsl, docbook_xml_dtd_412, avahi ? null, libdaemon, libidn, gss
 , libintl }:
 
+assert avahiSupport -> avahi != null;
+assert gtkWidgets -> gtk3 != null;
+
 let
-  edf = flag: feature: (if flag then "--with-" else "--without-") + feature;
-  optional = cond: elem: assert cond -> elem != null; if cond then [elem] else [];
+  mkFlag = flag: feature: (if flag then "--with-" else "--without-") + feature;
 
-in stdenv.mkDerivation rec {
+  self = stdenv.mkDerivation rec {
+    name = "libinfinity-${version}";
+    version = "0.7.1";
+    src = fetchurl {
+      url = "http://releases.0x539.de/libinfinity/${name}.tar.gz";
+      sha256 = "1jw2fhrcbpyz99bij07iyhy9ffyqdn87vl8cb1qz897y3f2f0vk2";
+    };
 
-  name = "libinfinity-${version}";
-  version = "0.7.1";
-  src = fetchurl {
-    url = "http://releases.0x539.de/libinfinity/${name}.tar.gz";
-    sha256 = "1jw2fhrcbpyz99bij07iyhy9ffyqdn87vl8cb1qz897y3f2f0vk2";
+    outputs = [ "bin" "out" "dev" "man" "devdoc" ];
+
+    nativeBuildInputs = [ pkgconfig gtk-doc docbook_xsl docbook_xml_dtd_412 gobjectIntrospection ];
+    buildInputs = [ glib libxml2 gsasl libidn gss libintl libdaemon ]
+      ++ stdenv.lib.optional gtkWidgets gtk3
+      ++ stdenv.lib.optional avahiSupport avahi;
+
+    propagatedBuildInputs = [ gnutls ];
+
+    configureFlags = [
+      "--enable-gtk-doc"
+      "--enable-introspection"
+      (mkFlag gtkWidgets "inftextgtk")
+      (mkFlag gtkWidgets "infgtk")
+      "--with-infinoted"
+      "--with-libdaemon"
+      (mkFlag avahiSupport "avahi")
+    ];
+
+    passthru = {
+      infinoted = "${self.bin}/bin/infinoted-${stdenv.lib.versions.majorMinor version}";
+    };
+
+    meta = {
+      homepage = http://gobby.0x539.de/;
+      description = "An implementation of the Infinote protocol written in GObject-based C";
+      license = stdenv.lib.licenses.lgpl2Plus;
+      maintainers = [ stdenv.lib.maintainers.phreedom ];
+      platforms = with stdenv.lib.platforms; linux ++ darwin;
+    };
   };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libxml2 gsasl libidn gss libintl ]
-    ++ optional gtkWidgets gtk2
-    ++ optional documentation gtkdoc
-    ++ optional avahiSupport avahi
-    ++ optional daemon libdaemon;
-
-  propagatedBuildInputs = [ gnutls ];
-
-  configureFlags = ''
-    ${if documentation then "--enable-gtk-doc" else "--disable-gtk-doc"}
-    ${edf gtkWidgets "inftextgtk"}
-    ${edf gtkWidgets "infgtk"}
-    ${edf daemon "infinoted"}
-    ${edf daemon "libdaemon"}
-    ${edf avahiSupport "avahi"}
-  '';
-
-  passthru = {
-    inherit version;
-  };
-
-  meta = {
-    homepage = http://gobby.0x539.de/;
-    description = "An implementation of the Infinote protocol written in GObject-based C";
-    license = stdenv.lib.licenses.lgpl2Plus;
-    maintainers = [ stdenv.lib.maintainers.phreedom ];
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
-  };
-
-}
+in self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10471,9 +10471,7 @@ with pkgs;
 
   libiec61883 = callPackage ../development/libraries/libiec61883 { };
 
-  libinfinity = callPackage ../development/libraries/libinfinity {
-    inherit (gnome2) gtkdoc;
-  };
+  libinfinity = callPackage ../development/libraries/libinfinity { };
 
   libinput = callPackage ../development/libraries/libinput {
     graphviz = graphviz-nox;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16499,9 +16499,7 @@ with pkgs;
 
   gocr = callPackage ../applications/graphics/gocr { };
 
-  gobby5 = callPackage ../applications/editors/gobby {
-    inherit (gnome2) gtksourceview;
-  };
+  gobby5 = callPackage ../applications/editors/gobby { };
 
   gphoto2 = callPackage ../applications/misc/gphoto2 { };
 


### PR DESCRIPTION
###### Motivation for this change
Had to update it to unstable in order to be able to build with the current `libinfinity`.

I also had to switch `libinfinity` to `gtk3`, since `gtk2` support was removed. While at it, I modernized the package a bit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Phreedom (maintainer)