### PR TITLE
aravis: init at 0.5.13

### DIFF
--- a/pkgs/development/libraries/aravis/default.nix
+++ b/pkgs/development/libraries/aravis/default.nix
@@ -1,0 +1,89 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk-doc, intltool
+, audit, glib, libusb, libxml2
+, wrapGAppsHook
+, gstreamer ? null
+, gst-plugins-base ? null
+, gst-plugins-good ? null
+, gst-plugins-bad ? null
+, libnotify ? null
+, gnome3 ? null
+, enableUsb ? true
+, enablePacketSocket ? true
+, enableViewer ? true
+, enableGstPlugin ? true
+, enableCppTest ? false
+, enableFastHeartbeat ? false
+, enableAsan ? false
+}:
+
+let
+  gstreamerAtLeastVersion1 =
+    stdenv.lib.all
+      (pkg: pkg != null && stdenv.lib.versionAtLeast (stdenv.lib.getVersion pkg) "1.0")
+      [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ];
+in
+  assert enableGstPlugin -> stdenv.lib.all (pkg: pkg != null) [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ];
+  assert enableViewer -> enableGstPlugin;
+  assert enableViewer -> libnotify != null;
+  assert enableViewer -> gnome3 != null;
+  assert enableViewer -> gstreamerAtLeastVersion1;
+
+  stdenv.mkDerivation rec {
+
+    pname = "aravis";
+    version = "0.5.13";
+    name = "${pname}-${version}";
+
+    src = fetchFromGitHub {
+      owner = "AravisProject";
+      repo = "aravis";
+      rev= "c56e530b8ef53b84e17618ea2f334d2cbae04f48";
+      sha256 = "1dj24dir239zmiscfhyy1m8z5rcbw0m1vx9lipx0r7c39bzzj5gy";
+    };
+
+    outputs = [ "bin" "dev" "out" "lib" ];
+
+    nativeBuildInputs = [
+      autoreconfHook
+      pkgconfig
+      intltool
+      gtk-doc
+    ] ++ stdenv.lib.optional enableViewer wrapGAppsHook;
+
+    buildInputs =
+      [ glib libxml2 ]
+      ++ stdenv.lib.optional enableUsb libusb
+      ++ stdenv.lib.optional enablePacketSocket audit
+      ++ stdenv.lib.optionals (enableViewer || enableGstPlugin) [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]
+      ++ stdenv.lib.optionals (enableViewer) [ libnotify gnome3.gtk3 gnome3.defaultIconTheme ];
+
+    preAutoreconf = ''./autogen.sh'';
+
+    configureFlags =
+      stdenv.lib.optional enableUsb "--enable-usb"
+        ++ stdenv.lib.optional enablePacketSocket "--enable-packet-socket"
+        ++ stdenv.lib.optional enableViewer "--enable-viewer"
+        ++ stdenv.lib.optional enableGstPlugin
+        (if gstreamerAtLeastVersion1 then "--enable-gst-plugin" else "--enable-gst-0.10-plugin")
+        ++ stdenv.lib.optional enableCppTest "--enable-cpp-test"
+        ++ stdenv.lib.optional enableFastHeartbeat "--enable-fast-heartbeat"
+        ++ stdenv.lib.optional enableAsan "--enable-asan";
+
+    postPatch = ''
+        ln -s ${gtk-doc}/share/gtk-doc/data/gtk-doc.make .
+      '';
+
+    doCheck = true;
+
+    meta = {
+      description = "Library for video acquisition using GenICam cameras";
+      longDescription = ''
+        Implements the gigabit ethernet and USB3 protocols used by industrial cameras.
+      '';
+      homepage = https://aravisproject.github.io/docs/aravis-0.5;
+      license = stdenv.lib.licenses.lgpl2;
+      maintainers = [];
+      platforms = stdenv.lib.platforms.unix;
+    };
+  }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9136,6 +9136,10 @@ with pkgs;
     #      apr with db58 on freebsd (nov 2015), for unknown reasons
   };
 
+  aravis = callPackage ../development/libraries/aravis {
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad;
+  };
+
   arb = callPackage ../development/libraries/arb {};
   arb-git = callPackage ../development/libraries/arb/git.nix {};
 


### PR DESCRIPTION
###### Motivation for this change

[aravis](https://github.com/AravisProject/aravis) is a library for interacting with [GenICam](https://en.wikipedia.org/wiki/GenICam) (industrial) cameras. It is primarily a library but also comes with a viewer application.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

