### PR TITLE
nixos/networkd: fix range assertions on 32 bit Nix

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -30,10 +30,14 @@ let
     (assertValueOneOf "UDPSegmentationOffload" boolValues)
     (assertValueOneOf "GenericReceiveOffload" boolValues)
     (assertValueOneOf "LargeReceiveOffload" boolValues)
-    (assertRange "RxChannels" 1 4294967295)
-    (assertRange "TxChannels" 1 4294967295)
-    (assertRange "OtherChannels" 1 4294967295)
-    (assertRange "CombinedChannels" 1 4294967295)
+    (assertInt "RxChannels")
+    (assertMinimum "RxChannels" 1)
+    (assertInt "TxChannels")
+    (assertMinimum "TxChannels" 1)
+    (assertInt "OtherChannels")
+    (assertMinimum "OtherChannels" 1)
+    (assertInt "CombinedChannels")
+    (assertMinimum "CombinedChannels" 1)
   ];
 
   checkNetdev = checkUnitConfig "Netdev" [
@@ -226,7 +230,8 @@ let
     (assertValueOneOf "UseTimezone" boolValues)
     (assertValueOneOf "CriticalConnection" boolValues)
     (assertValueOneOf "RequestBroadcast" boolValues)
-    (assertRange "RouteTable" 0 4294967295)
+    (assertInt "RouteTable")
+    (assertMinimum "RouteTable" 0)
     (assertValueOneOf "RapidCommit" boolValues)
   ];
 

--- a/nixos/modules/system/boot/systemd-lib.nix
+++ b/nixos/modules/system/boot/systemd-lib.nix
@@ -73,10 +73,18 @@ in rec {
     optional (attr ? ${name} && !(min <= attr.${name} && max >= attr.${name}))
       "Systemd ${group} field `${name}' is outside the range [${toString min},${toString max}]";
 
+  assertMinimum = name: min: group: attr:
+    optional (attr ? ${name} && attr.${name} < min)
+      "Systemd ${group} field `${name}' must be greater than or equal to ${toString min}";
+
   assertOnlyFields = fields: group: attr:
     let badFields = filter (name: ! elem name fields) (attrNames attr); in
     optional (badFields != [ ])
       "Systemd ${group} has extra fields [${concatStringsSep " " badFields}].";
+
+  assertInt = name: group: attr:
+    optional (attr ? ${name} && !isInt attr.${name})
+      "Systemd ${group} field `${name}' is not an integer";
 
   checkUnitConfig = group: checks: attrs: let
     # We're applied at the top-level type (attrsOf unitOption), so the actual


### PR DESCRIPTION
###### Motivation for this change

Range assertions were recently added to the networkd module that exceeded the range of a signed 32-bit int, breaking the module on 32 bit Nix.

###### Things done

This PR changes those assertions to checks that the value is an int, as suggested in https://github.com/NixOS/nixpkgs/pull/44233#issuecomment-415517693.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

