### PR TITLE
lib: Use lib.fixed-points.extends to avoid repetition

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -195,9 +195,10 @@ rec {
     let self = f self // {
           newScope = scope: newScope (self // scope);
           callPackage = self.newScope {};
+          # TODO(@Ericson2314): Haromonize argument order of `g` with everything else
           overrideScope = g:
             makeScope newScope
-            (self_: let super = f self_; in super // g super self_);
+            (lib.fixedPoints.extends (lib.flip g) f);
           packages = f;
         };
     in self;


### PR DESCRIPTION
###### Motivation for this change

Another attempt after my sloppy https://github.com/NixOS/nixpkgs/commit/48ccdf322d9e7a68d0caf5833511ee3e53ec7d3a.

@Infinisil, thanks again, reverted in https://github.com/NixOS/nixpkgs/commit/4794aa5de233b5bf2d1c3245946379699d023467 and explained my mistakes in https://github.com/NixOS/nixpkgs/commit/48ccdf322d9e7a68d0caf5833511ee3e53ec7d3a#commitcomment-29678643. I start with their work and provide this proof of this commit's correctness:
```nix
(lib.fixedPoints.extends (lib.flip g) f) # now
((f: rattrs: self: let super = rattrs self; in super // f self super) (lib.flip g) f) # inline extends
(self: let super = f self; in super // (lib.flip g) self super) # beta reduce
(self: let super = f self; in super // g super self)  # beta reduce
(self_: let super = f self_; in super // g super self_)  # alpha rename
(self_: let super = f self_; in super // g super self_) # original, same
```

Eventually we might harmonize `overrideScope`'s `g` parameter with the general pattern, but I leave that breaking change as a separate step. Best not to refactor and break at once, and at least the abstractions make the oddity clearer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

