### PR TITLE
msmtp: support passwordeval without final '\n'

### DIFF
--- a/pkgs/applications/networking/msmtp/default.nix
+++ b/pkgs/applications/networking/msmtp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoreconfHook, pkgconfig
+{ stdenv, lib, fetchpatch, fetchurl, autoreconfHook, pkgconfig
 , openssl, netcat-gnu, gnutls, gsasl, libidn, Security
 , withKeyring ? true, libsecret ? null
 , systemd ? null }:
@@ -19,6 +19,14 @@ in stdenv.mkDerivation rec {
 
   patches = [
     ./paths.patch
+
+    # To support passwordeval commands that do not print a final
+    # newline.
+    (fetchpatch {
+      name = "passwordeval-without-nl.patch";
+      url = "https://gitlab.marlam.de/marlam/msmtp/commit/df22dccf9d1af06fcd09dfdd0d6a38e1372dd5e8.patch";
+      sha256 = "06gbhvzi46zqigmmsin2aard7b9v3ihx62hbz5ljmfbj9rfs1x5y";
+    })
   ];
 
   buildInputs = [ openssl gnutls gsasl libidn ]


### PR DESCRIPTION
###### Motivation for this change

This applies an upstream patch (to be included in a future version of msmtp) that removes the requirement for passwordeval commands to print a `\n` character after the password. I'm adding this patch primarily for the benefit of the Home Manager email infrastructure, which promotes password commands that do not print a final newline.

I have tried the functionality of the msmtp tool with this patch applied and it sends mail just fine.

Maintainer CC: @garbas @peterhoeg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).