### PR TITLE
dcraw: fix build on Darwin

### DIFF
--- a/pkgs/tools/graphics/dcraw/default.nix
+++ b/pkgs/tools/graphics/dcraw/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, libjpeg, lcms2, gettext, jasper }:
+{stdenv, fetchurl, libjpeg, lcms2, gettext, jasper, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "dcraw-9.28.0";
@@ -8,15 +8,18 @@ stdenv.mkDerivation rec {
     sha256 = "1fdl3xa1fbm71xzc3760rsjkvf0x5jdjrvdzyg2l9ka24vdc7418";
   };
 
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
   buildInputs = [ libjpeg lcms2 gettext jasper ];
 
   patchPhase = ''
-    sed -i -e s@/usr/local@$out@ install
+    substituteInPlace install \
+      --replace 'prefix=/usr/local' 'prefix=$out' \
+      --replace gcc '$CC'
   '';
 
   buildPhase = ''
     mkdir -p $out/bin
-    sh install
+    sh -e install
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Noticed it was broken. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

