### PR TITLE
.github/CODEOWNERS: Add myself as for some stdenv stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,8 @@
 /pkgs/top-level/default.nix           @nbp @Ericson2314
 /pkgs/top-level/impure.nix            @nbp @Ericson2314
 /pkgs/top-level/stage.nix             @nbp @Ericson2314
-/pkgs/stdenv
+/pkgs/stdenv/generic                  @Ericson2314
+/pkgs/stdenv/cross                    @Ericson2314
 /pkgs/build-support/cc-wrapper        @Ericson2314 @orivej
 /pkgs/build-support/bintools-wrapper  @Ericson2314 @orivej
 /pkgs/build-support/setup-hooks       @Ericson2314


### PR DESCRIPTION
###### Motivation for this change

- `pkgs/stdenv/cross` is a small, low-churn, subtree. But hopefully this indicates people can bug me generally about cross things.
- `/pkgs/stdenv/generic` because it was heavily modified as part of the cross work. I'd love for someone else to join me on this one!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

