### PR TITLE
incron: init at 0.5.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23,6 +23,11 @@
     github = "a1russell";
     name = "Adam Russell";
   };
+  aanderse = {
+    email = "aaron@fosslib.net";
+    github = "aanderse";
+    name = "Aaron Andersen";
+  };
   aaronschif = {
     email = "aaronschif@gmail.com";
     github = "aaronschif";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -416,6 +416,7 @@
   ./services/monitoring/graphite.nix
   ./services/monitoring/hdaps.nix
   ./services/monitoring/heapster.nix
+  ./services/monitoring/incron.nix
   ./services/monitoring/longview.nix
   ./services/monitoring/monit.nix
   ./services/monitoring/munin.nix

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -51,7 +51,11 @@ in
 
     security.wrappers.incrontab.source = "${pkgs.incron}/bin/incrontab";
 
-    environment.etc."incron.d/system".text = "${cfg.systab}";
+    # incron won't read symlinks
+    environment.etc."incron.d/system" = {
+      mode = "0444";
+      text = "${cfg.systab}";
+    };
     environment.etc."incron.allow" = mkIf (cfg.allow != null) {
       text = "${concatStringsSep "\n" cfg.allow}";
     };

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -79,13 +79,13 @@ in
     # incron won't read symlinks
     environment.etc."incron.d/system" = {
       mode = "0444";
-      text = "${cfg.systab}";
+      text = ${cfg.systab};
     };
     environment.etc."incron.allow" = mkIf (cfg.allow != null) {
-      text = "${concatStringsSep "\n" cfg.allow}";
+      text = ${concatStringsSep "\n" cfg.allow};
     };
     environment.etc."incron.deny" = mkIf (cfg.deny != null) {
-      text = "${concatStringsSep "\n" cfg.deny}";
+      text = ${concatStringsSep "\n" cfg.deny};
     };
 
     systemd.services.incron = {

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -1,3 +1,4 @@
+
 { config, lib, pkgs, ... }:
 
 with lib;
@@ -16,7 +17,11 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether to enable the incron daemon.";
+        description = ''
+          Whether to enable the incron daemon.
+
+          Note that commands run under incrontab only support common Nix profiles for the PATH provided variable.
+        '';
       };
 
       allow = mkOption {

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.incron;
+
+in
+
+{
+  options = {
+
+    services.incron = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the incron daemon.";
+      };
+
+      allow = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        description = "Users allowed to use incrontab.";
+      };
+
+      deny = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        description = "Users forbidden from using incrontab.";
+      };
+
+      systab = mkOption {
+        type = types.lines;
+        default = "";
+        description = "The system incrontab contents.";
+        example = ''
+          "/var/mail IN_CLOSE_WRITE abc $@/$#"
+          "/tmp IN_ALL_EVENTS efg $@/$# $&"
+        '';
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.incron ];
+
+    security.wrappers.incrontab.source = "${pkgs.incron}/bin/incrontab";
+
+    environment.etc."incron.d/system".text = "${cfg.systab}";
+    environment.etc."incron.allow" = mkIf (cfg.allow != null) {
+      text = "${concatStringsSep "\n" cfg.allow}";
+    };
+    environment.etc."incron.deny" = mkIf (cfg.deny != null) {
+      text = "${concatStringsSep "\n" cfg.deny}";
+    };
+
+    systemd.services.incron = {
+      description = "File system events scheduler";
+      wantedBy = [ "multi-user.target" ];
+      path = [ config.system.path ];
+      preStart = "mkdir -m 710 -p /var/spool/incron";
+      serviceConfig.Type = "forking";
+      serviceConfig.PIDFile = "/run/incrond.pid";
+      serviceConfig.ExecStart = "${pkgs.incron}/bin/incrond";
+    };
+  };
+
+}

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -53,6 +53,13 @@ in
         '';
       };
 
+      extraPackages = mkOption {
+        type = types.listOf types.package;
+        default = [];
+        example = "[ pkgs.rsync ];";
+        description = "Extra packages available to the system incrontab.";
+      };
+
     };
 
   };
