### PR TITLE
navit: svn-5576 -> 0.5.1

### DIFF
--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -1,30 +1,58 @@
-{ stdenv, fetchsvn, pkgconfig, gtk2, SDL, fontconfig, freetype, imlib2, SDL_image, libGLU_combined,
-libXmu, freeglut, python, gettext, quesoglc, gd, postgresql, cmake, qt4, SDL_ttf, fribidi}:
-stdenv.mkDerivation rec {
-  name = "navit-svn-3537";
+{ stdenv, fetchFromGitHub, pkgconfig, gtk2, SDL, fontconfig, freetype, imlib2, SDL_image, libGLU_combined,
+libXmu, freeglut, pcre, dbus-glib, glib, librsvg, freeimage, libxslt,
+qtbase, qtquickcontrols, qtsvg, qtdeclarative, qtlocation, qtsensors, qtmultimedia, qtspeech, espeak,
+cairo, gdk_pixbuf, pango, atk, patchelf, fetchurl, bzip2,
+python, gettext, quesoglc, gd, postgresql, cmake, shapelib, SDL_ttf, fribidi}:
 
-  src = fetchsvn {
-    url = svn://svn.code.sf.net/p/navit/code/trunk/navit;
-    rev = 5576;
-    sha256 = "1xx62l5srfhh9cfi7n3pxj8hpcgr1rpa0hzfmbrqadzv09z36723";
+stdenv.mkDerivation rec {
+  name = "navit-${version}";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "navit-gps";
+    repo = "navit";
+    rev = "v${version}";
+    sha256 = "0jf2gjh2sszr5y5c2wvamfj2qggi2y5k3ynb32pak9vhf5xyl5xj";
   };
 
-  hardeningDisable = [ "format" ];
+  sample_map = fetchurl {
+    url = "http://www.navit-project.org/maps/osm_bbox_11.3,47.9,11.7,48.2.osm.bz2";
+    name = "sample_map.bz2";
+    sha256 = "0vg6b6rhsa2cxqj4rbhfhhfss71syhnfa6f1jg2i2d7l88dm5x7d";
+  };
 
-  buildInputs = [ gtk2 SDL fontconfig freetype imlib2 SDL_image libGLU_combined
-    libXmu freeglut python gettext quesoglc gd postgresql qt4 SDL_ttf fribidi ];
-
-  nativeBuildInputs = [ pkgconfig cmake ];
-
+  #hardeningDisable = [ "format" ];
   NIX_CFLAGS_COMPILE = [ "-I${SDL.dev}/include/SDL" ];
 
-  cmakeFlags = [ "-DSAMPLE_MAP=n" ];
+  # TODO: fix speech options.
+  cmakeFlags = [ "-DSAMPLE_MAP=n " "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-Dsupport/espeak=FALSE" "-Dspeech/qt5_espeak=FALSE" ];
 
-  meta = {
-    homepage = http://www.navit-project.org/;
+  buildInputs = [ gtk2 SDL fontconfig freetype imlib2 SDL_image libGLU_combined freeimage libxslt
+    libXmu freeglut python gettext quesoglc gd postgresql qtbase SDL_ttf fribidi pcre qtquickcontrols
+    espeak qtmultimedia qtspeech qtsensors qtlocation qtdeclarative qtsvg dbus-glib librsvg shapelib glib 
+    cairo gdk_pixbuf pango atk ];
+
+  nativeBuildInputs = [ pkgconfig cmake patchelf bzip2 ];
+
+  # we dont want blank screen by defaut
+  postInstall = ''
+    # emulate DSAMPLE_MAP
+    mkdir -p $out/share/navit/maps/maps
+    bzcat "${sample_map}" | $out/bin/maptool "$out/share/navit/maps/osm_bbox_11.3,47.9,11.7,48.2.bin"
+  '';
+
+  # TODO: fix upstream?
+  postFixup = ''
+    for lib in $(find "$out/lib/navit/" -iname "*.so" ); do
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath buildInputs} $lib
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.navit-project.org;
     description = "Car navigation system with routing engine using OSM maps";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ ];
-    platforms = with stdenv.lib.platforms; linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17684,7 +17684,7 @@ with pkgs;
 
   navipowm = callPackage ../applications/misc/navipowm { };
 
-  navit = callPackage ../applications/misc/navit { };
+  navit = libsForQt5.callPackage ../applications/misc/navit { };
 
   netbeans = callPackage ../applications/editors/netbeans { };
 


### PR DESCRIPTION
###### Motivation for this change

Latest was from svn revision 2013-08-13 . There is still some caveat on that derivation but it should not provide regression of feature (gtk and sdl graphics backend works; some stuff need to be fixed for qt5 and speech).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

