### PR TITLE
ghc: Use 8.2.2 binary for boot, no parallel builds on aarch64.

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.2-binary.nix
@@ -24,30 +24,30 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "8.2.1";
+  version = "8.2.2";
 
   name = "ghc-${version}-binary";
 
   src = fetchurl ({
     "i686-linux" = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-i386-deb8-linux.tar.xz";
-      sha256 = "d86f9c157dd4161a8acb14062c131c8985a4f65fc856603c373502be1d50c95e";
+      sha256 = "9e67d72d76482e0ba91c718e727b00386a1a12a32ed719714976dc56ca8c8223";
     };
     "x86_64-linux" = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-deb8-linux.tar.xz";
-      sha256 = "543b81bf610240bd0398111d6c6607a9094dc2d159b564057d46c8a3d1aaa130";
+      sha256 = "48e205c62b9dc1ccf6739a4bc15a71e56dde2f891a9d786a1b115f0286111b2a";
     };
     "armv7l-linux" = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-armv7-deb8-linux.tar.xz";
-      sha256 = "0f0e5e1d4fad3fa1a87ca1fe0d19242f4a94d158b7b8a08f99efefd98b51b019";
+      sha256 = "86e8d339c763575a9dba097fb1d8e17b9622156b7cede888187615682b46bbca";
     };
     "aarch64-linux" = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-aarch64-deb8-linux.tar.xz";
-      sha256 = "61dab9c95ef9f9af8bce7338863fda3e42945eb46194b12d922b6d0dc245d0c2";
+      sha256 = "676698b0b3744af80a610d9e18e40735b9cf8ec337c072d8314d85cba8af4acc";
     };
     "x86_64-darwin" = {
       url = "http://haskell.org/ghc/dist/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
-      sha256 = "900c802025fb630060dbd30f9738e5d107a4ca5a50d5c1262cd3e69fe4467188";
+      sha256 = "f90fcf62f7e0936a6dfc3601cf663729bfe9bbf85097d2d75f0a16f8c2e95c27";
     };
   }.${stdenv.hostPlatform.system}
     or (throw "cannot bootstrap GHC on this platform"));
@@ -169,6 +169,5 @@ stdenv.mkDerivation rec {
   };
 
   meta.license = stdenv.lib.licenses.bsd3;
-  # AArch64 should work in theory but eventually some builds start segfaulting
-  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin" "armv7l-linux" /* "aarch64-linux" */];
+  meta.platforms = ["x86_64-linux" "i686-linux" "x86_64-darwin" "armv7l-linux" "aarch64-linux"];
 }

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -87,7 +87,9 @@ stdenv.mkDerivation rec {
     sha256 = "1z05vkpaj54xdypmaml50hgsdpw29dhbs2r7magx0cm199iw73mv";
   };
 
