### PR TITLE
nixos/shells: Avoid overriding the environment for other child shells

### DIFF
--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -162,8 +162,13 @@ in
         /bin/sh
       '';
 
-    system.build.setEnvironment = pkgs.writeText "set-environment"
+    environment.etc."set-environment".text =
        ''
+         # DO NOT EDIT -- this file has been generated automatically.
+
+         # Prevent this file from being sourced by child shells.
+         export __NIXOS_SET_ENVIRONMENT_DONE=1
+
          ${exportedEnvVars}
 
          ${cfg.extraInit}

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -126,7 +126,9 @@ in
     programs.bash = {
 
       shellInit = ''
-        ${config.system.build.setEnvironment.text}
+        if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]; then
+          . /etc/set-environment
+        fi
 
         ${cfge.shellInit}
       '';

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -109,7 +109,9 @@ in
       set fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions $__fish_datadir/functions
       
       # source the NixOS environment config
-      fenv source ${config.system.build.setEnvironment}
+      if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]
+        fenv source /etc/set-environment
+      end
 
       # clear fish_function_path so that it will be correctly set when we return to $__fish_datadir/config.fish
       set -e fish_function_path

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -103,7 +103,9 @@ in
         if [ -n "$__ETC_ZSHENV_SOURCED" ]; then return; fi
         export __ETC_ZSHENV_SOURCED=1
 
-        ${config.system.build.setEnvironment.text}
+        if [ -z "$__NIXOS_SET_ENVIRONMENT_DONE" ]; then
+          . /etc/set-environment
+        fi
 
         ${cfge.shellInit}
 

--- a/nixos/modules/services/editors/emacs.nix
+++ b/nixos/modules/services/editors/emacs.nix
@@ -87,7 +87,7 @@ in {
 
       serviceConfig = {
         Type      = "forking";
-        ExecStart = "${pkgs.bash}/bin/bash -c 'source ${config.system.build.setEnvironment}; exec ${cfg.package}/bin/emacs --daemon'";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'source /etc/set-environment; exec ${cfg.package}/bin/emacs --daemon'";
         ExecStop  = "${cfg.package}/bin/emacsclient --eval (kill-emacs)";
         Restart   = "always";
       };


### PR DESCRIPTION
###### Motivation for this change

fixes #33219 

All new [ZSH](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/zsh/zsh.nix#L106) and [Bash](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/bash/bash.nix#L188) shells source [`system.build.setEnvironment`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/shells-environment.nix#L165) if it's not already done by a parent shell of the same type.

For instance, if ZSH is the default shell, launching a Bash shell will reset any modifications to `PATH`. 

One unfortunate effect of this behavior is `nix run` launching a bash shell with an incorrect `PATH` when run from ZSH in eg. the console or SSH (for some reason `nix-shell` isn't affected by this).

The broken `nix run` behavior is a blocker for #44497, as the environment is set up using a login shell of the users choice, ie. `/etc/profile` isn't sourced if using ZSH. In graphical sessions this was normally protected against by always [sourcing `/etc/profile`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/x11/display-managers/default.nix#L37)

cc @oxij as you've written a large part of the shell environment setup

###### Things done

This adds a shared exported guard, `__NIXOS_SET_ENVIRONMENT_DONE`, that prevents
interactive non-login child shells of any type sourcing `system.build.setEnvironment` if
it's already done.

Login shells on the other will always reset the basic environment.

I tried using `shopt -q login_shell` to get the bash code to be more similar to ZSH, but that broke `nixos.tests.login`. Not that happy with the resulting flow of code in `bash.nix`, so if someone knows a more portable way to check for a login shell, that would be preferable I think.

I've done some basic testing using both ZSH and Bash as default shells in a VM. Also tested `nixos.tests.login` and `nixos.tests.env`.

I haven't looked Fish, but the guard should be set, so launching Bash from fish should work as expected.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

