### PR TITLE
extract_url: init at 1.6.2

### DIFF
--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ PodChecker makeWrapper ];
-  propagatedBuildInputs = [ perl ] ++ perlDeps;
+  buildInputs = [ perl ] ++ perlDeps;
 
   makeFlags = "prefix=$(out)";
 

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -24,8 +24,8 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ PodChecker makeWrapper ];
   buildInputs = [ perl ] ++ perlDeps;
 
-  makeFlags = "prefix=$(out)";
-  installFlags = "INSTALL=install";
+  makeFlags = [ "prefix=$(out)" ];
+  installFlags = [ "INSTALL=install" ];
 
   postFixup = ''
     wrapProgram "$out/bin/extract_url" \

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -19,6 +19,10 @@ in stdenv.mkDerivation rec {
 
   makeFlags = "prefix=$(out)";
 
+  postPatch = ''
+    substituteInPlace Makefile --replace /usr/bin/install install
+  '';
+
   postFixup = ''
     wrapProgram "$out/bin/extract_url" \
       --set PERL5LIB "${lib.makeFullPerlPath perlDeps}"

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://www.memoryhole.net/~kyle/extract_url/";
+    homepage = https://www.memoryhole.net/~kyle/extract_url/;
     description = "Extracts URLs from MIME messages or plain text";
     license = licenses.bsd2;
     maintainers = [ maintainers.qyliss ];

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, perl
-, PodChecker, MIMEtools, HTMLParser
+, MIMEtools, HTMLParser
 , cursesSupport ? true, CursesUI
 , uriFindSupport ? true, URIFind
 }:
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
     sha256 = "05589lp15jmcpbj4y9a3hmf6n2gsqrm4ybcyh3hd4j6pc7hmnhny";
   };
 
-  nativeBuildInputs = [ PodChecker makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ perl ] ++ perlDeps;
 
   makeFlags = [ "prefix=$(out)" ];

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -14,6 +14,13 @@ in stdenv.mkDerivation rec {
   name = "extract_url-${version}";
   version = "1.6.2";
 
+  src = fetchFromGitHub {
+    owner = "m3m0ryh0l3";
+    repo = "extracturl";
+    rev = "v${version}";
+    sha256 = "05589lp15jmcpbj4y9a3hmf6n2gsqrm4ybcyh3hd4j6pc7hmnhny";
+  };
+
   nativeBuildInputs = [ PodChecker makeWrapper ];
   propagatedBuildInputs = [ perl ] ++ perlDeps;
 
@@ -27,13 +34,6 @@ in stdenv.mkDerivation rec {
     wrapProgram "$out/bin/extract_url" \
       --set PERL5LIB "${lib.makeFullPerlPath perlDeps}"
   '';
-
-  src = fetchFromGitHub {
-    owner = "m3m0ryh0l3";
-    repo = "extracturl";
-    rev = "v${version}";
-    sha256 = "05589lp15jmcpbj4y9a3hmf6n2gsqrm4ybcyh3hd4j6pc7hmnhny";
-  };
 
   meta = with lib; {
     homepage = "https://www.memoryhole.net/~kyle/extract_url/";

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, lib, fetchFromGitHub, makeWrapper, perl
+, PodChecker, MIMEtools, HTMLParser
+, cursesSupport ? true, CursesUI
+, uriFindSupport ? true, URIFind
+}:
+
+let
+  perlDeps =
+    [ MIMEtools HTMLParser ]
+    ++ lib.optional cursesSupport CursesUI
+    ++ lib.optional uriFindSupport URIFind;
+
+in stdenv.mkDerivation rec {
+  name = "extract_url-${version}";
+  version = "1.6.2";
+
+  nativeBuildInputs = [ PodChecker makeWrapper ];
+  propagatedBuildInputs = [ perl ] ++ perlDeps;
+
+  makeFlags = "prefix=$(out)";
+
+  postFixup = ''
+    wrapProgram "$out/bin/extract_url" \
+      --set PERL5LIB "${lib.makeFullPerlPath perlDeps}"
+  '';
+
+  src = fetchFromGitHub {
+    owner = "m3m0ryh0l3";
+    repo = "extracturl";
+    rev = "v${version}";
+    sha256 = "05589lp15jmcpbj4y9a3hmf6n2gsqrm4ybcyh3hd4j6pc7hmnhny";
+  };
+
+  meta = with lib; {
+    homepage = "https://www.memoryhole.net/~kyle/extract_url/";
+    description = "Extracts URLs from MIME messages or plain text";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.qyliss ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/extract_url/default.nix
+++ b/pkgs/applications/misc/extract_url/default.nix
@@ -25,10 +25,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ perl ] ++ perlDeps;
 
   makeFlags = "prefix=$(out)";
-
-  postPatch = ''
-    substituteInPlace Makefile --replace /usr/bin/install install
-  '';
+  installFlags = "INSTALL=install";
 
   postFixup = ''
     wrapProgram "$out/bin/extract_url" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2373,6 +2373,10 @@ with pkgs;
 
   ext4magic = callPackage ../tools/filesystems/ext4magic { };
 
+  extract_url = callPackage ../applications/misc/extract_url {
+    inherit (perlPackages) PodChecker MIMEtools HTMLParser CursesUI URIFind;
+  };
+
   extundelete = callPackage ../tools/filesystems/extundelete { };
 
   expect = callPackage ../tools/misc/expect { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2374,7 +2374,7 @@ with pkgs;
   ext4magic = callPackage ../tools/filesystems/ext4magic { };
 
   extract_url = callPackage ../applications/misc/extract_url {
-    inherit (perlPackages) PodChecker MIMEtools HTMLParser CursesUI URIFind;
+    inherit (perlPackages) MIMEtools HTMLParser CursesUI URIFind;
   };
 
   extundelete = callPackage ../tools/filesystems/extundelete { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3186,6 +3186,19 @@ let
     };
   };
 
+  CursesUI = buildPerlPackage rec {
+    name = "Curses-UI-0.9609";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MD/MDXI/${name}.tar.gz";
+      sha256 = "1bqf4h8z70f78nzqq5yj4ahvsbhxxal6bc2g301l9qdn2fjjgf0a";
+    };
+    meta = {
+      description = "curses based OO user interface framework";
+      license = stdenv.lib.licenses.artistic1;
+    };
+    propagatedBuildInputs = [ Curses TermReadKey ];
+  };
+
   CryptX = buildPerlPackage rec {
     name = "CryptX-0.061";
     src = fetchurl {


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---