### PR TITLE
nodePackages.tiddlywiki: init at 5.1.17

### DIFF
--- a/pkgs/development/node-packages/node-packages-v6.json
+++ b/pkgs/development/node-packages/node-packages-v6.json
@@ -104,6 +104,7 @@
 , "stylus"
 , "svgo"
 , "tern"
+, "tiddlywiki"
 , "titanium"
 , "typescript"
 , "typings"

--- a/pkgs/development/node-packages/node-packages-v6.nix
+++ b/pkgs/development/node-packages/node-packages-v6.nix
@@ -46763,6 +46763,23 @@ in
     production = true;
     bypassCache = false;
   };
+  tiddlywiki = nodeEnv.buildNodePackage {
+    name = "tiddlywiki";
+    packageName = "tiddlywiki";
+    version = "5.1.17";
+    src = fetchurl {
+      url = "https://registry.npmjs.org/tiddlywiki/-/tiddlywiki-5.1.17.tgz";
+      sha1 = "bd3311146ba67fb4beee9933dd2e6d55e92665ed";
+    };
+    buildInputs = globalBuildInputs;
+    meta = {
+      description = "a non-linear personal web notebook";
+      homepage = "https://github.com/Jermolene/TiddlyWiki5#readme";
+      license = "BSD";
+    };
+    production = true;
+    bypassCache = false;
+  };
   titanium = nodeEnv.buildNodePackage {
     name = "titanium";
     packageName = "titanium";


### PR DESCRIPTION
###### Motivation for this change

Not present in Nixpkgs. Well known, mature application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

