### PR TITLE
pythonPackages.fastcache: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/fastcache/default.nix
+++ b/pkgs/development/python-modules/fastcache/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, pytest }:
+
+buildPythonPackage rec {
+  pname = "fastcache";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rl489zfbm2x67n7i6r7r4nhrhwk6yz3yc7x9y2rky8p95vhaw46";
+  };
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "C implementation of Python3 lru_cache for Python 2 and 3";
+    homepage = https://github.com/pbrady/fastcache;
+    license = licenses.mit;
+    maintainers = [ maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2537,6 +2537,8 @@ in {
     };
   };
 
+  fastcache = callPackage ../development/python-modules/fastcache { };
+
   functools32 = if isPy3k then null else buildPythonPackage rec {
     name = "functools32-${version}";
     version = "3.2.3-2";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

