### PR TITLE
apmplanner2: init at 2.0.26

### DIFF
--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, qmake
+, qtbase, qtscript, qtwebkit, qtserialport, qtsvg, qtdeclarative, qtquickcontrols2
+, alsaLib, libsndfile, flite, openssl, udev, SDL2
+}:
+
+stdenv.mkDerivation rec {
+  name = "apmplanner2-${version}";
+  version = "2.0.26";
+  src = fetchFromGitHub {
+    owner = "ArduPilot";
+    repo = "apm_planner";
+    rev = "${version}";
+    sha256 = "0bnyi1r8k8ij5sq2zqv7mfbrxm0xdw97qrx3sk4rinqv2g6h6di4";
+  };
+
+  qtInputs = [
+    qtbase qtscript qtwebkit qtserialport qtsvg qtdeclarative qtquickcontrols2
+  ];
+
+  buildInputs = [ alsaLib libsndfile flite openssl udev SDL2 ] ++ qtInputs;
+  nativeBuildInputs = [ qmake ];
+
+  qmakeFlags = [ "apm_planner.pro" ];
+
+  # this ugly hack is necessary, as `bin/apmplanner2` needs the contents of `share/APMPlanner2` inside of `bin/`
+  preFixup = "ln --relative --symbolic $out/share/APMPlanner2/* $out/bin/";
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Ground station software for autonomous vehicles";
+    longDescription = ''
+      A GUI ground control station for autonomous vehicles using the MAVLink protocol.
+      Includes support for the APM and PX4 based controllers.
+    '';
+    homepage = http://ardupilot.org/planner2/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.wucke13 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21138,6 +21138,10 @@ with pkgs;
     withRootSupport = true;
   });
 
+  ### SCIENCE/ROBOTICS
+
+  apmplanner2 = libsForQt5.callPackage ../applications/science/robotics/apmplanner2 { };
+
   ### MISC
 
   android-file-transfer = libsForQt5.callPackage ../tools/filesystems/android-file-transfer { };


### PR DESCRIPTION
###### Motivation for this change
I would like to see more Ground Control Stations in the nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

