### PR TITLE
snakemake: init at 5.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1630,6 +1630,11 @@
     github = "heel";
     name = "Sergii Paryzhskyi";
   };
+  helkafen = {
+    email = "arnaudpourseb@gmail.com";
+    github = "Helkafen";
+    name = "Sébastian Méric de Bellefon";
+  };
   henrytill = {
     email = "henrytill@gmail.com";
     github = "henrytill";

--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -1,0 +1,41 @@
+{
+  stdenv
+, python
+}:
+
+python.buildPythonPackage rec {
+  pname = "snakemake";
+  version = "5.2.2";
+
+  propagatedBuildInputs = with python; [
+    appdirs
+    ConfigArgParse
+    datrie
+    docutils
+    jsonschema
+    pyyaml
+    ratelimiter
+    requests
+    wrapt
+  ];
+
+  src = python.fetchPypi {
+    inherit pname version;
+    sha256 = "adffe7e24b4a613a9e8bf0a2a320b3cea236d86afb9132bb0bbbc08b8e35a3a3";
+  };
+
+  doCheck = false; # Tests depend on Google Cloud credentials at ${HOME}/gcloud-service-key.json
+
+  meta = with stdenv.lib; {
+    homepage = http://snakemake.bitbucket.io;
+    license = licenses.mit;
+    description = "Python-based execution environment for make-like workflows";
+    longDescription = ''
+      Snakemake is a workflow management system that aims to reduce the complexity of
+      creating workflows by providing a fast and comfortable execution environment,
+      together with a clean and readable specification language in Python style. Snakemake
+      workflows are essentially Python scripts extended by declarative code to define
+      rules. Rules describe how to create output files from input files.
+    '';
+  };
+}

--- a/pkgs/development/python-modules/ratelimiter/default.nix
+++ b/pkgs/development/python-modules/ratelimiter/default.nix
@@ -1,0 +1,35 @@
+{
+  stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, glibcLocales
+}:
+
+buildPythonPackage rec {
+  pname = "ratelimiter";
+  version = "1.2.0.post0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7";
+  };
+
+  LC_ALL = "en_US.utf-8";
+
+  nativeBuildInputs = [ glibcLocales ];
+
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    py.test tests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/RazerM/ratelimiter;
+    license = licenses.asl20;
+    description = "Simple python rate limiting object";
+    maintainers = with maintainers; [ helkafen ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8677,6 +8677,8 @@ with pkgs;
 
   smc = callPackage ../tools/misc/smc { };
 
+  snakemake = callPackage ../applications/science/misc/snakemake { python = python3Packages; };
+
   snowman = qt5.callPackage ../development/tools/analysis/snowman { };
 
   sparse = callPackage ../development/tools/analysis/sparse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4354,6 +4354,8 @@ in {
 
   regex = callPackage ../development/python-modules/regex { };
 
+  ratelimiter = callPackage ../development/python-modules/ratelimiter { };
+
   repoze_lru = buildPythonPackage rec {
     name = "repoze.lru-0.6";
 


### PR DESCRIPTION
###### Motivation for this change

Snakemake is a workflow management system. Useful in bio-informatics and HPC, where reproducibility is appreciated.
Also add dependency: ratelimiter (init at 1.2.0.post0)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu 18.04)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

