### PR TITLE
carnix overrides: add gmp to rink-rs buildInputs & correct crateBin

### DIFF
--- a/pkgs/build-support/rust/default-crate-overrides.nix
+++ b/pkgs/build-support/rust/default-crate-overrides.nix
@@ -1,6 +1,6 @@
 { stdenv, pkgconfig, curl, darwin, libiconv, libgit2, libssh2,
   openssl, sqlite, zlib, dbus, dbus-glib, gdk_pixbuf, cairo, python3,
-  libsodium, postgresql, ... }:
+  libsodium, postgresql, gmp, ... }:
 
 let
   inherit (darwin.apple_sdk.frameworks) CoreFoundation Security;
@@ -57,6 +57,10 @@ in
   };
   gdk-pixbuf = attrs: {
     buildInputs = [ gdk_pixbuf ];
+  };
+  rink = attrs: {
+    buildInputs = [ gmp ];
+    crateBin = [ {  name = "rink"; path = "src/bin/rink.rs"; } ];
   };
   cairo-rs = attrs: {
     buildInputs = [ cairo ];


### PR DESCRIPTION
###### Motivation for this change

Carnix's defaultCratesOverrides doesn't have `rink-rs` correct name nor the `gmp` dependency. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

