### PR TITLE
keybase-gui: 2.3.0 -> 2.5.0

### DIFF
--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -38,10 +38,10 @@ let
 in
 stdenv.mkDerivation rec {
   name = "keybase-gui-${version}";
-  version = "2.3.0-20180627160031.8e0438e6fb";
+  version = "2.5.0-20180807164805.0fda758997";
   src = fetchurl {
     url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}_amd64.deb";
-    sha256 = "0xaxxjdfdmgv0wfy75dspfa0a7cdwdpphyy6my9vw82v8jxl3ffx";
+    sha256 = "135sm3h5i2h9j06py827psjbhhiqy1mb133s92p7jp6q1mhr8j1x";
   };
   phases = ["unpackPhase" "installPhase" "fixupPhase"];
   unpackPhase = ''
@@ -92,5 +92,6 @@ stdenv.mkDerivation rec {
     description = "The Keybase official GUI.";
     platforms = platforms.linux;
     maintainers = with maintainers; [ puffnfresh np ];
+    license = licenses.bsd3;
   };
 }


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---