### PR TITLE
lib: debian-style version comparison

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -48,6 +48,9 @@ let
     # Eval-time filesystem handling
     filesystem = callLibs ./filesystem.nix;
 
+    # Alternate version comparison strategies
+    versioning = callLibs ./versioning;
+
     # back-compat aliases
     platforms = systems.forMeta;
 

--- a/lib/versioning/debian.nix
+++ b/lib/versioning/debian.nix
@@ -1,0 +1,63 @@
+{lib, tools}:
+with builtins;
+with tools;
+let
+  injectVersionLetter = s:
+    let m = match "([a-zA-Z]+).*|([0-9]|$).*|([-+.~]).*" s; in
+    if m == null then
+      throw "unexpected in version: ${m}"
+    else
+      let letters = head m; in
+      let numbers = head (tail m); in
+      let punc = head (tail (tail m)); in
+      if letters != null then
+        letters + injectVersionLetter (substring (stringLength letters) (stringLength s) s)
+      else if numbers != null then
+        injectVersionNumber s
+      else if punc == "~" then
+        "!" + injectVersionLetter (substring 1 (stringLength s) s)
+      else
+        "~" + injectVersionPunc s;
+  injectVersionPunc = s:
+    let m = match "([a-zA-Z]).*|([0-9]|$).*|([-+.~]).*" s; in
+    if m == null then
+      throw "unexpected in version: ${m}"
+    else
+      let letters = head m; in
+      let numbers = head (tail m); in
+      let punc = head (tail (tail m)); in
+      if letters != null then
+        "$" + injectVersionLetter s
+      else if numbers != null then
+        "#" + injectVersionNumber s
+      else if punc == "~" then
+        "!" + injectVersionLetter (substring 1 (stringLength s) s)
+      else
+        punc + injectVersionLetter (substring 1 (stringLength s) s);
+  injectVersionNumber = s:
+    let m = match "0*([0-9]+|$).*" s; in
+    if m == null then
+      throw "unexpected in version: ${m}"
+    else if (head m) == "" then
+      "0"
+    else
+      levenCode (head m) + injectVersionPunc (substring (stringLength (head m)) (stringLength s) s);
+  injectVersionWithEpoch = s:
+    let m = match "([0-9]+):(.*)" s; in
+    if m == null then
+      "0" + injectVersionLetter s
+    else
+      let m = match "0*([0-9])*:(.*)" s; in
+      levenCode (head m) + injectVersionLetter (head (tail m));
+  injectRevision = s:
+    let m = match "(.*)-(.*)" s; in
+    if m == null then
+      injectVersionWithEpoch s + "0"
+    else
+      injectVersionWithEpoch (head m) + injectVersionLetter (head (tail m));
+  in
+{
+  plainVersion = mkVersioner injectVersionLetter;
+  version = mkVersioner injectVersionWithEpoch;
+  revision = mkVersioner injectRevision;
+}

--- a/lib/versioning/default.nix
+++ b/lib/versioning/default.nix
@@ -1,0 +1,6 @@
+{lib}:
+rec {
+  tools = import ./tools.nix {inherit lib;};
+  debian = import ./debian.nix {inherit lib tools;};
+  number = with tools; mkVersioner levenCode;
+}

--- a/lib/versioning/tools.nix
+++ b/lib/versioning/tools.nix
@@ -1,0 +1,14 @@
+{lib}:
+with builtins;
+rec {
+  levenCode = n:
+    let l = stringLength n; in
+    if l == 0 then "0"
+    else if l == 1 && n < "9" then n
+    else "9" + levenCode (toString l) + n;
+  mkVersioner = inject: rec {
+    inherit inject;
+    extract = x: if isString x then inject x else inject (lib.getVersion x);
+    compare = x: y: lib.compare (extract x) (extract y);
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Allow packages to check dependency versions in the other widely-used versioning system (adopted for instance by OPAM) without knowing what their bounds are going to look like in the nix versioning world.

(Unfortunately there can be no convention for embedding Debian versions monotonically in Nix versions that is universal, unobtrusive, and human-comprehensible, so such packages will either have to use a nix-env-inappropriate versioning scheme or a correspondence idiosyncratic to the individual package.)

Some of the tests don't really apply since this change is pure nix code that generates no derivations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

