### PR TITLE
nbd: 3.17 -> 3.18. Also, add which to buildInputs (needed by test pha…

### DIFF
--- a/pkgs/tools/networking/nbd/default.nix
+++ b/pkgs/tools/networking/nbd/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, glib }:
+{ stdenv, fetchurl, pkgconfig, glib, which }:
 
 stdenv.mkDerivation rec {
-  name = "nbd-3.17";
+  name = "nbd-3.18";
 
   src = fetchurl {
     url = "mirror://sourceforge/nbd/${name}.tar.xz";
-    sha256 = "12fil2hb3gkxslr3nl9kak93n4iyhfs3zdwrmx9vjcxblfqnnp6r";
+    sha256 = "0cb0sjiv0j9sh9dk24nrjm7sa0axbrcp2av5hc91g1ryzk764dyq";
   };
 
   buildInputs =
-    [ pkgconfig glib ]
+    [ pkgconfig glib which ]
     ++ stdenv.lib.optional (stdenv ? glibc) stdenv.glibc.linuxHeaders;
 
   postInstall = ''


### PR DESCRIPTION
…se).

###### Motivation for this change
To update nbd to the latest version. While building, I noticed the test scripts complaining about the lack of `which`, so I added that too. I have briefly tested the client and server with two real hosts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

