### PR TITLE
samba: 4.7.6 -> 4.7.9

### DIFF
--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -19,11 +19,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "samba-${version}";
-  version = "4.7.6";
+  version = "4.7.9";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${name}.tar.gz";
-    sha256 = "0vkxqp3wh7bpn1fd45lznmrpn2ma1fq75yq28vi08rggr07y7v8y";
+    sha256 = "1v0pd2k4rfdzcqbzb3g5gjiy8rwqamppwzwy5swz4x5rxyr5567c";
   };
 
   outputs = [ "out" "dev" "man" ];


### PR DESCRIPTION
Version 4.7.9 is a security release. The versions 4.7.7 & 4.7.8 contain
numerous bug fixes.

This fixes a couple of security related issues:
 - https://www.samba.org/samba/security/CVE-2018-10858.html
 - https://www.samba.org/samba/security/CVE-2018-10918.html
 - https://www.samba.org/samba/security/CVE-2018-10919.html
 - https://www.samba.org/samba/security/CVE-2018-1139.html

Changelogs for the version upgrades can be found below.

 - https://www.samba.org/samba/history/samba-4.7.7.html
 - https://www.samba.org/samba/history/samba-4.7.8.html
 - https://www.samba.org/samba/history/samba-4.7.9.html

(cherry picked from commit 67ea2c0ffe9a39111b780ce2995eb46c68d26cce)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

