### PR TITLE
treewide: Purge `stdenv.platform` and top-level `platform`

### DIFF
--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -28,7 +28,7 @@ with lib;
       ++ (if pkgs.stdenv.system == "aarch64-linux"
           then []
           else [ pkgs.grub2 pkgs.syslinux ]);
-    system.boot.loader.kernelFile = pkgs.stdenv.platform.kernelTarget;
+    system.boot.loader.kernelFile = pkgs.stdenv.hostPlatform.platform.kernelTarget;
 
     fileSystems."/" =
       { fsType = "tmpfs";
@@ -86,7 +86,7 @@ with lib;
 
     system.build.netbootIpxeScript = pkgs.writeTextDir "netboot.ipxe" ''
       #!ipxe
-      kernel ${pkgs.stdenv.platform.kernelTarget} init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
+      kernel ${pkgs.stdenv.hostPlatform.platform.kernelTarget} init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}
       initrd initrd
       boot
     '';

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
@@ -13,7 +13,7 @@ let
   };
 
   # Temporary check, for nixos to cope both with nixpkgs stdenv-updates and trunk
-  platform = pkgs.stdenv.platform;
+  inherit (pkgs.stdenv.hostPlatform) platform;
 
 in
 

--- a/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
+++ b/nixos/modules/system/boot/loader/raspberrypi/raspberrypi.nix
@@ -15,7 +15,7 @@ let
     inherit configTxt;
   };
 
-  platform = pkgs.stdenv.platform;
+  inherit (pkgs.stdenv.hostPlatform) platform;
 
   builderUboot = import ./builder_uboot.nix { inherit config; inherit pkgs; inherit configTxt; };
 

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -83,7 +83,7 @@ let
     in
       tarball //
         { meta = {
-            description = "NixOS system tarball for ${system} - ${stdenv.platform.name}";
+            description = "NixOS system tarball for ${system} - ${stdenv.hostPlatform.platform.name}";
             maintainers = map (x: lib.maintainers.${x}) maintainers;
           };
           inherit config;
@@ -106,7 +106,7 @@ let
     let
       configEvaled = import lib/eval-config.nix config;
       build = configEvaled.config.system.build;
-      kernelTarget = configEvaled.pkgs.stdenv.platform.kernelTarget;
+      kernelTarget = configEvaled.pkgs.stdenv.hostPlatform.platform.kernelTarget;
     in
       pkgs.symlinkJoin {
         name = "netboot";

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -1,6 +1,6 @@
 { pkgs
 , kernel ? pkgs.linux
-, img ? pkgs.stdenv.platform.kernelTarget
+, img ? pkgs.stdenv.hostPlatform.platform.kernelTarget
 , storeDir ? builtins.storeDir
 , rootModules ?
     [ "virtio_pci" "virtio_mmio" "virtio_blk" "virtio_balloon" "virtio_rng" "ext4" "unix" "9p" "9pnet_virtio" "crc32c_generic" ]

--- a/pkgs/development/compilers/chez/default.nix
+++ b/pkgs/development/compilers/chez/default.nix
@@ -61,7 +61,8 @@ stdenv.mkDerivation rec {
   **
   ** Ideally in the future this would be less of a hack and could be
   ** done by Chez itself. Alternatively, there could just be a big
-  ** case statement matching to the different stdenv.platform values...
+  ** case statement matching to the different stdenv.hostPlatform.platform
+  ** values...
   */
   postInstall = ''
     m="$(ls ./work/boot)"

--- a/pkgs/development/libraries/v8/3.16.14.nix
+++ b/pkgs/development/libraries/v8/3.16.14.nix
@@ -6,7 +6,7 @@ let
   arch = if stdenv.isAarch32
     then (if stdenv.is64bit then "arm64" else "arm")
     else (if stdenv.is64bit then "x64" else "ia32");
-  armHardFloat = stdenv.isAarch32 && (stdenv.platform.gcc.float or null) == "hard";
+  armHardFloat = stdenv.isAarch32 && (stdenv.hostPlatform.platform.gcc.float or null) == "hard";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/os-specific/gnu/default.nix
+++ b/pkgs/os-specific/gnu/default.nix
@@ -3,7 +3,7 @@
 args@{ fetchgit, stdenv, autoconf, automake, automake111x, libtool
 , texinfo, glibcCross, hurdPartedCross, libuuid, samba
 , gccCrossStageStatic, gcc
-, pkgsi686Linux, newScope, platform, config
+, pkgsi686Linux, newScope, config
 , targetPlatform, buildPlatform
 , overrides ? {}
 , buildPackages, pkgs

--- a/pkgs/os-specific/linux/kernel/hardened-config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened-config.nix
@@ -22,7 +22,7 @@ ${optionalString (versionAtLeast version "4.10") ''
   BUG_ON_DATA_CORRUPTION y
 ''}
 
-${optionalString (stdenv.platform.kernelArch == "x86_64") ''
+${optionalString (stdenv.hostPlatform.platform.kernelArch == "x86_64") ''
   DEFAULT_MMAP_MIN_ADDR 65536 # Prevent allocation of first 64K of memory
 
   # Reduce attack surface by disabling various emulations

--- a/pkgs/os-specific/linux/rtl8723bs/default.nix
+++ b/pkgs/os-specific/linux/rtl8723bs/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ nukeReferences ];
 
   makeFlags = concatStringsSep " " [
-    "ARCH=${stdenv.platform.kernelArch}" # Normally not needed, but the Makefile sets ARCH in a broken way.
+    "ARCH=${stdenv.hostPlatform.platform.kernelArch}" # Normally not needed, but the Makefile sets ARCH in a broken way.
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" # Makefile uses $(uname -r); breaks us.
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13742,9 +13742,7 @@ with pkgs;
   nmon = callPackage ../os-specific/linux/nmon { };
 
   # GNU/Hurd core packages.
-  gnu = recurseIntoAttrs (callPackage ../os-specific/gnu {
-    inherit platform;
-  });
+  gnu = recurseIntoAttrs (callPackage ../os-specific/gnu { });
 
   hwdata = callPackage ../os-specific/linux/hwdata { };
 
@@ -13865,7 +13863,7 @@ with pkgs;
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
       ]
-      ++ lib.optionals ((platform.kernelArch or null) == "mips")
+      ++ lib.optionals ((stdenv.hostPlatform.platform.kernelArch or null) == "mips")
       [ kernelPatches.mips_fpureg_emu
         kernelPatches.mips_fpu_sigill
         kernelPatches.mips_ext3_n32

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -82,11 +82,8 @@ let
   platformCompat = self: super: let
     inherit (super.stdenv) buildPlatform hostPlatform targetPlatform;
   in {
-    stdenv = super.stdenv // {
-      inherit (super.stdenv.buildPlatform) platform;
-    };
     inherit buildPlatform hostPlatform targetPlatform;
-    inherit (buildPlatform) system platform;
+    inherit (buildPlatform) system;
   };
 
   splice = self: super: import ./splice.nix lib self (buildPackages != null);


### PR DESCRIPTION
###### Motivation for this change

Progress towards #27069

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @volth 