### PR TITLE
[18.03] gnome3.gdm: fix CVE-2018-14424

### DIFF
--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig, glib, itstool, libxml2, xorg, dbus
 , intltool, accountsservice, libX11, gnome3, systemd, autoreconfHook
 , gtk, libcanberra-gtk3, pam, libtool, gobjectIntrospection, plymouth
-, librsvg, coreutils }:
+, librsvg, coreutils, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "gdm-${version}";
@@ -43,6 +43,16 @@ stdenv.mkDerivation rec {
   patches = [ ./sessions_dir.patch
               ./gdm-x-session_extra_args.patch
               ./gdm-session-worker_xserver-path.patch
+              (fetchpatch{
+                name = "CVE-2018-14424_A.patch";
+                url = https://gitlab.gnome.org/GNOME/gdm/commit/6060db704a19b0db68f2e9e6a2d020c0c78b6bba.patch;
+                sha256 = "1wp6b61jwdm43m696rgxa5iz8v39vk4il5xr4zgsx8y1pxqwb8n6";
+              })
+              (fetchpatch{
+                name = "CVE-2018-14424_B.patch";
+                url = https://gitlab.gnome.org/GNOME/gdm/commit/765b306c364885dd89d47fe9fe8618ce6a467bc1.patch;
+                sha256 = "07sani5mbgv8cnwkddj15xg4r7f90d1rp8xxh1hnfwigrm1hm69d";
+              })
              ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

This backports the changes done in the 2.28 branch of gdm to address the
issue.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

