### PR TITLE
makeself: backport megastep/makeself#142

### DIFF
--- a/pkgs/applications/misc/makeself/Use-rm-from-PATH.patch
+++ b/pkgs/applications/misc/makeself/Use-rm-from-PATH.patch
@@ -1,0 +1,43 @@
+From 81cf57e4653360af7f1718391e424fa05d8ea000 Mon Sep 17 00:00:00 2001
+From: Keshav Kini <keshav.kini@gmail.com>
+Date: Thu, 9 Aug 2018 18:36:15 -0700
+Subject: [PATCH] Use `rm` from PATH
+
+On NixOS (a Linux distribution), there is no `/bin/rm`, but an `rm`
+command will generally be available in one's path when running shell
+scripts. Here, I change a couple of invocations of `/bin/rm` into
+invocations of `rm` to deal with this issue.
+
+Since `rm` is already called elsewhere in the script without an
+absolute path, I assume this change will not cause any
+regressions. Still, I've tested this on a CentOS machine and a NixOS
+machine, though not other platforms.
+---
+ makeself-header.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/makeself-header.sh b/makeself-header.sh
+index 4d2c005..2babf34 100755
+--- a/makeself-header.sh
++++ b/makeself-header.sh
+@@ -515,7 +515,7 @@ if test x"\$quiet" = xn; then
+ fi
+ res=3
+ if test x"\$keep" = xn; then
+-    trap 'echo Signal caught, cleaning up >&2; cd \$TMPROOT; /bin/rm -rf "\$tmpdir"; eval \$finish; exit 15' 1 2 3 15
++    trap 'echo Signal caught, cleaning up >&2; cd \$TMPROOT; rm -rf "\$tmpdir"; eval \$finish; exit 15' 1 2 3 15
+ fi
+ 
+ if test x"\$nodiskspace" = xn; then
+@@ -581,7 +581,7 @@ if test x"\$script" != x; then
+ fi
+ if test x"\$keep" = xn; then
+     cd "\$TMPROOT"
+-    /bin/rm -rf "\$tmpdir"
++    rm -rf "\$tmpdir"
+ fi
+ eval \$finish; exit \$res
+ EOF
+-- 
+2.14.1
+

--- a/pkgs/applications/misc/makeself/default.nix
+++ b/pkgs/applications/misc/makeself/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1lw3gx1zpzp2wmzrw5v7k31vfsrdzadqha9ni309fp07g8inrr9n";
   };
 
-  patchPhase = ''
+  # backported from https://github.com/megastep/makeself/commit/77156e28ff21231c400423facc7049d9c60fd1bd
+  patches = [ ./Use-rm-from-PATH.patch ];
+
+  postPatch = ''
     sed -e "s|^HEADER=.*|HEADER=$out/share/${name}/makeself-header.sh|" -i makeself.sh
   '';
 


### PR DESCRIPTION
Currently, a self-extracting archive created by makeself will fail to properly execute on NixOS because the boilerplate Bash code it uses to clean up the temporary directory it extracted its contents into
assumes that the `rm` command is installed at `/bin/rm`, which is not the case on NixOS.

This commit, a backport of a pull request I made to the upstream repository at megastep/makeself#142, fixes the issue by causing the boilerplate code to call `rm` without specifying an absolute path, which allows the version of `rm` from one's current Nix environment to be used instead.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).