### PR TITLE
herbstluftwm: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/applications/window-managers/herbstluftwm/default.nix
+++ b/pkgs/applications/window-managers/herbstluftwm/default.nix
@@ -1,18 +1,19 @@
 { stdenv, fetchurl, pkgconfig, glib, libX11, libXext, libXinerama }:
 
 stdenv.mkDerivation rec {
-  name = "herbstluftwm-0.7.0";
+  name = "herbstluftwm-0.7.1";
 
   src = fetchurl {
     url = "https://herbstluftwm.org/tarballs/${name}.tar.gz";
-    sha256 = "09xfs213vg1dpird61wik5bqb9yf8kh63ssy18ihf54inwqgqbvy";
+    sha256 = "0d47lbjxxqd8d96hby47bdhyn9mlih7h28712j1vckiz05ig63nw";
   };
 
   patchPhase = ''
     substituteInPlace config.mk \
       --replace "/usr/local" "$out" \
       --replace "/etc" "$out/etc" \
-      --replace "/zsh/functions/Completion/X" "/zsh/site-functions"
+      --replace "/zsh/functions/Completion/X" "/zsh/site-functions" \
+      --replace "/usr/share" "\$(PREFIX)/share"
   '';
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

###### Things done

Note that commit https://github.com/herbstluftwm/herbstluftwm/commit/e5a52f2de0900277767c6ce6e10b5911e448e2fc introduces a new variable `FISHCOMPLETIONDIR` in `config.mk`, thus a new line in patchPhase is needed. The package does not seem to have been tested with a non-standard PREFIX (or it was, but `mkdir /usr/share/fish/vendor_completions.d` worked on a non-Nixos system), which anyway does not seem to be a priority (https://github.com/herbstluftwm/herbstluftwm/pull/107 is opened since 1 year).

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @the-kenny
