### PR TITLE
syscall_limiter: fix build

### DIFF
--- a/pkgs/os-specific/linux/syscall_limiter/default.nix
+++ b/pkgs/os-specific/linux/syscall_limiter/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name    = "syscall_limiter-${version}";
-  version = "20170123";
+  version = "2017-01-23";
 
   src = fetchFromGitHub {
     owner  = "vi";
@@ -16,11 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "0z5arj1kq1xczgrbw1b8m9kicbv3vs9bd32wvgfr4r6ndingsp5m";
   };
 
-  configurePhase = "";
-
-  buildPhase = ''
-    make CC="gcc -I${libseccomp}/include -L${libseccomp}/lib"
-  '';
+  buildInputs = [ libseccomp ];
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
Originally broken through using multiple outputs for libseccomp in
8d490ca9934d0c01e1e9ade455657e54e2e843c0

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

