### PR TITLE
nftables: enable works in linux kernel 4.17 and 4.18

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -146,6 +146,14 @@ let
 
       # needed for iwd WPS support (wpa_supplicant replacement)
       KEY_DH_OPERATIONS = whenAtLeast "4.7" yes;
+
+      # needed for nftables
+      NF_TABLES_INET              = whenAtLeast "4.17" yes;
+      NF_TABLES_NETDEV            = whenAtLeast "4.17" yes;
+      NF_TABLES_IPV4              = whenAtLeast "4.17" yes;
+      NF_TABLES_ARP               = whenAtLeast "4.17" yes;
+      NF_TABLES_IPV6              = whenAtLeast "4.17" yes;
+      NF_TABLES_BRIDGE            = whenAtLeast "4.17" yes;
     };
 
     wireless = {


### PR DESCRIPTION
###### Motivation for this change
Enable works nftables in linux kernel 4.17 and 4.18
See https://github.com/NixOS/nixpkgs/issues/45483
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

