### PR TITLE
efibootmgr: 16 -> 17

### DIFF
--- a/pkgs/tools/system/efibootmgr/default.nix
+++ b/pkgs/tools/system/efibootmgr/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "efibootmgr-${version}";
-  version = "16";
+  version = "17";
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     owner = "rhboot";
     repo = "efibootmgr";
     rev = version;
-    sha256 = "0b27h8vf1b6laln5n0wk2hkzyyh87sxanj7wrz9kimyx03dcq6vi";
+    sha256 = "1niicijxg59rsmiw3rsjwy4bvi1n42dynvm01lnp9haixdzdpq03";
   };
 
   makeFlags = [ "EFIDIR=nixos" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

