### PR TITLE
Gnome cleanup

### DIFF
--- a/pkgs/applications/networking/newsreaders/pan/default.nix
+++ b/pkgs/applications/networking/newsreaders/pan/default.nix
@@ -2,7 +2,7 @@
 , stdenv, fetchurl, pkgconfig, gtk3, gtkspell3 ? null
 , perl, gmime2, gettext, intltool, itstool, libxml2, dbus-glib, libnotify, gnutls
 , makeWrapper, gnupg
-, gnomeSupport ? true, libgnome-keyring3
+, gnomeSupport ? true, gnome3, libsecret
 }:
 
 assert spellChecking -> gtkspell3 != null;
@@ -17,10 +17,10 @@ stdenv.mkDerivation {
     sha256 = "1b4wamv33hprghcjk903bpvnd233yxyrm18qnh13alc8h1553nk8";
   };
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
-  buildInputs = [ gtk3 perl gmime2 gettext intltool itstool libxml2 dbus-glib libnotify gnutls ]
+  nativeBuildInputs = [ pkgconfig gettext intltool itstool libxml2 makeWrapper ];
+  buildInputs = [ gtk3 gmime2 libnotify gnutls ]
     ++ stdenv.lib.optional spellChecking gtkspell3
-    ++ stdenv.lib.optional gnomeSupport libgnome-keyring3;
+    ++ stdenv.lib.optionals gnomeSupport [ libsecret gnome3.gcr ];
 
   configureFlags = [
     "--with-dbus"

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxslt, which, libX11, gnome3, gtk3, glib
+{ stdenv, fetchurl, substituteAll, pkgconfig, libxslt, which, libX11, gnome3, gtk3, glib
 , intltool, libxml2, xkeyboard_config, isocodes, itstool, wayland
 , libseccomp, bubblewrap, gobjectIntrospection, gtk-doc, docbook_xsl }:
 
@@ -30,17 +30,15 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ gnome3.gsettings-desktop-schemas ];
 
   patches = [
-    ./bubblewrap-paths.patch
+    (substituteAll {
+      src = ./bubblewrap-paths.patch;
+      BUBBLEWRAP_BIN = "${bubblewrap}/bin/bwrap";
+    })
   ];
 
   configureFlags = [
     "--enable-gtk-doc"
   ];
-
-  postPatch = ''
-    substituteInPlace libgnome-desktop/gnome-desktop-thumbnail-script.c --subst-var-by \
-      BUBBLEWRAP_BIN "${bubblewrap}/bin/bwrap"
-  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, dbus, libgcrypt, libtasn1, pam, python2, glib, libxslt
-, intltool, pango, gcr, gdk_pixbuf, atk, p11-kit, openssh, wrapGAppsHook
-, docbook_xsl, docbook_xml_dtd_42, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, dbus, libgcrypt, pam, python2, glib, libxslt
+, gettext, gcr, libcap_ng, libselinux, p11-kit, openssh, wrapGAppsHook
+, docbook_xsl, docbook_xml_dtd_43, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "gnome-keyring-${version}";
@@ -11,21 +11,15 @@ stdenv.mkDerivation rec {
     sha256 = "0sk4las4ji8wv9nx8mldzqccmpmkvvr9pdwv9imj26r10xyin5w1";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gnome-keyring"; attrPath = "gnome3.gnome-keyring"; };
-  };
-
   outputs = [ "out" "dev" ];
 
-  buildInputs = with gnome3; [
-    dbus libgcrypt pam gtk3 libgnome-keyring openssh
-    pango gcr gdk_pixbuf atk p11-kit
+  buildInputs = [
+    glib libgcrypt pam openssh libcap_ng libselinux
+    gcr p11-kit
   ];
 
-  propagatedBuildInputs = [ glib libtasn1 libxslt ];
-
   nativeBuildInputs = [
-    pkgconfig intltool docbook_xsl docbook_xml_dtd_42 wrapGAppsHook
+    pkgconfig gettext libxslt docbook_xsl docbook_xml_dtd_43 wrapGAppsHook
   ];
 
   configureFlags = [
@@ -47,6 +41,13 @@ stdenv.mkDerivation rec {
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       make check
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gnome-keyring";
+      attrPath = "gnome3.gnome-keyring";
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Collection of components in GNOME that store secrets, passwords, keys, certificates and make them available to applications";

--- a/pkgs/desktops/xfce4-13/xfce4-settings/default.nix
+++ b/pkgs/desktops/xfce4-13/xfce4-settings/default.nix
@@ -1,4 +1,4 @@
-{ mkXfceDerivation, automakeAddFlags, dbus-glib, exo, garcon, gtk3
+{ mkXfceDerivation, automakeAddFlags, exo, garcon, gtk3
 , libnotify ? null, libxfce4ui, libxfce4util, libxklavier ? null
 , upower ? null, xfconf, xf86inputlibinput ? null }:
 
@@ -19,7 +19,6 @@ mkXfceDerivation rec {
   nativeBuildInputs = [ automakeAddFlags ];
 
   buildInputs = [
-    dbus-glib
     exo
     garcon
     gtk3

--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -1,9 +1,11 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, libtool
+{ stdenv, fetchFromGitHub, autoreconfHook, umockdev, gobjectIntrospection
 , pkgconfig, glib, systemd, libgudev, vala }:
 
 stdenv.mkDerivation rec {
   name = "umockdev-${version}";
   version = "0.11.3";
+
+  outputs = [ "bin" "out" "dev" "doc" ];
 
   src = fetchFromGitHub {
     owner  = "martinpitt";
@@ -19,7 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib systemd libgudev ];
 
-  nativeBuildInputs = [ autoreconfHook libtool pkgconfig vala ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig vala gobjectIntrospection ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, udev, libgudev, polkit, dbus-glib, ppp, gettext, pkgconfig
+{ stdenv, fetchurl, glib, udev, libgudev, polkit, ppp, gettext, pkgconfig
 , libmbim, libqmi, systemd, fetchpatch }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ gettext pkgconfig ];
 
-  buildInputs = [ udev libgudev polkit dbus-glib ppp libmbim libqmi systemd ];
+  buildInputs = [ glib udev libgudev polkit ppp libmbim libqmi systemd ];
 
   patches = [
     # Patch dependency on glib headers, this breaks packages using core headers (networkmanager-qt)


### PR DESCRIPTION
###### Motivation for this change
Mostly removing `dbus-glib` and `libgnome-keyring` where not used any more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

