### PR TITLE
vulkan: 1.1.77.0 -> 1.1.82.1

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -1,20 +1,28 @@
-{ stdenv, fetchFromGitHub, cmake, bison, spirv-tools, jq }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, bison, spirv-tools, jq }:
 
 stdenv.mkDerivation rec {
   name = "glslang-git-${version}";
-  version = "2018-06-21";
+  version = "2018-07-27";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "ef1f899b5d64a9628023f1bb129198674cba2b97";
-    sha256 = "052w6rahmy1wlphv533wz8nyn82icky28lprvl8w3acfq3831zg6";
+    rev = "e99a26810f65314183163c07664a40e05647c15f";
+    sha256 = "1w11z518xfbnf34xgzg1mp3xicpw2qmpcvaixlzw79s9ifqg5lqs";
   };
+
+  patches = [
+    # spirv-tools bump for vulkan sdk 1.1.82.1; remove on update
+    (fetchpatch {
+      url = "https://github.com/lenny-lunarg/glslang/commit/c7f4e818ac55f545289f87f8c37571b2eadcde86.patch";
+      sha256 = "197293alxjdpm3x1vd6pksdb1d9za42vlyn8yn2w786av0l7vf1k";
+    })
+  ];
 
   buildInputs = [ cmake bison jq ] ++ spirv-tools.buildInputs;
   enableParallelBuilding = true;
 
-  patchPhase = ''
+  postPatch = ''
     cp --no-preserve=mode -r "${spirv-tools.src}" External/spirv-tools
     ln -s "${spirv-tools.headers}" External/spirv-tools/external/spirv-headers
   '';
@@ -23,7 +31,7 @@ stdenv.mkDerivation rec {
     HEADERS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools/external/spirv-headers"))[0].commit')
     TOOLS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools"))[0].commit')
     if [ "$HEADERS_COMMIT" != "${spirv-tools.headers.rev}" ] || [ "$TOOLS_COMMIT" != "${spirv-tools.src.rev}" ]; then
-      echo "ERROR: spirv-tools commits do not match expected versions";
+      echo "ERROR: spirv-tools commits do not match expected versions: expected tools at $TOOLS_COMMIT, headers at $HEADERS_COMMIT";
       exit 1;
     fi
   '';

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   name = "vulkan-headers-${version}";
-  version = "1.1.77.0";
+  version = "1.1.82.0";
 
   buildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    sha256 = "1k01y5cj154mw7853w5xh135b2jp6k83kzwknw0dbs5adj4dx0kf";
+    sha256 = "1pp0kmgd89g8rz6qqfqmdmv209s0d6hbsshrzrlwrdm6dc25f20p";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, python3, vulkan-headers, pkgconfig,
   xlibsWrapper, libxcb, libXrandr, libXext, wayland, libGL_driver }:
-let version = "1.1.77.0"; in
+let version = "1.1.82.0"; in
 assert version == vulkan-headers.version;
 stdenv.mkDerivation rec {
   name = "vulkan-loader-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Loader";
     rev = "sdk-${version}";
-    sha256 = "1nzzkqh0i3j1d3h7kgmaxzi748l338m2p31lxkwxm4y81xp56a94";
+    sha256 = "16i4s1adfh822ahj3ywp279lv6szwd2sn2q5pmvpg2kk6mbh410d";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -7,14 +7,14 @@ spirv_sources = {
   tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "f2c93c6e124836797311facb8449f9a0b76fefc2";
-    sha256 = "03w5xk2hjijj1rfbx5dw3lhy7vb9zrssfcwvp09q47f77vkgl105";
+    rev = "1a283f41ed09e31cd720744f904af3d823ceddbf";
+    sha256 = "1z65wglg081pri9rmiyydvppgd67qr269ppphy4yhg2wg81gg72c";
   };
   headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "12f8de9f04327336b699b1b80aa390ae7f9ddbf4";
-    sha256 = "0fswk5ndvkmy64har3dmhpkv09zmvb0p4knbqc4fdl4qiggz0fvf";
+    rev = "ff684ffc6a35d2a58f0f63108877d0064ea33feb";
+    sha256 = "0ypjx61ksr6vda2iy3kxhyjia5qxf0x4qa4jij0giw9x5rsnga6g";
   };
 };
 
@@ -22,7 +22,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "spirv-tools-${version}";
-  version = "2018-06-06";
+  version = "2018-07-04";
 
   src = spirv_sources.tools;
   patchPhase = ''ln -sv ${spirv_sources.headers} external/spirv-headers'';

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "vulkan-validation-layers-${version}";
-  version = "1.1.77.0";
+  version = "1.1.82.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
     rev = "sdk-${version}";
-    sha256 = "1c7m0x63fv8paph4rlha9bzv6sd0d7j277b31hh1sqkdcv2mzjhj";
+    sha256 = "0vq2hbha2i5wsi6w6kmxbv01a5f0d55w2grl73nya9i06764fdg6";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "vulkan-tools-${version}";
-  version = "1.1.77.0";
+  version = "1.1.82.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Tools";
     rev = "sdk-${version}";
-    sha256 = "1c827n0xz8d7ydqpjchd58as943acyi182a0p4aq3bdsaxlmmpkg";
+    sha256 = "1viaqp1zfdgli3hw674rz8mrfzxpgv12vxcd07czwr8nyb19f2g5";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Lockstep update of all vulkan packages.

Subsumes #45124 and #45125.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

