### PR TITLE
Add licenses: libzip, minizip, bzip2, zip

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -26,9 +26,10 @@ stdenv.mkDerivation rec {
     ( cd $dev/include ; ln -s ../lib/libzip/include/zipconf.h zipconf.h )
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://www.nih.at/libzip;
     description = "A C library for reading, creating and modifying zip archives";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.bsd3;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/minizip/default.nix
+++ b/pkgs/development/libraries/minizip/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation {
   sourceRoot = "zlib-${zlib.version}/contrib/minizip";
 
   meta = {
+    inherit (zlib.meta) license homepage;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
+    homepage = https://zlib.net;
     description = "Lossless data-compression library";
     license = licenses.zlib;
     platforms = platforms.all;

--- a/pkgs/tools/archivers/zip/default.nix
+++ b/pkgs/tools/archivers/zip/default.nix
@@ -27,10 +27,11 @@ stdenv.mkDerivation {
   buildInputs = stdenv.lib.optional enableNLS libnatspec
     ++ stdenv.lib.optional stdenv.isCygwin libiconv;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Compressor/archiver for creating and modifying zipfiles";
     homepage = http://www.info-zip.org;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.bsdOriginal;
+    platforms = platforms.all;
     maintainers = [ ];
   };
 }

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -35,11 +35,10 @@ stdenv.mkDerivation rec {
   configureFlags =
     stdenv.lib.optionals linkStatic [ "--enable-static" "--disable-shared" ];
 
-  meta = {
-    homepage = http://www.bzip.org;
+  meta = with stdenv.lib; {
     description = "High-quality data compression program";
-
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.bsdOriginal;
+    platforms = platforms.all;
     maintainers = [];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Add missing licenses to 'zip' topic packages (see https://github.com/NixOS/nixpkgs/issues/43716)

###### Things done

- Add licenses
- Update homepage where applicable
- Remove `bzip2` homepage (seems to be gone: http://bzip.org/)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

