### PR TITLE
qtcreator: apply patch on aarch64

### DIFF
--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake makeWrapper ];
 
-  patches = optional stdenv.hostPlatform.isArm ./0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch;
+  patches = optional (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) ./0001-Fix-Allow-qt-creator-to-build-on-arm-aarch32-and-aar.patch;
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change
There was a mistake in https://github.com/NixOS/nixpkgs/pull/45312 which meant that the patch wasn't applied on aarch64, only on arm (aarch32).

###### Things done
added isAarch64 to the relevant expression

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @vcunat @akaWolf 
---
