### PR TITLE
vim-qml: init at 2018-07-22

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -2085,6 +2085,17 @@ self = rec {
 
   };
 
+  vim-qml = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-qml-2018-07-22";
+    src = fetchgit {
+      url = "https://github.com/peterhoeg/vim-qml";
+      rev = "8af43da6950ce5483704bb97f5b24471d8ffda1a";
+      sha256 = "1y1xvbfr1ffxyyk3zzf50xn87a85i1zszj4fqlq5ka8zhgdrnhvc";
+    };
+    dependencies = [];
+
+  };
+
   vim-markdown = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-markdown-2018-06-05";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -168,6 +168,7 @@
 "github:osyo-manga/vim-textobj-multiblock"
 "github:osyo-manga/vim-watchdogs"
 "github:pangloss/vim-javascript"
+"github:peterhoeg/vim-qml"
 "github:plasticboy/vim-markdown"
 "github:python-mode/python-mode"
 "github:Quramy/tsuquyomi"


### PR DESCRIPTION
###### Motivation for this change
Add vim plugin for editing Qt qml files.

###### Things done
Added vim-qml to vim-plugin-names. Added generated code to vim-plugins/default.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

