### PR TITLE
darktable: Fix compilation on macOS

### DIFF
--- a/pkgs/development/libraries/lensfun/default.nix
+++ b/pkgs/development/libraries/lensfun/default.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
   configureFlags = "-v";
 
   meta = with stdenv.lib; {
-    platforms = platforms.linux;
-    maintainers = [ ];
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ enzime ];
     license = stdenv.lib.licenses.lgpl3;
     description = "An opensource database of photographic lenses and their characteristics";
     homepage = http://lensfun.sourceforge.net/;

--- a/pkgs/development/libraries/osm-gps-map/default.nix
+++ b/pkgs/development/libraries/osm-gps-map/default.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation rec {
     homepage = https://nzjrs.github.io/osm-gps-map;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ hrdinka ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested without sandbox on macOS
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

