### PR TITLE
elixir: Fix minimum OTP version

### DIFF
--- a/pkgs/development/interpreters/elixir/1.6.nix
+++ b/pkgs/development/interpreters/elixir/1.6.nix
@@ -3,5 +3,5 @@
 mkDerivation rec {
   version = "1.6.5";
   sha256 = "0il1fraz6c8qbqv4wrp16jqrkf3xglfa9f3sdm6q4vv8kjf3lxxb";
-  minimumOTPVersion = "18";
+  minimumOTPVersion = "19";
 }

--- a/pkgs/development/interpreters/elixir/1.7.nix
+++ b/pkgs/development/interpreters/elixir/1.7.nix
@@ -3,5 +3,5 @@
 mkDerivation rec {
   version = "1.7.2";
   sha256 = "0wnrx6wlpmr23ypm8za0c4dl952nj4rjylcsdzz0xrma92ylrqfq";
-  minimumOTPVersion = "18";
+  minimumOTPVersion = "19";
 }


### PR DESCRIPTION
###### Motivation for this change

According to the [official Elixir documentation](https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp), Elixir 1.6 and 1.7 need OTP 19 at minimum. The variable `minimumOTPVersion` was set to `18` for both `elixir_1_6` and `elixir_1_7`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

