### PR TITLE
lmdbxx: init at 0.9.14.0

### DIFF
--- a/pkgs/development/libraries/lmdbxx/default.nix
+++ b/pkgs/development/libraries/lmdbxx/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetchFromGitHub
+, lmdb }:
+
+stdenv.mkDerivation rec {
+  name = "lmdbxx-${version}";
+  version = "0.9.14.0";
+
+  src = fetchFromGitHub {
+    owner = "bendiken";
+    repo = "lmdbxx";
+    rev = "${version}";
+    sha256 = "1jmb9wg2iqag6ps3z71bh72ymbcjrb6clwlkgrqf1sy80qwvlsn6";
+  };
+
+  buildInputs = [ lmdb ];
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    homepage = "https://github.com/bendiken/lmdbxx#readme";
+    description = "C++11 wrapper for the LMDB embedded B+ tree database library";
+    license = stdenv.lib.licenses.unlicense;
+    maintainers = with stdenv.lib.maintainers; [ fgaz ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9943,6 +9943,8 @@ with pkgs;
 
   lmdb = callPackage ../development/libraries/lmdb { };
 
+  lmdbxx = callPackage ../development/libraries/lmdbxx { };
+
   levmar = callPackage ../development/libraries/levmar { };
 
   leptonica = callPackage ../development/libraries/leptonica { };


### PR DESCRIPTION
###### Motivation for this change

It's just a header, but why not include it in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

