### PR TITLE
postman: 6.1.4 -> 6.2.5

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "postman-${version}";
-  version = "6.1.4";
+  version = "6.2.5";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "2f93a860f87d842c0e0433b55cd7c46e04d1d20c0adcae8680332585dffd86eb";
+    sha256 = "9fd52b4c4ac744d3c70f28e39dbfeda3d03a8640c562e82e3744c2f9d0f8ade1";
     name = "${name}.tar.gz";
   };
 


### PR DESCRIPTION

###### Motivation for this change
I needed some configuration value available in newest version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

