### PR TITLE
lightdm: 1.26.0 -> 1.28.0

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -9,7 +9,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "lightdm";
-  version = "1.26.0";
+  version = "1.28.0";
 
   name = "${pname}-${version}";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "CanonicalLtd";
     repo = pname;
     rev = version;
-    sha256 = "1mhj6l025cnf2dzxnbzlk0qa9fm4gj2aw58qh5fl4ky87dp4wdyb";
+    sha256 = "1mmqy1jdvgc0h0h9gli7n4vdv5p8m5019qjr5ni4h73iz6mjdj2b";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = https://github.com/CanonicalLtd/lightdm;
+    description = "A cross-desktop display manager.";
     platforms = platforms.linux;
     license = licenses.gpl3;
     maintainers = with maintainers; [ ocharles wkennington worldofpeace ];

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   name = "${pname}-${version}";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchFromGitHub {
     owner = "CanonicalLtd";
     repo = pname;


### PR DESCRIPTION
###### Motivation for this change
The same as #45817 but adds the missing description and adds a 'dev' output.
Closes #45817

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
87151912
87029760
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

