### PR TITLE
mypy-protobuf: init at 1.6

### DIFF
--- a/pkgs/development/python-modules/mypy-protobuf/default.nix
+++ b/pkgs/development/python-modules/mypy-protobuf/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, fetchPypi, buildPythonApplication, protobuf }:
+
+buildPythonApplication rec {
+  pname = "mypy-protobuf";
+  version = "1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bmpd82qm7rjnzc4i275lm18mmz8anhrjhwq2ci179l64hrfr0nb";
+  };
+
+  propagatedBuildInputs = [ protobuf ];
+
+  meta = with stdenv.lib; {
+    description = "Generate mypy stub files from protobuf specs";
+    homepage = "https://github.com/dropbox/mypy-protobuf";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lnl7 ];
+  };
+}

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -28,7 +28,10 @@ buildPythonPackage rec {
     export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION=2
   '';
 
-  preBuild = optionalString (versionAtLeast protobuf.version "2.6.0") ''
+  preBuild = ''
+    # Workaround for https://github.com/google/protobuf/issues/2895
+    ${python}/bin/${python.executable} setup.py build
+  '' + optionalString (versionAtLeast protobuf.version "2.6.0") ''
     ${python}/bin/${python.executable} setup.py build_ext --cpp_implementation
   '';
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7866,6 +7866,8 @@ in {
 
   mypy = callPackage ../development/python-modules/mypy { };
 
+  mypy-protobuf = callPackage ../development/python-modules/mypy-protobuf { };
+
   mwclient = buildPythonPackage rec {
     version = "0.8.3";
     pname = "mwclient";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

