### PR TITLE
palp: Add darwin support

### DIFF
--- a/pkgs/applications/science/math/palp/default.nix
+++ b/pkgs/applications/science/math/palp/default.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
     "strictoverflow" # causes runtime failure (tested in checkPhase)
   ];
 
+  patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace GNUmakefile --replace gcc cc
+  '';
+
   preBuild = ''
       echo Building PALP optimized for ${dim} dimensions
       sed -i "s/^#define[^a-zA-Z]*POLY_Dmax.*/#define POLY_Dmax ${dim}/" Global.h
@@ -77,6 +81,6 @@ stdenv.mkDerivation rec {
     # the right license.
     license = licenses.gpl2;
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Adds the ability to build `palp` on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

