### PR TITLE
sqldeveloper: simplify, add darwin support

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, openjdk }:
+{ stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, jdk }:
 
 let
   version = "17.4.1.054.0712";
@@ -46,29 +46,23 @@ in
 
         nix-prefetch-url --type sha256 file:///path/to/${name}
     '';
-    # obtained by `sha256sum sqldeveloper-${version}-no-jre.zip`
     sha256 = "7e92ca94d02489002db291c96f1d67f9b2501a8967ff3457103fcf60c1eb154a";
   };
 
   buildInputs = [ makeWrapper unzip ];
 
-  buildCommand = ''
-    mkdir -p $out/bin
-    echo  >$out/bin/sqldeveloper '#! ${stdenv.shell}'
-    echo >>$out/bin/sqldeveloper 'export JAVA_HOME=${openjdk}/lib/openjdk'
-    echo >>$out/bin/sqldeveloper 'export JDK_HOME=$JAVA_HOME'
-    echo >>$out/bin/sqldeveloper "cd $out/lib/${name}/sqldeveloper/bin"
-    echo >>$out/bin/sqldeveloper '${stdenv.shell} sqldeveloper "$@"'
-    chmod +x $out/bin/sqldeveloper
+  unpackCmd = "unzip $curSrc";
 
-    mkdir -p $out/lib/
-    cd $out
-    unzip ${src}
-    mv sqldeveloper $out/lib/${name}
+  installPhase = ''
+    mkdir -p $out/libexec $out/share/{applications,pixmaps}
+    mv * $out/libexec/
 
-    install -D -m 444 $out/lib/$name/icon.png $out/share/pixmaps/sqldeveloper.png
-    mkdir -p $out/share/applications
+    mv $out/libexec/icon.png $out/share/pixmaps/sqldeveloper.png
     cp ${desktopItem}/share/applications/* $out/share/applications
+
+    makeWrapper $out/libexec/sqldeveloper/bin/sqldeveloper $out/bin/sqldeveloper \
+      --set JAVA_HOME ${jdk.home} \
+      --run "cd $out/libexec/sqldeveloper/bin"
   '';
 
   meta = with stdenv.lib; {
@@ -84,7 +78,7 @@ in
     '';
     homepage = http://www.oracle.com/technetwork/developer-tools/sql-developer/overview/;
     license = licenses.unfree;
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.ardumont ];
-    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Use `unpackCmd` and `installPhase` instead of overwriting `buildCommand`.
This makes the derivation more readable, and adds binary stripping and
shebang patching of the output as a bonus :-)

Use `makeWrapper` instead of a custom wrapper script, and only export
environment variables that are used.

Set `JAVA_HOME` to `${jdk.home}`, making it more generic and independent of
the specific jdk path being used (was a different one on zulu). This
fixes sqldeveloper on darwin, so add it to supported platforms
(plus the known-working `x86_64-linux`)
 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

