### PR TITLE
deepin-icon-theme: 15.12.52 -> 15.12.59

### DIFF
--- a/pkgs/desktops/deepin/deepin-icon-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-icon-theme/default.nix
@@ -3,37 +3,32 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "deepin-icon-theme";
-  version = "15.12.52";
+  version = "15.12.59";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = pname;
     rev = version;
-    sha256 = "141in9jlflmckd8rg4605dfks84p1p6b1zdbhbiwrg11xbl66f3l";
-    
-    # Get rid of case collision in file names, which is an issue in
-    # darwin where file names are case insensitive.
-    extraPostFetch = ''
-      rm "$out"/Sea/apps/scalable/TeXmacs.svg
-      rm "$out"/deepin/apps/48/TeXmacs.svg
-    ''; 
+    sha256 = "1qkxhqx6a7pahkjhf6m9lm16lw9v9grk0d4j449h9622zwfjkxlq";
   };
 
   nativeBuildInputs = [ gtk3 papirus-icon-theme ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  postPatch = ''
+    patchShebangs .
 
-  postFixup = ''
-    for theme in $out/share/icons/*; do
-      gtk-update-icon-cache $theme
-    done
+    # install in $out
+    sed -i -e "s|/usr|$out|g" Makefile tools/hicolor.links
+
+    # keep icon-theme.cache
+    sed -i -e 's|\(-rm -f .*/icon-theme.cache\)|# \1|g' Makefile
   '';
 
   meta = with stdenv.lib; {
-    description = "Deepin icon theme";
+    description = "Icons for the Deepin Desktop Environment";
     homepage = https://github.com/linuxdeepin/deepin-icon-theme;
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Update to version 115.12.59
- Keep `*.cache` files instead of rebuilding them after installation.
- Slight better description
- Change platform to `unix`, as there are no file names differing only in case (which was a problem for darwin) anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).