### PR TITLE
coreutils: use openssl for faster *sum tools

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -395,7 +395,7 @@ in rec {
     allowedRequisites = (with pkgs; [
       xz.out xz.bin libcxx libcxxabi gmp.out gnumake findutils bzip2.out
       bzip2.bin llvmPackages.llvm llvmPackages.llvm.lib llvmPackages.compiler-rt llvmPackages.compiler-rt.dev
-      zlib.out zlib.dev libffi.out coreutils ed diffutils gnutar
+      zlib.out zlib.dev libffi.out coreutils ed diffutils gnutar openssl
       gzip ncurses.out ncurses.dev ncurses.man gnused bash gawk
       gnugrep llvmPackages.clang-unwrapped llvmPackages.clang-unwrapped.lib patch pcre.out gettext
       binutils.bintools darwin.binutils darwin.binutils.bintools

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -348,7 +348,7 @@ in
           ]
         # Library dependencies
         ++ map getLib (
-            [ attr acl zlib pcre ]
+            [ attr acl zlib pcre openssl ]
             ++ lib.optional (gawk.libsigsegv != null) gawk.libsigsegv
           )
         # More complicated cases

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   # Saw random failures like ‘help2man: can't get '--help' info from
   # man/sha512sum.td/sha512sum’.
-  enableParallelBuilding = true;
+  enableParallelBuilding = false;
 
   NIX_LDFLAGS = optionalString selinuxSupport "-lsepol";
   FORCE_UNSAFE_CONFIGURE = optionalString hostPlatform.isSunOS "1";

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -1,6 +1,5 @@
 { stdenv, lib, buildPackages
-, autoreconfHook, texinfo, fetchurl, perl, xz, libiconv, gmp ? null
-, openssl ? null
+, autoreconfHook, texinfo, fetchurl, perl, xz, libiconv, openssl, gmp ? null
 , hostPlatform, buildPlatform
 , aclSupport ? false, acl ? null
 , attrSupport ? false, attr ? null
@@ -38,7 +37,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "info" ];
 
   nativeBuildInputs = [ perl xz.bin ];
-  configureFlags = optional (openssl != null) "--with-openssl"
+  configureFlags = [ "--with-openssl" ]
     ++ optional (singleBinary != false)
       ("--enable-single-binary" + optionalString (isString singleBinary) "=${singleBinary}")
     ++ optional hostPlatform.isSunOS "ac_cv_func_inotify_init=no"

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -49,9 +49,8 @@ stdenv.mkDerivation rec {
     ];
 
 
-  buildInputs = [ gmp ]
+  buildInputs = [ gmp openssl ]
     ++ optional aclSupport acl
-    ++ optional stdenv.isLinux openssl
     ++ optional attrSupport attr
     ++ optionals hostPlatform.isCygwin [ autoreconfHook texinfo ]   # due to patch
     ++ optionals selinuxSupport [ libselinux libsepol ]

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -49,8 +49,9 @@ stdenv.mkDerivation rec {
     ];
 
 
-  buildInputs = [ gmp openssl ]
+  buildInputs = [ gmp ]
     ++ optional aclSupport acl
+    ++ optional stdenv.isLinux openssl
     ++ optional attrSupport attr
     ++ optionals hostPlatform.isCygwin [ autoreconfHook texinfo ]   # due to patch
     ++ optionals selinuxSupport [ libselinux libsepol ]


### PR DESCRIPTION
sha256sum, md5sum,. run much faster. Factor 2x to 4x.

You can evaluate that by comparing the cpu time of your 'time sha256sum bigfile' and 'time openssl sha256 bigfile'.

I tried this PR in https://github.com/NixOS/nixpkgs/pull/43983 not noticing that it altered stdenv.

I modified stdenv allowedRequisites so it is allowed in linux & darwin stdenv; @edolstra said that openssl for coreutils does not rise the stdenv size too much.

The other solution is to add a new coreutils-with-openssl that is referenced in NixOS but not in stdenv, so the user always calls the fast *sum versions.