### PR TITLE
noto-fonts-emoji: 2017-09-13 -> 2018-04-24

### DIFF
--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -86,14 +86,14 @@ rec {
       maintainers = with maintainers; [ mathnerd314 ];
     };
   };
-  noto-fonts-emoji = let version = "2017-09-13-design-refresh"; in stdenv.mkDerivation {
+  noto-fonts-emoji = let version = "2018-04-24-pistol-update"; in stdenv.mkDerivation {
     name = "noto-fonts-emoji-${version}";
 
     src = fetchFromGitHub {
       owner = "googlei18n";
       repo = "noto-emoji";
       rev = "v${version}";
-      sha256 = "1ixz03207kzh6jhmw8bpi77pxkfzq46dk26sr41m5kkvc14d14vl";
+      sha256 = "1f9k182j0619xvwk60gw2hng3lcd483sva2fabjdhznk8yf9f7jg";
     };
 
     buildInputs = [ cairo ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest emojiset

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

