### PR TITLE
qgis: patch for compatibility with cmake 3.12

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, gdal, cmake, qt4, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
+{ stdenv, fetchurl, fetchpatch, gdal, cmake, qt4, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
 , qwt, fcgi, python2Packages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper
 , qjson, qca2, txt2tags, openssl, darwin, pkgconfig
 , withGrass ? true, grass, IOKit, ApplicationServices
@@ -36,6 +36,14 @@ stdenv.mkDerivation rec {
     url = "https://qgis.org/downloads/${name}.tar.bz2";
     sha256 = "00b3a2hfn3i7bdx7x96vz2nj0976vpkhid4ss7n8c33fdvw3k82a";
   };
+
+  patches = [
+    # https://github.com/qgis/QGIS/pull/7765
+    (fetchpatch {
+      url = "https://github.com/qgis/QGIS/commit/6b61ef361a77f057dc29eb07463007bd9012b253.patch";
+      sha256 = "1xibcahm18n7nxff1xvwwzjf505hvhiw5dk12is7aclv49h0rdf7";
+    })
+  ];
 
   # CMAKE_FIND_FRAMEWORK=never stops the installer choosing system
   # installed frameworks


### PR DESCRIPTION
###### Motivation for this change

Work with cmake update in #44910. Reported upstream as https://github.com/qgis/QGIS/pull/7765.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

