### PR TITLE
PostgreSQL 10.5, 9.6.10, 9.5.14, 9.4.19 & 9.3.24 updates.

### DIFF
--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -97,9 +97,9 @@ let
 in {
 
   postgresql93 = common {
-    version = "9.3.23";
+    version = "9.3.24";
     psqlSchema = "9.3";
-    sha256 = "1jzncs7b6zrcgpnqjbjcc4y8303a96zqi3h31d3ix1g3vh31160x";
+    sha256 = "1a8dnv16n2rxnbwhqw7c0kjpj3xqvkpwk50kvimj4d917cxaf542";
   };
 
   postgresql94 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -109,9 +109,9 @@ in {
   };
 
   postgresql95 = common {
-    version = "9.5.13";
+    version = "9.5.14";
     psqlSchema = "9.5";
-    sha256 = "1vm55q9apja6lg672m9xl1zq3iwv2zwnn0d0qr003zan1dmbh22l";
+    sha256 = "0k8s62h6qd9p3xlx315j5irniskqsnx1nz4ir5r1yhqp07mdab1y";
   };
 
   postgresql96 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -103,9 +103,9 @@ in {
   };
 
   postgresql94 = common {
-    version = "9.4.18";
+    version = "9.4.19";
     psqlSchema = "9.4";
-    sha256 = "1h64yjyrlz3ppsp9k6sm4jihg6n9i7mqhkx4p0hymqzmnbr3g0s2";
+    sha256 = "12qn9h47rkn4k41gdbxkkvg0pff43k1113jmhc83f19adc1nnxq3";
   };
 
   postgresql95 = common {

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -121,9 +121,9 @@ in {
   };
 
   postgresql100 = common {
-    version = "10.4";
+    version = "10.5";
     psqlSchema = "10.0";
-    sha256 = "0j000bcs9w8wrllg8m7j1lxsd3n2x0yzkack5p35cmxx20iq2q0v";
+    sha256 = "04a07jkvc5s6zgh6jr78149kcjmsxclizsqabjw44ld4j5n633kc";
   };
 
 }

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -115,9 +115,9 @@ in {
   };
 
   postgresql96 = common {
-    version = "9.6.9";
+    version = "9.6.10";
     psqlSchema = "9.6";
-    sha256 = "0biy8j69dbvdmrag55pdszpc0702agzqhhcwdx21xp02mzim4ydr";
+    sha256 = "09l4zqs74fqnazdsyln9x657mq3wsbgng9wpvq71yh26cv2sq5c6";
   };
 
   postgresql100 = common {


### PR DESCRIPTION
###### Motivation for this change

PostgreSQL 10.5, 9.6.10, 9.5.14, 9.4.19 & 9.3.24 updates.

Fixes CVE-2018-10915 & CVE-2018-10925

Release notes: https://www.postgresql.org/about/news/1878/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

