### PR TITLE
pythonPackages.pysrim: init at 0.5.8

### DIFF
--- a/pkgs/development/python-modules/pysrim/default.nix
+++ b/pkgs/development/python-modules/pysrim/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pytestrunner
+, numpy
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "pysrim";
+  version = "0.5.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6c297b4ea6f037946c72e94ddd9a7624cf2fd97c488acbee9409001c970754f1";
+  };
+
+  buildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ numpy pyyaml ];
+
+  # Tests require git lfs download of repository
+  doCheck = false;
+
+  meta = {
+    description = "Srim Automation of Tasks via Python";
+    homepage = https://gitlab.com/costrouc/pysrim;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4114,6 +4114,8 @@ in {
 
   pyspf = callPackage ../development/python-modules/pyspf { };
 
+  pysrim = callPackage ../development/python-modules/pysrim { };
+
   pysrt = callPackage ../development/python-modules/pysrt { };
 
   pytools = callPackage ../development/python-modules/pytools { };


### PR DESCRIPTION
###### Motivation for this change

add package needed for scientific calculations.

###### Things done

 - compatible with 2.7, 3+
 - tests are not run due to requiring git lfs download of repository

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

