### PR TITLE
nixos/tests/munin: fix non-deterministic failure

### DIFF
--- a/nixos/tests/munin.nix
+++ b/nixos/tests/munin.nix
@@ -12,16 +12,23 @@ import ./make-test.nix ({ pkgs, ...} : {
       { config, ... }:
         {
           services = {
-           munin-node.enable = true;
-           munin-cron = {
+           munin-node = {
              enable = true;
-             hosts = ''
-               [${config.networking.hostName}]
-               address localhost
+             # disable a failing plugin to prevent irrelevant error message, see #23049
+             extraConfig = ''
+               ignore_file ^apc_nis$
              '';
            };
+           munin-cron = {
+            enable = true;
+            hosts = ''
+              [${config.networking.hostName}]
+              address localhost
+            '';
+           };
           };
-          systemd.services.munin-node.serviceConfig.TimeoutStartSec = "3min";
+          # long timeout to prevent hydra failure on high load
+          systemd.services.munin-node.serviceConfig.TimeoutStartSec = "10min";
         };
     };
 
@@ -29,7 +36,10 @@ import ./make-test.nix ({ pkgs, ...} : {
     startAll;
 
     $one->waitForUnit("munin-node.service");
+    # make sure the node is actually listening
+    $one->waitForOpenPort(4949);
     $one->succeed('systemctl start munin-cron');
+    # wait for munin-cron output
     $one->waitForFile("/var/lib/munin/one/one-uptime-uptime-g.rrd");
     $one->waitForFile("/var/www/munin/one/index.html");
   '';


### PR DESCRIPTION
###### Motivation for this change

The test failed (non-deterministically) on [hydra](https://hydra.nixos.org/build/80234566) due to a timing issue: the node wasn't listening yet when `munin-cron` service was started.

To make the test more reliable:

- wait for node to listen on its port before starting munin-cron
- increase timeout for munin-cron startup to prevent failure under high load
- disable a failing plugin to remove irrelevant error messages

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

