### PR TITLE
pythonPackages.nixpart0: fix nixops deploy

### DIFF
--- a/pkgs/tools/filesystems/nixpart/0.4/default.nix
+++ b/pkgs/tools/filesystems/nixpart/0.4/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, python, buildPythonApplication
 # Propagated to blivet
 , useNixUdev ? true
+# Needed by NixOps
+, udevSoMajor ? null
 # Propagated dependencies
 , pkgs, urlgrabber
 }:


### PR DESCRIPTION
re-introduce the unused "udevSoMajor" variable for nixops
backward-compatibilty (nixops master still uses it unlike claimed by previous comment).

This was removed by the treewide 52f53c69ce6dbc5538f7e4cd22f9d93baf1f64a2 cleanup

###### Motivation for this change

Fix nixops deployments

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

