### PR TITLE
libyaml: update from 0.1.7 to 0.2.1

### DIFF
--- a/pkgs/development/libraries/libyaml/default.nix
+++ b/pkgs/development/libraries/libyaml/default.nix
@@ -1,15 +1,16 @@
 { stdenv, fetchurl }:
 let
-  # 0.2.1 broke the tests of pythonPackages.pyyaml 3.13
-  version = "0.1.7";
+  version = "0.2.1";
 in
 stdenv.mkDerivation {
   name = "libyaml-${version}";
 
   src = fetchurl {
     url = "https://pyyaml.org/download/libyaml/yaml-${version}.tar.gz";
-    sha256 = "0a87931cx5m14a1x8rbjix3nz7agrcgndf4h392vm62a4rby9240";
+    sha256 = "1karpcfgacgppa82wm2drcfn2kb6q2wqfykf5nrhy20sci2i2a3q";
   };
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = https://pyyaml.org/;


### PR DESCRIPTION
Apparently, this update break the test suite of pythonPackages.pyyaml (version
3.13), which is odd because both packages come from the same upstream authors
and both have been released together. Needs investigation.

Related to https://github.com/NixOS/cabal2nix/issues/372.
