### PR TITLE
weechat-xmpp: create proper runtime environment

### DIFF
--- a/pkgs/applications/networking/instant-messengers/weechat-xmpp/default.nix
+++ b/pkgs/applications/networking/instant-messengers/weechat-xmpp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, xmpppy }:
+{ stdenv, fetchFromGitHub, xmpppy, pydns, substituteAll, buildEnv }:
 
 stdenv.mkDerivation {
   name = "weechat-jabber-2017-08-30";
@@ -15,15 +15,14 @@ stdenv.mkDerivation {
     cp jabber.py $out/share/jabber.py
   '';
 
-  buildInputs = [ xmpppy ];
-
-  postPatch = ''
-    substituteInPlace jabber.py \
-      --replace "__NIX_OUTPUT__" "${xmpppy}/lib/python2.7/site-packages"
-  '';
-
   patches = [
-    ./libpath.patch
+    (substituteAll {
+      src = ./libpath.patch;
+      env = "${buildEnv {
+        name = "weechat-xmpp-env";
+        paths = [ pydns xmpppy ];
+      }}/lib/python2.7/site-packages";
+    })
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/instant-messengers/weechat-xmpp/libpath.patch
+++ b/pkgs/applications/networking/instant-messengers/weechat-xmpp/libpath.patch
@@ -8,7 +8,7 @@ index 27006a3..e53c2c0 100644
  
 +import sys
 +
-+sys.path.append('__NIX_OUTPUT__')
++sys.path.append('@env@')
 +
 +
  import_ok = True

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18982,7 +18982,9 @@ with pkgs;
     inherit (luaPackages) cjson;
   };
 
-  weechat-xmpp = callPackage ../applications/networking/instant-messengers/weechat-xmpp {};
+  weechat-xmpp = callPackage ../applications/networking/instant-messengers/weechat-xmpp {
+    inherit (pythonPackages) pydns;
+  };
 
   westonLite = weston.override {
     pango = null;


### PR DESCRIPTION
###### Motivation for this change

The `weechat-xmpp` plugin requires `pydns` to properly resolve the
XMPP host. Furthermore it's much easier to use substituteAll rather than
messing around with substituteInPlace in a patched file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

