### PR TITLE
[WIP] singular: 4.1.1p2 -> 4.1.1p3

### DIFF
--- a/pkgs/applications/science/math/singular/default.nix
+++ b/pkgs/applications/science/math/singular/default.nix
@@ -2,50 +2,54 @@
 , lib
 , fetchpatch
 , autoreconfHook
+, sharutils
 , file
 , flint
 , ntl
 , cddlib
-, enableFactory ? true
 , enableGfanlib ? true
 }:
 
 stdenv.mkDerivation rec {
   name = "singular-${version}";
-  version = "4.1.1p2";
+  version = "4.1.1p3";
 
-  src = let
-    # singular sorts its tarballs in directories by base release (without patch version)
-    # for example 4.1.1p1 will be in the directory 4-1-1
-    baseVersion = builtins.head (lib.splitString "p" version);
-    urlVersion = builtins.replaceStrings [ "." ] [ "-" ] baseVersion;
-  in
-  fetchurl {
+  # singular sorts its tarballs in directories by base release (without patch version)
+  # for example 4.1.1p1 will be in the directory 4-1-1
+  baseVersion = builtins.head (lib.splitString "p" version);
+  urlVersion = builtins.replaceStrings [ "." ] [ "-" ] baseVersion;
+  src = fetchurl {
     url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${urlVersion}/singular-${version}.tar.gz";
-    sha256 = "07x9kri8vl4galik7lr6pscq3c51n8570pyw64i7gbj0m706f7wf";
+    sha256 = "1qqj9bm9pkzm0iyycpvm8x6s79wws3nq60lz25h8x1q61h3426sm";
+  };
+  tests = fetchurl {
+    url = "http://www.mathematik.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${urlVersion}/singular-tst-${version}.tar.gz";
+    sha256 = "10w3iabx0ykxwfk07n3z752jinan425wkp00f74nkv745bfhz139";
   };
 
   configureFlags = [
     "--with-ntl=${ntl}"
-  ] ++ lib.optionals enableFactory [
-    "--enable-factory"
   ] ++ lib.optionals enableGfanlib [
     "--enable-gfanlib"
   ];
 
-  postUnpack = ''
+  prePatch = ''
+    # move Tests into singular source root
+    tar xf "${tests}"
+
+    # don't let the tests depend on `hostname`
+    substituteInPlace Tst/regress.cmd --replace 'mysystem_catch("hostname")' 'nix_test_runner'
+
     patchShebangs .
   '';
 
   patches = [
-    # NTL error handler was introduced in the library part, preventing users of
-    # the library from implementing their own error handling
-    # https://www.singular.uni-kl.de/forum/viewtopic.php?t=2769
+    # Fix bug with gcd in Z[x]
+    # https://www.singular.uni-kl.de:8005/trac/ticket/834
     (fetchpatch {
-      name = "move_error_handler_out_of_libsingular.patch";
-      # rebased version of https://github.com/Singular/Sources/commit/502cf86d0bb2a96715be6764774b64a69c1ca34c.patch
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/singular/patches/singular-ntl-error-handler.patch?h=50b9ae2fd233c30860e1cbb3e63a26f2cc10560a";
-      sha256 = "0vgh4m9zn1kjl0br68n04j4nmn5i1igfn28cph0chnwf7dvr9194";
+      name = "gcd-fix.patch";
+      url = "https://github.com/Singular/Sources/commit/55ec4f789df5836f21154a2d6e25c0e9cb8cf814.patch";
+      sha256 = "1jy5gngdh8xawbbh59w6fnks22h778wpaqvzpq4h2l7xhz7dgdnb";
     })
   ];
 
@@ -68,6 +72,7 @@ stdenv.mkDerivation rec {
     perl
     pkgconfig
     autoreconfHook
+    sharutils # needed for regress.cmd install checks
   ];
 
   preAutoreconf = ''
@@ -85,6 +90,8 @@ stdenv.mkDerivation rec {
     # do nothing
   '';
 
+  doCheck = true; # very basic checks, does not test any libraries
+
   installPhase = ''
     mkdir -p "$out"
     cp -r Singular/LIB "$out/lib"
@@ -94,14 +101,47 @@ stdenv.mkDerivation rec {
     rm -rf libpolys factory resources omalloc Singular
   '';
 
+  # singular tests are a bit complicated, see
+  # https://github.com/Singular/Sources/tree/spielwiese/Tst
+  # https://www.singular.uni-kl.de/forum/viewtopic.php&t=2773
+  testsToRun = [
+    "Old/universal.lst"
+    "Buch/buch.lst"
+    "Plural/short.lst"
+    "Old/factor.tst"
+  ] ++ lib.optionals enableGfanlib [
+    # tests that require gfanlib
+    "Short/ok_s.lst"
+  ];
+
   # simple test to make sure singular starts and finds its libraries
   doInstallCheck = true;
   installCheckPhase = ''
+    # Very basic sanity check to make sure singular starts and finds its libraries.
+    # This is redundant with the below tests. It is only kept because the singular test
+    # runner is a bit complicated. In case we decide to give up those tests in the future,
+    # this will still be useful. It takes barely any time.
     "$out/bin/Singular" -c 'LIB "freegb.lib"; exit;'
     if [ $? -ne 0 ]; then
         echo >&2 "Error loading the freegb library in Singular."
         exit 1
     fi
+
+    # Run the test suite
+    cd Tst
+    perl ./regress.cmd \
+      -s "$out/bin/Singular" \
+      ${lib.concatStringsSep " " (map lib.escapeShellArg testsToRun)} \
+      2>"$TMPDIR/out-err.log"
+
+    # unfortunately regress.cmd always returns exit code 0, so check stderr
+    # https://www.singular.uni-kl.de/forum/viewtopic.php&t=2773
+    if [[ -s "$TMPDIR/out-err.log" ]]; then
+      cat "$TMPDIR/out-err.log"
+      exit 1
+    fi
+
+    echo "Exit status $?"
   '';
 
   enableParallelBuilding = true;
@@ -110,6 +150,7 @@ stdenv.mkDerivation rec {
     description = "A CAS for polynomial computations";
     maintainers = with maintainers; [ raskin timokau ];
     # 32 bit x86 fails with some link error: `undefined reference to `__divmoddi4@GCC_7.0.0'`
+    # https://www.singular.uni-kl.de:8002/trac/ticket/837
     platforms = subtractLists platforms.i686 platforms.linux;
     license = licenses.gpl3; # Or GPLv2 at your option - but not GPLv4
     homepage = http://www.singular.uni-kl.de;


### PR DESCRIPTION
###### Motivation for this change

Adds proper tests to avoid something like #39370 in the future. Upstream is [unclear](https://www.singular.uni-kl.de/forum/viewtopic.php?f=10&t=2773) about weather or not they are appropriate for packaging though. Since its a bit of a pain to contact upstream and they've been unresponsive for a while, I thought we may as well just try.

According to upstream, there may be difficulties with the tests running on 32 bit. Currently we don't compile on 32 bit anyways (reported that upstream too). As soon as we do, we can sort that out or disable some (or all if need be) tests.

Also removes the "enableFactory" option because singular actually enables factory by default and explicitly disabling it breaks the build. So the option was never really available.

@7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

