### PR TITLE
ocamlPackages: default to 4.06

### DIFF
--- a/pkgs/applications/virtualization/xen/4.10.nix
+++ b/pkgs/applications/virtualization/xen/4.10.nix
@@ -1,4 +1,5 @@
 { stdenv, callPackage, fetchurl, fetchpatch, fetchgit
+, ocaml-ng
 , withInternalQemu ? true
 , withInternalTraditionalQemu ? true
 , withInternalSeabios ? true
@@ -177,4 +178,4 @@ callPackage (import ./generic.nix (rec {
       else throw "this xen has no qemu builtin";
   };
 
-})) args
+})) ({ ocamlPackages = ocaml-ng.ocamlPackages_4_05; } // args)

--- a/pkgs/applications/virtualization/xen/4.8.nix
+++ b/pkgs/applications/virtualization/xen/4.8.nix
@@ -1,4 +1,5 @@
 { stdenv, callPackage, fetchurl, fetchpatch, fetchgit
+, ocaml-ng
 , withInternalQemu ? true
 , withInternalTraditionalQemu ? true
 , withInternalSeabios ? true
@@ -181,4 +182,4 @@ callPackage (import ./generic.nix (rec {
       else throw "this xen has no qemu builtin";
   };
 
-})) args
+})) ({ ocamlPackages = ocaml-ng.ocamlPackages_4_05; } // args)

--- a/pkgs/development/compilers/mezzo/default.nix
+++ b/pkgs/development/compilers/mezzo/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, menhir, yojson, ulex, pprint, fix, functory }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "mezzo is not available for OCaml ${ocaml.version}"
+else
+
 let
   check-ocaml-version = with stdenv.lib; versionAtLeast (getVersion ocaml);
 in

