### PR TITLE
nvidia_x11: 390.77 -> 390.87

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -22,6 +22,8 @@ rec {
     sha256_64bit = "07k1kq8lkgbvjyr2dnbxcz6nppcwpq17wf925w8kfq78345hla9q";
     settingsSha256 = "0xlaiy7jr95z0v2c6cwll89nxnb142pybw7m08jg44r7n13ffv3r";
     persistencedSha256 = "0mhwk321garyl6m12261cj03ycv0qz1sbrlbq6cqwjpq4f1s7h58";
+
+    patches = lib.optional (kernel.meta.branch == "4.19") ./drm_mode_connector.patch;
   };
 
   beta = stable; # not enough interest to maintain beta ATM

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -17,11 +17,11 @@ in
 rec {
   # Policy: use the highest stable version as the default (on our master).
   stable = generic {
-    version = "390.77";
-    sha256_32bit = "1yd313ghh2qbn07d5wbkshfwgkm4mh49vcqkydds3b3xk0mx4i8l";
-    sha256_64bit = "10kjccrkdn360035lh985cadhwy6lk9xrw3wlmww2wqfaa25f775";
-    settingsSha256 = "1wvxldpjkrx0ldjm5l6ycm6paxpcw89h0n6hfkznfkahkq7fwxdj";
-    persistencedSha256 = "1gklmc0v17m018cwpdlzwdyd45y4sjvjhj8a3l44baygix5zn30f";
+    version = "390.87";
+    sha256_32bit = "0rlr1f4lnpb8c4qz4w5r8xw5gdy9bzz26qww45qyl1qav3wwaaaw";
+    sha256_64bit = "07k1kq8lkgbvjyr2dnbxcz6nppcwpq17wf925w8kfq78345hla9q";
+    settingsSha256 = "0xlaiy7jr95z0v2c6cwll89nxnb142pybw7m08jg44r7n13ffv3r";
+    persistencedSha256 = "0mhwk321garyl6m12261cj03ycv0qz1sbrlbq6cqwjpq4f1s7h58";
   };
 
   beta = stable; # not enough interest to maintain beta ATM

--- a/pkgs/os-specific/linux/nvidia-x11/drm_mode_connector.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/drm_mode_connector.patch
@@ -1,0 +1,24 @@
+diff -ura a/kernel/nvidia-drm/nvidia-drm-connector.c b/kernel/nvidia-drm/nvidia-drm-connector.c
+--- a/kernel/nvidia-drm/nvidia-drm-connector.c	2018-09-07 17:38:31.807453997 -0400
++++ b/kernel/nvidia-drm/nvidia-drm-connector.c	2018-09-07 17:39:22.446185824 -0400
+@@ -226,7 +226,7 @@
+ 
+ 
+     if (nv_connector->edid != NULL) {
+-        drm_mode_connector_update_edid_property(
++        drm_connector_update_edid_property(
+             connector, nv_connector->edid);
+     }
+ 
+diff -ura a/kernel/nvidia-drm/nvidia-drm-encoder.c b/kernel/nvidia-drm/nvidia-drm-encoder.c
+--- a/kernel/nvidia-drm/nvidia-drm-encoder.c	2018-09-07 17:38:31.807453997 -0400
++++ b/kernel/nvidia-drm/nvidia-drm-encoder.c	2018-09-07 17:39:35.083798484 -0400
+@@ -216,7 +216,7 @@
+ 
+     /* Attach encoder and connector */
+ 
+-    ret = drm_mode_connector_attach_encoder(connector, encoder);
++    ret = drm_connector_attach_encoder(connector, encoder);
+ 
+     if (ret != 0) {
+         NV_DRM_DEV_LOG_ERR(


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

