### PR TITLE
Add licenses

### DIFF
--- a/pkgs/applications/editors/geany/default.nix
+++ b/pkgs/applications/editors/geany/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       - Plugin interface
     '';
     homepage = https://www.geany.org/;
-    license = "GPL";
+    license = licenses.gpl2;
     maintainers = [];
     platforms = platforms.all;
   };

--- a/pkgs/applications/editors/geany/with-vte.nix
+++ b/pkgs/applications/editors/geany/with-vte.nix
@@ -1,7 +1,7 @@
 { runCommand, makeWrapper, geany, gnome2 }:
 let name = builtins.replaceStrings ["geany-"] ["geany-with-vte-"] geany.name;
 in
-runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; } "
+runCommand "${name}" { nativeBuildInputs = [ makeWrapper ]; inherit (geany.meta); } "
    mkdir -p $out
    ln -s ${geany}/share $out
    makeWrapper ${geany}/bin/geany $out/bin/geany --prefix LD_LIBRARY_PATH : ${gnome2.vte}/lib

--- a/pkgs/applications/science/math/ginac/default.nix
+++ b/pkgs/applications/science/math/ginac/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     description = "GiNaC is Not a CAS";
     homepage    = http://www.ginac.de/;
     maintainers = with maintainers; [ lovek323 ];
+    license = licenses.gpl2;
     platforms   = platforms.all;
   };
 }

--- a/pkgs/applications/science/math/glsurf/default.nix
+++ b/pkgs/applications/science/math/glsurf/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://www.lama.univ-savoie.fr/~raffalli/glsurf;
     description = "A program to draw implicit surfaces and curves";
+    license = stdenv.lib.licenses.lgpl21;
   };
 }

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -104,4 +104,10 @@ stdenv.mkDerivation rec {
     inherit rubyEnv;
     ruby = rubyEnv.wrappedRuby;
   };
+
+  meta = with stdenv.lib; {
+    description = "Web-based Git-repository manager";
+    homepage = https://gitlab.com;
+    license = licenses.mit;
+  };
 }

--- a/pkgs/development/libraries/gdata-sharp/default.nix
+++ b/pkgs/development/libraries/gdata-sharp/default.nix
@@ -34,6 +34,8 @@ in stdenv.mkDerivation rec {
       The Google Data APIs provide a simple protocol for reading and writing
       data on the web.
     '';
+
+    license = licenses.asl20;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/gdcm/default.nix
+++ b/pkgs/development/libraries/gdcm/default.nix
@@ -26,14 +26,15 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake vtk ];
   propagatedBuildInputs = [ ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "The grassroots cross-platform DICOM implementation";
     longDescription = ''
       Grassroots DICOM (GDCM) is an implementation of the DICOM standard designed to be open source so that researchers may access clinical data directly.
       GDCM includes a file format definition and a network communications protocol, both of which should be extended to provide a full set of tools for a researcher or small medical imaging vendor to interface with an existing medical database.
     '';
     homepage = http://gdcm.sourceforge.net/;
-    platforms = stdenv.lib.platforms.all;
+    license = with licenses; [ bsd3 asl20 ];
+    platforms = platforms.all;
   };
 }
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -116,6 +116,7 @@ stdenv.mkDerivation rec {
     description = "A library for image loading and manipulation";
     homepage = http://library.gnome.org/devel/gdk-pixbuf/;
     maintainers = [ maintainers.eelco ];
+    license = licenses.lgpl21;
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with lib; {
     description = "Well integrated set of translation tools and documentation";
 
     longDescription = ''
@@ -76,8 +76,9 @@ stdenv.mkDerivation rec {
 
     homepage = http://www.gnu.org/software/gettext/;
 
-    maintainers = with lib.maintainers; [ zimbatm vrthra ];
-    platforms = lib.platforms.all;
+    maintainers = with maintainers; [ zimbatm vrthra ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
   };
 }
 

--- a/pkgs/development/libraries/giflib/4.1.nix
+++ b/pkgs/development/libraries/giflib/4.1.nix
@@ -10,9 +10,11 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "format" ];
 
-  meta = {
+  meta = with stdenv.lib; {
+    description = "A library for reading and writing gif images";
     branch = "4.1";
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.mit;
+    platforms = platforms.unix;
   };
 }
 

--- a/pkgs/development/libraries/gio-sharp/default.nix
+++ b/pkgs/development/libraries/gio-sharp/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "GIO API bindings";
+    homepage = https://github.com/mono/gio-sharp;
+    license = licenses.mit;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/gnet/default.nix
+++ b/pkgs/development/libraries/gnet/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     description = "A network library, written in C, object-oriented, and built upon GLib";
     homepage = https://developer.gnome.org/gnet/;
+    license = licenses.lgpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];
   };

