### PR TITLE
gdal: allow version 1.11 on Darwin

### DIFF
--- a/pkgs/development/libraries/gdal/gdal-1_11.nix
+++ b/pkgs/development/libraries/gdal/gdal-1_11.nix
@@ -58,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.gdal.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.marcweber ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
The GDAL 1.11 derivation has been Linux-only for its entire life, but builds just fine on Mac.

###### Motivation for this change

GDAL 1.11 is an upstream dependency for a project I am working with. Currently I need to set `allowUnsupportedSystem = true;` in my Nix configuration to use it on my Mac---but it seems to work just fine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

