### PR TITLE
gf2x: disable hardware-specific code

### DIFF
--- a/pkgs/development/libraries/gf2x/default.nix
+++ b/pkgs/development/libraries/gf2x/default.nix
@@ -1,19 +1,33 @@
-{stdenv, fetchurl}:
+{ stdenv
+, lib
+, fetchurl
+, optimize ? false # impure hardware optimizations
+}:
 stdenv.mkDerivation rec {
   name = "gf2x-${version}";
-  version = "1.2";
+  version = "1.2"; # remember to also update the url
 
   src = fetchurl {
     # find link to latest version (with file id) here: https://gforge.inria.fr/projects/gf2x/
-    url = "https://gforge.inria.fr/frs/download.php/file/36934/gf2x-1.2.tar.gz";
+    # Requested a predictable link:
+    # https://gforge.inria.fr/tracker/index.php?func=detail&aid=21704&group_id=1874&atid=6982
+    url = "https://gforge.inria.fr/frs/download.php/file/36934/gf2x-${version}.tar.gz";
     sha256 = "0d6vh1mxskvv3bxl6byp7gxxw3zzpkldrxnyajhnl05m0gx7yhk1";
   };
 
-  meta = with stdenv.lib; {
+  # no actual checks present yet (as of 1.2), but can't hurt trying
+  # for an indirect test, run ntl's test suite
+  doCheck = true;
+
+  configureFlags = lib.optionals (!optimize) [
+    "--disable-hardware-specific-code"
+  ];
+
+  meta = with lib; {
     description = ''Routines for fast arithmetic in GF(2)[x]'';
     homepage = http://gf2x.gforge.inria.fr;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ raskin timokau ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This was causing "Illegal instruction" issues in the ntl testsuite when
it was executed on a different cpu than the one gf2x was built on
(43679).

Thanks @grahamc @dezgeg and clever from IRC (don't know their github handle) for tracking this issue down!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

