### PR TITLE
javacard-devkit: allow overriding the java binary

### DIFF
--- a/pkgs/development/compilers/javacard-devkit/default.nix
+++ b/pkgs/development/compilers/javacard-devkit/default.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
         *.so) install -vD "$i" "$out/libexec/$pname/$(basename "$i")";;
         *) target="$out/bin/$(basename "$i")"
            install -vD "$i" "$target"
+           sed -i -e 's|^$JAVA_HOME/bin/java|''${JAVA:-$JAVA_HOME/bin/java}|' "$target"
            wrapProgram "$target" \
              --set JAVA_HOME "$JAVA_HOME" \
              --prefix CLASSPATH : "$out/share/$pname/api_export_files"
@@ -55,7 +56,9 @@ stdenv.mkDerivation rec {
 
       First, compile your '.java' (NixOS-specific: you should not need to set the class path -- if you need, it's a bug):
           javacardc -source 1.5 -target 1.5 [MyJavaFile].java
-      Then, convert the '.class' file into a '.cap':
+      Then, test with 'jcwde' (NixOS-specific: you can change the java version used to run jcwde with eg. JAVA=jdb):
+          CLASSPATH=. jcwde [MyJcwdeConfig].app & sleep 1 && apdutool [MyApdus].apdu
+      Finally, convert the '.class' file into a '.cap':
           converter -applet [AppletAID] [MyApplet] [myPackage] [PackageAID] [Version]
       For more details, please refer to the documentation by Oracle
     '';


### PR DESCRIPTION
###### Motivation for this change

This is required for debugging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

