### PR TITLE
puppet-lint: init at 2.3.6

### DIFF
--- a/pkgs/development/tools/puppet/puppet-lint/Gemfile
+++ b/pkgs/development/tools/puppet/puppet-lint/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "puppet-lint"

--- a/pkgs/development/tools/puppet/puppet-lint/Gemfile.lock
+++ b/pkgs/development/tools/puppet/puppet-lint/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    puppet-lint (2.3.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet-lint
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/development/tools/puppet/puppet-lint/default.nix
+++ b/pkgs/development/tools/puppet/puppet-lint/default.nix
@@ -1,0 +1,7 @@
+{ bundlerApp }:
+
+bundlerApp {
+  pname = "puppet-lint";
+  gemdir = ./.;
+  exes = [ "puppet-lint" ];
+}

--- a/pkgs/development/tools/puppet/puppet-lint/gemset.nix
+++ b/pkgs/development/tools/puppet/puppet-lint/gemset.nix
@@ -1,0 +1,10 @@
+{
+  puppet-lint = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wyk2l440d96ps3x127r52n51kqpqi2nzb3xlg92qn6aksqhnkis";
+      type = "gem";
+    };
+    version = "2.3.6";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8479,6 +8479,8 @@ with pkgs;
 
   pup = callPackage ../development/tools/pup { };
 
+  puppet-lint = callPackage ../development/tools/puppet/puppet-lint { };
+
   pyrseas = callPackage ../development/tools/database/pyrseas { };
 
   qtcreator = libsForQt5.callPackage ../development/tools/qtcreator { };


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---