### PR TITLE
buildRustPackage, fetchcargo: optionally use the real config from cargo vendor

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -42,7 +42,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0y5d1n6hkw85jb3rblcxqas2fp82h3nghssa4xqrhqnz25l799pj";
   };
 
-  cargoSha256 = "0q68qyl2h6i0qsz82z840myxlnjay8p1w5z7hfyr8fqp7wgwa9cx";
+  cargoSha256 = "194lzn9xjkc041lmqnm676ydgbhn45xx9jhrhz6lzlg99yr6b880";
+  useRealVendorConfig = true;
 
   meta = with stdenv.lib; {
     description = "A fast line-oriented regex search tool, similar to ag and ack";
@@ -63,6 +64,14 @@ When the `Cargo.lock`, provided by upstream, is not in sync with the
 `Cargo.toml`, it is possible to use `cargoPatches` to update it. All patches
 added in `cargoPatches` will also be prepended to the patches in `patches` at
 build-time.
+
+The `useRealVendorConfig` parameter tells cargo-vendor to include a Cargo
+configuration file in the fetched dependencies. This will fix problems with
+projects, where Crates are downloaded from non-crates.io sources. Please note,
+that currently this parameter defaults to `false` only due to compatibility
+reasons, as setting this to `true` requires a change in `cargoSha256`.
+Eventually this distinction will be deprecated, so please always set
+`useRealVendorConfig` to `true` and make sure to recompute the `cargoSha256`.
 
 To install crates with nix there is also an experimental project called
 [nixcrates](https://github.com/fractalide/nixcrates).

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -536,6 +536,27 @@ inherit (pkgs.nixos {
       a new paragraph.
     </para>
   </listitem>
+  <listitem>
+    <para>
+	    The <literal>buildRustPackage</literal> function got the new
+	    argument <literal>useRealVendorConfig</literal>, currently
+	    defaulting to <literal>false</literal>. Setting it to
+	    <literal>true</literal> necessates the recomputation of the
+	    <literal>cargoSha256</literal> and fixes a problem with
+	    dependencies, that were fetched from a non-crates.io source.
+	    Eventually only the <literal>true</literal> behaviour will be kept,
+	    so please set it explicitly to <literal>true</literal> and
+	    recompute your <literal>cargoSha256</literal>, so that we can
+	    migrate to the new behaviour and deprecate the option.
+    </para>
+    <para>
+	    While recomputing <literal>cargoSha256</literal>, it is important
+	    to first invalidate the hash (e.g. by changing a digit), so that
+	    Nix actually rebuilds the fixed-output derivation. Otherwise this
+	    could lead to hard to detect errors, where a package seemingly
+	    builds on your computer, but breaks on others!
+    </para>
+  </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/build-support/rust/fetchcargo.nix
+++ b/pkgs/build-support/rust/fetchcargo.nix
@@ -1,5 +1,5 @@
 { stdenv, cacert, git, rust, cargo-vendor }:
-{ name ? "cargo-deps", src, srcs, patches, sourceRoot, sha256, cargoUpdateHook ? "" }:
+{ name ? "cargo-deps", src, srcs, patches, sourceRoot, sha256, cargoUpdateHook ? "", writeVendorConfig ? false }:
 stdenv.mkDerivation {
   name = "${name}-vendor";
   nativeBuildInputs = [ cacert cargo-vendor git rust.cargo ];
@@ -23,9 +23,11 @@ stdenv.mkDerivation {
 
     ${cargoUpdateHook}
 
-    cargo vendor
-
-    cp -ar vendor $out
+    mkdir -p $out
+    cargo vendor $out > config
+  '' + stdenv.lib.optionalString writeVendorConfig ''
+    mkdir $out/.cargo
+    sed "s|directory = \".*\"|directory = \"./vendor\"|g" config > $out/.cargo/config
   '';
 
   outputHashAlgo = "sha256";


### PR DESCRIPTION
###### Motivation for this change

Current `fetchcargo` behaviour is not sufficient, when sources different from crates.io are used. An example where this makes packaging impossible is #44465.

As a naive change of the code would result in breaking `cargoSha256` all over the place, an additional argument is proposed to turn the new behaviour on.

###### Things done

This introduces `useRealVendorConfig` as a new argument to `buildRustPackage`. Whenever `buildRustPackage` fetches Cargo dependencies and `useRealVendorConfig` is true, `fetchcargo` writes its generated config into the vendor output.

Imho this behaviour should be desirable all the time. A possible migration path is proposed in the commit message.

This should trigger a rebuild in every package using `cargoSha256`.

###### How I tested this

- `nix-build -A rustracer --check`.
- Changed `cargoSha256` of `rustracer`, rebuilt, still wants the old hash.
- `nix-build -A cargo --check`, a package which uses `buildRustPackage` but not `fetchcargo`, same drv as on master.
- Packaged `sequoia-pgp` with `useRealVendorConfig = true`, a package with dependencies from non-crates.io sources.

Pinging @symphorien @madjar @cstrahan @wizeman @globin @Havvy @wkennington

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

