### PR TITLE
[staging-next]: Fix qt3/4 breakage

### DIFF
--- a/pkgs/development/libraries/qt-3/default.nix
+++ b/pkgs/development/libraries/qt-3/default.nix
@@ -30,38 +30,31 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ which ];
-  buildInputs = [
-    xextproto
-  ] ++ stdenv.lib.optionals openglSupport [
-    libGLU_combined libXmu
-  ] ++ stdenv.lib.optionals xftSupport [
-    libXft libXft.freetype libXft.fontconfig
-  ] ++ stdenv.lib.optional xrenderSupport libXrender
-    ++ stdenv.lib.optional xineramaSupport libXinerama
-    ++ stdenv.lib.optional xrandrSupport libXrandr
-    ++ stdenv.lib.optional xineramaSupport libXinerama;
-
-  propagatedBuildInputs = [ libpng xlibsWrapper libXft libXrender zlib libjpeg ];
+  propagatedBuildInputs = [libpng xlibsWrapper libXft libXrender zlib libjpeg];
 
   hardeningDisable = [ "format" ];
 
-  configurePlatforms = [];
-  configureFlags = let
-    mk = cond: name: "-${stdenv.lib.optionalString cond "no-"}${name}";
-  in [
-    "-v"
-    "-system-zlib" "-system-libpng" "-system-libjpeg"
-    "-qt-gif"
-    (mk xftSupport "xft")
-    (mk xrenderSupport "xrender")
-    (mk xrandrSupport "xrandr")
-    (mk xineramaSupport "xinerama")
-    (mk threadSupport "thread")
-  ] ++ stdenv.lib.optionals mysqlSupport [
-    "-qt-sql-mysql"
-    "-L${mysql.connector-c}/lib/mysql"
-    "-I${mysql.connector-c}/include/mysql"
-  ] ++ stdenv.lib.optional openglSupport "-dlopen-opengl";
+  configureFlags = "
+    -v
+    -system-zlib -system-libpng -system-libjpeg
+    -qt-gif
+    -I${xextproto}/include
+    ${if openglSupport then "-dlopen-opengl
+      -L${libGLU_combined}/lib -I${libGLU_combined}/include
+      -L${libXmu.out}/lib -I${libXmu.dev}/include" else ""}
+    ${if threadSupport then "-thread" else "-no-thread"}
+    ${if xrenderSupport then "-xrender -L${libXrender.out}/lib -I${libXrender.dev}/include" else "-no-xrender"}
+    ${if xrandrSupport then "-xrandr
+      -L${libXrandr.out}/lib -I${libXrandr.dev}/include
+      -I${randrproto}/include" else "-no-xrandr"}
+    ${if xineramaSupport then "-xinerama -L${libXinerama.out}/lib -I${libXinerama.dev}/include" else "-no-xinerama"}
+    ${if cursorSupport then "-L${libXcursor.out}/lib -I${libXcursor.dev}/include" else ""}
+    ${if mysqlSupport then "-qt-sql-mysql -L${mysql.connector-c}/lib/mysql -I${mysql.connector-c}/include/mysql" else ""}
+    ${if xftSupport then "-xft
+      -L${libXft.out}/lib -I${libXft.dev}/include
+      -L${libXft.freetype.out}/lib -I${libXft.freetype.dev}/include
+      -L${libXft.fontconfig.lib}/lib -I${libXft.fontconfig.dev}/include" else "-no-xft"}
+  ";
 
   patches = [
     # Don't strip everything so we can get useful backtraces.

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -141,7 +141,7 @@ stdenv.mkDerivation rec {
 
   configurePlatforms = [];
   configureFlags = let
-    mk = cond: name: "-${lib.optionalString cond "no-"}${name}";
+    mk = cond: name: "-${lib.optionalString (!cond) "no-"}${name}";
     platformFlag =
       if stdenv.hostPlatform != stdenv.buildPlatform
       then "-xplatform"
@@ -167,9 +167,9 @@ stdenv.mkDerivation rec {
     "-make" "libs" "-make" "tools" "-make" "translations"
     "-no-phonon" (mk buildWebkit "webkit") (mk buildMultimedia "multimedia") "-audio-backend"
   ]) ++ [
-    (mk demos "make") "demos"
-    (mk examples "make") "examples"
-    (mk docs "make") "docs"
+    "-${if demos then "" else "no"}make" "demos"
+    "-${if examples then "" else "no"}make" "examples"
+    "-${if docs then "" else "no"}make" "docs"
   ] ++ lib.optional developerBuild "-developer-build"
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ platformFlag "unsupported/macx-clang-libc++" ]
     ++ lib.optionals stdenv.hostPlatform.isWindows [ platformFlag "win32-g++-4.6" ];


### PR DESCRIPTION
###### Motivation for this change

eeb9837beba38e0f5c5e26357e478f74a7f6bc7c introduced some bugs:

- qt-4: Pass the correct configureFlags, in particular `mk` should prepend `no-`
  when `cond` is false.

- qt-3: simply revert the changes

###### Things done

Built qt3.

Built qt48Full and checked that qt48 and qt48Full gets the same flags as before eeb9837beba38e0f5c5e26357e478f74a7f6bc7c.