### PR TITLE
ydiff: init at 1.1

### DIFF
--- a/pkgs/development/tools/ydiff/default.nix
+++ b/pkgs/development/tools/ydiff/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, lib, pythonPackages, python3Packages, less, patchutils, git
+, subversion, coreutils, which }:
+
+with pythonPackages;
+
+buildPythonApplication rec {
+  pname = "ydiff";
+  version = "1.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0mxcl17sx1d4vaw22ammnnn3y19mm7r6ljbarcjzi519klz26bnf";
+  };
+
+  patchPhase = ''
+    substituteInPlace tests/test_ydiff.py \
+      --replace /bin/rm ${coreutils}/bin/rm \
+      --replace /bin/sh ${stdenv.shell}
+    substituteInPlace Makefile \
+      --replace "pep8 --ignore" "# pep8 --ignore" \
+      --replace "python3 \`which coverage\`" "${python3Packages.coverage}/bin/coverage3" \
+      --replace /bin/sh ${stdenv.shell} \
+      --replace tests/regression.sh "${stdenv.shell} tests/regression.sh"
+    patchShebangs tests/*.sh
+  '';
+
+  buildInputs = [ docutils pygments ];
+  propagatedBuildInputs = [ less patchutils ];
+  checkInputs = [ coverage coreutils git subversion which ];
+
+  checkTarget = if isPy3k then "test3" else "test";
+
+  meta = {
+    homepage = https://github.com/ymattw/ydiff;
+    description = "View colored, incremental diff in workspace or from stdin";
+    longDescription = ''
+      Term based tool to view colored, incremental diff in a version
+      controlled workspace (supports Git, Mercurial, Perforce and Svn
+      so far) or from stdin, with side by side (similar to diff -y)
+      and auto pager support.
+    '';
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19416,6 +19416,8 @@ with pkgs;
 
   yate = callPackage ../applications/misc/yate { };
 
+  ydiff = callPackage ../development/tools/ydiff { };
+
   yed = callPackage ../applications/graphics/yed {};
 
   inherit (gnome3) yelp;


### PR DESCRIPTION
###### Motivation for this change

Handy tool for working with diffs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

