### PR TITLE
flightgear: 2017.3.1 -> 2018.2.2 

### DIFF
--- a/pkgs/development/libraries/simgear/default.nix
+++ b/pkgs/development/libraries/simgear/default.nix
@@ -1,9 +1,20 @@
-{ stdenv, fetchurl, plib, freeglut, xproto, libX11, libXext, xextproto, libXi
+{ stdenv, fetchurl, fetchFromGitHub, plib, freeglut, xproto, libX11, libXext, xextproto, libXi
 , inputproto, libICE, libSM, libXt, libXmu, libGLU_combined, boost, zlib, libjpeg, freealut
 , openscenegraph, openal, expat, cmake, apr
 , curl
 }:
 
+let
+  openscenegraph-git = openscenegraph.overrideAttrs (oldAttrs: {
+    name = "openscenegraph-3.4.1";
+    src = fetchFromGitHub {
+      owner = "openscenegraph";
+      repo = "OpenSceneGraph";
+      rev = "OpenSceneGraph-3.4.1";
+      sha256 = "1fbzg1ihjpxk6smlq80p3h3ggllbr16ihd2fxpfwzam8yr8yxip9";
+    };
+  });
+in
 stdenv.mkDerivation rec {
   name = "simgear-${version}";
   version = "2017.3.1";
@@ -16,7 +27,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ plib freeglut xproto libX11 libXext xextproto libXi inputproto
                   libICE libSM libXt libXmu libGLU_combined boost zlib libjpeg freealut
-                  openscenegraph openal expat cmake apr curl ];
+                  openscenegraph-git openal expat cmake apr curl ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/simgear/default.nix
+++ b/pkgs/development/libraries/simgear/default.nix
@@ -17,12 +17,12 @@ let
 in
 stdenv.mkDerivation rec {
   name = "simgear-${version}";
-  version = "2017.3.1";
-  shortVersion = "2017.3";
+  version = "2018.2.2";
+  shortVersion = "2018.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${name}.tar.bz2";
-    sha256 = "1x71wvycs2bjgmmacswgk6091p65p46fr40mr7f4kcipnx88bq0f";
+    sha256 = "1r8w2pcm415mqiqqlsy00hv7d5p3rvqrsx2l04snzqxa6sy7c5gn";
   };
 
   buildInputs = [ plib freeglut xproto libX11 libXext xextproto libXi inputproto

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -6,14 +6,14 @@
 }:
 
 let
-  version = "2017.3.1";
-  shortVersion = "2017.3";
+  version = "2018.2.2";
+  shortVersion = "2018.2";
   data = stdenv.mkDerivation rec {
     name = "flightgear-base-${version}";
 
     src = fetchurl {
       url = "mirror://sourceforge/flightgear/release-${shortVersion}/FlightGear-${version}-data.tar.bz2";
-      sha256 = "166q0fsbp17lx1l1n6i8cfk3d1i79pasz1liya09z6m2i1pb026z";
+      sha256 = "1i0a81a01zpksagwjxiphr3pl7q5vnkcrxns52kyvdrwrzj996y8";
     };
 
     phases = [ "installPhase" ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${name}.tar.bz2";
-    sha256 = "1kccf91vmxnzyki6grx09s10dvr4j6qrz34ikj7jn81g5scisbkg";
+    sha256 = "0iw1f58nf9hbbnan2iy7d9d1plqkagnq7i7hav8hhs9z1bphky31";
   };
 
   # Of all the files in the source and data archives, there doesn't seem to be


### PR DESCRIPTION
###### Motivation for this change

Updating flightgear.

Building the old version of flightgear - 2017.3.1 - also needs the first commit, as https://github.com/NixOS/nixpkgs/commit/0624e4939d5491257d78b187c3009309c6cc793f breaks the build on master.

Sadly, while building fine, I get a segfault when running the fgfs binary on a 18.03 NixOS system when building on master. :/ When cherry picked to 18.03 it works though.

- [X]  Find out why it segfaults Edit: `glxinfo` segfaults as well... So it seems to be a more general problem
- [x]  Test patch against stable channel, maybe there is an issue with the master branch in general **EDIT:** Yep, works fine, when cherry-picking the three commits on channel/18.03. Has anyone an idea what's up with that?

Would supersede https://github.com/NixOS/nixpkgs/pull/38891  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

