### PR TITLE
ldc: 1.10.0 -> 1.11.0, dmd: 2.081.1 -> 2.081.2, dtools: 2.081.1 -> 2.081.2

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -2,10 +2,10 @@
 , makeWrapper, unzip, which
 , curl, tzdata, gdb, darwin
 , callPackage, targetPackages, ldc
-, version ? "2.081.1"
-, dmdSha256 ? "1xdz7p0pdzwkn57ai93mavgdkd8xb1sr2brlc6y3c12x84h43s8z"
-, druntimeSha256 ? "1vl8ag6rjvqqmc5bn5jk3yfynjb9ggy3hw1awwl7c76bq4f7nbif"
-, phobosSha256 ? "0h1jdc3yai1l42bxjdlyi9hf9qadh76v925rjk2q4ibv2fzl56b7"
+, version ? "2.081.2"
+, dmdSha256 ? "1wwk4shqldvgyczv1ihmljpfj3yidq7mxcj69i9kjl7jqx54hw62"
+, druntimeSha256 ? "0dqfsy34q2q7mk2gsi4ix3vgqg7szg3m067fghgx53vnvrzlpsc0"
+, phobosSha256 ? "1dan59lc4wggsrv5aax7jsxnzg7fz37xah84k1cbwjb3xxhhkd9n"
 }:
 
 let

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -2,8 +2,8 @@
 , python, libconfig, lit, gdb, unzip, darwin, bash
 , callPackage, makeWrapper, targetPackages
 , bootstrapVersion ? false
-, version ? "1.10.0"
-, ldcSha256 ? "0wc3vlblsz4qdwa9ay9plv9nvfd07zj2byqqffaa4a5gvjwf5dlr"
+, version ? "1.11.0"
+, ldcSha256 ? "0w4z261gzji31hn1xdnmi9dfkbyydpy6rz8aj4456q5w8yp4yil5"
 }:
 
 let

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "dtools-${version}";
-  version = "2.081.1";
+  version = "2.081.2";
 
   srcs = [
     (fetchFromGitHub {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "1xdz7p0pdzwkn57ai93mavgdkd8xb1sr2brlc6y3c12x84h43s8z";
+      sha256 = "1wwk4shqldvgyczv1ihmljpfj3yidq7mxcj69i9kjl7jqx54hw62";
       name = "dmd";
     })
     (fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change

Update to latest stable releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

