### PR TITLE
givaro: Add darwin support

### DIFF
--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -11,8 +11,12 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "199p8wyj5i63jbnk7j8qbdbfp5rm2lpmcxyk3mdjy9bz7ygx3hhy";
   };
+
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [autoconf automake libtool gmpxx];
+
   configureFlags = [
     "--disable-optimization"
   ] ++ stdenv.lib.optionals (!optimize) [
@@ -28,12 +32,18 @@ stdenv.mkDerivation rec {
     "--disable-fma"
     "--disable-fma4"
   ];
-  doCheck = true;
+
+  # On darwin, tests are linked to dylib in the nix store, so we need to make
+  # sure tests run after installPhase.
+  doInstallCheck = true;
+  installCheckTarget = "check";
+  doCheck = false;
+
   meta = {
     inherit version;
     description = ''A C++ library for arithmetic and algebraic computations'';
     license = stdenv.lib.licenses.cecill-b;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

