### PR TITLE
vitetris: init at 0.57.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3700,6 +3700,11 @@
     github = "siddharthist";
     name = "Langston Barrett";
   };
+  siers = {
+    email = "veinbahs+nixpkgs@gmail.com";
+    github = "siers";
+    name = "Raitis Veinbahs";
+  };
   sifmelcara = {
     email = "ming@culpring.com";
     github = "sifmelcara";

--- a/pkgs/games/vitetris/default.nix
+++ b/pkgs/games/vitetris/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, lib }:
+
+stdenv.mkDerivation rec {
+  name = "vitetris-${version}";
+  version = "0.57.2";
+
+  src = fetchFromGitHub {
+    owner = "vicgeralds";
+    repo = "vitetris";
+    rev = "v${version}";
+    sha256 = "0px0h4zrpzr6xd1vz7w9gr6rh0z74y66jfzschkcvj84plld10k6";
+  };
+
+  hardeningDisable = [ "format" ];
+
+  makeFlags = "INSTALL=install";
+
+  meta = {
+    description = "Terminal-based Tetris clone by Victor Nilsson";
+    homepage = http://www.victornils.net/tetris/;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ siers ];
+
+    longDescription = ''
+      vitetris is a terminal-based Tetris clone by Victor Nilsson. Gameplay is much
+      like the early Tetris games by Nintendo.
+
+      Features include: configurable keys, highscore table, two-player mode with
+      garbage, network play, joystick (gamepad) support on Linux or with Allegro.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20263,6 +20263,8 @@ with pkgs;
 
   vessel = pkgsi686Linux.callPackage ../games/vessel { };
 
+  vitetris = callPackage ../games/vitetris { };
+
   vms-empire = callPackage ../games/vms-empire { };
 
   voxelands = callPackage ../games/voxelands {


### PR DESCRIPTION
###### Motivation for this change

I need more tetris in my life and so should you.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).