### PR TITLE
slurm: 17.11.7 -> 17.11.9-2

### DIFF
--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -8,16 +8,16 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "17.11.7";
+  version = "17.11.9-2";
 
   # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
   # because the latter does not keep older releases.
   src = fetchFromGitHub {
     owner = "SchedMD";
     repo = "slurm";
-    # The release tags use - instead of ., and have an extra -1 suffix.
-    rev = "${builtins.replaceStrings ["."] ["-"] name}-1";
-    sha256 = "00dgirjd75i1x6pj80avp18hx5gr3dsnh13vbkqbf0iwpd72qyhp";
+    # The release tags use - instead of .
+    rev = "${builtins.replaceStrings ["."] ["-"] name}";
+    sha256 = "1lq4ac6yjai6wh979dciw8v3d99zbd3w36rfh0vpncqm672fg1qy";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change
Version bump

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
`nixos/tests/slurm.nix` succeeds
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

