### PR TITLE
 home-assistant: 0.75.2 -> 0.76.1

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -2,7 +2,8 @@ import ./make-test.nix ({ pkgs, ... }:
 
 let
   configDir = "/var/lib/foobar";
-  apiPassword = "secret";
+  apiPassword = "some_secret";
+  mqttPassword = "another_secret";
 
 in {
   name = "home-assistant";
@@ -33,7 +34,9 @@ in {
             };
             frontend = { };
             http.api_password = apiPassword;
-            mqtt = { }; # Use hbmqtt as broker
+            mqtt = { # Use hbmqtt as broker
+              password = mqttPassword;
+            };
             binary_sensor = [
               {
                 platform = "mqtt";
@@ -62,7 +65,7 @@ in {
 
     # Toggle a binary sensor using MQTT
     $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"off\"'");
-    $hass->waitUntilSucceeds("mosquitto_pub -V mqttv311 -t home-assistant/test -u homeassistant -P '${apiPassword}' -m let_there_be_light");
+    $hass->waitUntilSucceeds("mosquitto_pub -V mqttv311 -t home-assistant/test -u homeassistant -P '${mqttPassword}' -m let_there_be_light");
     $hass->succeed("curl http://localhost:8123/api/states/binary_sensor.mqtt_binary_sensor -H 'x-ha-access: ${apiPassword}' | grep -qF '\"state\": \"on\"'");
 
     # Print log to ease debugging

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -20,12 +20,10 @@
 , hypothesis
 }:
 
-let
-  version = "2.3";
-in assert version == cryptography_vectors.version; buildPythonPackage rec {
+buildPythonPackage rec {
   # also bump cryptography_vectors
   pname = "cryptography";
-  inherit version;
+  version = "2.3";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/netdisco/default.nix
+++ b/pkgs/development/python-modules/netdisco/default.nix
@@ -2,7 +2,7 @@
 
 buildPythonPackage rec {
   pname = "netdisco";
-  version = "1.5.0";
+  version = "2.0.0";
 
   disabled = !isPy3k;
 
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     owner = "home-assistant";
     repo = pname;
     rev = version;
-    sha256 = "1lr0zpzdjkhcaihyxq8wv7c1wjm7xgx2sl8xmwp1kyivkgybk6n9";
+    sha256 = "08x5ab7v6a20753y9br7pvfm6a054ywn7y7gh6fydqski0gad6l7";
   };
 
   propagatedBuildInputs = [ requests zeroconf netifaces ];

--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi
+, cryptography, ecdsa
+, pytestrunner, pytestcov, pytest }:
+
+buildPythonPackage rec {
+  pname = "PyJWT";
+  version = "1.6.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176";
+  };
+
+  propagatedBuildInputs = [ cryptography ecdsa ];
+
+  checkInputs = [ pytestrunner pytestcov pytest ];
+
+  meta = with lib; {
+    description = "JSON Web Token implementation in Python";
+    homepage = https://github.com/jpadilla/pyjwt;
+    license = licenses.mit;
+    maintainers = with maintainers; [ prikhi ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.75.2";
+  version = "0.76.1";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -112,6 +112,7 @@
     "binary_sensor.netatmo" = ps: with ps; [  ];
     "binary_sensor.nx584" = ps: with ps; [  ];
     "binary_sensor.octoprint" = ps: with ps; [  ];
+    "binary_sensor.openuv" = ps: with ps; [  ];
     "binary_sensor.pilight" = ps: with ps; [  ];
     "binary_sensor.ping" = ps: with ps; [  ];
     "binary_sensor.qwikswitch" = ps: with ps; [  ];
@@ -337,6 +338,7 @@
     "device_tracker.owntracks" = ps: with ps; [ libnacl paho-mqtt ];
     "device_tracker.owntracks_http" = ps: with ps; [ aiohttp-cors libnacl ];
     "device_tracker.ping" = ps: with ps; [  ];
+    "device_tracker.ritassist" = ps: with ps; [  ];
     "device_tracker.sky_hub" = ps: with ps; [  ];
     "device_tracker.snmp" = ps: with ps; [ pysnmp ];
     "device_tracker.swisscom" = ps: with ps; [  ];
@@ -383,7 +385,6 @@
     "fan.mqtt" = ps: with ps; [ paho-mqtt ];
     "fan.template" = ps: with ps; [  ];
     "fan.tuya" = ps: with ps; [  ];
-    "fan.velbus" = ps: with ps; [  ];
     "fan.wink" = ps: with ps; [  ];
     "fan.xiaomi_miio" = ps: with ps; [ construct ];
     "fan.zha" = ps: with ps; [  ];
@@ -536,7 +537,6 @@
     "light.tplink" = ps: with ps; [  ];
     "light.tradfri" = ps: with ps; [  ];
     "light.tuya" = ps: with ps; [  ];
-    "light.velbus" = ps: with ps; [  ];
     "light.vera" = ps: with ps; [  ];
     "light.wemo" = ps: with ps; [  ];
     "light.wink" = ps: with ps; [  ];
@@ -600,6 +600,7 @@
     "media_player.denon" = ps: with ps; [  ];
     "media_player.denonavr" = ps: with ps; [  ];
     "media_player.directv" = ps: with ps; [  ];
+    "media_player.dlna_dmr" = ps: with ps; [  ];
     "media_player.dunehd" = ps: with ps; [  ];
     "media_player.emby" = ps: with ps; [  ];
     "media_player.epson" = ps: with ps; [  ];
@@ -625,6 +626,7 @@
     "media_player.pandora" = ps: with ps; [ pexpect ];
     "media_player.philips_js" = ps: with ps; [  ];
     "media_player.pioneer" = ps: with ps; [  ];
+    "media_player.pjlink" = ps: with ps; [  ];
     "media_player.plex" = ps: with ps; [  ];
     "media_player.roku" = ps: with ps; [  ];
     "media_player.russound_rio" = ps: with ps; [  ];
@@ -691,7 +693,7 @@
     "notify.gntp" = ps: with ps; [  ];
     "notify.group" = ps: with ps; [  ];
     "notify.hipchat" = ps: with ps; [  ];
-    "notify.html5" = ps: with ps; [ pyjwt aiohttp-cors ];
+    "notify.html5" = ps: with ps; [ aiohttp-cors ];
     "notify.instapush" = ps: with ps; [  ];
     "notify.ios" = ps: with ps; [ aiohttp-cors zeroconf ];
     "notify.joaoapps_join" = ps: with ps; [  ];
@@ -723,7 +725,6 @@
     "notify.synology_chat" = ps: with ps; [  ];
     "notify.syslog" = ps: with ps; [  ];
     "notify.telegram" = ps: with ps; [ python-telegram-bot ];
-    "notify.telstra" = ps: with ps; [  ];
     "notify.twilio_call" = ps: with ps; [ aiohttp-cors twilio ];
     "notify.twilio_sms" = ps: with ps; [ aiohttp-cors twilio ];
     "notify.twitter" = ps: with ps; [  ];
@@ -736,6 +737,7 @@
     "onboarding" = ps: with ps; [ aiohttp-cors ];
     "onboarding.const" = ps: with ps; [  ];
     "onboarding.views" = ps: with ps; [  ];
+    "openuv" = ps: with ps; [  ];
     "panel_custom" = ps: with ps; [ aiohttp-cors ];
     "panel_iframe" = ps: with ps; [ aiohttp-cors ];
     "persistent_notification" = ps: with ps; [  ];
@@ -850,6 +852,7 @@
     "sensor.eliqonline" = ps: with ps; [  ];
     "sensor.emoncms" = ps: with ps; [  ];
     "sensor.enocean" = ps: with ps; [  ];
+    "sensor.enphase_envoy" = ps: with ps; [  ];
     "sensor.envirophat" = ps: with ps; [  ];
     "sensor.envisalink" = ps: with ps; [  ];
     "sensor.etherscan" = ps: with ps; [  ];
@@ -942,6 +945,7 @@
     "sensor.openexchangerates" = ps: with ps; [  ];
     "sensor.openhardwaremonitor" = ps: with ps; [  ];
     "sensor.opensky" = ps: with ps; [  ];
+    "sensor.openuv" = ps: with ps; [  ];
     "sensor.openweathermap" = ps: with ps; [ pyowm ];
     "sensor.otp" = ps: with ps; [  ];
     "sensor.pi_hole" = ps: with ps; [  ];
@@ -965,6 +969,7 @@
     "sensor.rfxtrx" = ps: with ps; [  ];
     "sensor.ring" = ps: with ps; [  ];
     "sensor.ripple" = ps: with ps; [  ];
+    "sensor.rmvtransport" = ps: with ps; [  ];
     "sensor.sabnzbd" = ps: with ps; [  ];
     "sensor.scrape" = ps: with ps; [ beautifulsoup4 ];
     "sensor.season" = ps: with ps; [ ephem ];
@@ -1085,6 +1090,7 @@
     "switch.bbb_gpio" = ps: with ps; [  ];
     "switch.broadlink" = ps: with ps; [  ];
     "switch.command_line" = ps: with ps; [  ];
+    "switch.deconz" = ps: with ps; [  ];
     "switch.deluge" = ps: with ps; [ deluge-client ];
     "switch.demo" = ps: with ps; [  ];
     "switch.digital_ocean" = ps: with ps; [ digital-ocean ];

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180804.0";
+  version = "20180818.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "50a9e74efe2b56fbc34fba07205829e0ea77315183e85c235d177cabff3b62ee";
+    sha256 = "b6101c342e49c943c59e3525d6741cd3a23af94b65549d59bdeee8cf3f07b294";
   };
 
   propagatedBuildInputs = [ user-agents ];

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ requests pyyaml pytz pip jinja2 voluptuous typing aiohttp async-timeout astral certifi attrs ])"
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ aiohttp astral async-timeout attrs certifi jinja2 pyjwt cryptography pip pytz pyyaml requests voluptuous ])"
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each component has an associated .py file,

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10684,35 +10684,7 @@ in {
     };
   };
 
