### PR TITLE
stage-1-init.sh: do not check mounted filesystems

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -263,6 +263,13 @@ checkFS() {
         return 0
     fi
 
+    # Device might be already mounted manually 
+    # e.g. NBD-device or the host filesystem of the file which contains encrypted root fs
+    if mount | grep -q "^$device on "; then
+        echo "skip checking already mounted $device"
+        return 0
+    fi
+
     # Optionally, skip fsck on journaling filesystems.  This option is
     # a hack - it's mostly because e2fsck on ext3 takes much longer to
     # recover the journal than the ext3 implementation in the kernel


### PR DESCRIPTION
###### Motivation for this change

```fsck``` of a mounted filesystems fails with error code 8 "Operational error" and halts the boot processing

It is a rare problem on simple disk configurations, but there are weird cloud hostings with network-only disks (scaleway)  or ones which do not allow disk partitioning (most XEN clouds) forcing to put encrypted root filesystem into a file.
In those cases ```boot.initrd.preLVMCommand``` is something like 
```mkOrder 100 ''mkdir /boot ; mount /dev/xvda /boot''``` 
and the fs is already mounted at the ```fsck``` time 

----
A simpler solution is to change
https://github.com/NixOS/nixpkgs/blob/8fb33bcb2d6d573176702d0daecf59187df44e11/nixos/modules/system/boot/stage-1-init.sh#L311
to
```if test $fsckResult -ge 9; then ```
allowing to go on booting if ```fsck``` failed with error code 8, but it might be too permissive