### PR TITLE
Androidndk standalone toolchain support

### DIFF
--- a/pkgs/development/mobile/androidenv/androidndk.nix
+++ b/pkgs/development/mobile/androidenv/androidndk.nix
@@ -1,100 +1,110 @@
 { stdenv, fetchurl, zlib, ncurses5, unzip, lib, makeWrapper
 , coreutils, file, findutils, gawk, gnugrep, gnused, jdk, which
-, platformTools, python3, libcxx, version, sha256, bash
+, platformTools, python3, libcxx, version, sha256, bash, runCommand
 , fullNDK ? false # set to true if you want other parts of the NDK
                   # that is not used by Nixpkgs like sources,
                   # examples, docs, or LLVM toolchains
 }:
 
-stdenv.mkDerivation rec {
-  name = "android-ndk-r${version}";
-  inherit version;
+let
+  makeStandaloneToolchain = api: arch: let
+      full_ndk = (ndk true);
+    in runCommand "makeStandaloneToolchain-${version}" {} ''
+      ${full_ndk}/libexec/${full_ndk.name}/build/tools/make_standalone_toolchain.py --api ${toString api} --arch ${arch} --install-dir $out
+    '';
+  ndk = fullNDK: stdenv.mkDerivation rec {
+    name = "android-ndk-r${version}";
+    inherit version;
 
-  src = if stdenv.hostPlatform.system == "x86_64-linux" then fetchurl {
+    src = if stdenv.hostPlatform.system == "x86_64-linux" then fetchurl {
       url = "https://dl.google.com/android/repository/${name}-linux-x86_64.zip";
       inherit sha256;
     } else throw "platform ${stdenv.hostPlatform.system} not supported!";
 
-  phases = "buildPhase";
+    phases = "buildPhase";
 
-  nativeBuildInputs = [ unzip makeWrapper file ];
+    nativeBuildInputs = [ unzip makeWrapper file ];
 
-  buildCommand = let
-    bin_path = "$out/bin";
-    pkg_path = "$out/libexec/${name}";
-    sed_script_1 =
-      "'s|^PROGDIR=`dirname $0`" +
-      "|PROGDIR=`dirname $(readlink -f $(which $0))`|'";
-    runtime_paths = (lib.makeBinPath [
-      coreutils file findutils
-      gawk gnugrep gnused
-      jdk python3 which
-    ]) + ":${platformTools}/platform-tools";
-  in ''
-    mkdir -pv $out/libexec
-    cd $out/libexec
-    unzip -qq $src
+    buildCommand = let
+      bin_path = "$out/bin";
+      pkg_path = "$out/libexec/${name}";
+      sed_script_1 =
+        "'s|^PROGDIR=`dirname $0`" +
+        "|PROGDIR=`dirname $(readlink -f $(which $0))`|'";
+      runtime_paths = (lib.makeBinPath [
+        coreutils file findutils
+        gawk gnugrep gnused
+        jdk python3 which
+      ]) + ":${platformTools}/platform-tools";
+    in ''
+      mkdir -pv $out/libexec
+      cd $out/libexec
+      unzip -qq $src
 
-    # so that it doesn't fail because of read-only permissions set
-    cd -
-    ${if (version == "10e") then
-        ''
-          patch -p1 \
-            --no-backup-if-mismatch \
-            -d $out/libexec/${name} < ${ ./make-standalone-toolchain_r10e.patch }
-        ''
-      else
-        ''
-          patch -p1 \
-            --no-backup-if-mismatch \
-            -d $out/libexec/${name} < ${ ./. + "/make_standalone_toolchain.py_${version}.patch" }
+      # so that it doesn't fail because of read-only permissions set
+      cd -
+      ${if (version == "10e") then
+          ''
+            patch -p1 \
+              --no-backup-if-mismatch \
+              -d $out/libexec/${name} < ${ ./make-standalone-toolchain_r10e.patch }
+          ''
+        else
+          ''
+            patch -p1 \
+              --no-backup-if-mismatch \
+              -d $out/libexec/${name} < ${ ./. + "/make_standalone_toolchain.py_" + "${version}" + ".patch" }
 
-          sed -i 's,#!/usr/bin/env python,#!${python3}/bin/python,g' ${pkg_path}/build/tools/make_standalone_toolchain.py
-          sed -i 's,#!/bin/bash,#!${bash}/bin/bash,g' ${pkg_path}/build/tools/make_standalone_toolchain.py
-          wrapProgram ${pkg_path}/build/tools/make_standalone_toolchain.py --prefix PATH : "${runtime_paths}"
-        ''
-    }
+            sed -i 's,#!/usr/bin/env python,#!${python3}/bin/python,g' ${pkg_path}/build/tools/make_standalone_toolchain.py
+            sed -i 's,#!/bin/bash,#!${bash}/bin/bash,g' ${pkg_path}/build/tools/make_standalone_toolchain.py
+            wrapProgram ${pkg_path}/build/tools/make_standalone_toolchain.py --prefix PATH : "${runtime_paths}"
+          ''
+      }
 
-    patchShebangs ${pkg_path}
+      patchShebangs ${pkg_path}
 
-    cd ${pkg_path}
+      cd ${pkg_path}
 
-  '' + lib.optionalString (!fullNDK) ''
-    # Steps to reduce output size
-    rm -rf docs sources tests
-    # We only support cross compiling with gcc for now
-    rm -rf toolchains/*-clang* toolchains/llvm*
-  '' +
+    '' + lib.optionalString (!fullNDK) ''
+      # Steps to reduce output size
+      rm -rf docs sources tests
+      # We only support cross compiling with gcc for now
+      rm -rf toolchains/*-clang* toolchains/llvm*
+    '' +
 
-  ''
-    find ${pkg_path}/toolchains \( \
-        \( -type f -a -name "*.so*" \) -o \
-        \( -type f -a -perm -0100 \) \
-        \) -exec patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-*so.? \
-                          --set-rpath ${stdenv.lib.makeLibraryPath [ libcxx zlib ncurses5 ]} {} \;
-    # fix ineffective PROGDIR / MYNDKDIR determination
-    for i in ndk-build ${lib.optionalString (version == "10e") "ndk-gdb ndk-gdb-py"}
-    do
-        sed -i -e ${sed_script_1} $i
-    done
+    ''
+      find ${pkg_path}/toolchains \( \
+          \( -type f -a -name "*.so*" \) -o \
+          \( -type f -a -perm -0100 \) \
+          \) -exec patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-*so.? \
+                            --set-rpath ${stdenv.lib.makeLibraryPath [ libcxx zlib ncurses5 ]} {} \;
+      # fix ineffective PROGDIR / MYNDKDIR determination
+      for i in ndk-build ${lib.optionalString (version == "10e") "ndk-gdb ndk-gdb-py"}
+      do
+          sed -i -e ${sed_script_1} $i
+      done
 
-    # wrap
-    for i in ndk-build ${lib.optionalString (version == "10e") "ndk-gdb ndk-gdb-py ndk-which"}
-    do
-        wrapProgram "$(pwd)/$i" --prefix PATH : "${runtime_paths}"
-    done
-    # make some executables available in PATH
-    mkdir -pv ${bin_path}
-    for i in \
-        ndk-build ${lib.optionalString (version == "10e") "ndk-depends ndk-gdb ndk-gdb-py ndk-gdb.py ndk-stack ndk-which"}
-    do
-        ln -sf ${pkg_path}/$i ${bin_path}/$i
-    done
-  '';
+      # wrap
+      for i in ndk-build ${lib.optionalString (version == "10e") "ndk-gdb ndk-gdb-py ndk-which"}
+      do
+          wrapProgram "$(pwd)/$i" --prefix PATH : "${runtime_paths}"
+      done
+      # make some executables available in PATH
+      mkdir -pv ${bin_path}
+      for i in \
+          ndk-build ${lib.optionalString (version == "10e") "ndk-depends ndk-gdb ndk-gdb-py ndk-gdb.py ndk-stack ndk-which"}
+      do
+          ln -sf ${pkg_path}/$i ${bin_path}/$i
+      done
+    '';
 
-  meta = {
-    platforms = stdenv.lib.platforms.linux;
-    hydraPlatforms = [];
-    license = stdenv.lib.licenses.asl20;
+    meta = {
+      platforms = stdenv.lib.platforms.linux;
+      hydraPlatforms = [];
+      license = stdenv.lib.licenses.asl20;
+    };
   };
-}
+  passthru = {
+    inherit makeStandaloneToolchain;
+  };
+in lib.extendDerivation true passthru (ndk fullNDK)


### PR DESCRIPTION
###### Motivation for this change

I wanted to use the android standalone toolchain ;)

Now a standalone toolchain is available via:
```
    let
      toolchain = (androidenv.androidndk.makeStandaloneToolchain 24 "arm64");
    in
    ...
```

CC @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

