### PR TITLE
spdlib: init at 3.3.0

### DIFF
--- a/pkgs/development/libraries/LAStools/default.nix
+++ b/pkgs/development/libraries/LAStools/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, fetchurl}:
+stdenv.mkDerivation rec {
+
+  version = "180812";
+  name = "LAStools-${version}";
+
+  src = fetchFromGitHub {
+    owner = "LAStools";
+    repo = "LAStools";
+    rev = "162cf032f25cac492712a8568a08b224a5fb40c2";
+    sha256 = "117c9csbfwsx424ha695l7d99cswi316k8q338mzk1lxlk8p3xbz";
+  };
+
+  nativeBuildInputs = [cmake];
+
+  meta = {
+    description = "Efficient tools for LiDAR processing.";
+    homepage = https://www.laszip.org;
+    license = stdenv.lib.licenses.lgpl2;
+    maintainers = [ stdenv.lib.maintainers.mpickering ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/development/libraries/spdlib/cmake-fixes.patch
+++ b/pkgs/development/libraries/spdlib/cmake-fixes.patch
@@ -1,0 +1,42 @@
+# HG changeset patch
+# User Matthew Pickering <matthewtpickering@gmail.com>
+# Date 1534545423 0
+#      Fri Aug 17 22:37:03 2018 +0000
+# Node ID c7b2e431cc4f013ac969a6eea56ccbdb6d1dbf7b
+# Parent  0e406b4f93ed01970ec3f7248c7f02b3cae82988
+Be more careful about the difference between the build and source dirs
+
+These places in the build system assumed that the build and souce direction were
+the same. They are not in general. In particular, `configure_file` treats a
+relative input path as though it's in the source directory and an output path
+as though it's in the build directory.
+
+diff -r 0e406b4f93ed -r c7b2e431cc4f CMakeLists.txt
+--- a/CMakeLists.txt	Fri Feb 23 14:07:40 2018 +0000
++++ b/CMakeLists.txt	Fri Aug 17 22:37:03 2018 +0000
+@@ -121,7 +121,7 @@
+ 
+ ###############################################################################
+ # Setup configure file
+-configure_file ( "${PROJECT_HEADER_DIR}/spd-config.h.in" "${PROJECT_HEADER_DIR}/spd/spd-config.h" )
++configure_file ( "${PROJECT_HEADER_DIR}/spd-config.h.in" "${CMAKE_SOURCE_DIR}/${PROJECT_HEADER_DIR}/spd/spd-config.h" )
+ configure_file ( "${PROJECT_TOOLS_DIR}/spd-config.in" "${PROJECT_BINARY_DIR}/spd-config" )
+ configure_file ( "${PROJECT_TOOLS_DIR}/spdbatchgen.py.in" "${PROJECT_BINARY_DIR}/spdbatchgen.py" )
+ configure_file ( "${PROJECT_TOOLS_DIR}/spdbuildmergecmd.py.in" "${PROJECT_BINARY_DIR}/spdbuildmergecmd.py" )
+@@ -405,11 +405,11 @@
+ 	install (TARGETS spdtranslate spdversion spdcopy spdstats spdmaskgen spdpmfgrd spdmccgrd spdpolygrd spdinterp spddefheight spddecomp spdlastest spdmetrics spdmerge spdsubset spdoverlap spddefrgb spdelevation spdproj spdrmnoise spdclearclass spdpffgrd spdinfo spdthin spdextract spdwarp spdprofile spddeftiles spdtileimg spdtiling spdgrdtidy spdclassify spdtsample spdsplit spdclassimg DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+ endif(SPDLIB_WITH_UTILITIES)
+ 
+-install (FILES "${PROJECT_BINARY_DIR}/spd-config" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+-install (FILES "${PROJECT_BINARY_DIR}/spdbatchgen.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+-install (FILES "${PROJECT_BINARY_DIR}/spdbuildmergecmd.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+-install (FILES "${PROJECT_BINARY_DIR}/spdcmdgen.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+-install (FILES "${PROJECT_BINARY_DIR}/spdbuildtileextractcmd.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install (FILES "${CMAKE_BINARY_DIR}/${PROJECT_BINARY_DIR}/spd-config" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install (FILES "${CMAKE_BINARY_DIR}/${PROJECT_BINARY_DIR}/spdbatchgen.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install (FILES "${CMAKE_BINARY_DIR}/${PROJECT_BINARY_DIR}/spdbuildmergecmd.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install (FILES "${CMAKE_BINARY_DIR}/${PROJECT_BINARY_DIR}/spdcmdgen.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++install (FILES "${CMAKE_BINARY_DIR}/${PROJECT_BINARY_DIR}/spdbuildtileextractcmd.py" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+ ###############################################################################
+ 
+ ###############################################################################

--- a/pkgs/development/libraries/spdlib/default.nix
+++ b/pkgs/development/libraries/spdlib/default.nix
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.spdlib.org/;
     license = stdenv.lib.licenses.gpl3;
     maintainers = [ stdenv.lib.maintainers.mpickering ];
-    platforms = with stdenv.lib.platforms; unix;
+    platforms = with stdenv.lib.platforms; x86;
   };
 }

--- a/pkgs/development/libraries/spdlib/default.nix
+++ b/pkgs/development/libraries/spdlib/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, cmake, fetchurl
+, boost, hdf5-cpp, gdal, LAStools, xercesc, gsl, proj, cgal, LASzip, gmp
+, mpfr
+}:
+
+
+stdenv.mkDerivation rec {
+  version = "3.3.0";
+  name = "spdlib-${version}";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/petebunting/spdlib/downloads/spdlib-${version}.tar.gz";
+    sha256 = "1ixrjlaprqbzzgyg10xx175rwvscz9njs7jam293nyyvxv2m1lyy";
+  };
+
+  patches = [ ./cmake-fixes.patch ./remove-old-flags.patch ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost hdf5-cpp gdal LAStools xercesc gsl proj cgal LASzip gmp
+                  mpfr ];
+
+  enableParallelBuilding = true;
+
+#  CMAKE_CXX_FLAGS = "-std=c++11 -Wno-deprecated-declarations -Wno-unused-result";
+
+  cmakeFlags = ["-DLIBLAS_INCLUDE_DIR=${LAStools}/include/LASlib"
+                "-DLIBLAS_LIB_PATH=${LAStools}/lib/LASlib"
+               ];
+
+  meta = {
+    description = "SPDLib is a set of open source software tools for processing laser scanning data (i.e., LiDAR), including data captured from airborne and terrestrial platforms. ";
+    homepage = http://www.spdlib.org/;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = [ stdenv.lib.maintainers.mpickering ];
+    platforms = with stdenv.lib.platforms; unix;
+  };
+}

--- a/pkgs/development/libraries/spdlib/remove-old-flags.patch
+++ b/pkgs/development/libraries/spdlib/remove-old-flags.patch
@@ -1,0 +1,35 @@
+# HG changeset patch
+# User Matthew Pickering <matthewtpickering@gmail.com>
+# Date 1534545685 0
+#      Fri Aug 17 22:41:25 2018 +0000
+# Node ID a7c8f87b57948a6fd654749e13a5a5ef3e17e4ad
+# Parent  c7b2e431cc4f013ac969a6eea56ccbdb6d1dbf7b
+Remove old recommended C++ flags
+
+diff -r c7b2e431cc4f -r a7c8f87b5794 CMakeLists.txt
+--- a/CMakeLists.txt	Fri Aug 17 22:37:03 2018 +0000
++++ b/CMakeLists.txt	Fri Aug 17 22:41:25 2018 +0000
+@@ -181,23 +181,6 @@
+         add_definitions(-DHAVE_GEOS)
+     endif()
+ 
+-else()
+-  # Recommended C++ compilation flags
+-  # -Weffc++
+-  set(SPDLIB_COMMON_CXX_FLAGS
+-	"-Wall -Wpointer-arith -Wcast-align -Wcast-qual -Wredundant-decls -Wno-long-long -DNDEBUG")
+-	#"-pedantic -ansi -Wall -Wpointer-arith -Wcast-align -Wcast-qual -Wfloat-equal -Wredundant-decls -Wno-long-long")
+-
+-  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
+-
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ${SPDLIB_COMMON_CXX_FLAGS}")
+-    if (CMAKE_COMPILER_IS_GNUCXX)
+-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+-    endif()
+-
+-  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER}" MATCHES "clang")
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SPDLIB_COMMON_CXX_FLAGS}")
+-  endif()
+ endif(WIN32)
+ 
+ if(APPLE)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11814,6 +11814,8 @@ with pkgs;
 
   spatialite_tools = callPackage ../development/libraries/spatialite-tools { };
 
+  spdlib = callPackage ../development/libraries/spdlib { };
+
   spdk = callPackage ../development/libraries/spdk { };
 
   speechd = callPackage ../development/libraries/speechd { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9809,6 +9809,8 @@ with pkgs;
 
   lasso = callPackage ../development/libraries/lasso { };
 
+  LAStools = callPackage ../development/libraries/LAStools { };
+
   LASzip = callPackage ../development/libraries/LASzip { };
 
   lcms = lcms1;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

