### PR TITLE
treewide: Deprecate platform aliases

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -127,8 +127,9 @@ let
         "`stdenv.isArm` is deprecated after 18.03. Please use `stdenv.isAarch32` instead"
         hostPlatform.isAarch32;
 
-      # The derivation's `system` is `buildPlatform.system`.
-      inherit (buildPlatform) system;
+      system = builtins.trace
+        ("`stdenv.system` is deprecated since 18.09. Please use `stdenv.hostPlatform.system`.")
+        hostPlatform.system;
 
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -89,7 +89,9 @@ let
     targetPlatform = lib.warn
       "top-level `targetPlatform` is deprecated since 18.09. Please use `stdenv.targetPlatform`."
       super.stdenv.targetPlatform;
-    inherit (super.stdenv.hostPlatform) system;
+    system = lib.warn
+      ("top-level `system` is deprecated since 18.09. Please use `stdenv.system` or `stdenv.hostPlatform.system`.")
+      super.stdenv.hostPlatform.system;
   };
 
   splice = self: super: import ./splice.nix lib self (buildPackages != null);


### PR DESCRIPTION
The first commit is succinct and does the depredations. You can just read it, but they are:

1. Left in this PR.
   ```
   system ==> stdenv.buildPlatform.system
   ```
2. Left in this PR.
   ```
   stdenv.system ==> stdenv.buildPlatform.system
   ```
3. Proposed in other open PR.
   ```
   configureFlags = "--foo --bar"; ==> configureFlags = [ "--foo" "--bar" ];
   ```
4. Message improved in other PR
   ```
   isArm ==> isAarch32 # Already done during 18.03
   ```
5. Done in other PR
   ```
   buildPlatform ==> stdenv.buildPlatform
   ```
6. Done in other PR
   ```
   hostPlatform ==> stdenv.hostPlatform
   ```
7. Done in other PR
   ```
   targetPlatform ==> stdenv.targetPlatform
   ```

The rest make Nixpkgs itself comply. If this is accepted, sometime after 18.09 is forked I'll merge another PR to actually remove them.

###### Motivation for this change

See #27069. This makes there be only one non-deprecated way to inspect the build/host/target platform in most cases. `stdenv.is*` is kept, unlike as in in the issue, since it is the most popular and already a shorthand.

The `configureFlags` change is unrelated except I earlier did the work of making nixpkgs obey it. It would be nice to deprecate that too so the work doesn't just bit-rot away.

###### Things done

No hashes should be changed.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

