### PR TITLE
davmail: 4.8.0 -> 4.8.6

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,17 +1,19 @@
-{ fetchurl, stdenv, jre, glib, libXtst, gtk2, makeWrapper }:
+{ fetchurl, stdenv, jre, glib, libXtst, gtk2, makeWrapper, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "davmail-4.8.0";
+  name = "davmail-4.8.6";
   src = fetchurl {
-    url = "mirror://sourceforge/davmail/4.8.0/davmail-linux-x86_64-4.8.0-2479.tgz";
-    sha256 = "0e650c4a060d64fd2b270ddb00baa906aac617865d5e60c9f526a281cdb27b62";
+    url = "mirror://sourceforge/davmail/4.8.6/davmail-4.8.6-2600.zip";
+    sha256 = "1wk4jxb46qlyipxj57flqadgm4mih243rhqq9sp9m5pifjqrw9dp";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeWrapper unzip ];
 
   installPhase = ''
     mkdir -p $out/share/davmail
-    cp -R ./* $out/share/davmail
+    cp -vR ./* $out/share/davmail
     makeWrapper $out/share/davmail/davmail.sh $out/bin/davmail \
       --prefix PATH : ${jre}/bin \
       --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

