### PR TITLE
ocamlPackages.reason: remove spurious dependency on opam

### DIFF
--- a/pkgs/development/compilers/reason/default.nix
+++ b/pkgs/development/compilers/reason/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, makeWrapper, buildOcaml, fetchFromGitHub,
-  ocaml, opam, jbuilder, menhir, merlin_extend, ppx_tools_versioned, utop }:
+{ stdenv, makeWrapper, fetchFromGitHub, ocaml, findlib, jbuilder
+, menhir, merlin_extend, ppx_tools_versioned, utop
+}:
 
-buildOcaml rec {
-  name = "reason";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-reason-${version}";
   version = "3.3.3";
 
   src = fetchFromGitHub {
@@ -14,11 +15,9 @@ buildOcaml rec {
 
   propagatedBuildInputs = [ menhir merlin_extend ppx_tools_versioned ];
 
-  buildInputs = [ makeWrapper opam jbuilder utop menhir ];
+  buildInputs = [ makeWrapper ocaml findlib jbuilder utop menhir ];
 
   buildFlags = [ "build" ]; # do not "make tests" before reason lib is installed
-
-  createFindlibDestdir = true;
 
   installPhase = ''
     for p in reason rtop
@@ -35,6 +34,7 @@ buildOcaml rec {
     homepage = https://reasonml.github.io/;
     description = "Facebook's friendly syntax to OCaml";
     license = licenses.mit;
+    inherit (ocaml.meta) platforms;
     maintainers = [ maintainers.volth ];
   };
 }


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

