### PR TITLE
astrolabe-generator: init at 3.3

### DIFF
--- a/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
+++ b/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, jre, makeWrapper, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "astrolabe-generator-${version}";
+  version = "3.3";
+
+  src = fetchurl {
+    url = "https://github.com/wymarc/astrolabe-generator/releases/download/v${version}/AstrolabeGenerator-${version}.zip";
+    sha256 = "141gfmrqa1mf2qas87qig4phym9fg9gbrcfl2idzd5gi91824dn9";
+  };
+
+  buildInputs = [ jre ];
+  nativeBuildInputs = [ makeWrapper unzip ];
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/java}
+    cp AstrolabeGenerator-${version}.jar $out/share/java
+
+    makeWrapper ${jre}/bin/java $out/bin/AstrolabeGenerator \
+      --add-flags "-jar $out/share/java/AstrolabeGenerator-${version}.jar"
+  '';
+
+  meta = with stdenv.lib;{
+    homepage = https://www.astrolabeproject.com;
+    description = "A Java-based tool for generating EPS files for constructing astrolabes and related tools";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21093,6 +21093,8 @@ with pkgs;
 
   stellarium = libsForQt5.callPackage ../applications/science/astronomy/stellarium { };
 
+  astrolabe-generator = callPackage ../applications/science/astronomy/astrolabe-generator { };
+
   tulip = callPackage ../applications/science/misc/tulip {
     cmake = cmake_2_8;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

