### PR TITLE
pythonPackages.sortedcontainers: 1.5.7 -> 2.0.4

### DIFF
--- a/pkgs/development/python-modules/sortedcontainers/default.nix
+++ b/pkgs/development/python-modules/sortedcontainers/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "sortedcontainers";
+  version = "2.0.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "607294c6e291a270948420f7ffa1fb3ed47384a4c08db6d1e9c92d08a6981982";
+  };
+
+  # pypi tarball does not come with tests
+  doCheck = false;
+
+  meta = {
+    description = "Python Sorted Container Types: SortedList, SortedDict, and SortedSet";
+    homepage = http://www.grantjenks.com/docs/sortedcontainers/;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -501,6 +501,8 @@ in {
 
   sip = callPackage ../development/python-modules/sip { };
 
+  sortedcontainers = callPackage ../development/python-modules/sortedcontainers { };
+
   sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
 
   slackclient = callPackage ../development/python-modules/slackclient { };
@@ -7593,26 +7595,6 @@ in {
   mistune = callPackage ../development/python-modules/mistune { };
 
   brotlipy = callPackage ../development/python-modules/brotlipy { };
-
-  sortedcontainers = buildPythonPackage rec {
-    name = "sortedcontainers-${version}";
-    version = "1.5.7";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/sortedcontainers/${name}.tar.gz";
-      sha256 = "1sjh8lccbmvwna91mlhl5m3z4320p07h063b8x8br4p4cll49w0g";
-    };
-
-    # tries to run tests for all python versions and uses virtualenv weirdly
-    doCheck = false;
-    #buildInputs = with self; [ tox nose ];
-
-    meta = {
-      description = "Python Sorted Container Types: SortedList, SortedDict, and SortedSet";
-      homepage = "http://www.grantjenks.com/docs/sortedcontainers/";
-      license = licenses.asl20;
-    };
-  };
 
   sortedcollections = buildPythonPackage rec {
     name = "sortedcollections-${version}";


### PR DESCRIPTION
###### Motivation for this change

Moving sortedcontianers from top-level -> python-modules and updating
to newest sortedcontianers release.

###### Things done

pythonPackages.sortedcontainers: 1.5.7 -> 2.0.4

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

