### PR TITLE
obuild: 0.1.8 -> 0.1.10

### DIFF
--- a/pkgs/development/tools/ocaml/obuild/default.nix
+++ b/pkgs/development/tools/ocaml/obuild/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchzip, ocaml }:
 
-let version = "0.1.8"; in
+let version = "0.1.10"; in
 
 stdenv.mkDerivation {
   name = "obuild-${version}";
 
   src = fetchzip {
     url = "https://github.com/ocaml-obuild/obuild/archive/obuild-v${version}.tar.gz";
-    sha256 = "1q1k2qqd08j1zakvydgvwgwpyn0ll7rs65gap0pvg3amnh5cp3wd";
+    sha256 = "15arsgbhk1c39vd8qhpa3pag94m44bwvzggdvkibx6hnpkv8z9bn";
   };
 
   buildInputs = [ ocaml ];


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.06.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

