### PR TITLE
freedesktop modules: init

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -83,7 +83,7 @@ in
 
       extraSetup = mkOption {
         type = types.lines;
-        default = [ ];
+        default = "";
         description = "Shell fragments to be run after the system environment has been created. This should only be used for things that need to modify the internals of the environment, e.g. generating MIME caches. The environment being built can be accessed at $out.";
       };
 

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -107,12 +107,7 @@ in
         "/etc/gtk-3.0"
         "/lib" # FIXME: remove and update debug-info.nix
         "/sbin"
-        "/share/applications"
-        "/share/desktop-directories"
         "/share/emacs"
-        "/share/icons"
-        "/share/menus"
-        "/share/mime"
         "/share/nano"
         "/share/org"
         "/share/themes"
@@ -132,10 +127,6 @@ in
       # outputs TODO: note that the tools will often not be linked by default
       postBuild =
         ''
-          if [ -x $out/bin/update-mime-database -a -w $out/share/mime ]; then
-              XDG_DATA_DIRS=$out/share $out/bin/update-mime-database -V $out/share/mime > /dev/null
-          fi
-
           if [ -x $out/bin/gtk-update-icon-cache -a -f $out/share/icons/hicolor/index.theme ]; then
               $out/bin/gtk-update-icon-cache $out/share/icons/hicolor
           fi
@@ -144,16 +135,16 @@ in
               $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas
           fi
 
