### PR TITLE
ats-pkg init at 3.2.1.8

### DIFF
--- a/pkgs/development/tools/ats-pkg/default.nix
+++ b/pkgs/development/tools/ats-pkg/default.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, ansi-wl-pprint, base, binary, bytestring, bzlib
+, Cabal, cli-setup, composition-prelude, containers, cpphs
+, dependency, dhall, directory, file-embed, filemanip, filepath
+, http-client, http-client-tls, lzma, microlens, mtl
+, optparse-applicative, parallel-io, process, shake, shake-ats
+, shake-c, shake-ext, stdenv, tar, temporary, text, unix
+, zip-archive, zlib
+}:
+mkDerivation {
+  pname = "ats-pkg";
+  version = "3.2.1.8";
+  src = fetchFromGitHub {
+    owner = "vmchale";
+    repo = "atspkg";
+    rev = "${version}";
+    sha256 = "10ncx90dd4z0hsb0rfr5lvsp8293s8h90k6q0xrfjs67gy0v20c7";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    ansi-wl-pprint base binary bytestring bzlib Cabal
+    composition-prelude containers dependency dhall directory
+    file-embed filemanip filepath http-client http-client-tls lzma
+    microlens mtl parallel-io process shake shake-ats shake-c shake-ext
+    tar text unix zip-archive zlib
+  ];
+  libraryToolDepends = [ cpphs ];
+  executableHaskellDepends = [
+    base bytestring cli-setup dependency directory microlens
+    optparse-applicative parallel-io shake shake-ats temporary text
+  ];
+  doHaddock = false;
+  description = "A build tool for ATS";
+  license = stdenv.lib.licenses.bsd3;
+  maintainers = with maintainers; [ vmchale bbarker ];
+}

--- a/pkgs/development/tools/ats-pkg/default.nix
+++ b/pkgs/development/tools/ats-pkg/default.nix
@@ -7,15 +7,15 @@
 , zip-archive, zlib
 }:
 let
-  version = "3.2.1.8";
+  ats-pkg-version = "3.2.1.8";
 in
 stdenv.mkDerivation rec {
-  pname = "ats-pkg";
-  version = "${version}";
+  name = "ats-pkg";
+  version = "${ats-pkg-version}";
   src = fetchFromGitHub {
     owner = "vmchale";
     repo = "atspkg";
-    rev = "${version}";
+    rev = "${ats-pkg-version}";
     sha256 = "10ncx90dd4z0hsb0rfr5lvsp8293s8h90k6q0xrfjs67gy0v20c7";
   };
   isLibrary = true;
@@ -34,7 +34,10 @@ stdenv.mkDerivation rec {
     optparse-applicative parallel-io shake shake-ats temporary text
   ];
   doHaddock = false;
-  description = "A build tool for ATS";
-  license = stdenv.lib.licenses.bsd3;
-  maintainers = with stdenv.lib.maintainers; [ vmchale bbarker ];
+  meta = with stdenv.lib; {
+    description = "A build tool for ATS";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ vmchale bbarker ];
+    homepage = "https://hackage.haskell.org/package/ats-pkg";
+  };
 }

--- a/pkgs/development/tools/ats-pkg/default.nix
+++ b/pkgs/development/tools/ats-pkg/default.nix
@@ -9,7 +9,7 @@
 let
   version = "3.2.1.8";
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "ats-pkg";
   version = "${version}";
   src = fetchFromGitHub {

--- a/pkgs/development/tools/ats-pkg/default.nix
+++ b/pkgs/development/tools/ats-pkg/default.nix
@@ -1,14 +1,17 @@
-{ mkDerivation, ansi-wl-pprint, base, binary, bytestring, bzlib
+{ ansi-wl-pprint, base, binary, bytestring, bzlib
 , Cabal, cli-setup, composition-prelude, containers, cpphs
-, dependency, dhall, directory, file-embed, filemanip, filepath
-, http-client, http-client-tls, lzma, microlens, mtl
+, dependency, dhall, directory, fetchFromGitHub, file-embed, filemanip
+, filepath, http-client, http-client-tls, lzma, microlens, mtl
 , optparse-applicative, parallel-io, process, shake, shake-ats
 , shake-c, shake-ext, stdenv, tar, temporary, text, unix
 , zip-archive, zlib
 }:
-mkDerivation {
-  pname = "ats-pkg";
+let
   version = "3.2.1.8";
+in
+stdenv.mkDerivation {
+  pname = "ats-pkg";
+  version = "${version}";
   src = fetchFromGitHub {
     owner = "vmchale";
     repo = "atspkg";
@@ -33,5 +36,5 @@ mkDerivation {
   doHaddock = false;
   description = "A build tool for ATS";
   license = stdenv.lib.licenses.bsd3;
-  maintainers = with maintainers; [ vmchale bbarker ];
+  maintainers = with stdenv.lib.maintainers; [ vmchale bbarker ];
 }

--- a/pkgs/development/tools/ats-pkg/default.nix
+++ b/pkgs/development/tools/ats-pkg/default.nix
@@ -7,7 +7,7 @@
 , zip-archive, zlib
 }:
 let
-  ats-pkg-version = "3.2.1.8";
+  ats-pkg-version = "3.2.1.9";
 in
 stdenv.mkDerivation rec {
   name = "ats-pkg";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     owner = "vmchale";
     repo = "atspkg";
     rev = "${ats-pkg-version}";
-    sha256 = "10ncx90dd4z0hsb0rfr5lvsp8293s8h90k6q0xrfjs67gy0v20c7";
+    sha256 = "0yzvnrnrdxyfx4h6r77qfb4vkzmx6x16p77bpfx1vr67z64krbaf";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/development/tools/ats-pkg/default.nix
+++ b/pkgs/development/tools/ats-pkg/default.nix
@@ -7,7 +7,7 @@
 , zip-archive, zlib
 }:
 let
-  ats-pkg-version = "3.2.1.9";
+  ats-pkg-version = "3.2.1.12";
 in
 stdenv.mkDerivation rec {
   name = "ats-pkg";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7921,7 +7921,7 @@ with pkgs;
 
   astyle = callPackage ../development/tools/misc/astyle { };
 
-  ats-pkg = callPackage ../development/tools/ats-pkg { };
+  ats-pkg = haskellPackages.callPackage ../development/tools/ats-pkg { };
 
   awf = callPackage ../development/tools/misc/awf { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7921,6 +7921,8 @@ with pkgs;
 
   astyle = callPackage ../development/tools/misc/astyle { };
 
+  ats-pkg = callPackage ../development/tools/ats-pkg { };
+
   awf = callPackage ../development/tools/misc/awf { };
 
   electron = callPackage ../development/tools/electron { };


### PR DESCRIPTION
###### Motivation for this change

Allow more ATS packages to be built in Nix

###### Things done

I actually haven't tested this locally, and suspect I did something stupid (or didn't do something smart) because `nix-env -I nixpkgs=/home/brandon/workspace/nixpkgs -i ats-pkg` fails with `error: selector 'ats-pkg' matches no derivations `.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

