### PR TITLE
ruby: default to version 2.5

### DIFF
--- a/pkgs/development/interpreters/ruby/patchsets.nix
+++ b/pkgs/development/interpreters/ruby/patchsets.nix
@@ -1,11 +1,6 @@
 { patchSet, useRailsExpress, ops, patchLevel }:
 
 rec {
-  "2.2.9" = ops useRailsExpress [
-    "${patchSet}/patches/ruby/2.2/head/railsexpress/01-zero-broken-tests.patch"
-    "${patchSet}/patches/ruby/2.2/head/railsexpress/02-improve-gc-stats.patch"
-    "${patchSet}/patches/ruby/2.2/head/railsexpress/03-display-more-detailed-stack-trace.patch"
-  ];
   "2.3.7" = ops useRailsExpress [
     "${patchSet}/patches/ruby/2.3/head/railsexpress/01-skip-broken-tests.patch"
     "${patchSet}/patches/ruby/2.3/head/railsexpress/02-improve-gc-stats.patch"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7722,7 +7722,7 @@ with pkgs;
     ruby_2_4
     ruby_2_5;
 
-  ruby = ruby_2_4;
+  ruby = ruby_2_5;
 
   mruby = callPackage ../development/compilers/mruby { };
 


### PR DESCRIPTION
###### Motivation for this change

Should be done before 18.09, Ruby 2.6 is almost out as well.

@zimbatm 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

