### PR TITLE
keepass-keeagent: 0.8.1 -> 0.10.1

### DIFF
--- a/pkgs/applications/misc/keepass-plugins/keeagent/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/keeagent/default.nix
@@ -1,19 +1,19 @@
 { stdenv, buildEnv, fetchzip, mono }:
 
 let
-  version = "0.8.1";
+  version = "0.10.1";
   drv = stdenv.mkDerivation {
     name = "keeagent-${version}";
 
     src = fetchzip {
-      url = http://lechnology.com/wp-content/uploads/2016/07/KeeAgent_v0.8.1.zip;
-      sha256 = "16x1qrnzg0xkvi7w29wj3z0ldmql2vcbwxksbsmnidzmygwg98hk";
+      url = "https://lechnology.com/wp-content/uploads/2018/04/KeeAgent_v0.10.1.zip";
+      sha256 = "0j7az6l9wcr8z66mfplkxwydd4bgz2p2vd69xncf0nxlfb0lshh7";
       stripRoot = false;
     };
 
     meta = {
       description = "KeePass plugin to allow other programs to access SSH keys stored in a KeePass database for authentication";
-      homepage    = http://lechnology.com/software/keeagent;
+      homepage    = "http://lechnology.com/software/keeagent";
       platforms   = with stdenv.lib.platforms; linux;
       license     = stdenv.lib.licenses.gpl2;
       maintainers = [ ];


### PR DESCRIPTION
I'm using this on NixOS, works fine so far.