### PR TITLE
pam_ldap,nss_ldap: fix build

### DIFF
--- a/pkgs/os-specific/linux/nss_ldap/default.nix
+++ b/pkgs/os-specific/linux/nss_ldap/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation {
   preConfigure = ''
     patchShebangs ./vers_string
     sed -i s,vers_string,./vers_string, Makefile*
+    substituteInPlace vers_string --replace "cvslib.pl" "./cvslib.pl"
   '';
 
   patches = [ ./crashes.patch ];

--- a/pkgs/os-specific/linux/pam_ldap/default.nix
+++ b/pkgs/os-specific/linux/pam_ldap/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs ./vers_string
+    substituteInPlace vers_string --replace "cvslib.pl" "./cvslib.pl"
   '';
 
   preInstall = "


### PR DESCRIPTION
###### Motivation for this change

Builds failed for [nss_ldap](https://hydra.nixos.org/job/nixpkgs/trunk/nss_ldap.x86_64-linux) and [pam_ldap](https://hydra.nixos.org/job/nixpkgs/trunk/pam_ldap.x86_64-linux).

An upstream perl script needed during build wasn't found, fix path

This also fixes the nixos/tests/ldap test.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

