### PR TITLE
[WIP] imagemagick: disable ghostscript vector formats

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/7.0.nix
+++ b/pkgs/applications/graphics/ImageMagick/7.0.nix
@@ -31,7 +31,11 @@ stdenv.mkDerivation rec {
     inherit (cfg) sha256;
   };
 
-  patches = [ ./imagetragick.patch ] ++ cfg.patches;
+  patches = [
+    ./imagetragick.patch
+    # work around for ghostscript vulnerability https://www.kb.cert.org/vuls/id/332928
+    ./disable_gs_formats.patch
+  ] ++ cfg.patches;
 
   outputs = [ "out" "dev" "doc" ]; # bin/ isn't really big
   outputMan = "out"; # it's tiny

--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -43,7 +43,11 @@ stdenv.mkDerivation rec {
     inherit (cfg) sha256;
   };
 
-  patches = [ ./imagetragick.patch ] ++ cfg.patches;
+  patches = [
+    ./imagetragick.patch
+    # work around for ghostscript vulnerability https://www.kb.cert.org/vuls/id/332928
+    ./disable_gs_formats.patch
+  ] ++ cfg.patches;
 
   outputs = [ "out" "dev" "doc" ]; # bin/ isn't really big
   outputMan = "out"; # it's tiny

--- a/pkgs/applications/graphics/ImageMagick/disable_gs_formats.patch
+++ b/pkgs/applications/graphics/ImageMagick/disable_gs_formats.patch
@@ -1,0 +1,13 @@
+diff --git a/config/policy.xml b/config/policy.xml
+index d497934..a763016 100644
+--- a/config/policy.xml
++++ b/config/policy.xml
+@@ -77,4 +77,8 @@
+   <!-- <policy domain="cache" name="memory-map" value="anonymous"/> -->
+   <!-- <policy domain="cache" name="synchronize" value="True"/> -->
+   <!-- <policy domain="cache" name="shared-secret" value="passphrase" stealth="true"/> -->
++  <policy domain="coder" rights="none" pattern="PS" />
++  <policy domain="coder" rights="none" pattern="EPS" />
++  <policy domain="coder" rights="none" pattern="PDF" />
++  <policy domain="coder" rights="none" pattern="XPS" />
+ </policymap>


### PR DESCRIPTION
###### Motivation for this change
Prevent a wecurity hole in ghostscript to be abused.
See https://www.kb.cert.org/vuls/id/332928 for more details

###### Things done

- Patch for `policy.xml`  disallowing conversion of PS/EPS/PDF/XPS files

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

