### PR TITLE
python.pkgs.pyls-black: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/pyls-black/default.nix
+++ b/pkgs/development/python-modules/pyls-black/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchFromGitHub
+, black, toml, pytest, python-language-server, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "pyls-black";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "rupert";
+    repo = "pyls-black";
+    rev = "v${version}";
+    sha256 = "0xa3iv8nhnj0lw0dh41qb0dqp55sb6rdxalbk60v8jll6qyc0si8";
+  };
+
+  disabled = !isPy3k;
+
+  checkPhase = ''
+    pytest
+  '';
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [ black toml python-language-server ];
+
+  meta = with lib; {
+    homepage = https://github.com/rupert/pyls-black;
+    description = "Black plugin for the Python Language Server";
+    license = licenses.mit;
+    maintainers = [ maintainers.mic92 ];
+  };
+}

--- a/pkgs/development/python-modules/pyls-isort/default.nix
+++ b/pkgs/development/python-modules/pyls-isort/default.nix
@@ -21,8 +21,8 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    homepage = https://github.com/palantir/python-language-server;
-    description = "An implementation of the Language Server Protocol for Python";
+    homepage = https://github.com/paradoxxxzero/pyls-isort;
+    description = "Isort plugin for python-language-server";
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
   };

--- a/pkgs/development/python-modules/pyls-mypy/default.nix
+++ b/pkgs/development/python-modules/pyls-mypy/default.nix
@@ -1,28 +1,20 @@
-{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch
+{ lib, buildPythonPackage, fetchFromGitHub
 , future, python-language-server, mypy, configparser
 , pytest, mock, isPy3k, pytestcov, coverage
 }:
 
 buildPythonPackage rec {
   pname = "pyls-mypy";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "tomv564";
     repo = "pyls-mypy";
     rev = version;
-    sha256 = "0wa038a8a8yj3wmrc7q909nj4b5d3lq70ysbw7rpsnyb0x06m826";
+    sha256 = "0v7ghcd1715lxlfq304b7xhchp31ahdd89lf6za4n0l59dz74swh";
   };
 
   disabled = !isPy3k;
-
-  patches = [
-    # also part of https://github.com/tomv564/pyls-mypy/pull/10
-    (fetchpatch {
-      url = "https://github.com/Mic92/pyls-mypy/commit/4c727120d2cbd8bf2825e1491cd55175f03266d2.patch";
-      sha256 = "1dgn5z742swpxwknmgvm65jpxq9zwzhggw4nl6ys7yw8r49kqgrl";
-    })
-  ];
 
   checkPhase = ''
     HOME=$TEMPDIR pytest
@@ -35,8 +27,8 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    homepage = https://github.com/palantir/python-language-server;
-    description = "An implementation of the Language Server Protocol for Python";
+    homepage = https://github.com/tomv564/pyls-mypy;
+    description = "Mypy plugin for the Python Language Server";
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11003,9 +11003,11 @@ in {
 
   python-language-server = callPackage ../development/python-modules/python-language-server {};
 
-  pyls-mypy = callPackage ../development/python-modules/pyls-mypy {};
+  pyls-black = callPackage ../development/python-modules/pyls-black {};
 
   pyls-isort = callPackage ../development/python-modules/pyls-isort {};
+
+  pyls-mypy = callPackage ../development/python-modules/pyls-mypy {};
 
   pyudev = callPackage ../development/python-modules/pyudev {
     inherit (pkgs) systemd;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

