### PR TITLE
masterpdfeditor: 4.3.89 -> 5.1.00

### DIFF
--- a/pkgs/applications/misc/masterpdfeditor/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchurl, sane-backends, qtbase, qtsvg, autoPatchelfHook }:
+{ stdenv, fetchurl, sane-backends, qtbase, qtsvg, nss, autoPatchelfHook }:
 let
-  version = "4.3.89";
+  version = "5.1.00";
 in stdenv.mkDerivation {
   name = "masterpdfeditor-${version}";
   src = fetchurl {
     url = "https://code-industry.net/public/master-pdf-editor-${version}_qt5.amd64.tar.gz";
-    sha256 = "0k5bzlhqglskiiq86nmy18mnh5bf2w3mr9cq3pibrwn5pisxnxxc";
+    sha256 = "1s2zhx9xr1ny5s8hmlb99v3z1v26vmx87iixk8cdgndz046p9bg9";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];
 
-  buildInputs = [ sane-backends qtbase qtsvg ];
+  buildInputs = [ nss qtbase qtsvg sane-backends stdenv.cc.cc ];
 
   dontStrip = true;
 
@@ -18,15 +18,15 @@ in stdenv.mkDerivation {
    p=$out/opt/masterpdfeditor
    mkdir -p $out/bin $p $out/share/applications $out/share/pixmaps
 
-   substituteInPlace masterpdfeditor4.desktop \
-     --replace 'Exec=/opt/master-pdf-editor-4' "Exec=$out/bin" \
-     --replace 'Path=/opt/master-pdf-editor-4' "Path=$out/bin" \
-     --replace 'Icon=/opt/master-pdf-editor-4' "Icon=$out/share/pixmaps"
-   cp -v masterpdfeditor4.png $out/share/pixmaps/
-   cp -v masterpdfeditor4.desktop $out/share/applications
+   substituteInPlace masterpdfeditor5.desktop \
+     --replace 'Exec=/opt/master-pdf-editor-5' "Exec=$out/bin" \
+     --replace 'Path=/opt/master-pdf-editor-5' "Path=$out/bin" \
+     --replace 'Icon=/opt/master-pdf-editor-5' "Icon=$out/share/pixmaps"
+   cp -v masterpdfeditor5.png $out/share/pixmaps/
+   cp -v masterpdfeditor5.desktop $out/share/applications
 
-   cp -v masterpdfeditor4 $p/
-   ln -s $p/masterpdfeditor4 $out/bin/masterpdfeditor4
+   cp -v masterpdfeditor5 $p/
+   ln -s $p/masterpdfeditor5 $out/bin/masterpdfeditor5
    cp -v -r stamps templates lang fonts $p
 
    install -D license.txt $out/share/$name/LICENSE


### PR DESCRIPTION
This bumps masterpdfeditor's version to their 5 series.
The download for masterpdfeditor 4 is gone from their servers :-/

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

