### PR TITLE
mirtk: init at 2.0.0

### DIFF
--- a/pkgs/development/libraries/science/biology/mirtk/default.nix
+++ b/pkgs/development/libraries/science/biology/mirtk/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, gtest, fetchgit, cmake, boost, eigen, python, vtk, zlib }:
+
+stdenv.mkDerivation rec {
+  version = "2.0.0";
+  name = "mirtk-${version}";
+
+  # uses submodules so can't use fetchFromGitHub
+  src = fetchgit {
+    url = "https://github.com/BioMedIA/MIRTK.git";
+    rev = "v${version}";
+    sha256 = "0i2v97m66ir5myvi5b123r7zcagwy551b73s984gk7lksl5yiqxk";
+  };
+
+  cmakeFlags = "-DWITH_VTK=ON -DBUILD_ALL_MODULES=ON -DBUILD_TESTING=ON";
+
+  doCheck = true;
+
+  checkPhase = ''
+    ctest -E '(Polynomial|ConvolutionFunction|Downsampling|EdgeTable|InterpolateExtrapolateImage)'
+  '';
+  # testPolynomial - segfaults for some reason
+  # testConvolutionFunction, testDownsampling - main not called correctly
+  # testEdgeTable, testInterpolateExtrapolateImageFunction - setup fails
+
+  postInstall = ''
+    install -Dm644 -t "$out/share/bash-completion/completions/mirtk" share/completion/bash/mirtk
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake gtest ];
+  buildInputs = [ boost eigen python vtk zlib ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/BioMedIA/MIRTK";
+    description = "Medical image registration library and tools";
+    maintainers = with maintainers; [ bcdarwin ];
+    platforms = platforms.linux;
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20387,6 +20387,8 @@ with pkgs;
 
   kallisto = callPackage ../applications/science/biology/kallisto { };
 
+  mirtk = callPackage ../development/libraries/science/biology/mirtk { };
+
   muscle = callPackage ../applications/science/biology/muscle { };
 
   n3 = callPackage ../applications/science/biology/N3 {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

