### PR TITLE
pythonPackages.pywatchman: 1.3.0 -> 1.4.1

### DIFF
--- a/pkgs/development/python-modules/pywatchman/default.nix
+++ b/pkgs/development/python-modules/pywatchman/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, watchman }:
+
+buildPythonPackage rec {
+  pname = "pywatchman";
+  version = "1.4.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1yf2gm20wc3djpb5larxii3l55xxby0il2ns3q0v1byyfnr7w16h";
+  };
+
+  postPatch = ''
+    substituteInPlace pywatchman/__init__.py \
+      --replace "'watchman'" "'${watchman}/bin/watchman'"
+  '';
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Watchman client for Python";
+    homepage = https://facebook.github.io/watchman/;
+    license = licenses.bsd3;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4429,21 +4429,7 @@ in {
     };
   };
 
-  pywatchman = buildPythonPackage rec {
-    name = "pywatchman-${version}";
-    version = "1.4.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/p/pywatchman/pywatchman-${version}.tar.gz";
-      sha256 = "1yf2gm20wc3djpb5larxii3l55xxby0il2ns3q0v1byyfnr7w16h";
-    };
-    postPatch = ''
-      substituteInPlace pywatchman/__init__.py \
-        --replace "'watchman'" "'${pkgs.watchman}/bin/watchman'"
-    '';
-    # No tests in archive
-    doCheck = false;
-
-  };
+  pywatchman = callPackage ../development/python-modules/pywatchman { };
 
   pywavelets = callPackage ../development/python-modules/pywavelets { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4431,17 +4431,15 @@ in {
 
   pywatchman = buildPythonPackage rec {
     name = "pywatchman-${version}";
-    version = "1.3.0";
+    version = "1.4.1";
     src = pkgs.fetchurl {
       url = "mirror://pypi/p/pywatchman/pywatchman-${version}.tar.gz";
-      sha256 = "c3d5be183b5b04f6ad575fc71b06dd196185dea1558d9f4d0598ba9beaab8245";
+      sha256 = "1yf2gm20wc3djpb5larxii3l55xxby0il2ns3q0v1byyfnr7w16h";
     };
     postPatch = ''
       substituteInPlace pywatchman/__init__.py \
         --replace "'watchman'" "'${pkgs.watchman}/bin/watchman'"
     '';
-    # SyntaxError
-    disabled = isPy3k;
     # No tests in archive
     doCheck = false;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

