### PR TITLE
upx: 3.94 -> 3.95

### DIFF
--- a/pkgs/tools/compression/upx/default.nix
+++ b/pkgs/tools/compression/upx/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "upx-${version}";
-  version = "3.94";
+  version = "3.95";
   src = fetchurl {
-    url = "https://github.com/upx/upx/releases/download/v3.94/upx-3.94-src.tar.xz";
-    sha256 = "08anybdliqsbsl6x835iwzljahnm9i7v26icdjkcv33xmk6p5vw1";
+    url = "https://github.com/upx/upx/releases/download/v${version}/${name}-src.tar.xz";
+    sha256 = "14jmgy7hvx4zqra20w8260wrcxmjf2h6ba2yrw7pcp18im35a3rv";
   };
 
   CXXFLAGS = "-Wno-unused-command-line-argument";


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---