### PR TITLE
haskellPackages.termonad: Add dontCheck and remove from dont-distribute-packages.

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -9066,7 +9066,6 @@ dont-distribute-packages:
   termcolor:                                      [ i686-linux, x86_64-linux, x86_64-darwin ]
   terminal-text:                                  [ i686-linux, x86_64-linux, x86_64-darwin ]
   termination-combinators:                        [ i686-linux, x86_64-linux, x86_64-darwin ]
-  termonad:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   termplot:                                       [ i686-linux, x86_64-linux, x86_64-darwin ]
   terntup:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]
   terrahs:                                        [ i686-linux, x86_64-linux, x86_64-darwin ]

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -507,4 +507,8 @@ self: super: builtins.intersectAttrs super {
   LDAP = dontCheck (overrideCabal super.LDAP (drv: {
     librarySystemDepends = drv.librarySystemDepends or [] ++ [ pkgs.cyrus_sasl.dev ];
   }));
+
+  # Doctests hang only when compiling with nix.
+  # https://github.com/cdepillabout/termonad/issues/15
+  termonad = dontCheck super.termonad;
 }


### PR DESCRIPTION
###### Motivation for this change

The doctests for termonad fail to build only with nix.  When building without nix, the doctests run correctly:

https://github.com/cdepillabout/termonad/issues/15

This PR disables the tests for termonad, as well as removing it from dont-distribute-packages.

This PR is based on the haskell-updates branch, as suggested by @basvandijk  in https://github.com/NixOS/nixpkgs/pull/44529#issuecomment-416055551.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

