### PR TITLE
alarm-clock-applet: fix build

### DIFF
--- a/pkgs/tools/misc/alarm-clock-applet/default.nix
+++ b/pkgs/tools/misc/alarm-clock-applet/default.nix
@@ -1,4 +1,9 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig
+{ stdenv, fetchFromGitHub
+, pkgconfig
+, autoconf
+, automake111x
+, libtool
+
 , glib
 , gtk2
 , gst_all_1
@@ -15,15 +20,26 @@ stdenv.mkDerivation rec {
   version = "0.3.4";
   name = "alarm-clock-applet-${version}";
 
-  src = fetchurl {
-    url = "http://launchpad.net/alarm-clock/trunk/${version}/+download/${name}.tar.gz";
-    sha256 = "1mrrw5cgv0izdmhdg83vprvbj6062yzk77b2nr1nx6hhmk00946r";
+  src = fetchFromGitHub {
+    owner = "joh";
+    repo = "alarm-clock";
+    rev = version;
+    sha256 = "18blvgy8hmw3jidz7xrv9yiiilnzcj65m6wxhw58nrnbcqbpydwn";
   };
 
   nativeBuildInputs = [
-    makeWrapper
     pkgconfig
+    intltool
+    automake111x
+    autoconf
+    libtool
+
+    gnome2.gnome-common
+
+    wrapGAppsHook
   ];
+
+  preConfigure = "./autogen.sh";
 
   buildInputs = [
     glib
@@ -34,8 +50,6 @@ stdenv.mkDerivation rec {
     libnotify
     libxml2
     libunique
-    intltool
-    wrapGAppsHook
   ] ++ gst_plugins;
 
   propagatedUserEnvPkgs = [ gnome2.GConf.out ];


### PR DESCRIPTION
###### Motivation for this change

The build has been failing because sourceforge-served release include
-Werror=format=2 flag, which enabled -Werror=format-y2k, which in turn
stopped the build because of a debug log message formatting.

Building release from GitHub works fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

