### PR TITLE
[WIP] buildRustPackage: optionally use vendor config from cargo-vendor

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -61,14 +61,20 @@ in stdenv.mkDerivation (args // {
     ${setupVendorDir}
 
     mkdir .cargo
-    cat >.cargo/config <<-EOF
-      [source.crates-io]
-      registry = 'https://github.com/rust-lang/crates.io-index'
-      replace-with = 'vendored-sources'
 
-      [source.vendored-sources]
-      directory = '$(pwd)/$cargoDepsCopy'
+    if [ -f "$(pwd)/$cargoDepsCopy/config" ]; then
+      sed "s|directory = \".*\"|directory = \"$(pwd)/$cargoDepsCopy\"|g" \
+        "$(pwd)/$cargoDepsCopy/config" > .cargo/config
+    else
+      cat >.cargo/config <<-EOF
+        [source.crates-io]
+        registry = 'https://github.com/rust-lang/crates.io-index'
+        replace-with = 'vendored-sources'
+
+        [source.vendored-sources]
+        directory = '$(pwd)/$cargoDepsCopy'
     EOF
+    fi
 
     unset cargoDepsCopy
 

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -23,9 +23,11 @@ stdenv.mkDerivation {
 
     ${cargoUpdateHook}
 
-    cargo vendor
+    mkdir $out
+    cargo vendor > $out/config
 
-    cp -ar vendor $out
+    cp -ar vendor/. $out/
+
   '';
 
   outputHashAlgo = "sha256";


### PR DESCRIPTION
This solves a problem, where the static vendor config in pkgs/build-support/rust/default.nix would not sufficiently replace all crates Cargo is looking for.

In the example of #44465, crates located at a git repo would be fetched by cargo-vendor, but not replaced in the Cargo config. Cargo then tried to access the network, resulting in build failure.

As this changes `fetchcargo`, this would cause all `cargoSha256` to break, so the solution might be more difficult than that. Just wanted to implement it once.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

