### PR TITLE
nixos/znc: More flexible module, cleanups

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -122,6 +122,14 @@
      the Python 2 or 3 version of the package.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      Options
+      <literal>services.znc.confOptions.networks.<replaceable>name</replaceable>.userName</literal> and
+      <literal>services.znc.confOptions.networks.<replaceable>name</replaceable>.modulePackages</literal>
+      were removed. They were never used for anything and can therefore safely be removed.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -634,7 +634,7 @@
   ./services/networking/zerobin.nix
   ./services/networking/zeronet.nix
   ./services/networking/zerotierone.nix
-  ./services/networking/znc.nix
+  ./services/networking/znc/default.nix
   ./services/printing/cupsd.nix
   ./services/scheduling/atd.nix
   ./services/scheduling/chronos.nix

--- a/nixos/modules/services/networking/znc/default.nix
+++ b/nixos/modules/services/networking/znc/default.nix
@@ -1,0 +1,170 @@
+{ config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  cfg = config.services.znc;
+
+  defaultUser = "znc"; # Default user to own process.
+
+  modules = pkgs.buildEnv {
+    name = "znc-modules";
+    paths = cfg.modulePackages;
+  };
+
+in
+
+{
+
+  imports = [
+    ./options.nix
+  ];
+
+  ###### Interface
+
+  options = {
+    services.znc = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable a ZNC service for a user.
+        '';
+      };
+
+      user = mkOption {
+        default = "znc";
+        example = "john";
+        type = types.string;
+        description = ''
+          The name of an existing user account to use to own the ZNC server process.
+          If not specified, a default user will be created to own the process.
+        '';
+      };
+
+      group = mkOption {
+        default = "";
+        example = "users";
+        type = types.string;
+        description = ''
+          Group to own the ZNCserver process.
+        '';
+      };
+
+      dataDir = mkOption {
+        default = "/var/lib/znc/";
+        example = "/home/john/.znc/";
+        type = types.path;
+        description = ''
+          The data directory. Used for configuration files and modules.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open ports in the firewall for ZNC.
+        '';
+      };
+
+      modulePackages = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExample "[ pkgs.zncModules.fish pkgs.zncModules.push ]";
+        description = ''
+          A list of global znc module packages to add to znc.
+        '';
+      };
+
+      mutable = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Indicates whether to allow the contents of the `dataDir` directory to be changed
+          by the user at run-time.
+          If true, modifications to the ZNC configuration after its initial creation are not
+            overwritten by a NixOS system rebuild.
+          If false, the ZNC configuration is rebuilt by every system rebuild.
+          If the user wants to manage the ZNC service using the web admin interface, this value
+            should be set to true.
+        '';
+      };
+
+      extraFlags = mkOption {
+        default = [ ];
+        example = [ "--debug" ];
+        type = types.listOf types.str;
+        description = ''
+          Extra flags to use when executing znc command.
+        '';
+      };
+    };
+  };
+
+
+  ###### Implementation
+
+  config = mkIf cfg.enable {
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ ]; # TODO: Add port
+    };
+
+    systemd.services.znc = {
+      description = "ZNC Server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.service" ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "always";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        ExecStop   = "${pkgs.coreutils}/bin/kill -INT $MAINPID";
+      };
+      preStart = ''
+        ${pkgs.coreutils}/bin/mkdir -p ${cfg.dataDir}/configs
+
+        # If mutable, regenerate conf file every time.
+        ${optionalString (!cfg.mutable) ''
+          ${pkgs.coreutils}/bin/echo "znc is set to be system-managed. Now deleting old znc.conf file to be regenerated."
+          ${pkgs.coreutils}/bin/rm -f ${cfg.dataDir}/configs/znc.conf
+        ''}
+
+        # Ensure essential files exist.
+        if [[ ! -f ${cfg.dataDir}/configs/znc.conf ]]; then
+            ${pkgs.coreutils}/bin/echo "No znc.conf file found in ${cfg.dataDir}. Creating one now."
+            ${pkgs.coreutils}/bin/cp --no-clobber ${/* TODO */"zncConfFile"} ${cfg.dataDir}/configs/znc.conf
+            ${pkgs.coreutils}/bin/chmod u+rw ${cfg.dataDir}/configs/znc.conf
+            ${pkgs.coreutils}/bin/chown ${cfg.user} ${cfg.dataDir}/configs/znc.conf
+        fi
+
+        if [[ ! -f ${cfg.dataDir}/znc.pem ]]; then
+          ${pkgs.coreutils}/bin/echo "No znc.pem file found in ${cfg.dataDir}. Creating one now."
+          ${pkgs.znc}/bin/znc --makepem --datadir ${cfg.dataDir}
+        fi
+
+        # Symlink modules
+        rm ${cfg.dataDir}/modules || true
+        ln -fs ${modules}/lib/znc ${cfg.dataDir}/modules
+      '';
+      script = "${pkgs.znc}/bin/znc --foreground --datadir ${cfg.dataDir} ${toString cfg.extraFlags}";
+    };
+
+    users.users = optional (cfg.user == defaultUser)
+      { name = defaultUser;
+        description = "ZNC server daemon owner";
+        group = defaultUser;
+        uid = config.ids.uids.znc;
+        home = cfg.dataDir;
+        createHome = true;
+      };
+
+    users.groups = optional (cfg.user == defaultUser)
+      { name = defaultUser;
+        gid = config.ids.gids.znc;
+        members = [ defaultUser ];
+      };
+
+  };
+}

