### PR TITLE
mbrola: init at 3.0.1h

### DIFF
--- a/pkgs/applications/audio/espeak-ng/mbrola-paths.patch
+++ b/pkgs/applications/audio/espeak-ng/mbrola-paths.patch
@@ -1,0 +1,22 @@
+--- a/src/libespeak-ng/mbrowrap.c
++++ b/src/libespeak-ng/mbrowrap.c
+@@ -205,7 +205,7 @@
+ 		signal(SIGTERM, SIG_IGN);
+ 
+ 		snprintf(charbuf, sizeof(charbuf), "%g", mbr_volume);
+-		execlp("mbrola", "mbrola", "-e", "-v", charbuf,
++		execlp("@mbrola@/bin/mbrola", "mbrola", "-e", "-v", charbuf,
+ 		       voice_path, "-", "-.wav", (char *)NULL);
+ 		/* if execution reaches this point then the exec() failed */
+ 		snprintf(mbr_errorbuf, sizeof(mbr_errorbuf),
+--- a/src/libespeak-ng/synth_mbrola.c
++++ b/src/libespeak-ng/synth_mbrola.c
+@@ -85,7 +85,7 @@
+ 	if (!load_MBR())
+ 		return ENS_MBROLA_NOT_FOUND;
+ 
+-	sprintf(path, "%s/mbrola/%s", path_home, mbrola_voice);
++	sprintf(path, "@mbrola@/share/mbrola/voices/%s/%s", mbrola_voice, mbrola_voice);
+ #ifdef PLATFORM_POSIX
+ 	// if not found, then also look in
+ 	//   usr/share/mbrola/xx, /usr/share/mbrola/xx/xx, /usr/share/mbrola/voices/xx

--- a/pkgs/applications/misc/mbrola/default.nix
+++ b/pkgs/applications/misc/mbrola/default.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
 
 	buildInputs = [ unzip ];
 	nativeBuildInputs = [ patchelf makeWrapper gcc_multi ];
-	propagatedBuildInputs = [ bash ];
 	
 	postUnpack = ''
 

--- a/pkgs/applications/misc/mbrola/default.nix
+++ b/pkgs/applications/misc/mbrola/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, unzip, bash, patchelf, stdenv_32bit, makeWrapper, gcc_multi }:
 
 let
-	TCTS="https://tcts.fpms.ac.be/synthesis/mbrola";
+	TCTS = "https://tcts.fpms.ac.be/synthesis/mbrola";
 
 	# debian provides manpage and libstrongexit.so
 	# read https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=856331;msg=5
@@ -11,20 +11,20 @@ let
 	};
 
 	binaries = rec {
-	      i686-linux = fetchurl  {
-		    url = "${TCTS}/bin/pclinux/mbr301h.zip";
-		    sha256 = "0vlxb2jpvps4nbgm9dfglik0973bf4fpr0v8rrpj08y8jynjyh6z";
-	      };
-	      x86_64-linux = i686-linux; # mbrola_AMD_Linux.zip is outofdate, we have to use 32bits
-	      powerpc-linux = i686-linux;
-    };
+		i686-linux = fetchurl  {
+			url = "${TCTS}/bin/pclinux/mbr301h.zip";
+			sha256 = "0vlxb2jpvps4nbgm9dfglik0973bf4fpr0v8rrpj08y8jynjyh6z";
+		};
+		x86_64-linux = i686-linux; # mbrola_AMD_Linux.zip is broken, we have to use 32bits
+		powerpc-linux = i686-linux;
+	};
 
