### PR TITLE
[wip] mips64el-linux

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -9,6 +9,7 @@ let
     "aarch64-linux"
     "armv5tel-linux" "armv6l-linux" "armv7l-linux"
 
+    "mips64el-linux"
     "mipsel-linux"
 
     "i686-cygwin" "i686-freebsd" "i686-linux" "i686-netbsd" "i686-openbsd"
@@ -31,7 +32,8 @@ in rec {
   x86     = filterDoubles predicates.isx86;
   i686    = filterDoubles predicates.isi686;
   x86_64  = filterDoubles predicates.isx86_64;
-  mips    = filterDoubles predicates.isMips;
+  mips32  = filterDoubles predicates.isMips32;
+  mips64  = filterDoubles predicates.isMips64;
 
   cygwin  = filterDoubles predicates.isCygwin;
   darwin  = filterDoubles predicates.isDarwin;
@@ -44,5 +46,5 @@ in rec {
   openbsd = filterDoubles predicates.isOpenBSD;
   unix    = filterDoubles predicates.isUnix;
 
-  mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux"];
+  mesaPlatforms = ["i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mips64el-linux"];
 }

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -29,6 +29,11 @@ rec {
     platform = platforms.aarch64-multiplatform;
   };
 
+  mips64el-multiplatform = rec {
+    config = "mips64el-unknown-linux-gnu";
+    platform = platforms.mips64el-multiplatform;
+  };
+
   armv5te-android-prebuilt = rec {
     config = "armv5tel-unknown-linux-androideabi";
     sdkVer = "21";

--- a/lib/systems/for-meta.nix
+++ b/lib/systems/for-meta.nix
@@ -14,7 +14,8 @@ in rec {
   x86     = [ patterns.isx86 ];
   i686    = [ patterns.isi686 ];
   x86_64  = [ patterns.isx86_64 ];
-  mips    = [ patterns.isMips ];
+  mips32  = [ patterns.isMips32 ];
+  mips64  = [ patterns.isMips64 ];
   riscv   = [ patterns.isRiscV ];
 
   cygwin  = [ patterns.isCygwin ];

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -14,7 +14,8 @@ rec {
     isx86          = { cpu = { family = "x86"; }; };
     isAarch32      = { cpu = { family = "arm"; bits = 32; }; };
     isAarch64      = { cpu = { family = "arm"; bits = 64; }; };
-    isMips         = { cpu = { family = "mips"; }; };
+    isMips32       = { cpu = { family = "mips"; bits = 32; }; };
+    isMips64       = { cpu = { family = "mips"; bits = 64; }; };
     isRiscV        = { cpu = { family = "riscv"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
     isWasm         = { cpu = { family = "wasm"; }; };

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -433,6 +433,24 @@ rec {
     };
   };
 
+  mips64el-multiplatform = {
+    name = "mips64el-multiplatform";
+    kernelArch = "mips";
+    kernelTarget = "vmlinux";
+    kernelAutoModules = true;
+#   kernelBaseConfig = "cavium_octeon_defconfig";
+    kernelBaseConfig = "malta_kvm_guest_defconfig";
+    kernelExtraConfig = ''
+      CPS y
+      MSA y
+    '';
+    gcc = {
+#     arch = "octeon+"; Cavium CN5020
+      arch = "mips64r2"; # qemu
+      abi = "64";
+    };
+  };
+
   ##
   ## Other
   ##
@@ -458,5 +476,6 @@ rec {
       "armv7l-linux" = armv7l-hf-multiplatform;
       "aarch64-linux" = aarch64-multiplatform;
       "mipsel-linux" = fuloong2f_n32;
+      "mips64el-linux" = mips64el-multiplatform;
     }.${system} or pcBase;
 }

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -17,6 +17,7 @@ in with lib.systems.doubles; lib.runTests {
   arm = assertTrue (mseteq arm [ "armv5tel-linux" "armv6l-linux" "armv7l-linux" ]);
   i686 = assertTrue (mseteq i686 [ "i686-linux" "i686-freebsd" "i686-netbsd" "i686-openbsd" "i686-cygwin" ]);
   mips = assertTrue (mseteq mips [ "mipsel-linux" ]);
+  mips64 = assertTrue (mseteq mips [ "mips64el-linux" ]);
   x86_64 = assertTrue (mseteq x86_64 [ "x86_64-linux" "x86_64-darwin" "x86_64-freebsd" "x86_64-openbsd" "x86_64-netbsd" "x86_64-cygwin" "x86_64-solaris" ]);
 
   cygwin = assertTrue (mseteq cygwin [ "i686-cygwin" "x86_64-cygwin" ]);
@@ -24,7 +25,7 @@ in with lib.systems.doubles; lib.runTests {
   freebsd = assertTrue (mseteq freebsd [ "i686-freebsd" "x86_64-freebsd" ]);
   gnu = assertTrue (mseteq gnu (linux /* ++ hurd ++ kfreebsd ++ ... */));
   illumos = assertTrue (mseteq illumos [ "x86_64-solaris" ]);
-  linux = assertTrue (mseteq linux [ "i686-linux" "x86_64-linux" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mipsel-linux" ]);
+  linux = assertTrue (mseteq linux [ "i686-linux" "x86_64-linux" "armv5tel-linux" "armv6l-linux" "armv7l-linux" "aarch64-linux" "mipsel-linux" "mips64el-linux" ]);
   netbsd = assertTrue (mseteq netbsd [ "i686-netbsd" "x86_64-netbsd" ]);
   openbsd = assertTrue (mseteq openbsd [ "i686-openbsd" "x86_64-openbsd" ]);
   unix = assertTrue (mseteq unix (linux ++ darwin ++ freebsd ++ openbsd ++ netbsd ++ illumos));

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -58,7 +58,8 @@ let
     else if (with targetPlatform; isAarch32 && isLinux)   then "${libc_lib}/lib/ld-linux*.so.3"
     else if targetPlatform.system == "aarch64-linux"  then "${libc_lib}/lib/ld-linux-aarch64.so.1"
     else if targetPlatform.system == "powerpc-linux"  then "${libc_lib}/lib/ld.so.1"
-    else if targetPlatform.isMips                     then "${libc_lib}/lib/ld.so.1"
+    else if targetPlatform.isMips32                   then "${libc_lib}/lib/ld.so.1"
+    else if targetPlatform.isMips64                   then "${libc_lib}/lib/ld.so.1"
     else if targetPlatform.isDarwin                   then "/usr/lib/dyld"
     else if stdenv.lib.hasSuffix "pc-gnu" targetPlatform.config then "ld.so.1"
     else null;
@@ -171,15 +172,17 @@ stdenv.mkDerivation {
       else if targetPlatform.isWindows then "pe"
       else "elf" + toString targetPlatform.parsed.cpu.bits;
     endianPrefix = if targetPlatform.isBigEndian then "big" else "little";
-    sep = optionalString (!targetPlatform.isMips) "-";
+    sep = optionalString (!(targetPlatform.isMips32 || targetPlatform.isMips64)) "-";
     arch =
       /**/ if targetPlatform.isAarch64 then endianPrefix + "aarch64"
       else if targetPlatform.isAarch32     then endianPrefix + "arm"
       else if targetPlatform.isx86_64  then "x86-64"
       else if targetPlatform.isi686    then "i386"
-      else if targetPlatform.isMips    then {
+      else if targetPlatform.isMips32  then {
           "mips"     = "btsmipn32"; # n32 variant
           "mipsel"   = "ltsmipn32"; # n32 variant
+        }.${targetPlatform.parsed.cpu.name}
+      else if targetPlatform.isMips64  then {
           "mips64"   = "btsmip";
           "mips64el" = "ltsmip";
         }.${targetPlatform.parsed.cpu.name}

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -285,7 +285,8 @@ postInstall() {
     # Disable RANDMMAP on grsec, which causes segfaults when using
     # precompiled headers.
     # See https://bugs.gentoo.org/show_bug.cgi?id=301299#c31
-    paxmark r $out/libexec/gcc/*/*/{cc1,cc1plus}
+    # Error is ignored because paxmark fails on 'mips64el' with "not a valid ELF executable (invalid PT_ entry:7)"
+    paxmark r $out/libexec/gcc/*/*/{cc1,cc1plus} || true
 
     # Two identical man pages are shipped (moving and compressing is done later)
     ln -sf gcc.1 "$out"/share/man/man1/g++.1

--- a/pkgs/development/compilers/ocaml/3.11.2.nix
+++ b/pkgs/development/compilers/ocaml/3.11.2.nix
@@ -2,7 +2,7 @@
 
 let
    useX11 = stdenv.isi686 || stdenv.isx86_64;
-   useNativeCompilers = stdenv.isi686 || stdenv.isx86_64 || stdenv.isMips;
+   useNativeCompilers = stdenv.isi686 || stdenv.isx86_64 || stdenv.isMips32;
    inherit (stdenv.lib) optionals optionalString;
 in
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   # Needed to avoid a SIGBUS on the final executable on mips
-  NIX_CFLAGS_COMPILE = if stdenv.isMips then "-fPIC" else "";
+  NIX_CFLAGS_COMPILE = if stdenv.isMips32 then "-fPIC" else "";
 
   patches = optionals stdenv.isDarwin [ ./gnused-on-osx-fix.patch ] ++
     [ (fetchurl {

--- a/pkgs/development/compilers/ocaml/3.12.1.nix
+++ b/pkgs/development/compilers/ocaml/3.12.1.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, ncurses, xlibsWrapper }:
 
 let
-   useX11 = !stdenv.isAarch32 && !stdenv.isMips;
-   useNativeCompilers = !stdenv.isMips;
+   useX11 = !stdenv.isAarch32 && !stdenv.isMips32;
+   useNativeCompilers = !stdenv.isMips32;
    inherit (stdenv.lib) optionals optionalString;
 in
 

--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, ncurses, xlibsWrapper }:
 
 let
-   useX11 = !stdenv.isAarch32 && !stdenv.isMips;
-   useNativeCompilers = !stdenv.isMips;
+   useX11 = !stdenv.isAarch32 && !stdenv.isMips32;
+   useNativeCompilers = !stdenv.isMips32;
    inherit (stdenv.lib) optionals optionalString;
 in
 

--- a/pkgs/development/compilers/ocaml/ber-metaocaml-104.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml-104.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   };
 
   # Needed to avoid a SIGBUS on the final executable on mips
-  NIX_CFLAGS_COMPILE = if stdenv.isMips then "-fPIC" else "";
+  NIX_CFLAGS_COMPILE = if stdenv.isMips32 then "-fPIC" else "";
 
   x11env = buildEnv { name = "x11env"; paths = [libX11 xproto];};
   x11lib = x11env + "/lib";

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -7,7 +7,7 @@ let
   real_url = if url == null then
     "http://caml.inria.fr/pub/distrib/ocaml-${versionNoPatch}/ocaml-${version}.tar.xz"
   else url;
-  safeX11 = stdenv: !(stdenv.isAarch32 || stdenv.isMips);
+  safeX11 = stdenv: !(stdenv.isAarch32 || stdenv.isMips32);
 in
 
 { stdenv, fetchurl, ncurses, buildEnv
@@ -15,11 +15,11 @@ in
 , flambdaSupport ? false
 }:
 
-assert useX11 -> !stdenv.isAarch32 && !stdenv.isMips;
+assert useX11 -> !stdenv.isAarch32 && !stdenv.isMips32;
 assert flambdaSupport -> stdenv.lib.versionAtLeast version "4.03";
 
 let
-   useNativeCompilers = !stdenv.isMips;
+   useNativeCompilers = !stdenv.isMips32;
    inherit (stdenv.lib) optional optionals optionalString;
    name = "ocaml${optionalString flambdaSupport "+flambda"}-${version}";
 in

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -88,7 +88,7 @@ let
 
     preConfigure = optionalString (!crossCompiling) ''
         configureFlags="$configureFlags -Dprefix=$out -Dman1dir=$out/share/man/man1 -Dman3dir=$out/share/man/man3"
-      '' + optionalString (stdenv.isAarch32 || stdenv.isMips) ''
+      '' + optionalString (stdenv.isAarch32 || stdenv.isMips32) ''
         configureFlagsArray=(-Dldflags="-lm -lrt")
       '' + optionalString stdenv.isDarwin ''
         substituteInPlace hints/darwin.sh --replace "env MACOSX_DEPLOYMENT_TARGET=10.3" ""

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -69,7 +69,8 @@ let
     # https://www.boost.org/doc/libs/1_66_0/libs/context/doc/html/context/architectures.html
     "abi=${if hostPlatform.parsed.cpu.family == "arm" then "aapcs"
            else if hostPlatform.isWindows then "ms"
-           else if hostPlatform.isMips then "o32"
+           else if hostPlatform.isMips32 then "o32"
+#          else if hostPlatform.isMips64 then "64"
            else "sysv"}"
   ] ++ optional (link != "static") "runtime-link=${runtime-link}"
     ++ optional (variant == "release") "debug-symbols=off"

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
       url = https://github.com/sorear/libffi-riscv/commit/e46492e8bb1695a19bc1053ed869e6c2bab02ff2.patch;
       sha256 = "1vl1vbvdkigs617kckxvj8j4m2cwg62kxm1clav1w5rnw9afxg0y";
     })
-    ++ stdenv.lib.optionals stdenv.isMips [
+    ++ stdenv.lib.optionals (stdenv.isMips32 || stdenv.isMips64) [
       (fetchpatch {
         name = "0001-mips-Use-compiler-internal-define-for-linux.patch";
         url = "http://cgit.openembedded.org/openembedded-core/plain/meta/recipes-support/libffi/libffi/0001-mips-Use-compiler-internal-define-for-linux.patch?id=318e33a708378652edcf61ce7d9d7f3a07743000";

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -40,7 +40,7 @@
 }:
 
 let
-  inherit (stdenv) is64bit isMips isDarwin isCygwin;
+  inherit (stdenv) is64bit isMips32 isMips64 isDarwin isCygwin;
   inherit (stdenv.lib) enableFeature optional optionals;
 in
 
@@ -101,8 +101,8 @@ stdenv.mkDerivation rec {
     (if sizeLimitSupport then "--size-limit=5120x3200" else null)
     "--disable-codec-srcs"
     (enableFeature debugLibsSupport "debug-libs")
-    (enableFeature isMips "dequant-tokens")
-    (enableFeature isMips "dc-recon")
+    (enableFeature (isMips32 || isMips64) "dequant-tokens")
+    (enableFeature (isMips32 || isMips64) "dc-recon")
     (enableFeature postprocSupport "postproc")
     (enableFeature (postprocSupport && (vp9DecoderSupport || vp9EncoderSupport)) "vp9-postproc")
     (enableFeature multithreadSupport "multithread")

--- a/pkgs/development/libraries/libvpx/git.nix
+++ b/pkgs/development/libraries/libvpx/git.nix
@@ -42,11 +42,11 @@
 }:
 
 let
-  inherit (stdenv) isi686 isx86_64 isAarch32 is64bit isMips isDarwin isCygwin;
+  inherit (stdenv) isi686 isx86_64 isAarch32 is64bit isMips32 isMips64 isDarwin isCygwin;
   inherit (stdenv.lib) enableFeature optional optionals;
 in
 
-assert isi686 || isx86_64 || isAarch32 || isMips; # Requires ARM with floating point support
+assert isi686 || isx86_64 || isAarch32 || isMips32 || isMips64; # Requires ARM with floating point support
 
 assert vp8DecoderSupport || vp8EncoderSupport || vp9DecoderSupport || vp9EncoderSupport;
 assert internalStatsSupport && (vp9DecoderSupport || vp9EncoderSupport) -> postprocSupport;
@@ -108,8 +108,8 @@ stdenv.mkDerivation rec {
     (enableFeature fastUnalignedSupport "fast-unaligned")
     "--disable-codec-srcs"
     (enableFeature debugLibsSupport "debug-libs")
-    (enableFeature isMips "dequant-tokens")
-    (enableFeature isMips "dc-recon")
+    (enableFeature (isMips32 || isMips64) "dequant-tokens")
+    (enableFeature (isMips32 || isMips64) "dc-recon")
     (enableFeature postprocSupport "postproc")
     (enableFeature (postprocSupport && (vp9DecoderSupport || vp9EncoderSupport)) "vp9-postproc")
     (enableFeature multithreadSupport "multithread")

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -24,7 +24,8 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "doc" "man" ];
 
-  configureFlags = optional (!hostPlatform.isRiscV) "--enable-jit" ++ [
+  # AVAILABILITY OF JIT SUPPORT: https://www.pcre.org/original/doc/html/pcrejit.html#SEC3
+  configureFlags = optional (!hostPlatform.isRiscV && !hostPlatform.isMips64) "--enable-jit" ++ [
     "--enable-unicode-properties"
     "--disable-cpp"
   ]

--- a/pkgs/misc/uboot/nanonote.nix
+++ b/pkgs/misc/uboot/nanonote.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    platforms = stdenv.lib.platforms.mips;
+    platforms = stdenv.lib.platforms.mips32;
   };
 }

--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
       # We get a warning in armv5tel-linux and the fuloong2f, so we
       # disable -Werror in it.
-      ${stdenv.lib.optionalString (stdenv.isAarch32 || stdenv.hostPlatform.isMips) ''
+      ${stdenv.lib.optionalString (stdenv.isAarch32 || stdenv.hostPlatform.isMips32) ''
         sed -i s/-Werror// src/Makefile.am
       ''}
     '';

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -88,7 +88,7 @@ in stdenv.mkDerivation rec {
     '';
 
   # One test fails on mips.
-  doCheck = !stdenv.isMips;
+  doCheck = !stdenv.isMips32;
 
   meta = with stdenv.lib; {
     description = "Linux user-space NFS utilities";

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -56,7 +56,7 @@ in lib.init bootStages ++ [
            # to recognize 64-bit DLLs
         ++ lib.optional (hostPlatform.config == "x86_64-w64-mingw32") buildPackages.file
         ++ lib.optional
-             (hostPlatform.isAarch64 || hostPlatform.isMips || hostPlatform.libc == "musl")
+             (hostPlatform.isAarch64 || hostPlatform.isMips32 || hostPlatform.isMips64 || hostPlatform.libc == "musl")
              buildPackages.updateAutotoolsGnuConfigScriptsHook
         ;
     });

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -46,6 +46,7 @@ in
     "armv7l-linux" = stagesLinux;
     "aarch64-linux" = stagesLinux;
     "mipsel-linux" = stagesLinux;
+    "mips64el-linux" = stagesLinux;
     "powerpc-linux" = /* stagesLinux */ stagesNative;
     "x86_64-darwin" = stagesDarwin;
     "x86_64-solaris" = stagesNix;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -122,7 +122,7 @@ let
       # Utility flags to test the type of platform.
       inherit (hostPlatform)
         isDarwin isLinux isSunOS isHurd isCygwin isFreeBSD isOpenBSD
-        isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian;
+        isi686 isx86_64 is64bit isAarch32 isAarch64 isMips32 isMips64 isBigEndian;
       isArm = builtins.trace "stdenv.isArm is deprecated after 18.03" hostPlatform.isArm;
 
       # Whether we should run paxctl to pax-mark binaries.

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -16,6 +16,7 @@
       "armv7l-linux" = import ./bootstrap-files/armv7l.nix;
       "aarch64-linux" = import ./bootstrap-files/aarch64.nix;
       "mipsel-linux" = import ./bootstrap-files/loongson2f.nix;
+#     "mips64el-linux" = import ./bootstrap-files/mips64el.nix;
     };
     "musl" = {
       "aarch64-linux" = import ./bootstrap-files/aarch64-musl.nix;

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -13,6 +13,7 @@ in with (import ../../../lib).systems.examples; {
   armv6l     = make raspberryPi;
   armv7l     = make armv7l-hf-multiplatform;
   aarch64    = make aarch64-multiplatform;
+  mips64el   = make mips64el-multiplatform;
   x86_64-musl  = make musl64;
   armv6l-musl  = make muslpi;
   aarch64-musl = make aarch64-multiplatform-musl;

--- a/pkgs/stdenv/linux/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools.nix
@@ -106,7 +106,7 @@ in with pkgs; rec {
         cp -d ${patch}/bin/* $out/bin
         cp ${patchelf}/bin/* $out/bin
 
-        cp -d ${gnugrep.pcre.out}/lib/libpcre*.so* $out/lib # needed by grep
+        cp -d ${gnugrep.pcre.out}/lib/libpcre*.so* $out/lib || true # needed by grep
 
         # Copy what we need of GCC.
         cp -d ${gcc.cc.out}/bin/gcc $out/bin
@@ -131,9 +131,9 @@ in with pkgs; rec {
         rm -rf $out/include/c++/*/ext/pb_ds
         rm -rf $out/include/c++/*/ext/parallel
 
-        cp -d ${gmpxx.out}/lib/libgmp*.so* $out/lib
-        cp -d ${mpfr.out}/lib/libmpfr*.so* $out/lib
-        cp -d ${libmpc.out}/lib/libmpc*.so* $out/lib
+        cp -d ${gmpxx.out}/lib/libgmp*.so* $out/lib   || true
+        cp -d ${mpfr.out}/lib/libmpfr*.so* $out/lib   || true
+        cp -d ${libmpc.out}/lib/libmpc*.so* $out/lib  || true
         cp -d ${zlib.out}/lib/libz.so* $out/lib
         cp -d ${libelf}/lib/libelf.so* $out/lib
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9622,7 +9622,7 @@ with pkgs;
 
   cairo = callPackage ../development/libraries/cairo {
     glSupport = config.cairo.gl or (stdenv.isLinux &&
-      !stdenv.isAarch32 && !stdenv.isMips);
+      !stdenv.isAarch32 && !stdenv.isMips32);
   };
 
 


### PR DESCRIPTION
###### Motivation for this change

The goal is to recover MIPS64 (Cavium Octeon) support which was here before https://github.com/NixOS/nixpkgs/pull/35247 and to cleanup the difference between MIPS32 and MIPS64 targets (like we already have it for ARM)

Target devices are Qemu and Ubiquiti EdgeRouter https://openwrt.org/toh/ubiquiti/edgerouter.lite

