### PR TITLE
treewide: remove mailing list references

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ See the nixpkgs manual for more details on [standard meta-attributes](https://ni
 
 ## Writing good commit messages
 
-In addition to writing properly formatted commit messages, it's important to include relevant information so other developers can later understand *why* a change was made. While this information usually can be found by digging code, mailing list archives, pull request discussions or upstream changes, it may require a lot of work.
+In addition to writing properly formatted commit messages, it's important to include relevant information so other developers can later understand *why* a change was made. While this information usually can be found by digging code, mailing list/Discourse archives, pull request discussions or upstream changes, it may require a lot of work.
 
 For package version upgrades and such a one-line commit message is usually sufficient.
 

--- a/README.md
+++ b/README.md
@@ -38,5 +38,4 @@ For pull-requests, please rebase onto nixpkgs `master`.
 Communication:
 
 * [Discourse Forum](https://discourse.nixos.org/)
-* [Mailing list](https://groups.google.com/forum/#!forum/nix-devel)
 * [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)

--- a/doc/reviewing-contributions.xml
+++ b/doc/reviewing-contributions.xml
@@ -605,10 +605,11 @@ policy.
 -->
 
   <para>
-   In a case a contributor leaves definitively the Nix community, he should
-   create an issue or notify the mailing list with references of packages and
-   modules he maintains so the maintainership can be taken over by other
-   contributors.
+   In a case a contributor leaves definitively the Nix community, he
+   should create an issue or post on <link
+   xlink:href="https://discourse.nixos.org">Discourse</link> with
+   references of packages and modules he maintains so the
+   maintainership can be taken over by other contributors.
   </para>
  </section>
 </chapter>

--- a/nixos/doc/manual/manual.xml
+++ b/nixos/doc/manual/manual.xml
@@ -17,8 +17,8 @@
   <para>
    If you encounter problems, please report them on the
    <literal
-    xlink:href="https://groups.google.com/forum/#!forum/nix-devel">nix-devel</literal>
-   mailing list or on the <link
+    xlink:href="https://discourse.nixos.org">Discourse</literal>
+   or on the <link
     xlink:href="irc://irc.freenode.net/#nixos">
    <literal>#nixos</literal> channel on Freenode</link>. Bugs should be
    reported in


### PR DESCRIPTION
###### Motivation for this change

We are no longer using the mailing list.

cc @zimbatm 