### PR TITLE
mint: 0.2.0 -> 0.2.1

### DIFF
--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -1,4 +1,9 @@
-{stdenv, lib, fetchFromGitHub, crystal, zlib, openssl, duktape}:
+# Updating the dependencies for this package:
+#
+#   wget https://github.com/mint-lang/mint/blob/0.2.1/shard.lock
+#   nix-shell -p crystal libyaml --run 'crystal run crystal2nix.cr'
+#
+{stdenv, lib, fetchFromGitHub, crystal, zlib, openssl, duktape, which }:
 let
   crystalPackages = lib.mapAttrs (name: src:
     stdenv.mkDerivation {
@@ -28,15 +33,16 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  version = "0.2.0";
+  version = "0.2.1";
   name = "mint-${version}";
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
-    rev = "0.2.0";
-    sha256 = "1ds9zrvbmnfy744i9ri6v4w37aw7ccmdxzxmy8l97h045hzz9cp3";
+    rev = version;
+    sha256 = "0r8hv2j5yz0rlvrbpnybihj44562pkmsssa8f0hjs45m1ifvf4b1";
   };
 
+  nativeBuildInputs = [ which ];
   buildInputs = [ crystal zlib openssl duktape ];
 
   buildPhase = ''

--- a/pkgs/development/compilers/mint/shards.nix
+++ b/pkgs/development/compilers/mint/shards.nix
@@ -2,8 +2,8 @@
   admiral = {
     owner = "jwaldrip";
     repo = "admiral.cr";
-    rev = "v1.7.2";
-    sha256 = "1j2cr4p3d44848v0gfl97p9kw2dslscnb1piyb7b3374iy345i0k";
+    rev = "v1.7.3";
+    sha256 = "0b98qjy43wsrc08am7lkhcdsxc7gplf9hcmbvd4p3dw4g107rk91";
   };
   ameba = {
     owner = "veelenga";
@@ -14,8 +14,8 @@
   baked_file_system = {
     owner = "schovi";
     repo = "baked_file_system";
-    rev = "24dbaf2180b872c0f0fc777b34e3759108959e6e";
-    sha256 = "01p7hzsvms9cywdgs0rcs6mxdi94491wk55823fw2vxv24hvxnvk";
+    rev = "v0.9.7";
+    sha256 = "1fi6zag1a6h4xwrfizy01dls3hhraqw0cmpwj7rjv1qcddjgig5z";
   };
   diff = {
     owner = "MakeNowJust";
@@ -38,8 +38,8 @@
   kemal = {
     owner = "kemalcr";
     repo = "kemal";
-    rev = "09bb1fcd4073a374b3a61c99e48e05a866b23c08";
-    sha256 = "0yyb59i897gr8cqjbf48d6s0znq68ibpxarxkxkgrqk7lbvrqqr7";
+    rev = "v0.24.0";
+    sha256 = "0sg7gy1lbhid9y9wh77m9sd00jygk92njm4mpb7w1fq8bjnm738k";
   };
   kilt = {
     owner = "jeromegn";


### PR DESCRIPTION
###### Motivation for this change

Now builds with crystal 0.26.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

