### PR TITLE
pythonPackages.dependency-injector: init at 3.13.1

### DIFF
--- a/pkgs/development/python-modules/dependency-injector/default.nix
+++ b/pkgs/development/python-modules/dependency-injector/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, six }:
+
+buildPythonPackage rec {
+  pname = "dependency-injector";
+  version = "3.13.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0bmcgdfjavgxdzkb904q968ig1x44arvpj2m4rpm5nc9vhhgq43q";
+  };
+
+  # TODO: Enable tests after upstream merges https://github.com/ets-labs/python-dependency-injector/pull/204
+  doCheck = false;
+
+  propagatedBuildInputs = [ six ];
+
+  meta = with stdenv.lib; {
+    description = "Dependency injection microframework for Python";
+    homepage = https://github.com/ets-labs/python-dependency-injector;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ gerschtli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -244,6 +244,8 @@ in {
 
   dendropy = callPackage ../development/python-modules/dendropy { };
 
+  dependency-injector = callPackage ../development/python-modules/dependency-injector { };
+
   dbf = callPackage ../development/python-modules/dbf { };
 
   dbfread = callPackage ../development/python-modules/dbfread { };


### PR DESCRIPTION
###### Motivation for this change

Adds `dependency_injector` python package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

