### PR TITLE
lib: ensure directories of linkFarm links exist

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -145,7 +145,10 @@ rec {
   # entries is a list of attribute sets like { name = "name" ; path = "/nix/store/..."; }
   linkFarm = name: entries: runCommand name { preferLocalBuild = true; }
     ("mkdir -p $out; cd $out; \n" +
-      (lib.concatMapStrings (x: "ln -s '${x.path}' '${x.name}';\n") entries));
+      (lib.concatMapStrings (x: ''
+        mkdir -p "$(dirname '${x.name}')"
+        ln -s '${x.path}' '${x.name}'
+      '') entries));
 
 
   # Print an error message if the file with the specified name and


### PR DESCRIPTION
There's no reason `linkFarm` can't be used for symlinks in subdirectories, except that currently it doesn't ensure the directory of the link exists. This backwards-compatible change expands the utility of the function.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---