### PR TITLE
buttersink: move out of pythonPackages

### DIFF
--- a/pkgs/tools/filesystems/buttersink/default.nix
+++ b/pkgs/tools/filesystems/buttersink/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy3k, boto, crcmod, psutil }:
+{ lib, python2 }:
 
-buildPythonPackage rec {
+python2.pkgs.buildPythonApplication rec {
   pname = "buttersink";
   version = "0.6.9";
-  disabled = isPy3k;
 
-  src = fetchPypi {
+  src = python2.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "c9c05982c44fbb85f17b7ef0e8bee11f375c03d89bcba50cbc2520013512107a";
+    sha256 = "a797b6e92ad2acdf41e033c1368ab365aa268f4d8458b396a5770fa6c2bc3f54";
   };
 
-  propagatedBuildInputs = [ boto crcmod psutil ];
+  propagatedBuildInputs = with python2.pkgs; [ boto crcmod psutil ];
 
-  meta = with stdenv.lib; {
+  # No tests implemented
+  doCheck = false;
+
+  meta = with lib; {
     description = "Synchronise btrfs snapshots";
     longDescription = ''
       ButterSink is like rsync, but for btrfs subvolumes instead of files,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -973,6 +973,8 @@ with pkgs;
 
   bustle = haskellPackages.bustle;
 
+  buttersink = callPackage ../tools/filesystems/buttersink { };
+
   bwm_ng = callPackage ../tools/networking/bwm-ng { };
 
   byobu = callPackage ../tools/misc/byobu {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1068,8 +1068,6 @@ in {
 
   bumps = callPackage ../development/python-modules/bumps {};
 
-  buttersink = callPackage ../development/python-modules/buttersink {};
-
   cached-property = callPackage ../development/python-modules/cached-property { };
 
   caffe = pkgs.caffe.override {


### PR DESCRIPTION
###### Motivation for this change
The hash of the uploaded tarball has been changed, too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @nckx 