### PR TITLE
processing: 3.3.7 -> 3.4

### DIFF
--- a/pkgs/applications/graphics/processing3/default.nix
+++ b/pkgs/applications/graphics/processing3/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, fetchurl, xmlstarlet, makeWrapper, ant, jdk, rsync, javaPackages, libXxf86vm, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
-  version = "3.3.7";
+  version = "3.4";
   name = "processing3-${version}";
 
   src = fetchFromGitHub {
     owner = "processing";
     repo = "processing";
-    rev = "processing-0264-3.3.7";
-    sha256 = "0a20z19lmc4xarfnr7xshcmlv3xkc2dgjxknis0iv79gxnwlqhpq";
+    rev = "processing-0265-${version}";
+    sha256 = "12wpxgn2wd5vbasx9584w5yb1s319smq1zh8m7dvp7gkqw9plwp4";
   };
 
   nativeBuildInputs = [ ant rsync makeWrapper ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     ${xmlstarlet}/bin/xmlstarlet ed --inplace -P -d '//get[@src="http://download.processing.org/reference.zip"]' build/build.xml
     install -D -m0444 ${fetchurl {
                           url    = http://download.processing.org/reference.zip;
-                          sha256 = "104zig026y8vbl4qksmscjq0bms8mi2jmri1ijdlbkxcqnv9bnlf";
+                          sha256 = "0dli1bdgw8hsx7g7b048ap81v2za9maa6pfcwdqm3qkfypr8q7pr";
                         }
                        } ./java/reference.zip
 


### PR DESCRIPTION
###### Motivation for this change

update and fix build because hash of ```http://download.processing.org/reference.zip``` has been changed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

