### PR TITLE
libqmatrixclient: enable Darwin platform

### DIFF
--- a/pkgs/development/libraries/libqmatrixclient/default.nix
+++ b/pkgs/development/libraries/libqmatrixclient/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     description= "A Qt5 library to write cross-platfrom clients for Matrix";
     homepage = https://matrix.org/docs/projects/sdk/libqmatrixclient.html;
     license = licenses.lgpl21;
-    platforms = platforms.linux;
+    platforms = with platforms; linux ++ darwin;
     maintainers = with maintainers; [ peterhoeg ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Darwin compatibility

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

