### PR TITLE
nixos/zsh: Adds enableGlobalCompInit option

### DIFF
--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -87,6 +87,19 @@ in
         type = types.bool;
       };
 
+
+      enableGlobalCompInit = mkOption {
+        default = cfg.enableCompletion;
+        description = ''
+          Enable execution of compinit call for all interactive zsh shells.
+
+          This option can be used if the user wants to extend its
+          <literal>fpath</literal> and a custom <literal>compinit</literal>
+          call in the local config is required.
+        '';
+        type = types.bool;
+      };
+
     };
 
   };
@@ -159,7 +172,7 @@ in
           fpath+=($p/share/zsh/site-functions $p/share/zsh/$ZSH_VERSION/functions $p/share/zsh/vendor-completions)
         done
 
-        ${optionalString cfg.enableCompletion "autoload -U compinit && compinit"}
+        ${optionalString cfg.enableGlobalCompInit "autoload -U compinit && compinit"}
 
         ${cfge.interactiveShellInit}
 

--- a/nixos/modules/programs/zsh/zsh.nix
+++ b/nixos/modules/programs/zsh/zsh.nix
@@ -93,7 +93,7 @@ in
         description = ''
           Enable execution of compinit call for all interactive zsh shells.
 
-          This option can be used if the user wants to extend its
+          This option can be disabled if the user wants to extend its
           <literal>fpath</literal> and a custom <literal>compinit</literal>
           call in the local config is required.
         '';


### PR DESCRIPTION
###### Motivation for this change

My current zsh setup requires setting the `fpath` variable in my local `~/.zshrc`. Therefore I need to run `compinit` after the `fpath` updates. I can't disable the `compinit` call without removing other zsh completion files, so I introduced `enableGlobalCompInit` for this exact purpose.

I need to disable the `compinit` call in `/etc/zshrc` because on slow devices the startup time of my shell can be remarkably decreased by calling `compinit` only in my local config

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

