### PR TITLE
nixos/tests/matrix-synapse: fix test

### DIFF
--- a/nixos/tests/matrix-synapse.nix
+++ b/nixos/tests/matrix-synapse.nix
@@ -6,12 +6,13 @@ import ./make-test.nix ({ pkgs, ... } : {
   };
 
   nodes = {
-    server_postgres = args: {
+    # Since 0.33.0, matrix-synapse doesn't allow underscores in server names
+    serverpostgres = args: {
       services.matrix-synapse.enable = true;
       services.matrix-synapse.database_type = "psycopg2";
     };
 
-    server_sqlite = args: {
+    serversqlite = args: {
       services.matrix-synapse.enable = true;
       services.matrix-synapse.database_type = "sqlite3";
     };
@@ -19,12 +20,12 @@ import ./make-test.nix ({ pkgs, ... } : {
 
   testScript = ''
     startAll;
-    $server_postgres->waitForUnit("matrix-synapse.service");
-    $server_postgres->waitUntilSucceeds("curl -Lk https://localhost:8448/");
-    $server_postgres->requireActiveUnit("postgresql.service");
-    $server_sqlite->waitForUnit("matrix-synapse.service");
-    $server_sqlite->waitUntilSucceeds("curl -Lk https://localhost:8448/");
-    $server_sqlite->mustSucceed("[ -e /var/lib/matrix-synapse/homeserver.db ]");
+    $serverpostgres->waitForUnit("matrix-synapse.service");
+    $serverpostgres->waitUntilSucceeds("curl -Lk https://localhost:8448/");
+    $serverpostgres->requireActiveUnit("postgresql.service");
+    $serversqlite->waitForUnit("matrix-synapse.service");
+    $serversqlite->waitUntilSucceeds("curl -Lk https://localhost:8448/");
+    $serversqlite->mustSucceed("[ -e /var/lib/matrix-synapse/homeserver.db ]");
   '';
 
 })


### PR DESCRIPTION
###### Motivation for this change

Since `matrix-synapse` was upgraded to 0.33.0,  underscores in server names are rejected by server name validation, causing the test to [fail on hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.matrix-synapse.x86_64-linux/all):
`valueError: Server name 'server_sqlite' contains invalid characters`
Relevant upstream change: https://github.com/matrix-org/synapse/commit/546bc9e28b3d7758c732df8e120639d58d455164

Not sure if this is an upstream bug or a deliberate decision, filed https://github.com/matrix-org/synapse/issues/3759 to check.

Anyway, we can just fix the tests by using server names without underscores.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
---

