### PR TITLE
intel-gpu-tools: 1.22 -> 1.23

### DIFF
--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -1,19 +1,20 @@
 { stdenv, fetchurl, pkgconfig, libdrm, libpciaccess, cairo, dri2proto, udev
 , libX11, libXext, libXv, libXrandr, glib, bison, libunwind, python3, kmod
-, procps, utilmacros, gnome2 }:
+, procps, utilmacros, gnome2, openssl }:
 
 stdenv.mkDerivation rec {
-  name = "intel-gpu-tools-1.22";
+  name = "intel-gpu-tools-${version}";
+  version = "1.23";
 
   src = fetchurl {
-    url = "https://xorg.freedesktop.org/archive/individual/app/${name}.tar.xz";
-    sha256 = "0p4swf9577p6hzglw1lh2sz63wjkk37b7691saj2qw8ha7fc2rix";
+    url = "https://xorg.freedesktop.org/archive/individual/app/igt-gpu-tools-${version}.tar.xz";
+    sha256 = "1l4s95m013p2wvddwr4cjqyvsgmc88zxx2887p1fbb1va5n0hjsd";
   };
 
   nativeBuildInputs = [ pkgconfig utilmacros ];
   buildInputs = [ libdrm libpciaccess cairo dri2proto udev libX11 kmod
     libXext libXv libXrandr glib bison libunwind python3 procps
-    gnome2.gtkdoc ];
+    gnome2.gtkdoc openssl ];
 
   preConfigure = ''
     ./autogen.sh


### PR DESCRIPTION
###### Motivation for this change
Update to latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closure size impact `129759152` -> `132430296`.