### PR TITLE
openjdk: Fix a cross problem

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -110,8 +110,8 @@ let
     # The configure script was confused by our passing these with full paths,
     # so we explicitly override them to short variants.
     + ''
-      CC=cc
-      CXX=c++
+      CC=${stdenv.cc.targetPrefix}cc
+      CXX=${stdenv.cc.targetPrefix}c++
     '';
 
     configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

38eea804e6c02542085c9f232cdd699d96c95a23 dropped the C and C++ compiler prefixes. Probably more work is needed to make cross work, but this at least helps preserve/establish the pattern.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

