### PR TITLE
opentimestamps-client: fix build

### DIFF
--- a/pkgs/tools/misc/opentimestamps-client/default.nix
+++ b/pkgs/tools/misc/opentimestamps-client/default.nix
@@ -1,5 +1,6 @@
 { lib, buildPythonApplication, fetchFromGitHub, isPy3k
-, opentimestamps, appdirs, GitPython, pysocks }:
+, opentimestamps, appdirs, GitPython, pysocks, fetchpatch, git
+}:
 
 buildPythonApplication rec {
   pname = "opentimestamps-client";
@@ -14,6 +15,15 @@ buildPythonApplication rec {
     rev = "opentimestamps-client-v${version}";
     sha256 = "05m8nllqad3k69mvby5q08y22i0wrj84gqifdgcldimrrn1i00xp";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/opentimestamps/opentimestamps-client/commit/1b328269ceee66916e9a639e8d5d7d13cd70d5d8.patch";
+      sha256 = "0bd3yalyvk5n4sflw9zilpay5k653ybdgkkfppyrk7c8z3i81hbl";
+    })
+  ];
+
+  checkInputs = [ git ];
 
   propagatedBuildInputs = [ opentimestamps appdirs GitPython pysocks ];
 


### PR DESCRIPTION
###### Motivation for this change

Build was broken as release-0.6.0 didn't support opentimestamps-0.4.0.
Applying the patch which relaxes the version contraints in `setup.py`
helps.

Furthermore the tests were broken as they missed the `git` executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

