### PR TITLE
nixos/firejail: add wrappedPackages option

### DIFF
--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -7,7 +7,6 @@ let
 
   wrappedBins = pkgs.stdenv.mkDerivation rec {
     name = "firejail-wrapped-binaries";
-    nativeBuildInputs = with pkgs; [ makeWrapper ];
     buildCommand = ''
       mkdir -p $out/bin
       ${lib.concatStringsSep "\n" (lib.mapAttrsToList (command: binary: ''
@@ -20,6 +19,25 @@ let
     '';
   };
 
+  wrappedPkgs = map (pkg:
+    pkgs.symlinkJoin {
+      name = "firejail-" + pkg.name;
+      paths = [ pkg ];
+      buildInputs = with pkgs; [ tree ];
+      postBuild = ''
+        for bin in $(find "$out/bin" -type l); do
+        oldbin="$(readlink "$bin")" 
+        rm "$bin"
+        cat <<_EOF >"$bin"
+        #!${pkgs.stdenv.shell} -e
+        /run/wrappers/bin/firejail "$oldbin" "\$@"
+        _EOF
+        chmod 0755 "$bin"
+        done
+      '';
+    }
+  ) cfg.wrappedPackages;
+
 in {
   options.programs.firejail = {
     enable = mkEnableOption "firejail";
@@ -27,6 +45,11 @@ in {
     wrappedBinaries = mkOption {
       type = types.attrs;
       default = {};
+      example = literalExample ''
+        {
+          mpv = "${pkgs.mpv}/bin/mpv";
+        }
+      '';
       description = ''
         Wrap the binaries in firejail and place them in the global path.
         </para>
@@ -36,12 +59,28 @@ in {
         not wrapped if they specify the absolute path to the binary.
       '';
     };
+
+    wrappedPackages = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = literalExample ''
+        [ pkgs.mpv ]
+      '';
+      description = ''
+        Put a package into <option>systemPackages</option>,
+        but wrap its binaries with firejail.
+        Compared to <option>wrappedBinaries</option>,
+        this e.g. has the advantage of providing desktop entries and icons.
+        However, you should be careful about using these packages'
+        libraries as they will not be wrapped.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     security.wrappers.firejail.source = "${lib.getBin pkgs.firejail}/bin/firejail";
 
-    environment.systemPackages = [ wrappedBins ];
+    environment.systemPackages = [ wrappedBins ] ++ wrappedPkgs;
   };
 
   meta.maintainers = with maintainers; [ peterhoeg ];


### PR DESCRIPTION
###### Motivation for this change
Using this, not only the wrapped binaries but also all other directories from the derivations are put into `/run/current-system/sw`. This is useful if you need desktop entries, icons, etc.

My `buildCommand` is certainly far from perfect because I'm not good at programming bash. I'm open for suggestions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg @adisbladis 