### PR TITLE
webtorrent-desktop: fix .desktop Path entries

### DIFF
--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -73,7 +73,7 @@
 
       # Fix the desktop link
       substituteInPlace $out/share/applications/webtorrent-desktop.desktop \
-        --replace /opt/webtorrent-desktop/WebTorrent $out/bin/WebTorrent
+        --replace /opt/webtorrent-desktop $out/bin
     '';
 
     meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes the `Path=/opt/webtorrent-desktop` entries [here](https://github.com/webtorrent/webtorrent-desktop/blob/41511c56153b878b0dd39b2adac9525fb66fb35c/static/linux/share/applications/webtorrent-desktop.desktop#L11-L13) -- presently these prevent users from launching the application using the `.desktop` entry.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

