### PR TITLE
elasticsearch plugins: don't use lib.version

### DIFF
--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -1,7 +1,5 @@
 { pkgs,  stdenv, fetchurl, unzip, elasticsearch-oss, javaPackages, elk6Version }:
 
-with pkgs.lib;
-
 let
   esPlugin = a@{
     pluginName,
@@ -18,7 +16,7 @@ let
       buildInputs = [ unzip ];
       meta = a.meta // {
         platforms = elasticsearch-oss.meta.platforms;
-        maintainers = (a.meta.maintainers or []) ++ [ maintainers.offline ];
+        maintainers = (a.meta.maintainers or []) ++ (with stdenv.lib.maintainers; [ offline ]);
       };
     });
 in {
@@ -31,14 +29,14 @@ in {
       url = "https://github.com/vhyza/elasticsearch-analysis-lemmagen/releases/download/v${version}/${name}-plugin.zip";
       sha256 = "1m4z05wixjrq4nlbdjyhvprkrwxjym8aba18scmzfn25fhbjgvkz";
     };
-    meta = {
+    meta = with stdenv.lib; {
       homepage = https://github.com/vhyza/elasticsearch-analysis-lemmagen;
       description = "LemmaGen Analysis plugin provides jLemmaGen lemmatizer as Elasticsearch token filter";
       license = licenses.asl20;
     };
   };
 
-  discovery-ec2 = esPlugin {
+  discovery-ec2 = esPlugin rec {
     name = "elasticsearch-discovery-ec2-${version}";
     pluginName = "discovery-ec2";
     version = "${elk6Version}";
@@ -46,7 +44,7 @@ in {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/discovery-ec2/discovery-ec2-${elk6Version}.zip";
       sha256 = "1i7ksy69132sr84h51lamgq967yz3a3dw0b54nckxpqwad9pcpj0";
     };
-    meta = {
+    meta = with stdenv.lib; {
       homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/discovery-ec2;
       description = "The EC2 discovery plugin uses the AWS API for unicast discovery.";
       license = licenses.asl20;
@@ -61,7 +59,7 @@ in {
       url = "mirror://maven/com/floragunn/search-guard-6/${version}/search-guard-6-${version}.zip";
       sha256 = "1r71h4h9bmxak1mq5gpm19xq5ji1gry1kp3sjmm8azy4ykdqdncx";
     };
-    meta = {
+    meta = with stdenv.lib; {
       homepage = https://github.com/floragunncom/search-guard;
       description = "Plugin to fetch data from JDBC sources for indexing into Elasticsearch";
       license = licenses.asl20;


### PR DESCRIPTION
This is wrong and makes the hash change on each nixpkgs commit. This also makes a false positive with nox-review.

Before:
/nix/store/bwsq9kv6ysyqw953mcw0fjwk6zmkfcyw-elasticsearch-discovery-ec2-18.09.git.3b19fdff26M.drv
after:
/nix/store/r635faz0k0dhmh41kwf73pibdy6267hz-elasticsearch-discovery-ec2-6.3.2

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

