### PR TITLE
dwm-git: init at 20180602

### DIFF
--- a/pkgs/applications/window-managers/dwm/git.nix
+++ b/pkgs/applications/window-managers/dwm/git.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchgit, libX11, libXinerama, libXft, patches ? [], conf ? null }:
+
+let
+  name = "dwm-git-20180602";
+in
+
+stdenv.mkDerivation {
+  inherit name;
+
+  src = fetchgit {
+    url = "git://git.suckless.org/dwm";
+    rev = "b69c870a3076d78ab595ed1cd4b41cf6b03b2610";
+    sha256 = "10i079h79l4gdch1qy2vrrb2xxxkgkjmgphr5r9a75jbbagwvz0k";
+  };
+
+  buildInputs = [ libX11 libXinerama libXft ];
+
+  prePatch = ''sed -i "s@/usr/local@$out@" config.mk'';
+
+  # Allow users set their own list of patches
+  inherit patches;
+
+  # Allow users to override the entire config file AFTER appying the patches
+  postPatch = stdenv.lib.optionalString (conf!=null) ''
+    echo -n '${conf}' > config.def.h
+  '';
+
+  buildPhase = "make";
+
+  meta = with stdenv.lib; {
+    homepage = https://suckless.org/;
+    description = "Dynamic window manager for X, development version";
+    license = licenses.mit;
+    maintainers = with maintainers; [xeji];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15941,6 +15941,11 @@ with pkgs;
     patches = config.dwm.patches or [];
   };
 
+  dwm-git = callPackage ../applications/window-managers/dwm/git.nix {
+    patches = config.dwm.patches or [];
+    conf = config.dwm.conf or null;
+  };
+
   dwm-status = callPackage ../applications/window-managers/dwm/dwm-status.nix { };
 
   dynamips = callPackage ../applications/virtualization/dynamips { };


### PR DESCRIPTION
###### Motivation for this change

The latest tagged release dwm 6.1 is from 2015. Newer patches/add-ons target the development version from git, which sucks even less :smile:

Also add an option to override the entire config file instead of generating a patch for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

