### PR TITLE
deepin-terminal: 3.0.0 -> 3.0.3

### DIFF
--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "deepin-terminal-${version}";
-  version = "3.0.0";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "linuxdeepin";
     repo = "deepin-terminal";
     rev = version;
-    sha256 = "11f2yc0fj05lwhgvdrbrs8xsdm7qgp6wb5wd1f9iyc5nxn7ccl1r";
+    sha256 = "04yvim97a4j8fq5lq2g6svs8qs79np9m4nl6x83iv02wkb9b7gqa";
   };
 
   patches = [
@@ -29,15 +29,17 @@ stdenv.mkDerivation rec {
     # For setup hook
     gobjectIntrospection
   ];
+
   buildInputs = [ gtk3 vte libgee wnck librsvg libsecret json-glib ];
 
   meta = with stdenv.lib; {
     description = "The default terminal emulation for Deepin";
     longDescription = ''
       Deepin terminal, it sharpens your focus in the world of command line!
-      It is an advanced terminal emulator with workspace, multiple windows, remote management, quake mode and other features.
+      It is an advanced terminal emulator with workspace, multiple
+      windows, remote management, quake mode and other features.
      '';
-    homepage = https://github.com/linuxdeepin/deepin-terminal/;
+    homepage = https://github.com/linuxdeepin/deepin-terminal;
     license = licenses.gpl3;
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change

Update to version 3.0.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).