### PR TITLE
splix: install color profiles and enable JBIG

### DIFF
--- a/pkgs/misc/cups/drivers/splix/default.nix
+++ b/pkgs/misc/cups/drivers/splix/default.nix
@@ -1,7 +1,27 @@
-{ stdenv, fetchsvn, cups, zlib }:
-let rev = "315"; in
-stdenv.mkDerivation rec {
+{ stdenv, fetchsvn, fetchurl, cups, cups-filters, jbigkit, zlib }:
+
+let
+  rev = "315";
+
+  color-profiles = stdenv.mkDerivation {
+    name = "splix-color-profiles-20070625";
+
+    src = fetchurl {
+      url = "http://splix.ap2c.org/samsung_cms.tar.bz2";
+      sha256 = "1156flics5m9m7a4hdmcc2nphbdyary6dfmbcrmsp9xb7ivsypdl";
+    };
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase = ''
+      mkdir -p $out/share/cups/profiles/samsung
+      cp * $out/share/cups/profiles/samsung/
+    '';
+  };
+
+in stdenv.mkDerivation {
   name = "splix-svn-${rev}";
+
   src = fetchsvn {
     # We build this from svn, because splix hasn't been in released in several years
     # although the community has been adding some new printer models.
@@ -10,15 +30,25 @@ stdenv.mkDerivation rec {
     sha256 = "16wbm4xnz35ca3mw2iggf5f4jaxpyna718ia190ka6y4ah932jxl";
   };
 
-  preBuild = ''
-    makeFlags="V=1 DISABLE_JBIG=1 CUPSFILTER=$out/lib/cups/filter CUPSPPD=$out/share/cups/model"
+  postPatch = ''
+    substituteInPlace src/pstoqpdl.cpp \
+      --replace "RASTERDIR \"/\" RASTERTOQPDL" "\"$out/lib/cups/filter/rastertoqpdl\"" \
+      --replace "RASTERDIR" "\"${cups-filters}/lib/cups/filter\"" \
   '';
 
-  buildInputs = [cups zlib];
+  makeFlags = [
+    "CUPSFILTER=$(out)/lib/cups/filter"
+    "CUPSPPD=$(out)/share/cups/model"
+    "CUPSPROFILE=${color-profiles}/share/cups/profiles"
+  ];
 
-  meta = {
-    homepage = http://splix.sourceforge.net;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.peti ];
+  buildInputs = [ cups zlib jbigkit ];
+
+  meta = with stdenv.lib; {
+    description = "CUPS drivers for SPL (Samsung Printer Language) printers";
+    homepage = http://splix.ap2c.org;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jfrankenau peti ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with color printers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @peti @abbradar @husnoo @emmanuelrosa 
