### PR TITLE
mixxx: 2.0.0 -> 2.1.3

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -1,34 +1,24 @@
-{ stdenv, fetchurl, chromaprint, fetchpatch, fftw, flac, faad2, mp4v2
+{ stdenv, fetchFromGitHub, chromaprint, fetchpatch, fftw, flac, faad2, mp4v2
 , libid3tag, libmad, libopus, libshout, libsndfile, libusb1, libvorbis
 , pkgconfig, portaudio, portmidi, protobuf, qt4, rubberband, scons, sqlite
-, taglib, vampSDK
+, taglib, upower, vampSDK
 }:
 
 stdenv.mkDerivation rec {
   name = "mixxx-${version}";
-  version = "2.0.0";
+  version = "2.1.3";
 
-  src = fetchurl {
-    url = "https://downloads.mixxx.org/${name}/${name}-src.tar.gz";
-    sha256 = "0vb71w1yq0xwwsclrn2jj9bk8w4n14rfv5c0aw46c11mp8xz7f71";
+  src = fetchFromGitHub {
+    owner = "mixxxdj";
+    repo = "mixxx";
+    rev = "release-${version}";
+    sha256 = "1fm8lkbnxka4haidf6yr8mb3r6vaxmc97hhrp8pcx0fvq2mnzvy2";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.net/data/main/m/mixxx/2.0.0~dfsg-7.1/debian/patches/0007-fix_gcc6_issue.patch";
-      sha256 = "0kpyv10wcjcvbijk6vpq54gx9sqzrq4kq2qilc1czmisp9qdy5sd";
-    })
-    (fetchpatch {
-      url = "https://622776.bugs.gentoo.org/attachment.cgi?id=487284";
-      name = "sqlite.patch";
-      sha256 = "1qqbd8nrxrjcc1dwvyqfq1k2yz3l071sfcgd2dmpk6j8d4j5kx31";
-    })
- ];
 
   buildInputs = [
     chromaprint fftw flac faad2 mp4v2 libid3tag libmad libopus libshout libsndfile
     libusb1 libvorbis pkgconfig portaudio portmidi protobuf qt4
-    rubberband scons sqlite taglib vampSDK
+    rubberband scons sqlite taglib upower vampSDK
   ];
 
   sconsFlags = [
@@ -56,7 +46,7 @@ stdenv.mkDerivation rec {
     homepage = https://mixxx.org;
     description = "Digital DJ mixing software";
     license = licenses.gpl2Plus;
-    maintainers = [ maintainers.aszlig maintainers.goibhniu ];
+    maintainers = [ maintainers.aszlig maintainers.goibhniu maintainers.bfortz ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Version bump. Switched to releases on GitHub.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

