### PR TITLE
[WIP] perl: build deterministically

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -86,7 +86,20 @@ let
 
     enableParallelBuilding = !crossCompiling;
 
-    preConfigure = optionalString (!crossCompiling) ''
+    preConfigure = ''
+      # perl includes the build date, the uname of the build system and the
+      # username of the build user in some files.
+      # We override these to make it build deterministically.
+      # Very much inspired by what Debian did for reproducibility: https://salsa.debian.org/perl-team/interpreter/perl/blob/debian-5.26/debian/config.over
+      # A ticket has been opened upstream to possibly clean some of this up: https://rt.perl.org/Public/Bug/Display.html?id=133452
+      fake_osversion=4.14.0
+      echo "myhostname='nixpkgs'" >config.over
+      ${if stdenv.hostPlatform.isLinux then ''echo "osvers='$fake_osversion'" >>config.over
+      echo "myuname='linux nixpkgs #1 smp nixos $fake_osversion $(date -d "@$SOURCE_DATE_EPOCH") gnulinux'" >>config.over
+      '' else ""}
+      echo "cf_time='$(date -d "@$SOURCE_DATE_EPOCH")'" >>config.over
+      echo "cf_by='nixpkgs'" >>config.over
+      '' + optionalString (!crossCompiling) ''
         configureFlags="$configureFlags -Dprefix=$out -Dman1dir=$out/share/man/man1 -Dman3dir=$out/share/man/man3"
       '' + optionalString (stdenv.isAarch32 || stdenv.isMips) ''
         configureFlagsArray=(-Dldflags="-lm -lrt")
@@ -96,6 +109,7 @@ let
         # We need to do this because the bootstrap doesn't have a static libpthread
         sed -i 's,\(libswanted.*\)pthread,\1,g' Configure
       '';
+    PERL_HASH_SEED="0";
 
     preBuild = optionalString (!(stdenv ? cc && stdenv.cc.nativeTools))
       ''


### PR DESCRIPTION
* removes a uname, username and date mention in the output
* resets the hash seed for the build
* sets configuration date to $SOURCE_DATE_EPOCH

###### Motivation for this change
As it is, Perl does not build deterministically because some information about the build system as well as the build date is written to the output. This patch seeks to remedy this situation.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS (x86-64 and ppc64le)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"` (I have no time to rebuild *all of nixpkgs*)
- [ ] Tested execution of all binary files (only those used in the build of further packages, e. g. the bootstrap files or a NixOS system)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

