### PR TITLE
corgi: init at 0.2.3

### DIFF
--- a/pkgs/development/tools/corgi/default.nix
+++ b/pkgs/development/tools/corgi/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "corgi-${rev}";
+  rev = "v0.2.3";
+
+  goPackagePath = "github.com/DrakeW/corgi";
+
+  src = fetchFromGitHub {
+    owner = "DrakeW";
+    repo = "corgi";
+    inherit rev;
+    sha256 = "0ahwpyd6dac04qw2ak51xfbwkr42sab1gkhh52i7hlcy12jpwl8q";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "CLI workflow manager";
+    longDescription = ''
+      Corgi is a command-line tool that helps with your repetitive command usages by organizing them into reusable snippet.
+    '';
+    homepage = https://github.com/DrakeW/corgi;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ kalbasit ];
+  };
+}

--- a/pkgs/development/tools/corgi/deps.nix
+++ b/pkgs/development/tools/corgi/deps.nix
@@ -1,0 +1,47 @@
+[
+  {
+    goPackagePath = "github.com/chzyer/readline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/readline";
+      rev = "2972be24d48e78746da79ba8e24e8b488c9880de";
+      sha256 = "104q8dazj8yf6b089jjr82fy9h1g80zyyzvp3g8b44a7d8ngjj6r";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "2d684516a8861da43017284349b7e303e809ac21";
+      sha256 = "1fcfmz4wji3gqmmsdx493r7d101s58hwjalqps6hy25nva5pvmfs";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "ae18d6b8b3205b561c79e8e5f69bff09736185f4";
+      sha256 = "0f0z0aa4wivk4z1y503dmnw0k0g0g403dly8i4q263gfshs82sbq";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "99dc123558852f67743bd0b2caf8383cb3c6d720";
+      sha256 = "0b2rjgycgpkpvpsqgvilqkr66bfk477lyd6l0jxmgxb1h0za5s25";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "d929dcbb10863323c436af3cf76cb16a6dfc9b29";
+      sha256 = "1qjmqvszs9cmic7brm7pknq86zjra4hq923bn88blfvr3bap5bc4";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -117,6 +117,8 @@ with pkgs;
 
   cmark = callPackage ../development/libraries/cmark { };
 
+  corgi = callPackage ../development/tools/corgi { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit dhall-nix;
   };


### PR DESCRIPTION
###### Motivation for this change

Corgi is a command-line workflow manager that helps with your repetitive command usages by organizing them into reusable snippet.

https://github.com/DrakeW/corgi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

