### PR TITLE
ocamlPackages.io-page: 1.6.1 -> 2.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/io-page/default.nix
+++ b/pkgs/development/ocaml-modules/io-page/default.nix
@@ -1,23 +1,24 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, cstruct }:
+{ stdenv, fetchzip, ocaml, findlib, jbuilder, configurator, cstruct }:
 
-let version = "1.6.1"; in
+let version = "2.0.1"; in
 
 stdenv.mkDerivation {
-  name = "ocaml-io-page-${version}";
+  name = "ocaml${ocaml.version}-io-page-${version}";
 
   src = fetchzip {
-    url = "https://github.com/mirage/io-page/archive/v${version}.tar.gz";
-    sha256 = "1djwks3ss12m55q6h4jsvfsy848cxfnpaxkilw10h26xj6jchflz";
+    url = "https://github.com/mirage/io-page/archive/${version}.tar.gz";
+    sha256 = "1rw04dwrlx5hah5dkjf7d63iff82j9cifr8ifjis5pdwhgwcff8i";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ ocaml findlib jbuilder configurator ];
   propagatedBuildInputs = [ cstruct ];
 
-  createFindlibDestdir = true;
+  inherit (jbuilder) installPhase;
 
   meta = {
     homepage = https://github.com/mirage/io-page;
-    platforms = ocaml.meta.platforms or [];
+    inherit (ocaml.meta) platforms;
+    license = stdenv.lib.licenses.isc;
     description = "IO memory page library for Mirage backends";
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
   };


### PR DESCRIPTION
###### Motivation for this change

Support for OCaml 4.07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

