### PR TITLE
obliv-c: 0.0pre20170827 -> 0.0pre20180624

### DIFF
--- a/pkgs/development/compilers/obliv-c/default.nix
+++ b/pkgs/development/compilers/obliv-c/default.nix
@@ -1,15 +1,15 @@
 { stdenv, libgcrypt, fetchFromGitHub, ocamlPackages, perl }:
 stdenv.mkDerivation rec {
   name = "obliv-c-${version}";
-  version = "0.0pre20170827";
+  version = "0.0pre20180624";
   buildInputs = [ perl ]
   ++ (with ocamlPackages; [ ocaml findlib ocamlbuild ]);
   propagatedBuildInputs = [ libgcrypt ];
   src = fetchFromGitHub {
     owner = "samee";
     repo = "obliv-c";
-    rev = "9a6be5a5f44d341bc357055e11922f6a4c4c3b65";
-    sha256 = "0jz2ayadx62zv2b5ji947bkvw63axl4a2q70lwli86zgmcl390gf";
+    rev = "3d6804ca0fd85868207a0ccbd2509ec064723ac2";
+    sha256 = "1ib21ngn7zr58xxq4sjigrpaxb0wx35x3k9l4qvwflzrmvnman20";
   };
 
   patches = [ ./ignore-complex-float128.patch ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

