### PR TITLE
ibtool: impure-symlink-style Darwin package

### DIFF
--- a/pkgs/os-specific/darwin/ibtool/default.nix
+++ b/pkgs/os-specific/darwin/ibtool/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+}:
+
+stdenv.mkDerivation rec
+{
+    name = "ibtool";
+
+    # Copying local files.
+    preferLocalBuild = true;
+
+    __propagatedImpureHostDeps = [ "/usr/lib/libxcselect.dylib"
+                                   "/usr/lib/libSystem.B.dylib"
+                                 ];
+
+    phases = [ "installPhase"
+               "fixupPhase"
+             ];
+
+    installPhase = ''
+        mkdir -p $out/bin
+        ln -s -L /usr/bin/ibtool $out/bin/ibtool
+    '';
+
+    meta = with stdenv.lib;
+    {
+        description = "ibtool xib compiler";
+        platforms = platforms.darwin;
+    };
+}

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -80,4 +80,6 @@ in
 
   darling = callPackage ../os-specific/darwin/darling/default.nix { };
 
+  ibtool = callPackage ../os-specific/darwin/ibtool/default.nix { };
+
 })


### PR DESCRIPTION
###### Motivation for this change
Adding an impure derivation for `ibtool`. My current motivation for doing this is packaging MoltenVK.

There are a few other impure Darwin derivations that work by making symlinks to system libraries/tools, but I'm sure I've broken some convention or something here. @copumpkin, I'm curious about the _right_ way to do this.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

