### PR TITLE
findlib: make scripts using `#use "topfind"` work

### DIFF
--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -17,7 +17,7 @@ let
  * Packages that use `topkg` may call this command as part of
  *  their `buildPhase` or `checkPhase`.
 */
-  run = "ocaml -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib/ pkg/pkg.ml";
+  run = "ocaml pkg/pkg.ml";
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -60,6 +60,12 @@ stdenv.mkDerivation rec {
     }
 
     addEnvHooks "$targetOffset" addOCamlPath
+
+    substUseTopfind () {
+        find . -name '*.ml' -print0 | xargs -r -0 -- sed -s -i -E -e '0,/^#[^!]/ s%^#use "topfind"%#use "@out@/lib/ocaml/${ocaml.version}/site-lib/topfind"%'
+    }
+
+    postPatchHooks+=("substUseTopfind")
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Up to now packages that use Ocaml as a scripting language have needed special handholding to work in nix (see `pkgs/development/ocaml-modules/topkg` for instance, because `topfind` which is used by most of them to find libraries is installed as part of this package, not `ocaml` itself, and therefore isn't in the default library search path for the Ocaml toplevel.  This patch solves that issue by adding a setup hook to rewrite uses of `topfind` to use the full path.

This improves the situation for #16085 although it does not fully address interactive use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

