### PR TITLE
kythe: init at 0.0.28

### DIFF
--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -14,11 +14,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  buildPhase = ''
-  '';
-
-  testPhase = ''
-  '';
+  dontBuild = true;
 
   installPhase = ''
     cd tools
@@ -34,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "kythe";
+    description = "A pluggable, (mostly) language-agnostic ecosystem for building tools that work with code.";
     longDescription = ''
     The Kythe project was founded to provide and support tools and standards
       that encourage interoperability among programs that manipulate source
@@ -46,5 +42,6 @@ stdenv.mkDerivation rec {
     homepage = https://kythe.io/;
     license = licenses.asl20;
     platforms = platforms.linux;
+    maintainers = [ maintainers.mpickering ];
   };
 }

--- a/pkgs/development/tools/kythe/default.nix
+++ b/pkgs/development/tools/kythe/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, binutils , fetchurl, glibc }:
+
+stdenv.mkDerivation rec {
+  version = "0.0.28";
+  name = "kythe-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/google/kythe/releases/download/v0.0.28/kythe-v0.0.28.tar.gz";
+    sha256 = "1qc7cngpxw66m3krpr5x50ns7gb3bpv2bdfzpb5afl12qp0mi6zm";
+  };
+
+  buildInputs =
+    [ binutils ];
+
+  doCheck = false;
+
+  buildPhase = ''
+  '';
+
+  testPhase = ''
+  '';
+
+  installPhase = ''
+    cd tools
+    for exe in http_server \
+                kythe read_entries triples verifier \
+                write_entries write_tables; do
+      echo "Patching:" $exe
+      patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $exe
+      patchelf --set-rpath "${stdenv.cc.cc.lib}/lib64" $exe
+    done
+    cd ../
+    cp -R ./ $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "kythe";
+    longDescription = ''
+    The Kythe project was founded to provide and support tools and standards
+      that encourage interoperability among programs that manipulate source
+      code. At a high level, the main goal of Kythe is to provide a standard,
+      language-agnostic interchange mechanism, allowing tools that operate on
+      source code — including build systems, compilers, interpreters, static
+      analyses, editors, code-review applications, and more — to share
+      information with each other smoothly.  '';
+    homepage = https://kythe.io/;
+    license = licenses.asl20;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8317,6 +8317,8 @@ with pkgs;
 
   kustomize = callPackage ../development/tools/kustomize { };
 
+  kythe = callPackage ../development/tools/kythe { };
+
   Literate = callPackage ../development/tools/literate-programming/Literate {};
 
   lcov = callPackage ../development/tools/analysis/lcov { };


### PR DESCRIPTION
Progress towards #27590

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

