### PR TITLE
pythonPackages.httpsig: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/httpsig/default.nix
+++ b/pkgs/development/python-modules/httpsig/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools_scm
+, pycryptodome
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "httpsig";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "19ng7y7blp13z081z5a6dxng1p8xlih7g6frmsg3q5ri8lvpybc7";
+  };
+
+  buildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ pycryptodome requests ];
+
+  # Jailbreak pycryptodome
+  preBuild = ''
+    substituteInPlace setup.py --replace "==3.4.7" ""
+  '';
+
+  meta = with lib; {
+    description = "Sign HTTP requests with secure signatures";
+    license = licenses.mit;
+    maintainers = with maintainers; [ srhb ];
+    homepage = https://github.com/ahknight/httpsig;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -304,6 +304,8 @@ in {
 
   habanero = callPackage ../development/python-modules/habanero { };
 
+  httpsig = callPackage ../development/python-modules/httpsig { };
+
   i3ipc = callPackage ../development/python-modules/i3ipc { };
 
   intelhex = callPackage ../development/python-modules/intelhex { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

