### PR TITLE
20kly: init at 1.4

### DIFF
--- a/pkgs/games/20kly/default.nix
+++ b/pkgs/games/20kly/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, fetchurl
+, python }:
+
+python.pkgs.buildPythonApplication rec {
+  pname = "20kly";
+  version = "1.4";
+  format = "other";
+  disabled = !(python.isPy2 or false);
+
+  src = fetchurl {
+    url = "http://jwhitham.org.uk/20kly/lightyears-${version}.tar.bz2";
+    sha256 = "13h73cmfjqkipffimfc4iv0hf89if490ng6vd6xf3wcalpgaim5d";
+  };
+
+  patchPhase = ''
+    substituteInPlace lightyears \
+      --replace \
+        "LIGHTYEARS_DIR = \".\"" \
+        "LIGHTYEARS_DIR = \"$out/share\""
+  '';
+
+  propagatedBuildInputs = with python.pkgs; [ pygame ];
+
+  buildPhase = "python -O -m compileall .";
+
+  installPhase = ''
+    mkdir -p "$out/share"
+    cp -r audio code data lightyears "$out/share"
+    install -Dm755 lightyears "$out/bin/lightyears"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A steampunk-themed strategy game where you have to manage a steam supply network";
+    homepage = http://jwhitham.org.uk/20kly/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19412,6 +19412,8 @@ with pkgs;
 
   _2048-in-terminal = callPackage ../games/2048-in-terminal { };
 
+  _20kly = callPackage ../games/20kly { };
+
   _90secondportraits = callPackage ../games/90secondportraits { love = love_0_10; };
 
   adom = callPackage ../games/adom { };


### PR DESCRIPTION
###### Motivation for this change

The classic "20,000 Light-Years Into Space" game

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  * +1.3M
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

