### PR TITLE
nano: updated 'nixSyntaxHighlight'

### DIFF
--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -14,8 +14,8 @@ let
   nixSyntaxHighlight = fetchFromGitHub {
     owner = "seitz";
     repo = "nanonix";
-    rev = "17e0de65e1cbba3d6baa82deaefa853b41f5c161";
-    sha256 = "1g51h65i31andfs2fbp1v3vih9405iknqn11fzywjxji00kjqv5s";
+    rev = "7483fd8b79f1f3f2179dbbd46aa400df4320ba10";
+    sha256 = "10pv75kfrgnziz8sr83hdbb0c3klm2fmsdw3i5cpqqf5va1fzb8h";
   };
 
 in stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change
newer syntax highlighting that also highlights all 'lib' and 'builtins' functions in a different color.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
---

