### PR TITLE
Revert "Define wrapper env vars as full paths"

### DIFF
--- a/pkgs/applications/graphics/exrtools/default.nix
+++ b/pkgs/applications/graphics/exrtools/default.nix
@@ -9,11 +9,6 @@ stdenv.mkDerivation rec {
     sha256 = "0jpkskqs1yjiighab4s91jy0c0qxcscwadfn94xy2mm2bx2qwp4z";
   };
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ stdenv openexr libpng12 libjpeg ];
 

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -81,11 +81,6 @@ stdenv.mkDerivation rec {
     cd ../../..
   '';
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   configureFlags = [
     "--disable-static"
     "--disable-staticbins"

--- a/pkgs/applications/science/logic/aiger/default.nix
+++ b/pkgs/applications/science/logic/aiger/default.nix
@@ -12,9 +12,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   configurePhase = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-
     # Set up picosat, so we can build 'aigbmc'
     mkdir ../picosat
     ln -s ${picosat}/include/picosat/picosat.h ../picosat/picosat.h

--- a/pkgs/applications/science/logic/verit/default.nix
+++ b/pkgs/applications/science/logic/verit/default.nix
@@ -15,11 +15,6 @@ stdenv.mkDerivation rec {
   # --disable-static actually enables static linking here...
   dontDisableStatic = true;
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}gcc
-    CXX=${stdenv.cc.targetPrefix}g++
-  '';
-
   makeFlags = [ "LEX=${flex}/bin/flex" ];
 
   preInstall = ''

--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -41,11 +41,6 @@ stdenv.mkDerivation rec {
      sed -i 's,/sbin/shutdown,shutdown,' lib/system/systemLinux.c
   '';
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   configureFlags = [ "--without-kernel-modules" "--without-xmlsecurity" ]
     ++ lib.optional (!withX) "--without-x";
 

--- a/pkgs/build-support/bintools-wrapper/setup-hook.sh
+++ b/pkgs/build-support/bintools-wrapper/setup-hook.sh
@@ -59,11 +59,11 @@ for cmd in \
     ar as ld nm objcopy objdump readelf ranlib strip strings size windres
 do
     if
-        cmd_path=$(PATH=$_PATH command -v "@targetPrefix@${cmd}")
+        PATH=$_PATH type -p "@targetPrefix@${cmd}" > /dev/null
     then
         upper_case="$(echo "$cmd" | tr "[:lower:]" "[:upper:]")"
-        export "${role_pre}${upper_case}=${cmd_path}";
-        export "${upper_case}${role_post}=${cmd_path}";
+        export "${role_pre}${upper_case}=@targetPrefix@${cmd}";
+        export "${upper_case}${role_post}=@targetPrefix@${cmd}";
     fi
 done
 
@@ -72,5 +72,5 @@ done
 export NIX_HARDENING_ENABLE
 
 # No local scope in sourced file
-unset -v role_pre role_post cmd cmd_path upper_case
+unset -v role_pre role_post cmd upper_case
 set +u

--- a/pkgs/build-support/cc-wrapper/setup-hook.sh
+++ b/pkgs/build-support/cc-wrapper/setup-hook.sh
@@ -109,10 +109,10 @@ fi
 
 export NIX_${role_pre}CC=@out@
 
-export ${role_pre}CC=@out@/bin/@named_cc@
-export ${role_pre}CXX=@out@/bin/@named_cxx@
-export CC${role_post}=@out@/bin/@named_cc@
-export CXX${role_post}=@out@/bin/@named_cxx@
+export ${role_pre}CC=@named_cc@
+export ${role_pre}CXX=@named_cxx@
+export CC${role_post}=@named_cc@
+export CXX${role_post}=@named_cxx@
 
 # If unset, assume the default hardening flags.
 : ${NIX_HARDENING_ENABLE="fortify stackprotector pic strictoverflow format relro bindnow"}

--- a/pkgs/development/compilers/ghc/8.0.2.nix
+++ b/pkgs/development/compilers/ghc/8.0.2.nix
@@ -102,16 +102,15 @@ stdenv.mkDerivation rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="$CC_FOR_TARGET"
-    export CXX="$CXX_FOR_TARGET"
-    # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
-    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="$AS_FOR_TARGET"
-    export AR="$AR_FOR_TARGET"
-    export NM="$NM_FOR_TARGET"
-    export RANLIB="$RANLIB_FOR_TARGET"
-    export READELF="$READELF_FOR_TARGET"
-    export STRIP="$STRIP_FOR_TARGET"
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
+    export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -134,16 +134,16 @@ stdenv.mkDerivation rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="$CC_FOR_TARGET"
-    export CXX="$CXX_FOR_TARGET"
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="$AS_FOR_TARGET"
-    export AR="$AR_FOR_TARGET"
-    export NM="$NM_FOR_TARGET"
-    export RANLIB="$RANLIB_FOR_TARGET"
-    export READELF="$READELF_FOR_TARGET"
-    export STRIP="$STRIP_FOR_TARGET"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.4.3.nix
+++ b/pkgs/development/compilers/ghc/8.4.3.nix
@@ -115,16 +115,16 @@ stdenv.mkDerivation (rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="$CC_FOR_TARGET"
-    export CXX="$CXX_FOR_TARGET"
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="$AS_FOR_TARGET"
-    export AR="$AR_FOR_TARGET"
-    export NM="$NM_FOR_TARGET"
-    export RANLIB="$RANLIB_FOR_TARGET"
-    export READELF="$READELF_FOR_TARGET"
-    export STRIP="$STRIP_FOR_TARGET"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/8.6.1.nix
+++ b/pkgs/development/compilers/ghc/8.6.1.nix
@@ -98,16 +98,16 @@ stdenv.mkDerivation (rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="$CC_FOR_TARGET"
-    export CXX="$CXX_FOR_TARGET"
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="$AS_FOR_TARGET"
-    export AR="$AR_FOR_TARGET"
-    export NM="$NM_FOR_TARGET"
-    export RANLIB="$RANLIB_FOR_TARGET"
-    export READELF="$READELF_FOR_TARGET"
-    export STRIP="$STRIP_FOR_TARGET"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
 
     echo -n "${buildMK}" > mk/build.mk
     sed -i -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||' configure

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -100,16 +100,16 @@ stdenv.mkDerivation rec {
     done
     # GHC is a bit confused on its cross terminology, as these would normally be
     # the *host* tools.
-    export CC="$CC_FOR_TARGET"
-    export CXX="$CXX_FOR_TARGET"
+    export CC="${targetCC}/bin/${targetCC.targetPrefix}cc"
+    export CXX="${targetCC}/bin/${targetCC.targetPrefix}cxx"
     # Use gold to work around https://sourceware.org/bugzilla/show_bug.cgi?id=16177
     export LD="${targetCC.bintools}/bin/${targetCC.bintools.targetPrefix}ld${stdenv.lib.optionalString targetPlatform.isAarch32 ".gold"}"
-    export AS="$AS_FOR_TARGET"
-    export AR="$AR_FOR_TARGET"
-    export NM="$NM_FOR_TARGET"
-    export RANLIB="$RANLIB_FOR_TARGET"
-    export READELF="$READELF_FOR_TARGET"
-    export STRIP="$STRIP_FOR_TARGET"
+    export AS="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}as"
+    export AR="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ar"
+    export NM="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}nm"
+    export RANLIB="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}ranlib"
+    export READELF="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}readelf"
+    export STRIP="${targetCC.bintools.bintools}/bin/${targetCC.bintools.targetPrefix}strip"
 
     echo -n "${buildMK}" > mk/build.mk
     echo ${version} >VERSION

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -106,12 +106,6 @@ let
     # https://github.com/JetBrains/jdk8u/commit/eaa5e0711a43d64874111254d74893fa299d5716
     + stdenv.lib.optionalString stdenv.cc.isGNU ''
       NIX_CFLAGS_COMPILE+=" -fno-lifetime-dse -fno-delete-null-pointer-checks -std=gnu++98 -Wno-error"
-    ''
-    # The configure script was confused by our passing these with full paths,
-    # so we explicitly override them to short variants.
-    + ''
-      CC=${stdenv.cc.targetPrefix}cc
-      CXX=${stdenv.cc.targetPrefix}c++
     '';
 
     configureFlags = [

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -46,16 +46,22 @@ stdenvNoLibs.mkDerivation rec {
     mkdir -p "$buildRoot/gcc"
     cd "$buildRoot/gcc"
     (
+      export AS_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$AS_FOR_BUILD
+      export CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CC_FOR_BUILD
+      export CPP_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CPP_FOR_BUILD
+      export CXX_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CXX_FOR_BUILD
+      export LD_FOR_BUILD=${buildPackages.stdenv.cc.bintools}/bin/$LD_FOR_BUILD
+
       export AS=$AS_FOR_BUILD
       export CC=$CC_FOR_BUILD
       export CPP=$CPP_FOR_BUILD
       export CXX=$CXX_FOR_BUILD
       export LD=$LD_FOR_BUILD
 
-      export AS_FOR_TARGET=$AS
-      export CC_FOR_TARGET=$CC
-      export CPP_FOR_TARGET=$CPP
-      export LD_FOR_TARGET=$LD
+      export AS_FOR_TARGET=${stdenvNoLibs.cc}/bin/$AS
+      export CC_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CC
+      export CPP_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CPP
+      export LD_FOR_TARGET=${stdenvNoLibs.cc.bintools}/bin/$LD
 
       export NIX_BUILD_CFLAGS_COMPILE+=' -DGENERATOR_FILE=1'
 
@@ -81,6 +87,23 @@ stdenvNoLibs.mkDerivation rec {
     cd "$buildRoot/gcc/${hostPlatform.config}/libgcc"
     configureScript=$sourceRoot/configure
     chmod +x "$configureScript"
+
+    export AS_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$AS_FOR_BUILD
+    export CC_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CC_FOR_BUILD
+    export CPP_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CPP_FOR_BUILD
+    export CXX_FOR_BUILD=${buildPackages.stdenv.cc}/bin/$CXX_FOR_BUILD
+    export LD_FOR_BUILD=${buildPackages.stdenv.cc.bintools}/bin/$LD_FOR_BUILD
+
+    export AS=${stdenvNoLibs.cc}/bin/$AS
+    export CC=${stdenvNoLibs.cc}/bin/$CC
+    export CPP=${stdenvNoLibs.cc}/bin/$CPP
+    export CXX=${stdenvNoLibs.cc}/bin/$CXX
+    export LD=${stdenvNoLibs.cc.bintools}/bin/$LD
+
+    export AS_FOR_TARGET=${stdenvNoLibs.cc}/bin/$AS_FOR_TARGET
+    export CC_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CC_FOR_TARGET
+    export CPP_FOR_TARGET=${stdenvNoLibs.cc}/bin/$CPP_FOR_TARGET
+    export LD_FOR_TARGET=${stdenvNoLibs.cc.bintools}/bin/$LD_FOR_TARGET
   '';
 
   gccConfigureFlags = [

--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -19,11 +19,6 @@ stdenv.mkDerivation rec {
   # TODO(@Dridus) remove the ++ libc at next hash break
   buildInputs = [ lua5 ] ++ stdenv.lib.optional stdenv.isLinux stdenv.cc.libc;
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   cmakeFlags = "-DPODOFO_BUILD_SHARED=ON -DPODOFO_BUILD_STATIC=OFF";
 
   meta = {

--- a/pkgs/development/libraries/zeroc-ice/default.nix
+++ b/pkgs/development/libraries/zeroc-ice/default.nix
@@ -27,11 +27,6 @@ stdenv.mkDerivation rec {
         --replace xcrun ""
   '';
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   makeFlags = [ "prefix=$(out)" "OPTIMIZE=yes" ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -28,10 +28,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gmp ];
 
   patchPhase = "patchShebangs ./z_pp.pl";
-
   configurePhase = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
     ./configure -installdir $out/lib/ocaml/${ocaml.version}/site-lib
   '';
   preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib";

--- a/pkgs/games/warmux/default.nix
+++ b/pkgs/games/warmux/default.nix
@@ -19,11 +19,6 @@ stdenv.mkDerivation rec {
       gettext intltool libtool perl
     ];
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   configureFlagsArray = ("CFLAGS=-include ${zlib.dev}/include/zlib.h");
 
   patches = [ ./gcc-fix.patch ];

--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -30,11 +30,6 @@ stdenv.mkDerivation rec {
                       --replace "which %s" "${which}/bin/which %s"
   '';
 
-  preConfigure = ''
-    CC=${stdenv.cc.targetPrefix}cc
-    CXX=${stdenv.cc.targetPrefix}c++
-  '';
-
   configureFlags = [ "--with-distributor=NixOS" ];
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
This reverts commit 89efc27f571368b475ce87e71445be10a9d1121a, reversing
changes made to d0f11020ca55dfe20ecad05005343e3a3e3cbd90. This is from PR #44767.

This PR had many unintended side effects. It seems prudent to just revert, hopefully making way to do this some time later on when all of the issues are resolved.