### PR TITLE
particl-core: 0.16.1 -> 0.16.2

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -90,5 +90,9 @@ rec {
   parity-ui = callPackage ./parity-ui { };
 
   particl-core = callPackage ./particl/particl-core.nix { boost = boost165; miniupnpc = miniupnpc_2; withGui = false; };
-  particl-qt = libsForQt5.callPackage ./particl/particl-core.nix { boost = boost165; miniupnpc = miniupnpc_2; withGui = true; };
+  particl-qt = libsForQt5.callPackage ./particl/particl-core.nix {
+    inherit (darwin.apple_sdk.frameworks) DiskArbitration;
+    boost = boost165;
+    miniupnpc = miniupnpc_2;
+    withGui = true; };
 }

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -89,5 +89,6 @@ rec {
   parity-beta = callPackage ./parity/beta.nix { };
   parity-ui = callPackage ./parity-ui { };
 
-  particl-core = callPackage ./particl/particl-core.nix { boost = boost165; miniupnpc = miniupnpc_2; };
+  particl-core = callPackage ./particl/particl-core.nix { boost = boost165; miniupnpc = miniupnpc_2; withGui = false; };
+  particl-qt = libsForQt5.callPackage ./particl/particl-core.nix { boost = boost165; miniupnpc = miniupnpc_2; withGui = true; };
 }

--- a/pkgs/applications/altcoins/particl/particl-core.nix
+++ b/pkgs/applications/altcoins/particl/particl-core.nix
@@ -10,6 +10,7 @@
 , zeromq
 , zlib
 , unixtools
+, DiskArbitration ? null
 , qtbase ? null
 , qttools ? null
 , qrencode ? null
@@ -35,6 +36,7 @@ stdenv.mkDerivation rec {
     ++ optionals withGui [ qtbase qttools qrencode protobuf hidapi ];
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+    ++ optionals stdenv.isDarwin [ DiskArbitration ]
     ++ optionals withGui [
     "--with-gui=qt5"
     "--enable-usbdevice=yes"

--- a/pkgs/applications/altcoins/particl/particl-core.nix
+++ b/pkgs/applications/altcoins/particl/particl-core.nix
@@ -10,26 +10,35 @@
 , zeromq
 , zlib
 , unixtools
+, qtbase ? null
+, qttools ? null
+, qrencode ? null
+, protobuf ? null
+, hidapi ? null
+, withGui
 }:
 
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "particl-core-${version}";
-  version     = "0.16.1.0";
+  name = "particl-${if withGui then "qt" else "core"}-${version}";
+  version     = "0.16.2.0";
 
   src = fetchurl {
     url = "https://github.com/particl/particl-core/archive/v${version}.tar.gz";
-    sha256 = "0rfqywyrl6cgxn3ba91zsa88ph2yf9d1vn706xpyz19pfb6mjfbg";
+    sha256 = "1d2vvg7avlhsg0rcpd5pbzafnk1w51a2y29xjjkpafi6iqs2l617";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
-    openssl db48 boost zlib miniupnpc libevent zeromq
-    unixtools.hexdump
-  ];
+    openssl db48 boost zlib miniupnpc libevent zeromq unixtools.hexdump ]
+    ++ optionals withGui [ qtbase qttools qrencode protobuf hidapi ];
 
-  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ];
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+    ++ optionals withGui [
+    "--with-gui=qt5"
+    "--enable-usbdevice=yes"
+    "--with-qt-bindir=${qtbase}/bin:${qttools}/bin:${qtbase.dev}/bin:${qttools.dev}/bin" ];
 
   meta = {
     description = "Privacy-Focused Marketplace & Decentralized Application Platform";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15307,6 +15307,7 @@ with pkgs;
   stellar-core = self.altcoins.stellar-core;
 
   particl-core = self.altcoins.particl-core;
+  particl-qt = self.altcoins.particl-qt;
 
   aumix = callPackage ../applications/audio/aumix {
     gtkGUI = false;


### PR DESCRIPTION
Particl Core updated. Added GUI version as particl-qt

###### Motivation for this change

https://github.com/particl/particl-core/releases/tag/v0.16.2.0

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

