### PR TITLE
buku: 3.7 -> 3.8

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,28 +1,23 @@
 { stdenv, python3, fetchFromGitHub, fetchpatch }:
 
 with python3.pkgs; buildPythonApplication rec {
-  version = "3.7";
+  version = "3.8";
   pname = "buku";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "buku";
     rev = "v${version}";
-    sha256 = "0qc6xkrhf2phaj9fhym19blr4rr2vllvnyljjz909xr4vsynvb41";
-  };
-
-  patches = fetchpatch {
-    url = https://github.com/jarun/Buku/commit/495d6eac4d9371e8ce6d3f601e2bb9e5e74962b4.patch;
-    sha256 = "0py4l5qcgdzqr0iqmcc8ddld1bspk8iwypz4dcr88y70j86588gk";
+    sha256 = "0gv26c4rr1akcaiff1nrwil03sv7d58mfxr86pgsw6nwld67ns0r";
   };
 
   checkInputs = [
     pytestcov
-    pytest-catchlog
     hypothesis
     pytest
     pylint
     flake8
+    pyyaml
   ];
 
   propagatedBuildInputs = [
@@ -30,6 +25,14 @@ with python3.pkgs; buildPythonApplication rec {
     beautifulsoup4
     requests
     urllib3
+    flask
+    flask-api
+    flask-bootstrap
+    flask-paginate
+    flask_wtf
+    arrow
+    werkzeug
+    click
   ];
 
   preCheck = ''
@@ -43,7 +46,7 @@ with python3.pkgs; buildPythonApplication rec {
       --replace "self.assertEqual(url, 'https://www.google.com')" ""
   '';
 
-  installPhase = ''
+  postInstall = ''
     make install PREFIX=$out
 
     mkdir -p $out/share/zsh/site-functions $out/share/bash-completion/completions $out/share/fish/vendor_completions.d

--- a/pkgs/development/python-modules/dominate/default.nix
+++ b/pkgs/development/python-modules/dominate/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "dominate";
+  version = "2.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0s9s9j9xmhkzw7apqx170fyvc0f800fd4a5jfn8xvj9k6vryd32b";
+  };
+
+  doCheck = !isPy3k;
+
+  meta = with lib; {
+    homepage = https://github.com/Knio/dominate/;
+    description = "Dominate is a Python library for creating and manipulating HTML documents using an elegant DOM API";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/flask-api/default.nix
+++ b/pkgs/development/python-modules/flask-api/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, flask, markdown }:
+
+buildPythonPackage rec {
+  pname = "Flask-API";
+  version = "1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dffcy2hdkajbvl2wkz9dam49v05x9d87cf2mh2cyvza2c5ah47w";
+  };
+
+  propagatedBuildInputs = [ flask markdown ];
+
+  meta = with lib; {
+    homepage = https://github.com/miracle2k/flask-assets;
+    description = "Browsable web APIs for Flask";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/flask-bootstrap/default.nix
+++ b/pkgs/development/python-modules/flask-bootstrap/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, flask, visitor, dominate }:
+
+buildPythonPackage rec {
+  pname = "Flask-Bootstrap";
+  version = "3.3.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1j1s2bplaifsnmr8vfxa3czca4rz78xyhrg4chx39xl306afs26b";
+  };
+
+  propagatedBuildInputs = [ flask visitor dominate ];
+
+  meta = with lib; {
+    homepage = https://github.com/mbr/flask-bootstrap;
+    description = "Ready-to-use Twitter-bootstrap for use in Flask.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/flask-paginate/default.nix
+++ b/pkgs/development/python-modules/flask-paginate/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, flask }:
+
+buildPythonPackage rec {
+  pname = "flask-paginate";
+  version = "0.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0pgk6ngqzh7lgq2nr6hraqp3z76f3f0kjhai50vxb6j1civ8v3mn";
+  };
+
+  propagatedBuildInputs = [ flask ];
+
+  meta = with lib; {
+    homepage = https://github.com/lixxu/flask-paginate;
+    description = "Pagination support for Flask";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/visitor/default.nix
+++ b/pkgs/development/python-modules/visitor/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "visitor";
+  version = "0.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02j87v93c50gz68gbgclmbqjcwcr7g7zgvk7c6y4x1mnn81pjwrc";
+  };
+
+  meta = with lib; {
+    homepage = https://github.com/mbr/visitor;
+    description = "A tiny pythonic visitor implementation";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5363,6 +5363,8 @@ in {
 
   flask = callPackage ../development/python-modules/flask { };
 
+  flask-api = callPackage ../development/python-modules/flask-api { };
+
   flask_assets = callPackage ../development/python-modules/flask-assets { };
 
   flask-autoindex = callPackage ../development/python-modules/flask-autoindex { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5369,6 +5369,8 @@ in {
 
   flask-babel = callPackage ../development/python-modules/flask-babel { };
 
+  flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };
+
   flask-caching = callPackage ../development/python-modules/flask-caching { };
 
   flask-common = callPackage ../development/python-modules/flask-common { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5397,6 +5397,8 @@ in {
 
   flask_oauthlib = callPackage ../development/python-modules/flask-oauthlib { };
 
+  flask-paginate = callPackage ../development/python-modules/flask-paginate { };
+
   flask_principal = callPackage ../development/python-modules/flask-principal { };
 
   flask-pymongo = callPackage ../development/python-modules/Flask-PyMongo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -254,6 +254,8 @@ in {
 
   docrep = callPackage ../development/python-modules/docrep { };
 
+  dominate = callPackage ../development/python-modules/dominate { };
+
   emcee = callPackage ../development/python-modules/emcee { };
 
   email_validator = callPackage ../development/python-modules/email-validator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17303,6 +17303,8 @@ EOF
 
   vine = callPackage ../development/python-modules/vine { };
 
+  visitor = callPackage ../development/python-modules/visitor { };
+
   whitenoise = callPackage ../development/python-modules/whitenoise { };
 
   XlsxWriter = callPackage ../development/python-modules/XlsxWriter { };


### PR DESCRIPTION
###### Motivation for this change
[Release notes](https://github.com/jarun/Buku/releases/tag/v3.8):


> - A self-hosted http server, bukuserver, that exposes core functionality
>   - browsable frontend on a local webhost server
>   - flask default cli interface is used instead custom one
>   - handle not only api but also html request
>   - statistic page
>   - CRUD on bookmark
>   - eplaces the earlier api module
> - Import complete folder hierarchy as tags during auto-import
> - Merge tags on import even if bookmark URL exists
> - Orgfile import/export
> - Show bookmarks to be deleted before deletion
> - Merge tags during import if bookmark exists
> - Escape regex metachars in regex input

The new server component requires a bunch of new packages.

Closure size diff: 116MB -> 156MB, due to the new server component

Ping @jfrankenau @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

