### PR TITLE
ptask: remove usage of nonexistent function is_error

### DIFF
--- a/pkgs/applications/misc/ptask/default.nix
+++ b/pkgs/applications/misc/ptask/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 
-  patches = [ ./tw-version.patch ];
+  patches = [ ./tw-version.patch ./json_c_is_error.patch ];
 
   preFixup = ''
     wrapProgram "$out/bin/ptask" \

--- a/pkgs/applications/misc/ptask/default.nix
+++ b/pkgs/applications/misc/ptask/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     description = "GTK-based GUI for taskwarrior";
     license = licenses.gpl2;
     maintainers = [ maintainers.spacefrogg ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/ptask/json_c_is_error.patch
+++ b/pkgs/applications/misc/ptask/json_c_is_error.patch
@@ -1,0 +1,13 @@
+diff --git a/src/tw.c b/src/tw.c
+index 602f7b3..ca601cd 100644
+--- a/src/tw.c
++++ b/src/tw.c
+@@ -163,7 +163,7 @@ static struct json_object *task_exec_json(const char *opts)
+ 
+ 	free(cmd);
+ 
+-	if (o && is_error(o))
++	if (!o)
+ 		return NULL;
+ 
+ 	return o;


### PR DESCRIPTION
see https://github.com/json-c/json-c/issues/304

###### Motivation for this change

Fix #45049

###### Things done

upstreaming the patch by mailing it to jeanfi@gmail.com

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

