### PR TITLE
vegur: init at 0.701

### DIFF
--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, rpmextract, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  version = "0.701";
+  name = "vegur-font-${version}";
+
+  # Upstream doesn't version their URLs.
+  # http://dotcolon.net/font/vegur/ → http://dotcolon.net/DL/font/vegur.zip
+  src = fetchurl {
+    url = "http://download.opensuse.org/repositories/M17N:/fonts/SLE_12_SP3/src/dotcolon-vegur-fonts-0.701-1.4.src.rpm";
+    sha256 = "0ra3fds3b352rpzn0015km539c3l2ik2lqd5x6fr65ss9fg2xn34";
+  };
+
+  nativeBuildInputs = [ rpmextract unzip ];
+
+  unpackPhase = ''
+    rpmextract $src
+    unzip vegur.zip
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/Vegur
+    cp *.otf $out/share/fonts/Vegur
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://dotcolon.net/font/vegur/;
+    description = "A humanist sans serif font.";
+    platforms = platforms.all;
+    maintainers = [ maintainers.samueldr ];
+    license = licenses.cc0;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15107,6 +15107,8 @@ with pkgs;
 
   vdrsymbols = callPackage ../data/fonts/vdrsymbols { };
 
+  vegur = callPackage ../data/fonts/vegur { };
+
   vistafonts = callPackage ../data/fonts/vista-fonts { };
 
   vistafonts-chs = callPackage ../data/fonts/vista-fonts-chs { };


### PR DESCRIPTION
###### Motivation for this change

Adds the font used by the NixOS Logo to the repository.... Except this isn't it!

The font used in the NixOS logo has been updated with different metrics. A Nix derivation for the font matching the metrics of the NixOS logo will be added to the nixos-artwork repository.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ❌ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

