### PR TITLE
Fix licenses (#43716)

### DIFF
--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     description = "A tool that shows statistics about SQLite databases";
     downloadPage = http://sqlite.org/download.html;
     homepage = http://www.sqlite.org;
+    license = licenses.publicDomain;
     maintainers = with maintainers; [ pesterhazy ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
     description = "A self-contained, serverless, zero-configuration, transactional SQL database engine";
     downloadPage = http://sqlite.org/download.html;
     homepage = http://www.sqlite.org/;
+    license = licenses.publicDomain;
     maintainers = with maintainers; [ eelco np ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/sqlite/sqlar.nix
+++ b/pkgs/development/libraries/sqlite/sqlar.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://sqlite.org/sqlar;
     description = "SQLite Archive utilities";
+    license = licenses.bsd2;
     platforms = platforms.all;
     maintainers = with maintainers; [ dtzWill ];
   };

--- a/pkgs/development/tools/sqsh/default.nix
+++ b/pkgs/development/tools/sqsh/default.nix
@@ -34,6 +34,7 @@ in stdenv.mkDerivation rec {
       it is intended as a replacement for the venerable 'isql' program supplied
       by Sybase.
     '';
+    license = licenses.gpl2;
     homepage = https://sourceforge.net/projects/sqsh/;
     platforms = platforms.all;
   };

--- a/pkgs/tools/filesystems/sshfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/sshfs-fuse/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     inherit (src.meta) homepage;
     description = "FUSE-based filesystem that allows remote filesystems to be mounted over SSH";
     platforms = platforms.linux;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ primeos ];
   };
 }

--- a/pkgs/tools/networking/sshpass/default.nix
+++ b/pkgs/tools/networking/sshpass/default.nix
@@ -9,10 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "0q7fblaczb7kwbsz0gdy9267z0sllzgmf0c7z5c9mf88wv74ycn6";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/sshpass/;
     description = "Non-interactive ssh password auth";
-    maintainers = [ stdenv.lib.maintainers.madjar ];
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.madjar ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/networking/ssmtp/default.nix
+++ b/pkgs/tools/networking/ssmtp/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ basvandijk ];
   };
 }

--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -45,6 +45,7 @@ python3Packages.buildPythonApplication rec {
       target network (though it does require Python 2 at both ends).
       Works with Linux and Mac OS and supports DNS tunneling.
     '';
+    license = licenses.gpl2;
     maintainers = with maintainers; [ domenkozar ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/43716

###### Things done
Added licenses for the following deviations:
* sqlar
* sqlite (includes sqlite-interactive, sqliteInteractive)
* sqlite-analyzer (includes sqlite3_analyzer)
* sqsh
* sshfs (includes: sshfs-fuse, sshfsFuse)
* sshpass
* sshuttle
* ssmtp

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

