### PR TITLE
pythonPackages.thumbor: 6.5.1 -> 6.5.2

### DIFF
--- a/pkgs/development/python-modules/thumbor/default.nix
+++ b/pkgs/development/python-modules/thumbor/default.nix
@@ -1,17 +1,17 @@
-{ buildPythonPackage, stdenv, tornado, pycrypto, pycurl, pytz
+{ buildPythonPackage, tornado, pycrypto, pycurl, pytz
 , pillow, derpconf, python_magic, pexif, libthumbor, opencv, webcolors
 , piexif, futures, statsd, thumborPexif, fetchPypi, isPy3k, lib
 }:
 
 buildPythonPackage rec {
   pname = "thumbor";
-  version = "6.5.1";
+  version = "6.5.2";
 
   disabled = isPy3k; # see https://github.com/thumbor/thumbor/issues/1004
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0yalqwpxb6m0dz2qfnyv1pqqd5dd020wl7hc0n0bvsvxg1ib9if0";
+    sha256 = "1icfnzwzi5lvnh576n7v3r819jaw15ph9ja2w3fwg5z9qs40xvl8";
   };
 
   postPatch = ''
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   # for further reference.
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A smart imaging service";
     homepage = https://github.com/thumbor/thumbor/wiki;
     license = licenses.mit;


### PR DESCRIPTION
###### Motivation for this change

6.5.2 allows Pillow==5.2.0 (see https://github.com/thumbor/thumbor/releases/tag/6.5.2).

See https://hydra.nixos.org/build/79403232 for further reference.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

