### PR TITLE
dtkcore: init at 2.0.9

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -9,6 +9,7 @@ let
       inherit (pkgs.gnome3) libgee vte;
       wnck = pkgs.libwnck3;
     };
+    dtkcore = callPackage ./dtkcore { };
 
   };
 

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, pythonPackages }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dtkcore";
+  version = "2.0.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0jfl4w3sviy59rl41a5507dbhqhsxy7hqw3gf64a57gjlbdskmm1";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    pythonPackages.wrapPython
+  ];
+
+  buildInputs = [
+    gsettings-qt
+  ];
+
+  postPatch = ''
+    sed -i src/src.pro src/dtk_module.prf \
+      -e "s,\$\''${QT_HOST_DATA}/mkspecs,$out/mkspecs,"
+
+    sed -i tools/script/dtk-translate.py \
+      -e "s,#!env,#!/usr/bin/env,"
+  '';
+
+  postFixup = ''
+    chmod +x $out/lib/dtk2/*.py
+    wrapPythonProgramsIn "$out/lib/dtk2" "$out $pythonPath"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Deepin tool kit core modules";
+    homepage = https://github.com/linuxdeepin/dtkcore;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [dtkcore](https://github.com/linuxdeepin/dtkcore), the Deepin tool kit core modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).