### PR TITLE
Mark broken kernel modules on Linux 4.18

### DIFF
--- a/pkgs/os-specific/linux/beegfs/kernel-module.nix
+++ b/pkgs/os-specific/linux/beegfs/kernel-module.nix
@@ -41,5 +41,6 @@ in stdenv.mkDerivation {
     platforms = [ "i686-linux" "x86_64-linux" ];
     license = licenses.gpl2;
     maintainers = with maintainers; [ markuskowa ];
+    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ makefu ];
     platforms = lib.platforms.linux;
+    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/os-specific/linux/phc-intel/default.nix
+++ b/pkgs/os-specific/linux/phc-intel/default.nix
@@ -48,5 +48,6 @@ in stdenv.mkDerivation rec {
     downloadPage = "http://www.linux-phc.org/forum/viewtopic.php?f=7&t=267";
     license = licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
+    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jcumming wizeman wkennington fpletz globin ];
+    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/os-specific/linux/tbs/default.nix
+++ b/pkgs/os-specific/linux/tbs/default.nix
@@ -59,5 +59,6 @@ in stdenv.mkDerivation {
     license = licenses.gpl2;
     maintainers = with maintainers; [ ck3d ];
     priority = -1;
+    broken = stdenv.lib.versionAtLeast kernel.version "4.18";
   };
 }

--- a/pkgs/servers/openafs/1.6/module.nix
+++ b/pkgs/servers/openafs/1.6/module.nix
@@ -51,7 +51,8 @@ in stdenv.mkDerivation rec {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = [ maintainers.z77z maintainers.spacefrogg ];
-    broken = versionOlder kernel.version "3.18";
+    broken = versionOlder kernel.version "3.18" ||
+             versionAtLeast kernel.version "4.18";
   };
 
 }

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -54,7 +54,9 @@ in stdenv.mkDerivation rec {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = [ maintainers.z77z maintainers.spacefrogg ];
-    broken = (versionOlder kernel.version "3.18") || stdenv.targetPlatform.isAarch64;
+    broken = (versionOlder kernel.version "3.18") ||
+             (versionAtLeast kernel.version "4.18") ||
+             stdenv.targetPlatform.isAarch64;
   };
 
 }


### PR DESCRIPTION
##### Motivation

Not having these marked as broken makes it difficult to `nox-review` kernel changes, since it's not clear whether modules have been broken by the change or were always broken.

##### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---