### PR TITLE
bundlerApp: take buildInputs

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -19,6 +19,7 @@
 , meta ? {}
 , groups ? ["default"]
 , ignoreCollisions ? false
+, buildInputs ? []
 , ...
 }@args:
 
@@ -96,7 +97,7 @@ let
   envPaths = lib.attrValues gems ++ lib.optional (!hasBundler) bundler;
 
   basicEnv = buildEnv {
-    inherit  ignoreCollisions;
+    inherit buildInputs ignoreCollisions;
 
     name = name';
 


### PR DESCRIPTION
It would be reasonable to have a Ruby program that depends on some other program being in the PATH. In this case, the obvious thing to do would be something like this:

```nix
bundlerApp {
  # ...
  buildInputs = [ makeWrapper ];
  postBuild = ''
    wrapProgram "$out/bin/foo" \
      --prefix PATH : ${lib.makeBinPath [ dep ]}
  '';
}
```

However, this doesn't work, because even though it just forwards most of its arguments to `runCommand`, `bundlerApp` won't take a `buildInputs` parameter. It doesn't even specify its own `buildInputs`, which means that the `scripts` parameter to `bundlerApp` (which depends on `makeWrapper`) is completely broken, and, as far as I can tell, has been since its inception. By making the default `[ makeWrapper ]`, I have fixed this.

I've added a `buildInputs` option to `bundlerApp`. It's also passed through to bundled-common because `postBuild` scripts are run there as well. This actually means that in this example we'd end up going through two layers of wrappers (one from `bundlerApp` and one from bundled-common), but that has always been the case and isn't likely to break anything. That oddity does suggest that it might be prudent to not forward `postBuild` to bundled-common (or to at least use a different option) though...

FWIW, as far as I can tell no package in nixpkgs uses either the `scripts` or `postBuild` options to `bundlerApp`.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---