### PR TITLE
wal-g: 0.1.8pre240_966f3c5f4 -> 0.1.10

### DIFF
--- a/pkgs/tools/backup/wal-g/default.nix
+++ b/pkgs/tools/backup/wal-g/default.nix
@@ -1,18 +1,14 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
-let
-  rev      = "966f3c5f45ba18b2225c5b06918e41f56e223e73";
-  revCount = "240";
-  sha256   = "1m70a5rpycrfwrrc83745mamgpg54pc0n75qpzr9jbvicbp8g66p";
-in
 buildGoPackage rec {
   name = "wal-g-${version}";
-  version = "0.1.8pre${revCount}_${builtins.substring 0 9 rev}";
+  version = "0.1.10";
 
   src = fetchFromGitHub {
-    owner = "wal-g";
-    repo  = "wal-g";
-    inherit rev sha256;
+    owner  = "wal-g";
+    repo   = "wal-g";
+    rev    = "v${version}";
+    sha256 = "0klqnrrjzzxcj3clg7vapmbga1vqsfh8mkci5r2ir1bjp0z1xfnp";
   };
 
   goPackagePath = "github.com/wal-g/wal-g";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

