### PR TITLE
stdenv: linux: inherit texinfo in stage4 instead of the final stdenv

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -263,7 +263,7 @@ in
       # because gcc (since JAR support) already depends on zlib, and
       # then if we already have a zlib we want to use that for the
       # other purposes (binutils and top-level pkgs) too.
-      inherit (prevStage) gettext gnum4 bison gmp perl zlib linuxHeaders;
+      inherit (prevStage) gettext gnum4 bison gmp perl texinfo zlib linuxHeaders;
       ${localSystem.libc} = getLibc prevStage;
       binutils = super.binutils.override {
         # Don't use stdenv's shell but our own
@@ -344,7 +344,6 @@ in
         concatMap (p: [ (getBin p) (getLib p) ])
           [ gzip bzip2 xz bash binutils.bintools coreutils diffutils findutils
             gawk gnumake gnused gnutar gnugrep gnupatch patchelf ed paxctl
-            texinfo
           ]
         # Library dependencies
         ++ map getLib (
@@ -363,7 +362,7 @@ in
         inherit (prevStage)
           gzip bzip2 xz bash coreutils diffutils findutils gawk
           gnumake gnused gnutar gnugrep gnupatch patchelf
-          attr acl paxctl zlib pcre texinfo;
+          attr acl paxctl zlib pcre;
         ${localSystem.libc} = getLibc prevStage;
       } // lib.optionalAttrs (super.targetPlatform == localSystem) {
         # Need to get rid of these when cross-compiling.


### PR DESCRIPTION
This reverts commit a809fdc8e1b0c1d49d40815d9bac0de27ddab5f1 and then
achieves the same result (not rebuilding texinfo three times)
but without dragging bootstrap tools into the closure.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/39457#issuecomment-412314431

###### Things done

- [X] Builds.
- [X] `nix-store -qR` for `stdenv`, `texinfo`, `texinfoInteractive` have no `bootstapTools`.