### PR TITLE
wabt: init at 1.0.5

### DIFF
--- a/pkgs/development/tools/wabt/default.nix
+++ b/pkgs/development/tools/wabt/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, cmake, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "wabt-${version}";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner  = "WebAssembly";
+    repo   = "wabt";
+    rev    = version;
+    sha256 = "1cbak3ach7cna98j2r0v3y38c59ih2gv0p6f43qp782pyj07hzfy";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
+  buildInputs = [ python3 ];
+
+  meta = with stdenv.lib; {
+    description = "The WebAssembly Binary Toolkit";
+    longDescription = ''
+      WABT (we pronounce it "wabbit") is a suite of tools for WebAssembly,
+      including:
+       * wat2wasm: translate from WebAssembly text format to the WebAssembly
+         binary format
+       * wasm2wat: the inverse of wat2wasm, translate from the binary format
+         back to the text format (also known as a .wat)
+       * wasm-objdump: print information about a wasm binary. Similiar to
+         objdump.
+       * wasm-interp: decode and run a WebAssembly binary file using a
+         stack-based interpreter
+       * wat-desugar: parse .wat text form as supported by the spec interpreter
+         (s-expressions, flat syntax, or mixed) and print "canonical" flat
+         format
+       * wasm2c: convert a WebAssembly binary file to a C source and header
+    '';
+    homepage = https://github.com/WebAssembly/wabt;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ekleog ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7388,6 +7388,8 @@ with pkgs;
   love_11 = callPackage ../development/interpreters/love/11.1.nix { };
   love = love_0_10;
 
+  wabt = callPackage ../development/tools/wabt { };
+
   ### LUA MODULES
 
   lua4 = callPackage ../development/interpreters/lua-4 { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

