### PR TITLE
[WIP] Set absolute sonames

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1500,6 +1500,15 @@ installTargets = "install-bin install-doc";</programlisting>
       </para>
      </listitem>
      <listitem>
+       <para>
+         On Linux, it uses <command>patchelf</command> on all libraries in
+         the <filename>lib</filename> tree to make the <varname>DT_SONAME</varname>
+         an absolute path to the library. This makes other binaries that
+         link against it access it directly rather than searching through
+         <varname>DT_RUNPATH</varname>, which increases efficiency.
+       </para>
+     </listitem>
+     <listitem>
       <para>
        It rewrites the interpreter paths of shell scripts to paths found in
        <envar>PATH</envar>. E.g., <filename>/usr/bin/perl</filename> will be
@@ -1620,6 +1629,18 @@ installTargets = "install-bin install-doc";</programlisting>
        unnecessary <literal>RPATH</literal> entries. Only applies to Linux.
       </para>
      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>
+        <varname>noAbsoluteSoname</varname>
+      </term>
+      <listitem>
+        <para>
+          If set, the <varname>DT_SONAME</varname> entries of the shared
+          libraries in the output will be left unmodified. Only applies
+          to Linux.
+        </para>
+      </listitem>
     </varlistentry>
     <varlistentry>
      <term>

--- a/pkgs/build-support/setup-hooks/set-soname.sh
+++ b/pkgs/build-support/setup-hooks/set-soname.sh
@@ -1,0 +1,8 @@
+[[ -z "$noAbsoluteSoname" ]] && fixupOutputHooks+=(_doAbsoluteSoname)
+
+_doAbsoluteSoname() {
+    echo "Making sonames absolute"
+    if test -d "$prefix" ; then
+        find "$prefix" -type f '(' -name "lib*.so.*" -or -name 'lib*.so' ')' -not -name 'ld*' -exec patchelf --set-soname {} {} ';'
+    fi
+}

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -162,6 +162,8 @@ stdenv.mkDerivation ({
 
   builder = ../builder.sh;
 
+  noAbsoluteSoname = true;
+
   src = fetchurl {
     url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
     sha256 = "1m0lr7938lw5d773dkvwld90hjlcq2282517d1gwvrfzmwgg42w5";

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -145,6 +145,8 @@ stdenv.mkDerivation ({
   # prevent a retained dependency on the bootstrap tools in the stdenv-linux
   # bootstrap.
   BASH_SHELL = "/bin/sh";
+
+  noAbsoluteSoname = true;
 }
 
 // (removeAttrs args [ "withLinuxHeaders" "withGd" ]) //

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ zlib ];
 
   inherit noSysDirs;
+  noAbsoluteSoname = true;
 
   preConfigure = ''
     # Clear the default library search path.

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -47,6 +47,7 @@ let
       ../../build-support/setup-hooks/compress-man-pages.sh
       ../../build-support/setup-hooks/strip.sh
       ../../build-support/setup-hooks/patch-shebangs.sh
+      ../../build-support/setup-hooks/set-soname.sh
     ]
       # FIXME this on Darwin; see
       # https://github.com/NixOS/nixpkgs/commit/94d164dd7#commitcomment-22030369


### PR DESCRIPTION
###### Motivation for this change
#24844

Most stuff I've tried building with this works. However, nixos won't build with this yet because the extra-tools initrd stuff doesn't build successfully. I'm getting the… interesting error message

```
Inconsistency detected by ld.so: dl-version.c: 205: _dl_check_map_versions: Assertion `needed != NULL' failed!
```

when it tries to test the udevadm in extra-utils. Help would be appreciated!

Also, thanks very much to @grahamc for having made the aarch64 community builder available. It's been invaluable for testing this, what with all the gcc rebuilds!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
