### PR TITLE
oracle-instantclient: fixes dylib rpath on macos

### DIFF
--- a/pkgs/development/libraries/oracle-instantclient/default.nix
+++ b/pkgs/development/libraries/oracle-instantclient/default.nix
@@ -1,13 +1,15 @@
-{ stdenv, requireFile, autoPatchelfHook, unzip, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
+{ stdenv, requireFile, autoPatchelfHook, fixDarwinDylibNames, unzip, libaio, makeWrapper, odbcSupport ? false, unixODBC }:
 
 assert odbcSupport -> unixODBC != null;
 
 let
+  inherit (stdenv.lib) optional optionals optionalString;
+
   baseVersion = "12.2";
   version = "${baseVersion}.0.1.0";
 
   requireSource = component: arch: version: rel: hash: (requireFile rec {
-    name = "instantclient-${component}-${arch}-${version}" + (stdenv.lib.optionalString (rel != "") "-${rel}") + ".zip";
+    name = "instantclient-${component}-${arch}-${version}" + (optionalString (rel != "") "-${rel}") + ".zip";
     url = "http://www.oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html";
     sha256 = hash;
   });
@@ -24,37 +26,46 @@ let
       (requireSource "basic" arch version "" "5015e3c9fba84e009f7519893f798a1622c37d1ae2c55104ff502c52a0fe5194")
       (requireSource "sdk" arch version "" "7f404c3573c062ce487a51ac4cfe650c878d7edf8e73b364ec852645ed1098cb")
       (requireSource "sqlplus" arch version "" "d49b2bd97376591ca07e7a836278933c3f251875c215044feac73ba9f451dfc2") ]
-      ++ stdenv.lib.optional odbcSupport (requireSource "odbc" arch version "2" "365a4ae32c7062d9fbc3fb41add748e7881f774484a175a4b41a2c294ce9095d");
+      ++ optional odbcSupport (requireSource "odbc" arch version "2" "365a4ae32c7062d9fbc3fb41add748e7881f774484a175a4b41a2c294ce9095d");
     "x86_64-darwin" = [
       (requireSource "basic" arch version "2" "3ed3102e5a24f0da638694191edb34933309fb472eb1df21ad5c86eedac3ebb9")
       (requireSource "sdk" arch version "2" "e0befca9c4e71ebc9f444957ffa70f01aeeec5976ea27c40406471b04c34848b")
       (requireSource "sqlplus" arch version "2" "d147cbb5b2a954fdcb4b642df4f0bd1153fd56e0f56e7fa301601b4f7e2abe0e") ]
-      ++ stdenv.lib.optional odbcSupport (requireSource "odbc" arch version "2" "1805c1ab6c8c5e8df7bdcc35d7f2b94c329ecf4dff9bde55d5f9b159ecd8b64e");
+      ++ optional odbcSupport (requireSource "odbc" arch version "2" "1805c1ab6c8c5e8df7bdcc35d7f2b94c329ecf4dff9bde55d5f9b159ecd8b64e");
   }."${stdenv.system}" or throwSystem;
 
+  extLib = stdenv.hostPlatform.extensions.sharedLibrary;
 in stdenv.mkDerivation rec {
   inherit version srcs;
   name = "oracle-instantclient-${version}";
 
   buildInputs = [ stdenv.cc.cc.lib ]
-    ++ stdenv.lib.optionals (stdenv.isLinux) [ libaio ]
-    ++ stdenv.lib.optional odbcSupport unixODBC;
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper unzip ];
+    ++ optionals (stdenv.isLinux) [ libaio ]
+    ++ optional odbcSupport unixODBC;
+
+  nativeBuildInputs = [ makeWrapper unzip ]
+    ++ optional stdenv.isLinux autoPatchelfHook
+    ++ optional stdenv.isDarwin fixDarwinDylibNames;
 
   unpackCmd = "unzip $curSrc";
 
   installPhase = ''
     mkdir -p "$out/"{bin,include,lib,"share/java","share/${name}/demo/"}
-
     install -Dm755 {sqlplus,adrci,genezi} $out/bin
-    ln -s $out/bin/sqlplus $out/bin/sqlplus64
-    install -Dm644 *${stdenv.hostPlatform.extensions.sharedLibrary}* $out/lib
+    ${optionalString stdenv.isDarwin ''
+      for exe in "$out/bin/"* ; do
+        install_name_tool -add_rpath "$out/lib" "$exe"
+      done
+    ''}
+    ln -sfn $out/bin/sqlplus $out/bin/sqlplus64
+    install -Dm644 *${extLib}* $out/lib
     install -Dm644 *.jar $out/share/java
     install -Dm644 sdk/include/* $out/include
     install -Dm644 sdk/demo/* $out/share/${name}/demo
 
     # PECL::oci8 will not build without this
-    ln -s $out/lib/libclntsh.so.12.1 $out/lib/libclntsh.so
+    # this symlink only exists in dist zipfiles for some platforms
+    ln -sfn $out/lib/libclntsh${extLib}.12.1 $out/lib/libclntsh${extLib}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Libraries and applications linked against the oracle-instantclient package on MacOS fail with the following error due to rpath not being patched:
```
dyld: Library not loaded: @rpath/libclntsh.dylib.12.1
  Referenced from: /nix/store/zhrzcdamy5vppxyg5h7w8pbiizqkbmxg-ocilib/lib/libocilib.4.dylib
  Reason: image not found
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ x ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ x ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@pesterhazy @flokli 