### PR TITLE
plasma/xfce/enlightenment: improve detection of application mime types for apps that use GIO (firefox)

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -33,7 +33,12 @@ in
       pkgs.xorg.xauth # used by kdesu
       pkgs.gtk2 # To get GTK+'s themes.
       pkgs.tango-icon-theme
+
+      # having these utilities on the path makes the system 
+      # path builder update mime entries
       pkgs.shared-mime-info
+      pkgs.desktop-file-utils
+
       pkgs.gnome2.gnomeicontheme
       pkgs.xorg.xcursorthemes
     ];

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -162,6 +162,11 @@ in
 
           libsForQt56.phonon-backend-gstreamer
           libsForQt5.phonon-backend-gstreamer
+
+          # having these utilities on the path makes the system 
+          # path builder update mime entries
+          shared-mime-info
+          desktop-file-utils
         ]
 
         ++ lib.optionals cfg.enableQt4Support [ pkgs.phonon-backend-gstreamer ]

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -59,6 +59,8 @@ in
       tango-icon-theme
       xfce4-icon-theme
 
+      # having these utilities on the path makes the system 
+      # path builder update mime entries
       desktop-file-utils
       shared-mime-info
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -11,8 +11,11 @@ lib.makeScope pkgs.newScope (self: with self; {
   maintainers = with pkgs.lib.maintainers; [ lethalman jtojnar ];
 
   corePackages = with gnome3; [
+    # having these utilities on the path makes the system 
+    # path builder update mime entries
     pkgs.desktop-file-utils
-    pkgs.shared-mime-info # for update-mime-database
+    pkgs.shared-mime-info 
+
     glib # for gsettings
     gtk3.out # for gtk-update-icon-cache
     glib-networking gvfs dconf gnome-backgrounds gnome-control-center


### PR DESCRIPTION
###### Motivation for this change
One the trail of https://github.com/NixOS/nixpkgs/issues/44849 (related https://github.com/NixOS/nixpkgs/issues/11355), I discovered that apps that use GIO use a slightly different (and possibly not standards compliant) way of finding mime types for applications.

One thing that came up was the presence of `share/applications/mimeinfo.cache`, and lo and behold, this is not present using my DE.

A bit of further tracking revealed that we *do* populate this using `update-desktop-database`, but only if it *happens* to be present on the path (see https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/system-path.nix#L147).

Adding this to `environment.systemPackages` for plasma results in firefox now having file associations! They're still wrong (it opens pdfs in evince rather than okular, which is what `xdg-open` says it should use), but that's for another day.

I added `desktop-file-utils` to the DEs that appear to be doing the same thing with `shared-mime-info` -  I wasn't brave enough to touch the others.

Separately, I'd like to talk about whether `system-path.nix` is doing the right thing. It feels quite fragile to just be relying on the presence of these executables, and I don't know what would be lost by always running them (and referring to the packages directly). There's also the issue that `mimeinfo.cache` is missing from my *profile*'s `share/applications`, and I'm not sure what should be responsible for building that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

