### PR TITLE
nixos/tests/networking: fix routes and virtual tests

### DIFF
--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -552,15 +552,15 @@ let
 
       testScript = ''
         my $targetIPv4Table = <<'END';
-        10.0.0.0/16 scope link mtu 1500 
+        10.0.0.0/16 proto static scope link mtu 1500 
         192.168.1.0/24 proto kernel scope link src 192.168.1.2 
-        192.168.2.0/24 via 192.168.1.1 
+        192.168.2.0/24 via 192.168.1.1 proto static 
         END
 
         my $targetIPv6Table = <<'END';
         2001:1470:fffd:2097::/64 proto kernel metric 256 pref medium
-        2001:1470:fffd:2098::/64 via fdfd:b3f0::1 metric 1024 pref medium
-        fdfd:b3f0::/48 metric 1024 pref medium
+        2001:1470:fffd:2098::/64 via fdfd:b3f0::1 proto static metric 1024 pref medium
+        fdfd:b3f0::/48 proto static metric 1024 pref medium
         END
 
         $machine->start;

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -448,8 +448,8 @@ let
 
       testScript = ''
         my $targetList = <<'END';
-        tap0: tap UNKNOWN_FLAGS:800 user 0
-        tun0: tun UNKNOWN_FLAGS:800 user 0
+        tap0: tap persist user 0
+        tun0: tun persist user 0
         END
 
         # Wait for networking to come up


### PR DESCRIPTION
###### Motivation for this change

The "routes" and "virtual" networking tests have failed on hydra for quite some time because the output of  `ip route` has changed. FIxed by modifying the expected outputs coded in the tests.

Hydra failures:

https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.networking.networkd.routes.x86_64-linux
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.networking.networkd.virtual.x86_64-linux
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.networking.scripted.routes.x86_64-linux
https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.networking.scripted.virtual.x86_64-linux


###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

cc #40257 

