### PR TITLE
jameica: get rid of launcher script, only use makeWrapper

### DIFF
--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -11,11 +11,6 @@ let
   else if stdenv.system == "x86_64-darwin" then "macos64"
   else throw "Unsupported system: ${stdenv.system}";
 
-  launcher = ''
-    #!${stdenv.shell}
-    exec ${jre}/bin/java -Xmx512m ${ stdenv.lib.optionalString stdenv.isDarwin ''-Xdock:name="Jameica" -XstartOnFirstThread''} de.willuhn.jameica.Main "$@"
-  '';
-
   desktopItem = makeDesktopItem {
     name = "jameica";
     exec = "jameica";
@@ -56,24 +51,24 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/libexec $out/lib $out/bin $out/share/applications
+    mkdir -p $out/libexec $out/lib $out/bin $out/share/{applications,${name},java}/
 
     # copy libraries except SWT
-    cp $(find lib -type f -iname '*.jar' | grep -ve 'swt/.*/swt.jar') $out/lib/
+    cp $(find lib -type f -iname '*.jar' | grep -ve 'swt/.*/swt.jar') $out/share/${name}/
     # copy platform-specific SWT
-    cp lib/swt/${swtSystem}/swt.jar $out/lib
+    cp lib/swt/${swtSystem}/swt.jar $out/share/${name}/
 
-    install -Dm644 releases/${_version}-*/jameica/jameica.jar $out/libexec/
-    install -Dm644 plugin.xml $out/libexec/
+    install -Dm644 releases/${_version}-*/jameica/jameica.jar $out/share/java/
+    install -Dm644 plugin.xml $out/share/java/
     install -Dm644 build/jameica-icon.png $out/share/pixmaps/jameica.png
     cp ${desktopItem}/share/applications/* $out/share/applications/
 
-    echo "${launcher}" > $out/bin/jameica
-    chmod +x $out/bin/jameica
-    wrapProgram $out/bin/jameica --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath buildInputs} \
-                                 --set CLASSPATH "$out/libexec/jameica.jar:$out/lib/*" \
-                                 --run "cd $out/libexec"
-                                 # jameica expects its working dir set to the "program directory"
+    makeWrapper ${jre}/bin/java $out/bin/jameica \
+      --add-flags "-cp $out/share/java/jameica.jar:$out/share/${name}/* ${
+        stdenv.lib.optionalString stdenv.isDarwin ''-Xdock:name="Jameica" -XstartOnFirstThread''
+      } de.willuhn.jameica.Main" \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath buildInputs} \
+      --run "cd $out/share/java/"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This also switches using java paths suggested by docs instead of
$out/share/libexec

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

