### PR TITLE
nixos/cfssl: don't create user/group unless service is enabled

### DIFF
--- a/nixos/modules/services/security/cfssl.nix
+++ b/nixos/modules/services/security/cfssl.nix
@@ -146,7 +146,7 @@ in {
     };
   };
 
-  config = {
+  config = mkIf cfg.enable {
     users.extraGroups.cfssl = {
       gid = config.ids.gids.cfssl;
     };
@@ -159,7 +159,7 @@ in {
       uid = config.ids.uids.cfssl;
     };
 
-    systemd.services.cfssl = mkIf cfg.enable {
+    systemd.services.cfssl = {
       description = "CFSSL CA API server";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];


### PR DESCRIPTION
###### Motivation for this change

The user creation for `cfssl` is always enabled, causing a `cfssl` user and group to be created along with the home directory `/var/lib/cfssl` on every NixOS user's system.

###### Things done

This PR adds a `mkIf cfg.enable` guard around the entire configuration.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

