### PR TITLE
numix-icon-theme: 2017-12-25 -> 18.07.17

### DIFF
--- a/pkgs/data/icons/numix-icon-theme/default.nix
+++ b/pkgs/data/icons/numix-icon-theme/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "numix-icon-theme";
-  version = "17-12-25";
+  version = "18.07.17";
 
   src = fetchFromGitHub {
     owner = "numixproject";
     repo = pname;
     rev = version;
-    sha256 = "0q3hpq2jc9iwnzzqpb12g1qzjsw4ckhdqkfqf6nirl87r5drkv6j";
+    sha256 = "0clh55kmhc52d33dfm2c6h3lg6ddfh8a088ir9lv1camn9kj55bd";
   };
 
   nativeBuildInputs = [ gtk3 hicolor-icon-theme ];

--- a/pkgs/data/icons/numix-icon-theme/default.nix
+++ b/pkgs/data/icons/numix-icon-theme/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
     description = "Numix icon theme";
     homepage = https://numixproject.org;
     license = licenses.gpl3;
-    platforms = platforms.all;
+    # darwin cannot deal with file names differing only in case
+    platforms = platforms.linux;
     maintainers = with maintainers; [ romildo jgeerds ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version 18.07.17.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).