### PR TITLE
bunny: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -832,6 +832,11 @@
     github = "couchemar";
     name = "Andrey Pavlov";
   };
+  countingsort = {
+    email = "niclas@countingsort.com";
+    github = "countingsort";
+    name = "Niclas Meyer";
+  };
   cpages = {
     email = "page@ruiec.cat";
     github = "cpages";

--- a/pkgs/tools/package-management/bunny/default.nix
+++ b/pkgs/tools/package-management/bunny/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A simple shell script wrapper around multiple package managers";
     homepage = https://gitlab.com/tim241/bunny;
-    licenses = licenses.gpl3;
+    license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ countingsort ];
   };

--- a/pkgs/tools/package-management/bunny/default.nix
+++ b/pkgs/tools/package-management/bunny/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitLab }:
+
+stdenv.mkDerivation rec {
+  name = "bunny-${version}";
+  version = "1.1";
+
+  src = fetchFromGitLab {
+    owner = "tim241";
+    repo = "bunny";
+    rev = version;
+    sha256 = "0mxhj23fscbyqb9hfpmimgjn6nbx1lx3dl2msgwdy281zs25w8ki";
+  };
+
+  dontBuild = true;
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A simple shell script wrapper around multiple package managers";
+    homepage = https://gitlab.com/tim241/bunny;
+    licenses = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ countingsort ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -635,6 +635,8 @@ with pkgs;
 
   bonfire = callPackage ../tools/misc/bonfire { };
 
+  bunny = callPackage ../tools/package-management/bunny { };
+
   cloud-sql-proxy = callPackage ../tools/misc/cloud-sql-proxy { };
 
   container-linux-config-transpiler = callPackage ../development/tools/container-linux-config-transpiler { };


### PR DESCRIPTION
###### Motivation for this change

Pretty useful not to have to think about what system you're on when
doing basic (un)installation tasks.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

