### PR TITLE
mruby: init at 1.4.1

### DIFF
--- a/pkgs/development/compilers/mruby/0001-Disables-IO-isatty-test-for-sandboxed-builds.patch
+++ b/pkgs/development/compilers/mruby/0001-Disables-IO-isatty-test-for-sandboxed-builds.patch
@@ -1,0 +1,36 @@
+From f3db284516105fd30b5513a5528104574a7b8545 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Thu, 9 Aug 2018 19:07:45 -0400
+Subject: [PATCH] Disables `IO#isatty` test for sandboxed builds.
+
+---
+ mrbgems/mruby-io/test/io.rb | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/mrbgems/mruby-io/test/io.rb b/mrbgems/mruby-io/test/io.rb
+index e06b1499..e8a54736 100644
+--- a/mrbgems/mruby-io/test/io.rb
++++ b/mrbgems/mruby-io/test/io.rb
+@@ -342,19 +342,6 @@ assert('IO#_read_buf') do
+   io.closed?
+ end
+ 
+-assert('IO#isatty') do
+-  skip "isatty is not supported on this platform" if MRubyIOTestUtil.win?
+-  f1 = File.open("/dev/tty")
+-  f2 = File.open($mrbtest_io_rfname)
+-
+-  assert_true  f1.isatty
+-  assert_false f2.isatty
+-
+-  f1.close
+-  f2.close
+-  true
+-end
+-
+ assert('IO#pos=, IO#seek') do
+   fd = IO.sysopen $mrbtest_io_rfname
+   io = IO.new fd
+-- 
+2.16.4
+

--- a/pkgs/development/compilers/mruby/default.nix
+++ b/pkgs/development/compilers/mruby/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ ruby bison ];
 
+  # Necessary so it uses `gcc` instead of `ld` for linking.
+  # https://github.com/mruby/mruby/blob/35be8b252495d92ca811d76996f03c470ee33380/tasks/toolchains/gcc.rake#L25
+  preBuild = if stdenv.isLinux then "unset LD" else null;
+
   installPhase = ''
     mkdir $out
     cp -R build/host/{bin,lib} $out

--- a/pkgs/development/compilers/mruby/default.nix
+++ b/pkgs/development/compilers/mruby/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, ruby, bison, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "mruby-${version}";
+  version = "1.4.1";
+
+  src = fetchFromGitHub {
+    owner   = "mruby";
+    repo    = "mruby";
+    rev     = version;
+    sha256  = "0pw72acbqgs4n1qa297nnja23v9hxz9g7190yfx9kwm7mgbllmww";
+  };
+
+  nativeBuildInputs = [ ruby bison ];
+
+  installPhase = ''
+    mkdir $out
+    cp -R build/host/{bin,lib} $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An embeddable implementation of the Ruby language";
+    homepage = https://mruby.org;
+    maintainers = [ maintainers.nicknovitski ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/mruby/default.nix
+++ b/pkgs/development/compilers/mruby/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256  = "0pw72acbqgs4n1qa297nnja23v9hxz9g7190yfx9kwm7mgbllmww";
   };
 
+  patches = [
+    ./0001-Disables-IO-isatty-test-for-sandboxed-builds.patch
+  ];
+
   nativeBuildInputs = [ ruby bison ];
 
   # Necessary so it uses `gcc` instead of `ld` for linking.
@@ -21,6 +25,8 @@ stdenv.mkDerivation rec {
     mkdir $out
     cp -R build/host/{bin,lib} $out
   '';
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "An embeddable implementation of the Ruby language";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7638,6 +7638,8 @@ with pkgs;
 
   ruby = ruby_2_4;
 
+  mruby = callPackage ../development/compilers/mruby { };
+
   scsh = callPackage ../development/interpreters/scsh { };
 
   scheme48 = callPackage ../development/interpreters/scheme48 { };


### PR DESCRIPTION
I'm surprised it wasn't already in the repository.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)~)
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- ~[ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---