### PR TITLE
gnatsd: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3868,6 +3868,11 @@
     github = "swarren83";
     name = "Shawn Warren";
   };
+  swdunlop = {
+    email = "swdunlop@gmail.com";
+    github = "swdunlop";
+    name = "Scott W. Dunlop";
+  };
   swflint = {
     email = "swflint@flintfam.org";
     github = "swflint";

--- a/pkgs/servers/gnatsd/default.nix
+++ b/pkgs/servers/gnatsd/default.nix
@@ -1,0 +1,26 @@
+{  buildGoPackage, fetchFromGitHub, lib  }:
+
+with lib;
+
+buildGoPackage rec {
+  name = "gnatsd-${version}";
+  version = "1.2.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/nats-io/gnatsd";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "nats-io";
+    repo = "gnatsd";
+    sha256 = "186xywzdrmvlhlh9wgjs71rqvgab8vinlr3gkzkknny82nv7hcjw";
+  };
+
+  meta = {
+    description = "High-Performance server for NATS";
+    license = licenses.asl20;
+    maintainers = [ maintainers.swdunlop ];
+    homepage = https://nats.io/;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12901,6 +12901,8 @@ with pkgs;
 
   glabels = callPackage ../applications/graphics/glabels { };
 
+  gnatsd = callPackage ../servers/gnatsd { };
+
   gofish = callPackage ../servers/gopher/gofish { };
 
   grafana = callPackage ../servers/monitoring/grafana { };


### PR DESCRIPTION
###### Motivation for this change

Support communication with applications via [NATS](https://nats.io).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

