### PR TITLE
treewide: abort -> throw where it makes sense

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -35,7 +35,7 @@ let
 
       name = mkOption {
         type = types.str;
-        apply = x: assert (builtins.stringLength x < 32 || abort "Username '${x}' is longer than 31 characters which is not allowed!"); x;
+        apply = x: assert (builtins.stringLength x < 32 || throw "Username '${x}' is longer than 31 characters which is not allowed!"); x;
         description = ''
           The name of the user account. If undefined, the name of the
           attribute set will be used.
@@ -92,7 +92,7 @@ let
 
       group = mkOption {
         type = types.str;
-        apply = x: assert (builtins.stringLength x < 32 || abort "Group name '${x}' is longer than 31 characters which is not allowed!"); x;
+        apply = x: assert (builtins.stringLength x < 32 || throw "Group name '${x}' is longer than 31 characters which is not allowed!"); x;
         default = "nogroup";
         description = "The user's primary group.";
       };

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -121,7 +121,7 @@ let
     else if (head list) == e then start
     else (indexOf default (start + (length (listenStreams (head list).socket))) (tail list) e);
 
-  systemdSocket = indexOf (abort "Socket not found") 0 allSockets;
+  systemdSocket = indexOf (throw "Socket not found") 0 allSockets;
 
   isUnixSocket = socket: hasPrefix "/" (if (isString socket) then socket else socket.socket);
   isPort = hasPrefix "*:";

--- a/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
@@ -42,7 +42,7 @@ let result = stdenv.mkDerivation rec {
   name = if packageType == "JDK"       then "oraclejdk-${version}"
     else if packageType == "JRE"       then "oraclejre-${version}"
     else if packageType == "ServerJRE" then "oracleserverjre-${version}"
-    else abort "unknown package Type ${packageType}";
+    else throw "unknown package Type ${packageType}";
 
   src =
     if packageType == "JDK" then
@@ -63,7 +63,7 @@ let result = stdenv.mkDerivation rec {
         url = "${downloadUrlBase}/sjre10-downloads-4417025.html";
         sha256 = "0hbcb4c6ncy0sbz02gyygyqcwkz0xpv4fwrx4sripia6vph9592c";
       }
-    else abort "unknown package Type ${packageType}";
+    else throw "unknown package Type ${packageType}";
 
   nativeBuildInputs = [ file ];
 

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -64,7 +64,7 @@ let
         fetchFromGitHub {
           inherit (goDep.fetch) owner repo rev sha256;
         }
-      else abort "Unrecognized package fetch type: ${goDep.fetch.type}";
+      else throw "Unrecognized package fetch type: ${goDep.fetch.type}";
     };
 
   importGodeps = { depsFile }:

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -31,7 +31,7 @@ with (
     };
 
   }.${majorVersion}
-    or (abort ''Unsupported configuration for cmake: majorVersion = "${majorVersion}";'')
+    or (throw ''Unsupported configuration for cmake: majorVersion = "${majorVersion}";'')
 );
 
 let

--- a/pkgs/games/steam/runtime-wrapped.nix
+++ b/pkgs/games/steam/runtime-wrapped.nix
@@ -20,7 +20,7 @@ let
 
   gnuArch = if steamArch == "amd64" then "x86_64-linux-gnu"
             else if steamArch == "i386" then "i386-linux-gnu"
-            else abort "Unsupported architecture";
+            else throw "Unsupported architecture";
 
   libs = [ "lib/${gnuArch}" "lib" "usr/lib/${gnuArch}" "usr/lib" ];
   bins = [ "bin" "usr/bin" ];

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -142,7 +142,7 @@ rec {
 
           validate = arg:
             if licensePred license then arg
-            else abort ''
+            else throw ''
               while building ${drv}:
               license `${builtins.toString license}' does not pass the predicate.
             '';

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -102,7 +102,7 @@ rec {
       # hardeningDisable additionally supports "all".
       erroneousHardeningFlags = lib.subtractLists supportedHardeningFlags (hardeningEnable ++ lib.remove "all" hardeningDisable);
     in if builtins.length erroneousHardeningFlags != 0
-    then abort ("mkDerivation was called with unsupported hardening flags: " + lib.generators.toPretty {} {
+    then throw ("mkDerivation was called with unsupported hardening flags: " + lib.generators.toPretty {} {
       inherit erroneousHardeningFlags hardeningDisable hardeningEnable supportedHardeningFlags;
     })
     else let

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -26,9 +26,9 @@
     };
   };
   archLookupTable = table.${localSystem.libc}
-    or (abort "unsupported libc for the pure Linux stdenv");
+    or (throw "unsupported libc for the pure Linux stdenv");
   files = archLookupTable.${localSystem.system}
-    or (abort "unsupported platform for the pure Linux stdenv");
+    or (throw "unsupported platform for the pure Linux stdenv");
   in files
 }:
 

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -40,7 +40,7 @@ releaseTools.sourceTarball rec {
     opts=(--option build-users-group "")
     nix-store --init
 
-    echo 'abort "Illegal use of <nixpkgs> in Nixpkgs."' > $TMPDIR/barf.nix
+    echo 'throw "Illegal use of <nixpkgs> in Nixpkgs."' > $TMPDIR/barf.nix
 
     # Make sure that Nixpkgs does not use <nixpkgs>.
     badFiles=$(find pkgs -type f -name '*.nix' -print | xargs grep -l '^[^#]*<nixpkgs\/' || true)

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -34,7 +34,7 @@ rec {
     else if system == "i686-freebsd" then pkgs_i686_freebsd
     else if system == "i686-cygwin" then pkgs_i686_cygwin
     else if system == "x86_64-cygwin" then pkgs_x86_64_cygwin
-    else abort "unsupported system type: ${system}";
+    else throw "unsupported system type: ${system}";
 
   pkgs_x86_64_linux = allPackages { system = "x86_64-linux"; };
   pkgs_i686_linux = allPackages { system = "i686-linux"; };


### PR DESCRIPTION
###### Motivation for this change
I don't really care about this getting merged, but I'd like to find out whether there's any reason for using aborts. Please let me know if you have any valid use case, because I couldn't find any. I also asked many people but nobody had one.

I have *NOT* tested this in any way, let me know if this breaks anything, which might just be a reason for having aborts then.

Note that I'm looking for *actual* use cases, not theoretical ones.

Ping @Profpatsch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