--- a/nixos/modules/services/networking/znc/options.nix
+++ b/nixos/modules/services/networking/znc/options.nix
@@ -1,11 +1,10 @@
-{ config, lib, pkgs, ...}:
+{ lib, config, ... }:
 
 with lib;
 
 let
-  cfg = config.services.znc;
 
-  defaultUser = "znc"; # Default user to own process.
+  cfg = config.services.znc;
 
   # Default user and pass:
   # un=znc
@@ -19,11 +18,6 @@ let
                 Salt = l5Xryew4g*!oa(ECfX2o
         </Pass>
   ";
-
-  modules = pkgs.buildEnv {
-    name = "znc-modules";
-    paths = cfg.modulePackages;
-  };
 
   # Keep znc.conf in nix store, then symlink or copy into `dataDir`, depending on `mutable`.
   mkZncConf = confOpts: ''
@@ -70,7 +64,7 @@ let
       else mkZncConf cfg.confOptions;
   };
 
-  networkOpts = { ... }: {
+  networkOpts = {
     options = {
       server = mkOption {
         type = types.str;
@@ -176,49 +170,6 @@ in
 
   options = {
     services.znc = {
-      enable = mkOption {
-        default = false;
-        type = types.bool;
-        description = ''
-          Enable a ZNC service for a user.
-        '';
-      };
-
-      user = mkOption {
-        default = "znc";
-        example = "john";
-        type = types.string;
-        description = ''
-          The name of an existing user account to use to own the ZNC server process.
-          If not specified, a default user will be created to own the process.
-        '';
-      };
-
-      group = mkOption {
-        default = "";
-        example = "users";
-        type = types.string;
-        description = ''
-          Group to own the ZNCserver process.
-        '';
-      };
-
-      dataDir = mkOption {
-        default = "/var/lib/znc/";
-        example = "/home/john/.znc/";
-        type = types.path;
-        description = ''
-          The data directory. Used for configuration files and modules.
-        '';
-      };
-
-      openFirewall = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to open ports in the firewall for ZNC.
-        '';
-      };
 
       zncConf = mkOption {
         default = "";
@@ -230,6 +181,7 @@ in
           If left empty, a conf file with default values will be used.
         '';
       };
+
 
       confOptions = {
         modules = mkOption {
@@ -329,103 +281,6 @@ in
         };
       };
 
-      modulePackages = mkOption {
-        type = types.listOf types.package;
-        default = [ ];
-        example = literalExample "[ pkgs.zncModules.fish pkgs.zncModules.push ]";
-        description = ''
-          A list of global znc module packages to add to znc.
-        '';
-      };
-
-      mutable = mkOption {
-        default = true;
-        type = types.bool;
-        description = ''
-          Indicates whether to allow the contents of the `dataDir` directory to be changed
-          by the user at run-time.
-          If true, modifications to the ZNC configuration after its initial creation are not
-            overwritten by a NixOS system rebuild.
-          If false, the ZNC configuration is rebuilt by every system rebuild.
-          If the user wants to manage the ZNC service using the web admin interface, this value
-            should be set to true.
-        '';
-      };
-
-      extraFlags = mkOption {
-        default = [ ];
-        example = [ "--debug" ];
-        type = types.listOf types.str;
-        description = ''
-          Extra flags to use when executing znc command.
-        '';
-      };
     };
-  };
-
-
-  ###### Implementation
-
-  config = mkIf cfg.enable {
-
-    networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.confOptions.port ];
-    };
-
-    systemd.services.znc = {
-      description = "ZNC Server";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.service" ];
-      serviceConfig = {
-        User = cfg.user;
-        Group = cfg.group;
-        Restart = "always";
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-        ExecStop   = "${pkgs.coreutils}/bin/kill -INT $MAINPID";
-      };
-      preStart = ''
-        ${pkgs.coreutils}/bin/mkdir -p ${cfg.dataDir}/configs
-
-        # If mutable, regenerate conf file every time.
-        ${optionalString (!cfg.mutable) ''
-          ${pkgs.coreutils}/bin/echo "znc is set to be system-managed. Now deleting old znc.conf file to be regenerated."
-          ${pkgs.coreutils}/bin/rm -f ${cfg.dataDir}/configs/znc.conf
-        ''}
-
-        # Ensure essential files exist.
-        if [[ ! -f ${cfg.dataDir}/configs/znc.conf ]]; then
-            ${pkgs.coreutils}/bin/echo "No znc.conf file found in ${cfg.dataDir}. Creating one now."
-            ${pkgs.coreutils}/bin/cp --no-clobber ${zncConfFile} ${cfg.dataDir}/configs/znc.conf
-            ${pkgs.coreutils}/bin/chmod u+rw ${cfg.dataDir}/configs/znc.conf
-            ${pkgs.coreutils}/bin/chown ${cfg.user} ${cfg.dataDir}/configs/znc.conf
-        fi
-
-        if [[ ! -f ${cfg.dataDir}/znc.pem ]]; then
-          ${pkgs.coreutils}/bin/echo "No znc.pem file found in ${cfg.dataDir}. Creating one now."
-          ${pkgs.znc}/bin/znc --makepem --datadir ${cfg.dataDir}
-        fi
-
-        # Symlink modules
-        rm ${cfg.dataDir}/modules || true
-        ln -fs ${modules}/lib/znc ${cfg.dataDir}/modules
-      '';
-      script = "${pkgs.znc}/bin/znc --foreground --datadir ${cfg.dataDir} ${toString cfg.extraFlags}";
-    };
-
-    users.users = optional (cfg.user == defaultUser)
-      { name = defaultUser;
-        description = "ZNC server daemon owner";
-        group = defaultUser;
-        uid = config.ids.uids.znc;
-        home = cfg.dataDir;
-        createHome = true;
-      };
-
-    users.groups = optional (cfg.user == defaultUser)
-      { name = defaultUser;
-        gid = config.ids.gids.znc;
-        members = [ defaultUser ];
-      };
-
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This is the follow up on https://github.com/NixOS/nixpkgs/pull/41467, which I needed to clean up for a while, and I finally did it.

This adds a new option `services.znc.config`, which can represent the full ZNC configuration as a Nix value, see its description for more info. It's much more flexible than the older `services.znc.confOptions.*` options. It allows the user to override previously fixed values and to set options that the module system might not know about, as it happens on every ZNC upgrade.

Because this new option doesn't know about all valid ZNC options however, it can't do any checks for it to be correct. This doesn't have an easy solution unfortunately. It will generate a syntactically valid file though.

Other changes:
- Clean up everything, remove unused options

It's now possible to:
- Have multiple users
- Set channels as detached
- Define QuitMsg
- And everything else that wasn't previously possible

The new config option will get converted into the xml-like syntax znc expects, works with all config values, see https://wiki.znc.in/Configuration. This is what one could look like:
```nix
services.znc.useLegacyConfig = false;
services.znc.config = {
  # Listener.l.Port = 5000; <- This is added by default
  LoadModule = [ "webadmin" "adminlog" ];
  User.paul = {
    Admin = true;
    Nick = "paul";
    AltNick = "paul1";
    LoadModule = [ "chansaver" "controlpanel" ];
    Network.freenode = {
      Server = "chat.freenode.net +6697";
      LoadModule = [ "simple_away" ];
      Chan = {
        "#nixos" = { Detached = false; };
        "##linux" = { Disabled = true; };
      };
    };
    Pass.password = {
      Method = "sha256";
      Hash = "e2ce303c7ea75c571d80d8540a8699b46535be6a085be3414947d638e48d9e93";
      Salt = "l5Xryew4g*!oa(ECfX2o";
    };
  };
}
```

To see the current config, you can either inspect it via `nix-instantiate`:
```
$ nix-instantiate --eval --strict '<nixpkgs/nixos>' -A config.services.znc.config
{ Listener = { l = { IPv4 = true; IPv6 = true; Port = 5000; SSL = true; }; }; LoadModule = [ "webadmin" "adminlog" ]; User = { znc = { Admin = true; AltNick = "znc-user_"; Ident = "znc-user"; LoadModule = [ "chansaver" "controlpanel" ]; Network = { freenode = { Chan = { }; LoadModule = [ "simple_away" ]; Server = "test +6697 "; extraConfig = null; }; }; Nick = "znc-user"; RealName = "znc-user"; extraConfig = [ "<Pass password>\n     Method = sha256\n     Hash = e2ce303c7ea75c571d80d8540a8699b46535be6a085be3414947d638e48d9e93\n     Salt = l5Xryew4g*!oa(ECfX2o\n</Pass>\n" ]; }; }; Version = "1.7.1"; }
```

Or directly build the config file and look at that:
```
$ nix-build '<nixpkgs/nixos>' -A config.services.znc.configFile
/nix/store/330zxcdjai2ciw3risy9iqymnda46i2i-znc-generated.conf
```

Unless you disable the new option `services.znc.useLegacyConfig`, the values in `services.znc.confOptions.*` will also have influence on `services.znc.config`, such as a default list of modules, default user, etc. This isn't problematic, the new `config` options handles merging without trouble.
###### Things done

Ping @nocoolnametom @viric @schneefux @LnL7 

Review commit by commit

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