-  pyjwt = buildPythonPackage rec {
-    version = "1.5.3";
-    name = "pyjwt-${version}";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "progrium";
-      repo = "pyjwt";
-      rev = version;
-      sha256 = "109zb3ka2lvp00r9nawa0lmljfikvhcj5yny19kcipz8mqia1gs8";
-    };
-
-    buildInputs = with self; [ pytestrunner pytestcov pytest coverage ];
-    propagatedBuildInputs = with self; [ cryptography ecdsa ];
-
-    # We don't need this specific version
-    postPatch = ''
-      substituteInPlace setup.py --replace "pytest==2.7.3" "pytest"
-    '';
-
-    meta = {
-      description = "JSON Web Token implementation in Python";
-      longDescription = "A Python implementation of JSON Web Token draft 01";
-      homepage = https://github.com/progrium/pyjwt;
-      downloadPage = https://github.com/progrium/pyjwt/releases;
-      license = licenses.mit;
-      maintainers = with maintainers; [ prikhi ];
-      platforms = platforms.unix;
-    };
-  };
+  pyjwt = callPackage ../development/python-modules/pyjwt { };
 
   pykickstart = buildPythonPackage rec {
     name = "pykickstart-${version}";


### PR DESCRIPTION
###### Motivation for this change
I also revamped the way vesions are pinned using `lib.composeExtensions`. Cf. #44426.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

