### PR TITLE
pbrt: 2017-01-12 -> 2018-08-15; cmake 3.12 compatibility

### DIFF
--- a/pkgs/applications/graphics/pbrt/default.nix
+++ b/pkgs/applications/graphics/pbrt/default.nix
@@ -2,16 +2,21 @@
 
 stdenv.mkDerivation rec {
 
-  version = "2017-01-12";
+  version = "2018-08-15";
   name = "pbrt-v3-${version}";
 
   src = fetchFromGitHub {
-    rev = "35b6da3429526f2026fe5e5ebaf36d593e113028";
+    rev = "86b5821308088deea70b207bc8c22219d0103d65";
     owner  = "mmp";
     repo   = "pbrt-v3";
-    sha256 = "10lvbph13p6ilzqb8sgrvn9gg1zmi8wpy3hhjbqp8dnsa4x0mhj7";
+    sha256 = "0f7ivsczba6zfk5f0bba1js6dcwf6w6jrkiby147qp1sx5k35cv8";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # https://github.com/mmp/pbrt-v3/issues/196
+    ./openexr-cmake-3.12.patch
+  ];
 
   buildInputs = [ git flex bison cmake zlib ];
 

--- a/pkgs/applications/graphics/pbrt/openexr-cmake-3.12.patch
+++ b/pkgs/applications/graphics/pbrt/openexr-cmake-3.12.patch
@@ -1,0 +1,26 @@
+diff -ur a/src/ext/openexr/CMakeLists.txt b/src/ext/openexr/CMakeLists.txt
+--- a/src/ext/openexr/CMakeLists.txt	1970-01-01 09:00:01.000000000 +0900
++++ b/src/ext/openexr/CMakeLists.txt	2018-08-31 21:44:56.490714484 +0900
+@@ -26,22 +26,4 @@
+   ${CMAKE_CURRENT_BINARY_DIR}/IlmBase/config
+ )
+ 
+-add_custom_target(CopyIlmBaseLibs
+-  COMMAND ${CMAKE_COMMAND} -E copy_directory
+-  ${CMAKE_CURRENT_BINARY_DIR}/IlmBase/Half/$<CONFIGURATION>
+-  ${CMAKE_CURRENT_BINARY_DIR}/OpenEXR/IlmImf/$<CONFIGURATION>
+-  COMMAND ${CMAKE_COMMAND} -E copy_directory
+-  ${CMAKE_CURRENT_BINARY_DIR}/IlmBase/IlmThread/$<CONFIGURATION>
+-  ${CMAKE_CURRENT_BINARY_DIR}/OpenEXR/IlmImf/$<CONFIGURATION>
+-  COMMAND ${CMAKE_COMMAND} -E copy_directory
+-  ${CMAKE_CURRENT_BINARY_DIR}/IlmBase/Iex/$<CONFIGURATION>
+-  ${CMAKE_CURRENT_BINARY_DIR}/OpenEXR/IlmImf/$<CONFIGURATION>
+-  COMMAND ${CMAKE_COMMAND} -E copy_directory
+-  ${CMAKE_CURRENT_BINARY_DIR}/IlmBase/Imath/$<CONFIGURATION>
+-  ${CMAKE_CURRENT_BINARY_DIR}/OpenEXR/IlmImf/$<CONFIGURATION>
+-)
+-add_dependencies(CopyIlmBaseLibs Iex Imath IlmThread Half)
+-
+ add_subdirectory(OpenEXR OpenEXR)
+-add_dependencies(b44ExpLogTable CopyIlmBaseLibs)
+-add_dependencies(dwaLookups CopyIlmBaseLibs)


### PR DESCRIPTION
###### Motivation for this change

Work with new cmake from #44910. See [upstream issue][].

[upstream issue]: https://github.com/mmp/pbrt-v3/issues/196

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

