### PR TITLE
snakemake: init at 5.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3381,6 +3381,11 @@
     github = "relrod";
     name = "Ricky Elrod";
   };
+  renatoGarcia = {
+    email = "fgarcia.renato@gmail.com";
+    github = "renatoGarcia";
+    name = "Renato Garcia";
+  };
   renzo = {
     email = "renzocarbonara@gmail.com";
     github = "k0001";

--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromBitbucket, python }:
+
+let
+  version = "5.2.2";
+  sha256 = "08nf0kfkj9wipaskmxpsv3ndha0wgkmmgb2hpdkkkzdz6n3l9bkq";
+in python.buildPythonApplication {
+  inherit version;
+  pname = "snakemake";
+
+  src = fetchFromBitbucket {
+    owner = "snakemake";
+    repo = "snakemake";
+    rev = "v${version}";
+    inherit sha256;
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    python.appdirs
+    python.datrie
+    python.ConfigArgParse
+    python.pyyaml
+    python.jsonschema
+    python.ratelimiter
+    python.docutils
+    python.wrapt
+    python.requests
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://snakemake.bitbucket.io;
+    description = "Workflow management system that aims to reduce the complexity of creating workflows.";
+    license = licenses.mit;
+    longDescription = ''
+      Snakemake is a workflow management system that aims to reduce the complexity of
+      creating workflows by providing a fast and comfortable execution environment,
+      together with a clean and readable specification language in Python style. Snakemake
+      workflows are essentially Python scripts extended by declarative code to define
+      rules. Rules describe how to create output files from input files.
+    '';
+    platforms = platforms.all;
+    maintainers = [ maintainers.renatoGarcia ];
+  };
+}

--- a/pkgs/development/python-modules/ratelimiter/default.nix
+++ b/pkgs/development/python-modules/ratelimiter/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest }:
+
+let
+  pname = "ratelimiter";
+  version = "1.2.0.post0";
+in buildPythonPackage {
+  inherit pname version;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7";
+  };
+
+  preConfigure = ''
+    export LC_ALL="en_US.UTF-8"
+  '';
+
+  buildInputs = [ pytest ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/RazerM/ratelimiter;
+    description = "Simple Python module providing rate limiting";
+    license = licenses.asl20;
+    longDescription = ''
+    The RateLimiter module ensures that an operation will not be executed more than a
+    given number of times on a given period. This can prove useful when working with third
+    parties APIs which require for example a maximum of 10 requests per second.
+    '';
+    platforms = platforms.all;
+    maintainers = [ maintainers.renatoGarcia ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8679,6 +8679,8 @@ with pkgs;
 
   smc = callPackage ../tools/misc/smc { };
 
+  snakemake = callPackage ../applications/science/misc/snakemake { python = python3Packages; };
+
   snowman = qt5.callPackage ../development/tools/analysis/snowman { };
 
   sparse = callPackage ../development/tools/analysis/sparse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17377,6 +17377,8 @@ EOF
   libtorrentRasterbar = (toPythonModule (pkgs.libtorrentRasterbar.override {
     inherit python;
   })).python;
+
+  ratelimiter = callPackage ../development/python-modules/ratelimiter { };
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
###### Motivation for this change
Adds the snakemake program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

