### PR TITLE
ghc-8.0.2: Fix #44987

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.0.x.nix
@@ -19,6 +19,7 @@ self: super: {
   filepath = null;
   ghc-boot = null;
   ghc-boot-th = null;
+  ghc-compact = null;
   ghc-prim = null;
   ghci = null;
   haskeline = null;


### PR DESCRIPTION
`nix-env -f '<nixpkgs>' -qaP -A haskell.packages.ghc802`

will run again, but the packages depending on ghc-compact will still not
build, as they have a constrain on base >= 4.10 and ghc 8.0.2 has base
4.9.1.0

###### Motivation for this change

Get `nix-env -f '<nixpkgs>' -qaP -A haskell.packages.ghc802` running again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` nox thinks, nothing changes.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

