### PR TITLE
nvidia_x11_beta: reinit at 410.57

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -1,6 +1,6 @@
 # This module provides the proprietary NVIDIA X11 / OpenGL drivers.
 
-{ config, lib, pkgs, pkgs_i686, ... }:
+{ stdenv, config, lib, pkgs, pkgs_i686, ... }:
 
 with lib;
 
@@ -23,7 +23,11 @@ let
     else null;
 
   nvidia_x11 = nvidiaForKernel config.boot.kernelPackages;
-  nvidia_libs32 = (nvidiaForKernel pkgs_i686.linuxPackages).override { libsOnly = true; kernel = null; };
+  nvidia_libs32 =
+    if versionOlder nvidia_x11.version "391" then
+      ((nvidiaForKernel pkgs_i686.linuxPackages).override { libsOnly = true; kernel = null; }).out
+    else
+      (nvidiaForKernel config.boot.kernelPackages).lib32;
 
   enabled = nvidia_x11 != null;
 
@@ -98,7 +102,7 @@ in
     assertions = [
       {
         assertion = config.services.xserver.displayManager.gdm.wayland;
-        message = "NVidia drivers don't support wayland";
+        message = "NVIDIA drivers don't support wayland";
       }
       {
         assertion = !optimusCfg.enable ||
@@ -161,7 +165,7 @@ in
     };
 
     hardware.opengl.package = nvidia_x11.out;
-    hardware.opengl.package32 = nvidia_libs32.out;
+    hardware.opengl.package32 = nvidia_libs32;
 
     environment.systemPackages = [ nvidia_x11.bin nvidia_x11.settings ]
       ++ lib.filter (p: p != null) [ nvidia_x11.persistenced ];

--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -26,32 +26,44 @@ buildPhase() {
     fi
 }
 
-    
+
 installPhase() {
     # Install libGL and friends.
+
+    # since version 391, 32bit libraries are bundled in the 32/ sub-directory
+    if [ "$i686bundled" = "1" ]; then
+        mkdir -p "$lib32/lib"
+        cp -prd 32/*.so.* 32/tls "$lib32/lib/"
+    fi
+
     mkdir -p "$out/lib"
     cp -prd *.so.* tls "$out/lib/"
-    rm $out/lib/lib{glx,nvidia-wfb}.so.* # handled separately
-    rm -f $out/lib/libnvidia-gtk* # built from source
-    if [ "$useGLVND" = "1" ]; then
-        # Pre-built libglvnd
-        rm $out/lib/lib{GL,GLX,EGL,GLESv1_CM,GLESv2,OpenGL,GLdispatch}.so.*
-    fi
-    # Use ocl-icd instead
-    rm $out/lib/libOpenCL.so*
-    # Move VDPAU libraries to their place
-    mkdir $out/lib/vdpau
-    mv $out/lib/libvdpau* $out/lib/vdpau
 
-    # Install ICDs.
-    install -Dm644 nvidia.icd $out/etc/OpenCL/vendors/nvidia.icd
-    if [ -e nvidia_icd.json.template ]; then
-        sed "s#__NV_VK_ICD__#libGLX_nvidia.so#" nvidia_icd.json.template > nvidia_icd.json
-        install -Dm644 nvidia_icd.json $out/share/vulkan/icd.d/nvidia.json
-    fi
-    if [ "$useGLVND" = "1" ]; then
-        install -Dm644 10_nvidia.json $out/share/glvnd/egl_vendor.d/nvidia.json
-    fi
+    for i in $lib32 $out; do
+        rm -f $i/lib/lib{glx,nvidia-wfb}.so.* # handled separately
+        rm -f $i/lib/libnvidia-gtk* # built from source
+        if [ "$useGLVND" = "1" ]; then
+            # Pre-built libglvnd
+            rm $i/lib/lib{GL,GLX,EGL,GLESv1_CM,GLESv2,OpenGL,GLdispatch}.so.*
+        fi
+        # Use ocl-icd instead
+        rm -f $i/lib/libOpenCL.so*
+        # Move VDPAU libraries to their place
+        mkdir $i/lib/vdpau
+        mv $i/lib/libvdpau* $i/lib/vdpau
+
+        # Install ICDs.
+        install -Dm644 nvidia.icd $i/etc/OpenCL/vendors/nvidia.icd
+        if [ -e nvidia_icd.json.template ]; then
+            sed "s#__NV_VK_ICD__#libGLX_nvidia.so#" nvidia_icd.json.template > nvidia_icd.json
+            install -Dm644 nvidia_icd.json $i/share/vulkan/icd.d/nvidia.json
+        fi
+        if [ "$useGLVND" = "1" ]; then
+            install -Dm644 10_nvidia.json $i/share/glvnd/egl_vendor.d/nvidia.json
+        fi
+
+    done
+
 
     if [ -n "$bin" ]; then
         # Install the X drivers.
@@ -60,7 +72,7 @@ installPhase() {
         mkdir -p $bin/lib/xorg/modules/drivers
         cp -p nvidia_drv.so $bin/lib/xorg/modules/drivers
         mkdir -p $bin/lib/xorg/modules/extensions
-        cp -p libglx.so.* $bin/lib/xorg/modules/extensions
+        cp -p libglx*.so* $bin/lib/xorg/modules/extensions
 
         # Install the kernel module.
         mkdir -p $bin/lib/modules/$kernelVersion/misc
@@ -78,7 +90,7 @@ installPhase() {
     fi
 
     # All libs except GUI-only are installed now, so fixup them.
-    for libname in `find "$out/lib/" -name '*.so.*'` `test -z "$bin" || find "$bin/lib/" -name '*.so.*'`
+    for libname in $(find "$out/lib/" $(test -n "$lib32" && echo "$lib32/lib/") $(test -n "$bin" && echo "$bin/lib/") -name '*.so.*')
     do
       # I'm lazy to differentiate needed libs per-library, as the closure is the same.
       # Unfortunately --shrink-rpath would strip too much.

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -26,8 +26,12 @@ rec {
     patches = lib.optional (kernel.meta.branch == "4.19") ./drm_mode_connector.patch;
   };
 
-  beta = stable; # not enough interest to maintain beta ATM
-
+  beta = generic {
+    version = "410.57";
+    sha256_64bit = "08534rv3wcmzslbwq11kd3s7cxm72p48dia6540c0586xwgjwg2w";
+    settingsSha256 = "1phhhzlc8n3rqdhrn757mnlqmsp616d079a6h1qjpa6jba9z9915";
+    persistencedSha256 = "1z7c1ff0y486yp9i5w0siwh9dnprml22x2avarbjfgqwm4f652lw";
+  };
 
   legacy_340 = generic {
     version = "340.104";

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -1,5 +1,5 @@
 { version
-, sha256_32bit
+, sha256_32bit ? null
 , sha256_64bit
 , settingsSha256
 , persistencedSha256
@@ -22,11 +22,15 @@
 
 with stdenv.lib;
 
-assert (!libsOnly) -> kernel != null;
+assert !libsOnly -> kernel != null;
+assert versionOlder version "391" -> sha256_32bit != null;
+assert ! versionOlder version "391" -> stdenv.hostPlatform.system == "x86_64-linux";
 
 let
   nameSuffix = optionalString (!libsOnly) "-${kernel.version}";
   pkgSuffix = optionalString (versionOlder version "304") "-pkg0";
+  i686bundled = versionAtLeast version "391";
+
 
   self = stdenv.mkDerivation {
     name = "nvidia-x11-${version}${nameSuffix}";
@@ -34,15 +38,15 @@ let
     builder = ./builder.sh;
 
     src =
-      if stdenv.hostPlatform.system == "i686-linux" then
-        fetchurl {
-          url = "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run";
-          sha256 = sha256_32bit;
-        }
-      else if stdenv.hostPlatform.system == "x86_64-linux" then
+      if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run";
           sha256 = sha256_64bit;
+        }
+      else if stdenv.hostPlatform.system == "i686-linux" then
+        fetchurl {
+          url = "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run";
+          sha256 = sha256_32bit;
         }
       else throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
 
@@ -50,8 +54,11 @@ let
     inherit prePatch;
     inherit version useGLVND useProfiles;
     inherit (stdenv.hostPlatform) system;
+    inherit i686bundled;
 
-    outputs = [ "out" ] ++ optional (!libsOnly) "bin";
+    outputs = [ "out" ]
+        ++ optional i686bundled "lib32"
+        ++ optional (!libsOnly) "bin";
     outputDev = if libsOnly then null else "bin";
 
     kernel = if libsOnly then null else kernel.dev;


### PR DESCRIPTION
- [x] Use i686 libs from the x86 package for > 391 (https://github.com/NixOS/nixpkgs/pull/45030/commits/6ce6812f61a3d7a06b376075039b93607a7c5d2d)

###### Motivation for this change
I prefer to use the latest drivers. Also @nyanloutre.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

