### PR TITLE
cfssl: Add patch for stripping authkey whitespaces

### DIFF
--- a/pkgs/tools/security/cfssl/default.nix
+++ b/pkgs/tools/security/cfssl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
 buildGoPackage rec {
   name = "cfssl-${version}";
@@ -12,6 +12,17 @@ buildGoPackage rec {
     rev = version;
     sha256 = "0j2gz2vl2pf7ir7sc7jrwmjnr67hk4qhxw09cjx132jbk337jc9x";
   };
+
+  # The following patch ensures that the auth-key decoder doesn't break,
+  # if the auth-key file contains leading or trailing whitespaces.
+  # https://github.com/cloudflare/cfssl/pull/923 is merged
+  # remove patch when it becomes part of a release.
+  patches = [
+    (fetchpatch {
+      url    = "https://github.com/cloudflare/cfssl/commit/7e13f60773c96644db9dd8d342d42fe3a4d26f36.patch";
+      sha256 = "1z2v2i8yj7qpj8zj5f2q739nhrr9s59jwzfzk52wfgssl4vv5mn5";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://cfssl.org/;


### PR DESCRIPTION
###### Motivation for this change
cfssl fails to read authkey from file, if the file contains whitespaces of any kind.
Having at least a terminating line feed is normally the case for most plain text files.

See: https://github.com/cloudflare/cfssl/pull/923

The fix is already merged into cfssl master. Adding a patch for the nix pkgs, which can be removed at next cfssl release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
**tests.cfssl**
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

