### PR TITLE
linux-hardkernel: 4.14.55-146 -> 4.14.66-147

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-hardkernel-4.14.nix
@@ -1,10 +1,10 @@
 { stdenv, buildPackages, hostPlatform, fetchFromGitHub, perl, buildLinux, libelf, utillinux, ... } @ args:
 
 buildLinux (args // rec {
-  version = "4.14.55-146";
+  version = "4.14.66-147";
 
   # modDirVersion needs to be x.y.z.
-  modDirVersion = "4.14.55";
+  modDirVersion = "4.14.66";
 
   # branchVersion needs to be x.y. 
   extraMeta.branch = "4.14";
@@ -13,7 +13,7 @@ buildLinux (args // rec {
     owner = "hardkernel";
     repo = "linux";
     rev = version;
-    sha256 = "1bm1njng4rwfylgnqv06vabkvybm9rikqj1lsb7p9qcs3y1kw6mh";
+    sha256 = "06v38jl4i7l8gl8zcpyp9vmjjhaqhbp7by15f82rxa724zppxi9x";
   };
 
   defconfig = "odroidxu4_defconfig";


### PR DESCRIPTION
###### Motivation for this change
Update the Hardkernel kernel. This is built and running right now on my Odroid HC2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

