### PR TITLE
pass: Fix dependencies on Darwin

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, pkgs, fetchurl, buildEnv
-, coreutils, gnused, getopt, git, tree, gnupg, which, procps, qrencode
-, makeWrapper
+, coreutils, gnused, getopt, git, tree, gnupg, openssl, which, procps
+, qrencode , makeWrapper
 
 , xclip ? null, xdotool ? null, dmenu ? null
 , x11Support ? !stdenv.isDarwin
@@ -66,7 +66,8 @@ let
       which
       qrencode
       procps
-    ] ++ ifEnable x11Support [ dmenu xclip xdotool ]);
+    ] ++ optional stdenv.isDarwin openssl
+      ++ ifEnable x11Support [ dmenu xclip xdotool ]);
 
     postFixup = ''
       # Link extensions env
@@ -97,6 +98,9 @@ let
              -e 's@^GPGS=.*''$@GPG=${gnupg}/bin/gpg2@' \
              -e '/which gpg/ d' \
         tests/setup.sh
+    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+      # 'pass edit' uses hdid, which is not available from the sandbox.
+      rm -f tests/t0200-edit-tests.sh
     '';
 
     doCheck = false;


### PR DESCRIPTION
password-store on Darwin does not pass unit tests in sandboxed
builds:

- 'openssl base64' is used on Darwin to compute base64. Add openssl
  to the environment of pass.
- t0200-edit-tests.sh tests 'pass edit', which uses hdid on Darwin.
  However hdid is not available in the sandbox.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

