### PR TITLE
lsyncd: 2.2.2 -> 2.2.3

### DIFF
--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -1,18 +1,26 @@
-{ stdenv, fetchFromGitHub, cmake, lua, pkgconfig, rsync,
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, lua, pkgconfig, rsync,
   asciidoc, libxml2, docbook_xml_dtd_45, docbook_xsl, libxslt }:
 
 stdenv.mkDerivation rec {
   name = "lsyncd-${version}";
-  version = "2.2.2";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "axkibe";
     repo = "lsyncd";
     rev = "release-${version}";
-    sha256 = "1q2ixp52r96ckghgmxdbms6xrq8dbziimp8gmgzqfq4lk1v1w80y";
+    sha256 = "1hbsih5hfq9lhgnxm0wb5mrj6xmlk2l0i9a79wzd5f6cnjil9l3x";
   };
 
-  patchPhase = ''
+  patches = [
+    (fetchpatch {
+      sha256 = "0b0h2qxh73l502p7phf6qgl8576nf6fvqqp2x5wy3nz7sc9qb1z8";
+      name = "fix-non-versioned-lua-not-search-in-cmake.patch";
+      url = "https://github.com/axkibe/lsyncd/pull/500/commits/0af99d8d5ba35118e8799684a2d4a8ea4b0c6957.patch";
+    })
+  ];
+
+  postPatch = ''
     substituteInPlace default-rsync.lua \
       --replace "/usr/bin/rsync" "${rsync}/bin/rsync"
   '';


### PR DESCRIPTION
lsyncd has been updated to 2.2.3 since last March. It introduced a problem with CMake not being able to find lua.
That was fixed in this PR https://github.com/axkibe/lsyncd/pull/500, which has been merged, but not yet released to a stable version.
That's why a patch was introduced in this PR.