### PR TITLE
nix-review: 0.5.0 -> 0.5.2

### DIFF
--- a/pkgs/tools/package-management/nix-review/default.nix
+++ b/pkgs/tools/package-management/nix-review/default.nix
@@ -8,13 +8,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "nix-review";
-  version = "0.5.0";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "nix-review";
     rev = version;
-    sha256 = "0ncifmp90870v6r651p92wbvpayfblm5k9nxikryjaj1fnvd2np3";
+    sha256 = "0csd7dkdv0csc63dz1h08c8xifxwv5fdz5dyk37sr6vh1ccjdapi";
   };
 
   makeWrapperArgs = [


### PR DESCRIPTION
fix cleanup issue: https://github.com/Mic92/nix-review/issues/10
fix overriding NIXPKGS_CONFIG: https://github.com/Mic92/nix-review/pull/12

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using ~`nix-shell -p nox --run "nox-review wip"`~ `nix-review pr 45770`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

