### PR TITLE
minijail: android-8.0.0_r34 -> android-9.0.0_r3

### DIFF
--- a/pkgs/tools/system/minijail/default.nix
+++ b/pkgs/tools/system/minijail/default.nix
@@ -3,12 +3,12 @@
 stdenv.mkDerivation rec {
   shortname = "minijail";
   name = "${shortname}-${version}";
-  version = "android-8.0.0_r34";
+  version = "android-9.0.0_r3";
 
   src = fetchgit {
     url = "https://android.googlesource.com/platform/external/minijail";
     rev = version;
-    sha256 = "1d0q08cgks6h6ffsw3zw8dz4rm9y2djj2pwwy3xi6flx7vwy0psf";
+    sha256 = "1g1g52s3q61amcnx8cv1332sbixpck1bmjzgsrjiw5ix7chrzkp2";
   };
 
   buildInputs = [ libcap ];


### PR DESCRIPTION


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).