### PR TITLE
pg_top: do not use docbook for longDescription

### DIFF
--- a/pkgs/tools/misc/pg_top/default.nix
+++ b/pkgs/tools/misc/pg_top/default.nix
@@ -14,13 +14,11 @@ stdenv.mkDerivation rec {
     description = "A 'top' like tool for PostgreSQL";
     longDescription = '' 
       pg_top allows you to: 
-      <itemizedlist>
-        <listitem>View currently running SQL statement of a process.</listitem>
-        <listitem>View query plan of a currently running SQL statement.</listitem>
-        <listitem>View locks held by a process.</listitem>
-        <listitem>View user table statistics.</listitem>
-        <listitem>View user index statistics.</listitem>
-      </itemizedlist>
+       * View currently running SQL statement of a process.
+       * View query plan of a currently running SQL statement.
+       * View locks held by a process.
+       * View user table statistics.
+       * View user index statistics.
     '';
 
     homepage = http://ptop.projects.postgresql.org/;


### PR DESCRIPTION
###### Motivation for this change

DocBook is not rendered in `longDescription`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

