### PR TITLE
podofo: patch for compatibility with cmake 3.12

### DIFF
--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, zlib, freetype, libjpeg, libtiff, fontconfig
-, openssl, libpng, lua5, pkgconfig, libidn, expat
+, openssl, libpng, lua5, pkgconfig, libidn, expat, fetchpatch
 , gcc5 # TODO(@Dridus) remove this at next hash break
 }:
 
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ zlib freetype libjpeg libtiff fontconfig openssl libpng libidn expat ];
+
+  patches = [
+    # https://sourceforge.net/p/podofo/tickets/24/
+    (fetchpatch {
+      url = "https://sourceforge.net/p/podofo/tickets/24/attachment/podofo-cmake-3.12.patch";
+      extraPrefix = "";
+      sha256 = "087h51x60zrakzx09baan77hwz99cwb5l1j802r5g4wj7pbjz0mb";
+    })
+  ];
 
   # TODO(@Dridus) remove the ++ ghc5 at next hash break
   nativeBuildInputs = [ cmake pkgconfig ] ++ stdenv.lib.optional stdenv.isLinux gcc5;


### PR DESCRIPTION
###### Motivation for this change

Broken by update to CMake in #44910. See [upstream ticket][] for details.

[upstream ticket]: https://sourceforge.net/p/podofo/tickets/24/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
