### PR TITLE
[18.03] libmspack: 0.6alpha -> 0.7.1alpha

### DIFF
--- a/pkgs/development/libraries/libmspack/default.nix
+++ b/pkgs/development/libraries/libmspack/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "libmspack-0.6alpha";
+  name = "libmspack-0.7.1alpha";
 
   src = fetchurl {
-    url = "http://www.cabextract.org.uk/libmspack/${name}.tar.gz";
-    sha256 = "08gr2pcinas6bdqz3k0286g5cnksmcx813skmdwyca6bmj1fxnqy";
+    url = "https://www.cabextract.org.uk/libmspack/${name}.tar.gz";
+    sha256 = "0zn4vwzk5ankgd0l88cipan19pzbzv0sm3fba17lvqwka3dp1acp";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This addresses the following issues:

- CVE-2018-14697
- CVE-2018-14680
- CVE-2018-14681
- CVE-2018-14682

(cherry picked from commit 3c1f5d96ff3dc863ba96179cb454ffa5dcd32dbf)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

