### PR TITLE
freedesktop modules: disable by default

### DIFF
--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -5,7 +5,7 @@ with lib;
   options = {
     xdg.autostart.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the 
         <link xlink:href="https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html">XDG Autostart specification</link>.

--- a/nixos/modules/config/xdg/icons.nix
+++ b/nixos/modules/config/xdg/icons.nix
@@ -5,7 +5,7 @@ with lib;
   options = {
     xdg.icons.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the 
         <link xlink:href="https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html">XDG Icon Theme specification</link>.

--- a/nixos/modules/config/xdg/menus.nix
+++ b/nixos/modules/config/xdg/menus.nix
@@ -5,7 +5,7 @@ with lib;
   options = {
     xdg.menus.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the 
         <link xlink:href="https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html">XDG Desktop Menu specification</link>.

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -5,7 +5,7 @@ with lib;
   options = {
     xdg.mime.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = ''
         Whether to install files to support the 
         <link xlink:href="https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html">XDG Shared MIME-info specification</link> and the


### PR DESCRIPTION
###### Motivation for this change
In the spirit of not asking for things unless they're actually needed, this sets the options introduced in https://github.com/NixOS/nixpkgs/pull/45058 to false by default. 

This should only affect headless systems, since they're set in `xserver.nix`. I think it's plausible that you don't need most of these on a headless system. *Maybe* some people use MIME info, but I wouldn't have thought so.

This should only be merged after the 18.09 branch off.

@jtojnar @samueldr 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