-    voicefr1 = fetchurl {
+	voicefr1 = fetchurl {
 		url = "${TCTS}/dba/fr1/fr1-990204.zip";
 		sha256 = "0c9qza71l6in4c6rgl5pqhy7x4as9fcfyb6sxqy3rxaf547w7d4f";
 	};
 
-    voicefr2 = fetchurl {
+	voicefr2 = fetchurl {
 		url = "${TCTS}/dba/fr2/fr2-980806.zip";
 		sha256 = "01qk4wq20gap1inj43igy1llg3rq685vdgrvsflhvl3fcxhn70rv";
 	};
@@ -32,51 +32,51 @@ in
 
 stdenv.mkDerivation rec {
 
-	pname = "mbrola";
-	name = "${pname}-${version}";
-	version = "3.0.1h";
-	
-	src = deb;
-	binary = binaries."${stdenv.system}" or (throw "unsupported system: ${stdenv.system}");
+pname = "mbrola";
+name = "${pname}-${version}";
+version = "3.0.1h";
 
-	buildInputs = [ unzip ];
-	nativeBuildInputs = [ patchelf makeWrapper gcc_multi ];
-	
-	postUnpack = ''
+src = deb;
+binary = binaries."${stdenv.system}" or (throw "unsupported system: ${stdenv.system}");
 
-		pushd $sourceRoot
-		unzip ${binary}
-		unzip ${voicefr1} 
-		unzip ${voicefr2}
-		popd
-	'';
+buildInputs = [ unzip ];
+nativeBuildInputs = [ patchelf makeWrapper gcc_multi ];
 
-	buildPhase = ''
-		case "${stdenv.system}" in
-			i686*)
-				cp mbrola-linux-i386 mbrola
-				;;
-			x86_64*)
-				cp mbrola-linux-i386 mbrola
-				gcc -m32 strongexit/strongexit.c -o libstrongexit.so -shared -fPIC
-				patchelf --set-interpreter                            \
-			        ${stdenv_32bit.cc.libc.out}/lib/32/ld-linux.so.2  \
-			        mbrola
-				;;
-			powerpc*)
-				cp mbrola302b-linux-ppc mbrola
-				;;
-			sparc)
-				cp mbrola-SuSElinux-ultra1.dat mbrola
-				;;
-			alpha)
-				cp mbrola-linux-alpha mbrola
-				;;
-			*)
-				echo "mbrola binary not available on this architecture."
-				exit 1
-		esac
-	'';
+postUnpack = ''
+
+	pushd $sourceRoot
+	unzip ${binary}
+	unzip ${voicefr1}
+	unzip ${voicefr2}
+	popd
+'';
+
+buildPhase = ''
+	case "${stdenv.system}" in
+		i686*)
+			cp mbrola-linux-i386 mbrola
+			;;
+		x86_64*)
+			cp mbrola-linux-i386 mbrola
+			gcc -m32 strongexit/strongexit.c -o libstrongexit.so -shared -fPIC
+			patchelf --set-interpreter                            \
+			${stdenv_32bit.cc.libc.out}/lib/32/ld-linux.so.2  \
+			mbrola
+		;;
+		powerpc*)
+			cp mbrola302b-linux-ppc mbrola
+		;;
+		sparc)
+			cp mbrola-SuSElinux-ultra1.dat mbrola
+		;;
+		alpha)
+			cp mbrola-linux-alpha mbrola
+		;;
+		*)
+			echo "mbrola binary not available on this architecture."
+			exit 1
+	esac
+'';
 
 	installPhase = ''
 		mkdir -p $out/{bin,share/mbrola/voices}
