### PR TITLE
zathura: keep wrapper's WM_CLASS consistent with unwrapped binary

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "1znr3psqda06xklzj8mn452w908llapcg1rj468jwpg0wzv6pxfn";
   };
 
+  outputs = [ "bin" "man" "dev" "out" ];
+
   nativeBuildInputs = [
     meson ninja pkgconfig appstream-glib desktop-file-utils python3.pkgs.sphinx
     gettext makeWrapper libxml2

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, meson, ninja, makeWrapper, pkgconfig
 , appstream-glib, desktop-file-utils, python3
 , gtk, girara, gettext, libxml2
-, file, sqlite, glib, texlive, libintl, libseccomp
+, sqlite, glib, texlive, libintl, libseccomp
 , gtk-mac-integration, synctexSupport ? true
 }:
 
@@ -24,15 +24,10 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    file gtk girara libintl libseccomp
+    gtk girara libintl libseccomp
     sqlite glib
   ] ++ optional synctexSupport texlive.bin.core
     ++ optional stdenv.isDarwin [ gtk-mac-integration ];
-
-  postInstall = ''
-    wrapProgram "$out/bin/zathura" \
-      --prefix PATH ":" "${makeBinPath [ file ]}"
-  '';
 
   meta = {
     homepage = https://pwmt.org/projects/zathura/;

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -6,12 +6,12 @@ let
 in symlinkJoin {
   name = "zathura-with-plugins-${zathura_core.version}";
 
-  paths = [ zathura_core ];
+  paths = with zathura_core; [ man dev out ];
 
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/zathura \
+    makeWrapper ${zathura_core.bin}/bin/zathura $out/bin/zathura \
       --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
       --add-flags --plugins-dir=${pluginsPath}
   '';

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, lib, makeWrapper, zathura_core, plugins ? [] }:
+{ symlinkJoin, lib, makeWrapper, zathura_core, file, plugins ? [] }:
 
 let
   pluginsPath = lib.makeSearchPath "lib/zathura" plugins;
@@ -11,7 +11,9 @@ in symlinkJoin {
   buildInputs = [ makeWrapper ];
 
   postBuild = ''
-    wrapProgram $out/bin/zathura --add-flags --plugins-dir=${pluginsPath}
+    wrapProgram $out/bin/zathura \
+      --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
+      --add-flags --plugins-dir=${pluginsPath}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

zathura's `WM_CLASS` property is inconsistent with what it was in the unwrapped zathura.
```
$ xprop | grep WM_CLASS
WM_CLASS(STRING) = ".zathura-wrapped_", ".zathura-wrapped_"
```

This makes some trouble when, in my case, adding a window rule for zathura in bspwm. I expected the following rule works:
```
bspc rule --add Zathura state=tiled
```
But actually I needed to do this:
```
bspc rule --add .zathura-wrapped_ state=tiled
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

