### PR TITLE
mono5.x: mark mono >=  5 broken on aarch64

### DIFF
--- a/pkgs/development/compilers/mono/generic-cmake.nix
+++ b/pkgs/development/compilers/mono/generic-cmake.nix
@@ -80,11 +80,13 @@ stdenv.mkDerivation rec {
 
   inherit enableParallelBuilding;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://mono-project.com/;
     description = "Cross platform, open source .NET development framework";
-    platforms = with stdenv.lib.platforms; darwin ++ linux;
-    maintainers = with stdenv.lib.maintainers; [ thoughtpolice obadz vrthra ];
-    license = stdenv.lib.licenses.free; # Combination of LGPL/X11/GPL ?
+    platforms = with platforms; darwin ++ linux;
+    maintainers = with maintainers; [ thoughtpolice obadz vrthra ];
+    license = licenses.free; # Combination of LGPL/X11/GPL ?
+    # 2018-08-21: mono 5.x is broken on aarch64 since at least 2017-07-06
+    broken = stdenv.isAarch64 && (versionAtLeast version "5");
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`mono` >= 5 has been broken for aarch64 on hydra since at least 2017-07-06. Looks like it never built.
Let's stop wasting hydra and ofborg resources on pointless rebuilds.

---

