### PR TITLE
systemd-cryptsetup-generator: cryptsetup belongs to buildInputs

### DIFF
--- a/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
+++ b/pkgs/os-specific/linux/systemd/cryptsetup-generator.nix
@@ -1,10 +1,10 @@
 { stdenv, systemd, cryptsetup }:
 
-stdenv.lib.overrideDerivation systemd (p: {
+systemd.overrideAttrs (p: {
   version = p.version;
   name = "systemd-cryptsetup-generator-${p.version}";
 
-  nativeBuildInputs = p.nativeBuildInputs ++ [ cryptsetup ];
+  buildInputs = p.buildInputs ++ [ cryptsetup ];
   outputs = [ "out" ];
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

This fixes the build. Noticed in https://github.com/NixOS/nixpkgs/pull/45385#issuecomment-416976919


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

