### PR TITLE
ir.lv2: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/applications/audio/ir.lv2/default.nix
+++ b/pkgs/applications/audio/ir.lv2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "ir.lv2-${version}";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "tomszilagyi";
     repo = "ir.lv2";
     rev = "${version}";
-    sha256 = "16vy06qb0vgwg4yx15grzh5m2q3cbzm3jd0p37g2qb8rgvjhladg";
+    sha256 = "1p6makmgr898fakdxzl4agh48qqwgv1k1kwm8cgq187n0mhiknp6";
   };
 
   buildInputs = [ fftw gtk2 lv2 libsamplerate libsndfile zita-convolver ];
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     mkdir "$out/include"
     mkdir -p "$out/share/doc"
 
-    make PREFIX="$out" install
+    make PREFIX="$out" INSTDIR="$out/lib/lv2" install
     install -Dm755 convert4chan "$out/bin/convert4chan"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

The previous version didn't build anymore due to a lib mismatch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

