### PR TITLE
pythonPackages.libkeepass: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/libkeepass/default.nix
+++ b/pkgs/development/python-modules/libkeepass/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, lxml, pycryptodome, colorama }:
+
+buildPythonPackage rec {
+  pname = "libkeepass";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3ed79ea786f7020b14b83c082612ed8fbcc6f8edf65e1697705837ab9e40e9d7";
+  };
+
+  propagatedBuildInputs = [ lxml pycryptodome colorama ];
+
+  # No tests on PyPI
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/libkeepass/libkeepass;
+    description = "A library to access KeePass 1.x/KeePassX (v3) and KeePass 2.x (v4) files";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ jqueiroz ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6927,6 +6927,8 @@ in {
     inherit (pkgs.linuxPackages) nvidia_x11;
   };
 
+  libkeepass = callPackage ../development/python-modules/libkeepass { };
+
   librepo = toPythonModule (pkgs.librepo.override {
     inherit python;
   });


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

