### PR TITLE
navit: 0.5.2 -> 0.5.3

### DIFF
--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -18,13 +18,13 @@ assert speechdSupport -> speechd != null;
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "navit-${version}";
-  version = "0.5.2";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "navit-gps";
     repo = "navit";
     rev = "v${version}";
-    sha256 = "11w85rlx612lws4s3q36li4iqib9b35v94kzf2zh9g1aphwqh2qa";
+    sha256 = "071drvqzxpxbfh0lf0lra5a97rv8ny40l96n9xl0dx0s8w30j61i";
   };
 
   sample_map = fetchurl {
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   # we choose only cmdline and speech-dispatcher speech options.
   # espeak builtins is made for non-cmdline OS as winCE
   cmakeFlags = [
-    "-DSAMPLE_MAP=n " "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    "-DSAMPLE_MAP=n " "-DCMAKE_BUILD_TYPE=Release"
     "-Dspeech/qt5_espeak=FALSE" "-Dsupport/espeak=FALSE"
   ];
 
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
   libPath = stdenv.lib.makeLibraryPath ([ stdenv.cc.libc ] ++ buildInputs );
   postFixup =
   ''
-	  find "$out/lib" -type f -name "*.so" -exec patchelf --set-rpath $libPath {} \;
+    find "$out/lib" -type f -name "*.so" -exec patchelf --set-rpath $libPath {} \;
 
     wrapProgram $out/bin/navit \
       --prefix PATH : ${makeBinPath (


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

