### PR TITLE
zn_poly: Add darwin support

### DIFF
--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
 
   libname = "libzn_poly${stdenv.targetPlatform.extensions.sharedLibrary}";
 
+  makeFlags = [ "CC=cc" ];
+
   # Tuning (either autotuning or with hand-written paramters) is possible
   # but not implemented here.
   # It seems buggy anyways (see homepage).
@@ -45,6 +47,6 @@ stdenv.mkDerivation rec {
     description = "Polynomial arithmetic over Z/nZ";
     license = with licenses; [ gpl3 ];
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

