### PR TITLE
navit: fix plugins

### DIFF
--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -68,10 +68,10 @@ stdenv.mkDerivation rec {
   '';
 
   # TODO: fix upstream?
+  libPath = stdenv.lib.makeLibraryPath ([ stdenv.cc.libc ] ++ buildInputs );
   postFixup = ''
-    for lib in $(find "$out/lib/navit/" -iname "*.so" ); do
-      patchelf --set-rpath ${makeLibraryPath buildInputs} $lib
-    done
+	  find "$out/lib" -type f -name "*.so" -exec patchelf --set-rpath $libPath {} \;
+
     wrapProgram $out/bin/navit \
       --prefix PATH : ${makeBinPath (
         optional xkbdSupport xkbd


### PR DESCRIPTION
###### Motivation for this change

there was still some broken plugins with glibc. This fix all. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

