### PR TITLE
jameica: add darwin support

### DIFF
--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk, jre, xmlstarlet, gtk2, glib, xorg }:
+{ stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, ant, jdk, jre, xmlstarlet, gtk2, glib, xorg, Cocoa }:
 
 let
   _version = "2.8.1";
@@ -8,11 +8,12 @@ let
 
   swtSystem = if stdenv.system == "i686-linux" then "linux"
   else if stdenv.system == "x86_64-linux" then "linux64"
+  else if stdenv.system == "x86_64-darwin" then "macos64"
   else throw "Unsupported system: ${stdenv.system}";
 
   launcher = ''
     #!${stdenv.shell}
-    exec ${jre}/bin/java -Xmx512m de.willuhn.jameica.Main "$@"
+    exec ${jre}/bin/java -Xmx512m ${ stdenv.lib.optionalString stdenv.isDarwin ''-Xdock:name="Jameica" -XstartOnFirstThread''} de.willuhn.jameica.Main "$@"
   '';
 
   desktopItem = makeDesktopItem {
@@ -28,7 +29,8 @@ stdenv.mkDerivation rec {
   inherit name version;
 
   nativeBuildInputs = [ ant jdk makeWrapper xmlstarlet ];
-  buildInputs = [ gtk2 glib xorg.libXtst ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ gtk2 glib xorg.libXtst ]
+                ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
 
   src = fetchFromGitHub {
     owner = "willuhn";
@@ -82,7 +84,7 @@ stdenv.mkDerivation rec {
       SynTAX (accounting) and JVerein (club management).
     '';
     license = licenses.gpl2Plus;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
     maintainers = with maintainers; [ flokli ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16869,7 +16869,9 @@ with pkgs;
 
   jalv = callPackage ../applications/audio/jalv { };
 
-  jameica = callPackage ../applications/office/jameica { };
+  jameica = callPackage ../applications/office/jameica {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   jamin = callPackage ../applications/audio/jamin { };
 


### PR DESCRIPTION
###### Motivation for this change
Followup of #44943.
Tried adding darwin support for fun, and turns out, it wasn't that hard :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

