### PR TITLE
hyper-haskell: 0.1.0.2 -> 0.2.1.0

### DIFF
--- a/pkgs/development/tools/haskell/hyper-haskell/default.nix
+++ b/pkgs/development/tools/haskell/hyper-haskell/default.nix
@@ -5,13 +5,13 @@ let
 
 in stdenv.mkDerivation rec {
   name = "hyper-haskell-${version}";
-  version = "0.1.0.2";
+  version = "0.2.1.0";
 
   src = fetchFromGitHub {
     owner = "HeinrichApfelmus";
     repo = "hyper-haskell";
     rev = "v${version}";
-    sha256 = "1k38h7qx12z7463z8466pji0nwfkp4qkg7q83kns2mzmwmw5jnmb";
+    sha256 = "14ll7n1lbj4dqdwjq7kg5js97qca2wi2lsbq25h99z77njqf3c3n";
   };
 
   propagatedBuildInputs = extra-packages;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

