### PR TITLE
postgresql: fix tzdata path

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -29,7 +29,7 @@ let
       "--with-libxml"
       "--sysconfdir=/etc"
       "--libdir=$(lib)/lib"
-      "--with-system-tzdata=${tzdata}"
+      "--with-system-tzdata=${tzdata}/share/zoneinfo"
       (if stdenv.isDarwin then "--with-uuid=e2fs" else "--with-ossp-uuid")
     ];
 


### PR DESCRIPTION
###### Motivation for this change

The timezone path is set incorrectly. Since e8682cafd6106ff33a589fc644fa5294a86b14c0 `tzdata` is used by default which broke my PostgreSQL installations.

PostgreSQL does use the full path to the timezone files as zone name. Thus the following does currently not work:

```
SELECT now() AT TIME ZONE 'Europe/Vienna';
```

While this does:

```
SELECT now() AT TIME ZONE 'share/zoneinfo/Europe/Vienna';
```

Timezone names can also be checked with:

```
SELECT * from pg_timezone_names;
```

This patch corrects the path set during configuration.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@ocharles, @dingxiangfei2009