--- a/pkgs/development/libraries/pth/default.nix
+++ b/pkgs/development/libraries/pth/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "pth-2.0.7";
-  
+
   src = fetchurl {
     url = "mirror://gnu/pth/${name}.tar.gz";
     sha256 = "0ckjqw5kz5m30srqi87idj7xhpw6bpki43mj07bazjm2qmh3cdbj";
@@ -12,9 +12,10 @@ stdenv.mkDerivation rec {
     configureFlagsArray=("CFLAGS=-DJB_SP=8 -DJB_PC=9")
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "The GNU Portable Threads library";
     homepage = http://www.gnu.org/software/pth;
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.lgpl21Plus;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/glock/default.nix
+++ b/pkgs/development/tools/glock/default.nix
@@ -19,6 +19,7 @@ buildGoPackage rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/robfig/glock;
     description = "A command-line tool to lock Go dependencies to specific revisions";
+    license = licenses.mit;
     maintainers = [ maintainers.rushmorem ];
   };
 }

--- a/pkgs/games/gl-117/default.nix
+++ b/pkgs/games/gl-117/default.nix
@@ -13,12 +13,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libGLU_combined SDL freeglut SDL_mixer autoconf automake libtool ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "An air combat simulator";
-    maintainers = with stdenv.lib.maintainers;
-    [
-      raskin
-    ];
-    platforms = stdenv.lib.platforms.linux;
+    homepage = https://sourceforge.net/projects/gl-117;
+    maintainers = with maintainers; [ raskin ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/emulators/gens-gs/default.nix
+++ b/pkgs/misc/emulators/gens-gs/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, gtk2, SDL, nasm, zlib, libpng, libGLU_combined }:
 
-stdenv.mkDerivation { 
+stdenv.mkDerivation {
   name = "gens-gs-7";
 
   src = fetchurl {
@@ -15,10 +15,11 @@ stdenv.mkDerivation {
   # See http://ubuntuforums.org/showthread.php?p=10535837
   NIX_CFLAGS_COMPILE = "-UGTK_DISABLE_DEPRECATED -UGSEAL_ENABLE";
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://segaretro.org/Gens/GS;
     description = "A Genesis/Mega Drive emulator";
     platforms = [ "i686-linux" ];
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -181,13 +181,12 @@ rec {
     inherit (s) url sha256;
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     inherit (s) version;
     description = "Distributed storage system";
-    maintainers = [
-      stdenv.lib.maintainers.raskin
-    ];
-    platforms = with stdenv.lib.platforms;
-      linux ++ freebsd;
+    homepage = https://www.gluster.org;
+    license = licenses.lgpl3Plus; # dual licese: choice of lgpl3Plus or gpl2
+    maintainers = [ maintainers.raskin ];
+    platforms = with platforms; linux ++ freebsd;
   };
 }

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -61,6 +61,15 @@ stdenv.mkDerivation rec {
     homepage = http://www.gnuplot.info/;
     description = "A portable command-line driven graphing utility for many platforms";
     platforms = platforms.linux ++ platforms.darwin;
+    license = {
+      # Essentially a BSD license with one modifaction:
+      # Permission to modify the software is granted, but not the right to
+      # distribute the complete modified source code.  Modifications are to
+      # be distributed as patches to the released version.  Permission to
+      # distribute binaries produced by compiling modified sources is granted,
+      # provided you: ...
+      url = https://sourceforge.net/p/gnuplot/gnuplot-main/ci/master/tree/Copyright;
+    };
     maintainers = with maintainers; [ lovek323 ];
   };
 }

--- a/pkgs/tools/misc/gnuvd/default.nix
+++ b/pkgs/tools/misc/gnuvd/default.nix
@@ -8,9 +8,10 @@ stdenv.mkDerivation {
     sha256 = "0mpy76a0pxy62zjiihlzmvl4752hiwxhfs8rm1v5zgdr78acxyxz";
   };
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Command-line dutch dictionary application";
     homepage = http://www.djcbsoftware.nl/code/gnuvd/;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.gpl2;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Another round for https://github.com/NixOS/nixpkgs/issues/43716

###### Things done
Update/add licenses for:
- data-sharp
- gdcm
- gdk_pixbuf
- geany[-with-vte]
- gengs (dead lownload link, https://github.com/NixOS/nixpkgs/issues/45076)
- gettext
- giflib_4_1
- ginac
- gio-sharp
- gitlab
- gl117
- glock
- glsurf
- glusterfs
- gnet
- gnuplot
- gnupth
- gnuvd

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

