### PR TITLE
clickhouse: 18.5.1 -> 18.10.3

### DIFF
--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -1,31 +1,32 @@
 { stdenv, fetchFromGitHub, cmake, libtool
 , boost, capnproto, cctz, clang-unwrapped, double-conversion, gperftools, icu
 , libcpuid, libxml2, lld, llvm, lz4 , mysql, openssl, poco, re2, rdkafka
-, readline, sparsehash, unixODBC, zstd, ninja
+, readline, sparsehash, unixODBC, zstd, ninja, jemalloc
 }:
 
 stdenv.mkDerivation rec {
   name = "clickhouse-${version}";
-  version = "18.5.1";
+  version = "18.10.3";
 
   src = fetchFromGitHub {
     owner  = "yandex";
     repo   = "ClickHouse";
     rev    = "v${version}-stable";
-    sha256 = "1bw1hx3ssd1jcg6jj85nmp6dnyhvaaphjpcr6x4xs410k140qx31";
+    sha256 = "1fm7jh9cxalvlic6pw58gblisvmvb6j0jzf3vr8p6cv7iw9238sp";
   };
 
   nativeBuildInputs = [ cmake libtool ninja ];
   buildInputs = [
     boost capnproto cctz clang-unwrapped double-conversion gperftools icu
     libcpuid libxml2 lld llvm lz4 mysql.connector-c openssl poco re2 rdkafka
-    readline sparsehash unixODBC zstd
+    readline sparsehash unixODBC zstd jemalloc
   ];
 
   cmakeFlags = [
     "-DENABLE_TESTS=OFF"
     "-DUNBUNDLED=ON"
     "-DUSE_STATIC_LIBRARIES=OFF"
+    "-DUSE_INTERNAL_SSL_LIBRARY=False"
   ];
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

