### PR TITLE
iosevka-bin: 1.14.3 -> 2.0.0

### DIFF
--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchzip }:
 
 let
-  version = "1.14.3";
+  version = "2.0.0";
 in fetchzip rec {
   name = "iosevka-bin-${version}";
 
-  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/iosevka-pack-${version}.zip";
+  url = "https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
     unzip -j $downloadedFile \*.ttc -d $out/share/fonts/iosevka
   '';
 
-  sha256 = "0qc5i6ijr25d2jwi5r4bcvbaw74y1p05a5fvlwss3l9rhmmxsfpl";
+  sha256 = "17ldxs8rn4y5mzpc6h5rms4khk9fp4d1ixz5bh0pglh1kdansz45";
 
   meta = with stdenv.lib; {
     homepage = https://be5invis.github.io/Iosevka/;


### PR DESCRIPTION
"iosevka" needs some work to update to 2.0.0
(config file must be used instead of arguments to make)
but don't know that the two necessarily need to be at the same version.

Also I "think" that using the 'ttc' zip is the equivalent of what
was previously the "pack" but noting this here since haven't found
this documented elsewhere and am not entirely sure.



Major update, adds extra new weights (extrabold, semibold) and adjusts existing 'bold'.

Other changes I'm not sure I follow O:).

Release notes: https://github.com/be5invis/Iosevka/releases/tag/v2.0.0


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---