### PR TITLE
cowsay: 3.0.3+dfsg1-16 -> 3.0.3+dfsg2

### DIFF
--- a/pkgs/tools/misc/cowsay/default.nix
+++ b/pkgs/tools/misc/cowsay/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchgit, perl }:
+{ stdenv, fetchurl, perl }:
 
-stdenv.mkDerivation {
-  name = "cowsay-3.03+dfsg1-16";
+stdenv.mkDerivation rec{
+  version = "3.03+dfsg2";
+  name = "cowsay-${version}";
 
-  src = fetchgit {
-    url = https://anonscm.debian.org/git/collab-maint/cowsay.git;
-    rev = "acb946c166fa3b9526b9c471ef1330f9f89f9c8b";
-    sha256 = "1ji66nrdcc8sh79hwils3nbaj897s352r5wp7kzjwiym8bm2azk6";
+  src = fetchurl {
+    url = "http://http.debian.net/debian/pool/main/c/cowsay/cowsay_${version}.orig.tar.gz";
+    sha256 = "0ghqnkp8njc3wyqx4mlg0qv0v0pc996x2nbyhqhz66bbgmf9d29v";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
The old source no longer exists.

Part of #45076.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).