### PR TITLE
catfish: 1.4.4 -> 1.4.6

### DIFF
--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -5,13 +5,13 @@
 
 pythonPackages.buildPythonApplication rec {
   majorver = "1.4";
-  minorver = "4";
+  minorver = "6";
   version = "${majorver}.${minorver}";
   pname = "catfish";
 
   src = fetchurl {
-    url = "https://launchpad.net/catfish-search/${majorver}/${version}/+download/${pname}-${version}.tar.gz";
-    sha256 = "1mw7py6si6y88jblmzm04hf049bpww7h87k2wypq07zm1dw55m52";
+    url = "https://archive.xfce.org/src/apps/${pname}/${majorver}/${pname}-${version}.tar.bz2";
+    sha256 = "1gxdk5gx0gjq95jhdbpiq39cxpzd4vmw00a78f0wg2i6qlafxjp1";
   };
 
   nativeBuildInputs = [
@@ -52,7 +52,7 @@ pythonPackages.buildPythonApplication rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = https://launchpad.net/catfish-search;
+    homepage = https://docs.xfce.org/apps/catfish/start;
     description = "A handy file search tool";
     longDescription = ''
       Catfish is a handy file searching tool. The interface is


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.4.6](https://bluesabre.org/2018/07/15/catfish-1-4-6-released-now-an-xfce-project/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).