### PR TITLE
Update Gambit and Gerbil

### DIFF
--- a/pkgs/development/compilers/gambit/default.nix
+++ b/pkgs/development/compilers/gambit/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl }:
+{ stdenv, callPackage, fetchurl }:
 
 callPackage ./build.nix {
   version = "4.8.9";
@@ -7,4 +7,5 @@ callPackage ./build.nix {
     url = "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.8/source/gambit-v4_8_9-devel.tgz";
     sha256 = "1gwzz1ag9hlv266nvfq1bhwzrps3f2yghhffasjjqy8i8xwnry5p";
   };
+  inherit stdenv;
 }

--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchgit }:
+{ stdenv, callPackage, fetchgit }:
 
 callPackage ./build.nix {
   version = "unstable-2018-08-06";
@@ -8,4 +8,5 @@ callPackage ./build.nix {
     rev = "91a4ad2c28375f067adedcaa61f9d66a4b536f4f";
     sha256 = "0px1ipvhh0hz8n38h6jv4y1nn163j8llvcy4l7p3hkdns5czwy1p";
   };
+  inherit stdenv;
 }

--- a/pkgs/development/compilers/gambit/unstable.nix
+++ b/pkgs/development/compilers/gambit/unstable.nix
@@ -1,10 +1,11 @@
 { callPackage, fetchgit }:
 
 callPackage ./build.nix {
-  version = "unstable-2018-05-30";
+  version = "unstable-2018-08-06";
+# git-version = "4.8.9-77-g91a4ad2c";
   SRC = fetchgit {
     url = "https://github.com/feeley/gambit.git";
-    rev = "ffe8841b56330eb86fd794b16dc7f83914ecc7c5";
-    sha256 = "1xzkwa2f6zazybbgd5zynhr36krayhr29vsbras5ld63hkrxrp7q";
+    rev = "91a4ad2c28375f067adedcaa61f9d66a4b536f4f";
+    sha256 = "0px1ipvhh0hz8n38h6jv4y1nn163j8llvcy4l7p3hkdns5czwy1p";
   };
 }

--- a/pkgs/development/compilers/gerbil/default.nix
+++ b/pkgs/development/compilers/gerbil/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl, gambit }:
+{ stdenv, callPackage, fetchurl, gambit }:
 
 callPackage ./build.nix {
   version = "0.12-RELEASE";
@@ -8,4 +8,5 @@ callPackage ./build.nix {
     url = "https://github.com/vyzo/gerbil/archive/v0.12.tar.gz";
     sha256 = "0nigr3mgrzai57q2jqac8f39zj8rcmic3277ynyzlgm8hhps71pq";
   };
+  inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchgit, gambit-unstable }:
+{ stdenv, callPackage, fetchgit, gambit-unstable }:
 
 callPackage ./build.nix {
   version = "unstable-2018-08-11";
@@ -9,4 +9,5 @@ callPackage ./build.nix {
     rev = "274e1a22b2d2b708d5582594274ab52ee9ba1686";
     sha256 = "10j44ar4xfl8xmh276zg1ykd3r0vy7w2f2cg4p8slwnk9r251g2s";
   };
+  inherit stdenv;
 }

--- a/pkgs/development/compilers/gerbil/unstable.nix
+++ b/pkgs/development/compilers/gerbil/unstable.nix
@@ -1,12 +1,12 @@
 { callPackage, fetchgit, gambit-unstable }:
 
 callPackage ./build.nix {
-  version = "unstable-2018-05-12";
-  git-version = "0.13-DEV-437-gaefdb47f";
+  version = "unstable-2018-08-11";
+  git-version = "0.13-DEV-542-g274e1a22";
   GAMBIT = gambit-unstable;
   SRC = fetchgit {
     url = "https://github.com/vyzo/gerbil.git";
-    rev = "aefdb47f3d1ceaa735fd5c3dcaac2aeb0d4d2436";
-    sha256 = "0xhsilm5kix5lsmykv273npp1gk6dgx9axh266mimwh7j0nxf7ms";
+    rev = "274e1a22b2d2b708d5582594274ab52ee9ba1686";
+    sha256 = "10j44ar4xfl8xmh276zg1ykd3r0vy7w2f2cg4p8slwnk9r251g2s";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6307,10 +6307,10 @@ with pkgs;
 
   fpc = callPackage ../development/compilers/fpc { };
 
-  gambit = callPackage ../development/compilers/gambit { };
-  gambit-unstable = callPackage ../development/compilers/gambit/unstable.nix { };
-  gerbil = callPackage ../development/compilers/gerbil { };
-  gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { };
+  gambit = callPackage ../development/compilers/gambit { stdenv = gccStdenv; };
+  gambit-unstable = callPackage ../development/compilers/gambit/unstable.nix { stdenv = gccStdenv; };
+  gerbil = callPackage ../development/compilers/gerbil { stdenv = gccStdenv; };
+  gerbil-unstable = callPackage ../development/compilers/gerbil/unstable.nix { stdenv = gccStdenv; };
 
   gccFun = callPackage ../development/compilers/gcc/7;
   gcc = gcc7;


### PR DESCRIPTION
###### Motivation for this change

Upstream update + make Gambit stable buildable with recent Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
