### PR TITLE
add licenses: alsa[Utils,Tools,Oss], altermime

### DIFF
--- a/pkgs/os-specific/linux/alsa-oss/default.nix
+++ b/pkgs/os-specific/linux/alsa-oss/default.nix
@@ -15,11 +15,7 @@ stdenv.mkDerivation rec {
 
   installFlags = "ASOUND_STATE_DIR=$(TMPDIR)/dummy";
 
-  preConfigure =
-    ''
-    '';
-
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.alsa-project.org/;
     description = "ALSA, the Advanced Linux Sound Architecture alsa-oss emulation";
 
@@ -28,6 +24,7 @@ stdenv.mkDerivation rec {
       MIDI functionality to the Linux-based operating system.
     '';
 
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/alsa-tools/default.nix
+++ b/pkgs/os-specific/linux/alsa-tools/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.alsa-project.org/;
     description = "ALSA, the Advanced Linux Sound Architecture tools";
 
@@ -47,7 +47,8 @@ stdenv.mkDerivation rec {
       MIDI functionality to the Linux-based operating system.
     '';
 
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.fps ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.fps ];
   };
 }

--- a/pkgs/os-specific/linux/alsa-utils/default.nix
+++ b/pkgs/os-specific/linux/alsa-utils/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   installFlags = "ASOUND_STATE_DIR=$(TMPDIR)/dummy";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.alsa-project.org/;
     description = "ALSA, the Advanced Linux Sound Architecture utils";
     longDescription = ''
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
       MIDI functionality to the Linux-based operating system.
     '';
 
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.AndersonTorres ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.AndersonTorres ];
   };
 }

--- a/pkgs/tools/networking/altermime/default.nix
+++ b/pkgs/tools/networking/altermime/default.nix
@@ -21,12 +21,11 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/bin"
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "MIME alteration tool";
-    maintainers = with stdenv.lib.maintainers; [
-      raskin
-    ];
-    platforms = with stdenv.lib.platforms; linux;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
+    license.fullName = "alterMIME LICENSE";
     downloadPage = "http://www.pldaniels.com/altermime/";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/43716

###### Things done
Add license meta data to the following packages
- alsaOss
- alsaPluginWrapper (just a wrapper, does not need a license?)
- alsaTools
- alsaUtils
- altermime (CC @7c6f434c homepage/download link is dead)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

