### PR TITLE
qtcreator: enable on aarch64 and armv7

### DIFF
--- a/pkgs/development/tools/qtcreator/0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch
+++ b/pkgs/development/tools/qtcreator/0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch
@@ -1,0 +1,94 @@
+From c6d02dba2911d93e2379cfb5e550b93558dd51bf Mon Sep 17 00:00:00 2001
+From: Greg Nietsky <gregory@distrotech.co.za>
+Date: Tue, 4 Mar 2014 11:33:40 +0200
+Subject: [PATCH] Fix: Allow qt-creator to build on arm aarch32 and aarch64
+
+Botan is imported hardwired for x86 this small patch allows it
+too operate on arm other platforms could be added.
+
+Task-number: QTCREATORBUG-8107
+Change-Id: Iddea28f21c9fa1afd2fdd5d16a44e6c96a516a7a
+---
+ src/libs/3rdparty/botan/botan.cpp | 16 +++++++++++++++-
+ src/libs/3rdparty/botan/botan.h   |  2 ++
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/src/libs/3rdparty/botan/botan.cpp b/src/libs/3rdparty/botan/botan.cpp
+index 917c385..4364a2e 100644
+--- a/src/libs/3rdparty/botan/botan.cpp
++++ b/src/libs/3rdparty/botan/botan.cpp
+@@ -1101,6 +1101,8 @@ class Montgomery_Exponentiator : public Modular_Exponentiator
+ 
+ #if (BOTAN_MP_WORD_BITS != 32)
+    #error The mp_x86_32 module requires that BOTAN_MP_WORD_BITS == 32
++#elif !defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
++typedef Botan::u64bit dword;
+ #endif
+ 
+ #ifdef Q_OS_UNIX
+@@ -1118,6 +1120,7 @@ extern "C" {
+ */
+ inline word word_madd2(word a, word b, word* c)
+    {
++#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+    asm(
+       ASM("mull %[b]")
+       ASM("addl %[c],%[a]")
+@@ -1127,6 +1130,11 @@ inline word word_madd2(word a, word b, word* c)
+       : "0"(a), "1"(b), [c]"g"(*c) : "cc");
+ 
+    return a;
++#else
++   dword z = (dword)a * b + *c;
++   *c = (word)(z >> BOTAN_MP_WORD_BITS);
++   return (word)z;
++#endif
+    }
+ 
+ /*
+@@ -1134,6 +1142,7 @@ inline word word_madd2(word a, word b, word* c)
+ */
+ inline word word_madd3(word a, word b, word c, word* d)
+    {
++#if defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+    asm(
+       ASM("mull %[b]")
+ 
+@@ -1147,6 +1156,11 @@ inline word word_madd3(word a, word b, word c, word* d)
+       : "0"(a), "1"(b), [c]"g"(c), [d]"g"(*d) : "cc");
+ 
+    return a;
++#else
++   dword z = (dword)a * b + c + *d;
++   *d = (word)(z >> BOTAN_MP_WORD_BITS);
++   return (word)z;
++#endif
+    }
+ 
+ }
+@@ -2315,7 +2329,7 @@ namespace Botan {
+ 
+ extern "C" {
+ 
+-#ifdef Q_OS_UNIX
++#if defined(Q_OS_UNIX) && defined(BOTAN_TARGET_CPU_IS_X86_FAMILY)
+ /*
+ * Helper Macros for x86 Assembly
+ */
+diff --git a/src/libs/3rdparty/botan/botan.h b/src/libs/3rdparty/botan/botan.h
+index 6a9cbe0..3bfdbc2 100644
+--- a/src/libs/3rdparty/botan/botan.h
++++ b/src/libs/3rdparty/botan/botan.h
+@@ -81,7 +81,9 @@
+ #endif
+ 
+ #define BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN
++#if !defined(__arm__) && !defined(__aarch64__)
+ #define BOTAN_TARGET_CPU_IS_X86_FAMILY
++#endif
+ #define BOTAN_TARGET_UNALIGNED_MEMORY_ACCESS_OK 1
+ 
+ #if defined(BOTAN_TARGET_CPU_IS_LITTLE_ENDIAN) || \
+-- 
+2.3.0
+

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake makeWrapper ];
 
-  patches = optional (stdenv.isAarch64 || stdenv.isAarch32) ./0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch;
+  patches = optional stdenv.hostPlatform.isArm ./0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch;
 
   doCheck = true;
 

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake makeWrapper ];
 
+  patches = optional (stdenv.isAarch64 || stdenv.isAarch32) ./0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch;
+
   doCheck = true;
 
   enableParallelBuilding = true;
@@ -55,6 +57,6 @@ stdenv.mkDerivation rec {
     homepage = https://wiki.qt.io/Category:Tools::QtCreator;
     license = "LGPL";
     maintainers = [ maintainers.akaWolf ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
   };
 }


### PR DESCRIPTION
Patch (from https://bugreports.qt.io/browse/QTCREATORBUG-8107) to allow botan to build on arm.

###### Motivation for this change
QtCreator can be built and run on aarch64 and aarch32, but one of its components, botan, requires patching. Patch taken from https://codereview.qt-project.org/#/c/79728/.

###### Things done
Added patch to fix qtcreator build on aarch64 and aarch32. Added these architectures to the supported platforms.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
N.B. Believe it should work on aarch32, but have only tested on aarch64 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @akaWolf 

---
I haven't yet looked into whether qtcreator's copy of botan differs significantly from the botan in pkgs/development/libraries/botan. It might make sense to patch that and make qtcreator use system botan instead of its bundled botan.