### PR TITLE
kubectx: init at v0.5.1

### DIFF
--- a/pkgs/development/tools/kubectx/default.nix
+++ b/pkgs/development/tools/kubectx/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchFromGitHub, kubectl, makeWrapper }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "kubectx";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "ahmetb";
+    repo = "${name}";
+    rev = "v${version}";
+    sha256 = "1bmmaj5fffx4hy55l6x4vl5gr9rp2yhg4vs5b9sya9rjvdkamdx5";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp kubectx $out/bin
+    cp kubens $out/bin
+
+    for f in $out/bin/*; do
+      wrapProgram $f --prefix PATH : ${makeBinPath [ kubectl ]}
+    done
+  '';
+
+  meta = {
+    description = "Fast way to switch between clusters and namespaces in kubectl!";
+    license = licenses.asl20;
+    homepage = https://github.com/ahmetb/kubectx;
+    maintainers = with maintainers; [ periklis ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8315,6 +8315,8 @@ with pkgs;
 
   kube-aws = callPackage ../development/tools/kube-aws { };
 
+  kubectx = callPackage ../development/tools/kubectx { };
+
   kustomize = callPackage ../development/tools/kustomize { };
 
   Literate = callPackage ../development/tools/literate-programming/Literate {};


### PR DESCRIPTION
###### Motivation for this change
Provides two simple bash utilities to make switching between different kubernetes clusters (e.g. dev, prod, minikube) as well as namespaces inside a cluster an easy task.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

