### PR TITLE
pythonPackages.bjoern: init at 2.2.2

### DIFF
--- a/pkgs/development/python-modules/bjoern/default.nix
+++ b/pkgs/development/python-modules/bjoern/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, libev, python }:
+
+buildPythonPackage rec {
+  pname = "bjoern";
+  version = "2.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1w5z9agacci4shmkg9gh46ifj2a724rrgbykdv14830f7jq3dcmi";
+  };
+
+  buildInputs = [ libev ];
+
+  checkPhase = ''
+    ${python.interpreter} tests/keep-alive-behaviour.py 2>/dev/null
+    ${python.interpreter} tests/test_wsgi_compliance.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jonashaag/bjoern;
+    description = "A screamingly fast Python 2/3 WSGI server written in C";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17233,6 +17233,8 @@ EOF
 
   black = callPackage ../development/python-modules/black { };
 
+  bjoern = callPackage ../development/python-modules/bjoern { };
+
   autobahn = callPackage ../development/python-modules/autobahn { };
 
   jsonref = callPackage ../development/python-modules/jsonref { };


### PR DESCRIPTION
###### Motivation for this change

Added bjoern. A screaming fast WSGI server!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

