### PR TITLE
krita: refactor to fix build on aarch64

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, fetchurl, cmake, extra-cmake-modules
+{ mkDerivation, lib, stdenv, fetchurl, cmake, extra-cmake-modules
 , karchive, kconfig, kwidgetsaddons, kcompletion, kcoreaddons
 , kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
 , kio, kcrash
@@ -23,10 +23,10 @@ mkDerivation rec {
     karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
     ki18n kitemmodels kitemviews kwindowsystem kio kcrash
     boost libraw fftw eigen exiv2 lcms2 gsl openexr libheif giflib
-    openjpeg opencolorio vc poppler_qt5 curl ilmbase
+    openjpeg opencolorio poppler_qt5 curl ilmbase
     qtmultimedia qtx11extras
     python3
-  ];
+  ] ++ lib.optional (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) vc;
 
   NIX_CFLAGS_COMPILE = [ "-I${ilmbase.dev}/include/OpenEXR" ];
 


### PR DESCRIPTION
An optional dependency, Vc, doesn't currently provide any optimisations
on aarch64 and causes a build failure in krita. Exclude it from the
build inputs on arm and aarch64.

###### Motivation for this change
Krita doesn't build on aarch64. Neon support in Vc is listed as 'in development', so it's not clear whether Vc currently offers any benefits on these platforms anyway.

###### Things done
Excluded vc from the build inputs on arm and aarch64. As it is an optional dependency, this means that cmake doesn't find it, Vc support is disabled, and the build succeeds. Other platforms should be unaffected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

