### PR TITLE
Revert "nix-repl: Remove"

### DIFF
--- a/pkgs/tools/package-management/nix-repl/default.nix
+++ b/pkgs/tools/package-management/nix-repl/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchFromGitHub, nix, readline }:
+
+let rev = "a1ea85e92b067a0a42354a28355c633eac7be65c"; in
+
+stdenv.mkDerivation {
+  name = "nix-repl-${lib.getVersion nix}-2016-02-28";
+
+  src = fetchFromGitHub {
+    owner = "edolstra";
+    repo = "nix-repl";
+    inherit rev;
+    sha256 = "0rf9711day64lgg6g6yqc5709x4sgj137zpqyn019k764i7m2xs8";
+  };
+
+  buildInputs = [ nix readline ];
+
+  dontBuild = true;
+
+  # FIXME: unfortunate cut&paste.
+  installPhase = ''
+    mkdir -p $out/bin
+    $CXX -O3 -Wall -std=c++0x \
+      -o $out/bin/nix-repl nix-repl.cc \
+      -I${nix.dev}/include/nix \
+      -lnixformat -lnixutil -lnixstore -lnixexpr -lnixmain -lreadline -lgc \
+      -DNIX_VERSION=\"${(builtins.parseDrvName nix.name).version}\"
+  '';
+
+  meta = {
+    homepage = https://github.com/edolstra/nix-repl;
+    description = "An interactive environment for evaluating and building Nix expressions";
+    maintainers = [ lib.maintainers.eelco ];
+    license = lib.licenses.gpl3;
+    platforms = nix.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21423,6 +21423,8 @@ with pkgs;
 
   nix-top = callPackage ../tools/package-management/nix-top { };
 
+  nix-repl = callPackage ../tools/package-management/nix-repl { nix = nix1; };
+
   nix-review = callPackage ../tools/package-management/nix-review { };
 
   nix-serve = callPackage ../tools/package-management/nix-serve { };


### PR DESCRIPTION
This reverts commit 490ca6aa8ae89d0639e1e148774c3cd426fc699a.

The minimum required Nix version for nixpkgs is still only 1.11, which
means we can't expect people to have `nix repl` available. Removing
nix-repl therefore removes potentially the only nix-repl available to
some people.

We should at least wait until the minimum version is bumped to 2.0, which might only happen in 19.03, see https://github.com/NixOS/nixpkgs/pull/37693. And then it should be a warning in the form of

```nix
{
  # ...
  nix-repl = throw "nix-repl has been retired for nix repl";
  # ...
}
```

Ping @edolstra

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

