### PR TITLE
curaengine: patch for compatibility with cmake 3.12

### DIFF
--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, libarcus, stb }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, libarcus, stb }:
 
 stdenv.mkDerivation rec {
   name = "curaengine-${version}";
@@ -10,6 +10,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "083jmhzmb60rmqw0fhbnlxyblzkmpn3k6zc75xq90x5g3h60wib4";
   };
+
+  patches = [
+    # Fixed upstream, but not yet released
+    (fetchpatch {
+      url = "https://github.com/Ultimaker/CuraEngine/commit/5aad55bf67e52ce5bdb27a3925af8a4cab441b38.patch";
+      sha256 = "1hxbslzhkvdg8p33mvlbrpw62gwfqpsdbfca6yhdng9hifl86j3f";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libarcus stb ];


### PR DESCRIPTION
###### Motivation for this change

Work with cmake from #44910.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

