### PR TITLE
teamspeak_server: 3.0.13.6 -> 3.3.0

### DIFF
--- a/nixos/modules/services/networking/teamspeak3.nix
+++ b/nixos/modules/services/networking/teamspeak3.nix
@@ -124,7 +124,7 @@ in
             dbsqlpath=${ts3}/lib/teamspeak/sql/ logpath=${cfg.logPath} \
             voice_ip=${cfg.voiceIP} default_voice_port=${toString cfg.defaultVoicePort} \
             filetransfer_ip=${cfg.fileTransferIP} filetransfer_port=${toString cfg.fileTransferPort} \
-            query_ip=${cfg.queryIP} query_port=${toString cfg.queryPort}
+            query_ip=${cfg.queryIP} query_port=${toString cfg.queryPort} license_accepted=1
         '';
         WorkingDirectory = cfg.dataDir;
         User = user;

--- a/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper }:
 
 let
-  version = "3.0.13.6";
+  version = "3.3.0";
   arch = if stdenv.is64bit then "amd64" else "x86";
   libDir = if stdenv.is64bit then "lib64" else "lib";
 in
@@ -14,9 +14,9 @@ stdenv.mkDerivation {
       "http://dl.4players.de/ts/releases/${version}/teamspeak3-server_linux_${arch}-${version}.tar.bz2"
       "http://teamspeak.gameserver.gamed.de/ts3/releases/${version}/teamspeak3-server_linux_${arch}-${version}.tar.bz2"
     ];
-    sha256 = if stdenv.is64bit 
-      then "19ccd8db5427758d972a864b70d4a1263ebb9628fcc42c3de75ba87de105d179"
-      else "2f70b3e70a3d9bf86106fab67a938922c8d27fec24e66e229913f78a0791b967";
+    sha256 = if stdenv.is64bit
+      then "1jv5c1br3ypxz8px7fl5rg75j0kfdg8mqasdk2gka6yvgf7qc97i"
+      else "0m889xl9iz3fmq7wyjjn42swprpspagbkn52a82nzkhgvagd45bz";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Updates teamspeak server to 3.3.0.

To fix following error, I introduced a new parameter in the systemd config `ExecStart`.

```
Please set the environment variable TS3SERVER_LICENSE to "accept" in order to accept the license agreement.
Alternatively, create a file named ".ts3server_license_accepted" in the working directory or start the server with the command line parameter "license_accepted=1".
To view the license agreement set TS3SERVER_LICENSE to "view" in order to print the license to the console.
Alternatively view the file "LICENSE" in your favorite text viewer yourself.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

