### PR TITLE
Add license meta tags

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -210,6 +210,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Common Public License 1.0";
   };
 
+  curl = {
+    fullName = "MIT/X11 derivate";
+    url = "https://curl.haxx.se/docs/copyright.html";
+  };
+
   doc = spdx {
     spdxId = "DOC";
     fullName = "DOC License";

--- a/pkgs/applications/version-management/cvs/default.nix
+++ b/pkgs/applications/version-management/cvs/default.nix
@@ -32,9 +32,10 @@ stdenv.mkDerivation {
 
   doCheck = false; # fails 1 of 1 tests
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://cvs.nongnu.org;
     description = "Concurrent Versions System - a source control system";
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2; # library is GPLv2, main is GPLv1
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -17,10 +17,11 @@ stdenv.mkDerivation rec {
     "ac_cv_func_realloc_0_nonnull=yes"
   ];
 
-  meta = {
+  meta = with stdenv.lib; {
     branch = "2.5.35";
     homepage = http://flex.sourceforge.net/;
     description = "A fast lexical analyser generator";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/parsing/flex/2.6.1.nix
+++ b/pkgs/development/tools/parsing/flex/2.6.1.nix
@@ -26,9 +26,10 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile.in --replace "tests" " ";
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/westes/flex;
     description = "A fast lexical analyser generator";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -41,9 +41,10 @@ stdenv.mkDerivation rec {
 
   dontDisableStatic = stdenv.buildPlatform != stdenv.hostPlatform;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/westes/flex;
     description = "A fast lexical analyser generator";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/os-specific/linux/atop/default.nix
+++ b/pkgs/os-specific/linux/atop/default.nix
@@ -33,15 +33,16 @@ stdenv.mkDerivation rec {
     make systemdinstall $makeFlags
   '';
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [raskin];
+  meta = with stdenv.lib; {
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raskin ];
     description = ''Console system performance monitor'';
 
     longDescription = ''
       Atop is an ASCII full-screen performance monitor that is capable of reporting the activity of all processes (even if processes have finished during the interval), daily logging of system and process activity for long-term analysis, highlighting overloaded system resources by using colors, etc. At regular intervals, it shows system-level activity related to the CPU, memory, swap, disks and network layers, and for every active process it shows the CPU utilization, memory growth, disk utilization, priority, username, state, and exit code.
     '';
     inherit version;
+    license = licenses.gpl2;
     downloadPage = http://atoptool.nl/downloadatop.php;
   };
 }

--- a/pkgs/os-specific/linux/iotop/default.nix
+++ b/pkgs/os-specific/linux/iotop/default.nix
@@ -10,9 +10,11 @@ python2Packages.buildPythonApplication rec {
 
   doCheck = false;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A tool to find out the processes doing the most IO";
-    maintainers = [ stdenv.lib.maintainers.raskin ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = http://guichaz.free.fr/iotop;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/bc/default.nix
+++ b/pkgs/tools/misc/bc/default.nix
@@ -1,4 +1,6 @@
-{stdenv, autoreconfHook, buildPackages, fetchurl, flex, readline, ed, texinfo}:
+{ stdenv, autoreconfHook, buildPackages
+, fetchurl, flex, readline, ed, texinfo
+}:
 
 stdenv.mkDerivation rec {
   name = "bc-1.07.1";
@@ -31,6 +33,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "GNU software calculator";
     homepage = http://www.gnu.org/software/bc/;
+    license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/tools/misc/fortune/default.nix
+++ b/pkgs/tools/misc/fortune/default.nix
@@ -23,8 +23,9 @@ stdenv.mkDerivation {
     rmdir $out/games
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A program that displays a pseudorandom message from a database of quotations";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.bsdOriginal;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -50,7 +50,8 @@ stdenv.mkDerivation {
 
   passthru.grubTarget = "";
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/less/default.nix
+++ b/pkgs/tools/misc/less/default.nix
@@ -13,10 +13,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.greenwoodsoftware.com/less/;
     description = "A more advanced file pager than ‘more’";
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    platforms = platforms.unix;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/tools/networking/curl/7_59.nix
+++ b/pkgs/tools/networking/curl/7_59.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation rec {
     description = "A command line tool for transferring files with URL syntax";
     homepage    = https://curl.haxx.se/;
     maintainers = with maintainers; [ lovek323 ];
+    license = licenses.curl;
     platforms   = platforms.all;
   };
 }

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -105,6 +105,7 @@ stdenv.mkDerivation rec {
     description = "A command line tool for transferring files with URL syntax";
     homepage    = https://curl.haxx.se/;
     maintainers = with maintainers; [ lovek323 ];
-    platforms   = platforms.all;
+    license = licenses.curl;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -20,9 +20,10 @@ stdenv.mkDerivation rec {
     stdenv.lib.optional (coreutils != null) "PR_PROGRAM=${coreutils}/bin/pr"
     ++ stdenv.lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.gnu.org/software/diffutils/diffutils.html;
     description = "Commands for showing the differences between files (diff, cmp, etc.)";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
another round for https://github.com/NixOS/nixpkgs/issues/43716

###### Things done
Added licenses fields to:

- less
- iotop
- grub-0.97
- fortune
- flex
- diffutils
- cvs
- curl
- bc
- atop

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

