### PR TITLE
dex: 0.7 -> 0.8.0

### DIFF
--- a/pkgs/tools/X11/dex/default.nix
+++ b/pkgs/tools/X11/dex/default.nix
@@ -3,16 +3,17 @@
 stdenv.mkDerivation rec {
   program = "dex";
   name = "${program}-${version}";
-  version = "0.7";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "jceb";
     repo = program;
     rev = "v${version}";
-    sha256 = "041ms01snalapapaniabr92d8iim1qrxian626nharjmp2rd69v5";
+    sha256 = "13dkjd1373mbvskrdrp0865llr3zvdr90sc6a6jqswh3crmgmz4k";
   };
 
   propagatedBuildInputs = [ python3 ];
+  nativeBuildInputs = [ python3.pkgs.sphinx ];
   makeFlags = [ "PREFIX=$(out)" "VERSION=$(version)" ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)

---

