### PR TITLE
mosml: init at 2.10.1

### DIFF
--- a/pkgs/development/compilers/mosml/default.nix
+++ b/pkgs/development/compilers/mosml/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, gmp, perl }:
+
+stdenv.mkDerivation rec {
+  name = "mosml-${version}";
+  version = "2.10.1";
+
+  buildInputs = [ gmp perl ];
+
+  makeFlags = "PREFIX=$(out)";
+
+  src = fetchurl {
+    url = "https://github.com/kfl/mosml/archive/ver-${version}.tar.gz";
+    sha256 = "13x7wj94p0inn84pzpj52dch5s9lznqrj287bd3nk3dqd0v3kmgy";
+  };
+
+  setSourceRoot = ''export sourceRoot="$(echo */src)"'';
+
+  meta = with stdenv.lib; {
+    description = "A light-weight implementation of Standard ML";
+    longDescription = ''
+      Moscow ML is a light-weight implementation of Standard ML (SML), a strict
+      functional language used in teaching and research.
+    '';
+    homepage = http://mosml.org/;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ vaibhavsagar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7014,6 +7014,8 @@ with pkgs;
 
   monoDLLFixer = callPackage ../build-support/mono-dll-fixer { };
 
+  mosml = callPackage ../development/compilers/mosml { };
+
   mozart-binary = callPackage ../development/compilers/mozart/binary.nix { };
   mozart = mozart-binary;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

