### PR TITLE
waf: 2.0.6 -> 2.0.10

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -1,15 +1,17 @@
-{ stdenv, fetchurl, python2 }:
+{ stdenv, fetchFromGitLab, python, ensureNewerSourcesForZipFilesHook }:
 
 stdenv.mkDerivation rec {
   name = "waf-${version}";
-  version = "2.0.6";
+  version = "2.0.10";
 
-  src = fetchurl {
-    url = "https://waf.io/waf-${version}.tar.bz2";
-    sha256 = "1wyl0jl10i0p2rj49sig5riyppgkqlkqmbvv35d5bqxri3y4r38q";
+  src = fetchFromGitLab {
+    owner = "ita1024";
+    repo = "waf";
+    rev = name;
+    sha256 = "12p5myq72r5qg7wp2gwbnyvh6lzzcrwp9h3dw194x38g52m0prc7";
   };
 
-  buildInputs = [ python2 ];
+  buildInputs = [ python ensureNewerSourcesForZipFilesHook ];
 
   configurePhase = ''
     python waf-light configure
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Meta build system";
-    homepage    = "https://waf.io/";
+    homepage    = https://waf.io;
     license     = licenses.bsd3;
     platforms   = platforms.all;
     maintainers = with maintainers; [ vrthra ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5937,7 +5937,7 @@ with pkgs;
 
   volumeicon = callPackage ../tools/audio/volumeicon { };
 
-  waf = callPackage ../development/tools/build-managers/waf { };
+  waf = callPackage ../development/tools/build-managers/waf { python = python3; };
 
   wakelan = callPackage ../tools/networking/wakelan { };
 


### PR DESCRIPTION
This commit also swaps the build tool to use python3 internally (which waf fully
supports and prefers) and swaps the src to be downloaded from gitlab. The waf.io
site only keeps source tarballs of the latest version, so once a new waf comes
out we can no longer reproduce older versions.

We need the ensureNewerSources hook to avoid this error, in both `python2` and `python3`:

    ValueError: ZIP does not support timestamps before 1980

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

