### PR TITLE
$toplevel/system: buildPlatform.system -> hostPlatform.system

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -74,7 +74,7 @@ let
       echo -n "$configurationName" > $out/configuration-name
       echo -n "systemd ${toString config.systemd.package.interfaceVersion}" > $out/init-interface-version
       echo -n "$nixosLabel" > $out/nixos-version
-      echo -n "$system" > $out/system
+      echo -n "${pkgs.stdenv.hostPlatform.system}" > $out/system
 
       mkdir $out/fine-tune
       childCount=0


### PR DESCRIPTION
###### Motivation for this change

```$toplevel/system``` file to contain the name of the system where the closure to be run instead of the platform where the closure have been built

So it might me used in
```
qemu-system-$(cat $toplevel/system | sed 's/-linux$//') \
  -kernel $toplevel/kernel \
  -initrd $toplevel/initrd \
  ...
```

Fixes https://github.com/NixOS/nixpkgs/issues/45386
