### PR TITLE
ntl: 11.2.1 -> 11.3.0

### DIFF
--- a/pkgs/development/libraries/ntl/default.nix
+++ b/pkgs/development/libraries/ntl/default.nix
@@ -14,10 +14,11 @@ assert withGf2x -> gf2x != null;
 
 stdenv.mkDerivation rec {
   name = "ntl-${version}";
-  version = "11.2.1";
+  version = "11.3.0";
+
   src = fetchurl {
     url = "http://www.shoup.net/ntl/ntl-${version}.tar.gz";
-    sha256 = "04avzmqflx2a33n7v9jj32g83p7m6z712fg1mw308jk5ca2qp489";
+    sha256 = "1pcib3vz1sdqlk0n561wbf7fwq44jm5cpx710w4vqljxgrjd7q1s";
   };
 
   patchPhase = stdenv.lib.optionalString stdenv.isDarwin ''
@@ -66,6 +67,8 @@ stdenv.mkDerivation rec {
       length integers, and for vectors, matrices, and polynomials over
       the integers and over finite fields.
     '';
+    # Upstream contact: maintainer is victorshoup on GitHub. Alternatively the
+    # email listed on the homepage.
     homepage = http://www.shoup.net/ntl/;
     maintainers = with maintainers; [ timokau ];
     license = licenses.gpl2Plus;


### PR DESCRIPTION
###### Motivation for this change

https://groups.google.com/forum/#!topic/sage-devel/2yFgWLNzHno

I'm still testing the sage build locally. Until then, ofBorg can do its thing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

