### PR TITLE
subberthehut: init at 20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1970,6 +1970,11 @@
     github = "jpotier";
     name = "Martin Potier";
   };
+  jqueiroz = {
+    email = "nixos@johnjq.com";
+    github = "jqueiroz";
+    name = "Jonathan Queiroz";
+  };
   jraygauthier = {
     email = "jraygauthier@gmail.com";
     github = "jraygauthier";

--- a/pkgs/tools/misc/subberthehut/default.nix
+++ b/pkgs/tools/misc/subberthehut/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, pkgconfig, xmlrpc_c, glib, zlib }:
+stdenv.mkDerivation rec {
+  name = "subberthehut-${version}";
+  version = "20";
+
+  src = fetchFromGitHub {
+    owner  = "mus65";
+    repo   = "subberthehut";
+    rev    = version;
+    sha256 = "19prdqbk19h0wak318g2jn1mnfm7l7f83a633bh0rhskysmqrsj1";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ xmlrpc_c glib zlib ];
+
+  installPhase = ''
+    install -Dm755 subberthehut $out/bin/subberthehut
+    install -Dm644 bash_completion $out/share/bash-completion/completions/subberthehut
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mus65/subberthehut;
+    description = "An OpenSubtitles.org downloader";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jqueiroz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5302,6 +5302,8 @@ with pkgs;
 
   su-exec = callPackage ../tools/security/su-exec {};
 
+  subberthehut = callPackage ../tools/misc/subberthehut { };
+
   subsurface = libsForQt5.callPackage ../applications/misc/subsurface { };
 
   sudo = callPackage ../tools/security/sudo { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

