### PR TITLE
texlive: fix fmtutil invocation, generate all formats

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -203,7 +203,7 @@ in buildEnv {
 
     perl `type -P mktexlsr.pl` ./share/texmf
     texlinks.sh "$out/bin" && wrapBin
-    (perl `type -P fmtutil.pl` --sys --refresh || true) | grep '^fmtutil' # too verbose
+    (perl `type -P fmtutil.pl` --sys --all || true) | grep '^fmtutil' # too verbose
     #texlinks.sh "$out/bin" && wrapBin # do we need to regenerate format links?
     perl `type -P updmap.pl` --sys --syncwithtrees --force
     perl `type -P mktexlsr.pl` ./share/texmf-* # to make sure


### PR DESCRIPTION
Since the latest texlive 2017 update (#40826) fmtutil didn't generate all formats when the `texlive.combined.scheme-xxx` packages were built, so they would have to be generated on-demand at runtime and put in the user's `~/.texlive201?`. This has broken some hydra builds  (e.g. `cddlib` because there is no writable `$HOME` in the sandbox, see discussion in #40826 . 

This fix by @dtzWill  (thanks!) applies both to texlive 2017 (current master) and texlive 2018 (#45432). Putting it in a PR to let ofborg check the number of rebuilds.

---

cc @vcunat @timokau 
