### PR TITLE
urbit: 0.4.5 -> 0.6.0

### DIFF
--- a/pkgs/misc/urbit/default.nix
+++ b/pkgs/misc/urbit/default.nix
@@ -1,20 +1,35 @@
-{ stdenv, fetchFromGitHub, gcc, gmp, libsigsegv, openssl, automake, autoconf, ragel,
-  cmake, re2c, libtool, ncurses, perl, zlib, python2, curl }:
+{ stdenv, fetchFromGitHub, curl, gcc, gmp, libsigsegv, libtool, libuv, ncurses,
+  openssl, perl, python2, ragel, re2c, zlib,
+  pkgconfig, meson, ninja
+}:
 
 stdenv.mkDerivation rec {
   name = "urbit-${version}";
-  version = "0.4.5";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "urbit";
     repo = "urbit";
-    rev = "v${version}";
-    sha256 = "1zgxgqbz74nsgfyrvsnjj6xxpb64mrnby7bb5qy733sy04gmzgik";
+    rev = "urbit-${version}";
+    sha256 = "158mz6c6y5z1b6piid8hvrl5mcqh8q1ny185gz51jayia51azmgs";
+    fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [ pkgconfig meson ninja ];
   buildInputs = with stdenv.lib; [
-    gcc gmp libsigsegv openssl automake autoconf ragel cmake re2c libtool
-    ncurses perl zlib python2 curl
+    curl
+    gcc
+    gmp
+    libsigsegv
+    libtool
+    libuv
+    ncurses
+    openssl
+    perl
+    python2
+    ragel
+    re2c
+    zlib
   ];
 
   # uses 'readdir_r' deprecated by glibc 2.24
@@ -25,11 +40,9 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    sed -i 's/-lcurses/-lncurses/' Makefile
-    mkdir -p $out
-    cp -r . $out/
-    cd $out
-    make
+    mkdir -p "$out/bin"
+    meson . "$out/bin" --buildtype=release
+    ninja -C "$out/bin"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Updated to latest released version, verified working with the latest network breach.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

