### PR TITLE
nixos/doc: add  instructions for installation behind a proxy

### DIFF
--- a/nixos/doc/manual/installation/installing-behind-a-proxy.xml
+++ b/nixos/doc/manual/installation/installing-behind-a-proxy.xml
@@ -1,0 +1,47 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0"
+         xml:id="sec-installing-behind-proxy">
+ <title>Installing behind a proxy</title>
+
+<para>
+  To install NixOS behind a proxy, do the following before running
+  <literal>nixos-install</literal>.
+</para>
+<orderedlist numeration="arabic">
+  <listitem>
+    <para>
+      Update proxy configuration in
+      <literal>/mnt/etc/nixos/configuration.nix</literal> to keep the
+      internet accessible after reboot.
+    </para>
+    <programlisting>
+networking.proxy.default = &quot;http://user:password@proxy:port/&quot;;
+networking.proxy.noProxy = &quot;127.0.0.1,localhost,internal.domain&quot;;
+</programlisting>
+  </listitem>
+  <listitem>
+    <para>
+      Setup the proxy environment variables in the shell where you are
+      running <literal>nixos-install</literal>.
+    </para>
+    <programlisting>
+# proxy_url=&quot;http://user:password@proxy:port/&quot;
+# export http_proxy=&quot;$proxy_url&quot;
+# export HTTP_PROXY=&quot;$proxy_url&quot;
+# export https_proxy=&quot;$proxy_url&quot;
+# export HTTPS_PROXY=&quot;$proxy_url&quot;
+</programlisting>
+  </listitem>
+</orderedlist>
+
+<note>
+<para>
+  If you are switching networks with different proxy configurations, use the
+  <literal>nesting.clone</literal> option in
+  <literal>configuration.nix</literal> to switch proxies at runtime.
+  Refer to <xref linkend="ch-options" /> for more information.
+</para>
+</note>
+</section>

--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -443,4 +443,5 @@ $ nix-env -i w3m</screen>
  <xi:include href="installing-pxe.xml" />
  <xi:include href="installing-virtualbox-guest.xml" />
  <xi:include href="installing-from-other-distro.xml" />
+ <xi:include href="installing-behind-a-proxy.xml" />
 </chapter>

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -574,6 +574,10 @@ $bootLoaderConfig
   # networking.hostName = "nixos"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
+  # Configure network proxy if necessary
+  # networking.proxy.default = "http://user:password@proxy:port/";
+  # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
+
   # Select internationalisation properties.
   # i18n = {
   #   consoleFont = "Lat2-Terminus16";

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -162,6 +162,13 @@ in
       description = ''
         Additional configurations to build based on the current
         configuration which then has a lower priority.
+
+        To switch to a cloned configuration (e.g. <literal>child-1</literal>)
+        at runtime, run
+
+        <programlisting>
+        # sudo /run/current-system/fine-tune/child-1/bin/switch-to-configuration test
+        </programlisting>
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

The instructions to install nixos behind a proxy were not clear.  While one could guess that setting http_proxy variables can get the install rolling, one could end up with an installed system where the proxy settings for the nix-daemon are not configured.

This commit updates the documentation with 

1. steps to install behind a proxy
2. configure the global proxy settings so that nix-daemon can access internet.
3. Pointers to use `nesting.clone` in case one has to use different proxy settings on different networks.

###### Things done
- [X] Documentation built and output reviewed in browser
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

