### PR TITLE
{cc,bintools}-wrapper, ghc, libgcc: Define wrapper env vars as full paths

### DIFF
--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -59,11 +59,11 @@ for cmd in \
     ar as ld nm objcopy objdump readelf ranlib strip strings size windres
 do
     if
-        PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
+        cmd_path=$(PATH=$_PATH command -v "@targetPrefix@${cmd}")
     then
         upper_case="$(echo "$cmd" | tr "[:lower:]" "[:upper:]")"
-        export "${role_pre}${upper_case}=@targetPrefix@${cmd}";
-        export "${upper_case}${role_post}=@targetPrefix@${cmd}";
+        export "${role_pre}${upper_case}=${cmd_path}";
+        export "${upper_case}${role_post}=${cmd_path}";
     fi
 done
 
@@ -72,5 +72,5 @@ done
 export NIX_HARDENING_ENABLE
 
 # No local scope in sourced file
-unset -v role_pre role_post cmd upper_case
+unset -v role_pre role_post cmd cmd_path upper_case
 set +u

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -109,10 +109,10 @@ fi
 
 export NIX_${role_pre}CC=@out@
 
-export ${role_pre}CC=@named_cc@
-export ${role_pre}CXX=@named_cxx@
-export CC${role_post}=@named_cc@
-export CXX${role_post}=@named_cxx@
+export ${role_pre}CC=@out@/bin/@named_cc@
+export ${role_pre}CXX=@out@/bin/@named_cxx@
+export CC${role_post}=@out@/bin/@named_cc@
+export CXX${role_post}=@out@/bin/@named_cxx@
 
 # If unset, assume the default hardening flags.
 : ${NIX_HARDENING_ENABLE="fortify stackprotector pic strictoverflow format relro bindnow"}

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -102,15 +102,16 @@ stdenv.mkDerivation rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+    export CC="$CC_FOR_TARGET"
+    export CXX="$CXX_FOR_TARGET"
+    # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
+    export AS="$AS_FOR_TARGET"
+    export AR="$AR_FOR_TARGET"
+    export NM="$NM_FOR_TARGET"
+    export RANLIB="$RANLIB_FOR_TARGET"
+    export READELF="$READELF_FOR_TARGET"
+    export STRIP="$STRIP_FOR_TARGET"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -134,16 +134,16 @@ stdenv.mkDerivation rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export CC="$CC_FOR_TARGET"
+    export CXX="$CXX_FOR_TARGET"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+    export AS="$AS_FOR_TARGET"
+    export AR="$AR_FOR_TARGET"
+    export NM="$NM_FOR_TARGET"
+    export RANLIB="$RANLIB_FOR_TARGET"
+    export READELF="$READELF_FOR_TARGET"
+    export STRIP="$STRIP_FOR_TARGET"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -106,16 +106,16 @@ stdenv.mkDerivation (rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export CC="$CC_FOR_TARGET"
+    export CXX="$CXX_FOR_TARGET"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+    export AS="$AS_FOR_TARGET"
+    export AR="$AR_FOR_TARGET"
+    export NM="$NM_FOR_TARGET"
+    export RANLIB="$RANLIB_FOR_TARGET"
+    export READELF="$READELF_FOR_TARGET"
+    export STRIP="$STRIP_FOR_TARGET"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -98,16 +98,16 @@ stdenv.mkDerivation (rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export CC="$CC_FOR_TARGET"
+    export CXX="$CXX_FOR_TARGET"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+    export AS="$AS_FOR_TARGET"
+    export AR="$AR_FOR_TARGET"
+    export NM="$NM_FOR_TARGET"
+    export RANLIB="$RANLIB_FOR_TARGET"
+    export READELF="$READELF_FOR_TARGET"
+    export STRIP="$STRIP_FOR_TARGET"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -100,16 +100,16 @@ stdenv.mkDerivation rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
-    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export CC="$CC_FOR_TARGET"
+    export CXX="$CXX_FOR_TARGET"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
-    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
-    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
-    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
-    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
-    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
+    export AS="$AS_FOR_TARGET"
+    export AR="$AR_FOR_TARGET"
+    export NM="$NM_FOR_TARGET"
+    export RANLIB="$RANLIB_FOR_TARGET"
+    export READELF="$READELF_FOR_TARGET"
+    export STRIP="$STRIP_FOR_TARGET"
 
     echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -46,22 +46,16 @@ stdenvNoLibs.mkDerivation rec {
     mkdir -p "$buildRoot/gcc"
     cd "$buildRoot/gcc"
     (
-      export AS_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$AS_FOR_BUILD
-      export CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CC_FOR_BUILD
-      export CPP_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CPP_FOR_BUILD
-      export CXX_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CXX_FOR_BUILD
-      export LD_FOR_BUILD=${buildPackages.stdenv.cc.bintools}/bin/$LD_FOR_BUILD
-
       export AS=$AS_FOR_BUILD
       export CC=$CC_FOR_BUILD
       export CPP=$CPP_FOR_BUILD
       export CXX=$CXX_FOR_BUILD
       export LD=$LD_FOR_BUILD
 
-      export AS_FOR_TARGET=${stdenvNoLibs.cc}/bin/$AS
-      export CC_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CC
-      export CPP_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CPP
-      export LD_FOR_TARGET=${stdenvNoLibs.cc.bintools}/bin/$LD
+      export AS_FOR_TARGET=$AS
+      export CC_FOR_TARGET=$CC
+      export CPP_FOR_TARGET=$CPP
+      export LD_FOR_TARGET=$LD
 
       export NIX_BUILD_CFLAGS_COMPILE+=' -DGENERATOR_FILE=1'
 
@@ -87,23 +81,6 @@ stdenvNoLibs.mkDerivation rec {
     cd "$buildRoot/gcc/${hostPlatform.config}/libgcc"
     configureScript=$sourceRoot/configure
     chmod +x "$configureScript"
-
-    export AS_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$AS_FOR_BUILD
-    export CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CC_FOR_BUILD
-    export CPP_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CPP_FOR_BUILD
-    export CXX_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CXX_FOR_BUILD
-    export LD_FOR_BUILD=${buildPackages.stdenv.cc.bintools}/bin/$LD_FOR_BUILD
-
-    export AS=${stdenvNoLibs.cc}/bin/$AS
-    export CC=${stdenvNoLibs.cc}/bin/$CC
-    export CPP=${stdenvNoLibs.cc}/bin/$CPP
-    export CXX=${stdenvNoLibs.cc}/bin/$CXX
-    export LD=${stdenvNoLibs.cc.bintools}/bin/$LD
-
-    export AS_FOR_TARGET=${stdenvNoLibs.cc}/bin/$AS_FOR_TARGET
-    export CC_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CC_FOR_TARGET
-    export CPP_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CPP_FOR_TARGET
-    export LD_FOR_TARGET=${stdenvNoLibs.cc.bintools}/bin/$LD_FOR_TARGET
   '';
 
   gccConfigureFlags = [


### PR DESCRIPTION
###### Motivation for this change

This makes builds more robust by having the env vars not rely on the PATH. That, for example, helps keep separate toolchains untangled even when on native builds neither are prefixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @bgamari we talked about this once

