### PR TITLE
can-isotp: init at 20180629

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1302,6 +1302,11 @@
     github = "etu";
     name = "Elis Hirwing";
   };
+  evck = {
+    email = "eric@evenchick.com";
+    github = "ericevenchick";
+    name = "Eric Evenchick";
+  };
   exfalso = {
     email = "0slemi0@gmail.com";
     github = "exfalso";

--- a/pkgs/os-specific/linux/can-isotp/default.nix
+++ b/pkgs/os-specific/linux/can-isotp/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, kernel, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "can-isotp-${version}";
+  version = "20180629";
+
+  hardeningDisable = [ "pic" ];
+  
+  src = fetchFromGitHub {
+    owner = "hartkopp";
+    repo = "can-isotp";
+    rev = "6003f9997587e6a563cebf1f246bcd0eb6deff3d";
+    sha256 = "0b2pqb0vd1wgv2zpl7lvfavqkzr8mrwhrv7zdqkq3rz9givcv8w7";
+  };
+
+  KERNELDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = "\${out}";
+
+  buildPhase = ''
+    make modules
+  '';
+
+  installPhase = ''
+    make modules_install
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+  
+  meta = with stdenv.lib; {
+    description = "Kernel module for ISO-TP (ISO 15765-2)";
+    homepage = "https://github.com/hartkopp/can-isotp";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.evck ];
+  };
+}  

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14176,6 +14176,8 @@ with pkgs;
      }) zfsStable zfsUnstable;
 
      zfs = zfsStable;
+
+     can-isotp = callPackage ../os-specific/linux/can-isotp { };
   });
 
   # The current default kernel / kernel modules.


### PR DESCRIPTION
###### Motivation for this change

NixOS already has the can_utils package which provides utilities for interacting with CAN devices/buses, but does not have the kernel module needed for the ISO-TP utilities (isotprecv, isotpsend, isotpsniffer, etc...). This adds the required can-isotp kernel module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

