### PR TITLE
vim-lastplace: init at 2017-06-13

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -1029,6 +1029,17 @@ self = rec {
 
   };
 
+  vim-lastplace = buildVimPluginFrom2Nix { # created by nix#NixDerivation
+    name = "vim-lastplace-2017-06-13";
+    src = fetchgit {
+      url = "https://github.com/farmergreg/vim-lastplace";
+      rev = "102b68348eff0d639ce88c5094dab0fdbe4f7c55";
+      sha256 = "1d0mjjyissjvl80wgmn7z1gsjs3fhk0vnmx84l9q7g04ql4l9pja";
+    };
+    dependencies = [];
+
+  };
+
   vim-go = buildVimPluginFrom2Nix { # created by nix#NixDerivation
     name = "vim-go-2018-07-22";
     src = fetchgit {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -50,6 +50,7 @@
 "github:ensime/ensime-vim"
 "github:ervandew/supertab"
 "github:esneider/YUNOcommit.vim"
+"github:farmergreg/vim-lastplace"
 "github:fatih/vim-go"
 "github:FelikZ/ctrlp-py-matcher"
 "github:fisadev/vim-isort"


### PR DESCRIPTION
###### Motivation for this change
Add vim plugin which remembers cursor positions in previously edited files.

###### Things done
Added vim-lastplace to vim-plugin-names. Added generated code to vim-plugins/default.nix

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

