### PR TITLE
Add licenses

### DIFF
--- a/pkgs/applications/graphics/xfig/default.nix
+++ b/pkgs/applications/graphics/xfig/default.nix
@@ -41,7 +41,10 @@ stdenv.mkDerivation {
 
   meta = {
     description = "An interactive drawing tool for X11";
-    homepage = http://xfig.org;
+    homepage = http://mcj.sourceforge.net/;
+    license = {
+      url = "http://mcj.sourceforge.net/authors.html#xfig";
+    };
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;         # arbitrary choice
   };
 }

--- a/pkgs/data/documentation/man-pages/default.nix
+++ b/pkgs/data/documentation/man-pages/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     description = "Linux development manual pages";
     homepage = https://www.kernel.org/doc/man-pages/;
     repositories.git = http://git.kernel.org/pub/scm/docs/man-pages/man-pages;
+    license = licenses.gpl2Plus;
     platforms = with platforms; unix;
     priority = 30; # if a package comes with its own man page, prefer it
   };

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -152,7 +152,7 @@ let
     meta = {
       homepage = https://www.perl.org/;
       description = "The standard implementation of the Perl 5 programmming language";
-      license = licenses.gpl1;
+      license = licenses.artistic1;
       maintainers = [ maintainers.eelco ];
       platforms = platforms.all;
     };

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -152,6 +152,7 @@ let
     meta = {
       homepage = https://www.perl.org/;
       description = "The standard implementation of the Perl 5 programmming language";
+      license = licenses.gpl1;
       maintainers = [ maintainers.eelco ];
       platforms = platforms.all;
     };

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -27,6 +27,7 @@ let
     meta = with lib; {
       description = "Free TLS/SSL implementation";
       homepage    = "https://www.libressl.org";
+      license = with licenses; [ publicDomain bsdOriginal bsd0 bsd3 gpl3 isc ];
       platforms   = platforms.all;
       maintainers = with maintainers; [ thoughtpolice wkennington fpletz globin ];
     };

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -108,9 +108,10 @@ in stdenv.mkDerivation rec {
     rm -f "$out"/lib/*.a
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://developer.mozilla.org/en-US/docs/NSS;
     description = "A set of libraries for development of security-enabled client and server applications";
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.mpl20;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage    = http://www.openldap.org/;
     description = "An open source implementation of the Lightweight Directory Access Protocol";
+    license = licenses.openldap;
     maintainers = with maintainers; [ lovek323 ];
     platforms   = platforms.unix;
   };

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -107,11 +107,12 @@ let
       fi
     '';
 
-    meta = {
+    meta = with stdenv.lib; {
       homepage = https://www.openssl.org/;
       description = "A cryptographic library that implements the SSL and TLS protocols";
-      platforms = stdenv.lib.platforms.all;
-      maintainers = [ stdenv.lib.maintainers.peti ];
+      license = licenses.openssl;
+      platforms = platforms.all;
+      maintainers = [ maintainers.peti ];
       priority = 10; # resolves collision with ‘man-pages’
     };
   };

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -83,6 +83,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/polkit;
     description = "A toolkit for defining and handling the policy that allows unprivileged processes to speak to privileged processes";
+    license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ ];
   };

--- a/pkgs/os-specific/linux/lsscsi/default.nix
+++ b/pkgs/os-specific/linux/lsscsi/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation {
     substituteInPlace Makefile.in --replace /usr "$out"
   '';
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/lvm2/default.nix
+++ b/pkgs/os-specific/linux/lvm2/default.nix
@@ -78,11 +78,12 @@ stdenv.mkDerivation {
       cp scripts/lvm2_activation_generator_systemd_red_hat $out/lib/systemd/system-generators
     '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://sourceware.org/lvm2/;
     description = "Tools to support Logical Volume Management (LVM) on Linux";
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [raskin];
+    platforms = platforms.linux;
+    license = with licenses; [ gpl2 bsd2 lgpl21 ];
+    maintainers = with maintainers; [raskin];
     inherit version;
     downloadPage = "ftp://sources.redhat.com/pub/lvm2/";
   };

--- a/pkgs/os-specific/linux/mdadm/default.nix
+++ b/pkgs/os-specific/linux/mdadm/default.nix
@@ -44,9 +44,10 @@ stdenv.mkDerivation rec {
         -e 's@/usr/sbin/sendmail@${sendmail-script}@' -i Makefile
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Programs for managing RAID arrays under Linux";
     homepage = http://neil.brown.name/blog/mdadm;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/mingetty/default.nix
+++ b/pkgs/os-specific/linux/mingetty/default.nix
@@ -13,8 +13,9 @@ stdenv.mkDerivation {
     makeFlagsArray=(SBINDIR=$out/sbin MANDIR=$out/share/man/man8)
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/mingetty;
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/nss_ldap/default.nix
+++ b/pkgs/os-specific/linux/nss_ldap/default.nix
@@ -1,8 +1,8 @@
 {stdenv, fetchurl, openldap, perl}:
-   
+
 stdenv.mkDerivation {
   name = "nss_ldap-265";
-   
+
   src = fetchurl {
     url = http://www.padl.com/download/nss_ldap-265.tar.gz;
     sha256 = "1a16q9p97d2blrj0h6vl1xr7dg7i4s8x8namipr79mshby84vdbp";
@@ -29,7 +29,9 @@ stdenv.mkDerivation {
 
   buildInputs = [ openldap perl ];
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
+  meta = with stdenv.lib; {
+    description = "LDAP module for the Solaris Nameservice Switch (NSS)";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/shadow/default.nix
+++ b/pkgs/os-specific/linux/shadow/default.nix
@@ -81,10 +81,11 @@ stdenv.mkDerivation rec {
       mv $out/bin/su $su/bin
     '';
 
-  meta = {
-    homepage = http://pkg-shadow.alioth.debian.org/;
+  meta = with stdenv.lib; {
+    homepage = https://github.com/shadow-maint;
     description = "Suite containing authentication-related tools such as passwd and su";
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
   };
 
   passthru = {

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -198,10 +198,11 @@ in stdenv.mkDerivation rec {
   # runtime; otherwise we can't and we need to reboot.
   passthru.interfaceVersion = 2;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://www.freedesktop.org/wiki/Software/systemd;
     description = "A system and service manager for Linux";
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = http://www.ntp.org/;
     description = "An implementation of the Network Time Protocol";
+    license = {
+      # very close to isc and bsd2
+      url = https://www.eecis.udel.edu/~mills/ntp/html/copyright.html;
+    };
     maintainers = [ maintainers.eelco ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -55,10 +55,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://ppp.samba.org/;
     description = "Point-to-point implementation for Linux and Solaris";
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.falsifian ];
+    license = with licenses; [ bsdOriginal publicDomain gpl2 lgpl2 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.falsifian ];
   };
 }

--- a/pkgs/tools/networking/pptp/default.nix
+++ b/pkgs/tools/networking/pptp/default.nix
@@ -22,10 +22,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl which ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "PPTP client for Linux";
     homepage = http://pptpclient.sourceforge.net/;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/security/mktemp/default.nix
+++ b/pkgs/tools/security/mktemp/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation {
     sha256 = "0x969152znxxjbj7387xb38waslr4yv6bnj5jmhb4rpqxphvk54f";
   };
 
-  meta = {
-    platforms = stdenv.lib.platforms.unix;
+  meta = with stdenv.lib; {
+    description = "Simple tool to make temporary file handling in shells scripts safe and simple";
+    homepage = https://www.mktemp.org;
+    license = licenses.isc;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Another round for https://github.com/NixOS/nixpkgs/issues/43716

###### Things done
Added license tags to:
- xfig
- systemd
- shadow
- pptp
- ppp
- polkit
- perl
- openssl
- openldap
- nss_ldap
- nss
- mktemp
- mingetty
- man-pages
- mdadm
- lvm2
- lsscsi
- libressl
 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

