### PR TITLE
okteta: 17.12.3 -> 0.25.2

### DIFF
--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -4,16 +4,16 @@
 
 stdenv.mkDerivation rec {
   name = "okteta-${version}";
-  version = "17.12.3";
+  version = "0.25.2";
 
   src = fetchurl {
-    url = "mirror://kde/stable/applications/${version}/src/${name}.tar.xz";
-    sha256 = "03wsv83l1cay2dpcsksad124wzan7kh8zxdw1h0yicn398kdbck4";
+    url = "mirror://kde/stable/okteta/${version}/src/${name}.tar.xz";
+    sha256 = "00mw8gdqvn6vn6ir6kqnp7xi3lpn6iyp4f5aknxwq6mdcxgjmh1p";
   };
-  
+
   nativeBuildInputs = [ qtscript extra-cmake-modules kdoctools ];
   buildInputs = [ shared-mime-info ];
-  
+
   propagatedBuildInputs = [
     kconfig
     kinit
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     karchive
     kcrash
   ];
-  
+
   meta = with stdenv.lib; {
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg bkchr ];


### PR DESCRIPTION
###### Motivation for this change

Version scheme changed when okteta moved away from the kde applications release cycle.

Cc: @bkchr 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

