### PR TITLE
lhapdf: fix "lhapdf list" interactive tool

### DIFF
--- a/pkgs/development/libraries/physics/lhapdf/default.nix
+++ b/pkgs/development/libraries/physics/lhapdf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python2 }:
+{ stdenv, fetchurl, python2, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "lhapdf-${version}";
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0bi02xcmq5as0wf0jn6i3hx0qy0hj61m02sbrbzd1gwjhpccwmvd";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ python2 ];
 
   enableParallelBuilding = true;
@@ -16,6 +17,10 @@ stdenv.mkDerivation rec {
   passthru = {
     pdf_sets = import ./pdf_sets.nix { inherit stdenv fetchurl; };
   };
+
+  postInstall = ''
+    wrapProgram $out/bin/lhapdf --prefix PYTHONPATH : "$(toPythonPath "$out")"
+  '';
 
   meta = {
     description = "A general purpose interpolator, used for evaluating Parton Distribution Functions from discretised data files";


### PR DESCRIPTION
In version 6.2.1 the "list" command now uses python bindings, which need
to be imported, so we need to set the PYTHONPATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

