### PR TITLE
audit-tmpdir: fix processing of files with spaces, quote variables

### DIFF
--- a/pkgs/build-support/setup-hooks/audit-tmpdir.sh
+++ b/pkgs/build-support/setup-hooks/audit-tmpdir.sh
@@ -27,7 +27,7 @@ auditTmpdir() {
         fi
 
         if  isScript "$i"; then
-            if [ -e "$(dirname $i)/.$(basename $i)-wrapped" ]; then
+            if [ -e "$(dirname "$i")/.$(basename "$i")-wrapped" ]; then
                 if grep -q -F "$TMPDIR" "$i"; then
                     echo "wrapper script $i contains a forbidden reference to $TMPDIR"
                     exit 1


### PR DESCRIPTION
Noticed errors invoking "dirname" and "basename" in my build logs
while packaging and tracked the problem back to this location.

Quote variable when expanding like is done elsewhere in the script.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---