### PR TITLE
virtualbox: Change the virtualbox tests to not build the unfree tests by default

### DIFF
--- a/nixos/tests/virtualbox.nix
+++ b/nixos/tests/virtualbox.nix
@@ -1,4 +1,4 @@
-{ system ? builtins.currentSystem, debug ? false }:
+{ system ? builtins.currentSystem, debug ? false, enableUnfree ? false }:
 
 with import ../lib/testing.nix { inherit system; };
 with pkgs.lib;
@@ -378,6 +378,26 @@ let
     };
   };
 
+  unfreeTests = mapAttrs (mkVBoxTest true vboxVMsWithExtpack) {
+    enable-extension-pack = ''
+      createVM_testExtensionPack;
+      vbm("startvm testExtensionPack");
+      waitForStartup_testExtensionPack;
+      $machine->screenshot("cli_started");
+      waitForVMBoot_testExtensionPack;
+      $machine->screenshot("cli_booted");
+
+      $machine->nest("Checking for privilege escalation", sub {
+        $machine->fail("test -e '/root/VirtualBox VMs'");
+        $machine->fail("test -e '/root/.config/VirtualBox'");
+        $machine->succeed("test -e '/home/alice/VirtualBox VMs'");
+      });
+
+      shutdownVM_testExtensionPack;
+      destroyVM_testExtensionPack;
+    '';
+  };
+
 in mapAttrs (mkVBoxTest false vboxVMs) {
   simple-gui = ''
     createVM_simple;
@@ -484,22 +504,4 @@ in mapAttrs (mkVBoxTest false vboxVMs) {
     destroyVM_test1;
     destroyVM_test2;
   '';
-} // mapAttrs (mkVBoxTest true vboxVMsWithExtpack) {
-  enable-extension-pack = ''
-    createVM_testExtensionPack;
-    vbm("startvm testExtensionPack");
-    waitForStartup_testExtensionPack;
-    $machine->screenshot("cli_started");
-    waitForVMBoot_testExtensionPack;
-    $machine->screenshot("cli_booted");
-
-    $machine->nest("Checking for privilege escalation", sub {
-      $machine->fail("test -e '/root/VirtualBox VMs'");
-      $machine->fail("test -e '/root/.config/VirtualBox'");
-      $machine->succeed("test -e '/home/alice/VirtualBox VMs'");
-    });
-
-    shutdownVM_testExtensionPack;
-    destroyVM_testExtensionPack;
-  '';
-}
+} // (if enableUnfree then unfreeTests else {})


### PR DESCRIPTION
###### Motivation for this change

This PR changes the VirtualBox tests not to build the unfree tests by default.

The problem was that cache.nixos.org was running the tests, which caused the VirtualBox Oracle Extension Pack to be downloaded and cached.  cache.nixos.org was then serving the Extension Pack to people when they tried to download it.

However, the license for the Extension Pack explicitly states that it cannot be served by third parties.

This PR changes the code for the VirtualBox test to not build and run the unfree tests by default.  This causes cache.nixos.org to not build and cache the Extension Pack.

The VirtualBox tests can be run like the following:

```sh
$ cd nixos/tests
$ nix-build virtualbox.nix
```

This will only build and run the normal tests.

In order to build and run the unfree test, you must use the following command:

```sh
$ nix-build virtualbox.nix -A enable-extension-pack --arg enableUnfree true
```

If you try to run the `enable-extension-pack` test without setting the `enableUnfree` argument to `true`, you will get the following error:

```sh
$ nix-build virtualbox.nix -A enable-extension-pack
error: attribute 'enable-extension-pack' in selection path 'enable-extension-pack' not found
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

