### PR TITLE
ocamlPackages.javalib: 2.3.4 -> 2.3.5

### DIFF
--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -1,4 +1,6 @@
-{stdenv, fetchurl, which, ocaml, findlib, camlzip, extlib, camlp4}:
+{ stdenv, fetchurl, which, ocaml, findlib, camlp4
+, camlzip, camomile, extlib
+}:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4"
 then throw "javalib not supported for ocaml ${ocaml.version}"
@@ -10,11 +12,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-${pname}-${version}";
-  version = "2.3.4";
+  version = "2.3.5";
 
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/37154/javalib-2.3.4.tar.bz2";
-    sha256 = "1ajzbyli5a3y9s8f46913drpxdzlby3i4g3c2fqacmnbyvhpaqb6";
+    url = "https://gforge.inria.fr/frs/download.php/file/37655/javalib-2.3.5.tar.bz2";
+    sha256 = "1gks12ghcmv9lm8j4diw8bvjqxfl7xwk0sxbi227saxg9irpwwkd";
   };
 
   buildInputs = [ which ocaml findlib camlp4 ];
@@ -34,7 +36,7 @@ stdenv.mkDerivation rec {
     export OCAMLPATH=$out/lib/ocaml/${ocaml.version}/site-lib/:$OCAMLPATH;
   '';
 
-  propagatedBuildInputs = [ camlzip extlib ];
+  propagatedBuildInputs = [ camlzip camomile extlib ];
 
   meta = with stdenv.lib; {
     description = "A library that parses Java .class files into OCaml data structures";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -298,7 +298,7 @@ let
     iso8601 = callPackage ../development/ocaml-modules/iso8601 { };
 
     javalib = callPackage ../development/ocaml-modules/javalib {
-      extlib = ocaml_extlib_maximal;
+      extlib = ocaml_extlib;
     };
 
     dypgen = callPackage ../development/ocaml-modules/dypgen { };


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml ≥ 4.06

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

