### PR TITLE
iputils: 20161105 -> 20180629

### DIFF
--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -1,33 +1,45 @@
-{ stdenv, fetchurl
-, sysfsutils, openssl
-, libcap, opensp, docbook_sgml_dtd_31
-, libidn, nettle
-, SGMLSpm, libgcrypt }:
+{ stdenv, fetchFromGitHub, fetchpatch
+, libxslt, docbook_xsl, docbook_xml_dtd_44
+, sysfsutils, openssl, libcap, libgcrypt, nettle, libidn2
+}:
 
 let
-  time = "20161105";
+  time = "20180629";
 in
 stdenv.mkDerivation rec {
   name = "iputils-${time}";
 
-  src = fetchurl {
-    url = "https://github.com/iputils/iputils/archive/s${time}.tar.gz";
-    sha256 = "12mdmh4qbf5610csaw3rkzhpzf6djndi4jsl4gyr8wni0cphj4zq";
+  src = fetchFromGitHub {
+    owner = "iputils";
+    repo = "iputils";
+    rev = "s${time}";
+    sha256 = "19rpl48pjgmyqlm4h7sml5gy7yg4cxciadxcs24q1zj40c05jls0";
   };
 
+  patches = [
+   (fetchpatch {
+      name = "dont-hardcode-the-location-of-xsltproc.patch";
+      url = "https://github.com/iputils/iputils/commit/d0ff83e87ea9064d9215a18e93076b85f0f9e828.patch";
+      sha256 = "05wrwf0bfmax69bsgzh3b40n7rvyzw097j8z5ix0xsg0kciygjvx";
+    })
+  ];
+
   prePatch = ''
-    sed -e s/sgmlspl/sgmlspl.pl/ \
-        -e s/nsgmls/onsgmls/ \
-      -i doc/Makefile
+    substituteInPlace doc/custom-man.xsl \
+      --replace "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl" "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
+    for xmlFile in doc/*.xml; do
+      substituteInPlace $xmlFile \
+        --replace "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" "${docbook_xml_dtd_44}/xml/dtd/docbook/docbookx.dtd"
+    done
   '';
 
   # Disable idn usage w/musl: https://github.com/iputils/iputils/pull/111
   makeFlags = [ "USE_GNUTLS=no" ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "USE_IDN=no";
 
-  depsBuildBuild = [ opensp SGMLSpm docbook_sgml_dtd_31 ];
+  nativeBuildInputs = [ libxslt.bin ];
   buildInputs = [
     sysfsutils openssl libcap libgcrypt nettle
-  ] ++ stdenv.lib.optional (!stdenv.hostPlatform.isMusl) libidn;
+  ] ++ stdenv.lib.optional (!stdenv.hostPlatform.isMusl) libidn2;
 
   # ninfod probably could build on cross, but the Makefile doesn't pass --host etc to the sub configure...
   buildFlags = "man all" + stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) " ninfod";
@@ -35,21 +47,23 @@ stdenv.mkDerivation rec {
   installPhase =
     ''
       mkdir -p $out/bin
-      cp -p ping tracepath clockdiff arping rdisc rarpd $out/bin/
+      cp -p arping clockdiff ping rarpd rdisc tftpd tracepath traceroute6 $out/bin/
       if [ -x ninfod/ninfod ]; then
         cp -p ninfod/ninfod $out/bin
       fi
 
       mkdir -p $out/share/man/man8
+      cd doc
       cp -p \
-        doc/clockdiff.8 doc/arping.8 doc/ping.8 doc/rdisc.8 doc/rarpd.8 doc/tracepath.8 doc/ninfod.8 \
+        arping.8 clockdiff.8 ninfod.8 pg3.8 ping.8 rarpd.8 rdisc.8 tftpd.8 tracepath.8 traceroute6.8 \
         $out/share/man/man8
     '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/iputils/iputils;
     description = "A set of small useful utilities for Linux networking";
+    license = with licenses; [ gpl2Plus bsd3 ]; # TODO: AS-IS, SUN MICROSYSTEMS license
     platforms = platforms.linux;
-    maintainers = with maintainers; [ lheckemann ];
+    maintainers = with maintainers; [ primeos lheckemann ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13734,9 +13734,7 @@ with pkgs;
 
   iproute = callPackage ../os-specific/linux/iproute { };
 
-  iputils = callPackage ../os-specific/linux/iputils {
-    inherit (buildPackages.buildPackages.perlPackages) SGMLSpm;
-  };
+  iputils = callPackage ../os-specific/linux/iputils { };
 
   iptables = callPackage ../os-specific/linux/iptables { };
 


### PR DESCRIPTION
###### Relevant changes

I don't see any relevant changes that should go into the NixOS changelog.
I've added the `traceroute6` binary.
The build workflow for the man pages changed (SGML -> XML), but that shouldn't cause any problems.
Dependency changes: `libidn` -> `libidn2` (and the build system for the man pages).
The code is still a bit hacky to be honest but it should be fine for now (I'll try to improve/refactor it soon).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [x] nixos/tests/ipv6.nix
  - [x] nixos/tests/virtualbox.nix
  - [x] nixos/tests/dnscrypt-proxy.nix
  - ...
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Result: 38112648 -> 39570592 (+1,457,944 or 3.8%)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Changes (git shortlog s20161105..s20180629):

Brian Norris (1):
      ping: Fix signed overflow/conversion warning

Claudius Zingerli (1):
      Ping: Correct rounding of timing displays

Cyril Hrubis (1):
      ping_common.c: POLLERRR is ignored in events

David Heidelberg (37):
      Merge pull request #67 from locasity/master
      Merge pull request #69 from nmeyerhans/traceroute6
      Merge pull request #87 from jsynacek/fix-pmtudisc
      gitignore: prepare for Meson
      meson: add experimental meson buildsystem support
      ping: fix typo in error tos error message
      ping: parsetos verification is enough, allow decimal values
      ping: flowinfo: fixup checks for flowinfo and also add decimal numbers support
      ping: fix conflicting defines
      remove iputils.spec
      RELNOTES: deprecated in favor of git history & github
      travis-ci: cleanup and switch to Ubuntu 14.04 build
      doc: convert from converting SGML to XML
      Merge pull request #89 from metan-ucw/master
      ping: fix incorrect packet loss calculation
      LICENSE: add information about licenses
      doc: ping - document mdev behaviour
      LICENSE: convert BSD4 to BSD3 license
      licenses: fill missing clockdiff.c and ping_common.c license
      cleanup: really old code, simplify little bit
      Merge pull request #103 from kerolasa/remove-libsysfs
      Merge pull request #107 from jsynacek/master
      Merge pull request #106 from kerolasa/tracepath-asan
      Merge pull request #97 from nmav/tmp-idn2
      Merge pull request #108 from Whissi/symlinked-tracepath-call
      Merge pull request #101 from pevik/cleanup/working_recverr
      Merge pull request #100 from pevik/fix-regression-57
      Merge pull request #113 from pevik/doc/ping-modern-commands
      Merge pull request #114 from pevik/doc/ping-no-need-to-use-link-specification
      Merge pull request #116 from pevik/fix-readme
      Merge pull request #75 from soheilhy/ping-errqueue
      Merge pull request #126 from deastoe/ping6-device-bind
      Merge pull request #123 from bbczeuz/dev_zseng_fix_time_rounding
      Merge pull request #121 from pingz/patch-1
      Merge pull request #131 from pevik/fix-ping-on-C-locale
      Merge pull request #134 from computersforpeace/warnings
      iputils-s20180629

Duncan Eastoe (1):
      ping6: Fix device binding

Jan Synacek (5):
      ping: prevent possible double free after cap_free()
      arping: exit if network disappears while running
      fix multicast setsockopt calls on big endian
      ping: fix pmtu discovery for ipv6
      ping: remove spurious error message

Nathaniel White (3):
      traceroute6: Fix use after free for hostname
      traceroute6: Fix leaking the idn memory
      traceroute6: Fix traceroute to IPv6 address

Nikos Mavrogiannopoulos (6):
      arping,tracepath: removed unused idna header
      traceroute6: use getaddrinfo IDNA conversion
      ping6: simplified IDNA usage
      ping: use libidn2 instead of libidn
      .travis.yml: install libidn2
      .travis.yml: corrected variable values in matrix

Noah Meyerhans (1):
      traceroute6: Fix udp packet port specification.

Petr Vorel (6):
      ping: Remove workaround for bug in IP_RECVERR on raw sockets
      Revert "correctly initialize first hop"
      doc/ping: Replace deprecated commands in "SEE ALSO" section
      doc/ping: Update Interface section
      docs: Tiny fixes in README.md
      ping: Fix ping name encoded using ACE on C locale

Sami Kerola (2):
      arping: do not use libsysfs to read from /sys
      tracepath: fix heap-buffer-overflow [asan]

Seishinryohosha (1):
      tracepath,doc: Added -4, -6 Parameter in doc and void usage(void)

Singh (1):
      Add strict pattern matching on response when pattern was provided

Soheil Hassas Yeganeh (1):
      ping: read from error queue when POLLERR is set

Thomas Deutschmann (1):
      tracepath: Support calling `tracepath` as `tracepath4` or `tracepath6`

pingz (1):
      fix checksum always success in IPv4 ping.