### PR TITLE
krb5: add linux keyring support

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, perl, yacc, bootstrap_cmds
-, openssl, openldap, libedit
+, openssl, openldap, libedit, keyutils
 
 # Extra Arguments
 , type ? ""
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     # Provides the mig command used by the build scripts
     ++ optional stdenv.isDarwin bootstrap_cmds;
   buildInputs = [ openssl ]
+    ++ optionals (stdenv.hostPlatform.isLinux) [ keyutils ]
     ++ optionals (!libOnly) [ openldap libedit ];
 
   preConfigure = "cd ./src";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13604,7 +13604,8 @@ with pkgs;
       '';
     };
 
-  keyutils = callPackage ../os-specific/linux/keyutils { };
+  # Using fetchurlBoot because this is used by kerberos (on Linux), which curl depends on
+  keyutils = callPackage ../os-specific/linux/keyutils { fetchurl = fetchurlBoot; };
 
   libselinux = callPackage ../os-specific/linux/libselinux { };
 


### PR DESCRIPTION
This requires some minor hoop-hopping because it's involved in the
Linux bootstrap, but it's nothing too complicated.

Fixes #43289

Backport of #45360
