### PR TITLE
install-grub.pl: avoid double '/' in menu.lst and grub.conf

### DIFF
--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -248,7 +248,7 @@ if ($grubVersion == 1) {
     ";
     if ($splashImage) {
         copy $splashImage, "$bootPath/background.xpm.gz" or die "cannot copy $splashImage to $bootPath\n";
-        $conf .= "splashimage " . $grubBoot->path . "/background.xpm.gz\n";
+        $conf .= "splashimage " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/background.xpm.gz\n";
     }
 }
 
@@ -289,7 +289,7 @@ else {
         copy $font, "$bootPath/converted-font.pf2" or die "cannot copy $font to $bootPath\n";
         $conf .= "
             insmod font
-            if loadfont " . $grubBoot->path . "/converted-font.pf2; then
+            if loadfont " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/converted-font.pf2; then
               insmod gfxterm
               if [ \"\${grub_platform}\" = \"efi\" ]; then
                 set gfxmode=$gfxmodeEfi
@@ -317,7 +317,7 @@ else {
         copy $splashImage, "$bootPath/background$suffix" or die "cannot copy $splashImage to $bootPath\n";
         $conf .= "
             insmod " . substr($suffix, 1) . "
-            if background_image --mode '$splashMode' " . $grubBoot->path . "/background$suffix; then
+            if background_image --mode '$splashMode' " . ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/background$suffix; then
               set color_normal=white/black
               set color_highlight=black/white
             else
@@ -352,7 +352,7 @@ sub copyToKernelsDir {
         rename $tmp, $dst or die "cannot rename $tmp to $dst\n";
     }
     $copied{$dst} = 1;
-    return $grubBoot->path . "/kernels/$name";
+    return ($grubBoot->path eq "/" ? "" : $grubBoot->path) . "/kernels/$name";
 }
 
 sub addEntry {


### PR DESCRIPTION
###### Motivation for this change

Although double ```/``` in paths is not a problem for the GRUB supplied with nixpkgs (it interprets ```//``` as ```/```), sometimes NixOS's ```grub.conf``` read by external GRUB and there are versions of GRUB which fail parsing config like this:

![](http://i.imgur.com/SlkYaBB.png)