-  enableParallelBuilding = true;
+  # We cannot use concurrent GHC on aarch64, see:
+  # <https://ghc.haskell.org/trac/ghc/ticket/15449>
+  enableParallelBuilding = !(stdenv.isAarch64);
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -89,7 +89,9 @@ stdenv.mkDerivation (rec {
     sha256 = "1mk046vb561j75saz05rghhbkps46ym5aci4264dwc2qk3dayixf";
   };
 
-  enableParallelBuilding = true;
+  # We cannot use concurrent GHC on aarch64, see:
+  # <https://ghc.haskell.org/trac/ghc/ticket/15449>
+  enableParallelBuilding = !(stdenv.isAarch64);
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -85,7 +85,9 @@ stdenv.mkDerivation (rec {
     sha256 = "0b3nyjs4lsh67lfw7wh7r7kkf4g2xiypdxd77aycmwd3pdxj09yw";
   };
 
-  enableParallelBuilding = true;
+  # We cannot use concurrent GHC on aarch64, see:
+  # <https://ghc.haskell.org/trac/ghc/ticket/15449>
+  enableParallelBuilding = !(stdenv.isAarch64);
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -87,7 +87,9 @@ stdenv.mkDerivation rec {
     sha256 = "1gdcr10dd968d40qgljdwx9vfkva3yrvjm9a4nis7whaaac3ag58";
   };
 
-  enableParallelBuilding = true;
+  # We cannot use concurrent GHC on aarch64, see:
+  # <https://ghc.haskell.org/trac/ghc/ticket/15449>
+  enableParallelBuilding = !(stdenv.isAarch64);
 
   outputs = [ "out" "doc" ];
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -115,7 +115,10 @@ let
   # We cannot enable -j<n> parallelism for libraries because GHC is far more
   # likely to generate a non-determistic library ID in that case. Further
   # details are at <https://github.com/peti/ghc-library-id-bug>.
-  enableParallelBuilding = (versionOlder "7.8" ghc.version && !isLibrary) || versionOlder "8.0.1" ghc.version;
+  enableParallelBuilding = ((versionOlder "7.8" ghc.version && !isLibrary) || versionOlder "8.0.1" ghc.version)
+                        # We cannot use concurrent GHC on aarch64, see:
+                        # <https://ghc.haskell.org/trac/ghc/ticket/15449>
+                        && (!(stdenv.isAarch64));
 
   crossCabalFlags = [
     "--with-ghc=${ghc.targetPrefix}ghc"

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -8,6 +8,7 @@ let
   integerSimpleExcludes = [
     "ghc7103Binary"
     "ghc821Binary"
+    "ghc822Binary"
     "ghcjs"
     "ghcjs710"
     "ghcjs80"
@@ -44,6 +45,7 @@ in rec {
 
     ghc7103Binary = callPackage ../development/compilers/ghc/7.10.3-binary.nix { };
     ghc821Binary = callPackage ../development/compilers/ghc/8.2.1-binary.nix { };
+    ghc822Binary = callPackage ../development/compilers/ghc/8.2.2-binary.nix { };
 
     ghc7103 = callPackage ../development/compilers/ghc/7.10.3.nix rec {
       bootPkgs = packages.ghc7103Binary;
@@ -59,7 +61,7 @@ in rec {
       llvmPackages = pkgs.llvmPackages_37;
     };
     ghc822 = callPackage ../development/compilers/ghc/8.2.2.nix rec {
-      bootPkgs = packages.ghc821Binary;
+      bootPkgs = packages.ghc822Binary;
       inherit (bootPkgs) hscolour alex happy;
       inherit buildPlatform targetPlatform;
       sphinx = pkgs.python3Packages.sphinx;
@@ -67,7 +69,7 @@ in rec {
       llvmPackages = pkgs.llvmPackages_39;
     };
     ghc843 = callPackage ../development/compilers/ghc/8.4.3.nix rec {
-      bootPkgs = packages.ghc821Binary;
+      bootPkgs = packages.ghc822Binary;
       inherit (bootPkgs) alex happy hscolour;
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
@@ -79,7 +81,7 @@ in rec {
       llvmPackages = pkgs.llvmPackages_6;
     };
     ghcHEAD = callPackage ../development/compilers/ghc/head.nix rec {
-      bootPkgs = packages.ghc821Binary;
+      bootPkgs = packages.ghc822Binary;
       inherit (bootPkgs) alex happy hscolour;
       buildLlvmPackages = buildPackages.llvmPackages_5;
       llvmPackages = pkgs.llvmPackages_5;
@@ -143,6 +145,12 @@ in rec {
     ghc821Binary = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc821Binary;
       ghc = bh.compiler.ghc821Binary;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
+      packageSetConfig = bootstrapPackageSet;
+    };
+    ghc822Binary = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc822Binary;
+      ghc = bh.compiler.ghc822Binary;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.2.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };


### PR DESCRIPTION
###### Motivation for this change
GHC 8.2.1 is rather broken. Upstream's build system actually complains if you attempt to build with it (see [this bug](https://ghc.haskell.org/trac/ghc/ticket/15281)). This is especially true of aarch64. It would be nice to bootstrap with upstream's binary 8.2.2 instead.

[This bug](https://ghc.haskell.org/trac/ghc/ticket/15449) also severely affects GHC on aarch64, and without disabling parallel building GHC is next to useless on that platform. Until a fix for that bug makes it into a release, it would be better to disable parallel builds on aarch64.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

