### PR TITLE
libinotify-kqueue: init at 20180201

### DIFF
--- a/pkgs/development/libraries/libinotify-kqueue/default.nix
+++ b/pkgs/development/libraries/libinotify-kqueue/default.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  doCheck = true;
+  checkFlags = [ "test" ];
+
   meta = with stdenv.lib; {
     description = "Inotify shim for macOS and BSD";
     homepage = https://github.com/libinotify-kqueue/libinotify-kqueue;

--- a/pkgs/development/libraries/libinotify-kqueue/default.nix
+++ b/pkgs/development/libraries/libinotify-kqueue/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchzip, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "libinotify-kqueue-${version}";
+  version = "20180201";
+
+  src = fetchzip {
+    url = "https://github.com/libinotify-kqueue/libinotify-kqueue/archive/${version}.tar.gz";
+    sha256 = "0dkh6n0ghhcl7cjkjmpin118h7al6i4vlkmw57vip5f6ngr6q3pl";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    description = "Inotify shim for macOS and BSD";
+    homepage = https://github.com/libinotify-kqueue/libinotify-kqueue;
+    license = licenses.mit;
+    maintainers = with maintainers; [ yegortimoshenko ];
+    platforms = with platforms; darwin ++ freebsd ++ netbsd ++ openbsd;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10351,6 +10351,8 @@ with pkgs;
   libindicator-gtk3 = libindicator.override { gtkVersion = "3"; };
   libindicator = callPackage ../development/libraries/libindicator { };
 
+  libinotify-kqueue = callPackage ../development/libraries/libinotify-kqueue { };
+
   libiodbc = callPackage ../development/libraries/libiodbc {
     useGTK = config.libiodbc.gtk or false;
   };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/libinotify-kqueue/libinotify-kqueue

Inotify shim for systems with Kqueue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

