### PR TITLE
[WIP] namecoin: nc0.15.99-name-tab-beta2 -> nc0.16.2

### DIFF
--- a/pkgs/applications/altcoins/namecoin.nix
+++ b/pkgs/applications/altcoins/namecoin.nix
@@ -3,14 +3,14 @@
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
-  version = "nc0.15.99-name-tab-beta2";
+  version = "nc0.16.2";
   name = "namecoin" + toString (optional (!withGui) "d") + "-" + version;
 
   src = fetchFromGitHub {
     owner = "namecoin";
     repo = "namecoin-core";
     rev = version;
-    sha256 = "1r0v0yvlazmidxp6xhapbdawqb8fhzrdp11d4an5vgxa208s6wdf";
+    sha256 = "0msjpzx8zb9pk9h3p2z5wbv679nq5aywg1q4bm5x04x3nszwfvyf";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Was outdated. Running it currently I'm having some trouble with the display of transactions (they show as unknown), I'll see if starting fresh will solve this (I used the beta version for half the state I currently have).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

