### PR TITLE
pythonPackages.sympy: 1.1.1 -> 1.2

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -136,6 +136,13 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch?id2=8.4.beta0&id=8bef4fd2876a61969b516fe4eb3b8ad7cc076c5e";
       sha256 = "00p3hfsfn3w2vxgd9fjd23mz7xfxjfravf8ysjxkyd657jbkpjmk";
     })
+
+    # https://trac.sagemath.org/ticket/26117
+    (fetchpatch {
+      name = "sympy-1.2.patch";
+      url = "https://git.sagemath.org/sage.git/patch?id2=8.4.beta2&id=d94a0a3a3fb4aec05a6f4d95166d90c284f05c36";
+      sha256 = "0an2xl1pp3jg36kgg2m1vb7sns7rprk1h3d0qy1gxwdab6i7qnvi";
+    })
   ];
 
   patches = nixPatches ++ packageUpgradePatches ++ [

--- a/pkgs/development/python-modules/sympy/default.nix
+++ b/pkgs/development/python-modules/sympy/default.nix
@@ -8,44 +8,36 @@
 
 buildPythonPackage rec {
   pname = "sympy";
-  version = "1.1.1";
+  version = "1.2"; # Upgrades may break sage. Please test.
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ac5b57691bc43919dcc21167660a57cc51797c28a4301a6144eff07b751216a4";
+    sha256 = "0pr2v7dl51ngch1cfs423qsb472l9ys1m8m7vrhhh99fsxqa0v18";
   };
 
   checkInputs = [ glibcLocales ];
 
   propagatedBuildInputs = [ mpmath ];
 
-  # Bunch of failures including transients.
+  # some tests fail: https://github.com/sympy/sympy/issues/15149
   doCheck = false;
+
+  patches = [
+    # to be fixed by https://github.com/sympy/sympy/pull/13476
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympy/patches/03_undeffun_sage.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "1mh2va1rlgizgvx8yzqwgvbf5wvswarn511002b361mc8yy0bnhr";
+    })
+  ];
 
   preCheck = ''
     export LANG="en_US.UTF-8"
   '';
 
-  patches = [
-    # see https://trac.sagemath.org/ticket/20204 and https://github.com/sympy/sympy/issues/12825
-    # There is also an upstream patch for this, included in the next release (PR #128826).
-    # However that doesn't quite fix the issue yet. Apparently some changes by sage are required.
-    # TODO re-evaluate the change once a new sympy version is released (open a sage trac ticket about
-    # it).
-    (fetchpatch {
-      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/sympy/patches/03_undeffun_sage.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
-      sha256 = "1mh2va1rlgizgvx8yzqwgvbf5wvswarn511002b361mc8yy0bnhr";
-    })
-    (fetchpatch {
-      url = "https://github.com/sympy/sympy/pull/13276.patch";
-      sha256 = "1rz74b5c74vwh3pj9axxgh610i02l3555vvsvr4a15ya7siw7zxh";
-    })
-  ];
-
   meta = {
     description = "A Python library for symbolic mathematics";
     homepage    = http://www.sympy.org/;
     license     = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ lovek323 ];
+    maintainers = with lib.maintainers; [ lovek323 timokau ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Needs a sage patch. @FRidh is it okay to merge this outside of your python updates?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

