### PR TITLE
ocamlPackages.piqi{,-ocaml}: fix build with OCaml 4.06

### DIFF
--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocaml, findlib, piqi, camlp4 }:
+{ stdenv, fetchurl, fetchpatch, ocaml, findlib, piqi, camlp4 }:
 
 stdenv.mkDerivation rec {
   version = "0.7.5";
@@ -8,6 +8,11 @@ stdenv.mkDerivation rec {
     url = "https://github.com/alavrik/piqi-ocaml/archive/v${version}.tar.gz";
     sha256 = "0ngz6y8i98i5v2ma8nk6mc83pdsmf2z0ks7m3xi6clfg3zqbddrv";
   };
+
+  patches = [ (fetchpatch {
+    url = https://github.com/alavrik/piqi-ocaml/commit/336e8fdb84e77f4105e9bbb5ab545b8729101308.patch;
+    sha256 = "071s4xjyr6xx95v6az2lbl2igc87n7z5jqnnbhfq2pidrxakd0la";
+  })];
 
   buildInputs = [ ocaml findlib piqi camlp4 ];
 

--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ocaml, findlib, camlp4, which, ulex, easy-format, ocaml_optcomp, xmlm, base64}:
+{ stdenv, fetchurl, ocaml, findlib, which, ulex, easy-format, ocaml_optcomp, xmlm, base64 }:
 
 stdenv.mkDerivation rec {
   version = "0.6.13";
@@ -9,10 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1whqr2bb3gds2zmrzqnv8vqka9928w4lx6mi6g244kmbwb2h8d8l";
   };
 
-  buildInputs = [ocaml findlib camlp4 which ocaml_optcomp];
+  buildInputs = [ ocaml findlib which ocaml_optcomp ];
   propagatedBuildInputs = [ulex xmlm easy-format base64];
 
-  patches = [ ./no-ocamlpath-override.patch ];
+  patches = [ ./no-ocamlpath-override.patch ./safe-string.patch ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/piqi/safe-string.patch
+++ b/pkgs/development/ocaml-modules/piqi/safe-string.patch
@@ -1,0 +1,13 @@
+--- a/piqilib/piqi_json_parser.mll
++++ b/piqilib/piqi_json_parser.mll
+@@ -189,8 +189,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+     let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in
+     let s = lexbuf.lex_buffer in
+     let start = lexbuf.lex_start_pos in
+-    check_adjust_utf8 v lexbuf s start len;
+-    Buffer.add_substring v.buf s start len
++    check_adjust_utf8 v lexbuf (Bytes.unsafe_to_string s) start len;
++    Buffer.add_subbytes v.buf s start len
+ 
+   let map_lexeme f lexbuf =
+     let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.06.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

