### PR TITLE
cargo-web: init at 0.6.15

### DIFF
--- a/pkgs/development/tools/cargo-web/default.nix
+++ b/pkgs/development/tools/cargo-web/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, openssl, pkgconfig, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "cargo-web-${version}";
+  version = "0.6.15";
+
+  src = fetchFromGitHub {
+    owner = "koute";
+    repo = "cargo-web";
+    rev = version;
+    sha256 = "076g7cd9v53vi8xvd4kfsiyzw1m2hhd1lwlwcv2dx2s5vlw4dxzh";
+  };
+
+  cargoSha256 = "157av9zkirr00w9v11mh7yp8w36sy7rw6i80i5jmi0mgrdvcg5si";
+
+  nativeBuildInputs = [ openssl pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "A Cargo subcommand for the client-side Web";
+    homepage = https://github.com/koute/cargo-web;
+    license = with licenses; [asl20 /* or */ mit];
+    maintainers = [ maintainers.kevincox ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7159,6 +7159,8 @@ with pkgs;
 
   cargo-vendor = callPackage ../build-support/rust/cargo-vendor { };
 
+  cargo-web = callPackage ../development/tools/cargo-web { };
+
   carnix = (callPackage ../build-support/rust/carnix.nix { }).carnix { };
 
   defaultCrateOverrides = callPackage ../build-support/rust/default-crate-overrides.nix { };


### PR DESCRIPTION
###### Motivation for this change
Make cargo-web available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

