### PR TITLE
haskell-ci: f7ab8c -> v0.1.0.0

### DIFF
--- a/pkgs/development/tools/haskell/multi-ghc-travis/default.nix
+++ b/pkgs/development/tools/haskell/multi-ghc-travis/default.nix
@@ -3,14 +3,14 @@
 , tasty-golden, transformers, fetchFromGitHub
 }:
 
-mkDerivation {
+mkDerivation rec {
   pname = "haskell-ci";
-  version = "0";
+  version = "v0.1.0.0";
   src = fetchFromGitHub {
     owner = "haskell-CI";
     repo = "haskell-ci";
-    rev = "f7ab8c794d7a957370d89f9b4e285a6d20bf8af8";
-    sha256 = "0w8qjdy8hzdrwmqnkf4y967r9xh0k21w3hxqlsjp66cay1vby2s8";
+    rev = version;
+    sha256 = "1r79dbgjq97h30xa3xhf75l0bivag8an9ag00mgzgpglvgc96czm";
   };
   isLibrary = true;
   isExecutable = true;


### PR DESCRIPTION
###### Motivation for this change
Update to first numbered version, released 16 days ago

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

