### PR TITLE
qtwebengine: Fix inputs on aarch64

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -134,7 +134,7 @@ EOF
     harfbuzz icu
 
     libevent
-  ] ++ optionals stdenv.hostPlatform.isArm [
+  ] ++ optionals (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) [
     ffmpeg
   ] ++ optionals (!stdenv.isDarwin) [
     dbus zlib minizip snappy nss protobuf jsoncpp


### PR DESCRIPTION
A mistake in the previous commit meant that ffmpeg wasn't added to the
propagatedBuildInputs on aarch64.

###### Motivation for this change
I made a mistake in https://github.com/NixOS/nixpkgs/pull/45122

###### Things done
Fixed qtwebengine's propagatedBuildInputs to include ffmpeg on aarch64

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Build ongoing, but it's passed the configure stage where this mistake was causing it to fail)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

