### PR TITLE
pdftag: init at 1.0.4

### DIFF
--- a/pkgs/tools/graphics/pdftag/default.nix
+++ b/pkgs/tools/graphics/pdftag/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, pkgconfig, meson, vala, ninja
+, gtk3, poppler, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "pdftag";
+  name = "${pname}-${version}";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "arrufat";
+    repo = pname;
+    rev = version;
+    sha256 = "17zk42h0n33b4p8fqlq2riqwcdi8y9m5n0ccydnk6a4x8rli97b3";
+  };
+
+  nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook ];
+  buildInputs = [ gtk3 poppler vala ];
+
+  patchPhase = ''substituteInPlace meson.build \
+    --replace "install_dir: '/usr" "install_dir: '$out"
+  '';
+
+  preInstall = "mkdir -p $out/share/licenses/${pname}";
+
+  meta = with stdenv.lib; {
+    description = "Edit metadata found in PDFs";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4552,6 +4552,8 @@ with pkgs;
 
   pdfcrack = callPackage ../tools/security/pdfcrack { };
 
+  pdftag = callPackage ../tools/graphics/pdftag { };
+
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };
 
   fmodex = callPackage ../games/zandronum/fmod.nix { };


### PR DESCRIPTION
###### Motivation for this change

User friendly tool for editing metadata was still missing.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

