### PR TITLE
fwupd: do not wrap efi capsule

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -79,6 +79,19 @@ in stdenv.mkDerivation {
 
   FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
 
+  # TODO: wrapGAppsHook wraps efi capsule even though it is not elf
+  dontWrapGApps = true;
+  # so we need to wrap the executables manually
+  postFixup = ''
+    find -L "$out/bin" "$out/libexec" -type f -executable -print0 \
+      | while IFS= read -r -d ''' file; do
+      if [[ "''${file}" != *.efi ]]; then
+        echo "Wrapping program ''${file}"
+        wrapProgram "''${file}" "''${gappsWrapperArgs[@]}"
+      fi
+    done
+  '';
+
   # /etc/fwupd/uefi.conf is created by the services.hardware.fwupd NixOS module
   passthru = {
     filesInstalledToEtc = [


### PR DESCRIPTION
###### Motivation for this change
wrapGAppsHook is not able to skip efi capsules so we need to switch to manual wrapping.

Closes: https://github.com/NixOS/nixpkgs/issues/45715

cc @tadfisher @Moredread 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

