### PR TITLE
udftools: 1.0.0b3 -> 2.0

### DIFF
--- a/pkgs/tools/filesystems/udftools/default.nix
+++ b/pkgs/tools/filesystems/udftools/default.nix
@@ -1,14 +1,17 @@
-{ stdenv, fetchurl, ncurses, readline }:
+{ stdenv, fetchFromGitHub, ncurses, readline, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "udftools-${version}";
-  version = "1.0.0b3";
-  src = fetchurl {
-    url = "mirror://sourceforge/linux-udf/udftools/${version}/${name}.tar.gz";
-    sha256 = "180414z7jblby64556i8p24rcaas937zwnyp1zg073jdin3rw1y5";
+  version = "2.0";
+  src = fetchFromGitHub {
+    owner = "pali";
+    repo = "udftools";
+    rev = "${version}";
+    sha256 = "0mz04h3rki6ljwfs15z83gf4vv816w7xgz923waiqgmfj9xpvx87";
   };
 
   buildInputs = [ ncurses readline ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   hardeningDisable = [ "fortify" ];
 
@@ -21,6 +24,12 @@ stdenv.mkDerivation rec {
     sed -e '38i#include <string.h>' -i wrudf/wrudf-cdrw.c
     sed -e '12i#include <string.h>' -i wrudf/wrudf-cdr.c
     sed -e '37i#include <stdlib.h>' -i wrudf/ide-pc.c
+
+    sed -e "s@\$(DESTDIR)/lib/udev/rules.d@$out/lib/udev/rules.d@" -i pktsetup/Makefile.am
+  '';
+
+  postFixup = ''
+    sed -i -e "s@/usr/sbin/pktsetup@$out/sbin/pktsetup@" $out/lib/udev/rules.d/80-pktsetup.rules
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
This path also migrates to the github repo.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

