### PR TITLE
mandoc: 1.13.4 -> 1.14.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -425,6 +425,11 @@
     github = "Baughn";
     name = "Svein Ove Aas";
   };
+  bb010g = {
+    email = "me@bb010g.com";
+    github = "bb010g";
+    name = "Brayden Banks";
+  };
   bbarker = {
     email = "brandon.barker@gmail.com";
     github = "bbarker";

--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -19,7 +19,12 @@ stdenv.mkDerivation rec {
     HAVE_MANPATH=1
     LD_OHASH="-lutil"
     BUILD_DB=0
+    CC=${stdenv.cc.targetPrefix}cc
   '';
+
+  patches = [
+    ./remove-broken-cc-check.patch
+  ];
 
   preConfigure = ''
     echo $configureLocal > configure.local

--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mandoc-${version}";
-  version = "1.13.4";
+  version = "1.14.4";
 
   src = fetchurl {
-    url = "http://mdocml.bsd.lv/snapshots/mdocml-${version}.tar.gz";
-    sha256 = "1vz0g5nvjbz1ckrg9cn6ivlnb13bcl1r6nc4yzb7300qvfnw2m8a";
+    url = "https://mandoc.bsd.lv/snapshots/mandoc-${version}.tar.gz";
+    sha256 = "24eb72103768987dcc63b53d27fdc085796330782f44b3b40c4660b1e1ee9b9c";
   };
 
   buildInputs = [ zlib ];
@@ -26,10 +26,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://mdocml.bsd.lv/;
+    homepage = https://mandoc.bsd.lv/;
     description = "suite of tools compiling mdoc and man";
+    downloadPage = "http://mandoc.bsd.lv/snapshots/";
     license = licenses.bsd3;
     platforms = platforms.all;
-    maintainers = with maintainers; [ ramkromberg ];
+    maintainers = with maintainers; [ bb010g ramkromberg ];
   };
 }

--- a/pkgs/tools/misc/mandoc/remove-broken-cc-check.patch
+++ b/pkgs/tools/misc/mandoc/remove-broken-cc-check.patch
@@ -1,0 +1,11 @@
+--- mandoc-1.14.4.org/configure	2018-08-08 15:51:51.000000000 +0100
++++ mandoc-1.14.4/configure	2018-08-27 08:19:40.391912427 +0100
+@@ -40,7 +40,7 @@
+ OSNAME=
+ UTF8_LOCALE=
+ 
+-CC=`printf "all:\\n\\t@echo \\\$(CC)\\n" | env -i make -sf -`
++CC=
+ CFLAGS=
+ LDADD=
+ LDFLAGS=


### PR DESCRIPTION
Should I modify `meta.maintainers`? 1.14.1, the first update after 1.13.4, was in Feb 2017, so I'm not sure if @RamKromberg is still interested in maintaining mandoc.

[Changelog here](http://mandoc.bsd.lv/NEWS). It's late here, so I haven't really done testing outside of it successfully outputting HTML from mdoc, but I can do so if necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] (N/A) Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

