### PR TITLE
openjdk10: add darwin support

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/10.nix
+++ b/pkgs/development/compilers/openjdk/darwin/10.nix
@@ -1,0 +1,59 @@
+{ stdenv, fetchurl, unzip, setJavaClassPath, freetype }:
+let
+  jce-policies = fetchurl {
+    # Ugh, unversioned URLs... I hope this doesn't change often enough to cause pain before we move to a Darwin source build of OpenJDK!
+    url    = "http://cdn.azul.com/zcek/bin/ZuluJCEPolicies.zip";
+    sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
+  };
+
+  jdk = stdenv.mkDerivation {
+    name = "zulu10.1+11-jdk10";
+
+    src = fetchurl {
+      url = "https://cdn.azul.com/zulu/bin/zulu10.1+11-jdk10-macosx_x64.zip";
+      sha256 = "1c5ib136nv6gz7ij31mg15nhzrl6zr7kp8spm17zwm1ib82bc73y";
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
+    };
+
+    buildInputs = [ unzip freetype ];
+
+    installPhase = ''
+      mkdir -p $out
+      mv * $out
+
+      unzip ${jce-policies}
+      mv -f ZuluJCEPolicies/*.jar $out/lib/security/
+
+      # jni.h expects jni_md.h to be in the header search path.
+      ln -s $out/include/darwin/*_md.h $out/include/
+
+      if [ -f $out/LICENSE ]; then
+        install -D $out/LICENSE $out/share/zulu/LICENSE
+        rm $out/LICENSE
+      fi
+    '';
+
+    preFixup = ''
+      # Propagate the setJavaClassPath setup hook from the JRE so that
+      # any package that depends on the JRE has $CLASSPATH set up
+      # properly.
+      mkdir -p $out/nix-support
+      printWords ${setJavaClassPath} > $out/nix-support/propagated-build-inputs
+
+      install_name_tool -change /usr/X11/lib/libfreetype.6.dylib ${freetype}/lib/libfreetype.6.dylib $out/lib/libfontmanager.dylib
+
+      # Set JAVA_HOME automatically.
+      cat <<EOF >> $out/nix-support/setup-hook
+      if [ -z "\$JAVA_HOME" ]; then export JAVA_HOME=$out; fi
+      EOF
+    '';
+
+    passthru = {
+      jre = jdk;
+      home = jdk;
+    };
+
+    meta.platforms = stdenv.lib.platforms.darwin;
+
+  };
+in jdk

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6793,6 +6793,9 @@ with pkgs;
       };
 
   openjdk10 =
+    if stdenv.isDarwin then
+      callPackage ../development/compilers/openjdk/darwin/10.nix { }
+    else
       callPackage ../development/compilers/openjdk/10.nix {
         inherit (gnome2) GConf gnome_vfs;
       };


### PR DESCRIPTION
###### Motivation for this change

Copied from the jdk8 derivation and adjusted for jdk10: https://github.com/NixOS/nixpkgs/blob/beaa0984c63f6e93a9ddfae18c70d39602e90cca/pkgs/development/compilers/openjdk/darwin/8.nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
