### PR TITLE
rustup: wrap bindgen to find header files in a nix-shell

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform, makeWrapper, llvmPackages }:
-
-# Future work: Automatically communicate NIX_CFLAGS_COMPILE to bindgen's tests and the bindgen executable itself.
+{ stdenv, fetchFromGitHub, fetchpatch, rustPlatform, clang, llvmPackages, rustfmt, writeScriptBin }:
 
 rustPlatform.buildRustPackage rec {
   name = "rust-bindgen-${version}";
@@ -13,23 +11,54 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0cqjr7qspjrfgqcp4nqxljmhhbqyijb2jpw3lajgjj48y6wrnw93";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ llvmPackages.clang-unwrapped.lib ];
+  cargoSha256 = "0b8v6c7q1abibzygrigldpd31lyd5ngmj4vq5d7zni96m20mm85w";
+
+  libclang = llvmPackages.libclang.lib; #for substituteAll
+
+  buildInputs = [ libclang ];
+
+  propagatedBuildInputs = [ clang ]; # to populate NIX_CXXSTDLIB_COMPILE
+
+  patches = [
+    # https://github.com/rust-lang-nursery/rust-bindgen/pull/1376
+    (fetchpatch {
+      url = https://github.com/rust-lang-nursery/rust-bindgen/commit/c8b5406f08af82a92bf8faf852c21ba941d9c176.patch;
+      sha256 = "16ibr2rplh0qz8rsq6gir45xlz5nasad4y8fprwhrb7ssv8wfkss";
+    })
+  ];
 
   configurePhase = ''
-    export LIBCLANG_PATH="${llvmPackages.clang-unwrapped.lib}/lib"
+    export LIBCLANG_PATH="${libclang}/lib"
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/bindgen --set LIBCLANG_PATH "${llvmPackages.clang-unwrapped.lib}/lib"
+    mv $out/bin/{bindgen,.bindgen-wrapped};
+    substituteAll ${./wrapper.sh} $out/bin/bindgen
+    chmod +x $out/bin/bindgen
   '';
 
-  cargoSha256 = "0b8v6c7q1abibzygrigldpd31lyd5ngmj4vq5d7zni96m20mm85w";
-
-  doCheck = false; # A test fails because it can't find standard headers in NixOS
+  doCheck = false; # half the tests fail because our rustfmt is not nightly enough
+  checkInputs =
+    let fakeRustup = writeScriptBin "rustup" ''
+      #!${stdenv.shell}
+      shift
+      shift
+      exec "$@"
+    '';
+  in [
+    rustfmt
+    fakeRustup # the test suite insists in calling `rustup run nightly rustfmt`
+    clang
+  ];
 
   meta = with stdenv.lib; {
     description = "C and C++ binding generator";
+    longDescription = ''
+      Bindgen takes a c or c++ header file and turns them into
+      rust ffi declarations.
+      As with most compiler related software, this will only work
+      inside a nix-shell with the required libraries as buildInputs.
+    '';
     homepage = https://github.com/rust-lang-nursery/rust-bindgen;
     license = with licenses; [ bsd3 ];
     maintainers = [ maintainers.ralith ];

--- a/pkgs/development/tools/rust/bindgen/wrapper.sh
+++ b/pkgs/development/tools/rust/bindgen/wrapper.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+sep='--'   # whether to add -- before new options
+cxx=0      # whether cxx was explicitly requested
+lastWasx=0 # whether the last argument passed was -x
+for e in "$@"; do
+  if [[ "$e" == "--" ]]; then
+    sep=
+  fi;
+  if [[ "$sep" == "" ]]; then
+    # we look for -x c++ after -- only
+    if [[ "$e" == "-x" ]]; then
+      lastWasx=1
+    fi;
+    if [[ $lastWasx -eq 1 && "$e" == "c++" ]]; then
+      lastWasx=0
+      cxx=1
+    fi;
+    if [[ "$e" == "-xc++" || "$e" == -std=c++* ]]; then
+      cxx=1
+    fi;
+  fi;
+done;
+cxxflags=
+if [[ $cxx -eq 1 ]]; then
+  cxxflags=$NIX_CXXSTDLIB_COMPILE
+fi;
+if [[ -n "$NIX_DEBUG" ]]; then
+  set -x;
+fi;
+export LIBCLANG_PATH="@libclang@/lib"
+# shellcheck disable=SC2086
+# cxxflags and NIX_CFLAGS_COMPILE should be word-split
+exec -a "$0" @out@/bin/.bindgen-wrapped "$@" $sep $cxxflags $NIX_CFLAGS_COMPILE
+# note that we add the flags after $@ which is incorrect. This is only for the sake
+# of simplicity.
+


### PR DESCRIPTION
###### Motivation for this change
this is a second attempt at https://github.com/NixOS/nixpkgs/pull/40746
it should work in any nix-shell where the header file is correctly parsed by clang, as long as -x c++ is
explicitly specified for c++ headers.

This is done in two commits: the first one is the one which wraps bindgen. The second one is an attempt at making tests works. Around 190/300 pass, but the test suite requires nightly rustfmt so most if not all failures are just a question of formatting :(
This second commit is therefore unnecessary, but when we update rustc or when rustfmt becomes stable it may prove useful. I was not sure whether to leave it, so if you think I should remove it from the PR just tell me.

About closure size: to have NIX_CXXSTDLIB_COMPILE populated, the only non absurd way I found was to add clang as propagatedBuildInputs. This is wasteful, but I could not get `libstdcxxHook` to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

