### PR TITLE
sphinx-jinja: 0.2.1 -> 1.1.0, Python 3 support

### DIFF
--- a/pkgs/development/python-modules/sphinx-jinja/default.nix
+++ b/pkgs/development/python-modules/sphinx-jinja/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, pbr, sphinx, sphinx-testing, nose, glibcLocales }:
+
+buildPythonPackage rec {
+  pname = "sphinx-jinja";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02pgp9pbn0zrs0lggrc74mv6cvlnlq8wib84ga6yjvq30gda9v8q";
+  };
+
+  buildInputs = [ pbr ];
+  propagatedBuildInputs = [ sphinx ];
+
+  checkInputs = [ sphinx-testing nose glibcLocales ];
+
+  checkPhase = ''
+    # Zip (epub) does not support files with epoch timestamp
+    LC_ALL="en_US.UTF-8" nosetests -e test_build_epub
+  '';
+
+  meta = with lib; {
+    description = "Sphinx extension to include jinja templates in documentation";
+    maintainers = with maintainers; [ nand0p ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13170,26 +13170,7 @@ in {
     };
   });
 
-  sphinx-jinja = buildPythonPackage (rec {
-    name = "${pname}-${version}";
-    pname = "sphinx-jinja";
-    version = "0.2.1";
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/s/${pname}/${name}.tar.gz";
-      sha256 = "1zsnhc573rvaww9qqyzs4f5h4hhvxklvppv14450vi5dk8rij81z";
-    };
-    buildInputs = with self; [ sphinx-testing pytest pbr];
-    propagatedBuildInputs = with self; [ sphinx blockdiag ];
-    checkPhase = ''
-      py.test -k "not test_build_epub"
-    '';
-    disabled = isPy3k;
-    meta = {
-      description = "includes jinja templates in a documentation";
-      maintainers = with maintainers; [ nand0p ];
-      license = licenses.mit;
-    };
-  });
+  sphinx-jinja = callPackage ../development/python-modules/sphinx-jinja { };
 
   sphinx_pypi_upload = buildPythonPackage (rec {
     name = "Sphinx-PyPI-upload-0.2.1";


### PR DESCRIPTION
###### Motivation for this change

Updates sphinx-jinja to the latest version, and enables Python 3 support.

###### Things done

The main issues with Python 3 support were that the tests were run with pytest when they were designed to be run with nose (pytest tried to inject fixtures into function arguments). Also there is an issue where a UTF-8 file is read in the tests without specifying a codec, which requires the locale to be set to UTF-8.

I also removed the blockdiag dependency, because I could not see how it was required. @nand0p why was blockdiag necessary?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

