### PR TITLE
libvirt: fix dlopen("libjansson.so.4")

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -59,6 +59,10 @@ in stdenv.mkDerivation rec {
     substituteInPlace src/lxc/lxc_conf.c \
       --replace 'lxc_path,' '"/run/libvirt/nix-emulators/libvirt_lxc",'
 
+    [ -f ${jansson}/lib/libjansson.so.4 ] || exit 1
+    substituteInPlace src/util/virjsoncompat.c \
+      --replace '"libjansson.so.4"' '"${jansson}/lib/libjansson.so.4"'
+
     patchShebangs . # fixes /usr/bin/python references
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix for [another regression of libvirt 4.5.0->4.6.0 update](https://github.com/NixOS/nixpkgs/pull/44566#issuecomment-412269173)

@Izorkin @Mic92 