### PR TITLE
libxnd and libndypes: init at 0.2.0dev3

### DIFF
--- a/pkgs/development/libraries/libndtypes/default.nix
+++ b/pkgs/development/libraries/libndtypes/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  name = "libndtypes-${version}";
+  version = "0.2.0dev3";
+
+  src = fetchFromGitHub {
+    owner = "plures";
+    repo = "ndtypes";
+    rev = "v${version}";
+    sha256 = "0dpvv13mrid8l5zkjlz18qvirz3nr0v98agx9bcvkqbiahlfgjli";
+  };
+
+  makeFlags = [ "CONFIGURE_LDFLAGS='-shared'" ];
+
+  meta = {
+    description = "Dynamic types for data description and in-memory computations";
+    homepage = https://xnd.io/;
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/libraries/libxnd/default.nix
+++ b/pkgs/development/libraries/libxnd/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, libndtypes
+}:
+
+stdenv.mkDerivation rec {
+  name = "libxnd-${version}";
+  version = "0.2.0dev3";
+
+  src = fetchFromGitHub {
+    owner = "plures";
+    repo = "xnd";
+    rev = "v${version}";
+    sha256 = "0byq7jspyr2wxrhihw4q7nf0y4sb6j5ax0ndd5dnq5dz88c7qqm2";
+  };
+
+  buildInputs = [ libndtypes ];
+
+  configureFlags = [ "XND_INCLUDE='-I${libndtypes}/include'"
+                     "XND_LINK='-L${libndtypes}/lib'" ];
+
+  makeFlags = [ "CONFIGURE_LDFLAGS='-shared'" ];
+
+  meta = {
+    description = "General container that maps a wide range of Python values directly to memory";
+    homepage = https://xnd.io/;
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1390,6 +1390,8 @@ with pkgs;
 
   libndtypes = callPackages ../development/libraries/libndtypes { };
 
+  libxnd = callPackages ../development/libraries/libxnd { };
+
   loadwatch = callPackage ../tools/system/loadwatch { };
 
   loccount = callPackage ../development/tools/misc/loccount { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1388,6 +1388,8 @@ with pkgs;
 
   lief = callPackage ../development/libraries/lief {};
 
+  libndtypes = callPackages ../development/libraries/libndtypes { };
+
   loadwatch = callPackage ../tools/system/loadwatch { };
 
   loccount = callPackage ../development/tools/misc/loccount { };


### PR DESCRIPTION
###### Motivation for this change

Wanted to experiment with xnd package in nix so created packaging description.

###### Things done

libxnd: init at 0.2.0dev3
libndtypes: init at 0.2.0dev3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

