### PR TITLE
[DO NOT MERGE] teamviewer service: fix PID file warning

### DIFF
--- a/nixos/modules/services/monitoring/teamviewer.nix
+++ b/nixos/modules/services/monitoring/teamviewer.nix
@@ -33,8 +33,8 @@ in
 
       serviceConfig = {
         Type = "forking";
-        ExecStart = "${pkgs.teamviewer}/bin/teamviewerd -d";
-        PIDFile = "/run/teamviewerd.pid";
+        ExecStart = "${pkgs.teamviewer}/bin/teamviewerd daemon start";
+        GuessMainPID = true;
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         Restart = "on-abort";
         StartLimitInterval = "60";


### PR DESCRIPTION
Teamviewer startup script doesn't support changing of PIDFile, it manages it's PIDFile in `/var/run/teamviewerd.pid`. This confuses systemd (services claims to be started but it haven't created `/run/teamviewerd.pid`). Systemd fixes this on it's own by creating second PID file in `/run/teamviewerd.pid`.

If someone wants to patch teamviewer startup scripts instead - we warned, it's a mess not worth bothering... 

Fixes https://github.com/NixOS/nixpkgs/issues/44307

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

