### PR TITLE
libxml2: fix CVE-2018-14567 & CVE-2018-14404

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl
+{ stdenv, lib, fetchurl, fetchpatch
 , zlib, xz, python2, findXMLCatalogs
 , buildPlatform, hostPlatform
 , pythonSupport ? buildPlatform == hostPlatform
@@ -20,9 +20,15 @@ in stdenv.mkDerivation rec {
   };
 
   patches = [
-    (fetchurl { # CVE-2018-9251
-      url = https://gitlab.gnome.org/GNOME/libxml2/commit/2240fbf5912054af025fb6e01e26375100275e74.diff;
-      sha256 = "01c5dnipz2rmv2dgma1ycvhyiyfvy9makyn6ywahm10jwk5chn3i";
+    (fetchpatch {
+      name = "CVE-2018-14567_CVE-2018-9251.patch";
+      url = https://gitlab.gnome.org/GNOME/libxml2/commit/2240fbf5912054af025fb6e01e26375100275e74.patch;
+      sha256 = "1xpqsfkzhrqasza51c821mnds5l317djrz8086fmzpyf68vld03h";
+    })
+    (fetchpatch {
+      name = "CVE-2018-14404.patch";
+      url = https://gitlab.gnome.org/GNOME/libxml2/commit/a436374994c47b12d5de1b8b1d191a098fa23594.patch;
+      sha256 = "19vp7p32vrninnfa7vk9ipw7n4cl1gg16xxbhjy2d0kwp1crvzqh";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes CVE-2018-14567 & CVE-2018-14404

Since the already added patch for CVE-2018-9251 also affects
CVE-2018-14567 I renamed the applied patch accordingly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

