### PR TITLE
enlightenment: 0.22.3 -> 0.22.4

### DIFF
--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -57,16 +57,6 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    # In order to get the available keyboard layouts Enlightenment looks for
-    # the file xorg.lst, that should be provided by xkeyboard-config (when
-    # configured with option --with-xkb-rules-symlink=xorg). Currently
-    # xkeyboard-config is not configured with this option in
-    # NixOS. Therefore it is needed to add base.lst (which xorg.lst would be
-    # a symbolic link to) explicitly as an alternative.
-
-    sed "/#ifdef XKB_BASE/a XKB_BASE \"\/rules\/base.lst\"," \
-      -i src/modules/wizard/page_011.c src/modules/xkbswitch/e_mod_parse.c
-
     # edge_cc is a binary provided by efl and cannot be found at the directory
     # given by e_prefix_bin_get(), which is $out/bin
 

--- a/pkgs/desktops/enlightenment/enlightenment.nix
+++ b/pkgs/desktops/enlightenment/enlightenment.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "enlightenment-${version}";
-  version = "0.22.3";
+  version = "0.22.4";
 
   src = fetchurl {
     url = "http://download.enlightenment.org/rel/apps/enlightenment/${name}.tar.xz";
-    sha256 = "16zydv7z94aw3rywmb9gr8ya85k7b75h22wng95lfx1x0y1yb0ad";
+    sha256 = "0ygy891rrw5c7lhk539nhif77j88phvz2h0fhx172iaridy9kx2r";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.22.4](https://www.enlightenment.org/news/e0.22.4_release).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).