### PR TITLE
Gstreamer: 1.14.0 -> 1.14.2

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -17,7 +17,8 @@ let
   inherit (stdenv.lib) optional;
 in
 stdenv.mkDerivation rec {
-  name = "gst-plugins-bad-1.14.0";
+  name = "gst-plugins-bad-${version}";
+  version = "1.14.2";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Bad Plugins";
@@ -53,7 +54,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-bad/${name}.tar.xz";
-    sha256 = "17sgzgx1c54k5rzz7ljyz3is0n7yj56k74vv05h8z1gjnsnjnppd";
+    sha256 = "1bqy3dn7q4kdkd4lqznyly8fv854d0hhncv88jk6ai4rf3dbgyil";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -9,7 +9,8 @@
 , enableCdparanoia ? (!stdenv.isDarwin), cdparanoia }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-base-1.14.0";
+  name = "gst-plugins-base-${version}";
+  version = "1.14.2";
 
   meta = with lib; {
     description = "Base plugins and helper libraries";
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-base/${name}.tar.xz";
-    sha256 = "0h39bcp7fcd9kgb189lxr8l0hm0almvzpzgpdh1jpq2nzxh4d43y";
+    sha256 = "0z0wy0p0nxxqhsis3n517d6ykldm02g7rca9fhq9kxb9m05yidx4";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -6,7 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gstreamer-1.14.0";
+  name = "gstreamer-${version}";
+  version = "1.14.2";
 
   meta = with lib ;{
     description = "Open source multimedia framework";
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer/${name}.tar.xz";
-    sha256 = "0vj6k01lp2yva6rfd95fkyng9jdr62gkz0x8d2l81dyly1ki6dpw";
+    sha256 = "029fi3v0vrravysgfwhfkrb3ndg64sjmigbb0iwr7wpkk5r15mjb";
   };
 
   patches = [

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -4,7 +4,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gstreamer-editing-services-1.14.0";
+  name = "gstreamer-editing-services-${version}";
+  version = "1.14.2";
 
   meta = with stdenv.lib; {
     description = "Library for creation of audio/video non-linear editors";
@@ -15,7 +16,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer-editing-services/${name}.tar.xz";
-    sha256 = "14cdd6y9p4k603hsnyhdjw2igg855gwpx0362jmg8k1gagmr0pwd";
+    sha256 = "0d0zqvgxp51mmffz5vvscsdzqqw9mjsv6bnk6ivg2dxnkv8q1ch5";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -15,7 +15,8 @@ let
   inherit (stdenv.lib) optional optionals;
 in
 stdenv.mkDerivation rec {
-  name = "gst-plugins-good-1.14.0";
+  name = "gst-plugins-good-${version}";
+  version = "1.14.2";
 
   meta = with stdenv.lib; {
     description = "Gstreamer Good Plugins";
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-good/${name}.tar.xz";
-    sha256 = "1226s30cf7pqg3fj8shd20l7sp93yw9sqplgxns3m3ajgms3byka";
+    sha256 = "1bfa4n6xhr4v4wga8pv1y00rm1aka498snw6kgszy2w624l5wmy0";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -9,7 +9,8 @@
 assert withSystemLibav -> libav != null;
 
 stdenv.mkDerivation rec {
-  name = "gst-libav-1.14.0";
+  name = "gst-libav-${version}";
+  version = "1.14.2";
 
   meta = {
     homepage = https://gstreamer.freedesktop.org;
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-libav/${name}.tar.xz";
-    sha256 = "12gglx6rarnxbaj0h1wivlgkv467n1bz2bwjigplciq57r6ln4zv";
+    sha256 = "1pknqpjxq1l3vlprdsmxxwk0lwqa555fqd543k9vphngqlwiqdca";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -3,7 +3,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-rtsp-server-1.14.0";
+  name = "gst-rtsp-server-${version}";
+  version = "1.14.2";
 
   meta = with stdenv.lib; {
     description = "Gstreamer RTSP server";
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-rtsp-server/${name}.tar.xz";
-    sha256 = "0mlp9ms5hfbyzyvmc9xgi7934g4zrh1sbgky2p9zc5fqprvs0rbb";
+    sha256 = "161c49hg21xpkdw5ppc7ljbg6kyslxd1y3v1shsg7ibarxapff7p";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -6,7 +6,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-plugins-ugly-1.14.0";
+  name = "gst-plugins-ugly-${version}";
+  version = "1.14.2";
 
   meta = with lib; {
     description = "Gstreamer Ugly Plugins";
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-plugins-ugly/${name}.tar.xz";
-    sha256 = "1la2nny9hfw3rf3wvqggkg8ivn52qrqqs4n4mqz4ppm2r1gymf9z";
+    sha256 = "0s9xrz8knfv06fj1nbv3iq4xj7dj4cnzj3xvgb7zs89rv7crgq2m";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gst-vaapi-${version}";
-  version = "1.14.0";
+  version = "1.14.2";
 
   src = fetchurl {
     url = "${meta.homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz";
-    sha256 = "1whxk428badv8ibji00sn6hj17cp8l9n93rr948bz2gjbq41zqz4";
+    sha256 = "12hdyfma2lnfj38dj6y891vsxnxrlbqjbd36xx13mgasgzi6843z";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gstreamer/validate/default.nix
+++ b/pkgs/development/libraries/gstreamer/validate/default.nix
@@ -3,7 +3,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gst-validate-1.14.0";
+  name = "gst-validate-${version}";
+  version = "1.14.2";
 
   meta = {
     description = "Integration testing infrastructure for the GStreamer framework";
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "${meta.homepage}/src/gst-validate/${name}.tar.xz";
-    sha256 = "1pzzxqkv1spjrzpzpazdm2h4s2wk7gg5gag8nxj5v2gjfyzhiprk";
+    sha256 = "17zilvmwv13l6rbj0a7dnbg4kz5bwwa1gshaibpqbvvhahz457pa";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/gst-python/default.nix
+++ b/pkgs/development/python-modules/gst-python/default.nix
@@ -4,7 +4,7 @@
 
 let
   pname = "gst-python";
-  version = "1.14.0";
+  version = "1.14.2";
   name = "${pname}-${version}";
 in buildPythonPackage rec {
   inherit pname version;
@@ -15,7 +15,7 @@ in buildPythonPackage rec {
       "${meta.homepage}/src/gst-python/${name}.tar.xz"
       "mirror://gentoo/distfiles/${name}.tar.xz"
       ];
-    sha256 = "1rlr6gl4lg97ng4jxh3gb2ldmywm15vwsa72nvggr8qa2l8q3fg0";
+    sha256 = "08nb011acyvlz48fqh8c084k0dlssz9b7wha7zzk797inidbwh6w";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

I could not run `nox-review wip`, as the resulting `nix-build` used more than 20GB of RAM...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

