### PR TITLE
libimobiledevice updates

### DIFF
--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -25,8 +25,8 @@ in stdenv.mkDerivation rec {
   propagatedBuildInputs = [ glib libxml2 sqlite zlib sg3_utils
     gdk_pixbuf taglib libimobiledevice python pygobject2 mutagen ];
 
-  nativeBuildInputs = [ gettext perlXMLParser intltool pkgconfig perl
-    libimobiledevice.swig ] ++ lib.optionals monoSupport [ mono gtk-sharp-2_0 ];
+  nativeBuildInputs = [ gettext perlXMLParser intltool pkgconfig perl] ++
+   lib.optionals monoSupport [ mono gtk-sharp-2_0 ];
 
   meta = {
     homepage = http://gtkpod.sourceforge.net/;

--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -1,32 +1,46 @@
-{ stdenv, fetchurl, fetchpatch, python2, pkgconfig, usbmuxd, glib, libgcrypt,
-  libtasn1, libplist, readline, libusbmuxd, openssl }:
+{ stdenv, fetchFromGitHub, automake, autoconf, libtool, pkgconfig, gnutls
+, libgcrypt, libtasn1, glib, libplist, libusbmuxd }:
 
 stdenv.mkDerivation rec {
-  name = "libimobiledevice-1.2.0";
+  pname = "libimobiledevice";
+  version = "2018-07-24";
 
-  nativeBuildInputs = [ python2 libplist.swig pkgconfig ];
-  buildInputs = [ readline ];
-  propagatedBuildInputs = [ libusbmuxd glib libgcrypt libtasn1 libplist openssl ];
+  name = "${pname}-${version}";
 
-  patches = [
-    ./disable_sslv3.patch
-    (fetchpatch {
-      name = "CVE-2016-5104.patch";
-      url = "https://github.com/libimobiledevice/libimobiledevice/commit/df1f5c4d70d0c19ad40072f5246ca457e7f9849e.patch";
-      sha256 = "06ygb9aqcvm4v08wrldsddjgyqv5bkpq6lxzq2a1nwqp9mq4a4k1";
-    })
-  ];
-
-  postPatch = ''sed -e 's@1\.3\.21@@' -i configure'';
-  passthru.swig = libplist.swig;
-
-  src = fetchurl {
-    url = "${meta.homepage}/downloads/${name}.tar.bz2";
-    sha256 = "0dqhy4qwj30mw8pwckvjmgnj1qqrh6p8c6jknmhvylshhzh0ssvq";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "d7a2e04d2e7880c56116fd35489a7f98755501b7";
+    sha256 = "0cj0j10lmfr28c7nh79n2mcmy31xx50g93h0bqs0l7y76ph4dqkc";
   };
 
-  meta = {
-    homepage = http://www.libimobiledevice.org;
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkgconfig
+  ];
+  propagatedBuildInputs = [
+    glib
+    gnutls
+    libgcrypt
+    libplist
+    libtasn1
+    libusbmuxd
+  ];
+
+  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
+
+  configureFlags = [
+    "--disable-static"
+    "--disable-openssl"
+    "--without-cython"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/libimobiledevice/libimobiledevice;
     description = "A software library that talks the protocols to support iPhone®, iPod Touch® and iPad® devices on Linux";
     longDescription = ''
       libimobiledevice is a software library that talks the protocols to support
@@ -38,7 +52,10 @@ stdenv.mkDerivation rec {
       installed applications, retrieve addressbook/calendars/notes and bookmarks
       and synchronize music and video to the device. The library is in
       development since August 2007 with the goal to bring support for these
-      devices to the Linux Desktop.'';
-    inherit (usbmuxd.meta) platforms maintainers;
+      devices to the Linux Desktop.
+    '';
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -1,31 +1,41 @@
-{ stdenv, fetchurl, pkgconfig, swig2, python2Packages, glib }:
+{ stdenv,  autoreconfHook, fetchFromGitHub, pkgconfig, python2Packages, glib }:
 
 let
   inherit (python2Packages) python cython;
-in stdenv.mkDerivation rec {
-  name = "libplist-${version}";
-  version = "2.0.0";
+in
+stdenv.mkDerivation rec {
+  pname = "libplist";
+  version = "2018-07-25";
 
-  nativeBuildInputs = [ pkgconfig swig2 python cython ];
+  name = "${pname}-${version}";
 
-  propagatedBuildInputs = [ glib ];
-
-  passthru.swig = swig2;
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "db68a9d1070b363eee93147f072f46526064acbc";
+    sha256 = "0lxyb35jjg31m8dxhsv1jr2ccy5s19fsqzisy7lfjk46w7brs4h5";
+  };
 
   outputs = ["bin" "dev" "out" "py"];
+
+  nativeBuildInputs = [
+    pkgconfig
+    python
+    cython
+    autoreconfHook
+  ];
+
+  propagatedBuildInputs = [ glib ];
 
   postFixup = ''
     moveToOutput "lib/${python.libPrefix}" "$py"
   '';
 
-  src = fetchurl {
-    url = "https://www.libimobiledevice.org/downloads/${name}.tar.bz2";
-    sha256 = "00pnh9zf3iwdji2faccns7vagbmbrwbj9a8zp9s53a6rqaa9czis";
-  };
-
-  meta = {
-    homepage = https://github.com/JonathanBeck/libplist;
-    platforms = stdenv.lib.platforms.all;
+  meta = with stdenv.lib; {
+    description = "A library to handle Apple Property List format in binary or XML";
+    homepage = https://github.com/libimobiledevice/libplist;
+    license = licenses.lgpl21Plus;
     maintainers = [ ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libusbmuxd/default.nix
+++ b/pkgs/development/libraries/libusbmuxd/default.nix
@@ -1,25 +1,26 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, libplist }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libplist }:
 
 stdenv.mkDerivation rec {
-  name = "libusbmuxd-1.0.10";
-  src = fetchurl {
-    url = "https://www.libimobiledevice.org/downloads/${name}.tar.bz2";
-    sha256 = "1wn9zq2224786mdr12c5hxad643d29wg4z6b7jn888jx4s8i78hs";
+  pname = "libusbmuxd";
+  version = "2018-07-23";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "78df9be5fc8222ed53846cb553de9b5d24c85c6c";
+    sha256 = "05hbn0mbmv5ln9hfsvnf7i1mnp6ncbyfnl5w331kg4fi12wjshc5";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2016-5104.patch";
-      url = "https://github.com/libimobiledevice/libusbmuxd/commit/4397b3376dc4e4cb1c991d0aed61ce6482614196.patch";
-      sha256 = "0cl3vys7bkwbdzf64d0rz3zlqpfc30w4l7j49ljv01agh42ywhgk";
-    })
-  ];
-
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libplist ];
 
-  meta = {
-    homepage = http://www.libimobiledevice.org;
-    platforms = stdenv.lib.platforms.unix;
+  meta = with stdenv.lib; {
+    description = "A client library to multiplex connections from and to iOS devices";
+    homepage    = https://github.com/libimobiledevice/libusbmuxd;
+    license     = licenses.lgpl21Plus;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/filesystems/ifuse/default.nix
+++ b/pkgs/tools/filesystems/ifuse/default.nix
@@ -1,25 +1,31 @@
-{ stdenv, fetchurl, pkgconfig, usbmuxd, fuse, gnutls, libgcrypt,
-  libplist, libimobiledevice }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, usbmuxd, fuse, libimobiledevice }:
 
 stdenv.mkDerivation rec {
-  name = "ifuse-1.1.3";
+  pname = "ifuse";
+  version = "1.1.3";
 
-  nativeBuildInputs = [ pkgconfig fuse libplist usbmuxd gnutls libgcrypt libimobiledevice ];
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "${meta.homepage}/downloads/${name}.tar.bz2";
-    sha256 = "1p9a4n36jb194cnp6v57cz2bggwbywaz8pbpb95ch83pzdkdx257";
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = version;
+    sha256 = "0p01rds3vc5864v48swgqw5dv0h937nqnxggryixg9pkvzhc6cx5";
   };
 
-  meta = {
-    homepage = http://www.libimobiledevice.org;
-    license = stdenv.lib.licenses.lgpl21Plus;
+  nativeBuildInputs = [ autoreconfHook pkgconfig fuse usbmuxd libimobiledevice ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/libimobiledevice/ifuse;
     description = "A fuse filesystem implementation to access the contents of iOS devices";
     longDescription = ''
-    Mount directories of an iOS device locally using fuse. By default the media
-    directory is mounted, options allow to also mount the sandbox container of an
-    app, an app's documents folder or even the root filesystem on jailbroken
-    devices.'';
-    inherit (usbmuxd.meta) platforms maintainers;
+      Mount directories of an iOS device locally using fuse. By default the media
+      directory is mounted, options allow to also mount the sandbox container of an
+      app, an app's documents folder or even the root filesystem on jailbroken
+      devices.
+    '';
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/misc/usbmuxd/default.nix
+++ b/pkgs/tools/misc/usbmuxd/default.nix
@@ -1,30 +1,40 @@
-{ stdenv, fetchurl, libplist, libusb1, pkgconfig, libimobiledevice }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1, libimobiledevice }:
 
 stdenv.mkDerivation rec {
-  name = "usbmuxd-${version}";
-  version = "1.1.0";
+  pname = "usbmuxd";
+  version = "2018-07-22";
 
-  src = fetchurl {
-    url = "https://www.libimobiledevice.org/downloads/${name}.tar.bz2";
-    sha256 = "0bdlc7a8plvglqqx39qqampqm6y0hcdws76l9dffwl22zss4i29y";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "ee85938c21043ef5f7cd4dfbc7677f385814d4d8";
+    sha256 = "1qsnxvcagxa92rz0w78m0n2drgaghi0pqpbjdk2080sczzi1g76y";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  propagatedBuildInputs = [ libusb1 libplist libimobiledevice ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  propagatedBuildInputs = [ libimobiledevice libusb1 ];
 
   preConfigure = ''
     configureFlags="$configureFlags --with-udevrulesdir=$out/lib/udev/rules.d"
     configureFlags="$configureFlags --with-systemdsystemunitdir=$out/lib/systemd/system"
   '';
 
-  meta = {
-    homepage = http://marcansoft.com/blog/iphonelinux/usbmuxd/;
-    description = "USB Multiplex Daemon (for talking to iPhone or iPod)";
+  meta = with stdenv.lib; {
+    homepage = https://github.com/libimobiledevice/usbmuxd;
+    description = "A socket daemon to multiplex connections from and to iOS devices";
     longDescription = ''
-      usbmuxd: USB Multiplex Daemon. This bit of software is in charge of
-      talking to your iPhone or iPod Touch over USB and coordinating access to
-      its services by other applications.'';
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ ];
+      usbmuxd stands for "USB multiplexing daemon". This daemon is in charge of
+      multiplexing connections over USB to an iOS device. To users, it means
+      you can sync your music, contacts, photos, etc. over USB. To developers, it
+      means you can connect to any listening localhost socket on the device. usbmuxd
+      is not used for tethering data transfer which uses a dedicated USB interface as
+      a virtual network device. Multiple connections to different TCP ports can happen
+      in parallel. The higher-level layers are handled by libimobiledevice.
+    '';
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Obscene package versions mostly :)

This should give function to devices with newer IOS versions.

Also #40952 is partially finished (no longer outdated) but they still are without a maintainer.

Testing with new devices would be nice and always kind reviewers :+1:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

