### PR TITLE
mariadb: 10.2.16 -> 10.2.17

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -348,7 +348,7 @@ in rec {
   tests.mumble = callTest tests/mumble.nix {};
   tests.munin = callTest tests/munin.nix {};
   tests.mutableUsers = callTest tests/mutable-users.nix {};
-  tests.mysql = callTest tests/mysql.nix {};
+  tests.mysql = callSubTests tests/mysql.nix {};
   tests.mysqlBackup = callTest tests/mysql-backup.nix {};
   tests.mysqlReplication = callTest tests/mysql-replication.nix {};
   tests.nat.firewall = callTest tests/nat.nix { withFirewall = true; };

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -1,24 +1,34 @@
-import ./make-test.nix ({ pkgs, ...} : {
-  name = "mysql";
-  meta = with pkgs.stdenv.lib.maintainers; {
-    maintainers = [ eelco chaoflow shlevy ];
+{ system ? builtins.currentSystem }:
+with import ../lib/testing.nix { inherit system; };
+let
+  packages = {
+    mysql = pkgs.mysql;
+    mariadb = pkgs.mariadb;
   };
 
-  nodes = {
-    master =
-      { pkgs, ... }:
+  make-mysql-test = package: makeTest {
+    name = "mysql";
+    meta = with pkgs.stdenv.lib.maintainers; {
+      maintainers = [ eelco chaoflow shlevy ];
+    };
 
-      {
-        services.mysql.enable = true;
-        services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
-        services.mysql.package = pkgs.mysql;
-      };
+    nodes = {
+      master =
+        { pkgs, ... }:
+
+        {
+          services.mysql.enable = true;
+          services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+          services.mysql.package = package;
+        };
+    };
+
+    testScript = ''
+      startAll;
+
+      $master->waitForUnit("mysql");
+      $master->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
+    '';
   };
-
-  testScript = ''
-    startAll;
-
-    $master->waitForUnit("mysql");
-    $master->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
-  '';
-})
+in
+  pkgs.lib.mapAttrs' (name: pkg: { inherit name; value = make-mysql-test pkg; }) packages

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -22,14 +22,14 @@ galeraLibs = buildEnv {
 };
 
 common = rec { # attributes common to both builds
-  version = "10.2.16";
+  version = "10.2.17";
 
   src = fetchurl {
     urls = [
       "https://downloads.mariadb.org/f/mariadb-${version}/source/mariadb-${version}.tar.gz"
       "https://downloads.mariadb.com/MariaDB/mariadb-${version}/source/mariadb-${version}.tar.gz"
     ];
-    sha256 = "1i2dwpp96ywjk147qqpcad8vqcy4rxmfbv2cb8ww3sffpa9yx0n1";
+    sha256 = "09xy6mgnz22mz8zgqlnddn8nzgs9xlz8lai4a7aa8x78in7hgcz7";
     name   = "mariadb-${version}.tar.gz";
   };
 


### PR DESCRIPTION
###### Motivation for this change

mariadb: 10.2.16 -> 10.2.17

Bump to latest stable version of the 10.2.x branch. Besides many bug fixes the
following security related issues have been fixed:
 - CVE-2018-3060
 - CVE-2018-3064
 - CVE-2018-3063
 - CVE-2018-3058
 - CVE-2018-3066

Also includes a test for mariadb based on the existing mysql test.

This should be considered for backporting since the version in **18.03** has even more open issues...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

