### PR TITLE
tilix: 1.8.1 -> 1.8.3

### DIFF
--- a/pkgs/applications/misc/tilix/default.nix
+++ b/pkgs/applications/misc/tilix/default.nix
@@ -1,23 +1,23 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, dmd, gnome3, dbus
-, gsettings-desktop-schemas, desktop-file-utils, gettext, gtkd
+, gsettings-desktop-schemas, desktop-file-utils, gettext, gtkd, libsecret
 , perlPackages, wrapGAppsHook, xdg_utils }:
 
 stdenv.mkDerivation rec {
   name = "tilix-${version}";
-  version = "1.8.1";
+  version = "1.8.3";
 
   src = fetchFromGitHub {
     owner = "gnunn1";
     repo = "tilix";
     rev = "${version}";
-    sha256 = "19dx3hlj40cqwph98pcifkm6axfszfr0v9k6sr3caw4ycml84ci1";
+    sha256 = "05x2nyyb5w3122j90g0f7lh9jl7xi1nk176sl01vl2ks7zar00dq";
   };
 
   nativeBuildInputs = [
     autoreconfHook dmd desktop-file-utils perlPackages.Po4a pkgconfig xdg_utils
     wrapGAppsHook
   ];
-  buildInputs = [ gnome3.dconf gettext gsettings-desktop-schemas gtkd dbus ];
+  buildInputs = [ gnome3.dconf gettext gsettings-desktop-schemas gtkd dbus libsecret ];
 
   preBuild = ''
     makeFlagsArray=(
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
 
   postInstall = with gnome3; ''
     ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
+
+    wrapProgram $out/bin/tilix \
+      --prefix LD_LIBRARY_PATH ":" "${libsecret}/lib"
   '';
 
 


### PR DESCRIPTION
###### Motivation for this change

Update to newest version of tilix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

