### PR TITLE
docs: properly document what jdk really points to, explain home passthru

### DIFF
--- a/doc/languages-frameworks/java.xml
+++ b/doc/languages-frameworks/java.xml
@@ -15,13 +15,17 @@ stdenv.mkDerivation {
   buildPhase = "ant";
 }
 </programlisting>
-  Note that <varname>jdk</varname> is an alias for the OpenJDK.
- </para>
+  Note that <varname>jdk</varname> is an alias for the OpenJDK (self-built
+  where available, or pre-built via Zulu).
+  Platforms with OpenJDK not (yet) in Nixpkgs (<literal>Aarch32</literal>,
+  <literal>Aarch64</literal>) point to the (unfree)
+  <literal>oraclejdk</literal>.
+</para>
 
  <para>
   JAR files that are intended to be used by other packages should be installed
-  in <filename>$out/share/java</filename>. The OpenJDK has a stdenv setup hook
-  that adds any JARs in the <filename>share/java</filename> directories of the
+  in <filename>$out/share/java</filename>. JDKs have a stdenv setup hook
+  that add any JARs in the <filename>share/java</filename> directories of the
   build inputs to the <envar>CLASSPATH</envar> environment variable. For
   instance, if the package <literal>libfoo</literal> installs a JAR named
   <filename>foo.jar</filename> in its <filename>share/java</filename>

--- a/doc/languages-frameworks/java.xml
+++ b/doc/languages-frameworks/java.xml
@@ -61,7 +61,18 @@ installPhase =
   <literal>${jre}/bin/java</literal> instead of
   <literal>${jdk}/bin/java</literal>, you prevent your package from depending
   on the JDK at runtime.
- </para>
+</para>
+
+<para>
+  Note all JDKs passthru <literal>home</literal>, so if your application
+  requires environment variables like <envar>JAVA_HOME</envar> being set, that
+  can be done in a generic fashion with the <literal>--set</literal> argument
+  of <literal>makeWrapper</literal>:
+
+<programlisting>
+  --set JAVA_HOME ${jdk.home}
+</programlisting>
+</para>
 
  <para>
   It is possible to use a different Java compiler than <command>javac</command>


### PR DESCRIPTION
###### Motivation for this change
This PR documents to what `pkgs.jdk` really points to, and documents the `home` passthru of all JDKs, together with a usage example. 

[Build Nixpkgs manual](https://nixos.wiki/wiki/Contributing_to_Nix_documentation#How_to_build_the_Nixpkgs_manual).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

