### PR TITLE
nixos/tests/netdata: fix non-deterministic failure

### DIFF
--- a/nixos/tests/netdata.nix
+++ b/nixos/tests/netdata.nix
@@ -20,6 +20,9 @@ import ./make-test.nix ({ pkgs, ...} : {
 
     $netdata->waitForUnit("netdata.service");
 
+    # wait for the service to listen before sending a request
+    $netdata->waitForOpenPort(19999);
+
     # check if the netdata main page loads.
     $netdata->succeed("curl --fail http://localhost:19999/");
 


### PR DESCRIPTION
###### Motivation for this change

The test sporadically failed on hydra for [x86_64-linux](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.netdata.x86_64-linux)  and [i686](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.netdata.i686-linux) when a request was made
before the service was actually listening on its port.

Explicitly wait for the port to open.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

