### PR TITLE
Bazel patch perl

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, runCommand, makeWrapper
 , jdk, zip, unzip, bash, writeCBin, coreutils
-, which, python, gnused, gnugrep, findutils
+, which, python, perl, gnused, gnugrep, findutils
 # Always assume all markers valid (don't redownload dependencies).
 # Also, don't clean up environment variables.
 , enableNixHacks ? false
@@ -138,6 +138,11 @@ stdenv.mkDerivation rec {
       echo "PATH=$PATH:${defaultShellPath}" >> runfiles.bash.tmp
       cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
       mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
+
+      # the bash completion requires perl
+      # https://github.com/bazelbuild/bazel/issues/5943
+      substituteInPlace scripts/bazel-complete-template.bash \
+        --replace "perl" "${perl}/bin/perl"
 
       patchShebangs .
     '';

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  srcDeps = stdenv.lib.singleton (
+  srcDeps = lib.singleton (
     fetchurl {
       url = "https://github.com/google/desugar_jdk_libs/archive/f5e6d80c6b4ec6b0a46603f72b015d45cf3c11cd.zip";
       sha256 = "c80f3f3d442d8a6ca7adc83f90ecd638c3864087fdd6787ffac070b6f1cc8f9b";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   version = "0.15.2";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "https://github.com/bazelbuild/bazel/";
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
@@ -74,71 +74,75 @@ stdenv.mkDerivation rec {
     }
   '';
 
-  postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Disable Bazel's Xcode toolchain detection which would configure compilers
-    # and linkers from Xcode instead of from PATH
-    export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+  postPatch = let
+    darwinPatches = ''
+      # Disable Bazel's Xcode toolchain detection which would configure compilers
+      # and linkers from Xcode instead of from PATH
+      export BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
 
-    # Framework search paths aren't added by bintools hook
-    # https://github.com/NixOS/nixpkgs/pull/41914
-    export NIX_LDFLAGS="$NIX_LDFLAGS -F${CoreFoundation}/Library/Frameworks -F${CoreServices}/Library/Frameworks -F${Foundation}/Library/Frameworks"
+      # Framework search paths aren't added by bintools hook
+      # https://github.com/NixOS/nixpkgs/pull/41914
+      export NIX_LDFLAGS="$NIX_LDFLAGS -F${CoreFoundation}/Library/Frameworks -F${CoreServices}/Library/Frameworks -F${Foundation}/Library/Frameworks"
 
-    # libcxx includes aren't added by libcxx hook
-    # https://github.com/NixOS/nixpkgs/pull/41589
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${libcxx}/include/c++/v1"
+      # libcxx includes aren't added by libcxx hook
+      # https://github.com/NixOS/nixpkgs/pull/41589
+      export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${libcxx}/include/c++/v1"
 
-    # don't use system installed Xcode to run clang, use Nix clang instead
-    sed -i -e "s;/usr/bin/xcrun clang;${clang}/bin/clang $NIX_CFLAGS_COMPILE $NIX_LDFLAGS -framework CoreFoundation;g" \
-      scripts/bootstrap/compile.sh \
-      src/tools/xcode/realpath/BUILD \
-      src/tools/xcode/stdredirect/BUILD \
-      tools/osx/BUILD
+      # don't use system installed Xcode to run clang, use Nix clang instead
+      sed -i -e "s;/usr/bin/xcrun clang;${clang}/bin/clang $NIX_CFLAGS_COMPILE $NIX_LDFLAGS -framework CoreFoundation;g" \
+        scripts/bootstrap/compile.sh \
+        src/tools/xcode/realpath/BUILD \
+        src/tools/xcode/stdredirect/BUILD \
+        tools/osx/BUILD
 
-    # clang installed from Xcode has a compatibility wrapper that forwards
-    # invocations of gcc to clang, but vanilla clang doesn't
-    sed -i -e 's;_find_generic(repository_ctx, "gcc", "CC", overriden_tools);_find_generic(repository_ctx, "clang", "CC", overriden_tools);g' tools/cpp/unix_cc_configure.bzl
+      # clang installed from Xcode has a compatibility wrapper that forwards
+      # invocations of gcc to clang, but vanilla clang doesn't
+      sed -i -e 's;_find_generic(repository_ctx, "gcc", "CC", overriden_tools);_find_generic(repository_ctx, "clang", "CC", overriden_tools);g' tools/cpp/unix_cc_configure.bzl
 
-    sed -i -e 's;/usr/bin/libtool;${cctools}/bin/libtool;g' tools/cpp/unix_cc_configure.bzl
-    wrappers=( tools/cpp/osx_cc_wrapper.sh tools/cpp/osx_cc_wrapper.sh.tpl )
-    for wrapper in "''${wrappers[@]}"; do
-      sed -i -e "s,/usr/bin/install_name_tool,${cctools}/bin/install_name_tool,g" $wrapper
-    done
-  '' + ''
-    find src/main/java/com/google/devtools -type f -print0 | while IFS="" read -r -d "" path; do
-      substituteInPlace "$path" \
-        --replace /bin/bash ${customBash}/bin/bash \
-        --replace /usr/bin/env ${coreutils}/bin/env
-    done
-    # Fixup scripts that generate scripts. Not fixed up by patchShebangs below.
-    substituteInPlace scripts/bootstrap/compile.sh \
-        --replace /bin/sh ${customBash}/bin/bash
+      sed -i -e 's;/usr/bin/libtool;${cctools}/bin/libtool;g' tools/cpp/unix_cc_configure.bzl
+      wrappers=( tools/cpp/osx_cc_wrapper.sh tools/cpp/osx_cc_wrapper.sh.tpl )
+      for wrapper in "''${wrappers[@]}"; do
+        sed -i -e "s,/usr/bin/install_name_tool,${cctools}/bin/install_name_tool,g" $wrapper
+      done
+    '';
+    genericPatches = ''
+      find src/main/java/com/google/devtools -type f -print0 | while IFS="" read -r -d "" path; do
+        substituteInPlace "$path" \
+          --replace /bin/bash ${customBash}/bin/bash \
+          --replace /usr/bin/env ${coreutils}/bin/env
+      done
+      # Fixup scripts that generate scripts. Not fixed up by patchShebangs below.
+      substituteInPlace scripts/bootstrap/compile.sh \
+          --replace /bin/sh ${customBash}/bin/bash
 
-    echo "build --experimental_distdir=${distDir}" >> .bazelrc
-    echo "fetch --experimental_distdir=${distDir}" >> .bazelrc
-    echo "build --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\"" >> .bazelrc
-    echo "build --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\"" >> .bazelrc
-    echo "build --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\"" >> .bazelrc
-    echo "build --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\"" >> .bazelrc
-    sed -i -e "361 a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
-    sed -i -e "361 a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
-    sed -i -e "361 a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
-    sed -i -e "361 a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
+      echo "build --experimental_distdir=${distDir}" >> .bazelrc
+      echo "fetch --experimental_distdir=${distDir}" >> .bazelrc
+      echo "build --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\"" >> .bazelrc
+      echo "build --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\"" >> .bazelrc
+      echo "build --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\"" >> .bazelrc
+      echo "build --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\"" >> .bazelrc
+      sed -i -e "361 a --copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "361 a --host_copt=\"$(echo $NIX_CFLAGS_COMPILE | sed -e 's/ /" --host_copt=\"/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "361 a --linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
+      sed -i -e "361 a --host_linkopt=\"-Wl,$(echo $NIX_LDFLAGS | sed -e 's/ /" --host_linkopt=\"-Wl,/g')\" \\\\" scripts/bootstrap/compile.sh
 
-    # --experimental_strict_action_env (which will soon become the
-    # default, see bazelbuild/bazel#2574) hardcodes the default
-    # action environment to a value that on NixOS at least is bogus.
-    # So we hardcode it to something useful.
-    substituteInPlace \
-		  src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java \
-      --replace /bin:/usr/bin ${defaultShellPath}
+      # --experimental_strict_action_env (which will soon become the
+      # default, see bazelbuild/bazel#2574) hardcodes the default
+      # action environment to a value that on NixOS at least is bogus.
+      # So we hardcode it to something useful.
+      substituteInPlace \
+        src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java \
+        --replace /bin:/usr/bin ${defaultShellPath}
 
-    # append the PATH with defaultShellPath in tools/bash/runfiles/runfiles.bash
-    echo "PATH=$PATH:${defaultShellPath}" >> runfiles.bash.tmp
-    cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
-    mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
+      # append the PATH with defaultShellPath in tools/bash/runfiles/runfiles.bash
+      echo "PATH=$PATH:${defaultShellPath}" >> runfiles.bash.tmp
+      cat tools/bash/runfiles/runfiles.bash >> runfiles.bash.tmp
+      mv runfiles.bash.tmp tools/bash/runfiles/runfiles.bash
 
-    patchShebangs .
-  '';
+      patchShebangs .
+    '';
+    in lib.optionalString stdenv.hostPlatform.isDarwin darwinPatches
+     + genericPatches;
 
   buildInputs = [
     jdk


### PR DESCRIPTION
The bash completions require `perl`. Until it is fixed upstream, we have to put it into the closure.
First commit is a bit of housekeeping.

cc @mboes 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

