### PR TITLE
astroid: 0.11.1 -> 0.13

### DIFF
--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,22 +1,23 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, webkitgtk24x-gtk3
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, protobuf
 , libsass, notmuch, boost, wrapGAppsHook, glib-networking }:
 
 stdenv.mkDerivation rec {
   name = "astroid-${version}";
-  version = "0.11.1";
+  version = "0.13";
 
   src = fetchFromGitHub {
     owner = "astroidmail";
     repo = "astroid";
     rev = "v${version}";
-    sha256 = "1z48rvlzwi7bq7j55rnb0gg1a4k486yj910z2cxz1p46lxk332j1";
+    sha256 = "105x5g44hng3fi03h67j3an53088148jbq8726nmcp0zs0cy9gac";
   };
 
   nativeBuildInputs = [ cmake pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ gnome3.gtkmm gmime3 webkitgtk24x-gtk3 libsass gnome3.libpeas
-                  notmuch boost gnome3.gsettings-desktop-schemas
-                  glib-networking ];
+  buildInputs = [
+    boost glib-networking gmime3 gnome3.gsettings-desktop-schemas gnome3.gtkmm
+    gnome3.libpeas gnome3.webkitgtk libsass notmuch protobuf
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://astroidmail.github.io/;


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

