### PR TITLE
servant-sphinx-documentation: fix sha256sum

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -727,7 +727,7 @@ self: super: {
           owner = "haskell-servant";
           repo = "servant";
           rev = "v${ver}";
-          sha256 = "0bwd5dy3crn08dijn06dr3mdsww98kqxfp8v5mvrdws5glvcxdsg";
+          sha256 = "0kqglih3rv12nmkzxvalhfaaafk4b2irvv9x5xmc48i1ns71y23l";
         }}/doc";
         buildInputs = with pkgs.pythonPackages; [ sphinx recommonmark sphinx_rtd_theme ];
         makeFlags = "html";


### PR DESCRIPTION
###### Motivation for this change
Error build cachix - 
```
nix build -f ~/nixpkgs cachix                                                                                                                                                                                                
fixed-output derivation produced path '/nix/store/8z8njf3i1jydzjq1zlc0v3qb7813jm2f-source' with sha256 hash '0kqglih3rv12nmkzxvalhfaaafk4b2irvv9x5xmc48i1ns71y23l' instead of the expected hash '0bwd5dy3crn08dijn06dr3mdsww98kqxfp8v5mvrdws5glvcxdsg'
cannot build derivation '/nix/store/dj3lpyqdjd432823wfzpp5ps8m8vkp88-servant-sphinx-documentation-0.14.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/l10yggix3irvz371vc0h3sbnf2l5fjcd-servant-0.14.1.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/fax8wkbv8fzvrlhagbwxh4lrmjs2h5wh-cachix-0.1.1.drv': 1 dependencies couldn't be built
[0 built (1 failed)]
error: build of '/nix/store/fax8wkbv8fzvrlhagbwxh4lrmjs2h5wh-cachix-0.1.1.drv' failed
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

