### PR TITLE
img2pdf init at 0.3.1

### DIFF
--- a/pkgs/applications/misc/img2pdf/default.nix
+++ b/pkgs/applications/misc/img2pdf/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonApplication, fetchPypi, python3Packages }:
+
+buildPythonApplication rec {
+  pname = "img2pdf";
+  version = "0.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "071s3gf28nb8ifxkix7dzjny6vib7791mnp0v3f4zagcjcic22a4";
+  };
+
+  doCheck = false; # needs pdfrw
+
+  propagatedBuildInputs = with python3Packages; [
+    pillow
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Convert images to PDF via direct JPEG inclusion";
+    homepage = https://gitlab.mister-muffin.de/josch/img2pdf;
+    license = licenses.lgpl2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.veprbl ];
+  };
+}

--- a/pkgs/applications/misc/img2pdf/default.nix
+++ b/pkgs/applications/misc/img2pdf/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, buildPythonApplication, fetchPypi, python3Packages }:
+{ stdenv, python3Packages }:
+
+with python3Packages;
 
 buildPythonApplication rec {
   pname = "img2pdf";
@@ -11,7 +13,7 @@ buildPythonApplication rec {
 
   doCheck = false; # needs pdfrw
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     pillow
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16856,6 +16856,10 @@ with pkgs;
 
   inherit (nodePackages) imapnotify;
 
+  img2pdf = callPackage ../applications/misc/img2pdf {
+    inherit (python3Packages) buildPythonApplication fetchPypi;
+  };
+
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16856,9 +16856,7 @@ with pkgs;
 
   inherit (nodePackages) imapnotify;
 
-  img2pdf = callPackage ../applications/misc/img2pdf {
-    inherit (python3Packages) buildPythonApplication fetchPypi;
-  };
+  img2pdf = callPackage ../applications/misc/img2pdf { };
 
   # Impressive, formerly known as "KeyJNote".
   impressive = callPackage ../applications/office/impressive { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

