### PR TITLE
ssdeep: 2.13 -> 2.14.1

### DIFF
--- a/pkgs/tools/security/ssdeep/default.nix
+++ b/pkgs/tools/security/ssdeep/default.nix
@@ -1,23 +1,20 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name    = "ssdeep-${version}";
-  version = "2.13";
+  version = "2.14.1";
 
-  src = fetchurl {
-    url    = "mirror://sourceforge/ssdeep/${name}.tar.gz";
-    sha256 = "1igqy0j7jrklb8fdlrm6ald4cyl1fda5ipfl8crzyl6bax2ajk3f";
+  src = fetchFromGitHub {
+    owner = "ssdeep-project";
+    repo = "ssdeep";
+    rev = "release-${version}";
+    sha256 = "1yx6yjkggshw5yl89m4kvyzarjdg2l3hs0bbjbrfzwp1lkfd8i0c";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   # Hack to avoid TMPDIR in RPATHs.
   preFixup = ''rm -rf "$(pwd)" '';
-
-  # For some reason (probably a build system bug), the binary isn't
-  # properly linked to $out/lib to find libfuzzy.so
-  postFixup = stdenv.lib.optionalString (!stdenv.isDarwin) ''
-    rp=$(patchelf --print-rpath $out/bin/ssdeep)
-    patchelf --set-rpath $rp:$out/lib $out/bin/ssdeep
-  '';
 
   meta = {
     description = "A program for calculating fuzzy hashes";


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---