### PR TITLE
openjdk: 10.0.1 -> 10.0.2

### DIFF
--- a/pkgs/development/compilers/openjdk/10.nix
+++ b/pkgs/development/compilers/openjdk/10.nix
@@ -17,8 +17,8 @@ let
       "i386"
     else "amd64";
 
-  update = "10.0.1";
-  build = "10";
+  update = "10.0.2";
+  build = "13";
   repover = "jdk-${update}+${build}";
   paxflags = if stdenv.isi686 then "msp" else "m";
 
@@ -27,7 +27,7 @@ let
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk10u/archive/${repover}.tar.gz";
-      sha256 = "1fg0rl5pd3f2y3v3bq8p3zdkrpa1pyslwdln4s64clyr7spvxkjw";
+      sha256 = "0y7hyzgvn6z8gyp3h9xvxwj6zda899y6i629jn6yxqzj96q56jpk";
     };
 
     outputs = [ "out" "jre" ];

--- a/pkgs/development/compilers/openjdk/darwin/10.nix
+++ b/pkgs/development/compilers/openjdk/darwin/10.nix
@@ -7,11 +7,11 @@ let
   };
 
   jdk = stdenv.mkDerivation {
-    name = "zulu10.1+11-jdk10";
+    name = "zulu10.3+5-jdk10";
 
     src = fetchurl {
-      url = "https://cdn.azul.com/zulu/bin/zulu10.1+11-jdk10-macosx_x64.zip";
-      sha256 = "1c5ib136nv6gz7ij31mg15nhzrl6zr7kp8spm17zwm1ib82bc73y";
+      url = https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-macosx_x64.zip;
+      sha256 = "05pxfjn8fqw6ddr8m5hzyphwzqgrq8w6b4h3lwc1s7ymh05xmspz";
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
     };
 


### PR DESCRIPTION
###### Motivation for this change

this fixes a series of potential security issues:

CVE-2018-2940, CVE-2018-2941, CVE-2018-2952, CVE-2018-2964,
CVE-2018-2972 & CVE-2018-2973

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

