### PR TITLE
libvirt: darwin/linux fix dlopen("libjansson.so.4")

### DIFF
--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -60,7 +60,9 @@ in stdenv.mkDerivation rec {
       --replace 'lxc_path,' '"/run/libvirt/nix-emulators/libvirt_lxc",'
 
     patchShebangs . # fixes /usr/bin/python references
-  '';
+    substituteInPlace src/util/virjsoncompat.c --replace \
+        '"libjansson.so.4"' '"${jansson}/lib/libjansson${stdenv.targetPlatform.extensions.sharedLibrary}"'
+   '';
 
   configureFlags = [
     "--localstatedir=/var"


### PR DESCRIPTION
###### Motivation for this change

Commit 59027e28800dd5c2cd1c9d434c1a71d39be19266 broke libvirt
 Revert "libvirt: fix dlopen("libjansson.so.4")" 

broke libvirt/nixops on linux :/ I am not sure what's the proper fix but meanwhile could we wrap the change in an if darwin ?

cf
https://github.com/NixOS/nixpkgs/pull/44900

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

