### PR TITLE
scallion: use mono4

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5029,7 +5029,7 @@ with pkgs;
 
   sasview = callPackage ../applications/science/misc/sasview {};
 
-  scallion = callPackage ../tools/security/scallion { };
+  scallion = callPackage ../tools/security/scallion { mono = mono4; };
 
   scanbd = callPackage ../tools/graphics/scanbd { };
 


### PR DESCRIPTION
###### Motivation for this change

scallion does not work with ```mono5``` (which is the default now)