@@ -88,10 +88,10 @@ stdenv.mkDerivation rec {
 		mkdir -p $out/lib/
 		cp libstrongexit.so $out/lib/
 		wrapProgram $out/bin/mbrola \
-			--prefix LD_PRELOAD : "$out/lib/libstrongexit.so"
+		--prefix LD_PRELOAD : "$out/lib/libstrongexit.so"
 
 		for voice in ??[0-9]; do
-			cp -a $voice $out/share/mbrola/voices
+		cp -a $voice $out/share/mbrola/voices
 		done
 	'';
 

--- a/pkgs/applications/misc/mbrola/default.nix
+++ b/pkgs/applications/misc/mbrola/default.nix
@@ -1,0 +1,106 @@
+{ stdenv, fetchurl, unzip, bash, patchelf, stdenv_32bit, makeWrapper, gcc_multi }:
+
+let
+	TCTS="https://tcts.fpms.ac.be/synthesis/mbrola";
+
+	# debian provides manpage and libstrongexit.so
+	# read https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=856331;msg=5
+	deb = fetchurl {
+		url = "http://http.debian.net/debian/pool/non-free/m/mbrola/mbrola_3.01h+2-3.debian.tar.xz";
+		sha256 = "16m99l5xscq20vishdk4y9svsmzfdw3f54ifjdhikgpsw2blbnq0";
+	};
+
+	binaries = rec {
+	      i686-linux = fetchurl  {
+		    url = "${TCTS}/bin/pclinux/mbr301h.zip";
+		    sha256 = "0vlxb2jpvps4nbgm9dfglik0973bf4fpr0v8rrpj08y8jynjyh6z";
+	      };
+	      x86_64-linux = i686-linux; # mbrola_AMD_Linux.zip is outofdate, we have to use 32bits
+	      powerpc-linux = i686-linux;
+    };
+
+    voicefr1 = fetchurl {
+		url = "${TCTS}/dba/fr1/fr1-990204.zip";
+		sha256 = "0c9qza71l6in4c6rgl5pqhy7x4as9fcfyb6sxqy3rxaf547w7d4f";
+	};
+
+    voicefr2 = fetchurl {
+		url = "${TCTS}/dba/fr2/fr2-980806.zip";
+		sha256 = "01qk4wq20gap1inj43igy1llg3rq685vdgrvsflhvl3fcxhn70rv";
+	};
+in
+
+stdenv.mkDerivation rec {
+
+	pname = "mbrola";
+	name = "${pname}-${version}";
+	version = "3.0.1h";
+	
+	src = deb;
+	binary = binaries."${stdenv.system}" or (throw "unsupported system: ${stdenv.system}");
+
+	buildInputs = [ unzip ];
+	nativeBuildInputs = [ patchelf makeWrapper gcc_multi ];
+	propagatedBuildInputs = [ bash ];
+	
+	postUnpack = ''
+
+		pushd $sourceRoot
+		unzip ${binary}
+		unzip ${voicefr1} 
+		unzip ${voicefr2}
+		popd
+	'';
+
+	buildPhase = ''
+		case "${stdenv.system}" in
+			i686*)
+				cp mbrola-linux-i386 mbrola
+				;;
+			x86_64*)
+				cp mbrola-linux-i386 mbrola
+				gcc -m32 strongexit/strongexit.c -o libstrongexit.so -shared -fPIC
+				patchelf --set-interpreter                            \
+			        ${stdenv_32bit.cc.libc.out}/lib/32/ld-linux.so.2  \
+			        mbrola
+				;;
+			powerpc*)
+				cp mbrola302b-linux-ppc mbrola
+				;;
+			sparc)
+				cp mbrola-SuSElinux-ultra1.dat mbrola
+				;;
+			alpha)
+				cp mbrola-linux-alpha mbrola
+				;;
+			*)
+				echo "mbrola binary not available on this architecture."
+				exit 1
+		esac
+	'';
+
+	installPhase = ''
+		mkdir -p $out/{bin,share/mbrola/voices}
+		cp mbrola $out/bin/mbrola
+
+		mkdir -p $out/share/man/man1
+		cp mbrola.1 $out/share/man/man1
+
+		mkdir -p $out/lib/
+		cp libstrongexit.so $out/lib/
+		wrapProgram $out/bin/mbrola \
+			--prefix LD_PRELOAD : "$out/lib/libstrongexit.so"
+
+		for voice in ??[0-9]; do
+			cp -a $voice $out/share/mbrola/voices
+		done
+	'';
+
+	meta = with stdenv.lib; {
+		homepage = https://tcts.fpms.ac.be/synthesis/mbrola.html;
+		description = "Speech synthesizer based on the concatenation of diphones";
+		license = licenses.unfree; #MBROLA
+		maintainers = [ maintainers.genesis ];
+		platforms = [ "x86_64-linux" ];
+	};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8401,6 +8401,8 @@ with pkgs;
   maven = maven3;
   maven3 = callPackage ../development/tools/build-managers/apache-maven { };
 
+  mbrola = callPackage ../applications/misc/mbrola { };
+  
   go-md2man = callPackage ../development/tools/misc/md2man {};
 
   minify = callPackage ../development/web/minify { };


### PR DESCRIPTION
###### Motivation for this change

old abandonneware, but still relevant for good tts. Lot of stuff to make it works!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

