### PR TITLE
emby: 3.4.1.0 -> 3.5.2.0

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono46, ffmpeg, ... }:
+{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono, ffmpeg, ... }:
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.4.1.0";
+  version = "3.5.2.0";
 
   src = fetchurl {
-    url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "08jr6v8xhmiwbby0lfvpjrlma280inwh5qp6v4p93lzd07fjynh5";
+    url = "https://github.com/MediaBrowser/Emby.Releases/releases/download/${version}/embyserver-mono_${version}.zip";
+    sha256 = "12f9skvnr9qxnrvr3q014yggfwvkpjk0ynbgf0fwk56h4kal7fx8";
   };
 
   buildInputs = with pkgs; [
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
   propagatedBuildInputs = with pkgs; [
-    mono46
+    mono
     sqlite
   ];
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -r * $out/bin
 
-    makeWrapper "${mono46}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
+    makeWrapper "${mono}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
       --add-flags "$out/bin/MediaBrowser.Server.Mono.exe -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 


### PR DESCRIPTION
This version requires Mono 5.4 or higher, so let's just use
the default (5.8 at the moment).

###### Motivation for this change

Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @fadenb
