### PR TITLE
linux-libre: init

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -4,6 +4,7 @@
     rev = "r15295";
     sha256 = "03kqbjy7w9zg6ry86h9sxa33z0rblznhba109lwmjwy0wx7yk1cs";
   }
+, ...
 }:
 
 let

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchsvn, linux
+, scripts ? fetchsvn {
+    url = "https://www.fsfla.org/svn/fsfla/software/linux-libre/releases/tags/";
+    rev = "r15295";
+    sha256 = "03kqbjy7w9zg6ry86h9sxa33z0rblznhba109lwmjwy0wx7yk1cs";
+  }
+}:
+
+let
+  majorMinor = lib.versions.majorMinor linux.modDirVersion;
+
+  major = lib.versions.major linux.modDirVersion;
+  minor = lib.versions.minor linux.modDirVersion;
+  patch = lib.versions.patch linux.modDirVersion;
+
+in linux.override {
+  argsOverride = {
+    modDirVersion = "${linux.modDirVersion}-gnu";
+    src = stdenv.mkDerivation {
+      name = "${linux.name}-libre-src";
+      src = linux.src;
+      buildPhase = ''
+        ${scripts}/${majorMinor}-gnu/deblob-${majorMinor} \
+            ${major} ${minor} ${patch}
+      '';
+      checkPhase = ''
+        ${scripts}/deblob-check
+      '';
+      installPhase = ''
+        cp -r . "$out"
+      '';
+    };
+  };
+}

--- a/pkgs/os-specific/linux/kernel/linux-libre.nix
+++ b/pkgs/os-specific/linux/kernel/linux-libre.nix
@@ -16,6 +16,7 @@ let
 in linux.override {
   argsOverride = {
     modDirVersion = "${linux.modDirVersion}-gnu";
+
     src = stdenv.mkDerivation {
       name = "${linux.name}-libre-src";
       src = linux.src;
@@ -30,5 +31,7 @@ in linux.override {
         cp -r . "$out"
       '';
     };
+
+    maintainers = [ lib.maintainers.qyliss ];
   };
 }

--- a/pkgs/servers/openafs/1.6/module.nix
+++ b/pkgs/servers/openafs/1.6/module.nix
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p ${modDestDir}
-    cp src/libafs/MODLOAD-*/libafs-${kernel.version}.* ${modDestDir}/libafs.ko
+    cp src/libafs/MODLOAD-*/libafs-${kernel.modDirVersion}.* ${modDestDir}/libafs.ko
     xz -f ${modDestDir}/libafs.ko
   '';
 

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p ${modDestDir}
-    cp src/libafs/MODLOAD-*/libafs-${kernel.version}.* ${modDestDir}/libafs.ko
+    cp src/libafs/MODLOAD-*/libafs-${kernel.modDirVersion}.* ${modDestDir}/libafs.ko
     xz -f ${modDestDir}/libafs.ko
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14210,6 +14210,12 @@ with pkgs;
   linuxPackages_hardkernel_latest = linuxPackages_hardkernel_4_14;
   linux_hardkernel_latest = linuxPackages_hardkernel_latest.kernel;
 
+  # GNU Linux-libre kernels
+  linuxPackages-libre = recurseIntoAttrs (linuxPackagesFor linux-libre);
+  linux-libre = callPackage ../os-specific/linux/kernel/linux-libre.nix {};
+  linuxPackages_latest-libre = recurseIntoAttrs (linuxPackagesFor linux_latest-libre);
+  linux_latest-libre = linux-libre.override { linux = linux_latest; };
+
   # A function to build a manually-configured kernel
   linuxManualConfig = makeOverridable (callPackage ../os-specific/linux/kernel/manual-config.nix {});
 


### PR DESCRIPTION
###### Motivation for this change

GNU Linux-libre is a linux kernel distribution that has all non-free binary blobs stripped. The project distributes both deblobbed kernel sources, and scripts for each kernel version that perform the deblobbing. Here, I have used the scripts rather than the pre-deblobbed sources, because this allows an arbitrary kernel to be passed in and deblobbed with no extra effort, which seems more in the spirit of Nix and allows deblobbing to be composed with other kernel customisations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

With the small fix to openafs included in this PR, `linuxPackages-libre` and `linuxPackages_latest-libre` can build all kernel modules that the corresponding non-deblobbed kernels can build. (This does not mean that `nox-review` will pass, because some kernel modules are currently broken on non-deblobbed Linux 4.18 anyway. See #45410.) The fix to openafs does not break any existing kernels where it was previously able to build. I have booted and used a deblobbed kernel successfully, with the exception of some of my laptop's hardware not working, which is to be expected with a deblobbed kernel.