### PR TITLE
weechat-matrix-bridge: 2018-01-10 -> 2018-05-29

### DIFF
--- a/pkgs/applications/networking/instant-messengers/weechat-matrix-bridge/default.nix
+++ b/pkgs/applications/networking/instant-messengers/weechat-matrix-bridge/default.nix
@@ -1,12 +1,12 @@
 { stdenv, curl, fetchFromGitHub, cjson, olm, luaffi }:
 
 stdenv.mkDerivation {
-  name = "weechat-matrix-bridge-2018-01-10";
+  name = "weechat-matrix-bridge-2018-05-29";
   src = fetchFromGitHub {
     owner = "torhve";
     repo = "weechat-matrix-protocol-script";
-    rev = "a8e4ce04665c09ee7f24d6b319cd85cfb56dfbd7";
-    sha256 = "0822xcxvwanwm8qbzqhn3f1m6hhxs29pyf8lnv6v29bl8136vcq3";
+    rev = "ace3fefc0e35a627f8a528032df2e3111e41eb1b";
+    sha256 = "1snf8vn5n9wzrnqnvdrcli4199s5p114jbjlgrj5c27i53173wqw";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Ma27 
