### PR TITLE
vala: 0.34.17 -> 0.34.18, 0.36.13 -> 0.36.15, 0.38.9 -> 0.38.10, 0.40.6 -> 0.40.9

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -51,8 +51,8 @@ in rec {
 
   vala_0_36 = generic {
     major   = "0.36";
-    minor   = "13";
-    sha256  = "0gxz7yisd9vh5d2889p60knaifz5zndgj98zkdfkkaykdfdq4m9k";
+    minor   = "15";
+    sha256  = "11lnwjbhiz2l7g6y1f0jb0s81ymgssinlil3alibzcwmzpk175ix";
   };
 
   vala_0_38 = generic {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -57,8 +57,8 @@ in rec {
 
   vala_0_38 = generic {
     major   = "0.38";
-    minor   = "9";
-    sha256  = "1dh1qacfsc1nr6hxwhn9lqmhnq39rv8gxbapdmj1v65zs96j3fn3";
+    minor   = "10";
+    sha256  = "1rdwwqs973qv225v8b5izcgwvqn56jxgr4pa3wxxbliar3aww5sw";
     extraNativeBuildInputs = [ autoconf ] ++ lib.optional stdenv.isDarwin libtool;
   };
 

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -45,8 +45,8 @@ let
 in rec {
   vala_0_34 = generic {
     major   = "0.34";
-    minor   = "17";
-    sha256  = "0wd2zxww4z1ys4iqz218lvzjqjjqwsaad4x2by8pcyy43sbr7qp2";
+    minor   = "18";
+    sha256  = "1lhw3ghns059y5d6pdldy5p4yjwlhcls84k892i6qmbhxg34945q";
   };
 
   vala_0_36 = generic {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

builds for me, but nix-review is not finished yet.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

