### PR TITLE
libgit2: 0.26.0 -> 0.26.6 (security, fixes)

### DIFF
--- a/pkgs/development/libraries/git2/default.nix
+++ b/pkgs/development/libraries/git2/default.nix
@@ -5,14 +5,14 @@
 
 stdenv.mkDerivation (rec {
   name = "libgit2-${version}";
-  version = "0.26.0";
+  version = "0.26.6";
   # keep the version in sync with pythonPackages.pygit2 and gnome3.libgit2-glib
 
   src = fetchFromGitHub {
     owner = "libgit2";
     repo = "libgit2";
     rev = "v${version}";
-    sha256 = "0zrrmfkfhd2xb4879z5khjb6xsdklrm01f1lscrs2ks68v25fk78";
+    sha256 = "17pjvprmdrx4h6bb1hhc98w9qi6ki7yl57f090n9kbhswxqfs7s3";
   };
 
   cmakeFlags = [ "-DTHREADSAFE=ON" ];


### PR DESCRIPTION
Don't know that there's a reason to keep the patch level
fixed at 0, optimistically bumping to latest (6).

(cherry picked from commit 8c78eee4a15d0a47d2f9dc16044285cc244c1e57)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

