### PR TITLE
xapian_1_2_22: fix build

### DIFF
--- a/pkgs/development/libraries/xapian/default.nix
+++ b/pkgs/development/libraries/xapian/default.nix
@@ -11,7 +11,7 @@ let
       inherit sha256;
     };
 
-    patches = [
+    patches = stdenv.lib.optional (version == "1.4.7") [
       # fix notmuch build, see https://notmuchmail.org/faq/#index12h2
       # cannot fetchpatch this because base directory differs
       # TODO: remove on next xapian update


### PR DESCRIPTION
In 6ea7b48c2b20ab88334cea9b368fe0d0354b4926 a `notmuch`-related patch written for `xapian` 1.4.7 was applied unconditionally, breaking the build of xapian 1.2.22. Thanks @matthewbauer for pointing this out.

---
