### PR TITLE
go_1_11: init at 1.11 and set as default

### DIFF
--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, boost155, boost165, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3 }:
+{ callPackage, boost155, boost165, openssl_1_1_0, haskellPackages, darwin, libsForQt5, miniupnpc_2, python3, buildGo110Package }:
 
 rec {
 
@@ -51,10 +51,13 @@ rec {
 
   freicoin = callPackage ./freicoin.nix { boost = boost155; };
   go-ethereum = callPackage ./go-ethereum.nix {
+    buildGoPackage = buildGo110Package;
     inherit (darwin) libobjc;
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
-  go-ethereum-classic = callPackage ./go-ethereum-classic { };
+  go-ethereum-classic = callPackage ./go-ethereum-classic {
+    buildGoPackage = buildGo110Package;
+  };
 
   litecoin  = callPackage ./litecoin.nix { withGui = true; };
   litecoind = callPackage ./litecoin.nix { withGui = false; };

--- a/pkgs/applications/networking/gopher/gopherclient/default.nix
+++ b/pkgs/applications/networking/gopher/gopherclient/default.nix
@@ -40,5 +40,6 @@ buildGoPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ orivej ];
     platforms = platforms.linux;
+    broken = true;
   };
 }

--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -1,0 +1,194 @@
+{ stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
+, perl, which, pkgconfig, patch, procps
+, pcre, cacert, llvm
+, Security, Foundation
+, makeWrapper, git, subversion, mercurial, bazaar }:
+
+let
+
+  inherit (stdenv.lib) optionals optionalString;
+
+  clangHack = writeScriptBin "clang" ''
+    #!${stdenv.shell}
+    exec ${stdenv.cc}/bin/clang "$@" 2> >(sed '/ld: warning:.*ignoring unexpected dylib file/ d' 1>&2)
+  '';
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+in
+
+stdenv.mkDerivation rec {
+  name = "go-${version}";
+  version = "1.11";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "go";
+    rev = "go${version}";
+    sha256 = "1k18d6rkijlgzn1zw4wphzcv6a6w9hb1msgrsh1102jb18644f2q";
+  };
+
+  GOCACHE = "off";
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkgconfig patch makeWrapper procps ];
+  buildInputs = [ cacert pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+  propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${stdenv.shell}'
+
+    # Disabling the 'os/http/net' tests (they want files not available in
+    # chroot builds)
+    rm src/net/{listen,parse}_test.go
+    rm src/syscall/exec_linux_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
+    sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/areturn' src/net/net_test.go
+    # Disable the hostname test
+    sed -i '/TestHostname/areturn' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/areturn' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/areturn' src/cmd/go/go_test.go
+    # Remove the timezone naming test
+    sed -i '/TestLoadFixed/areturn' src/time/time_test.go
+    # Remove disable setgid test
+    sed -i '/TestRespectSetgidDir/areturn' src/cmd/go/internal/work/build_test.go
+    # Remove cert tests that conflict with NixOS's cert resolution
+    sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/areturn' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/areturn' src/net/timeout_test.go
+
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+  '' + optionalString stdenv.isAarch32 ''
+    echo '#!${stdenv.shell}' > misc/cgo/testplugin/test.bash
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/areturn' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/areturn' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/areturn' src/os/os_test.go
+    sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/areturn' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+  '';
+
+  patches = [
+    ./remove-tools-1.11.patch
+    ./ssl-cert-file-1.9.patch
+    ./remove-test-pie.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+    ./remove-fhs-test-references.patch
+    ./skip-external-network-tests.patch
+    ./skip-nohup-tests.patch
+  ];
+
+  postPatch = optionalString stdenv.isDarwin ''
+    echo "substitute hardcoded dsymutil with ${llvm}/bin/llvm-dsymutil"
+    substituteInPlace "src/cmd/link/internal/ld/lib.go" --replace dsymutil ${llvm}/bin/llvm-dsymutil
+  '';
+
+  GOOS = if stdenv.isDarwin then "darwin" else "linux";
+  GOARCH = if stdenv.isDarwin then "amd64"
+           else if stdenv.system == "i686-linux" then "386"
+           else if stdenv.system == "x86_64-linux" then "amd64"
+           else if stdenv.isAarch32 then "arm"
+           else if stdenv.isAarch64 then "arm64"
+           else throw "Unsupported system";
+  GOARM = optionalString (stdenv.system == "armv5tel-linux") "5";
+  GO386 = 387; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
+  # Hopefully avoids test timeouts on Hydra
+  GO_TEST_TIMEOUT_SCALE = 3;
+
+  # The go build actually checks for CC=*/clang and does something different, so we don't
+  # just want the generic `cc` here.
+  CC = if stdenv.isDarwin then "clang" else "cc";
+
+  configurePhase = ''
+    # Indicate that we are running on build infrastructure
+    # Some tests assume things like home directories and users exists
+    export GO_BUILDER_NAME=nix
+
+    mkdir -p $out/share/go/bin
+    export GOROOT=$out/share/go
+    export GOBIN=$GOROOT/bin
+    export PATH=$GOBIN:$PATH
+    ulimit -a
+  '';
+
+  postConfigure = optionalString stdenv.isDarwin ''
+    export PATH=${clangHack}/bin:$PATH
+  '';
+
+  installPhase = ''
+    cp -r . $GOROOT
+    ( cd $GOROOT/src && ./all.bash )
+
+    # (https://github.com/golang/go/wiki/GoGetTools)
+    wrapProgram $out/share/go/bin/go --prefix PATH ":" "${stdenv.lib.makeBinPath [ git subversion mercurial bazaar ]}"
+  '';
+
+  preFixup = ''
+    rm -r $out/share/go/pkg/bootstrap
+    ln -s $out/share/go/bin $out/bin
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  disallowedReferences = [ go_bootstrap ];
+
+  meta = with stdenv.lib; {
+    branch = "1.9";
+    homepage = http://golang.org/;
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan orivej velovix mic92 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/compilers/go/remove-fhs-test-references.patch
+++ b/pkgs/development/compilers/go/remove-fhs-test-references.patch
@@ -1,0 +1,13 @@
+diff --git a/src/cmd/vendor/golang.org/x/sys/unix/syscall_unix_test.go b/src/cmd/vendor/golang.org/x/sys/unix/syscall_unix_test.go
+index d694990..87fa259 100644
+--- a/src/cmd/vendor/golang.org/x/sys/unix/syscall_unix_test.go
++++ b/src/cmd/vendor/golang.org/x/sys/unix/syscall_unix_test.go
+@@ -452,7 +452,7 @@ func TestGetwd(t *testing.T) {
+ 	defer fd.Close()
+ 	// These are chosen carefully not to be symlinks on a Mac
+ 	// (unlike, say, /var, /etc)
+-	dirs := []string{"/", "/usr/bin"}
++	dirs := []string{"/"}
+ 	switch runtime.GOOS {
+ 	case "android":
+ 		dirs = []string{"/", "/system/bin"}

--- a/pkgs/development/compilers/go/remove-tools-1.11.patch
+++ b/pkgs/development/compilers/go/remove-tools-1.11.patch
@@ -1,0 +1,35 @@
+diff --git a/src/go/build/build.go b/src/go/build/build.go
+index b68a712..b60bf19 100644
+--- a/src/go/build/build.go
++++ b/src/go/build/build.go
+@@ -1708,7 +1708,7 @@ func init() {
+ }
+ 
+ // ToolDir is the directory containing build tools.
+-var ToolDir = getToolDir()
++var ToolDir = runtime.GOTOOLDIR()
+ 
+ // IsLocalImport reports whether the import path is
+ // a local import path, like ".", "..", "./foo", or "../foo".
+diff --git a/src/runtime/extern.go b/src/runtime/extern.go
+index 7171b13..18a942c 100644
+--- a/src/runtime/extern.go
++++ b/src/runtime/extern.go
+@@ -229,6 +229,17 @@ func GOROOT() string {
+ 	return sys.DefaultGoroot
+ }
+ 
++// GOTOOLDIR returns the root of the Go tree.
++// It uses the GOTOOLDIR environment variable, if set,
++// or else the root used during the Go build.
++func GOTOOLDIR() string {
++	s := gogetenv("GOTOOLDIR")
++	if s != "" {
++		return s
++	}
++	return GOROOT() + "/pkg/tool/" + GOOS + "_" + GOARCH
++}
++
+ // Version returns the Go tree's version string.
+ // It is either the commit hash and date at the time of the build or,
+ // when possible, a release tag like "go1.3".

--- a/pkgs/development/compilers/go/skip-external-network-tests.patch
+++ b/pkgs/development/compilers/go/skip-external-network-tests.patch
@@ -1,0 +1,26 @@
+diff --git a/src/cmd/go/go_test.go b/src/cmd/go/go_test.go
+index 85cae90..94b4edd 100644
+--- a/src/cmd/go/go_test.go
++++ b/src/cmd/go/go_test.go
+@@ -4946,6 +4946,8 @@ func TestBuildmodePIE(t *testing.T) {
+ }
+ 
+ func TestExecBuildX(t *testing.T) {
++	t.Skipf("skipping, test requires networking")
++
+ 	tooSlow(t)
+ 	if !canCgo {
+ 		t.Skip("skipping because cgo not enabled")
+diff --git a/src/net/dial_test.go b/src/net/dial_test.go
+index 00a84d1..27f9ec9 100644
+--- a/src/net/dial_test.go
++++ b/src/net/dial_test.go
+@@ -968,6 +968,8 @@ func TestDialerControl(t *testing.T) {
+ // mustHaveExternalNetwork is like testenv.MustHaveExternalNetwork
+ // except that it won't skip testing on non-iOS builders.
+ func mustHaveExternalNetwork(t *testing.T) {
++	t.Skipf("Nix sandbox does not have networking")
++
+ 	t.Helper()
+ 	ios := runtime.GOOS == "darwin" && (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64")
+ 	if testenv.Builder() == "" || ios {

--- a/pkgs/development/compilers/go/skip-nohup-tests.patch
+++ b/pkgs/development/compilers/go/skip-nohup-tests.patch
@@ -1,0 +1,22 @@
+diff --git a/src/os/signal/signal_test.go b/src/os/signal/signal_test.go
+index 3d79c7a..6e0f7b4 100644
+--- a/src/os/signal/signal_test.go
++++ b/src/os/signal/signal_test.go
+@@ -217,6 +217,8 @@ var checkSighupIgnored = flag.Bool("check_sighup_ignored", false, "if true, Test
+ 
+ // Test that Ignored(SIGHUP) correctly detects whether it is being run under nohup.
+ func TestDetectNohup(t *testing.T) {
++	t.Skip("Fails in nix build environment")
++
+ 	if *checkSighupIgnored {
+ 		if !Ignored(syscall.SIGHUP) {
+ 			t.Fatal("SIGHUP is not ignored.")
+@@ -306,6 +308,8 @@ func TestStop(t *testing.T) {
+ // Test that when run under nohup, an uncaught SIGHUP does not kill the program,
+ // but a
+ func TestNohup(t *testing.T) {
++	t.Skip("Fails in nix build environment")
++
+ 	// Ugly: ask for SIGHUP so that child will not have no-hup set
+ 	// even if test is running under nohup environment.
+ 	// We have no intention of reading from c.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6748,6 +6748,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
+  go_1_11 = callPackage ../development/compilers/go/1.11.nix {
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  };
+
   go = go_1_10;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -706,7 +706,9 @@ with pkgs;
 
   asc-key-to-qr-code-gif = callPackage ../tools/security/asc-key-to-qr-code-gif { };
 
-  gopass = callPackage ../tools/security/gopass { };
+  gopass = callPackage ../tools/security/gopass {
+    buildGoPackage = buildGo110Package;
+  };
 
   browserpass = callPackage ../tools/security/browserpass { };
 
@@ -1348,7 +1350,9 @@ with pkgs;
 
   gmic = callPackage ../tools/graphics/gmic { };
 
-  goa = callPackage ../development/tools/goa { };
+  goa = callPackage ../development/tools/goa {
+    buildGoPackage = buildGo110Package;
+  };
 
   gohai = callPackage ../tools/system/gohai { };
 
@@ -2091,13 +2095,17 @@ with pkgs;
 
   dev86 = callPackage ../development/compilers/dev86 { };
 
-  diskrsync = callPackage ../tools/backup/diskrsync { };
+  diskrsync = callPackage ../tools/backup/diskrsync {
+    buildGoPackage = buildGo110Package;
+  };
 
   djbdns = callPackage ../tools/networking/djbdns { };
 
   dnscrypt-proxy = callPackage ../tools/networking/dnscrypt-proxy/1.x { };
 
-  dnscrypt-proxy2 = callPackage ../tools/networking/dnscrypt-proxy/2.x { };
+  dnscrypt-proxy2 = callPackage ../tools/networking/dnscrypt-proxy/2.x {
+    buildGoPackage = buildGo110Package;
+  };
 
   dnscrypt-wrapper = callPackage ../tools/networking/dnscrypt-wrapper { };
 
@@ -2933,8 +2941,12 @@ with pkgs;
     stdenv = stdenv_32bit;
   };
 
-  gx = callPackage ../tools/package-management/gx { };
-  gx-go = callPackage ../tools/package-management/gx/go { };
+  gx = callPackage ../tools/package-management/gx {
+    buildGoPackage = buildGo110Package;
+  };
+  gx-go = callPackage ../tools/package-management/gx/go {
+    buildGoPackage = buildGo110Package;
+  };
 
   sbsigntool = callPackage ../tools/security/sbsigntool { };
 
@@ -3278,7 +3290,9 @@ with pkgs;
   ipfs = callPackage ../applications/networking/ipfs { };
   ipfs-migrator = callPackage ../applications/networking/ipfs-migrator { };
 
-  ipget = callPackage ../applications/networking/ipget { };
+  ipget = callPackage ../applications/networking/ipget {
+    buildGoPackage = buildGo110Package;
+  };
 
   ipmitool = callPackage ../tools/system/ipmitool {
     static = false;
@@ -3960,7 +3974,9 @@ with pkgs;
 
   mimetic = callPackage ../development/libraries/mimetic { };
 
-  minio-client = callPackage ../tools/networking/minio-client { };
+  minio-client = callPackage ../tools/networking/minio-client {
+    buildGoPackage = buildGo110Package;
+  };
 
   minissdpd = callPackage ../tools/networking/minissdpd { };
 
@@ -4194,7 +4210,9 @@ with pkgs;
 
   noip = callPackage ../tools/networking/noip { };
 
-  nomad = callPackage ../applications/networking/cluster/nomad { };
+  nomad = callPackage ../applications/networking/cluster/nomad {
+    buildGoPackage = buildGo110Package;
+  };
 
   miller = callPackage ../tools/text/miller { };
 
@@ -4246,7 +4264,9 @@ with pkgs;
 
   nnn = callPackage ../applications/misc/nnn { };
 
-  notary = callPackage ../tools/security/notary { };
+  notary = callPackage ../tools/security/notary {
+    buildGoPackage = buildGo110Package;
+  };
 
   notify-osd = callPackage ../applications/misc/notify-osd { };
 
@@ -5522,7 +5542,9 @@ with pkgs;
 
   tmuxPlugins = recurseIntoAttrs (callPackage ../misc/tmux-plugins { });
 
-  tmsu = callPackage ../tools/filesystems/tmsu { };
+  tmsu = callPackage ../tools/filesystems/tmsu {
+    go = go_1_10;
+  };
 
   toilet = callPackage ../tools/misc/toilet { };
 
@@ -6752,7 +6774,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
-  go = go_1_10;
+  go = go_1_11;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 
@@ -12638,8 +12660,11 @@ with pkgs;
   buildGo110Package = callPackage ../development/go-modules/generic {
     go = go_1_10;
   };
+  buildGo111Package = callPackage ../development/go-modules/generic {
+    go = go_1_11;
+  };
 
-  buildGoPackage = buildGo110Package;
+  buildGoPackage = buildGo111Package;
 
   go2nix = callPackage ../development/tools/go2nix { };
 
@@ -12997,13 +13022,17 @@ with pkgs;
 
   mediatomb = callPackage ../servers/mediatomb { };
 
-  meguca = callPackage ../servers/meguca { };
+  meguca = callPackage ../servers/meguca {
+    buildGoPackage = buildGo110Package;
+  };
 
   memcached = callPackage ../servers/memcached {};
 
   meteor = callPackage ../servers/meteor { };
 
-  minio = callPackage ../servers/minio { };
+  minio = callPackage ../servers/minio {
+    buildGoPackage = buildGo110Package;
+  };
 
   # Backwards compatibility.
   mod_dnssd = pkgs.apacheHttpdPackages.mod_dnssd;
@@ -13266,7 +13295,9 @@ with pkgs;
 
   postgresql_jdbc = callPackage ../servers/sql/postgresql/jdbc { };
 
-  inherit (callPackage ../servers/monitoring/prometheus {})
+  inherit (callPackage ../servers/monitoring/prometheus {
+    buildGoPackage = buildGo110Package;
+  })
       prometheus_1
       prometheus_2
       ;
@@ -13292,7 +13323,9 @@ with pkgs;
   prometheus-postfix-exporter = callPackage ../servers/monitoring/prometheus/postfix-exporter.nix { };
   prometheus-pushgateway = callPackage ../servers/monitoring/prometheus/pushgateway.nix { };
   prometheus-rabbitmq-exporter = callPackage ../servers/monitoring/prometheus/rabbitmq-exporter.nix { };
-  prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix { };
+  prometheus-snmp-exporter = callPackage ../servers/monitoring/prometheus/snmp-exporter.nix {
+    buildGoPackage = buildGo110Package;
+  };
   prometheus-statsd-exporter = callPackage ../servers/monitoring/prometheus/statsd-bridge.nix { };
   prometheus-surfboard-exporter = callPackage ../servers/monitoring/prometheus/surfboard-exporter.nix { };
   prometheus-unifi-exporter = callPackage ../servers/monitoring/prometheus/unifi-exporter { };
@@ -13670,7 +13703,9 @@ with pkgs;
   dstat = callPackage ../os-specific/linux/dstat { };
 
   # unstable until the first 1.x release
-  fscrypt-experimental = callPackage ../os-specific/linux/fscrypt { };
+  fscrypt-experimental = callPackage ../os-specific/linux/fscrypt {
+    buildGoPackage = buildGo110Package;
+  };
   fscryptctl-experimental = callPackage ../os-specific/linux/fscryptctl { };
 
   fwupd = callPackage ../os-specific/linux/firmware/fwupd { };
@@ -14389,7 +14424,9 @@ with pkgs;
 
   gomodifytags = callPackage ../development/tools/gomodifytags { };
 
-  go-langserver = callPackage ../development/tools/go-langserver { };
+  go-langserver = callPackage ../development/tools/go-langserver {
+    buildGoPackage = buildGo110Package;
+  };
 
   gotests = callPackage ../development/tools/gotests { };
 
@@ -21931,7 +21968,9 @@ with pkgs;
 
   valauncher = callPackage ../applications/misc/valauncher { };
 
-  vault = callPackage ../tools/security/vault { };
+  vault = callPackage ../tools/security/vault {
+    go = go_1_10;
+  };
 
   vaultenv = haskellPackages.vaultenv;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

note: I want to set this as default but need to run `nox-review` first.

cc @cstrahan @orivej @velovix @Mic92 

I recently started https://github.com/adisbladis/vgo2nix to use the new modules support with Nix.