### PR TITLE
buildRustPackage: allow patches to fix Cargo.lock

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -7,6 +7,7 @@ in
 { name, cargoSha256 ? "unset"
 , src ? null
 , srcs ? null
+, patches ? []
 , sourceRoot ? null
 , logLevel ? ""
 , buildInputs ? []
@@ -22,7 +23,7 @@ assert cargoVendorDir == null -> cargoSha256 != "unset";
 let
   cargoDeps = if cargoVendorDir == null
     then fetchcargo {
-        inherit name src srcs sourceRoot cargoUpdateHook;
+        inherit name src srcs patches sourceRoot cargoUpdateHook;
         sha256 = cargoSha256;
       }
     else null;

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -1,11 +1,11 @@
 { stdenv, cacert, git, rust, cargo-vendor }:
-{ name ? "cargo-deps", src, srcs, sourceRoot, sha256, cargoUpdateHook ? "" }:
+{ name ? "cargo-deps", src, srcs, patches, sourceRoot, sha256, cargoUpdateHook ? "" }:
 stdenv.mkDerivation {
   name = "${name}-vendor";
   nativeBuildInputs = [ cacert cargo-vendor git rust.cargo ];
-  inherit src srcs sourceRoot;
+  inherit src srcs patches sourceRoot;
 
-  phases = "unpackPhase installPhase";
+  phases = "unpackPhase patchPhase installPhase";
 
   installPhase = ''
     if [[ ! -f Cargo.lock ]]; then


### PR DESCRIPTION
###### Motivation for this change

Sometime maintainers forget to update their `Cargo.lock` before pushing a release.

This change makes it possible for the packager to use a patch updating the `Cargo.lock`.

cc @Mic92 @LnL7 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

