### PR TITLE
modules/alertmanager: add clusterAdvertiseAddress option

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -30,6 +30,17 @@ in {
         '';
       };
 
+      clusterAdvertiseAddress = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          If Alertmanager cannot find any private IP address on the host
+          machine, will fail to start unless an explicit advertise address is
+          provided.  In that case, you can use the machine's public IP address
+          here.
+        '';
+      };
+
       configuration = mkOption {
         type = types.attrs;
         default = {};
@@ -115,6 +126,7 @@ in {
         --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
         --log.level ${cfg.logLevel} \
         ${optionalString (cfg.webExternalUrl != null) ''--web.external-url ${cfg.webExternalUrl} \''}
+        ${optionalString (cfg.clusterAdvertiseAddress != null) ''--cluster.advertise-address ${cfg.clusterAdvertiseAddress} \''}
         ${optionalString (cfg.logFormat != null) "--log.format ${cfg.logFormat}"}
       '';
 


### PR DESCRIPTION
This is https://github.com/NixOS/nixpkgs/pull/45191 which I closed accidentally by rebasing my fork's master onto `nixos-unstable`, sorry about that.  I don't know why it says it was merged, because there should have been nothing to merge.

Alertmanager fails to start when the memberlist library cannot find any private IP addresses on the system.  This is a safeguard to avoid exposing cluster ports over the internet unintentionally.  The workaround is to pass the --cluster.advertise-address argument to AlertManager.

See also:
https://github.com/prometheus/alertmanager/pull/1437
https://github.com/prometheus/alertmanager/issues/1434

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

