### PR TITLE
Criterion package

### DIFF
--- a/pkgs/development/libraries/boxfort/default.nix
+++ b/pkgs/development/libraries/boxfort/default.nix
@@ -1,0 +1,21 @@
+{stdenv, fetchFromGitHub, cmake} :
+
+stdenv.mkDerivation {
+  name = "boxfort-0.0.1";
+  src = fetchFromGitHub {
+    owner = "diacritic";
+    repo = "BoxFort";
+    rev = "4bac60bf13a49eadb76f55343164cbe8199b8d66";
+    sha256 = "1y3iywqhplffrmmydplkc9641ndyp7x8wq9h7ap5083s6ff5nk1g";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    homepage = "https://github.com/diacritic/BoxFort";
+    description = "A simple, cross-platform sandboxing C library powering Criterion";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/libraries/criterion/default.nix
+++ b/pkgs/development/libraries/criterion/default.nix
@@ -1,0 +1,25 @@
+{stdenv, pkgconfig, fetchFromGitHub, cmake, dyncall, nanomsg, boxfort, csptr, libgit2} :
+
+stdenv.mkDerivation {
+  name = "criterion-2.3.2";
+  src = fetchFromGitHub {
+    owner = "Snaipe";
+    repo = "Criterion";
+    rev = "9b70365825aced7333d7867bb5c64c63919ce510";
+    sha256 = "1i1ccgrnsq8ka5a0hfipd48baya138m2v411myg6jqkhwknplzz9";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ dyncall boxfort csptr nanomsg libgit2 ];
+
+  LIBGIT2_SYS_USE_PKG_CONFIG=1;
+
+  meta = {
+    homepage = "https://github.com/Snaipe/Criterion";
+    description = "A cross-platform C and C++ unit testing framework for the 21th century";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/development/libraries/csptr/default.nix
+++ b/pkgs/development/libraries/csptr/default.nix
@@ -1,0 +1,21 @@
+{stdenv, fetchFromGitHub, cmake} :
+
+stdenv.mkDerivation {
+  name = "csptr-2.0.4";
+  src = fetchFromGitHub {
+    owner = "Snaipe";
+    repo = "libcsptr";
+    rev = "82d3b1beafe7ed9f13f75e0d3367c60205e10f27";
+    sha256 = "0i1498h2i6zq3fn3zf3iw7glv6brn597165hnibgwccqa8sh3ich";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    homepage = "https://github.com/Snaipe/libcsptr";
+    description = "This project is an attempt to bring smart pointer constructs to the (GNU) C programming language";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8871,6 +8871,8 @@ with pkgs;
   botan = callPackage ../development/libraries/botan { };
   botan2 = callPackage ../development/libraries/botan/2.0.nix { };
 
+  boxfort = callPackage ../development/libraries/boxfort { };
+
   box2d = callPackage ../development/libraries/box2d { };
 
   buddy = callPackage ../development/libraries/buddy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8984,6 +8984,8 @@ with pkgs;
 
   coredumper = callPackage ../development/libraries/coredumper { };
 
+  criterion = callPackage ../development/libraries/criterion { };
+
   ctl = callPackage ../development/libraries/ctl { };
 
   ctpp2 = callPackage ../development/libraries/ctpp2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9013,6 +9013,8 @@ with pkgs;
 
   cryptominisat = callPackage ../applications/science/logic/cryptominisat { };
 
+  csptr = callPackage ../development/libraries/csptr { };
+
   curlcpp = callPackage ../development/libraries/curlcpp { };
 
   cutee = callPackage ../development/libraries/cutee { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to use Criterion as my unit testing framework, but it wasn't present yet as a nixos package.
These are the first packages I've added, so it's best if someone thoroughly looks at this request.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

