### PR TITLE
cquery: 2018-05-01 -> 2018-08-08

### DIFF
--- a/pkgs/development/tools/misc/cquery/default.nix
+++ b/pkgs/development/tools/misc/cquery/default.nix
@@ -5,8 +5,8 @@ let
   src = fetchFromGitHub {
     owner = "cquery-project";
     repo = "cquery";
-    rev = "34b357bc5e873d52d2aa41287c6e138244cea109";
-    sha256 = "0i34v30cl73485bzpbis539x0iq9whpv0403ca5a9h6vqwnvdn7c";
+    rev = "e17df5b41e5a687559a0b75dba9c0f1f399c4aea";
+    sha256 = "06z8bg73jppb4msiqvsjbpz6pawwny831k56w5kcxrjgp22v24s1";
     fetchSubmodules = true;
   };
 
@@ -15,7 +15,7 @@ let
 in
 stdenv.mkDerivation rec {
   name    = "cquery-${version}";
-  version = "2018-05-01";
+  version = "2018-08-08";
 
   inherit src;
 
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DSYSTEM_CLANG=ON"
     "-DCLANG_CXX=ON"
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12"
   ];
 
   shell = stdenv.shell;
@@ -47,6 +48,10 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     pushd ${src}
     $out/bin/cquery --ci --test-unit
+
+    # The integration tests have to be disabled because cquery ignores `--init`
+    # if they are invoked, which means it won't find the system includes.
+    #$out/bin/cquery --ci --test-index
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/cquery/wrapper
+++ b/pkgs/development/tools/misc/cquery/wrapper
@@ -1,6 +1,6 @@
 #! @shell@ -e
 
-initString="--init={\"extraClangArguments\": [@standard_library_includes@"
+initString="--init={\"cacheDirectory\": \"/tmp/cquery\", \"extraClangArguments\": [@standard_library_includes@"
 
 if [ "${NIX_CFLAGS_COMPILE}" != "" ]; then
   read -a cflags_array <<< ${NIX_CFLAGS_COMPILE}


### PR DESCRIPTION
###### Motivation for this change
Update to latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

