### PR TITLE
Add missing \n in  configuration generator for systemd-boot

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -42,7 +42,7 @@ def write_loader_conf(profile, generation):
         else:
             f.write("default nixos-generation-%d\n" % (generation))
         if not @editor@:
-            f.write("editor 0");
+            f.write("editor 0\n");
         f.write("console-mode @consoleMode@\n");
     os.rename("@efiSysMountPoint@/loader/loader.conf.tmp", "@efiSysMountPoint@/loader/loader.conf")
 


### PR DESCRIPTION
###### Motivation for this change

This adds a missing \n in the configuratin generator for systemd-boot (formerly gummiboot).  Because of the missing \n, the following config bit:

```` 
boot.loader.systemd-boot.editor = false;
boot.loader.systemd-boot.consoleMode = "auto";
````

would produce a file ending with:

````
editor 0console-mode auto
````

instead of

````
editor 0
console-mode auto
````

###### Things done

(None yet, sorry.   I have no idea how to test this, and I assume the change is straightforward enough.  Just tell me if you want any of these tests done, I'll look up how :)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