--- a/pkgs/development/ocaml-modules/bin_prot/default.nix
+++ b/pkgs/development/ocaml-modules/bin_prot/default.nix
@@ -1,4 +1,8 @@
-{stdenv, buildOcaml, fetchurl, type_conv}:
+{ stdenv, buildOcaml, fetchurl, ocaml, type_conv }:
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "bin_prot-112.24.00 is not available for OCaml ${ocaml.version}"
+else
 
 buildOcaml rec {
   name = "bin_prot";

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -5,6 +5,10 @@ let inherit (stdenv.lib) getVersion versionAtLeast; in
 assert versionAtLeast (getVersion ocaml) "4.00.0";
 assert versionAtLeast (getVersion findlib) "1.3.3";
 
+if versionAtLeast ocaml.version "4.06"
+then throw "bolt is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
 
   name = "bolt-1.4";

--- a/pkgs/development/ocaml-modules/camlimages/4.1.nix
+++ b/pkgs/development/ocaml-modules/camlimages/4.1.nix
@@ -2,6 +2,10 @@
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.00";
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "camlimages-4.1.2 is not available for OCaml ${ocaml.version}"
+else
+
 let
   pname = "camlimages";
   version = "4.1.2";

--- a/pkgs/development/ocaml-modules/cil/default.nix
+++ b/pkgs/development/ocaml-modules/cil/default.nix
@@ -1,4 +1,9 @@
 { stdenv, fetchurl, perl, ocaml, findlib, ocamlbuild }:
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "cil is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-cil-1.7.3";
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -1,5 +1,9 @@
 {stdenv, fetchurl, ocaml, findlib}:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "cryptgps is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   name = "ocaml-cryptgps-${version}";
   version = "0.2.1";

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -4,6 +4,10 @@ let
   pname = "dypgen";
 in
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   version = "20120619-1";

--- a/pkgs/development/ocaml-modules/enumerate/default.nix
+++ b/pkgs/development/ocaml-modules/enumerate/default.nix
@@ -2,6 +2,10 @@
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.00";
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "enumerate-111.08.00 is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-enumerate-111.08.00";
 

--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "erm_xml is not available for OCaml ${ocaml.version}"
+else
+
 let version = "0.3"; in
 
 stdenv.mkDerivation {

--- a/pkgs/development/ocaml-modules/faillib/default.nix
+++ b/pkgs/development/ocaml-modules/faillib/default.nix
@@ -1,4 +1,8 @@
-{stdenv, buildOcaml, fetchurl, herelib, camlp4}:
+{ stdenv, buildOcaml, fetchurl, ocaml, herelib, camlp4 }:
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "faillib-111.17.00 is not available for OCaml ${ocaml.version}"
+else
 
 buildOcaml rec {
   minimumSupportedOcamlVersion = "4.00";

--- a/pkgs/development/ocaml-modules/fieldslib/default.nix
+++ b/pkgs/development/ocaml-modules/fieldslib/default.nix
@@ -2,6 +2,10 @@
 
 assert stdenv.lib.versionOlder "4.00" (stdenv.lib.getVersion ocaml);
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "fieldslib-109.20.03 is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-fieldslib-109.20.03";
 

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -1,4 +1,8 @@
-{lib, buildOcaml, fetchurl}:
+{ lib, buildOcaml, fetchurl, ocaml }:
+
+if lib.versionAtLeast ocaml.version "4.06"
+then throw "FrontC is not available for OCaml ${ocaml.version}"
+else
 
 buildOcaml rec {
   name = "FrontC";

--- a/pkgs/development/ocaml-modules/gtktop/default.nix
+++ b/pkgs/development/ocaml-modules/gtktop/default.nix
@@ -2,6 +2,10 @@
 
 let pname = "gtktop-2.0"; in
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-${pname}";
 

--- a/pkgs/development/ocaml-modules/lwt/legacy.nix
+++ b/pkgs/development/ocaml-modules/lwt/legacy.nix
@@ -6,6 +6,7 @@
 }:
 
 if !stdenv.lib.versionAtLeast ocaml.version "4"
+ || stdenv.lib.versionAtLeast ocaml.version "4.06"
 then throw "lwt is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/development/ocaml-modules/magick/default.nix
+++ b/pkgs/development/ocaml-modules/magick/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl, which, pkgconfig, ocaml, findlib, imagemagick }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "magick is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-magick-0.34";
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -4,6 +4,10 @@ let
   pname = "ocaml-cairo";
 in
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   version = "1.2.0";

--- a/pkgs/development/ocaml-modules/ocamlsdl/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlsdl/default.nix
@@ -4,6 +4,10 @@ let
   pname = "ocamlsdl";
 in
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "${pname} is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   version = "0.9.1";

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchurl, ocaml, findlib, ocamlbuild, type_conv, ounit, camlp4 }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "ocaml-data-notation is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-data-notation-0.0.11";
 

--- a/pkgs/development/ocaml-modules/ojquery/default.nix
+++ b/pkgs/development/ocaml-modules/ojquery/default.nix
@@ -1,5 +1,9 @@
 { stdenv, fetchgit, ocaml, findlib, ocamlbuild, js_of_ocaml, js_of_ocaml-camlp4, camlp4, lwt3, react }:
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "ojquery is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   version = "0.1";
   name = "ocaml-ojquery-${version}";

--- a/pkgs/development/ocaml-modules/pa_ounit/default.nix
+++ b/pkgs/development/ocaml-modules/pa_ounit/default.nix
@@ -1,4 +1,8 @@
-{stdenv, buildOcaml, fetchurl, ounit}:
+{ stdenv, buildOcaml, ocaml, fetchurl, ounit }:
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "pa_ounit is not available for OCaml ${ocaml.version}"
+else
 
 buildOcaml rec {
   name = "pa_ounit";

--- a/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
@@ -2,6 +2,10 @@
 
 assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "3.12";
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "sqlite3EZ is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
   name = "ocaml-sqlite3EZ-0.1.0";
 

--- a/pkgs/development/ocaml-modules/ulex/0.8/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/0.8/default.nix
@@ -4,6 +4,10 @@ let
   pname = "ulex";
 in
 
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "ulex-0.8 is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   version = "0.8";

--- a/pkgs/development/ocaml-modules/variantslib/default.nix
+++ b/pkgs/development/ocaml-modules/variantslib/default.nix
@@ -1,4 +1,8 @@
-{stdenv, buildOcaml, fetchurl, type_conv}:
+{ stdenv, buildOcaml, ocaml, fetchurl, type_conv }:
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "variantslib-109.15.03 is not available for OCaml ${ocaml.version}"
+else
 
 buildOcaml rec {
   name = "variantslib";

--- a/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
+++ b/pkgs/development/tools/ocaml/omake/0.9.8.6-rc1.nix
@@ -4,6 +4,11 @@ let
   version = "0.9.8.6-0.rc1";
   webpage = "http://omake.metaprl.org";
 in
+
+if stdenv.lib.versionAtLeast ocaml.version "4.06"
+then throw "${pname}-${version} is not available for OCaml ${ocaml.version}"
+else
+
 stdenv.mkDerivation {
 
   name = "${pname}-${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8089,7 +8089,9 @@ with pkgs;
   # Does not actually depend on Qt 5
   inherit (kdeFrameworks) extra-cmake-modules kapidox kdoctools;
 
-  coccinelle = callPackage ../development/tools/misc/coccinelle { };
+  coccinelle = callPackage ../development/tools/misc/coccinelle {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   cpptest = callPackage ../development/libraries/cpptest { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7088,7 +7088,9 @@ with pkgs;
 
   nvidia_cg_toolkit = callPackage ../development/compilers/nvidia-cg-toolkit { };
 
-  obliv-c = callPackage ../development/compilers/obliv-c {};
+  obliv-c = callPackage ../development/compilers/obliv-c {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   ocaml-ng = callPackage ./ocaml-packages.nix { };
   ocaml = ocamlPackages.ocaml;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20876,7 +20876,9 @@ with pkgs;
 
   caprice32 = callPackage ../misc/emulators/caprice32 { };
 
-  cubicle = callPackage ../applications/science/logic/cubicle { };
+  cubicle = callPackage ../applications/science/logic/cubicle {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   cvc3 = callPackage ../applications/science/logic/cvc3 {
     gmp = lib.overrideDerivation gmp (a: { dontDisableStatic = true; });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20855,7 +20855,9 @@ with pkgs;
 
   inherit (callPackage ./coq-packages.nix {
     inherit (ocaml-ng) ocamlPackages_3_12_1
-                       ocamlPackages_4_02;
+                       ocamlPackages_4_02
+                       ocamlPackages_4_05
+    ;
   }) mkCoqPackages
     coq_8_3 coq_8_4 coq_8_5 coq_8_6 coq_8_7 coq_8_8
     coqPackages_8_5 coqPackages_8_6 coqPackages_8_7 coqPackages_8_8

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20978,7 +20978,9 @@ with pkgs;
     stdenv = gccStdenv;
   };
 
-  statverif = callPackage ../applications/science/logic/statverif { };
+  statverif = callPackage ../applications/science/logic/statverif {
+    inherit (ocaml-ng.ocamlPackages_4_05) ocaml;
+  };
 
   tptp = callPackage ../applications/science/logic/tptp {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20839,7 +20839,9 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_05;
   };
 
-  alt-ergo = callPackage ../applications/science/logic/alt-ergo { };
+  alt-ergo = callPackage ../applications/science/logic/alt-ergo {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   aspino = callPackage ../applications/science/logic/aspino {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20835,7 +20835,9 @@ with pkgs;
 
   abella = callPackage ../applications/science/logic/abella {};
 
-  acgtk = callPackage ../applications/science/logic/acgtk { };
+  acgtk = callPackage ../applications/science/logic/acgtk {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   alt-ergo = callPackage ../applications/science/logic/alt-ergo { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17454,7 +17454,9 @@ with pkgs;
 
   mjpg-streamer = callPackage ../applications/video/mjpg-streamer { };
 
-  mldonkey = callPackage ../applications/networking/p2p/mldonkey { };
+  mldonkey = callPackage ../applications/networking/p2p/mldonkey {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   MMA = callPackage ../applications/audio/MMA { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6716,7 +6716,7 @@ with pkgs;
       graphviz = graphviz-nox;
     });
 
-  inherit (ocamlPackages.haxe) haxe_3_2 haxe_3_4;
+  inherit (ocaml-ng.ocamlPackages_4_05.haxe) haxe_3_2 haxe_3_4;
   haxe = haxe_3_4;
   haxePackages = recurseIntoAttrs (callPackage ./haxe-packages.nix { });
   inherit (haxePackages) hxcpp;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6050,7 +6050,9 @@ with pkgs;
 
   wv2 = callPackage ../tools/misc/wv2 { };
 
-  wyrd = callPackage ../tools/misc/wyrd { };
+  wyrd = callPackage ../tools/misc/wyrd {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   x86info = callPackage ../os-specific/linux/x86info { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6735,13 +6735,9 @@ with pkgs;
     mono = mono46;
   };
 
-  fstar = callPackage ../development/compilers/fstar {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_06;
-  };
+  fstar = callPackage ../development/compilers/fstar { };
 
-  pyre = callPackage ../development/tools/pyre {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_06;
-  };
+  pyre = callPackage ../development/tools/pyre { };
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix {});
 
@@ -21862,9 +21858,7 @@ with pkgs;
 
   sane-frontends = callPackage ../applications/graphics/sane/frontends.nix { };
 
-  satysfi = callPackage ../tools/typesetting/satysfi {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_06;
-  };
+  satysfi = callPackage ../tools/typesetting/satysfi { };
 
   sc-controller = pythonPackages.callPackage ../misc/drivers/sc-controller {
     inherit libusb1; # Shadow python.pkgs.libusb1.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16844,7 +16844,9 @@ with pkgs;
     extra-packages = [ csound ];
   };
 
-  jackline = callPackage ../applications/networking/instant-messengers/jackline { };
+  jackline = callPackage ../applications/networking/instant-messengers/jackline {
+    ocamlPackages = ocaml-ng.ocamlPackages_4_05;
+  };
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10095,7 +10095,7 @@ with pkgs;
   libb2 = callPackage ../development/libraries/libb2 { };
 
   libbap = callPackage ../development/libraries/libbap {
-    inherit (ocamlPackages) bap ocaml findlib ctypes;
+    inherit (ocaml-ng.ocamlPackages_4_05) bap ocaml findlib ctypes;
   };
 
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18898,7 +18898,7 @@ with pkgs;
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
-  inherit (ocamlPackages) unison;
+  inherit (ocaml-ng.ocamlPackages_4_05) unison;
 
   unpaper = callPackage ../tools/graphics/unpaper { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7113,7 +7113,9 @@ with pkgs;
 
   opaline = callPackage ../development/tools/ocaml/opaline { };
 
-  opam = callPackage ../development/tools/ocaml/opam { };
+  opam = callPackage ../development/tools/ocaml/opam {
+    inherit (ocaml-ng.ocamlPackages_4_05) ocaml;
+  };
 
   picat = callPackage ../development/compilers/picat {
     stdenv = overrideCC stdenv gcc49;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21023,7 +21023,9 @@ with pkgs;
   z3 = callPackage ../applications/science/logic/z3 { python = python2; };
 
   tlaplus = callPackage ../applications/science/logic/tlaplus {};
-  tlaps = callPackage ../applications/science/logic/tlaplus/tlaps.nix {};
+  tlaps = callPackage ../applications/science/logic/tlaplus/tlaps.nix {
+    inherit (ocaml-ng.ocamlPackages_4_05) ocaml;
+  };
   tlaplusToolbox = callPackage ../applications/science/logic/tlaplus/toolbox.nix {gtk = gtk2;};
 
   aiger = callPackage ../applications/science/logic/aiger {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20964,7 +20964,9 @@ with pkgs;
 
   proverif = callPackage ../applications/science/logic/proverif { };
 
-  sapic = callPackage ../applications/science/logic/sapic { };
+  sapic = callPackage ../applications/science/logic/sapic {
+    inherit (ocaml-ng.ocamlPackages_4_05) ocaml;
+  };
 
   satallax = callPackage ../applications/science/logic/satallax {
     ocaml = ocaml-ng.ocamlPackages_4_01_0.ocaml;

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -70,6 +70,7 @@ in rec {
     version = "8.5pl3";
   };
   coq_8_6 = callPackage ../applications/science/logic/coq {
+    ocamlPackages = ocamlPackages_4_05;
     version = "8.6.1";
   };
   coq_8_7 = callPackage ../applications/science/logic/coq {

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -2,6 +2,7 @@
 , gnumake3
 , ocamlPackages_3_12_1
 , ocamlPackages_4_02
+, ocamlPackages_4_05
 }:
 
 let
@@ -65,6 +66,7 @@ in rec {
     camlp5 = ocamlPackages_4_02.camlp5_transitional;
   };
   coq_8_5 = callPackage ../applications/science/logic/coq {
+    ocamlPackages = ocamlPackages_4_05;
     version = "8.5pl3";
   };
   coq_8_6 = callPackage ../applications/science/logic/coq {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1072,10 +1072,5 @@ in rec
 
   ocamlPackages_latest = ocamlPackages_4_07;
 
-  ocamlPackages =
-    # OCaml 4.05 is broken on aarch64
-    if system == "aarch64-linux" then
-      ocamlPackages_4_06
-    else
-      ocamlPackages_4_05;
+  ocamlPackages = ocamlPackages_4_06;
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -610,9 +610,6 @@ let
       else null;
 
     ocaml_extlib = callPackage ../development/ocaml-modules/extlib { };
-    ocaml_extlib_maximal = callPackage ../development/ocaml-modules/extlib {
-      minimal = false;
-    };
 
     ocb-stubblr = callPackage ../development/ocaml-modules/ocb-stubblr { };
 


### PR DESCRIPTION
###### Motivation for this change

OCaml 4.06 has been out for a while, 4.07 is already here; time to update.

This PR disables a few legacy OCaml libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

