### PR TITLE
ecos: init at 2.0.6

### DIFF
--- a/pkgs/development/libraries/science/math/ecos/default.nix
+++ b/pkgs/development/libraries/science/math/ecos/default.nix
@@ -11,12 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "11v958j66wq30gxpjpkgl7n3rvla845lygz8fl39pgf1vk9sdyc7";
   };
 
-  doCheck = true;
-
   buildPhase = ''
     make all shared
   '';
 
+  doCheck = true;
   checkPhase = ''
     make test
     ./runecos
@@ -32,6 +31,7 @@ stdenv.mkDerivation rec {
     description = "A lightweight conic solver for second-order cone programming";
     homepage = https://www.embotech.com/ECOS;
     license = licenses.gpl3;
+    platforms = platforms.all;
     maintainers = [ maintainers.bhipple ];
   };
 }

--- a/pkgs/development/libraries/science/math/ecos/default.nix
+++ b/pkgs/development/libraries/science/math/ecos/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "ecos-${version}";
+  version = "2.0.6";
+
+  src = fetchFromGitHub {
+    owner = "embotech";
+    repo = "ecos";
+    rev = "v${version}";
+    sha256 = "11v958j66wq30gxpjpkgl7n3rvla845lygz8fl39pgf1vk9sdyc7";
+  };
+
+  doCheck = true;
+
+  buildPhase = ''
+    make all shared
+  '';
+
+  checkPhase = ''
+    make test
+    ./runecos
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp lib*.a lib*.so $out/lib
+    cp -r include $out/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A lightweight conic solver for second-order cone programming";
+    homepage = https://www.embotech.com/ECOS;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20552,6 +20552,8 @@ with pkgs;
 
   cliquer = callPackage ../development/libraries/science/math/cliquer { };
 
+  ecos = callPackage ../development/libraries/science/math/ecos { };
+
   flintqs = callPackage ../development/libraries/science/math/flintqs { };
 
   gurobi = callPackage ../applications/science/math/gurobi { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

