### PR TITLE
blastem: init at 0.5.1

### DIFF
--- a/pkgs/misc/emulators/blastem/default.nix
+++ b/pkgs/misc/emulators/blastem/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, SDL2, glew, xcftools, python, pillow, makeWrapper }:
+
+let
+  vasm =
+    stdenv.mkDerivation rec {
+      name = "vasm-${version}";
+      version = "1.8c";
+      src = fetchFromGitHub {
+        owner = "mbitsnbites";
+        repo = "vasm";
+        rev = "244f8bbbdf64ae603f9f6c09a3067943837459ec";
+        sha256 = "0x4y5q7ygxfjfy2wxijkps9khsjjfb169sbda410vaw0m88wqj5p";
+      };
+      makeFlags = "CPU=m68k SYNTAX=mot";
+      installPhase = ''
+        mkdir -p $out/bin
+        cp vasmm68k_mot $out/bin
+      '';
+    };
+in
+stdenv.mkDerivation rec {
+  name = "blastem-${version}";
+  version = "0.5.1";
+  src = fetchurl {
+    url = "https://www.retrodev.com/repos/blastem/archive/3d48cb0c28be.tar.gz";
+    sha256 = "07wzbmzp0y8mh59jxg81q17gqagz3psxigxh8dmzsipgg68y6a8r";
+  };
+  buildInputs = [ pkgconfig SDL2 glew xcftools python pillow vasm makeWrapper ];
+  preBuild = ''
+    patchShebangs img2tiles.py
+  '';
+  postBuild = ''
+    make menu.bin
+  '';
+  installPhase = ''
+    mkdir -p $out/bin $out/share/blastem
+    cp -r {blastem,menu.bin,default.cfg,rom.db,shaders} $out/share/blastem/
+    makeWrapper $out/share/blastem/blastem $out/bin/blastem
+  '';
+
+  meta = {
+    homepage = https://www.retrodev.com/blastem/;
+    description = "The fast and accurate Genesis emulator";
+    maintainers = with stdenv.lib.maintainers; [ puffnfresh ];
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1659,6 +1659,10 @@ with pkgs;
 
   biber = callPackage ../tools/typesetting/biber { };
 
+  blastem = callPackage ../misc/emulators/blastem {
+    inherit (python27Packages) pillow;
+  };
+
   blueman = callPackage ../tools/bluetooth/blueman {
     withPulseAudio = config.pulseaudio or true;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

