### PR TITLE
nixos/doc: New installer note on unattended installs

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -326,10 +326,9 @@ Retype new UNIX password: ***
     </screen>
     <note>
      <para>
-      To prevent the password prompt, set
-      <code><xref linkend="opt-users.mutableUsers"/> = false;</code> in
-      <filename>configuration.nix</filename>, which allows unattended
-      installation necessary in automation.
+      For unattended installations, it is possible to use
+      <command>nixos-install --no-root-passwd</command>
+      in order to disable the password prompt entirely.
      </para>
     </note>
    </para>


### PR DESCRIPTION
###### Motivation for this change
The installer no longer automatically switches off the prompt for the new root password based on `mutableUsers`, but instead takes a switch `--no-root-passwd`

Fixes #44906

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

