### PR TITLE
ipfs-cluster: init at v0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1862,6 +1862,11 @@
     github = "jgillich";
     name = "Jakob Gillich";
   };
+  jglukasik = {
+    email = "joseph@jgl.me";
+    github = "jglukasik";
+    name = "Joseph Lukasik";
+  };
   jhhuh = {
     email = "jhhuh.note@gmail.com";
     github = "jhhuh";

--- a/pkgs/applications/networking/ipfs-cluster/default.nix
+++ b/pkgs/applications/networking/ipfs-cluster/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx, gx-go }:
+
+buildGoPackage rec {
+  name = "ipfs-cluster-${version}";
+  version = "0.5.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/ipfs/ipfs-cluster";
+
+  extraSrcPaths = [
+    (fetchgx {
+      inherit name src;
+      sha256 = "0jwz3kd07i5fs0sxds80j8d338skhgxgxra377qxsk0cr2hhj2vm";
+    })
+  ];
+
+  src = fetchFromGitHub {
+    owner = "ipfs";
+    repo = "ipfs-cluster";
+    inherit rev;
+    sha256 = "132whjyplcifq8747hcdrgbc0amhp618dg049jq5nyslcxfgdypm";
+  };
+
+  preBuild = ''
+    # fetchgx stores packages by their ipfs hash
+    # this will rewrite github.com/ imports to gx/ipfs/
+    cd go/src/${goPackagePath}
+    ${gx-go}/bin/gx-go rewrite
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Allocate, replicate, and track Pins across a cluster of IPFS daemons";
+    homepage = https://cluster.ipfs.io/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jglukasik ];
+  };
+}
+

--- a/pkgs/applications/networking/ipfs-cluster/default.nix
+++ b/pkgs/applications/networking/ipfs-cluster/default.nix
@@ -21,11 +21,13 @@ buildGoPackage rec {
     sha256 = "132whjyplcifq8747hcdrgbc0amhp618dg049jq5nyslcxfgdypm";
   };
 
+  nativeBuildInputs = [ gx-go ];
+
   preBuild = ''
     # fetchgx stores packages by their ipfs hash
     # this will rewrite github.com/ imports to gx/ipfs/
     cd go/src/${goPackagePath}
-    ${gx-go}/bin/gx-go rewrite
+    gx-go rewrite
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3307,6 +3307,7 @@ with pkgs;
 
   ipfs = callPackage ../applications/networking/ipfs { };
   ipfs-migrator = callPackage ../applications/networking/ipfs-migrator { };
+  ipfs-cluster = callPackage ../applications/networking/ipfs-cluster { };
 
   ipget = callPackage ../applications/networking/ipget {
     buildGoPackage = buildGo110Package;


### PR DESCRIPTION
###### Motivation for this change

I've been using the [ipfs-cluster](https://cluster.ipfs.io) recently, but there was no nixpkg to build it. This adds the ipfs-cluster nixpkg (which includes the `ipfs-cluster-service` and `ipfs-cluster-ctl` binaries).

Longer term, it might be nice to add some of the ipfs-cluster-service functionality to the ipfs NixOS service itself, but I'll until I have more experience using ipfs-cluster to tackle that.

There was only one complication. The ipfs-cluster repo keeps the go imports in the "github.com/" format, but when the GX package manager (called by `fetchgx`) gets the packages, it stores them in the `src/` directory by their IPFS hash in "gx/ipfs". I added a `preBuild` step to rewrite these paths using the `gx-go` utility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

