### PR TITLE
solargraph: 0.23.6 -> 0.25.1

### DIFF
--- a/pkgs/development/ruby-modules/solargraph/Gemfile.lock
+++ b/pkgs/development/ruby-modules/solargraph/Gemfile.lock
@@ -25,8 +25,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
-    solargraph (0.23.6)
+    ruby-progressbar (1.10.0)
+    solargraph (0.25.1)
       coderay (~> 1.1)
       eventmachine (~> 1.2, >= 1.2.5)
       htmlentities (~> 4.3, >= 4.3.4)
@@ -40,7 +40,7 @@ GEM
     thor (0.20.0)
     tilt (2.0.8)
     unicode-display_width (1.4.0)
-    yard (0.9.15)
+    yard (0.9.16)
 
 PLATFORMS
   ruby
@@ -49,4 +49,4 @@ DEPENDENCIES
   solargraph!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/pkgs/development/ruby-modules/solargraph/gemset.nix
+++ b/pkgs/development/ruby-modules/solargraph/gemset.nix
@@ -118,19 +118,19 @@
   ruby-progressbar = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1igh1xivf5h5g3y5m9b4i4j2mhz2r43kngh4ww3q1r80ch21nbfk";
+      sha256 = "1cv2ym3rl09svw8940ny67bav7b2db4ms39i4raaqzkf59jmhglk";
       type = "gem";
     };
-    version = "1.9.0";
+    version = "1.10.0";
   };
   solargraph = {
     dependencies = ["coderay" "eventmachine" "htmlentities" "kramdown" "parser" "reverse_markdown" "rubocop" "thor" "tilt" "yard"];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01lh5vibr277vhhrgk6zl09ivb262c1qpk54ahzhc40zs309842b";
+      sha256 = "1b5dljgskjpkpv2l0jpb6i8j73hidskcbp2v7fhjp7kpx94x6php";
       type = "gem";
     };
-    version = "0.23.6";
+    version = "0.25.1";
   };
   thor = {
     source = {
@@ -159,9 +159,9 @@
   yard = {
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "145pbc0x95s6x296kh1wp5ykwy6srfcz946dgj83s35g8p52z4q4";
+      sha256 = "0lmmr1839qgbb3zxfa7jf5mzy17yjl1yirwlgzdhws4452gqhn67";
       type = "gem";
     };
-    version = "0.9.15";
+    version = "0.9.16";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
An update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

