### PR TITLE
fbreader: 0.99.4 -> 0.99.6, switch to fetchFromGitHub, add more build options

### DIFF
--- a/pkgs/applications/misc/fbreader/default.nix
+++ b/pkgs/applications/misc/fbreader/default.nix
@@ -1,38 +1,68 @@
-{ stdenv, fetchurl, pkgconfig, bzip2, curl, expat, fribidi
-, libunibreak, qt4, sqlite, zlib }:
+{ stdenv, fetchFromGitHub, pkgconfig
+, bzip2, curl, expat, fribidi, libunibreak, sqlite, zlib
+, uiTarget ? if !stdenv.isDarwin then "desktop" else "macosx"
+, uiType ? if !stdenv.isDarwin then "qt4" else "cocoa"
+, qt4, gtk2
+, AppKit, Cocoa
+}:
+
+with stdenv.lib;
+
+assert elem uiTarget [ "desktop" "macosx" ];
+assert elem uiType [ "qt4" "gtk" "cocoa" ];
+assert uiTarget == "macosx" -> uiType == "cocoa";
+
+# Note: "qt" uiType option mentioned in ${src}/README.build is qt3,
+# which is way to old and no longer in nixpkgs.
 
 stdenv.mkDerivation {
-  name = "fbreader-0.99.4";
+  name = "fbreader-${uiType}-0.99.6";
 
-  src = fetchurl {
-    url = https://fbreader.org/files/desktop/fbreader-sources-0.99.4.tgz;
-    sha256 = "1sdq3vvwkq4bkyrvh0p884d66gaddz8hlab3m798ji9ixbak2z1x";
+  src = fetchFromGitHub {
+    owner = "geometer";
+    repo = "FBReader";
+    rev = "9e608db14372ae580beae4976eec7241fa069e75";
+    sha256 = "0lzafk02mv0cf2l2a61q5y4743zi913byik4bw1ix0gr1drnsa7y";
   };
 
+  patches = [ ./typecheck.patch ];
+
+  postPatch = ''
+    cat << EOF > makefiles/target.mk
+    TARGET_ARCH = ${uiTarget}
+    TARGET_STATUS = release
+    UI_TYPE = ${uiType}
+    EOF
+
+    substituteInPlace makefiles/arch/desktop.mk \
+      --replace ccache "" \
+      --replace moc-qt4 moc
+
+    # libunibreak supersedes liblinebreak
+    substituteInPlace zlibrary/text/Makefile \
+      --replace -llinebreak -lunibreak
+  '';
+
   nativeBuildInputs = [ pkgconfig ];
+
   buildInputs = [
-    bzip2 curl expat fribidi libunibreak
-    qt4 sqlite zlib
-  ];
+    bzip2 curl expat fribidi libunibreak sqlite zlib
+  ]
+  ++ optional (uiType == "qt4") qt4
+  ++ optional (uiType == "gtk") gtk2
+  ++ optionals (uiType == "cocoa") [ AppKit Cocoa ];
 
   makeFlags = "INSTALLDIR=$(out)";
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=narrowing" ]; # since gcc-6
 
-  patchPhase = ''
-    # don't try to use ccache
-    substituteInPlace makefiles/arch/desktop.mk \
-      --replace "CCACHE = " "# CCACHE = "
-
-    substituteInPlace fbreader/desktop/Makefile \
-      --replace "/usr/share" "$out/share"
-  '';
-
   meta = with stdenv.lib; {
     description = "An e-book reader for Linux";
     homepage = http://www.fbreader.org/;
     license = licenses.gpl3;
-    platforms = platforms.linux; # possibly also on unix general
+    broken = stdenv.isDarwin  # untested, might work
+          || uiType == "gtk"; # builds, but the result is unusable, hangs a lot
+    platforms = platforms.unix;
     maintainers = [ maintainers.coroa ];
-  }; 
+  };
 }

--- a/pkgs/applications/misc/fbreader/typecheck.patch
+++ b/pkgs/applications/misc/fbreader/typecheck.patch
@@ -1,0 +1,11 @@
+diff --git a/fbreader/src/database/booksdb/BooksDB.cpp b/fbreader/src/database/booksdb/BooksDB.cpp
+index e33a22e76..1b6092800 100644
+--- a/fbreader/src/database/booksdb/BooksDB.cpp
++++ b/fbreader/src/database/booksdb/BooksDB.cpp
+@@ -146,5 +146,5 @@ shared_ptr<Book> BooksDB::loadBook(const std::string &fileName) {
+ 	myFindFileId->setFileName(fileName);
+ 	if (!myFindFileId->run()) {
+-		return false;
++		return 0;
+ 	}
+ 	((DBIntValue&)*myLoadBook->parameter("@file_id").value()) = myFindFileId->fileId();

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16253,7 +16253,9 @@ with pkgs;
 
   fbpanel = callPackage ../applications/window-managers/fbpanel { };
 
-  fbreader = callPackage ../applications/misc/fbreader { };
+  fbreader = callPackage ../applications/misc/fbreader {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
+  };
 
   fdr = libsForQt5.callPackage ../applications/science/programming/fdr { };
 


### PR DESCRIPTION
This, apparently, is not an official release (it's tagged, but the tarball is not available on the official site), but this repo is the official repo mentioned on the official site.

This fixes a bunch of very annoying bugs present 0.99.4, e.g.

```
$ FBReader filename
```

does not crash anymore. Yay!

###### Motivation for this change

I hate that crash.

###### Things done

- [X] Build and works for me on Linux.
- [ ] I added the plumbing for Darwin emulating other similar packages, but have not tested it.