### PR TITLE
airwindows: init at 20-08-2018

### DIFF
--- a/pkgs/applications/audio/airwindows/default.nix
+++ b/pkgs/applications/audio/airwindows/default.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchFromGitHub, requireFile, unzip, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "airwindows-${version}";
+  version = "20-08-2018";
+
+  src = fetchFromGitHub {
+    owner = "airwindows";
+    repo = "airwindows";
+    rev = "2384d83b0fe4f455722e47df9315885ba3c74011";
+    sha256 = "1f52zvcva1cy8y6hsqdjqa4vgg9k7b4spbvdq2ggk9cmdlnl2vgh";
+  };
+
+  vst-sdk = stdenv.mkDerivation rec {
+    name = "vstsdk3610_11_06_2018_build_37";
+    src = requireFile {
+      name = "${name}.zip";
+      url = "http://www.steinberg.net/en/company/developers.html";
+      sha256 = "176lr4gadgdnvv56q19amf533g5wbgvq4s28fi0zldjnjl1iwp9y";
+    };
+    nativeBuildInputs = [ unzip ];
+    installPhase = "cp -r . $out";
+  };
+
+  airwindows-ports = stdenv.mkDerivation rec {
+    name = "airwindows-ports";
+    src = fetchFromGitHub {
+      owner = "ech2";
+      repo = "airwindows-ports";
+      rev = "0.4.0";
+      sha256 = "1ya4qbc63sb52nzisdapsydrnnpqnjsl5kgxibbr3dxf32474g89";
+    };
+    installPhase = "cp -r . $out";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  patchPhase = ''
+    cd plugins/LinuxVST
+    rm build/CMakeCache.txt
+    mkdir -p include/vstsdk
+    cp -r ${airwindows-ports}/include/vstsdk/CMakeLists.txt include/vstsdk/
+    cp -r ${vst-sdk}/VST2_SDK/pluginterfaces include/vstsdk/pluginterfaces
+    cp -r ${vst-sdk}/VST2_SDK/public.sdk/source/vst2.x/* include/vstsdk/
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib/lxvst
+    cp *.so $out/lib/lxvst
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Handsewn bespoke linuxvst plugins";
+    homepage = http://www.airwindows.com/airwindows-linux/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15244,6 +15244,8 @@ with pkgs;
 
   airwave = callPackage ../applications/audio/airwave { };
 
+  airwindows = callPackage ../applications/audio/airwindows { };
+
   alembic = callPackage ../development/libraries/alembic {};
 
   alchemy = callPackage ../applications/graphics/alchemy { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

