### PR TITLE
vdiff-magit: Include git in nativeBuildInputs

### DIFF
--- a/pkgs/applications/editors/emacs-modes/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-packages.nix
@@ -202,6 +202,12 @@ self:
       # missing OCaml
       utop = markBroken super.utop;
 
+      vdiff-magit =
+        (super.vdiff-magit.overrideAttrs (attrs: {
+          nativeBuildInputs =
+            (attrs.nativeBuildInputs or []) ++ [ external.git ];
+        }));
+
       # upstream issue: missing file header
       voca-builder = markBroken super.voca-builder;
 

--- a/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
+++ b/pkgs/applications/editors/emacs-modes/melpa-stable-packages.nix
@@ -194,6 +194,12 @@ self:
       # missing OCaml
       utop = markBroken super.utop;
 
+      vdiff-magit =
+        (super.vdiff-magit.overrideAttrs (attrs: {
+          nativeBuildInputs =
+            (attrs.nativeBuildInputs or []) ++ [ external.git ];
+        }));
+
       # upstream issue: missing file header
       voca-builder = markBroken super.voca-builder;
 


### PR DESCRIPTION
Like magit, vdiff-magit expects git to be present at install time.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---