### PR TITLE
wt: 3.3.10 -> 3.3.11, 4.0.3 -> 4.0.4

### DIFF
--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -43,8 +43,8 @@ let
     };
 in {
   wt3 = generic {
-    version = "3.3.10";
-    sha256 = "1y25mhghgbgjgycpny0x4z95xn98q0wraab1c5gkwnay097bgwdy";
+    version = "3.3.11";
+    sha256 = "1s1bwg3s7brnspr9ya1vg5mr29dbvhf05s606fiv409b7ladqvxq";
   };
 
   wt4 = generic {

--- a/pkgs/development/libraries/wt/default.nix
+++ b/pkgs/development/libraries/wt/default.nix
@@ -48,7 +48,7 @@ in {
   };
 
   wt4 = generic {
-    version = "4.0.3";
-    sha256 = "01xch5dkpcanwhr515236wa9mdmnq2a2j13dn7smyhwzqgbpknsg";
+    version = "4.0.4";
+    sha256 = "17kq9fxc0xqx7q7kyryiph3mg0d3hnd3jw0rl55zvzfsdd71220w";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
New patch releases for [wt3](https://github.com/emweb/wt/releases/tag/3.3.11) and [wt4](https://github.com/emweb/wt/releases/tag/4.0.4)

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- N/A Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

