### PR TITLE
usb-storage -> uas

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -318,7 +318,7 @@ in
         options = [ "allow_other" "cow" "nonempty" "chroot=/mnt-root" "max_files=32768" "hide_meta_files" "dirs=/nix/.rw-store=rw:/nix/.ro-store=ro" ];
       };
 
-    boot.initrd.availableKernelModules = [ "squashfs" "iso9660" "usb-storage" "uas" ];
+    boot.initrd.availableKernelModules = [ "squashfs" "iso9660" "uas" ];
 
     boot.blacklistedKernelModules = [ "nouveau" ];
 

--- a/nixos/modules/profiles/all-hardware.nix
+++ b/nixos/modules/profiles/all-hardware.nix
@@ -33,7 +33,7 @@
 
       # USB support, especially for booting from USB CD-ROM
       # drives.
-      "usb_storage"
+      "uas"
 
       # Firewire support.  Not tested.
       "ohci1394" "sbp2"


### PR DESCRIPTION
Following up https://github.com/NixOS/nixpkgs/pull/23665

Bootable USB-drives are not limited to ISO-images, there can be "normal" MBR/GPT-partitioned disk connected via USB-rack.
Also, "uas" implies "usb-storage", so there is no need to mention both.
