### PR TITLE
 numactl: 2.0.11 -> 2.0.12

### DIFF
--- a/pkgs/os-specific/linux/numactl/default.nix
+++ b/pkgs/os-specific/linux/numactl/default.nix
@@ -2,23 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "numactl-${version}";
-  version = "2.0.11";
+  version = "2.0.12";
 
   src = fetchFromGitHub {
     owner = "numactl";
     repo = "numactl";
     rev = "v${version}";
-    sha256 = "0bcffqawwbyrnza8np0whii25mfd0dria35zal9v3l55xcrya3j9";
+    sha256 = "0crhpxwakp0gvd7wwpbkfd3brnrdf89lkbf03axnbrs0b6kaygg2";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  patches = [
-    (fetchpatch {
-      url = https://raw.githubusercontent.com/gentoo/gentoo/b64d15e731e3d6a7671f0ec6c34a20203cf2609d/sys-process/numactl/files/numactl-2.0.11-sysmacros.patch;
-      sha256 = "05277kv3x12n2xlh3fgnmxclxfc384mkwb0v9pd91046khj6h843";
-    })
-  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
+  patches = stdenv.lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
       url = https://git.alpinelinux.org/cgit/aports/plain/testing/numactl/musl.patch?id=0592b128c71c3e70d493bc7a13caed0d7fae91dd;
       sha256 = "080b0sygmg7104qbbh1amh3b322yyiajwi2d3d0vayffgva0720v";
     });

--- a/pkgs/os-specific/linux/numactl/default.nix
+++ b/pkgs/os-specific/linux/numactl/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library and tools for non-uniform memory access (NUMA) machines";
-    homepage = http://oss.sgi.com/projects/libnuma/;
-    license = licenses.gpl2;
+    homepage = https://github.com/numactl/numactl;
+    license = with licenses; [ gpl2 lgpl21 ]; # libnuma is lgpl21
     platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
     maintainers = with maintainers; [ wkennington ];
   };


### PR DESCRIPTION
###### Motivation for this change
Update version and meta data

###### Things done
- 2.0.11 -> 2.0.12
- removed sysmacro patch (is included in 2.0.12)
- update license and homepage
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