@@ -84,7 +91,7 @@ in
     systemd.services.incron = {
       description = "File system events scheduler";
       wantedBy = [ "multi-user.target" ];
-      path = [ config.system.path ];
+      path = cfg.extraPackages;
       preStart = "mkdir -m 710 -p /var/spool/incron";
       serviceConfig.Type = "forking";
       serviceConfig.PIDFile = "/run/incrond.pid";

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -59,6 +59,12 @@ in
 
   config = mkIf cfg.enable {
 
+    assertions = [
+      { assertion = cfg.allow != null -> cfg.deny == null;
+        message = "If `services.incron.allow` is set then `services.incron.deny` will be ignored.";
+      }
+    ];
+
     environment.systemPackages = [ pkgs.incron ];
 
     security.wrappers.incrontab.source = "${pkgs.incron}/bin/incrontab";

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -22,7 +22,14 @@ in
       allow = mkOption {
         type = types.nullOr (types.listOf types.str);
         default = null;
-        description = "Users allowed to use incrontab.";
+        description = ''
+          Users allowed to use incrontab.
+
+          If empty then no user will be allowed to have their own incrontab.
+          If null then will defer to <option>deny</option>.
+          If both <option>allow</option> and <option>deny</option> are null
+          then all users will be allowed to have their own incrontab.
+        '';
       };
 
       deny = mkOption {

--- a/nixos/modules/services/monitoring/incron.nix
+++ b/nixos/modules/services/monitoring/incron.nix
@@ -89,10 +89,9 @@ in
       description = "File System Events Scheduler";
       wantedBy = [ "multi-user.target" ];
       path = cfg.extraPackages;
-      serviceConfig.Type = "forking";
       serviceConfig.PIDFile = "/run/incrond.pid";
       serviceConfig.ExecStartPre = "${pkgs.coreutils}/bin/mkdir -m 710 -p /var/spool/incron";
-      serviceConfig.ExecStart = "${pkgs.incron}/bin/incrond";
+      serviceConfig.ExecStart = "${pkgs.incron}/bin/incrond --foreground";
     };
   };
 

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -7,10 +7,11 @@ stdenv.mkDerivation rec {
     sha256 = "14cgsfyl43pd86wy40m1xwr7ww023n2jyks66ngybz5s4gbhps6c";
   };
 
-  patchPhase = ''
+  patches = [ ./default_path.patch ];
+
+  prePatch = ''
     sed -i "s|PREFIX = /usr/local|PREFIX = $out|g" Makefile
     sed -i "s|/bin/bash|${bash}/bin/bash|g" usertable.cpp
-    sed -i "s|/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin|/run/current-system/sw/bin|g" usertable.cpp
   '';
 
   installPhase = ''

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, fetchurl, bash }:
+{ stdenv, fetchFromGitHub, bash }:
 
 stdenv.mkDerivation rec {
   name = "incron-0.5.12";
-  src = fetchurl {
-    url = "https://github.com/ar-/incron/archive/0.5.12.tar.gz";
-    sha256 = "14cgsfyl43pd86wy40m1xwr7ww023n2jyks66ngybz5s4gbhps6c";
+  src = fetchFromGitHub {
+    owner = "ar-";
+    repo = "incron";
+    rev = "incron-0.5.12";
+    sha256 = "11d5f98cjafiv9h9zzzrw2s06s2fvdg8gp64km7mdprd2xmy6dih";
   };
 
   patches = [ ./default_path.patch ];

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -25,10 +25,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "
-      The inotify cron daemon (incrond) is a daemon which monitors filesystem events and executes commands defined in system and user tables. It's use is generally similar to cron.";
-    license = licenses.gpl2;
+    description = "A daemon which monitors filesystem events and executes commands defined in system and user tables";
     homepage = https://github.com/ar-/incron;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.aanderse ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -16,15 +16,15 @@ stdenv.mkDerivation rec {
     sed -i "s|/bin/bash|${bash}/bin/bash|g" usertable.cpp
   '';
 
-  installPhase = ''
+  installFlags = [ "PREFIX=$(out)" ];
+  installTargets = [ "install-man" ];
+
+  preInstall = ''
     mkdir -p $out/bin
 
     # make install doesn't work because setuid and permissions
     # just manually install the binaries instead
     cp incrond incrontab $out/bin/
-
-    # make install-man is fine for documentation
-    make install-man
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ar-";
     repo = "incron";
-    rev = "incron-0.5.12";
+    rev = name;
     sha256 = "11d5f98cjafiv9h9zzzrw2s06s2fvdg8gp64km7mdprd2xmy6dih";
   };
 

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "A daemon which monitors filesystem events and executes commands defined in system and user tables";
+    description = "A cron-like daemon which handles filesystem events.";
     homepage = https://github.com/ar-/incron;
     license = licenses.gpl2;
     maintainers = [ maintainers.aanderse ];

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -12,7 +12,6 @@ stdenv.mkDerivation rec {
   patches = [ ./default_path.patch ];
 
   prePatch = ''
-    sed -i "s|PREFIX = /usr/local|PREFIX = $out|g" Makefile
     sed -i "s|/bin/bash|${bash}/bin/bash|g" usertable.cpp
   '';
 

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "
       The inotify cron daemon (incrond) is a daemon which monitors filesystem events and executes commands defined in system and user tables. It's use is generally similar to cron.";
-    license = gpl2;
+    license = licenses.gpl2;
     homepage = https://github.com/ar-/incron;
     platforms = platforms.linux;
   };

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, bash }:
+
+stdenv.mkDerivation rec {
+  name = "incron-0.5.12";
+  src = fetchurl {
+    url = "https://github.com/ar-/incron/archive/0.5.12.tar.gz";
+    sha256 = "14cgsfyl43pd86wy40m1xwr7ww023n2jyks66ngybz5s4gbhps6c";
+  };
+
+  patchPhase = ''
+    sed -i "s|PREFIX = /usr/local|PREFIX = $out|g" Makefile
+    sed -i "s|/bin/bash|${bash}/bin/bash|g" usertable.cpp
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    # make install doesn't work because setuid and permissions
+    # just manually install the binaries instead
+    cp incrond incrontab $out/bin/
+
+    # make install-man is fine for documentation
+    make install-man
+  '';
+
+  meta = with stdenv.lib; {
+    description = "
+      The inotify cron daemon (incrond) is a daemon which monitors filesystem events and executes commands defined in system and user tables. It's use is generally similar to cron.";
+    license = gpl2;
+    homepage = https://github.com/ar-/incron;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/system/incron/default.nix
+++ b/pkgs/tools/system/incron/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     sed -i "s|PREFIX = /usr/local|PREFIX = $out|g" Makefile
     sed -i "s|/bin/bash|${bash}/bin/bash|g" usertable.cpp
+    sed -i "s|/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin|/run/current-system/sw/bin|g" usertable.cpp
   '';
 
   installPhase = ''

--- a/pkgs/tools/system/incron/default_path.patch
+++ b/pkgs/tools/system/incron/default_path.patch
@@ -18,8 +18,8 @@ index 11fd04b..a8681bd 100644
  
 +    // try to recreate the user path as best as possible
 +    std::string DEFAULT_PATH;
-+    DEFAULT_PATH += "/run/wrappers/bin:/home/";
-+    DEFAULT_PATH += pwd->pw_name;
++    DEFAULT_PATH += "/run/wrappers/bin:";
++    DEFAULT_PATH += pwd->pw_dir;
 +    DEFAULT_PATH += "/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/";
 +    DEFAULT_PATH += pwd->pw_name;
 +    DEFAULT_PATH += "/bin";

--- a/pkgs/tools/system/incron/default_path.patch
+++ b/pkgs/tools/system/incron/default_path.patch
@@ -1,0 +1,36 @@
+diff --git usertable.cpp usertable.cpp
+index 11fd04b..a8681bd 100644
+--- a/usertable.cpp
++++ b/usertable.cpp
+@@ -43,9 +43,6 @@
+ #define DONT_FOLLOW(mask) (false)
+ #endif // IN_DONT_FOLLOW
+ 
+-// this is not enough, but...
+-#define DEFAULT_PATH "/usr/local/bin:/usr/bin:/bin:/usr/X11R6/bin"
+-
+ 
+ PROC_MAP UserTable::s_procMap;
+ 
+@@ -597,12 +594,20 @@ void UserTable::RunAsUser(std::string cmd) const
+     if (clearenv() != 0)
+       goto failed;
+ 
++    // try to recreate the user path as best as possible
++    std::string DEFAULT_PATH;
++    DEFAULT_PATH += "/run/wrappers/bin:/home/";
++    DEFAULT_PATH += pwd->pw_name;
++    DEFAULT_PATH += "/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/";
++    DEFAULT_PATH += pwd->pw_name;
++    DEFAULT_PATH += "/bin";
++
+     if (    setenv("LOGNAME",   pwd->pw_name,   1) != 0
+         ||  setenv("USER",      pwd->pw_name,   1) != 0
+         ||  setenv("USERNAME",  pwd->pw_name,   1) != 0
+         ||  setenv("HOME",      pwd->pw_dir,    1) != 0
+         ||  setenv("SHELL",     pwd->pw_shell,  1) != 0
+-        ||  setenv("PATH",      DEFAULT_PATH,   1) != 0)
++        ||  setenv("PATH",      DEFAULT_PATH.c_str(),   1) != 0)
+     {
+       goto failed;
+     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3237,6 +3237,8 @@ with pkgs;
 
   inboxer = callPackage ../applications/networking/mailreaders/inboxer { };
 
+  incron = callPackage ../tools/system/incron { };
+
   inetutils = callPackage ../tools/networking/inetutils { };
 
   infiniband-diags = callPackage ../tools/networking/infiniband-diags { };


### PR DESCRIPTION
###### Motivation for this change
The incron package is available on many other distributions but lacking in NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Thorough application testing within a fresh nixos container.
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

