### PR TITLE
Revert "psmisc: 23.1 -> 23.2 (#45169)"

### DIFF
--- a/pkgs/os-specific/linux/psmisc/default.nix
+++ b/pkgs/os-specific/linux/psmisc/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, ncurses}:
 
 stdenv.mkDerivation rec {
-  name = "psmisc-23.2";
+  name = "psmisc-23.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/psmisc/${name}.tar.xz";
-    sha256 = "0s1kjhrik0wzqbm7hv4gkhywhjrwhp9ajw0ad05fwharikk6ah49";
+    sha256 = "0c5s94hqpwfmyswx2f96gifa6wdbpxxpkyxcrlzbxpvmrxsd911f";
   };
 
   buildInputs = [ncurses];


### PR DESCRIPTION
23.2 isn't an actual release yet
(for example, not listed here:
https://gitlab.com/psmisc/psmisc/tags )

and 23.2 apparently has caused problems elsewhere,
https://github.com/void-linux/void-packages/issues/2288

If this doesn't make branch-off might need to be picked over.

I have not experienced problems with this yet AFAIK.

This reverts commit b4411ab4797596b32740f78a89020a1c3e8c3af4.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---