### PR TITLE
 nixos/triggerhappy: add module for triggerhappy hotkey daemon

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -274,6 +274,7 @@
   ./services/hardware/tlp.nix
   ./services/hardware/thinkfan.nix
   ./services/hardware/trezord.nix
+  ./services/hardware/triggerhappy.nix
   ./services/hardware/u2f.nix
   ./services/hardware/udev.nix
   ./services/hardware/udisks2.nix

--- a/nixos/modules/services/hardware/triggerhappy.nix
+++ b/nixos/modules/services/hardware/triggerhappy.nix
@@ -1,0 +1,114 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.triggerhappy;
+
+  socket = "/run/thd.socket";
+
+  configFile = pkgs.writeText "triggerhappy.conf" ''
+    ${concatMapStringsSep "\n"
+      ({ keys, event, cmd, ... }:
+        ''${concatMapStringsSep "+" (x: "KEY_" + x) keys} ${toString { press = 1; hold = 2; release = 0; }.${event}} ${cmd}''
+      )
+      cfg.bindings}
+    ${cfg.extraConfig}
+  '';
+
+  bindingCfg = { config, ... }: {
+    options = {
+
+      keys = mkOption {
+        type = types.listOf types.str;
+        description = "List of keys to match.  Key names as defined in linux/input-event-codes.h";
+      };
+
+      event = mkOption {
+        type = types.enum ["press" "hold" "release"];
+        default = "press";
+        description = "Event to match.";
+      };
+
+      cmd = mkOption {
+        type = types.str;
+        description = "What to run.";
+      };
+
+    };
+  };
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.triggerhappy = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the <command>triggerhappy</command> hotkey daemon.
+        '';
+      };
+
+      bindings = mkOption {
+        type = types.listOf (types.submodule bindingCfg);
+        default = [];
+        example = lib.literalExample ''
+          [ { keys = ["PLAYPAUSE"];  cmd = "''${pkgs.mpc_cli}/bin/mpc -q toggle"; } ]
+        '';
+        description = ''
+          Key bindings for <command>triggerhappy</command>.
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Literal contents to append to the end of <command>triggerhappy</command> configuration file.
+        '';
+      };
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    systemd.sockets.triggerhappy = {
+      description = "Triggerhappy Socket";
+      wantedBy = [ "sockets.target" ];
+      socketConfig.ListenDatagram = socket;
+    };
+
+    systemd.services.triggerhappy = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "local-fs.target" ];
+      description = "Global hotkey daemon";
+      serviceConfig = {
+        ExecStart = "${pkgs.triggerhappy}/bin/thd --user nobody --socket ${socket} --triggers ${configFile} --deviceglob /dev/input/event*";
+      };
+    };
+
+    services.udev.packages = lib.singleton (pkgs.writeTextFile {
+      name = "triggerhappy-udev-rules";
+      destination = "/etc/udev/rules.d/61-triggerhappy.rules";
+      text = ''
+        ACTION=="add", SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{name}!="triggerhappy", \
+          RUN+="${pkgs.triggerhappy}/bin/th-cmd --socket ${socket} --passfd --udev"
+      '';
+    });
+
+  };
+
+}

--- a/pkgs/tools/inputmethods/triggerhappy/default.nix
+++ b/pkgs/tools/inputmethods/triggerhappy/default.nix
@@ -1,26 +1,23 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchFromGitHub, pkgconfig, perl, systemd }:
 
 stdenv.mkDerivation rec {
   name = "triggerhappy-${version}";
   version = "0.5.0";
 
-  src = fetchurl {
-    url = "https://github.com/wertarbyte/triggerhappy/archive/release/${version}.tar.gz";
-    sha256 = "af0fc196202f2d35153be401769a9ad9107b5b6387146cfa8895ae9cafad631c";
+  src = fetchFromGitHub {
+    owner = "wertarbyte";
+    repo = "triggerhappy";
+    rev = "release/${version}";
+    sha256 = "0gb1qhrxwq7i5abd408d01a2dpf28nr1fph1fg7w7n0i5i1nnk90";
   };
 
-  buildInputs = [ perl ];
-  installFlags = [ "DESTDIR=$(out)" ];  
+  nativeBuildInputs = [ pkgconfig perl ];
+  buildInputs = [ systemd ];
 
-  postPatch = ''
-    substituteInPlace Makefile --replace "/usr/" "/"
-    substituteInPlace Makefile --replace "/sbin/" "/bin/"
-  '';
+  makeFlags = [ "PREFIX=$(out)" "BINDIR=$(out)/bin" ];
 
   postInstall = ''
     install -D -m 644 -t "$out/etc/triggerhappy/triggers.d" "triggerhappy.conf.examples"
-    install -D -m 644 -t "$out/usr/lib/systemd/system" "systemd/triggerhappy.service" "systemd/triggerhappy.socket"
-    install -D -m 644 -t "$out/usr/lib/udev/rules.d" "udev/triggerhappy-udev.rules"
   '';
 
   meta = with stdenv.lib; {
@@ -34,6 +31,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/wertarbyte/triggerhappy/;
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = [ maintainers.taha ];
+    maintainers = with maintainers; [ jfrankenau taha ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

While actkbd is quite similar and we already have a NixOS module for it, triggerhappy allows specifiying keys by their names instead of keycodes which is much simpler. It is equally light and needs only one process for all input devices as new devices are added using an udev rule and announcing them to the triggerhappy daemon.

###### Things done

The new triggerhappy module is based on the actkbd module.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @taha