### PR TITLE
hunspell-hs: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -672,6 +672,9 @@ self: super: {
   # https://github.com/bos/bloomfilter/issues/7
   bloomfilter = appendPatch super.bloomfilter ./patches/bloomfilter-fix-on-32bit.patch;
 
+  # https://github.com/ashutoshrishi/hunspell-hs/pull/3
+  hunspell-hs = addPkgconfigDepend (dontCheck (appendPatch super.hunspell-hs ./patches/hunspell.patch)) pkgs.hunspell;
+
   # https://github.com/pxqr/base32-bytestring/issues/4
   base32-bytestring = dontCheck super.base32-bytestring;
 

--- a/pkgs/development/haskell-modules/patches/hunspell.patch
+++ b/pkgs/development/haskell-modules/patches/hunspell.patch
@@ -1,0 +1,30 @@
+diff -Naur hunspell-hs-0.1.0.0.orig/hunspell-hs.cabal hunspell-hs-0.1.0.0/hunspell-hs.cabal
+--- hunspell-hs-0.1.0.0.orig/hunspell-hs.cabal	2018-08-26 20:23:33.053763300 +0200
++++ hunspell-hs-0.1.0.0/hunspell-hs.cabal	2018-08-26 20:42:05.886074510 +0200
+@@ -37,7 +37,7 @@
+       base >=4.7 && <5
+     , stm
+   if os(linux)
+-    extra-libraries:
++    pkgconfig-depends:
+         hunspell
+   if os(darwin)
+     include-dirs:
+@@ -63,7 +63,7 @@
+     , hunspell-hs
+     , stm
+   if os(linux)
+-    extra-libraries:
++    pkgconfig-depends:
+         hunspell
+   if os(darwin)
+     include-dirs:
+@@ -88,7 +88,7 @@
+     , hunspell-hs
+     , stm
+   if os(linux)
+-    extra-libraries:
++    pkgconfig-depends:
+         hunspell
+   if os(darwin)
+     include-dirs:


### PR DESCRIPTION
There is no library hunspell, but hunspell-1.6,
hunspell-1.4 (not in nixpkgs), and so on.

Disables tests as some necessary data files
aren't included on hackage.

###### Motivation for this change

Get hunspell-hs building again.

###### Things done

Fixed `extra-libraries` and disabled tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

