### PR TITLE
libmsgpack: 2.1.5 -> 3.0.1

### DIFF
--- a/pkgs/development/libraries/libmsgpack/default.nix
+++ b/pkgs/development/libraries/libmsgpack/default.nix
@@ -1,12 +1,12 @@
 { callPackage, fetchFromGitHub, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "2.1.5";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner  = "msgpack";
     repo   = "msgpack-c";
     rev    = "cpp-${version}";
-    sha256 = "0n4kvma3dldfsvv7b0zw23qln6av5im2aqqd6m890i75zwwkw0zv";
+    sha256 = "0nr6y9v4xbvzv717j9w9lhmags1y2s5mq103v044qlyd2jkbg2p4";
   };
 })


### PR DESCRIPTION
###### Motivation for this change

The major version change is [only](https://github.com/msgpack/msgpack-c/blob/cpp-3.0.1/CHANGELOG.md#-breaking-changes-) due to [this](https://github.com/msgpack/msgpack-c/issues/637) bug fix, which affects the reported offset in a malformed msgpack message after trying to parse it (and the previously reported offset was useless). This is not likely to have an effect on any software compatible with msgpack 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
