### PR TITLE
pythonPackages.singledispatch: move expression

### DIFF
--- a/pkgs/development/python-modules/singledispatch/default.nix
+++ b/pkgs/development/python-modules/singledispatch/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "singledispatch";
+  version = "3.4.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  # pypi singledispatch tarbal does not contain tests
+  doCheck = false;
+
+  meta = {
+    description = "This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3.";
+    homepage = https://docs.python.org/3/library/functools.html;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -499,6 +499,8 @@ in {
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 
+  singledispatch = callPackage ../development/python-modules/singledispatch { };
+
   sip = callPackage ../development/python-modules/sip { };
 
   sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
@@ -2577,21 +2579,6 @@ in {
       homepage = https://code.google.com/p/funcparserlib/;
       license = licenses.mit;
       platforms = platforms.unix;
-    };
-  };
-
-  singledispatch = buildPythonPackage rec {
-    name = "singledispatch-3.4.0.3";
-
-    propagatedBuildInputs = with self; [ six ];
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/singledispatch/${name}.tar.gz";
-      sha256 = "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c";
-    };
-
-    meta = {
-      homepage = https://docs.python.org/3/library/functools.html;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

no change in version just moving singledispatch to python-modules

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

