### PR TITLE
aws-okta: init at 0.19.0

### DIFF
--- a/pkgs/tools/security/aws-okta/default.nix
+++ b/pkgs/tools/security/aws-okta/default.nix
@@ -1,0 +1,26 @@
+{ buildGoPackage, fetchFromGitHub, stdenv }:
+buildGoPackage rec {
+  name = "aws-okta-${version}";
+  version = "0.19.0";
+
+  goPackagePath = "github.com/segmentio/aws-okta";
+
+  src = fetchFromGitHub {
+    owner = "segmentio";
+    repo = "aws-okta";
+    rev = "v${version}";
+    sha256 = "1c9mn492yva7cdsx2b0n8g2fdl9660v3xma0v82jzb0c9y9rq0ms";
+  };
+
+  buildFlags = "--tags release";
+
+  meta = with stdenv.lib; {
+    inherit version;
+    description = "aws-vault like tool for Okta authentication";
+    license = licenses.mit;
+    maintainers = [maintainers.imalsogreg];
+    platforms = platforms.all;
+    homepage = https://github.com/segmentio/aws-okta;
+    downloadPage = "https://github.com/segmentio/aws-okta";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -573,6 +573,8 @@ with pkgs;
 
   awslogs = callPackage ../tools/admin/awslogs { };
 
+  aws-okta = callPackage ../tools/security/aws-okta { };
+
   aws-rotate-key = callPackage ../tools/admin/aws-rotate-key { };
 
   aws_shell = pythonPackages.callPackage ../tools/admin/aws_shell { };


### PR DESCRIPTION
###### Motivation for this change

Adding a useful tool for people that need to use Okta for AWS cli access. This package could also be used later in an okta-aws nixos module if we want to provide a less imperative okta login.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

