### PR TITLE
nixos/tests/i3wm: prevent non-deterministic failure

### DIFF
--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -16,18 +16,20 @@ import ./make-test.nix ({ pkgs, ...} : {
     $machine->waitForFile("/home/alice/.Xauthority");
     $machine->succeed("xauth merge ~alice/.Xauthority");
     $machine->waitForWindow(qr/first configuration/);
-    $machine->sleep(1);
+    $machine->sleep(2);
     $machine->screenshot("started");
     $machine->sendKeys("ret");
-    $machine->sleep(1);
+    $machine->sleep(2);
     $machine->sendKeys("alt");
-    $machine->sleep(1);
+    $machine->sleep(2);
     $machine->screenshot("configured");
     $machine->sendKeys("ret");
+    # make sure the config file is created before we continue
+    $machine->waitForFile("/home/alice/.config/i3/config");
     $machine->sleep(2);
     $machine->sendKeys("alt-ret");
     $machine->waitForWindow(qr/machine.*alice/);
-    $machine->sleep(1);
+    $machine->sleep(2);
     $machine->screenshot("terminal");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Test failed sporadically on [Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.i3wm.x86_64-linux), probably due to timing issues according to the logs.
These changes should make that less likely to occur.

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
---

