### PR TITLE
ocamlModules.wasm: add wasm binary

### DIFF
--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -21,11 +21,16 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
+  postInstall = ''
+    mkdir $out/bin
+    cp -L interpreter/wasm $out/bin
+  '';
+
   meta = {
-    description = "An OCaml library to read and write Web Assembly (wasm) files and manipulate their AST";
+    description = "An executable and OCaml library to run, read and write Web Assembly (wasm) files and manipulate their AST";
     license = stdenv.lib.licenses.asl20;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (src.meta) homepage;
+    homepage = https://github.com/WebAssembly/spec/tree/master/interpreter;
     inherit (ocaml.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Upstream distributes a binary along with the package. Just adding the binary to the output (and fixing the homepage to a link a bit more helpful)

cc @vbgl 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

