### PR TITLE
qtwebengine: Use system ffmpeg on aarch64

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -13,6 +13,7 @@
 , systemd
 , enableProprietaryCodecs ? true
 , gn, darwin, openbsm
+, ffmpeg ? null
 , lib, stdenv # lib.optional, needsPax
 }:
 
@@ -117,7 +118,9 @@ EOF
     fi
    '';
 
-  qmakeFlags = optional enableProprietaryCodecs "-- -proprietary-codecs";
+  qmakeFlags = if stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64
+    then [ "--" "-system-ffmpeg" ] ++ optional enableProprietaryCodecs "-proprietary-codecs"
+    else optional enableProprietaryCodecs "-- -proprietary-codecs";
 
   propagatedBuildInputs = [
     # Image formats
@@ -133,6 +136,8 @@ EOF
     harfbuzz icu
 
     libevent
+  ] ++ optionals stdenv.hostPlatform.isArm [
+    ffmpeg
   ] ++ optionals (!stdenv.isDarwin) [
     dbus zlib minizip snappy nss protobuf jsoncpp
 


### PR DESCRIPTION
On aarch64, linking against the vendored ffmpeg fails. Including ffmpeg
as a dependency and passing -system-ffmpeg to qmake fixes this.

###### Motivation for this change
QtWebengine fails to build on aarch64 due to problems linking against the bundled ffmpeg.

###### Things done
Added a qmake flag `-system-ffmpeg` when building for Aarch64 or Aarch32
Added ffmpeg as an optional dependency

Note: So far, I have only tested Qt 5.11's qtwebengine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @matthewbauer 