### PR TITLE
pythonPackages.pex: 1.2.7 -> 1.4.5

### DIFF
--- a/pkgs/development/python-modules/pex/default.nix
+++ b/pkgs/development/python-modules/pex/default.nix
@@ -1,4 +1,4 @@
-{lib, buildPythonPackage, fetchPypi, setuptools, wheel, pytest}:
+{lib, buildPythonPackage, fetchPypi, setuptools, wheel, requests, pytest}:
 
 buildPythonPackage rec {
   name = "pex-${version}";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     inherit version;
   };
 
-  propagatedBuildInputs = [ setuptools wheel ];
+  propagatedBuildInputs = [ setuptools wheel requests ];
   checkInputs = [ pytest ];
 
   prePatch = ''

--- a/pkgs/development/python-modules/pex/default.nix
+++ b/pkgs/development/python-modules/pex/default.nix
@@ -1,21 +1,23 @@
-{lib, buildPythonPackage, fetchPypi}:
+{lib, buildPythonPackage, fetchPypi, setuptools, wheel, pytest}:
 
 buildPythonPackage rec {
   name = "pex-${version}";
-  version = "1.2.7";
+  version = "1.4.5";
 
   src = fetchPypi {
     pname  = "pex";
-    sha256 = "1m0gx9182w1dybkyjwwjyd6i87x2dzv252ks2fj8yn6avlcp5z4q";
+    sha256 = "04s9qvx87ngfs3m91qsrmk0ll16s0ldrvlxjbg4y1ic4bgsjq3hj";
     inherit version;
   };
 
+  propagatedBuildInputs = [ setuptools wheel ];
+  checkInputs = [ pytest ];
+
   prePatch = ''
-    substituteInPlace setup.py --replace 'SETUPTOOLS_REQUIREMENT,' '"setuptools"'
+    substituteInPlace setup.py --replace 'SETUPTOOLS_REQUIREMENT,' '"setuptools",'
+    substituteInPlace setup.py --replace 'WHEEL_REQUIREMENT,' '"wheel",'
   '';
 
-  # A few more dependencies I don't want to handle right now...
-  doCheck = false;
 
   meta = {
     description = "A library and tool for generating .pex (Python EXecutable) files";

--- a/pkgs/development/python-modules/pex/default.nix
+++ b/pkgs/development/python-modules/pex/default.nix
@@ -18,6 +18,7 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace 'WHEEL_REQUIREMENT,' '"wheel",'
   '';
 
+  patches = [ ./set-source-date-epoch.patch ];
 
   meta = {
     description = "A library and tool for generating .pex (Python EXecutable) files";

--- a/pkgs/development/python-modules/pex/default.nix
+++ b/pkgs/development/python-modules/pex/default.nix
@@ -1,0 +1,26 @@
+{lib, buildPythonPackage, fetchPypi}:
+
+buildPythonPackage rec {
+  name = "pex-${version}";
+  version = "1.2.7";
+
+  src = fetchPypi {
+    pname  = "pex";
+    sha256 = "1m0gx9182w1dybkyjwwjyd6i87x2dzv252ks2fj8yn6avlcp5z4q";
+    inherit version;
+  };
+
+  prePatch = ''
+    substituteInPlace setup.py --replace 'SETUPTOOLS_REQUIREMENT,' '"setuptools"'
+  '';
+
+  # A few more dependencies I don't want to handle right now...
+  doCheck = false;
+
+  meta = {
+    description = "A library and tool for generating .pex (Python EXecutable) files";
+    homepage = "https://github.com/pantsbuild/pex";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ copumpkin ];
+  };
+}

--- a/pkgs/development/python-modules/pex/set-source-date-epoch.patch
+++ b/pkgs/development/python-modules/pex/set-source-date-epoch.patch
@@ -1,0 +1,15 @@
+--- a/pex/interpreter.py	2018-07-30 12:06:51.000000000 +0200
++++ b/pex/interpreter.py	2018-07-30 12:06:40.000000000 +0200
+@@ -451,6 +451,12 @@
+     # installation of 2.7 breaks.
+     env_copy = os.environ.copy()
+     env_copy.pop('MACOSX_DEPLOYMENT_TARGET', None)
++    # Tell bdist_wheel to use a date of 1980 for files added to
++    # wheels. This is to avoid "ValueError: ZIP does not support
++    # timestamps before 1980" when pex calls bdist_wheel on sources
++    # from /nix/store. See:
++    # https://nixos.org/nixpkgs/manual/#python-setup.py-bdist_wheel-cannot-create-.whl
++    env_copy['SOURCE_DATE_EPOCH'] = '315532800'
+     return env_copy
+ 
+   @classmethod

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3707,30 +3707,7 @@ in {
     };
   };
 
-  pex = buildPythonPackage rec {
-    name = "pex-${version}";
-    version = "1.2.7";
-
-    src = self.fetchPypi {
-      pname  = "pex";
-      sha256 = "1m0gx9182w1dybkyjwwjyd6i87x2dzv252ks2fj8yn6avlcp5z4q";
-      inherit version;
-    };
-
-    prePatch = ''
-      substituteInPlace setup.py --replace 'SETUPTOOLS_REQUIREMENT,' '"setuptools"'
-    '';
-
-    # A few more dependencies I don't want to handle right now...
-    doCheck = false;
-
-    meta = {
-      description = "A library and tool for generating .pex (Python EXecutable) files";
-      homepage = "https://github.com/pantsbuild/pex";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ copumpkin ];
-    };
-  };
+  pex = callPackage ../development/python-modules/pex { };
 
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 


### PR DESCRIPTION
###### Motivation for this change

This packages a new version of pex and moves it to a top-level tool, similarly to how Pipenv is packaged.

I'm not sure what the impact is of the move from `pkgs/top-level/python-packages.nix` to `pkgs/top-level/all-packages.nix`, but since pex is more of a command line tool than a Python library, the change makes sense to me :-) Please advice if this is bad for some reason or if there is followup work to be done!

The packaging was tested locally on a MacOS machine and a Ubuntu VM. The packaging was also executed on a Hydra installation with the sandbox enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

