### PR TITLE
ncurses: patch wrong st-0.7 terminfo

### DIFF
--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation rec {
     sha256 = "05qdmbmrrn88ii9f66rkcmcyzp1kb1ymkx7g040lfkd1nkp7w1da";
   };
 
-  patches = lib.optional (!stdenv.cc.isClang) ./clang.patch;
+  # The patch st-0.7.patch needs to be removed, if ncurses is upgraded in the future.
+  # It is necessary for the 6.1 version of ncurses.
+  patches = [ ./st-0.7.patch ] ++ lib.optional (!stdenv.cc.isClang) ./clang.patch;
 
   outputs = [ "out" "dev" "man" ];
   setOutputFlags = false; # some aren't supported

--- a/pkgs/development/libraries/ncurses/st-0.7.patch
+++ b/pkgs/development/libraries/ncurses/st-0.7.patch
@@ -1,0 +1,13 @@
+diff --git a/misc/terminfo.src b/misc/terminfo.src
+index 84f4810..ac300a7 100644
+--- a/misc/terminfo.src
++++ b/misc/terminfo.src
+@@ -6260,7 +6260,7 @@ st-0.7|simpleterm 0.7,
+ 	     %=%t3%e%p1%d%;m,
+ 	sgr=%?%p9%t\E(0%e\E(B%;\E[0%?%p6%t;1%;%?%p2%t;4%;%?%p1%p3%|
+ 	    %t;7%;%?%p4%t;5%;%?%p5%t;2%;%?%p7%t;8%;m,
+-	Ss=\E]52;%p1%s;%p2%s\007, kDN3=\E[1;3B, kDN5=\E[1;5B,
++	Ms=\E]52;%p1%s;%p2%s\007, kDN3=\E[1;3B, kDN5=\E[1;5B,
+ 	kLFT3=\E[1;3D, kLFT5=\E[1;5D, kNXT3=\E[6;3~,
+ 	kNXT5=\E[6;5~, kPRV3=\E[5;3~, kPRV5=\E[5;5~,
+ 	kRIT3=\E[1;3C, kRIT5=\E[1;5C, kUP3=\E[1;3A, kUP5=\E[1;5A,


### PR DESCRIPTION
###### Motivation for this change
ncurses 6.1 has a defective st-0.7 terminfo entry according to

https://github.com/tmux/tmux/issues/1264#issuecomment-367385211

which resulted in tmux crashing if it is used within st and neovim
is started inside. Which is my use case with nix on debian8. On nixos
the issue can't be reproduced as the terminfo database out of
/run/current-system is also used, which contains ncurses 6.0
on my system.

Of course it is a bit unfortunate that a correction to the terminfo database
necessitates a rebuild of so many packages :(

###### Things done

Applied the fix stated in the comment above and checked that the crash doesn't
occur any more.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  Sadly this ate all my ram and was killed by oom.

- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

