### PR TITLE
flint: Add darwin support

### DIFF
--- a/pkgs/development/libraries/flint/default.nix
+++ b/pkgs/development/libraries/flint/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   # issues with ntl -- https://github.com/wbhart/flint2/issues/487
-  NIX_CFLAGS_COMPILE = [ "-std=c++11" ];
+  NIX_CXXSTDLIB_COMPILE = [ "-std=c++11" ];
 
   patches = [
     (fetchpatch {
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     description = ''Fast Library for Number Theory'';
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     homepage = http://www.flintlib.org/;
     downloadPage = "http://www.flintlib.org/downloads.html";
     updateWalker = true;

--- a/pkgs/development/libraries/mpir/default.nix
+++ b/pkgs/development/libraries/mpir/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = ''A highly optimised library for bignum arithmetic forked from GMP'';
     license = stdenv.lib.licenses.lgpl3Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     downloadPage = "http://mpir.org/downloads.html";
     homepage = http://mpir.org/;
     updateWalker = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

