### PR TITLE
Bumping mono to 5.4.1.6 for Emby package

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono46, ffmpeg, ... }:
+{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono54, ffmpeg, ... }:
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
   propagatedBuildInputs = with pkgs; [
-    mono46
+    mono54
     sqlite
   ];
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp -r * $out/bin
 
-    makeWrapper "${mono46}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
+    makeWrapper "${mono54}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
       --add-flags "$out/bin/MediaBrowser.Server.Mono.exe -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Following a discussion on [emby forums](https://emby.media/community/index.php?/topic/61935-cant-download-subtitles-systemiofilenotfoundexception) that I started because I had a bunch of stack trace in current unstable emby, one of the admin has mentioned that the current valid mono version is 5.4.

This PR is just doing that: switching to mono 5.4.

Also, I'm very new to Nixos, still digging in the documentation, but I was able to build this correctly and tested on my personal server, so I assume it's working.

I'll check all the "things to do" mentioned below later to check as much as possible.

Thanks !

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

