### PR TITLE
certmgr: Add patch for optional trust of self-signed certificates at remote cfssl apiserver

### DIFF
--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -30,12 +30,19 @@ let
 
   preStart = ''
     ${concatStringsSep " \\\n" (["mkdir -p"] ++ map escapeShellArg specPaths)}
-    ${pkgs.certmgr}/bin/certmgr -f ${certmgrYaml} check
+    ${cfg.package}/bin/certmgr -f ${certmgrYaml} check
   '';
 in
 {
   options.services.certmgr = {
     enable = mkEnableOption "certmgr";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.certmgr;
+      defaultText = "pkgs.certmgr";
+      description = "Which certmgr package to use in the service.";
+    };
 
     defaultRemote = mkOption {
       type = types.str;
@@ -187,7 +194,7 @@ in
       serviceConfig = {
         Restart = "always";
         RestartSec = "10s";
-        ExecStart = "${pkgs.certmgr}/bin/certmgr -f ${certmgrYaml}";
+        ExecStart = "${cfg.package}/bin/certmgr -f ${certmgrYaml}";
       };
     };
   };

--- a/pkgs/tools/security/certmgr/default.nix
+++ b/pkgs/tools/security/certmgr/default.nix
@@ -1,33 +1,43 @@
 { stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
-buildGoPackage rec {
-  version = "1.6.1";
-  name = "certmgr-${version}";
+let
+  generic = { patches ? [] }:
+    buildGoPackage rec {
+      version = "1.6.1";
+      name = "certmgr-${version}";
 
-  goPackagePath = "github.com/cloudflare/certmgr/";
+      goPackagePath = "github.com/cloudflare/certmgr/";
 
-  src = fetchFromGitHub {
-    owner = "cloudflare";
-    repo = "certmgr";
-    rev = "v${version}";
-    sha256 = "1ky2pw1wxrb2fxfygg50h0mid5l023x6xz9zj5754a023d01qqr2";
-  };
+      src = fetchFromGitHub {
+        owner = "cloudflare";
+        repo = "certmgr";
+        rev = "v${version}";
+        sha256 = "1ky2pw1wxrb2fxfygg50h0mid5l023x6xz9zj5754a023d01qqr2";
+      };
 
-  # The following patch makes it possible to use a self-signed x509 cert
-  # for the cfssl apiserver.
-  # TODO: remove patch when PR is merged.
-  patches = [
-    (fetchpatch {
-      url    = "https://github.com/cloudflare/certmgr/pull/51.patch";
-      sha256 = "0jhsw159d2mgybvbbn6pmvj4yqr5cwcal5fjwkcn9m4f4zlb6qrs";
-    })
-  ];
+      inherit patches;
 
-  meta = with stdenv.lib; {
-    homepage = https://cfssl.org/;
-    description = "Cloudflare's certificate manager";
-    platforms = platforms.linux;
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ johanot srhb ];
+      meta = with stdenv.lib; {
+        homepage = https://cfssl.org/;
+        description = "Cloudflare's certificate manager";
+        platforms = platforms.linux;
+        license = licenses.bsd2;
+        maintainers = with maintainers; [ johanot srhb ];
+      };
+    };
+in
+{
+  certmgr = generic {};
+
+  certmgr-selfsigned = generic {
+    # The following patch makes it possible to use a self-signed x509 cert
+    # for the cfssl apiserver.
+    # TODO: remove patch when PR is merged.
+    patches = [
+      (fetchpatch {
+        url    = "https://github.com/cloudflare/certmgr/pull/51.patch";
+        sha256 = "0jhsw159d2mgybvbbn6pmvj4yqr5cwcal5fjwkcn9m4f4zlb6qrs";
+      })
+    ];
   };
 }

--- a/pkgs/tools/security/certmgr/default.nix
+++ b/pkgs/tools/security/certmgr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
 buildGoPackage rec {
   version = "1.6.1";
@@ -12,6 +12,16 @@ buildGoPackage rec {
     rev = "v${version}";
     sha256 = "1ky2pw1wxrb2fxfygg50h0mid5l023x6xz9zj5754a023d01qqr2";
   };
+
+  # The following patch makes it possible to use a self-signed x509 cert
+  # for the cfssl apiserver.
+  # TODO: remove patch when PR is merged.
+  patches = [
+    (fetchpatch {
+      url    = "https://github.com/cloudflare/certmgr/pull/51.patch";
+      sha256 = "0jhsw159d2mgybvbbn6pmvj4yqr5cwcal5fjwkcn9m4f4zlb6qrs";
+    })
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://cfssl.org/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1877,7 +1877,8 @@ in
   };
   ceph-dev = ceph;
 
-  certmgr = callPackage ../tools/security/certmgr { };
+  inherit (callPackages ../tools/security/certmgr { })
+    certmgr certmgr-selfsigned;
 
   cfdg = callPackage ../tools/graphics/cfdg {
     ffmpeg = ffmpeg_2;


### PR DESCRIPTION
###### Motivation for this change

Without this patch, it is not possible to use a self-signed certificate for a remote cfssl server without certmgr rejecting the cert as untrusted. 

This patch allows for the user to configure (optionally) a trusted CA-cert as part of any certmgr cert-spec.

See also: https://github.com/cloudflare/certmgr/pull/51

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
