### PR TITLE
spl: use correct version to fix binary substitution

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -10,11 +10,12 @@ assert kernel != null;
 
 stdenv.mkDerivation rec {
   name = "spl-${version}-${kernel.version}";
+  version = "0.7.9";
 
   src = fetchFromGitHub {
     owner = "zfsonlinux";
     repo = "spl";
-    rev = "spl-0.7.9";
+    rev = "spl-${version}";
     sha256 = "0540m1dv9jvrzk9kw61glg0h0cwj976mr9zb42y3nh17k47ywff0";
   };
 


### PR DESCRIPTION
###### Motivation for this change

During the recent refactoring of SPL, the version attribute was mistakenly removed, causing SPL to inherit a `version` attribute from somewhere in the nixpkgs lib. This version is included in the derivation name, and since it differs between Hydra (`18.09pre-git`) and normal NixOS machines (something like `18.09pre149424.ce522e4ad27`), the SPL is not substituted from the binary cache. Also it should be fixed because this version has nothing to do with SPL.

###### Things done

This PR adds a correct version attribute to the derivation.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

