### PR TITLE
Fix evaluation of two tests

### DIFF
--- a/nixos/tests/yabar.nix
+++ b/nixos/tests/yabar.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ pkgs, lib }:
+import ./make-test.nix ({ pkgs, lib, ... }:
 
 with lib;
 

--- a/pkgs/build-support/fetchdocker/credentials.nix
+++ b/pkgs/build-support/fetchdocker/credentials.nix
@@ -32,7 +32,7 @@
 let
   pathParts =
    (builtins.filter
-    ({prefix}: "DOCKER_CREDENTIALS" == prefix)
+    ({prefix, path}: "DOCKER_CREDENTIALS" == prefix)
     builtins.nixPath);
 in
   if (pathParts != []) then (builtins.head pathParts).path else ""


### PR DESCRIPTION
###### Motivation for this change
Fix evaluation of two tests.
yabar builds fine now, but not hocker fetchdocker.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

