### PR TITLE
smartgithg: 17.1.4 -> 18.1.4

### DIFF
--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation rec {
   name = "smartgithg-${version}";
-  version = "17_1_4";
+  version = "18_1_4";
 
   src = fetchurl {
     url = "https://www.syntevo.com/downloads/smartgit/smartgit-linux-${version}.tar.gz";
-    sha256 = "1x8s1mdxg7m3fy3izgnb1smrn4ng3q31x0sqnjlchkb5vx7gp5rh";
+    sha256 = "18gyfcs5g7xq8fqnn1zjzx350jaynrniain0giay8sxych12p4cm";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     mkdir -pv ${pkg_path}
     # unpacking should have produced a dir named 'smartgit'
     cp -a smartgit/* ${pkg_path}
+    # prevent using packaged jre
+    rm -r ${pkg_path}/jre
     mkdir -pv ${bin_path}
     jre=${jre.home}
     makeWrapper ${pkg_path}/bin/smartgit.sh ${bin_path}/smartgit \
@@ -45,6 +47,7 @@ stdenv.mkDerivation rec {
       --prefix JRE_HOME : ${jre} \
       --prefix JAVA_HOME : ${jre} \
       --prefix SMARTGITHG_JAVA_HOME : ${jre}
+    sed -i '/ --login/d' ${pkg_path}/bin/smartgit.sh
     patchShebangs $out
     cp ${bin_path}/smartgit ${bin_path}/smartgithg
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

