### PR TITLE
thonny: init at 3.0.0b3

### DIFF
--- a/pkgs/applications/editors/thonny/default.nix
+++ b/pkgs/applications/editors/thonny/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromBitbucket, python3 }:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "thonny";
+  version = "3.0.0b3";
+
+  src = fetchFromBitbucket {
+    owner = "plas";
+    repo = pname;
+    rev = "a511d4539c532b6dddf6d7f1586d30e1ac35bd86";
+    sha256 = "1s3pp97r6p3j81idglnml4faxryk7saszxmv3gys1agdfj75qczr";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ jedi pyserial tkinter docutils pylint ];
+
+  preInstall = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  preFixup = ''
+    wrapProgram "$out/bin/thonny" \
+       --prefix PYTHONPATH : $PYTHONPATH:$(toPythonPath ${python3.pkgs.jedi})
+  '';
+
+  # Tests need a DISPLAY
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Python IDE for beginners";
+    longDescription = ''
+      Thonny is a Python IDE for beginners. It supports different ways
+      of stepping through the code, step-by-step expression
+      evaluation, detailed visualization of the call stack and a mode
+      for explaining the concepts of references and heap.
+    '';
+    homepage = https://www.thonny.org/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18736,6 +18736,8 @@ with pkgs;
 
   nylas-mail-bin = callPackage ../applications/networking/mailreaders/nylas-mail-bin { };
 
+  thonny = callPackage ../applications/editors/thonny { };
+
   thunderbird = callPackage ../applications/networking/mailreaders/thunderbird {
     inherit (gnome2) libIDL;
     libpng = libpng_apng;


### PR DESCRIPTION
###### Motivation for this change

Good Python IDE for beginners.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

