### PR TITLE
gdbm: avoid a warning on Darwin

### DIFF
--- a/pkgs/development/libraries/gdbm/default.nix
+++ b/pkgs/development/libraries/gdbm/default.nix
@@ -2,6 +2,8 @@
 
 stdenv.mkDerivation rec {
   name = "gdbm-1.17";
+  # FIXME: remove on update to > 1.17
+  NIX_CFLAGS_COMPILE = if stdenv.cc.isClang then "-Wno-error=return-type" else null;
 
   src = fetchurl {
     url = "mirror://gnu/gdbm/${name}.tar.gz";


### PR DESCRIPTION
This is just to minimize rebuilds.  The actual bugfix doesn't seem to
hurry, as the function has been returning void until now, so if the int
returned isn't a meaningful value in some cases, nothing should happen
yet.

- - -
No rebuild except on Darwin (where it was failing).

_I wasn't sure when this is required on cross-compilation, so the condition might be imprecise._