### PR TITLE
dragon: init at 18.04.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1940,6 +1940,11 @@
     github = "jonafato";
     name = "Jon Banafato";
   };
+  jonathanreeve = {
+    email = "jon.reeve@gmail.com";
+    github = "JonathanReeve";
+    name = "Jonathan Reeve";
+  };
   joncojonathan = {
     email = "joncojonathan@gmail.com";
     github = "joncojonathan";

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -77,6 +77,7 @@ let
       calendarsupport = callPackage ./calendarsupport.nix {};
       dolphin = callPackage ./dolphin.nix {};
       dolphin-plugins = callPackage ./dolphin-plugins.nix {};
+      dragon = callPackage ./dragon.nix {};
       eventviews = callPackage ./eventviews.nix {};
       ffmpegthumbs = callPackage ./ffmpegthumbs.nix { };
       filelight = callPackage ./filelight.nix {};

--- a/pkgs/applications/kde/dragon.nix
+++ b/pkgs/applications/kde/dragon.nix
@@ -12,7 +12,7 @@ mkDerivation {
   meta = {
     license = with lib.licenses; [ gpl2 fdl12 ];
     description = "A simple media player for KDE";
-    maintainers = [ lib.maintainers.ttuegel ];
+    maintainers = [ lib.maintainers.jonathanreeve ];
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   propagatedBuildInputs = [

--- a/pkgs/applications/kde/dragon.nix
+++ b/pkgs/applications/kde/dragon.nix
@@ -1,0 +1,25 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules, kdoctools,
+  baloo, baloo-widgets, kactivities, kbookmarks, kcmutils,
+  kcompletion, kconfig, kcoreaddons, kdelibs4support, kdbusaddons,
+  kfilemetadata, ki18n, kiconthemes, kinit, kio, knewstuff, knotifications,
+  kparts, ktexteditor, kwindowsystem, phonon, solid, phonon-backend-gstreamer
+}:
+
+mkDerivation {
+  name = "dragon";
+  meta = {
+    license = with lib.licenses; [ gpl2 fdl12 ];
+    description = "A simple media player for KDE";
+    maintainers = [ lib.maintainers.ttuegel ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  propagatedBuildInputs = [
+    baloo baloo-widgets kactivities kbookmarks kcmutils kcompletion kconfig
+    kcoreaddons kdelibs4support kdbusaddons kfilemetadata ki18n kiconthemes
+    kinit kio knewstuff knotifications kparts ktexteditor kwindowsystem
+    phonon solid phonon-backend-gstreamer
+  ];
+  outputs = [ "out" "dev" ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16982,7 +16982,7 @@ with pkgs;
       recurseIntoAttrs (makeOverridable mkApplications attrs);
 
   inherit (kdeApplications)
-    akonadi akregator ark dolphin ffmpegthumbs filelight gwenview k3b
+    akonadi akregator ark dolphin dragon ffmpegthumbs filelight gwenview k3b
     kaddressbook kate kcachegrind kcalc kcolorchooser kcontacts kdenlive kdf kdialog keditbookmarks
     kget kgpg khelpcenter kig kleopatra kmail kmix kolourpaint kompare konsole
     kontact korganizer krdc krfb ksystemlog kwalletmanager marble minuet okular spectacle;


### PR DESCRIPTION
Add Dragon Player, the KDE video and media player, so that KDE
users will have a way to play videos and audio files.

###### Motivation for this change

There is currently no video/media player for KDE in the Nixpkgs repos. However, the mechanism for sourcing the application is already provided by the KDE infrastructure in nixpkgs. So this just makes a formal package out of it, so that KDE users can play videos out-of-the-box. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

