### PR TITLE
qhull: 2012.1 -> 2016.1

### DIFF
--- a/pkgs/development/libraries/qhull/default.nix
+++ b/pkgs/development/libraries/qhull/default.nix
@@ -1,28 +1,22 @@
-{stdenv, fetchurl, cmake}:
+{ stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "qhull-2012.1";
+  name = "qhull-2016.1";
 
-  src = fetchurl {
-    url = "${meta.homepage}/download/${name}-src.tgz";
-    sha256 = "127zpjp6sm8c101hz239k82lpxqcqf4ksdyfqc2py2sm22kclpm3";
+  src = fetchFromGitHub {
+    owner = "qhull";
+    repo = "qhull";
+    rev = "5bbc75608c817b50383a0c24c3977cc09d0bbfde";
+    sha256 = "0wrgqc2mih7h8fs9v5jcn9dr56afqi9bgh2w9dcvzvzvxizr9kjj";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = "-DMAN_INSTALL_DIR=share/man/man1 -DDOC_INSTALL_DIR=share/doc/qhull";
-
-  hardeningDisable = [ "format" ];
-
-  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
-    sed -i 's/namespace std { struct bidirectional_iterator_tag; struct random_access_iterator_tag; }/#include <iterator>/' ./src/libqhullcpp/QhullIterator.h
-    sed -i 's/namespace std { struct bidirectional_iterator_tag; struct random_access_iterator_tag; }/#include <iterator>/' ./src/libqhullcpp/QhullLinkedList.h
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.qhull.org/;
-    description = "Computes the convex hull, Delaunay triangulation, Voronoi diagram and more";
-    license = stdenv.lib.licenses.free;
-    platforms = stdenv.lib.platforms.unix;
+    description = "Compute the convex hull, Delaunay triangulation, Voronoi diagram and more";
+    license = licenses.free;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ orivej ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This release was not announced in [Announce.txt](https://github.com/qhull/qhull/blob/master/Announce.txt), but it is a slight improvement over the last announced release 2015.2. qhull repo does not have tags, here is the referenced commit: https://github.com/qhull/qhull/commit/5bbc75608c817b50383a0c24c3977cc09d0bbfde

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
