### PR TITLE
qradiolink: init at 0.5.0

### DIFF
--- a/pkgs/applications/misc/qradiolink/default.nix
+++ b/pkgs/applications/misc/qradiolink/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub, alsaLib, boost
+, qt4, libpulseaudio, codec2, libconfig
+, gnuradio, gnuradio-osmosdr, gsm
+, libopus, libjpeg, protobuf, qwt, speex
+} :
+
+let
+  version = "0.5.0";
+
+in stdenv.mkDerivation {
+  name = "qradiolink-${version}";
+
+  src = fetchFromGitHub {
+    owner = "kantooon";
+    repo = "qradiolink";
+    rev = "${version}";
+    sha256 = "0xhg5zhjznmls5m3rhpk1qx0dipxmca12s85w15d0i7qwva2f1gi";
+  };
+
+  preBuild = ''
+    cd ext
+    protoc --cpp_out=. Mumble.proto
+    protoc --cpp_out=. QRadioLink.proto
+    cd ..
+    qmake
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp qradiolink $out/bin
+  '';
+
+  buildInputs = [
+    qt4
+    alsaLib
+    boost
+    libpulseaudio
+    codec2
+    libconfig
+    gsm
+    gnuradio
+    gnuradio-osmosdr
+    libopus
+    libjpeg
+    protobuf
+    speex
+    qwt
+  ];
+
+  meta = with stdenv.lib; {
+    description = "SDR transceiver application for analog and digital modes";
+    homepage = http://qradiolink.org/;
+    license = licenses.agpl3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/codec2/default.nix
+++ b/pkgs/development/libraries/codec2/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchsvn, cmake } :
+
+let
+  version = "0.8";
+
+in stdenv.mkDerivation {
+  name = "codec2-${version}";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/freetel/code/codec2/branches/${version}";
+    sha256 = "0qbyaqdn37253s30n6m2ric8nfdsxhkslb9h572kdx18j2yjccki";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Speech codec designed for communications quality speech at low data rates";
+    homepage = http://www.rowetel.com/blog/?page_id=452;
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1119,6 +1119,8 @@ with pkgs;
 
   codesearch = callPackage ../tools/text/codesearch { };
 
+  codec2 = callPackage ../development/libraries/codec2 { };
+
   contacts = callPackage ../tools/misc/contacts {
     inherit (darwin.apple_sdk.frameworks) Foundation AddressBook;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11751,6 +11751,8 @@ with pkgs;
 
   lvtk = callPackage ../development/libraries/audio/lvtk { };
 
+  qradiolink = callPackage ../applications/misc/qradiolink { };
+
   qrupdate = callPackage ../development/libraries/qrupdate { };
 
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };


### PR DESCRIPTION
###### Motivation for this change
`qradiolink` is GUI based SDR transceiver application for analog and digital modes. 

###### Things done
* init `codec2` at 0.8
* qradiolink

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

