### PR TITLE
xsecurelock: git-2018-07-10 -> 1.0

### DIFF
--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -3,13 +3,14 @@
 , pamtester, xscreensaver }:
 
 stdenv.mkDerivation rec {
-  name = "xsecurelock-git-2018-07-10";
+  name = "xsecurelock-${version}";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "xsecurelock";
-    rev = "0fa0d7dd87a4cc4bdb402323f95c3fcacc6f5049";
-    sha256 = "071b3gslszql1mgabs53r82jgbk9mn263m5v6adskfxbkamks8g0";
+    rev = "v${version}";
+    sha256 = "0k135hnfnn1j82wvc03b8jkq06wws1xk325x5m25ps6xwsn725sw";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
v1.0 released

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
@fpletz