### PR TITLE
nixos/tests/mesos: fix test

### DIFF
--- a/nixos/tests/mesos.nix
+++ b/nixos/tests/mesos.nix
@@ -33,6 +33,7 @@ import ./make-test.nix ({ pkgs, ...} : rec {
 
   simpleDocker = pkgs.dockerTools.buildImage {
     name = "echo";
+    tag = "latest";
     contents = [ pkgs.stdenv.shellPackage pkgs.coreutils ];
     config = {
       Env = [


### PR DESCRIPTION
###### Motivation for this change

fallout from 39e678e24e38f1f374eaf5463b424ebdf75df9af :
dockerTools.buildImage no longer applies default tag "latest"

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
---

