### PR TITLE
home-assistant: 0.76.1 -> 0.77.1

### DIFF
--- a/pkgs/development/python-modules/pyotp/default.nix
+++ b/pkgs/development/python-modules/pyotp/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "pyotp";
+  version = "2.2.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "dd9130dd91a0340d89a0f06f887dbd76dd07fb95a8886dc4bc401239f2eebd69";
+  };
+
+  meta = with lib; {
+    description = "Python One Time Password Library";
+    homepage = https://github.com/pyotp/pyotp;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/pyqrcode/default.nix
+++ b/pkgs/development/python-modules/pyqrcode/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "PyQRCode";
+  version = "1.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fdbf7634733e56b72e27f9bce46e4550b75a3a2c420414035cae9d9d26b234d5";
+  };
+
+  # No tests in PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A QR code generator written purely in Python with SVG, EPS, PNG and terminal output";
+    homepage = https://github.com/mnooner256/pyqrcode;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "0.76.1";
+  version = "0.77.1";
   components = {
     "abode" = ps: with ps; [  ];
     "ads" = ps: with ps; [  ];
@@ -48,6 +48,7 @@
     "auth" = ps: with ps; [ aiohttp-cors ];
     "auth.indieauth" = ps: with ps; [  ];
     "auth.login_flow" = ps: with ps; [  ];
+    "auth.mfa_setup_flow" = ps: with ps; [  ];
     "automation" = ps: with ps; [  ];
     "automation.event" = ps: with ps; [  ];
     "automation.homeassistant" = ps: with ps; [  ];
@@ -96,7 +97,7 @@
     "binary_sensor.homematicip_cloud" = ps: with ps; [  ];
     "binary_sensor.hydrawise" = ps: with ps; [  ];
     "binary_sensor.ihc" = ps: with ps; [  ];
-    "binary_sensor.insteon_plm" = ps: with ps; [  ];
+    "binary_sensor.insteon" = ps: with ps; [  ];
     "binary_sensor.iss" = ps: with ps; [  ];
     "binary_sensor.isy994" = ps: with ps; [  ];
     "binary_sensor.knx" = ps: with ps; [  ];
@@ -185,7 +186,7 @@
     "camera.netatmo" = ps: with ps; [  ];
     "camera.onvif" = ps: with ps; [ ha-ffmpeg ];
     "camera.proxy" = ps: with ps; [ pillow ];
-    "camera.push" = ps: with ps; [  ];
+    "camera.push" = ps: with ps; [ aiohttp-cors ];
     "camera.ring" = ps: with ps; [ ha-ffmpeg ];
     "camera.rpi_camera" = ps: with ps; [  ];
     "camera.skybell" = ps: with ps; [  ];
@@ -249,7 +250,6 @@
     "comfoconnect" = ps: with ps; [  ];
     "config" = ps: with ps; [ aiohttp-cors ];
     "config.auth" = ps: with ps; [  ];
-    "config.auth_provider_homeassistant" = ps: with ps; [  ];
     "config.automation" = ps: with ps; [  ];
     "config.config_entries" = ps: with ps; [ voluptuous-serialize ];
     "config.core" = ps: with ps; [  ];
@@ -261,6 +261,7 @@
     "config.zwave" = ps: with ps; [  ];
     "configurator" = ps: with ps; [  ];
     "conversation" = ps: with ps; [ aiohttp-cors ];
+    "conversation.util" = ps: with ps; [  ];
     "counter" = ps: with ps; [  ];
     "cover" = ps: with ps; [  ];
     "cover.abode" = ps: with ps; [  ];
@@ -366,6 +367,7 @@
     "dweet" = ps: with ps; [  ];
     "dyson" = ps: with ps; [  ];
     "ecobee" = ps: with ps; [  ];
+    "ecovacs" = ps: with ps; [  ];
     "egardia" = ps: with ps; [  ];
     "eight_sleep" = ps: with ps; [  ];
     "emoncms_history" = ps: with ps; [  ];
@@ -379,8 +381,7 @@
     "fan.comfoconnect" = ps: with ps; [  ];
     "fan.demo" = ps: with ps; [  ];
     "fan.dyson" = ps: with ps; [  ];
-    "fan.insteon_local" = ps: with ps; [  ];
-    "fan.insteon_plm" = ps: with ps; [  ];
+    "fan.insteon" = ps: with ps; [  ];
     "fan.isy994" = ps: with ps; [  ];
     "fan.mqtt" = ps: with ps; [ paho-mqtt ];
     "fan.template" = ps: with ps; [  ];
@@ -409,6 +410,10 @@
     "google_domains" = ps: with ps; [  ];
     "graphite" = ps: with ps; [  ];
     "group" = ps: with ps; [  ];
+    "hangouts" = ps: with ps; [  ];
+    "hangouts.config_flow" = ps: with ps; [  ];
+    "hangouts.const" = ps: with ps; [  ];
+    "hangouts.hangouts_bot" = ps: with ps; [  ];
     "hassio" = ps: with ps; [ aiohttp-cors ];
     "hassio.handler" = ps: with ps; [  ];
     "hassio.http" = ps: with ps; [  ];
@@ -463,6 +468,7 @@
     "input_number" = ps: with ps; [  ];
     "input_select" = ps: with ps; [  ];
     "input_text" = ps: with ps; [  ];
+    "insteon" = ps: with ps; [  ];
     "insteon_local" = ps: with ps; [  ];
     "insteon_plm" = ps: with ps; [  ];
     "intent_script" = ps: with ps; [  ];
@@ -502,8 +508,7 @@
     "light.hyperion" = ps: with ps; [  ];
     "light.iglo" = ps: with ps; [  ];
     "light.ihc" = ps: with ps; [  ];
-    "light.insteon_local" = ps: with ps; [  ];
-    "light.insteon_plm" = ps: with ps; [  ];
+    "light.insteon" = ps: with ps; [  ];
     "light.isy994" = ps: with ps; [  ];
     "light.knx" = ps: with ps; [  ];
     "light.lifx" = ps: with ps; [  ];
@@ -692,6 +697,7 @@
     "notify.free_mobile" = ps: with ps; [  ];
     "notify.gntp" = ps: with ps; [  ];
     "notify.group" = ps: with ps; [  ];
+    "notify.hangouts" = ps: with ps; [  ];
     "notify.hipchat" = ps: with ps; [  ];
     "notify.html5" = ps: with ps; [ aiohttp-cors ];
     "notify.instapush" = ps: with ps; [  ];
@@ -893,7 +899,7 @@
     "sensor.imap" = ps: with ps; [ aioimaplib ];
     "sensor.imap_email_content" = ps: with ps; [  ];
     "sensor.influxdb" = ps: with ps; [ influxdb ];
-    "sensor.insteon_plm" = ps: with ps; [  ];
+    "sensor.insteon" = ps: with ps; [  ];
     "sensor.ios" = ps: with ps; [ aiohttp-cors zeroconf ];
     "sensor.iota" = ps: with ps; [  ];
     "sensor.iperf3" = ps: with ps; [  ];
@@ -932,9 +938,11 @@
     "sensor.nederlandse_spoorwegen" = ps: with ps; [  ];
     "sensor.nest" = ps: with ps; [  ];
     "sensor.netatmo" = ps: with ps; [  ];
+    "sensor.netatmo_public" = ps: with ps; [  ];
     "sensor.netdata" = ps: with ps; [  ];
     "sensor.netgear_lte" = ps: with ps; [  ];
     "sensor.neurio_energy" = ps: with ps; [  ];
+    "sensor.noaa_tides" = ps: with ps; [  ];
     "sensor.nsw_fuel_station" = ps: with ps; [  ];
     "sensor.nut" = ps: with ps; [  ];
     "sensor.nzbget" = ps: with ps; [  ];
@@ -1113,8 +1121,7 @@
     "switch.hook" = ps: with ps; [  ];
     "switch.hydrawise" = ps: with ps; [  ];
     "switch.ihc" = ps: with ps; [  ];
-    "switch.insteon_local" = ps: with ps; [  ];
-    "switch.insteon_plm" = ps: with ps; [  ];
+    "switch.insteon" = ps: with ps; [  ];
     "switch.isy994" = ps: with ps; [  ];
     "switch.kankun" = ps: with ps; [  ];
     "switch.knx" = ps: with ps; [  ];
@@ -1212,6 +1219,7 @@
     "vacuum" = ps: with ps; [  ];
     "vacuum.demo" = ps: with ps; [  ];
     "vacuum.dyson" = ps: with ps; [  ];
+    "vacuum.ecovacs" = ps: with ps; [  ];
     "vacuum.mqtt" = ps: with ps; [ paho-mqtt ];
     "vacuum.neato" = ps: with ps; [  ];
     "vacuum.roomba" = ps: with ps; [  ];

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -18,12 +18,14 @@ let
 
   defaultOverrides = [
     # Override the version of some packages pinned in Home Assistant's setup.py
-    (mkOverride "aiohttp" "3.3.2"
-      "f20deec7a3fbaec7b5eb7ad99878427ad2ee4cc16a46732b705e8121cbb3cc12")
+    (mkOverride "aiohttp" "3.4.0"
+      "9b15efa7411dcf3b59c1f4766eb16ba1aba4531a33e54d469ee22106eabce460")
     (mkOverride "astral" "1.6.1"
       "ab0c08f2467d35fcaeb7bad15274743d3ac1ad18b5391f64a0058a9cd192d37d")
     (mkOverride "attrs" "18.1.0"
       "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b")
+    (mkOverride "bcrypt" "3.1.4"
+      "67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d")
     (mkOverride "pyjwt" "1.6.4"
       "4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176")
     (mkOverride "cryptography" "2.3.1"
@@ -73,7 +75,7 @@ let
   extraBuildInputs = extraPackages py.pkgs;
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "0.76.1";
+  hassVersion = "0.77.1";
 
 in with py.pkgs; buildPythonApplication rec {
   pname = "homeassistant";
@@ -88,14 +90,14 @@ in with py.pkgs; buildPythonApplication rec {
     owner = "home-assistant";
     repo = "home-assistant";
     rev = version;
-    sha256 = "0bqvb6wsbv1irp92ijdvx62vqicsqhyk301ixf8yb2d1dwwwmid3";
+    sha256 = "1dqxxirglcl0srb4znwz61lxqba47g7q66bw4v1nfdwhxb0kj0w5";
   };
 
   propagatedBuildInputs = [
     # From setup.py
-    aiohttp astral async-timeout attrs certifi jinja2 pyjwt cryptography pip pytz pyyaml requests voluptuous
-    # From http, frontend, recorder and config.config_entries components
-    sqlalchemy aiohttp-cors hass-frontend voluptuous-serialize
+    aiohttp astral async-timeout attrs bcrypt certifi jinja2 pyjwt cryptography pip pytz pyyaml requests voluptuous
+    # From http, frontend, recorder and config.config_entries components and auth.mfa_modules.totp
+    sqlalchemy aiohttp-cors hass-frontend voluptuous-serialize pyotp pyqrcode
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   checkInputs = [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-frontend";
-  version = "20180818.0";
+  version = "20180829.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b6101c342e49c943c59e3525d6741cd3a23af94b65549d59bdeee8cf3f07b294";
+    sha256 = "c3e1e3472760b6ebab5f73395e9fe332edf8bf6b0a30027fa68cf719fdb0df36";
   };
 
   propagatedBuildInputs = [ user-agents ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10400,6 +10400,8 @@ in {
 
   pyopencl = callPackage ../development/python-modules/pyopencl { };
 
+  pyotp = callPackage ../development/python-modules/pyotp { };
+
   pyproj = callPackage ../development/python-modules/pyproj {
     # pyproj does *work* if you want to use a system supplied proj, but with the current version(s) the tests fail by
     # a few decimal places, so caveat emptor.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10408,6 +10408,8 @@ in {
     proj = null;
   };
 
+  pyqrcode = callPackage ../development/python-modules/pyqrcode { };
+
   pyrr = callPackage ../development/python-modules/pyrr { };
 
   pysha3 = callPackage ../development/python-modules/pysha3 { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peterhoeg 