### PR TITLE
 wasm-gc: init at 0.1.6 

### DIFF
--- a/pkgs/development/interpreters/wasm-gc/default.nix
+++ b/pkgs/development/interpreters/wasm-gc/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "wasm-gc-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner = "alexcrichton";
+    repo = "wasm-gc";
+    rev = version;
+    sha256 = "1lc30xxqp3vv1r269xzznh2lf2dzdq89bi5f1vmqjw4yc3xmawm7";
+  };
+
+  cargoPatches = [ ./fix-build.patch ]; # Cargo.lock is not up-to-date
+
+  cargoSha256 = "1jvk9n324p3x3j6q6x0p5diig3b5c683k74cfflff25i7gsmmvc7";
+
+  meta = with stdenv.lib; {
+    description = "gc-sections for wasm";
+    homepage = "https://github.com/alexcrichton/wasm-gc";
+    maintainers = with maintainers; [ ekleog ];
+    platforms = platforms.all;
+    license = with licenses; [ mit asl20 ];
+  };
+}

--- a/pkgs/development/interpreters/wasm-gc/fix-build.patch
+++ b/pkgs/development/interpreters/wasm-gc/fix-build.patch
@@ -1,0 +1,34 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 923ed91..71f17c8 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -212,16 +212,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "wasm-gc"
+-version = "0.1.1"
++version = "0.1.6"
+ dependencies = [
+  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "wasm-gc-api 0.1.5",
++ "wasm-gc-api 0.1.6",
+ ]
+ 
+ [[package]]
+ name = "wasm-gc-api"
+-version = "0.1.5"
++version = "0.1.6"
+ dependencies = [
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "parity-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -234,7 +234,7 @@ version = "0.1.0"
+ dependencies = [
+  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "wasm-bindgen 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "wasm-gc-api 0.1.5",
++ "wasm-gc-api 0.1.6",
+ ]
+ 
+ [[package]]
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7808,6 +7808,8 @@ with pkgs;
 
   wasm = callPackage ../development/interpreters/wasm { };
 
+  wasm-gc = callPackage ../development/interpreters/wasm-gc { };
+
 
   ### DEVELOPMENT / MISC
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

