### PR TITLE
pythonPackages.orderedset: Fix maintainers list

### DIFF
--- a/pkgs/development/python-modules/orderedset/default.nix
+++ b/pkgs/development/python-modules/orderedset/default.nix
@@ -13,6 +13,6 @@ buildPythonPackage rec {
     description = "An Ordered Set implementation in Cython";
     homepage = https://pypi.python.org/pypi/orderedset;
     license = licenses.bsd3;
-    maintainers = maintainers.jtojnar;
+    maintainers = [ maintainers.jtojnar] ;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

