### PR TITLE
dbxml: move db62 to propagatedBuildInputs.

### DIFF
--- a/pkgs/development/libraries/dbxml/default.nix
+++ b/pkgs/development/libraries/dbxml/default.nix
@@ -15,7 +15,11 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    db62 xercesc xqilla
+    xercesc xqilla
+  ];
+
+  propagatedBuildInputs = [
+    db62
   ];
 
   configureFlags = [


### PR DESCRIPTION
Some public DB XML headers include db.h from Berkeley DB. Move db62
to propagatedBuildInputs, to ensure that packages with a dependency
on dbxml, but without a dependency on db compile.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

