### PR TITLE
nixos/tests/wordpress: fix test

### DIFF
--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -18,9 +18,6 @@ import ./make-test.nix ({ pkgs, ... }:
             enable = true;
             logPerVirtualHost = true;
             adminAddr="js@lastlog.de";
-            extraModules = [
-              { name = "php7"; path = "${pkgs.php}/modules/libphp7.so"; }
-            ];
 
             virtualHosts = [
               {
@@ -30,7 +27,7 @@ import ./make-test.nix ({ pkgs, ... }:
                     {
                       serviceType = "wordpress";
                       dbPassword = "wordpress";
-                      wordpressUploads = "/data/uploads";
+                      dbHost = "127.0.0.1";
                       languages = [ "de_DE" "en_GB" ];
                     }
                   ];


### PR DESCRIPTION
###### Motivation for this change

Test was broken on [hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.wordpress.x86_64-linux/all).

- explicitly add dbHost to fix test
- while at it, remove unnecessary options that the wordpress module sets by default anyway

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

