### PR TITLE
pythonPackages.docrep: init at 0.2.3

### DIFF
--- a/pkgs/development/python-modules/docrep/default.nix
+++ b/pkgs/development/python-modules/docrep/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "docrep";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7d195b6dfcf4efe5cb65402b6c6f6d7e6db77ce255887fae32c9a8288a022659";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    py.test
+  '';
+
+  # tests not packaged with PyPi download
+  doCheck = false;
+
+  meta = {
+    description = "Python package for docstring repetition";
+    homepage = https://github.com/Chilipp/docrep;
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -250,6 +250,8 @@ in {
 
   diff_cover = callPackage ../development/python-modules/diff_cover { };
 
+  docrep = callPackage ../development/python-modules/docrep { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   email_validator = callPackage ../development/python-modules/email-validator { };


### PR DESCRIPTION
###### Motivation for this change

docrep is dependency for package that I would like to build `dask-jobqueue`.

###### Things done

pythonPackages.docrep: init at 0.2.3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

