### PR TITLE
sqldeveloper_18: init at 18.2.0.183.1748

### DIFF
--- a/pkgs/development/tools/database/sqldeveloper/18.2.nix
+++ b/pkgs/development/tools/database/sqldeveloper/18.2.nix
@@ -1,0 +1,84 @@
+{ stdenv, makeDesktopItem, makeWrapper, requireFile, unzip, jdk }:
+
+let
+  version = "18.2.0.183.1748";
+
+  desktopItem = makeDesktopItem {
+    name = "sqldeveloper";
+    exec = "sqldeveloper";
+    icon = "sqldeveloper";
+    desktopName = "Oracle SQL Developer 18";
+    genericName = "Oracle SQL Developer 18";
+    comment = "Oracle's Oracle DB GUI client";
+    categories = "Application;Development;";
+  };
+in
+  stdenv.mkDerivation rec {
+
+  inherit version;
+  name = "sqldeveloper-${version}";
+
+  src = requireFile rec {
+    name = "sqldeveloper-${version}-no-jre.zip";
+    url = "http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/";
+    message = ''
+      This Nix expression requires that ${name} already be part of the store. To
+      obtain it you need to
+
+      - navigate to ${url}
+      - make sure that it says "Version ${version}" above the list of downloads
+        - if it does not, click on the "Previous Version" link below the downloads
+          and repeat until the version is correct. This is necessarry because as the
+          time of this writing there exists no permanent link for the current version
+          yet.
+          Also consider updating this package yourself (you probably just need to
+          change the `version` variable and update the sha256 to the one of the
+          new file) or opening an issue at the nixpkgs repo.
+      - accept the license agreement
+      - download the file listed under "Other Platforms"
+      - sign in or create an oracle account if neccessary
+
+      and then add the file to the Nix store using either:
+
+        nix-store --add-fixed sha256 ${name}
+
+      or
+
+        nix-prefetch-url --type sha256 file:///path/to/${name}
+    '';
+    sha256 = "0clz2w4ghqczy9sz6j4qqygk20whdwkca192pd3v0dw09875as0k";
+  };
+
+  buildInputs = [ makeWrapper unzip ];
+
+  unpackCmd = "unzip $curSrc";
+
+  installPhase = ''
+    mkdir -p $out/libexec $out/share/{applications,pixmaps}
+    mv * $out/libexec/
+
+    mv $out/libexec/icon.png $out/share/pixmaps/sqldeveloper.png
+    cp ${desktopItem}/share/applications/* $out/share/applications
+
+    makeWrapper $out/libexec/sqldeveloper/bin/sqldeveloper $out/bin/sqldeveloper \
+      --set JAVA_HOME ${jdk.home} \
+      --run "cd $out/libexec/sqldeveloper/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Oracle's Oracle DB GUI client";
+    longDescription = ''
+      Oracle SQL Developer is a free integrated development environment that
+      simplifies the development and management of Oracle Database in both
+      traditional and Cloud deployments. SQL Developer offers complete
+      end-to-end development of your PL/SQL applications, a worksheet for
+      running queries and scripts, a DBA console for managing the database,
+      a reports interface, a complete data modeling solution, and a migration
+      platform for moving your 3rd party databases to Oracle.
+    '';
+    homepage = http://www.oracle.com/technetwork/developer-tools/sql-developer/overview/;
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ ardumont flokli ma27 ];
+  };
+}

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -79,6 +79,6 @@ in
     homepage = http://www.oracle.com/technetwork/developer-tools/sql-developer/overview/;
     license = licenses.unfree;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
-    maintainers = [ maintainers.ardumont ];
+    maintainers = with maintainers; [ ardumont flokli ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7169,6 +7169,13 @@ with pkgs;
 
   sqldeveloper = callPackage ../development/tools/database/sqldeveloper { };
 
+  # sqldeveloper_18 needs JavaFX, which currently only is available inside the
+  # (non-free and net yet packaged for Darwin) OracleJDK
+  # we might be able to get rid of it, as soon as we have an OpenJDK with OpenJFX included
+  sqldeveloper_18 = callPackage ../development/tools/database/sqldeveloper/18.2.nix {
+    jdk = oraclejdk;
+  };
+
   squeak = callPackage ../development/compilers/squeak { };
 
   squirrel-sql = callPackage ../development/tools/database/squirrel-sql {


### PR DESCRIPTION
###### Motivation for this change
This adds sqldeveloper 18.2, which brings some more features compared to 17.4, but requires JavaFX (and thus currently oraclejdk, as we did not yet package OpenJFX) - see https://github.com/NixOS/nixpkgs/pull/44624 for a detailed explanation.

ping @Ma27 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

