### PR TITLE
tootle: init 0.1.5

### DIFF
--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub
+, meson, ninja, pkgconfig
+, gnome3, vala, gobjectIntrospection, wrapGAppsHook
+, gtk3, granite
+, json-glib, glib, glib-networking
+}:
+
+let
+  pname = "tootle";
+  version = "0.1.5";
+in stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "bleakgrey";
+    repo = pname;
+    rev = version;
+    sha256 = "022h1rh1jk3m1f9al0s1rylmnqnkydyc81idfc8jf1g0frnvn5i6";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig vala gobjectIntrospection wrapGAppsHook ];
+  buildInputs = [
+    gtk3 granite json-glib glib glib-networking
+    gnome3.libgee gnome3.libsoup gnome3.gsettings-desktop-schemas
+  ];
+
+  postPatch = ''
+    chmod +x ./meson/post_install.py
+    patchShebangs ./meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple Mastodon client designed for elementary OS";
+    homepage    = https://github.com/bleakgrey/tootle;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18769,6 +18769,8 @@ with pkgs;
 
   toot = callPackage ../applications/misc/toot { };
 
+  tootle = callPackage ../applications/misc/tootle { };
+
   toxic = callPackage ../applications/networking/instant-messengers/toxic { };
 
   toxiproxy = callPackage ../development/tools/toxiproxy { };


### PR DESCRIPTION
Simple Mastodon client designed for elementary OS.

It's relatively new but is already useful as-is,
unsure how far it will be developed given self-described as "Simple".

Anyway, enjoy!


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---