### PR TITLE
bumblebee: allow the use of different driver versions

### DIFF
--- a/nixos/modules/hardware/video/bumblebee.nix
+++ b/nixos/modules/hardware/video/bumblebee.nix
@@ -55,6 +55,14 @@ in
         '';
       };
 
+      package = mkOption {
+        default = kernel.nvidia_x11;
+        type = types.package;
+        description  = ''
+          Name of the driver package to use
+        '';
+      };
+
       driver = mkOption {
         default = "nvidia";
         type = types.enum [ "nvidia" "nouveau" ];
@@ -77,7 +85,7 @@ in
   config = mkIf cfg.enable {
     boot.blacklistedKernelModules = [ "nvidia-drm" "nvidia" "nouveau" ];
     boot.kernelModules = optional useBbswitch "bbswitch";
-    boot.extraModulePackages = optional useBbswitch kernel.bbswitch ++ optional useNvidia kernel.nvidia_x11.bin;
+    boot.extraModulePackages = optional useBbswitch kernel.bbswitch ++ optional useNvidia cfg.package.bin;
 
     environment.systemPackages = [ bumblebee primus ];
 


### PR DESCRIPTION
###### Motivation for this change
Not really perfect, though allows me to use the short-lived branch with a bit of extra configuration. `nvidia_x11_beta` is set to the short-lived branch on my nixpkgs.

```nix
  nixpkgs = {
    overlays = [
      (self: super: {
        bumblebee = super.bumblebee.override {
          nvidia_x11 = config.boot.kernelPackages.nvidia_x11_beta;
        };
      })
    ];
  };
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

