### PR TITLE
mixxx 2.1.3: Fixed glibc locale bug

### DIFF
--- a/pkgs/applications/audio/mixxx/default.nix
+++ b/pkgs/applications/audio/mixxx/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, chromaprint, fetchpatch, fftw, flac, faad2, mp4v2
+{ stdenv, fetchFromGitHub, makeWrapper, chromaprint, fetchpatch
+, fftw, flac, faad2, glibcLocales, mp4v2
 , libid3tag, libmad, libopus, libshout, libsndfile, libusb1, libvorbis
 , pkgconfig, portaudio, portmidi, protobuf, qt4, rubberband, scons, sqlite
 , taglib, upower, vampSDK
@@ -15,8 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "1fm8lkbnxka4haidf6yr8mb3r6vaxmc97hhrp8pcx0fvq2mnzvy2";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   buildInputs = [
-    chromaprint fftw flac faad2 mp4v2 libid3tag libmad libopus libshout libsndfile
+    chromaprint fftw flac faad2 glibcLocales mp4v2 libid3tag libmad libopus libshout libsndfile
     libusb1 libvorbis pkgconfig portaudio portmidi protobuf qt4
     rubberband scons sqlite taglib upower vampSDK
   ];
@@ -42,6 +45,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  fixupPhase = ''
+    wrapProgram $out/bin/mixxx \
+      --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive;
+  '';
+    
   meta = with stdenv.lib; {
     homepage = https://mixxx.org;
     description = "Digital DJ mixing software";


### PR DESCRIPTION
###### Motivation for this change

This patch fixes an ugly critical bug with filename character encoding on systems with glibc 2.26 installed as default but mixxx build with glibc 2.27.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

