### PR TITLE
quaternion: Darwin support, fix dependencies and installed outputs

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, qtbase, qtquickcontrols, cmake, libqmatrixclient }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, qtbase, qtquickcontrols, cmake, libqmatrixclient }:
 
 stdenv.mkDerivation rec {
   name = "quaternion-${version}";
@@ -11,9 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "0zrr4khbbdf5ziq65gi0cb1yb1d0y5rv18wld22w1x96f7fkmrib";
   };
 
-  buildInputs = [ qtbase qtquickcontrols libqmatrixclient ];
+  buildInputs = [ qtbase qtquickcontrols ];
 
   nativeBuildInputs = [ cmake ];
+
+  patches = [
+    # https://github.com/QMatrixClient/Quaternion/pull/400
+    (fetchpatch {
+      url = "https://github.com/QMatrixClient/Quaternion/commit/6cb29834efc343dc2bcf1db62cfad2dc4c121c54.patch";
+      sha256 = "0n7mgzzrvx9sa657rfb99i0mjh1k0sn5br344mknqy3wgqdr7s3x";
+    })
+  ];
 
   # libqmatrixclient is now compiled as a dynamic library but quarternion cannot use it yet
   # https://github.com/QMatrixClient/Quaternion/issues/239
@@ -22,7 +30,11 @@ stdenv.mkDerivation rec {
     ln -s ${libqmatrixclient.src} lib
   '';
 
-  postInstall = ''
+  postInstall = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    mv $out/bin/quaternion.app $out/Applications
+    rmdir $out/bin || :
+  '' else ''
     substituteInPlace $out/share/applications/quaternion.desktop \
       --replace 'Exec=quaternion' "Exec=$out/bin/quaternion"
   '';


### PR DESCRIPTION
###### Motivation for this change

Darwin support, and tidying things up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

