### PR TITLE
p7zip: vendor debian patches

### DIFF
--- a/pkgs/tools/archivers/p7zip/12-CVE-2016-9296.patch
+++ b/pkgs/tools/archivers/p7zip/12-CVE-2016-9296.patch
@@ -1,0 +1,23 @@
+From: Robert Luberda <robert@debian.org>
+Date: Sat, 19 Nov 2016 08:48:08 +0100
+Subject: Fix nullptr dereference (CVE-2016-9296)
+
+Patch taken from https://sourceforge.net/p/p7zip/bugs/185/
+---
+ CPP/7zip/Archive/7z/7zIn.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CPP/7zip/Archive/7z/7zIn.cpp b/CPP/7zip/Archive/7z/7zIn.cpp
+index b0c6b98..7c6dde2 100644
+--- a/CPP/7zip/Archive/7z/7zIn.cpp
++++ b/CPP/7zip/Archive/7z/7zIn.cpp
+@@ -1097,7 +1097,8 @@ HRESULT CInArchive::ReadAndDecodePackedStreams(
+       if (CrcCalc(data, unpackSize) != folders.FolderCRCs.Vals[i])
+         ThrowIncorrect();
+   }
+-  HeadersSize += folders.PackPositions[folders.NumPackStreams];
++  if (folders.PackPositions)
++      HeadersSize += folders.PackPositions[folders.NumPackStreams];
+   return S_OK;
+ }
+ 

--- a/pkgs/tools/archivers/p7zip/13-CVE-2017-17969.patch
+++ b/pkgs/tools/archivers/p7zip/13-CVE-2017-17969.patch
@@ -1,0 +1,35 @@
+From: =?utf-8?q?Antoine_Beaupr=C3=A9?= <anarcat@debian.org>
+Date: Fri, 2 Feb 2018 11:11:41 +0100
+Subject: Heap-based buffer overflow in 7zip/Compress/ShrinkDecoder.cpp
+
+Origin: vendor, https://sourceforge.net/p/p7zip/bugs/_discuss/thread/0920f369/27d7/attachment/CVE-2017-17969.patch
+Forwarded: https://sourceforge.net/p/p7zip/bugs/_discuss/thread/0920f369/#27d7
+Bug: https://sourceforge.net/p/p7zip/bugs/204/
+Bug-Debian: https://bugs.debian.org/888297
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2017-17969
+Reviewed-by: Salvatore Bonaccorso <carnil@debian.org>
+Last-Update: 2018-02-01
+Applied-Upstream: 18.00-beta
+---
+ CPP/7zip/Compress/ShrinkDecoder.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CPP/7zip/Compress/ShrinkDecoder.cpp b/CPP/7zip/Compress/ShrinkDecoder.cpp
+index 80b7e67..ca37764 100644
+--- a/CPP/7zip/Compress/ShrinkDecoder.cpp
++++ b/CPP/7zip/Compress/ShrinkDecoder.cpp
+@@ -121,8 +121,13 @@ HRESULT CDecoder::CodeReal(ISequentialInStream *inStream, ISequentialOutStream *
+     {
+       _stack[i++] = _suffixes[cur];
+       cur = _parents[cur];
++      if (cur >= kNumItems || i >= kNumItems)
++        break;
+     }
+-    
++
++    if (cur >= kNumItems || i >= kNumItems)
++      break;
++
+     _stack[i++] = (Byte)cur;
+     lastChar2 = (Byte)cur;
+ 

--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchpatch }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "p7zip-${version}";
@@ -10,16 +10,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (fetchpatch rec {
-      name = "CVE-2016-9296.patch";
-      url = "https://salsa.debian.org/debian/p7zip/raw/debian/${version}+dfsg-6/debian/patches/12-${name}";
-      sha256 = "09wbkzai46bwm8zmplsz0m4jck3qn7snr68i9p1gsih300zidj0m";
-    })
-    (fetchpatch rec {
-      name = "CVE-2017-17969.patch";
-      url = "https://salsa.debian.org/debian/p7zip/raw/debian/${version}+dfsg-6/debian/patches/13-${name}";
-      sha256 = "00pycdwx6gw7w591bg54ym6zhbxgn47p3zhms6mnmaycfzw09mkn";
-    })
+    ./12-CVE-2016-9296.patch
+    ./13-CVE-2017-17969.patch
   ];
 
   # Default makefile is full of impurities on Darwin. The patch doesn't hurt Linux so I'm leaving it unconditional


### PR DESCRIPTION
A few months ago I moved these patches to the new debian alsa instance [1], but
it looks like their `sha256`s on the tag at the remote have changed again.

It doesn't appear that debian's source remote is stable in the way we need it to
be; let's just vendor the patches to avoid future issues.

[1] https://github.com/NixOS/nixpkgs/pull/41769

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

