### PR TITLE
faustlive: init at 2017-12-05

### DIFF
--- a/pkgs/applications/audio/faust/faustlive.nix
+++ b/pkgs/applications/audio/faust/faustlive.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub
+, llvm, qt48Full, libqrencode, libmicrohttpd, libjack2, alsaLib, faust, curl
+, bc, coreutils, which
+}:
+
+stdenv.mkDerivation rec {
+  name = "faustlive-${version}";
+  version = "2017-12-05";
+  src = fetchFromGitHub {
+    owner = "grame-cncm";
+    repo = "faustlive";
+    rev = "281fcb852dcd94f8c57ade1b2a7a3937542e1b2d";
+    sha256 = "0sw44yd9928rid9ib0b5mx2x129m7zljrayfm6jz6hrwdc5q3k9a";
+  };
+
+  buildInputs = [
+    llvm qt48Full libqrencode libmicrohttpd libjack2 alsaLib faust curl
+    bc coreutils which
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preBuild = "patchShebangs Build/Linux/buildversion";
+
+  meta = with stdenv.lib; {
+    description = "A standalone just-in-time Faust compiler";
+    longDescription = ''
+      FaustLive is a standalone just-in-time Faust compiler. It tries to bring
+      together the convenience of a standalone interpreted language with the
+      efficiency of a compiled language. It's ideal for fast prototyping.
+    '';
+    homepage = http://faust.grame.fr/;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21345,6 +21345,8 @@ with pkgs;
 
   faust2lv2 = callPackage ../applications/audio/faust/faust2lv2.nix { };
 
+  faustlive = callPackage ../applications/audio/faust/faustlive.nix { };
+
   fceux = callPackage ../misc/emulators/fceux { };
 
   flockit = callPackage ../tools/backup/flockit { };


### PR DESCRIPTION
###### Motivation for this change
Added FaustLive package for fast prototyping with FAUST programming language

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

