### PR TITLE
zopfli: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/tools/compression/zopfli/default.nix
+++ b/pkgs/tools/compression/zopfli/default.nix
@@ -2,27 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "zopfli-${version}";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "zopfli";
     rev = name;
     name = "${name}-src";
-    sha256 = "1dclll3b5azy79jfb8vhb21drivi7vaay5iw0lzs4lrh6dgyvg6y";
+    sha256 = "1l551hx2p4qi0w9lk96qklbv6ll68gxbah07fhqx1ly28rv5wy9y";
   };
 
   patches = [
-    (fetchpatch {
-      sha256 = "07z6df1ahx40hnsrcs5mx3fc58rqv8fm0pvyc7gb7kc5mwwghvvp";
-      name = "Fix-invalid-read-outside-allocated-memory.patch";
-      url = "https://github.com/google/zopfli/commit/9429e20de3885c0e0d9beac23f703fce58461021.patch";
-    })
-    (fetchpatch {
-      sha256 = "07m8q5kipr84cg8i1l4zd22ai9bmdrblpdrsc96llg7cm51vqdqy";
-      name = "zopfli-bug-and-typo-fixes.patch";
-      url = "https://github.com/google/zopfli/commit/7190e08ecac2446c7c9157cfbdb7157b18912a92.patch";
-    })
     (fetchpatch {
       name = "zopfli-cmake.patch";
       url = "https://github.com/google/zopfli/commit/7554e4d34e7000b0595aa606e7d72357cf46ba86.patch";


### PR DESCRIPTION
Zopfli 1.0.2 was released last May. It includes patches that were manually added to the Nix derivation. These are not needed anymore.

This was build with `useSandbox` and could ran on NixOS.