### PR TITLE
skypeforlinux: Add GSettings schemas

### DIFF
--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -68,6 +68,8 @@ in stdenv.mkDerivation {
 
   inherit src;
 
+  nativeBuildInputs = [ gtk3 ];
+
   buildInputs = [ dpkg makeWrapper ];
 
   unpackPhase = "true";
@@ -89,6 +91,10 @@ in stdenv.mkDerivation {
     done
 
     ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin/skypeforlinux"
+
+    wrapProgram $out/bin/skypeforlinux \
+      --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/skypeforlinux.desktop \

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -68,9 +68,10 @@ in stdenv.mkDerivation {
 
   inherit src;
 
-  nativeBuildInputs = [ wrapGAppsHook ];
+  # For setup hook populating GSETTINGS_SCHEMA_PATH
+  nativeBuildInputs = [ wrapGAppsHook glib ];
 
-  buildInputs = [ dpkg gtk3 ];
+  buildInputs = [ dpkg ];
 
   unpackPhase = "true";
   installPhase = ''

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -68,9 +68,9 @@ in stdenv.mkDerivation {
 
   inherit src;
 
-  nativeBuildInputs = [ gtk3 wrapGAppsHook ];
+  nativeBuildInputs = [ wrapGAppsHook ];
 
-  buildInputs = [ dpkg makeWrapper ];
+  buildInputs = [ dpkg gtk3 makeWrapper ];
 
   unpackPhase = "true";
   installPhase = ''

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, dpkg, makeWrapper
+{ stdenv, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, glibc, gnome3
 , gtk3, libnotify, libpulseaudio, libsecret, libv4l, nspr, nss, pango, systemd, wrapGAppsHook, xorg }:
 
@@ -70,7 +70,7 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [ wrapGAppsHook ];
 
-  buildInputs = [ dpkg gtk3 makeWrapper ];
+  buildInputs = [ dpkg gtk3 ];
 
   unpackPhase = "true";
   installPhase = ''

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, dpkg, makeWrapper
 , alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk_pixbuf, glib, glibc, gnome3
-, gtk3, libnotify, libpulseaudio, libsecret, libv4l, nspr, nss, pango, systemd, xorg }:
+, gtk3, libnotify, libpulseaudio, libsecret, libv4l, nspr, nss, pango, systemd, wrapGAppsHook, xorg }:
 
 let
 
@@ -68,7 +68,7 @@ in stdenv.mkDerivation {
 
   inherit src;
 
-  nativeBuildInputs = [ gtk3 ];
+  nativeBuildInputs = [ gtk3 wrapGAppsHook ];
 
   buildInputs = [ dpkg makeWrapper ];
 
@@ -80,6 +80,8 @@ in stdenv.mkDerivation {
     rm -rf $out/opt $out/usr
     rm $out/bin/skypeforlinux
 
+    ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin/skypeforlinux"
+
     # Otherwise it looks "suspicious"
     chmod -R g-w $out
   '';
@@ -89,12 +91,6 @@ in stdenv.mkDerivation {
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
       patchelf --set-rpath ${rpath}:$out/share/skypeforlinux $file || true
     done
-
-    ln -s "$out/share/skypeforlinux/skypeforlinux" "$out/bin/skypeforlinux"
-
-    wrapProgram $out/bin/skypeforlinux \
-      --suffix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
 
     # Fix the desktop link
     substituteInPlace $out/share/applications/skypeforlinux.desktop \


### PR DESCRIPTION
###### Motivation for this change

Attempting to upload an attachment in Skype causes it to crash, with the error:

`No GSettings schemas are installed on the system`

These changes should resolve that issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

