### PR TITLE
python/grpcio: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, buildPythonPackage, fetchPypi, lib
-, six, protobuf, enum34, futures, isPy27, isPy34 }:
+{ stdenv, buildPythonPackage, fetchPypi, lib, darwin
+, six, protobuf, enum34, futures, isPy27, isPy34, pkgconfig }:
 
+with stdenv.lib;
 buildPythonPackage rec {
   pname = "grpcio";
   version = "1.13.0";
@@ -10,9 +11,13 @@ buildPythonPackage rec {
     sha256 = "6324581e215157f0fbe335dff2e21a65b4406db98ac7cca05f1e23b4f510b426";
   };
 
+  nativeBuildInputs = [ pkgconfig ] ++ optional stdenv.isDarwin darwin.cctools;
+
   propagatedBuildInputs = [ six protobuf ]
                         ++ lib.optionals (isPy27 || isPy34) [ enum34 ]
                         ++ lib.optionals (isPy27) [ futures ];
+
+  preBuild = optionalString stdenv.isDarwin "unset AR";
 
   meta = with stdenv.lib; {
     description = "HTTP/2-based RPC framework";


### PR DESCRIPTION
grpcio currently does not build on Darwin (10.13.6). Due to the
following issues:

* ar is invoked with incorrect flags (#33765).
* libtool cannot be found, with a libtool dependency, with libtool
  the option '-no_warning_for_no_symbols' is not recognized.
* the module build cannot find boringssl that is packaged with
  python-grpcio when pkgconfig is not installed (grpc/#10058).

###### Motivation for this change

See above. Unfortunately, I could not test on NixOS, since I am in an airport ;).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

