### PR TITLE
rubygems: 2.7.6 -> 2.7.7 and update src URL to official HTTPS location

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -3,6 +3,6 @@
 , sha256 ? "1jsmmd31j8j066b83lin4bbqz19jhrirarzb41f3sjhfdjiwkcjc"
 }:
 fetchurl {
-  url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";
+  url = "https://rubygems.org/rubygems/rubygems-${version}.tgz";
   sha256 = sha256;
 }

--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,6 +1,6 @@
 { fetchurl
-, version ? "2.7.6"
-, sha256 ? "1sqy6z1kngq91nxmv1hw4xhw1ycwx9s76hfbpcdlgkm9haji9xv7"
+, version ? "2.7.7"
+, sha256 ? "1jsmmd31j8j066b83lin4bbqz19jhrirarzb41f3sjhfdjiwkcjc"
 }:
 fetchurl {
   url = "http://production.cf.rubygems.org/rubygems/rubygems-${version}.tgz";


### PR DESCRIPTION
###### Motivation for this change

Rubygems 2.7.7 was released in May[1] which fixes some bugs. I also updated the `src`'s URL to use the official HTTPS location in a separate commit in this PR branch.

[1] https://blog.rubygems.org/2018/05/18/2.7.7-released.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`): `tested ./result/bin/ruby --version`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md): `I created a separate commit for changing the URL location for the source to the official HTTPS location for the archive and created appropriate commit messages for both changes.`

---

