### PR TITLE
hydra: 2017-11-21 -> 2018-08-07

### DIFF
--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -2,14 +2,11 @@ import ../make-test.nix ({ pkgs, ...} :
 
 let
    trivialJob = pkgs.writeTextDir "trivial.nix" ''
-     with import <nix/config.nix>;
-
      { trivial = builtins.derivation {
          name = "trivial";
          system = "x86_64-linux";
-         PATH = coreutils;
-         builder = shell;
-         args = ["-c" "touch $out; exit 0"];
+         builder = "/bin/sh";
+         args = ["-c" "echo success > $out; exit 0"];
        };
      }
    '';
@@ -27,7 +24,7 @@ let
 in {
   name = "hydra-init-localdb";
   meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ pstn lewo ];
+    maintainers = [ pstn lewo ma27 ];
   };
 
   machine =
@@ -50,6 +47,8 @@ in {
           hostName = "localhost";
           systems = [ "x86_64-linux" ];
         }];
+
+        binaryCaches = [];
       };
     };
 
@@ -74,5 +73,5 @@ in {
       $machine->succeed("create-trivial-project.sh");
 
       $machine->waitUntilSucceeds('curl -L -s http://localhost:3000/build/1 -H "Accept: application/json" |  jq .buildstatus | xargs test 0 -eq');
-     '';
+    '';
 })

--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -3,11 +3,18 @@
 , gitAndTools, mercurial, darcs, subversion, bazaar, openssl, bzip2, libxslt
 , guile, perl, postgresql, nukeReferences, git, boehmgc
 , docbook_xsl, openssh, gnused, coreutils, findutils, gzip, lzma, gnutar
-, rpm, dpkg, cdrkit, pixz }:
+, rpm, dpkg, cdrkit, pixz, lib, fetchpatch, boost, autoreconfHook
+}:
 
 with stdenv;
 
 let
+  isGreaterNix20 = with lib.versions;
+    let
+      inherit (nix) version;
+      inherit (lib) toInt;
+    in major version == "2" && toInt (minor version) >= 1 || toInt (major version) > 2;
+
   perlDeps = buildEnv {
     name = "hydra-perl-deps";
     paths = with perlPackages;
@@ -63,15 +70,15 @@ let
   };
 in releaseTools.nixBuild rec {
   name = "hydra-${version}";
-  version = "2017-11-21";
+  version = "2018-08-07";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "b7bc4384b7b471d1ddf892cb03f16189a66d5a0d";
-    sha256 = "05g37z3ilazzqa5rqj5zljndwxjbvpc18xibh6jlwjwpvg3kpbbh";
+    rev = "4dca8fe14d3f782bdf927f37efce722acefffff3";
+    sha256 = "1yas4psmvfp7lhcp81ia2sy93b78j9hiw9a6n3q2m1a616hwpm25";
   };
 
   buildInputs =
@@ -80,17 +87,24 @@ in releaseTools.nixBuild rec {
       guile # optional, for Guile + Guix support
       perlDeps perl nix
       postgresql # for running the tests
-    ];
+    ] ++ lib.optionals isGreaterNix20 [ boost ];
 
   hydraPath = lib.makeBinPath (
     [ sqlite subversion openssh nix coreutils findutils pixz
       gzip bzip2 lzma gnutar unzip git gitAndTools.topGit mercurial darcs gnused bazaar
     ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
 
-  postUnpack = ''
-    # Clean up when building from a working tree.
-    (cd $sourceRoot && (git ls-files -o --directory | xargs -r rm -rfv)) || true
-  '';
+  nativeBuildInputs = [ autoreconfHook ];
+
+  # adds a patch which ensures compatibility with the API of Nix 2.0.
+  # it has been reverted in https://github.com/NixOS/hydra/commit/162d671c48a418bd10a8a171ca36787ef3695a44,
+  # for Nix 2.1/unstable compatibility. Reapplying helps if Nix 2.0 is used to keep the build functional.
+  patches = lib.optionals (!isGreaterNix20) [
+    (fetchpatch {
+      url = "https://github.com/NixOS/hydra/commit/08de434bdd0b0a22abc2081be6064a6c846d3920.patch";
+      sha256 = "0kz77njp5ynn9l81g3q8zrryvnsr06nk3iw0a60187wxqzf5fmf8";
+    })
+  ];
 
   configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
 
@@ -98,8 +112,6 @@ in releaseTools.nixBuild rec {
     PATH=$(pwd)/src/script:$(pwd)/src/hydra-eval-jobs:$(pwd)/src/hydra-queue-runner:$(pwd)/src/hydra-evaluator:$PATH
     PERL5LIB=$(pwd)/src/lib:$PERL5LIB;
   '';
-
-  preConfigure = "autoreconf -vfi";
 
   enableParallelBuilding = true;
 
@@ -130,6 +142,6 @@ in releaseTools.nixBuild rec {
     description = "Nix-based continuous build system";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ domenkozar ];
+    maintainers = with maintainers; [ domenkozar ma27 ];
   };
- }
+}

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -132,7 +132,7 @@ in rec {
       url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
       sha256 = "0ca5782fc37d62238d13a620a7b4bff6a200bab1bd63003709249a776162357c";
     };
-  }) // { perl-bindings = nixStable; };
+  }) // { perl-bindings = nix1; };
 
   nixStable = (common rec {
     name = "nix-2.0.4";


### PR DESCRIPTION
###### Motivation for this change

* The first commit fixes a minor issue with the exported perl bindings for Nix.
* The second commit bumps Hydra and applies some minor fixes to the derivation:
    * Compatibility with Nix 2.0 and Nix 2.1 (there's a slight API incompatibility between the versions, please read the commit message for further reference).
    * Dropped obsolete `postUnpack` hook.
    * Added myself as maintainer to help out in case of further breakage.

Fixes #44044 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

