### PR TITLE
 qemu-ga: fix working guest-shutdown

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -71,8 +71,10 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "ga" ];
 
-  patches = [ ./no-etc-install.patch ]
-    ++ optional nixosTestRunner ./force-uid0-on-9p.patch
+  patches = [
+    ./no-etc-install.patch
+    ./fix-qemu-ga.patch
+  ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optional pulseSupport ./fix-hda-recording.patch
     ++ optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {

--- a/pkgs/applications/virtualization/qemu/fix-qemu-ga.patch
+++ b/pkgs/applications/virtualization/qemu/fix-qemu-ga.patch
@@ -1,0 +1,22 @@
+diff --git a/qga/commands-posix.c b/qga/commands-posix.c
+index 0dc219d..9d020d3 100644
+--- a/qga/commands-posix.c
++++ b/qga/commands-posix.c
+@@ -102,6 +102,8 @@ void qmp_guest_shutdown(bool has_mode, const char *mode, Error **errp)
+         reopen_fd_to_null(1);
+         reopen_fd_to_null(2);
+
++        execle("/run/current-system/sw/bin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
++               "hypervisor initiated shutdown", (char*)NULL, environ);
+         execle("/sbin/shutdown", "shutdown", "-h", shutdown_flag, "+0",
+                "hypervisor initiated shutdown", (char*)NULL, environ);
+         _exit(EXIT_FAILURE);
+@@ -189,6 +191,8 @@ void qmp_guest_set_time(bool has_time, int64_t time_ns, Error **errp)
+
+         /* Use '/sbin/hwclock -w' to set RTC from the system time,
+          * or '/sbin/hwclock -s' to set the system time from RTC. */
++        execle("/run/current-system/sw/bin/hwclock", "hwclock", has_time ? "-w" : "-s",
++               NULL, environ);
+         execle("/sbin/hwclock", "hwclock", has_time ? "-w" : "-s",
+                NULL, environ);
+         _exit(EXIT_FAILURE);


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

