### PR TITLE
Add some substitutions for the ip calls in ManagedRoutes. Fixes #45022

### DIFF
--- a/pkgs/tools/networking/zerotierone/default.nix
+++ b/pkgs/tools/networking/zerotierone/default.nix
@@ -10,6 +10,12 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
+      substituteInPlace ./osdep/ManagedRoute.cpp \
+        --replace '/usr/sbin/ip' '${iproute}/bin/ip'
+
+      substituteInPlace ./osdep/ManagedRoute.cpp \
+        --replace '/sbin/ip' '${iproute}/bin/ip'
+
       substituteInPlace ./osdep/LinuxEthernetTap.cpp \
         --replace 'execlp("ip",' 'execlp("${iproute}/bin/ip",'
 


### PR DESCRIPTION
Fixes #45022 Superceeds #45383

###### Motivation for this change

Manged routes aren't being created

###### Things done

Pulled in and fixed a change from @zimbatm in #45383 and also caught another instance. I've tested this in a nixos module pointing at a zerotier network with a managed route that wasn't visible in the routing table before this change and now is.

 ---

