### PR TITLE
tdlib: init at 2018-03-20

### DIFF
--- a/pkgs/development/libraries/tdlib/default.nix
+++ b/pkgs/development/libraries/tdlib/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, gperf, openssl, readline, zlib }:
+
+stdenv.mkDerivation rec {
+  version = "2018-03-20";
+  name = "tdlib-${version}";
+
+  src = fetchFromGitHub {
+    owner = "tdlib";
+    repo = "td";
+    rev = "cfe4d9bdcee9305632eb228a46a95407d05b5c7a";
+    sha256 = "0445hiqp2gmkd60kcv7r10li7k09bjrzy3ywd43iwc99jay1pwc1";
+  };
+
+  buildInputs = [ gperf openssl readline zlib ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform library for building Telegram clients";
+    homepage = "https://core.telegram.org/tdlib/";
+    license = [ licenses.boost ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12093,6 +12093,8 @@ with pkgs;
 
   tclx = callPackage ../development/libraries/tclx { };
 
+  tdlib = callPackage ../development/libraries/tdlib { };
+
   ntdb = callPackage ../development/libraries/ntdb {
     python = python2;
   };


### PR DESCRIPTION
###### Motivation for this change

This PR adds library to call [Telegram API](https://core.telegram.org/tdlib/).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

