### PR TITLE
mesos: fix build

### DIFF
--- a/pkgs/applications/networking/cluster/mesos/default.nix
+++ b/pkgs/applications/networking/cluster/mesos/default.nix
@@ -4,6 +4,7 @@
 , leveldb, glog, perf, utillinux, libnl, iproute, openssl, libevent
 , ethtool, coreutils, which, iptables, maven
 , bash, autoreconfHook
+, utf8proc, lz4
 , withJava ? !stdenv.isDarwin
 }:
 
@@ -50,6 +51,7 @@ in stdenv.mkDerivation rec {
     makeWrapper curl sasl
     python wrapPython boto setuptools leveldb
     subversion apr glog openssl libevent
+    utf8proc lz4
   ] ++ lib.optionals stdenv.isLinux [
     libnl
   ] ++ lib.optionals withJava [


### PR DESCRIPTION
###### Motivation for this change

Build was [broken](https://hydra.nixos.org/job/nixpkgs/trunk/mesos.x86_64-linux) due to missing dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

