### PR TITLE
remake: fix build with glibc2.27

### DIFF
--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1zi16pl7sqn1aa8b7zqm9qnd9vjqyfywqm8s6iap4clf86l7kss2";
   };
 
+  patches = [
+    ./glibc-2.27-glob.patch
+  ];
+
   buildInputs = [ readline ];
 
   meta = {

--- a/pkgs/development/tools/build-managers/remake/glibc-2.27-glob.patch
+++ b/pkgs/development/tools/build-managers/remake/glibc-2.27-glob.patch
@@ -1,0 +1,34 @@
+diff --git a/glob/glob.c b/glob/glob.c
+index f3911bcd861..6cb76e8e162 100644
+--- a/glob/glob.c
++++ b/glob/glob.c
+@@ -208,29 +208,8 @@ my_realloc (p, n)
+ #endif /* __GNU_LIBRARY__ || __DJGPP__ */
+ 
+ 
+-#if !defined __alloca && !defined __GNU_LIBRARY__
+-
+-# ifdef	__GNUC__
+-#  undef alloca
+-#  define alloca(n)	__builtin_alloca (n)
+-# else	/* Not GCC.  */
+-#  ifdef HAVE_ALLOCA_H
+-#   include <alloca.h>
+-#  else	/* Not HAVE_ALLOCA_H.  */
+-#   ifndef _AIX
+-#    ifdef WINDOWS32
+-#     include <malloc.h>
+-#    else
+-extern char *alloca ();
+-#    endif /* WINDOWS32 */
+-#   endif /* Not _AIX.  */
+-#  endif /* sparc or HAVE_ALLOCA_H.  */
+-# endif	/* GCC.  */
+-
+ # define __alloca	alloca
+ 
+-#endif
+-
+ #ifndef __GNU_LIBRARY__
+ # define __stat stat
+ # ifdef STAT_MACROS_BROKEN


### PR DESCRIPTION
Same fix as applied for gnumake in 519f0b8db2f91e73964375ee81fc411153bf3aa3

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

