### PR TITLE
buildRustPackage: allow patches to fix Cargo.lock

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -59,6 +59,11 @@ all crate sources of this package. Currently it is obtained by inserting a
 fake checksum into the expression and building the package once. The correct
 checksum can be then take from the failed build.
 
+When the `Cargo.lock`, provided by upstream, is not in sync with the
+`Cargo.toml`, it is possible to use `cargoPatches` to update it. All patches
+added in `cargoPatches` will also be prepended to the patches in `patches` at
+build-time.
+
 To install crates with nix there is also an experimental project called
 [nixcrates](https://github.com/fractalide/nixcrates).
 

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -7,6 +7,8 @@ in
 { name, cargoSha256 ? "unset"
 , src ? null
 , srcs ? null
+, cargoPatches ? []
+, patches ? []
 , sourceRoot ? null
 , logLevel ? ""
 , buildInputs ? []
@@ -23,6 +25,7 @@ let
   cargoDeps = if cargoVendorDir == null
     then fetchcargo {
         inherit name src srcs sourceRoot cargoUpdateHook;
+        patches = cargoPatches;
         sha256 = cargoSha256;
       }
     else null;
@@ -43,6 +46,8 @@ in stdenv.mkDerivation (args // {
   patchRegistryDeps = ./patch-registry-deps;
 
   buildInputs = [ cacert git rust.cargo rust.rustc ] ++ buildInputs;
+
+  patches = cargoPatches ++ patches;
 
   configurePhase = args.configurePhase or ''
     runHook preConfigure

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -1,11 +1,11 @@
 { stdenv, cacert, git, rust, cargo-vendor }:
-{ name ? "cargo-deps", src, srcs, sourceRoot, sha256, cargoUpdateHook ? "" }:
+{ name ? "cargo-deps", src, srcs, patches, sourceRoot, sha256, cargoUpdateHook ? "" }:
 stdenv.mkDerivation {
   name = "${name}-vendor";
   nativeBuildInputs = [ cacert cargo-vendor git rust.cargo ];
-  inherit src srcs sourceRoot;
+  inherit src srcs patches sourceRoot;
 
-  phases = "unpackPhase installPhase";
+  phases = "unpackPhase patchPhase installPhase";
 
   installPhase = ''
     if [[ ! -f Cargo.lock ]]; then


### PR DESCRIPTION
###### Motivation for this change

Version that should work of https://github.com/NixOS/nixpkgs/pull/44967

I have checked building a package that requires it (https://github.com/NixOS/nixpkgs/pull/44968) and a project that uses dynamic patches (`rustracer`). `rustracer`'s hashes appear to not have changed, so I guess it's alright :)

cc @Mic92 @LnL7 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

