### PR TITLE
Fix documentation of default option priority

### DIFF
--- a/nixos/doc/manual/development/option-def.xml
+++ b/nixos/doc/manual/development/option-def.xml
@@ -65,7 +65,7 @@ config = {
    A module can override the definitions of an option in other modules by
    setting a <emphasis>priority</emphasis>. All option definitions that do not
    have the lowest priority value are discarded. By default, option definitions
-   have priority 1000. You can specify an explicit priority by using
+   have priority 100. You can specify an explicit priority by using
    <varname>mkOverride</varname>, e.g.
 <programlisting>
 services.openssh.enable = mkOverride 10 false;


### PR DESCRIPTION
###### Motivation for this change

The documentation for the default option priority seems to be incorrect, stating that options have priority 1000 by default, while [lib/modules.nix#L429](https://github.com/NixOS/nixpkgs/blob/master/lib/modules.nix#L429) indicates that the default priority is 100.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

