### PR TITLE
feedgnuplot: fix build

### DIFF
--- a/pkgs/tools/graphics/feedgnuplot/default.nix
+++ b/pkgs/tools/graphics/feedgnuplot/default.nix
@@ -19,6 +19,8 @@ buildPerlPackage rec {
     sha256 = "1bjnx36rsxlj845w9apvdjpza8vd9rbs3dlmgvky6yznrwa6sm02";
   };
 
+  outputs = [ "out" ];
+
   nativeBuildInputs = [ makeWrapper gawk ];
 
   buildInputs = [ gnuplot perl ]


### PR DESCRIPTION
###### Motivation for this change

feedgnuplot has no devdoc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

