### PR TITLE
nixos/lightdm-gtk-greeter: make it overridable by other greeters

### DIFF
--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/enso-os.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/enso-os.nix
@@ -148,12 +148,6 @@ in {
         package = wrappedEnsoGreeter;
         name = "lightdm-enso-os-greeter";
       };
-
-      greeters = {
-        gtk = {
-          enable = mkDefault false;
-        };
-      };
     };
   };
 }

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -150,7 +150,7 @@ in
 
   config = mkIf (ldmcfg.enable && cfg.enable) {
 
-    services.xserver.displayManager.lightdm.greeter = mkDefault {
+    services.xserver.displayManager.lightdm.greeter = mkOptionDefault {
       package = wrappedGtkGreeter;
       name = "lightdm-gtk-greeter";
     };

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -148,14 +148,19 @@ in
 
   };
 
-  config = mkIf (ldmcfg.enable && cfg.enable) {
+  config = mkMerge [
+    (mkIf (ldmcfg.enable && cfg.enable) {
 
-    services.xserver.displayManager.lightdm.greeter = mkOptionDefault {
-      package = wrappedGtkGreeter;
-      name = "lightdm-gtk-greeter";
-    };
+      services.xserver.displayManager.lightdm.greeter = mkOptionDefault {
+        package = wrappedGtkGreeter;
+        name = "lightdm-gtk-greeter";
+      };
 
-    environment.etc."lightdm/lightdm-gtk-greeter.conf".source = gtkGreeterConf;
+    })
+    (mkIf (ldmcfg.enable && cfg.enable && ldmcfg.greeter.name == "lightdm-gtk-greeter") {
 
-  };
+      environment.etc."lightdm/lightdm-gtk-greeter.conf".source = gtkGreeterConf;
+
+    })
+  ];
 }

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
@@ -87,8 +87,6 @@ in
 
   config = mkIf (ldmcfg.enable && cfg.enable) {
 
-    services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
-
     services.xserver.displayManager.lightdm.greeter = mkDefault {
       package = xgreeters;
       name = "lightdm-mini-greeter";

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -74,9 +74,6 @@ let
   defaultSessionName = dmDefault + optionalString (wmDefault != "none") ("+" + wmDefault);
 in
 {
-  # Note: the order in which lightdm greeter modules are imported
-  # here determines the default: later modules (if enable) are
-  # preferred.
   imports = [
     ./lightdm-greeters/gtk.nix
     ./lightdm-greeters/mini.nix


### PR DESCRIPTION
###### Motivation for this change

So that we do not have to care about the order to import greeters modules: https://github.com/NixOS/nixpkgs/blob/bb3f7d14a17e88e4341872c55d8b32127c6f8101/nixos/modules/services/x11/display-managers/lightdm.nix#L70-L76

<s>Moreover, I added the second commit in which gtk greeter is disabled automatically if any other greeter is enabled.</s> Currently, every time when adding a greeter module, one has to add
```
services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
```
in the config section. By this PR, no need to do it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

