### PR TITLE
checksec: switch to binutils-unwrapped

### DIFF
--- a/pkgs/os-specific/linux/checksec/default.nix
+++ b/pkgs/os-specific/linux/checksec/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, file, findutils, binutils, glibc, coreutils, sysctl }:
+{ stdenv, fetchurl, file, findutils, binutils-unwrapped, glibc, coreutils, sysctl }:
 
 stdenv.mkDerivation rec {
   name = "checksec-${version}";
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/bin/checksec --replace find ${findutils}/bin/find
     substituteInPlace $out/bin/checksec --replace "file $" "${file}/bin/file $"
     substituteInPlace $out/bin/checksec --replace "xargs file" "xargs ${file}/bin/file"
-    substituteInPlace $out/bin/checksec --replace " readelf -" " ${binutils.out}/bin/readelf -"
-    substituteInPlace $out/bin/checksec --replace "(readelf -" "(${binutils.out}/bin/readelf -"
-    substituteInPlace $out/bin/checksec --replace "command_exists readelf" "command_exists ${binutils.out}/bin/readelf"
+    substituteInPlace $out/bin/checksec --replace " readelf -" " ${binutils-unwrapped}/bin/readelf -"
+    substituteInPlace $out/bin/checksec --replace "(readelf -" "(${binutils-unwrapped}/bin/readelf -"
+    substituteInPlace $out/bin/checksec --replace "command_exists readelf" "command_exists ${binutils-unwrapped}/bin/readelf"
     substituteInPlace $out/bin/checksec --replace "/sbin/sysctl -" "${sysctl}/bin/sysctl -"
     substituteInPlace $out/bin/checksec --replace "/usr/bin/id -" "${coreutils}/bin/id -"
   '';


### PR DESCRIPTION
###### Motivation for this change

checksec wasn't working because it couldn't find the readelf command.
This happened because binutils doesn't expose the readelf binary.


###### Things done

Change the derivation to depend on binutils-unwrapped instead, that does
expose the readelf binary.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

