### PR TITLE
sysvtools: fix build

### DIFF
--- a/pkgs/os-specific/linux/sysvinit/default.nix
+++ b/pkgs/os-specific/linux/sysvinit/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
       rm -rf $out/include
       rm -rf $out/share/man/man5
       rm $(for i in $out/share/man/man8/*; do echo $i; done | grep -v 'pidof\|killall5')
-      rm $out/bin/{mountpoint,wall} $out/share/man/man1/{mountpoint.1,wall.1}
+      rm $out/bin/wall $out/share/man/man1/wall.1
     '';
 
   meta = {


### PR DESCRIPTION
mountpoint from utillinux is now preferred, not installed anymore in sysvinit

See http://git.savannah.nongnu.org/cgit/sysvinit.git/commit/?id=3cb95c83714161a18f140814eece9345aebb42c0