### PR TITLE
openscenegraph: 3.4.0 -> 3.6.2

### DIFF
--- a/pkgs/development/libraries/openscenegraph/default.nix
+++ b/pkgs/development/libraries/openscenegraph/default.nix
@@ -1,33 +1,72 @@
-{ stdenv, lib, fetchurl, cmake, pkgconfig, doxygen, unzip
-, freetype, libjpeg, jasper, libxml2, zlib, gdal, curl, libX11
-, cairo, poppler, librsvg, libpng, libtiff, libXrandr
-, xineLib, boost
-, withApps ? false
-, withSDL ? false, SDL
-, withQt4 ? false, qt4
+{ stdenv, lib, fetchFromGitHub, cmake, pkgconfig, doxygen,
+  libX11, libXinerama, libXrandr, libGLU_combined,
+  glib, ilmbase, libxml2, pcre, zlib,
+  jpegSupport ? true, libjpeg,
+  jasperSupport ? true, jasper,
+  exrSupport ? false, openexr,
+  gifSupport ? true, giflib,
+  pngSupport ? true, libpng,
+  tiffSupport ? true, libtiff,
+  gdalSupport ? false, gdal,
+  curlSupport ? true, curl,
+  colladaSupport ? false, opencollada,
+  opencascadeSupport ? false, opencascade,
+  ffmpegSupport ? false, ffmpeg,
+  nvttSupport ? false, nvidia-texture-tools,
+  freetypeSupport ? true, freetype,
+  svgSupport ? false, librsvg,
+  pdfSupport ? false, poppler,
+  vncSupport ? false, libvncserver,
+  lasSupport ? false, libLAS,
+  luaSupport ? false, lua,
+  sdlSupport ? false, SDL2,
+  restSupport ? false, asio, boost,
+  withApps ? false,
+  withExamples ? false, fltk, wxGTK,
 }:
 
 stdenv.mkDerivation rec {
   name = "openscenegraph-${version}";
-  version = "3.4.0";
+  version = "3.6.2";
 
-  src = fetchurl {
-    url = "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-${version}.zip";
-    sha256 = "03h4wfqqk7rf3mpz0sa99gy715cwpala7964z2npd8jxfn27swjw";
+  src = fetchFromGitHub {
+    owner = "openscenegraph";
+    repo = "OpenSceneGraph";
+    rev = "fb40a0d1db018ff39a08699a7f17f7eb6d949c36";
+    sha256 = "03jk6lclyd4biniaw04w7j0z1spkm69f1c19i37b8v9x3zv1p1id";
   };
 
-  nativeBuildInputs = [ pkgconfig cmake doxygen unzip ];
+  nativeBuildInputs = [ pkgconfig cmake doxygen ];
 
   buildInputs = [
-    freetype libjpeg jasper libxml2 zlib gdal curl libX11
-    cairo poppler librsvg libpng libtiff libXrandr boost
-    xineLib
-  ] ++ lib.optional withSDL SDL
-    ++ lib.optional withQt4 qt4;
+    libX11 libXinerama libXrandr libGLU_combined
+    glib ilmbase libxml2 pcre zlib
+  ] ++ lib.optional jpegSupport libjpeg
+    ++ lib.optional jasperSupport jasper
+    ++ lib.optional exrSupport openexr
+    ++ lib.optional gifSupport giflib
+    ++ lib.optional pngSupport libpng
+    ++ lib.optional tiffSupport libtiff
+    ++ lib.optional gdalSupport gdal
+    ++ lib.optional curlSupport curl
+    ++ lib.optional colladaSupport opencollada
+    ++ lib.optional opencascadeSupport opencascade
+    ++ lib.optional ffmpegSupport ffmpeg
+    ++ lib.optional nvttSupport nvidia-texture-tools
+    ++ lib.optional freetypeSupport freetype
+    ++ lib.optional svgSupport librsvg
+    ++ lib.optional pdfSupport poppler
+    ++ lib.optional vncSupport libvncserver
+    ++ lib.optional lasSupport libLAS
+    ++ lib.optional luaSupport lua
+    ++ lib.optional sdlSupport SDL2
+    ++ lib.optionals restSupport [ asio boost ]
+    ++ lib.optionals withExamples [ fltk wxGTK ]
+  ;
 
   enableParallelBuilding = true;
 
-  cmakeFlags = lib.optional (!withApps) "-DBUILD_OSG_APPLICATIONS=OFF";
+  cmakeFlags = lib.optional (!withApps) "-DBUILD_OSG_APPLICATIONS=OFF" ++ lib.optional withExamples "-DBUILD_OSG_EXAMPLES=ON";
 
   meta = with stdenv.lib; {
     description = "A 3D graphics toolkit";


### PR DESCRIPTION
Looking for approval by @7c6f434c as they are the maintainer.

###### Motivation for this change
version bump

###### Things done
 bumped openscenegraph version from 3.4 to 3.6.2 and added more options for building it

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

