### PR TITLE
Add license meta tags

### DIFF
--- a/pkgs/development/libraries/cppunit/default.nix
+++ b/pkgs/development/libraries/cppunit/default.nix
@@ -9,9 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1027cyfx5gsjkdkaf6c2wnjh68882grw8n672018cj3vs9lrhmix";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://freedesktop.org/wiki/Software/cppunit/;
     description = "C++ unit testing framework";
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    license = licenses.lgpl21;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage    = https://github.com/cracklib/cracklib;
     description = "A library for checking the strength of passwords";
+    license = licenses.lgpl21; # Different license for the wordlist: http://www.openwall.com/wordlists
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;
   };

--- a/pkgs/os-specific/linux/cpufrequtils/default.nix
+++ b/pkgs/os-specific/linux/cpufrequtils/default.nix
@@ -21,8 +21,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ stdenv.cc.libc.linuxHeaders libtool gettext ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Tools to display or change the CPU governor settings";
-    platforms = stdenv.lib.platforms.linux;
+    homepage = http://ftp.be.debian.org/pub/linux/utils/kernel/cpufreq/cpufrequtils.html;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/cramfsswap/default.nix
+++ b/pkgs/os-specific/linux/cramfsswap/default.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation {
 
   buildInputs = [zlib];
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    description = "swap endianess of a cram filesystem (cramfs)";
+    homepage = "https://packages.debian.org/sid/utils/cramfsswap";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/archivers/cpio/default.nix
+++ b/pkgs/tools/archivers/cpio/default.nix
@@ -31,10 +31,11 @@ in stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.gnu.org/software/cpio/;
     description = "A program to create or extract from cpio archives";
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl3;
+    platforms = platforms.all;
     priority = 6; # resolves collision with gnutar's "libexec/rmt"
   };
 }

--- a/pkgs/tools/archivers/cromfs/default.nix
+++ b/pkgs/tools/archivers/cromfs/default.nix
@@ -21,10 +21,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ fuse perl ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "FUSE Compressed ROM filesystem with lzma";
     homepage = https://bisqwit.iki.fi/source/cromfs.html;
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.viric ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/cowsay/default.nix
+++ b/pkgs/tools/misc/cowsay/default.nix
@@ -15,10 +15,11 @@ stdenv.mkDerivation {
     bash ./install.sh $out
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A program which generates ASCII pictures of a cow with a message";
-    homepage = http://www.nog.net/~tony/warez/cowsay.shtml;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.rob ];
+    homepage = https://en.wikipedia.org/wiki/Cowsay;
+    license = licenses.gpl1;
+    platforms = platforms.all;
+    maintainers = [ maintainers.rob ];
   };
 }

--- a/pkgs/tools/system/cron/default.nix
+++ b/pkgs/tools/system/cron/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   hardeningEnable = [ "pie" ];
 
   preBuild = ''
-    # do not set sticky bit in /nix/store 
+    # do not set sticky bit in /nix/store
     substituteInPlace Makefile --replace ' -o root' ' ' --replace 111 755 --replace 4755 0755
     # do not strip during install, broken on cross and we'll do ourselves as needed
     substituteInPlace Makefile --replace ' -s cron' ' cron'
@@ -36,8 +36,9 @@ stdenv.mkDerivation {
 
   preInstall = "mkdir -p $out/bin $out/sbin $out/share/man/man1 $out/share/man/man5 $out/share/man/man8";
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Daemon for running commands at specific times (Vixie Cron)";
-    platforms = with stdenv.lib.platforms; linux ++ darwin;
+    license = licenses.bsd0;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/tools/virtualization/cri-tools/default.nix
+++ b/pkgs/tools/virtualization/cri-tools/default.nix
@@ -1,4 +1,4 @@
-{ buildGoPackage, fetchurl }:
+{ buildGoPackage, fetchurl, lib }:
 
 buildGoPackage
   { name = "cri-tools-1.0.0-alpha.0";
@@ -9,6 +9,10 @@ buildGoPackage
 
     goPackagePath = "github.com/kubernetes-incubator/cri-tools";
     subPackages = [ "cmd/crictl" "cmd/critest" ];
+
+    meta = {
+      license = lib.licenses.asl20;
+    };
 
     goDeps = ./deps.nix;
   }


### PR DESCRIPTION
###### Motivation for this change
See https://github.com/NixOS/nixpkgs/issues/43716

###### Things done
Opened https://github.com/NixOS/nixpkgs/issues/45076 to track dead download links

Added license tags to:
- cri-tools
- cron
- cowsay (CC @rbvermaa download link is dead)
- cromfs
- cpio
- cramfsswap
- cpufrequtils
- cracklib
- cppunit


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

