### PR TITLE
add gtk3 as propagatedBuildInput to vte

### DIFF
--- a/pkgs/desktops/gnome-3/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/core/vte/default.nix
@@ -19,7 +19,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gobjectIntrospection intltool pkgconfig vala gperf libxml2 ];
   buildInputs = [ gnome3.glib gnome3.gtk3 ncurses ];
 
-  propagatedBuildInputs = [ gnutls pcre2 ];
+  propagatedBuildInputs = [
+    # Needed because Vte-2.91.gir depends on Gtk-3.0.gir
+    gnome3.gtk3
+    gnutls
+    pcre2
+  ];
 
   preConfigure = "patchShebangs .";
 

--- a/pkgs/desktops/gnome-3/core/vte/default.nix
+++ b/pkgs/desktops/gnome-3/core/vte/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gnome3.glib gnome3.gtk3 ncurses ];
 
   propagatedBuildInputs = [
-    # Needed because Vte-2.91.gir depends on Gtk-3.0.gir
+    # Required by vte-2.91.pc.
     gnome3.gtk3
     gnutls
     pcre2


### PR DESCRIPTION
###### Motivation for this change

`Vte.2.91.gir` imports `Gtk.3.0.gir`.  So in order to use `Vte.2.91.gir`, you must also have `Gtk.3.0.gir` on the GI_TYPELIB_PATH. Adding gtk3 to the `propagatedBuildInputs` of vte accomplishes this.

This affects the the `gi-vte` Haskell package, which currently only depends on `vte` but not `gtk`.  `gi-vte` does not currently build on NixOS, and this PR fixes one of the reasons. Here is the current definition of `gi-vte` for reference:

```nix
  "gi-vte" = callPackage
    ({ mkDerivation, base, bytestring, Cabal, containers, gi-atk
     , gi-gdk, gi-gio, gi-glib, gi-gobject, gi-gtk, gi-pango, haskell-gi
     , haskell-gi-base, haskell-gi-overloading, text, transformers, vte
     }:
     mkDerivation {
       pname = "gi-vte";
       version = "2.91.18";
       sha256 = "0rixrkw0k2vz59y20lsd8zw54n7l069mij0n76dnmah2bjjk1r7w";
       setupHaskellDepends = [ base Cabal haskell-gi ];
       libraryHaskellDepends = [
         base bytestring containers gi-atk gi-gdk gi-gio gi-glib gi-gobject
         gi-gtk gi-pango haskell-gi haskell-gi-base haskell-gi-overloading
         text transformers
       ];
       libraryPkgconfigDepends = [ vte ];
       doHaddock = false;
       description = "Vte bindings";
       license = stdenv.lib.licenses.lgpl21;
       hydraPlatforms = stdenv.lib.platforms.none;
     }) {inherit (pkgs.gnome3) vte;};
```

Merging in this PR will help `gi-vte` build.

This fix is exactly the same as the fix for other Gnome packages, for instance `gtksourceview`:

https://github.com/NixOS/nixpkgs/blob/42eca7ca2debc8eadc21a25011b55171b2db730f/pkgs/development/libraries/gtksourceview/3.x.nix#L15-L20

This was discussed on the following issue:

https://github.com/haskell-gi/haskell-gi/issues/183

That issue was inspired by the following PR:

https://github.com/NixOS/nixpkgs/pull/44529

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

