### PR TITLE
Fix backblaze CLI bash autocomplete issue

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -22,7 +22,7 @@ buildPythonApplication rec {
   postInstall = ''
     mv "$out/bin/b2" "$out/bin/backblaze-b2"
 
-    sed 's/^have b2 \&\&$/have backblaze-b2 \&\&/'   -i contrib/bash_completion/b2
+    sed 's/^have b2 \&\&$/_have backblaze-b2 \&\&/'  -i contrib/bash_completion/b2
     sed 's/^\(complete -F _b2\) b2/\1 backblaze-b2/' -i contrib/bash_completion/b2
 
     mkdir -p "$out/etc/bash_completion.d"


### PR DESCRIPTION
Backblaze's CLI tool is relying on `have` function which is
[deprecated](https://github.com/scop/bash-completion/blob/4d88339928aa064a567d5feb40694dfd24a274c5/bash_completion#L114) and gets [de-referenced](https://github.com/scop/bash-completion/blob/4d88339928aa064a567d5feb40694dfd24a274c5/bash_completion#L2103) at the end of `bash-completion`.

This causes issues for NixOS because those bash completions are
run after [bash-completion](https://github.com/NixOS/nixpkgs/blob/80b6513fbf5789ff0208c19a89bae49df2b503ad/nixos/modules/programs/bash/bash.nix#L22) has already run and unset the
`have` function.

I have submitted [patch](https://github.com/Backblaze/B2_Command_Line_Tool/pull/497) upstream but I suspect it will take a while before new version is released so I think we should patch it on our end in the meanwhile.

###### Motivation for this change

Without the patch every time bash is opened: 
````
have: command not found
````
because `have` has been unset already because it's deprecated (see description).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

