### PR TITLE
vagrant: mark bundler as system plugin

### DIFF
--- a/pkgs/development/tools/vagrant/default.nix
+++ b/pkgs/development/tools/vagrant/default.nix
@@ -38,6 +38,7 @@ in buildRubyGem rec {
 
   patches = [
     ./unofficial-installation-nowarn.patch
+    ./use-system-bundler-version.patch
   ];
 
   # PATH additions:

--- a/pkgs/development/tools/vagrant/use-system-bundler-version.patch
+++ b/pkgs/development/tools/vagrant/use-system-bundler-version.patch
@@ -1,0 +1,13 @@
+diff --git i/lib/vagrant/bundler.rb w/lib/vagrant/bundler.rb
+index 301e40e37..e361ab510 100644
+--- i/lib/vagrant/bundler.rb
++++ w/lib/vagrant/bundler.rb
+@@ -217,7 +217,7 @@ module Vagrant
+       source_list = {}
+       system_plugins = plugins.map do |plugin_name, plugin_info|
+         plugin_name if plugin_info["system"]
+-      end.compact
++      end.compact << "bundler"
+       installer_set = VagrantSet.new(:both)
+       installer_set.system_plugins = system_plugins
+ 


### PR DESCRIPTION
This will cause Vagrant to use the rubygems version of bundler
without complaint.

###### Motivation for this change

Great suggestion from @calbrecht in https://github.com/NixOS/nixpkgs/issues/36880#issuecomment-416151360. Fixes #36880.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).