### PR TITLE
lcalc: Add darwin support

### DIFF
--- a/pkgs/development/libraries/science/math/lcalc/default.nix
+++ b/pkgs/development/libraries/science/math/lcalc/default.nix
@@ -69,7 +69,15 @@ stdenv.mkDerivation rec {
       url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/lcalc-c++11.patch?h=packages/lcalc&id=3607b97df5a8c231191115b0cb5c62426b339e71";
       sha256 = "1ccrl61lv2vvx8ggldq54m5d0n1iy6mym7qz0i8nj6yj0dshnpk3";
     })
-  ];
+  ] ++ stdenv.lib.optional stdenv.isDarwin
+  (fetchpatch {
+    url = "https://git.sagemath.org/sage.git/plain/build/pkgs/lcalc/patches/clang.patch";
+    sha256 = "0bb7656z6cp6i4p2qj745cmq0lhh52v2akl9whi760dynfdxbl18";
+  });
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    substituteInPlace src/Makefile --replace g++ c++
+  '';
 
   installFlags = [
     "DESTDIR=$(out)"


### PR DESCRIPTION
###### Motivation for this change

Add darwin support for `lcalc`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

