### PR TITLE
apmplanner2: fixed wrong path in .desktop file

### DIFF
--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -23,8 +23,12 @@ stdenv.mkDerivation rec {
   qmakeFlags = [ "apm_planner.pro" ];
 
   # this ugly hack is necessary, as `bin/apmplanner2` needs the contents of `share/APMPlanner2` inside of `bin/`
-  preFixup = "ln --relative --symbolic $out/share/APMPlanner2/* $out/bin/";
-
+  preFixup = ''
+    ln --relative --symbolic $out/share/APMPlanner2/* $out/bin/
+    substituteInPlace $out/share/applications/apmplanner2.desktop \
+                      --replace /usr $out
+  '';
+  
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION


###### Motivation for this change

The `apmplanner2.desktop` file defaults to `/usr/share/...` regardless which out
prefix is given to make. So I chose to fix it manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

