### PR TITLE
protonmail-bridge - add warning in description about enabling gnome-keyring

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -6,7 +6,9 @@ let
 
   description = ''
     An application that runs on your computer in the background and seamlessly encrypts
-    and decrypts your mail as it enters and leaves your computer
+    and decrypts your mail as it enters and leaves your computer.
+
+    To work, gnome-keyring service must be enabled.
   '';
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
###### Motivation for this change

As a follop up of the issue #45070, this PR adds an important information about enabling gnome-keyring service for protonmail-bridge to work.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

