### PR TITLE
dotty: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/development/compilers/scala/dotty-bare.nix
+++ b/pkgs/development/compilers/scala/dotty-bare.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre }:
 
 stdenv.mkDerivation rec {
-  version = "0.8.0-RC1";
+  version = "0.9.0-RC1";
   name = "dotty-bare-${version}";
 
   src = fetchurl {
     url = "https://github.com/lampepfl/dotty/releases/download/${version}/dotty-${version}.tar.gz";
-    sha256 = "e5b7a9bb6f1007146a440ddfff871cc312075e5d69b9ab7e279ad7c3514f7065";
+    sha256 = "1c24692081231415cb560ff1288ede3f0d28c8b994ce8ca7c7b06edf7978bfb8";
   };
 
   propagatedBuildInputs = [ jre ] ;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/lampepfl/dotty/releases/tag/0.9.0-RC1

Notable Changes
- Support for implicit conversions on singleton types 
- The REPL now uses JLine3 under the hood which means support for Windows, better completions and multi-line editing
- Documentation support in the IDE
- Drop requirement that implicit functions must be non-empty
- Improved auto-completion in the REPL
- An experimental stream library built using quotes and splices
- A step toward tree inspection in macros
- Optimise applyOrElse for partial function literals
- Emit feature warnings for implicit conversions
- Optimise s and raw interpolators
- Support for compiler plugins

As well as many bug fixes and stability work

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

