### PR TITLE
docker-credential-gcr: remove platforms

### DIFF
--- a/pkgs/tools/admin/docker-credential-gcr/default.nix
+++ b/pkgs/tools/admin/docker-credential-gcr/default.nix
@@ -23,6 +23,5 @@ buildGoPackage rec {
     homepage = https://github.com/GoogleCloudPlatform/docker-credential-gcr;
     license = licenses.asl20;
     maintainers = with maintainers; [ suvash ];
-    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

It works fine in OSX, so let's just inherit go's supported platforms. /cc @suvash 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

