### PR TITLE
xkbd: init at 0.8.18

### DIFF
--- a/pkgs/applications/misc/xkbd/default.nix
+++ b/pkgs/applications/misc/xkbd/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, freetype, libXrender, libXft, xextproto
+, xinput, libXi, libXext, libXtst, libXpm, libX11, xproto, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  name = "xkbd-${version}";
+  version = "0.8.18";
+
+  src = fetchFromGitHub {
+    owner = "mahatma-kaganovich";
+    repo = "xkbd";
+    rev = name;
+    sha256 = "05ry6q75jq545kf6p20nhfywaqf2wdkfiyp6iwdpv9jh238hf7m9";
+  };
+
+  buildInputs = [
+    freetype libXrender libXft libXext libXtst libXpm libX11
+    libXi xextproto xinput xproto
+  ];
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mahatma-kaganovich/xkbd;
+    description = "onscreen soft keyboard for X11";
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1456,6 +1456,8 @@ with pkgs;
 
   onboard = callPackage ../applications/misc/onboard { };
 
+  xkbd = callPackage ../applications/misc/xkbd { };
+
   optar = callPackage ../tools/graphics/optar {};
 
   patdiff = callPackage ../tools/misc/patdiff { };


### PR DESCRIPTION
###### Motivation for this change

i need this to fix onscreen in navit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

