### PR TITLE
ansible: install man pages

### DIFF
--- a/pkgs/tools/admin/ansible/default.nix
+++ b/pkgs/tools/admin/ansible/default.nix
@@ -7,6 +7,8 @@ let
     pname = "ansible";
     inherit version;
 
+    outputs = [ "out" "man" ];
+
     src = fetchurl {
       url = "https://releases.ansible.com/ansible/${pname}-${version}.tar.gz";
       inherit sha256;
@@ -14,6 +16,12 @@ let
 
     prePatch = ''
       sed -i "s,/usr/,$out," lib/ansible/constants.py
+    '';
+
+    postInstall = ''
+      for m in docs/man/man1/*; do
+        install -vD $m -t $man/share/man/man1
+      done
     '';
 
     doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

This patch provides a postInstall script to install manual pages for 'ansible'.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

