### PR TITLE
mimic: init at 1.2.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2877,6 +2877,11 @@
     github = "nocoolnametom";
     name = "Tom Doggett";
   };
+  noneucat = {
+    email = "andy@lolc.at";
+    github = "noneucat";
+    name = "Andy Chun";
+  };
   notthemessiah = {
     email = "brian.cohen.88@gmail.com";
     github = "notthemessiah";

--- a/pkgs/applications/audio/mimic/default.nix
+++ b/pkgs/applications/audio/mimic/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, autoreconfHook, fetchFromGitHub, pkgconfig
+, alsaLib, libtool, icu
+, pulseaudioSupport ? true, libpulseaudio }:
+
+stdenv.mkDerivation rec {
+  name = "mimic-${version}";
+  version = "1.2.0.2";
+
+  src = fetchFromGitHub {
+    rev = version;
+    repo = "mimic";
+    owner = "MycroftAI";
+    sha256 = "1wkpbwk88lsahzkc7pzbznmyy0lc02vsp0vkj8f1ags1gh0lc52j";
+  };
+
+  nativeBuildInputs = [ 
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    alsaLib
+    libtool
+    icu 
+  ] ++ stdenv.lib.optional pulseaudioSupport libpulseaudio;
+
+  meta = {
+    description = "Mycroft's TTS engine, based on CMU's Flite (Festival Lite)";
+    homepage = https://mimic.mycroft.ai/; 
+    license = stdenv.lib.licenses.free;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.noneucat ]; 
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17277,6 +17277,10 @@ with pkgs;
 
   minitube = libsForQt5.callPackage ../applications/video/minitube { };
 
+  mimic = callPackage ../applications/audio/mimic { 
+    pulseaudioSupport = config.pulseaudio or false;
+  };
+
   mimms = callPackage ../applications/audio/mimms {};
 
   meh = callPackage ../applications/graphics/meh {};


### PR DESCRIPTION
###### Motivation for this change
Addition of `mimic`, Mycroft's TTS engine. Includes an executable and a `pkgconfig` library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---