### PR TITLE
granite: 5.0 -> 5.1.0

### DIFF
--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "granite-${version}";
-  version = "5.0";
+  version = "5.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "granite";
     rev = version;
-    sha256 = "015hkclcxirssg7a8s6mkns5xdk77m1jnkshlyfdw041nzyc5jh1";
+    sha256 = "1v1yhz6rp616xi417m9r8072s6mpz5i8vkdyj264b73p0lgjwh40";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
An update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
**Of dependent packages**
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