-          if [ -x $out/bin/update-desktop-database -a -w $out/share/applications ]; then
-              $out/bin/update-desktop-database $out/share/applications
-          fi
-
           if [ -x $out/bin/install-info -a -w $out/share/info ]; then
             shopt -s nullglob
             for i in $out/share/info/*.info $out/share/info/*.info.gz; do
                 $out/bin/install-info $i $out/share/info/dir
             done
           fi
+        '' ++ optionalString config.xdg.mime.enable ''
+          XDG_DATA_DIRS=$out/share ${pkgs.shared-mime-info}/bin/update-mime-database -V $out/share/mime > /dev/null
+
+          ${pkgs.desktop-file-utils}/bin/update-desktop-database $out/share/applications
         '';
     };
 

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -81,6 +81,12 @@ in
         description = "List of additional package outputs to be symlinked into <filename>/run/current-system/sw</filename>.";
       };
 
+      extraSetup = mkOption {
+        type = types.lines;
+        default = [ ];
+        description = "Shell fragments to be run after the system environment has been created. This should only be used for things that need to modify the internals of the environment, e.g. generating MIME caches. The environment being built can be accessed at $out.";
+      };
+
     };
 
     system = {
@@ -134,17 +140,8 @@ in
           if [ -x $out/bin/glib-compile-schemas -a -w $out/share/glib-2.0/schemas ]; then
               $out/bin/glib-compile-schemas $out/share/glib-2.0/schemas
           fi
-
-          if [ -x $out/bin/install-info -a -w $out/share/info ]; then
-            shopt -s nullglob
-            for i in $out/share/info/*.info $out/share/info/*.info.gz; do
-                $out/bin/install-info $i $out/share/info/dir
-            done
-          fi
-        '' ++ optionalString config.xdg.mime.enable ''
-          XDG_DATA_DIRS=$out/share ${pkgs.shared-mime-info}/bin/update-mime-database -V $out/share/mime > /dev/null
-
-          ${pkgs.desktop-file-utils}/bin/update-desktop-database $out/share/applications
+          
+          ${config.environment.extraSetup}
         '';
     };
 

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+
+with lib;
+{
+  options = {
+    xdg.autostart.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install files to support the 
+        <link xlink:href="https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html">XDG Autostart specification</link>.
+      '';
+    };
+  };
+
+  config = mkIf config.xdg.autostart.enable {
+    environment.pathsToLink = [ 
+      "/etc/xdg/autostart"
+    ];
+  };
+
+}

--- a/nixos/modules/config/xdg/icons.nix
+++ b/nixos/modules/config/xdg/icons.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }:
+
+with lib;
+{
+  options = {
+    xdg.icons.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install files to support the 
+        <link xlink:href="https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html">XDG Icon Theme specification</link>.
+      '';
+    };
+  };
+
+  config = mkIf config.xdg.icons.enable {
+    environment.pathsToLink = [ 
+      "/share/icons" 
+      "/share/pixmaps" 
+    ];
+    
+    environment.profileRelativeEnvVars = {
+      XCURSOR_PATH = [ "/share/icons" ];
+    };
+  };
+
+}

--- a/nixos/modules/config/xdg/menus.nix
+++ b/nixos/modules/config/xdg/menus.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+
+with lib;
+{
+  options = {
+    xdg.menus.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install files to support the 
+        <link xlink:href="https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html">XDG Desktop Menu specification</link>.
+      '';
+    };
+  };
+
+  config = mkIf config.xdg.menus.enable {
+    environment.pathsToLink = [ 
+      "/share/applications"
+      "/share/desktop-directories"
+      "/etc/xdg/menus"
+      "/etc/xdg/menus/applications-merged"
+    ];
+  };
+
+}

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+{
+  options = {
+    xdg.mime.enable = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install files to support the 
+        <link xlink:href="https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html">XDG Shared MIME-info specification</link> and the
+        <link xlink:href="https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html">XDG MIME Applications specification</link>.
+      '';
+    };
+  };
+
+  config = mkIf config.xdg.mime.enable {
+    environment.pathsToLink = [ "/share/mime" ];
+
+    environment.systemPackages = [ 
+      # this package also installs some useful data, as well as its utilities 
+      pkgs.shared-mime-info 
+    ];
+  };
+
+}

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -21,6 +21,16 @@ with lib;
       # this package also installs some useful data, as well as its utilities 
       pkgs.shared-mime-info 
     ];
+
+    environment.extraSetup = ''
+      if [ -w $out/share/mime ]; then
+        XDG_DATA_DIRS=$out/share ${pkgs.shared-mime-info}/bin/update-mime-database -V $out/share/mime > /dev/null
+      fi
+
+      if [ -w $out/share/applications ]; then
+        ${pkgs.desktop-file-utils}/bin/update-desktop-database $out/share/applications
+      fi
+    '';
   };
 
 }

--- a/nixos/modules/misc/documentation.nix
+++ b/nixos/modules/misc/documentation.nix
@@ -82,6 +82,14 @@ let cfg = config.documentation; in
       environment.systemPackages = [ pkgs.texinfoInteractive ];
       environment.pathsToLink = [ "/share/info" ];
       environment.extraOutputsToInstall = [ "info" ] ++ optional cfg.dev.enable "devinfo";
+      environment.extraSetup = ''
+        if [ -w $out/share/info ]; then
+          shopt -s nullglob
+          for i in $out/share/info/*.info $out/share/info/*.info.gz; do
+              ${pkgs.texinfo}/bin/install-info $i $out/share/info/dir
+          done
+        fi
+      '';
     })
 
     (mkIf cfg.doc.enable {

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -7,6 +7,10 @@
   ./config/fonts/fontdir.nix
   ./config/fonts/fonts.nix
   ./config/fonts/ghostscript.nix
+  ./config/xdg/autostart.nix
+  ./config/xdg/icons.nix
+  ./config/xdg/menus.nix
+  ./config/xdg/mime.nix
   ./config/gnu.nix
   ./config/i18n.nix
   ./config/iproute2.nix

--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -40,7 +40,6 @@ in
         GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" ];
         XDG_CONFIG_DIRS = [ "/etc/xdg" ];
         XDG_DATA_DIRS = [ "/share" ];
-        XCURSOR_PATH = [ "/share/icons" ];
         MOZ_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
         LIBEXEC_PATH = [ "/lib/libexec" ];
       };

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -93,10 +93,14 @@ in
 
   config = mkIf cfg.enable {
 
-    # copied from <nixos/modules/services/x11/xserver.nix>
     # xrdp can run X11 program even if "services.xserver.enable = false"
-    environment.pathsToLink =
-      [ "/etc/xdg" "/share/xdg" "/share/applications" "/share/icons" "/share/pixmaps" ];
+    xdg = {
+      autostart.enable = true;
+      menus.enable = true;
+      mime.enable = true;
+      icons.enable = true;
+    };
+
     fonts.enableDefaultFonts = mkDefault true;
 
     systemd = {

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -33,12 +33,17 @@ in
       pkgs.xorg.xauth # used by kdesu
       pkgs.gtk2 # To get GTK+'s themes.
       pkgs.tango-icon-theme
-      pkgs.shared-mime-info
+
       pkgs.gnome2.gnomeicontheme
       pkgs.xorg.xcursorthemes
     ];
 
-    environment.pathsToLink = [ "/etc/enlightenment" "/etc/xdg" "/share/enlightenment" "/share/elementary" "/share/applications" "/share/locale" "/share/icons" "/share/themes" "/share/mime" "/share/desktop-directories" ];
+    environment.pathsToLink = [ 
+      "/etc/enlightenment" 
+      "/share/enlightenment" 
+      "/share/elementary" 
+      "/share/locale"
+    ];
 
     services.xserver.desktopManager.session = [
     { name = "Enlightenment";

--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -41,9 +41,8 @@ in
 
     # Link some extra directories in /run/current-system/software/share
     environment.pathsToLink = [
-      "/share/desktop-directories"
-      "/share/icons"
       "/share/lumina"
+      # FIXME: modules should link subdirs of `/share` rather than relying on this
       "/share"
     ];
 

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -174,7 +174,10 @@ in
         ++ lib.optional config.services.colord.enable colord-kde
         ++ lib.optionals config.services.samba.enable [ kdenetwork-filesharing pkgs.samba ];
 
-      environment.pathsToLink = [ "/share" ];
+      environment.pathsToLink = [ 
+        # FIXME: modules should link subdirs of `/share` rather than relying on this
+        "/share" 
+      ];
 
       environment.etc = singleton {
         source = xcfg.xkbDir;

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -59,9 +59,6 @@ in
       tango-icon-theme
       xfce4-icon-theme
 
-      desktop-file-utils
-      shared-mime-info
-
       # Needed by Xfce's xinitrc script
       # TODO: replace with command -v
       which
@@ -100,8 +97,6 @@ in
     environment.pathsToLink = [
       "/share/xfce4"
       "/share/themes"
-      "/share/mime"
-      "/share/desktop-directories"
       "/share/gtksourceview-2.0"
     ];
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -616,8 +616,12 @@ in
       ]
       ++ optional (elem "virtualbox" cfg.videoDrivers) xorg.xrefresh;
 
-    environment.pathsToLink =
-      [ "/etc/xdg" "/share/xdg" "/share/applications" "/share/icons" "/share/pixmaps" ];
+    xdg = { 
+      autostart.enable = true;
+      menus.enable = true;
+      mime.enable = true;
+      icons.enable = true;
+    };
 
     # The default max inotify watches is 8192.
     # Nowadays most apps require a good number of inotify watches,


### PR DESCRIPTION
###### Motivation for this change
Follow-up to/supersedes https://github.com/NixOS/nixpkgs/pull/44866.

This adds some modules that handle various parts of the XDG specs. This allows us to move some of the logic out of `system-path.nix`, and have a more sensible way to decide whether to update MIME caches.

I then added an option to `system-path` to allow extra environment setup commands to be defined by other modules, so the MIME module can also have the setup code in it.

Points I'm unsure about
- Should the XDG modules be enabled by default? Lots of things probably assume they are, but I could see the argument for not doing so. Currently all the DEs turn them on, so off by default would mean that a machine without a DE or X would also not have all the MIME stuff linked in, and so on.
- I wasn't brave enough to try and have a module controlling the use of the base directory spec - this is pretty deeply woven into everything, so I'm not sure that gains us much. However, it would give us a central location to define the constants `/share` and `/etc/xdg`, which might have some value.
- Is the `extraSetup` mechanism for `system-path` OK? It's a bit ugly that clients use `$out` to be the output of another derivation.

@jtojnar @vcunat 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

