### PR TITLE
python3Packages.git-annex-adapter: fix build

### DIFF
--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -22,12 +22,29 @@ buildPythonPackage rec {
       --replace "'git-annex'" "'${git-annex}/bin/git-annex'"
   '';
 
-  # TODO: Remove for next version
   patches = [
+    # fixes the "not-a-git-repo" testcase where recent git versions expect a slightly different error.
     ./not-a-git-repo-testcase.patch
+
+    # fixes the testcase which parses the output of `git-annex info` where several
+    # new lines are displayed that broke the test.
+    (fetchpatch {
+      url = "https://github.com/Ma27/git-annex-adapter/commit/39cb6da69c1aec3d57ea9f68c2dea5113ae1b764.patch";
+      sha256 = "0wyy2icqan3jpiw7dm50arfq3mgq4b5s3g91k82srap763r9hg5m";
+    })
+
+    # fixes the testcase which runs "git status" and complies with the
+    # slightly altered output.
     (fetchpatch {
       url = "https://github.com/alpernebbi/git-annex-adapter/commit/9f64c4b99cae7b681820c6c7382e1e40489f4d1e.patch";
       sha256 = "0yh66gial6bx7kbl7s7lkzljnkpgvgr8yahqqcq9z76d0w752dir";
+    })
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    # `rev` is part of utillinux on NixOS which is not available on `nixpks` for darwin:
+    # https://logs.nix.ci/?key=nixos/nixpkgs.45061&attempt_id=271763ba-2ae7-4098-b469-b82b1d8edb9b
+    (fetchpatch {
+      url = "https://github.com/alpernebbi/git-annex-adapter/commit/0b60b4577528b309f6ac9d47b55a00dbda9850ea.patch";
+      sha256 = "0z608hpmyzv1mm01dxr7d6bi1hc77h4yafghkynmv99ijgnm1qk7";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

`git-annex` version 6.20180719 enhances the output of `git-annex info`
with a description and UUID of the repository which broke the testcase
`test_process_annex_info_batch` which parses the output of the info
command.

The testcase has been fixed accordingly and the patch was filed upstream
here: https://github.com/alpernebbi/git-annex-adapter/pull/6

I rechecked the functionality in a simple python environment with the
following expression:

```
with import ./. {};
python3.withPackages (ps: with ps; [ git-annex-adapter ])
```

And tested the main in a Python REPL within the environment.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

