### PR TITLE
nixos/networkd: replace range with assertRange

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -30,10 +30,10 @@ let
     (assertValueOneOf "UDPSegmentationOffload" boolValues)
     (assertValueOneOf "GenericReceiveOffload" boolValues)
     (assertValueOneOf "LargeReceiveOffload" boolValues)
-    (range "RxChannels" 1 4294967295)
-    (range "TxChannels" 1 4294967295)
-    (range "OtherChannels" 1 4294967295)
-    (range "CombinedChannels" 1 4294967295)
+    (assertRange "RxChannels" 1 4294967295)
+    (assertRange "TxChannels" 1 4294967295)
+    (assertRange "OtherChannels" 1 4294967295)
+    (assertRange "CombinedChannels" 1 4294967295)
   ];
 
   checkNetdev = checkUnitConfig "Netdev" [


### PR DESCRIPTION
###### Motivation for this change

It appears that the [`range`](https://github.com/NixOS/nixpkgs/blob/master/lib/lists.nix#L224) function was mistakenly used instead of the `assertRange` function in #44233, which completely broke networkd link configurations.

###### Things done

This PR replaces `range` with `assertRange`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

