### PR TITLE
[WIP] sage: Add darwin support

### DIFF
--- a/pkgs/applications/science/math/gap/default.nix
+++ b/pkgs/applications/science/math/gap/default.nix
@@ -5,6 +5,7 @@
 , makeWrapper
 , m4
 , gmp
+, libtool
 # one of
 # - "minimal" (~400M):
 #     Install the bare minimum of packages required by gap to start.
@@ -68,6 +69,8 @@ stdenv.mkDerivation rec {
     sha256 = "0cp6ddk0469zzv1m1vair6gm27ic6c5m77ri8rn0znq3gaps6x94";
   };
 
+  enableParallelBuilding = true;
+
   # remove all non-essential packages (which take up a lot of space)
   preConfigure = lib.optionalString (!keepAll) (removeNonWhitelistedPkgs packagesToKeep) + ''
     patchShebangs .
@@ -78,7 +81,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     m4
     gmp
-  ];
+  ] ++ lib.optional stdenv.isDarwin libtool;
 
   nativeBuildInputs = [
     makeWrapper
@@ -169,7 +172,6 @@ stdenv.mkDerivation rec {
       timokau
     ];
     platforms = platforms.all;
-    broken = stdenv.isDarwin;
     # keeping all packages increases the package size considerably, wchich
     # is why a local build is preferable in that situation. The timeframe
     # is reasonable and that way the binary cache doesn't get overloaded.

--- a/pkgs/applications/science/math/giac/default.nix
+++ b/pkgs/applications/science/math/giac/default.nix
@@ -104,9 +104,7 @@ stdenv.mkDerivation rec {
     description = "A free computer algebra system (CAS)";
     homepage = "https://www-fourier.ujf-grenoble.fr/~parisse/giac.html";
     license = licenses.gpl3Plus;
-    ## xcas is buildable on darwin but there are specific instructions I could
-    ## not test
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.symphorien ];
   };
 }

--- a/pkgs/applications/science/math/lrcalc/default.nix
+++ b/pkgs/applications/science/math/lrcalc/default.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation rec {
     homepage = http://math.rutgers.edu/~asbuch/lrcalc/;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = ''Programs for computing automorphism groups of graphs and digraphs'';
     license = licenses.asl20;
     maintainers = with maintainers; [ raskin timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     homepage = http://pallini.di.uniroma1.it/;
   };
 }

--- a/pkgs/applications/science/math/pynac/default.nix
+++ b/pkgs/applications/science/math/pynac/default.nix
@@ -43,6 +43,6 @@ stdenv.mkDerivation rec {
     homepage    = http://pynac.org;
     license = licenses.gpl3;
     maintainers = with maintainers; [ timokau ];
-    platforms   = platforms.linux;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation rec {
     description = "A CAS for polynomial computations";
     maintainers = with maintainers; [ raskin timokau ];
     # 32 bit x86 fails with some link error: `undefined reference to `__divmoddi4@GCC_7.0.0'`
-    platforms = subtractLists platforms.i686 platforms.linux;
+    platforms = subtractLists platforms.i686 platforms.unix;
     license = licenses.gpl3; # Or GPLv2 at your option - but not GPLv4
     homepage = http://www.singular.uni-kl.de;
     downloadPage = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/";

--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -78,6 +78,6 @@ stdenv.mkDerivation {
     description = "Lisp implementation aiming to be small, fast and easy to embed";
     license = stdenv.lib.licenses.mit ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/arb/default.nix
+++ b/pkgs/development/libraries/arb/default.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     description = ''A library for arbitrary-precision interval arithmetic'';
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = with maintainers; [ raskin timokau ];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/fplll/default.nix
+++ b/pkgs/development/libraries/fplll/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     description = ''Lattice algorithms using floating-point arithmetic'';
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/iml/default.nix
+++ b/pkgs/development/libraries/iml/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = ''Algorithms for computing exact solutions to dense systems of linear equations over the integers'';
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     homepage = https://cs.uwaterloo.ca/~astorjoh/iml.html;
     updateWalker = true;
   };

--- a/pkgs/development/libraries/libgap/default.nix
+++ b/pkgs/development/libraries/libgap/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = ''A library-packaged fork of the GAP kernel'';
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libgap/default.nix
+++ b/pkgs/development/libraries/libgap/default.nix
@@ -20,6 +20,6 @@ stdenv.mkDerivation rec {
     description = ''A library-packaged fork of the GAP kernel'';
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.unix;
+    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/mpfi/default.nix
+++ b/pkgs/development/libraries/mpfi/default.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation rec {
     homepage = https://gforge.inria.fr/projects/mpfi/;
     license = stdenv.lib.licenses.lgpl21Plus;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/brial/default.nix
+++ b/pkgs/development/libraries/science/math/brial/default.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "Legacy version of PolyBoRi maintained by sagemath developers";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/cliquer/default.nix
+++ b/pkgs/development/libraries/science/math/cliquer/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/m4ri/default.nix
+++ b/pkgs/development/libraries/science/math/m4ri/default.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     description = "Library to do fast arithmetic with dense matrices over F_2";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/m4rie/default.nix
+++ b/pkgs/development/libraries/science/math/m4rie/default.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/rankwidth/default.nix
+++ b/pkgs/development/libraries/science/math/rankwidth/default.nix
@@ -22,6 +22,6 @@ stdenv.mkDerivation rec {
     description = "Calculates rank-width and rank-decompositions";
     license = with licenses; [ gpl2Plus ];
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/rubiks/default.nix
+++ b/pkgs/development/libraries/science/math/rubiks/default.nix
@@ -76,6 +76,6 @@ stdenv.mkDerivation rec {
       mit # Dik T. Winter's software
     ];
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/sympow/default.nix
+++ b/pkgs/development/libraries/science/math/sympow/default.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation rec {
       free = true;
     };
     maintainers = with maintainers; [ timokau ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/cvxopt/default.nix
+++ b/pkgs/development/python-modules/cvxopt/default.nix
@@ -65,7 +65,6 @@ buildPythonPackage rec {
       programming language.
     '';
     maintainers = with maintainers; [ edwtjo ];
-    broken = stdenv.targetPlatform.isDarwin;
     license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I want `sage` to build on `darwin`. Lot's of packages just need their platforms updated.

Right now, I'm having trouble getting `sagelib` to build, failing with an error
```
clang++ -bundle -undefined dynamic_lookup build/temp.macosx-10.10-x86_64-2.7/build/cythonized/sage/libs/linbox/linbox.o -L/nix/store/5w9j23h0qsar813vdvsi1dyhg73iczlh-givaro-4.0.4/lib -L/nix/store/l3xnp9rniv92n69m2mls4ww0s14jqln0-linbox-1.5.2/lib -L/private/tmp/nix-build-python2.7-sagelib-8.3.drv-1/sage-src-8.3/lib -L/nix/store/xkksa1sdiddm4m7hd2mx87acvbs3rzjd-python-2.7.15/lib -llinbox -llinboxsage -lblas -lgivaro -lgmp -lgmpxx -lstdc++ -o build/lib.macosx-10.10-x86_64-2.7/sage/libs/linbox/linbox.so
ld: warning: directory not found for option '-L/private/tmp/nix-build-python2.7-sagelib-8.3.drv-1/sage-src-8.3/lib'
ld: library not found for -lblas
clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
```

I know it's `blas` related, but there's a lot of `blas` stuff going on in `pkgs/applications/science/math/sage/sagelib.nix`. @timokau any thoughts?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

