### PR TITLE
dde-qt-dbus-factory: init at 1.0.4

### DIFF
--- a/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dde-qt-dbus-factory/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, python }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-qt-dbus-factory";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0j0f57byzlz2ixgj6qr1pda83bpwn2q8kxv4i2jv99n6g0qw4nmw";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    python
+  ];
+
+  postPatch = ''
+    sed -i libdframeworkdbus/{DFrameworkdbusConfig.in,libdframeworkdbus.pro} \
+      -e "s,/usr,$out,"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Qt DBus interface library for Deepin software";
+    homepage = https://github.com/linuxdeepin/dde-qt-dbus-factory;
+    license = with licenses; [ gpl3Plus lgpl2Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -3,6 +3,7 @@
 let
   packages = self: with self; {
 
+    dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
     deepin-terminal = callPackage ./deepin-terminal {


### PR DESCRIPTION
###### Motivation for this change

Add [dde-qt-dbus-factory](https://github.com/linuxdeepin/dde-qt-dbus-factory), a Qt DBus interface library for Deepin software.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).