### PR TITLE
Cleanup homepage links

### DIFF
--- a/pkgs/applications/audio/axoloti/dfu-util.nix
+++ b/pkgs/applications/audio/axoloti/dfu-util.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       phones. With dfu-util you are able to download firmware to your device or
       upload firmware from it.
     '';
-    homepage = http://dfu-util.gnumonks.org/;
+    homepage = http://dfu-util.sourceforge.net;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ ];

--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "WYSIWYG PostScript annotator";
-    homepage = http://http://flpsed.org/flpsed.html;
+    homepage = http://flpsed.org/flpsed.html;
     license = licenses.gpl3;
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ fuuzetsu ];

--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance";
-    homepage = http://code.google.co/p/grafx2/;
+    homepage = http://pulkomandy.tk/projects/GrafX2;
     license = stdenv.lib.licenses.gpl2;
     platforms = [ "x86_64-linux" "i686-linux" ];
     maintainers = [ stdenv.lib.maintainers.zoomulator ];

--- a/pkgs/applications/misc/orpie/default.nix
+++ b/pkgs/applications/misc/orpie/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses gsl ] ++ (with ocamlPackages; [ ocaml camlp4 ]);
 
   meta = {
-    homepage = http://pessimization.com/software/orpie/;
+    homepage = https://github.com/pelzlpj/orpie;
     description = "A fullscreen RPN calculator for the console";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/applications/misc/pdfshuffler/default.nix
+++ b/pkgs/applications/misc/pdfshuffler/default.nix
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication rec {
   doCheck = false; # no tests
 
   meta = with stdenv.lib; {
-    homepage = https://gna.org/projects/pdfshuffler/;
+    homepage = https://sourceforge.net/p/pdfshuffler/wiki/Home;
     description = "Merge or split pdf documents and rotate, crop and rearrange their pages";
     platforms = platforms.linux;
     maintainers = with maintainers; [ mic92 ];

--- a/pkgs/applications/misc/pinfo/default.nix
+++ b/pkgs/applications/misc/pinfo/default.nix
@@ -17,7 +17,6 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A viewer for info files";
-    homepage = https://alioth.debian.org/projects/pinfo/;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A command-line time tracker";
-    homepage = https://tasktools.org/projects/timewarrior.html;
+    homepage = https://taskwarrior.org/docs/timewarrior;
     license = licenses.mit;
     maintainers = with maintainers; [ mrVanDalo ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin-plugins/tox-prpl/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
-    homepage = http://tox.dhs.org/;
+    homepage = https://github.com/jin-eld/tox-prpl;
     description = "Tox plugin for Pidgin / libpurple";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/networking/mailreaders/sup/default.nix
+++ b/pkgs/applications/networking/mailreaders/sup/default.nix
@@ -15,7 +15,7 @@ bundlerEnv {
 
   meta = with lib; {
     description = "A curses threads-with-tags style email client";
-    homepage    = http://supmua.org;
+    homepage    = http://sup-heliotrope.github.io;
     license     = licenses.gpl2;
     maintainers = with maintainers; [ cstrahan lovek323 ];
     platforms   = platforms.unix;

--- a/pkgs/applications/office/keepnote/default.nix
+++ b/pkgs/applications/office/keepnote/default.nix
@@ -16,7 +16,7 @@ python2Packages.buildPythonApplication {
 
   meta = {
     description = "Note taking application";
-    homepage = http://rasm.ods.org/keepnote;
+    homepage = http://keepnote.org;
     license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/applications/science/logic/jonprl/default.nix
+++ b/pkgs/applications/science/logic/jonprl/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       based on Brouwer-realizability & meaning explanations.
       Inspired by Nuprl
     '';
-    homepage = http://www.jonprl.org/;
+    homepage = https://github.com/jonsterling/JonPRL;
     license = stdenv.lib.licenses.mit;
     maintainers = with stdenv.lib.maintainers; [ puffnfresh ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/science/math/jags/default.nix
+++ b/pkgs/applications/science/math/jags/default.nix
@@ -9,11 +9,11 @@ stdenv.mkDerivation rec {
   buildInputs = [gfortran openblas];
   configureFlags = [ "--with-blas=-lopenblas" "--with-lapack=-lopenblas" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Just Another Gibbs Sampler";
-    license     = "GPL2";
-    homepage    = http://www-ice.iarc.fr/~martyn/software/jags/;
-    maintainers = [stdenv.lib.maintainers.andres];
-    platforms = stdenv.lib.platforms.unix;
+    license     = licenses.gpl2;
+    homepage    = http://mcmc-jags.sourceforge.net;
+    maintainers = [ maintainers.andres ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/math/symmetrica/default.nix
+++ b/pkgs/applications/science/math/symmetrica/default.nix
@@ -57,6 +57,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.publicDomain;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.unix;
-    homepage = http://www.symmetrica.de/;
+    homepage = http://www.algorithm.uni-bayreuth.de/en/research/SYMMETRICA/index.html;
   };
 }

--- a/pkgs/applications/science/programming/plm/default.nix
+++ b/pkgs/applications/science/programming/plm/default.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Free cross-platform programming exerciser";
-    homepage = http://webloria.loria.fr/~quinson/Teaching/PLM/;
     license = licenses.gpl3;
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
+    broken = true;
   };
 }

--- a/pkgs/applications/version-management/tkcvs/default.nix
+++ b/pkgs/applications/version-management/tkcvs/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation
   '';
 
   meta = {
-    homepage = http://www.twobarleycorns.net/tkcvs.html;
+    homepage = https://tkcvs.sourceforge.io;
     description = "TCL/TK GUI for cvs and subversion";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/applications/video/uvccapture/default.nix
+++ b/pkgs/applications/video/uvccapture/default.nix
@@ -10,7 +10,7 @@ in
 
 stdenv.mkDerivation rec {
   name = "uvccapture-0.5";
-  
+
   src = fetchurl {
     url = "mirror://debian/pool/main/u/uvccapture/uvccapture_0.5.orig.tar.gz";
     sha256 = "1b3akkcmr3brbf93akr8xi20w8zqf2g0qfq928500wy04qi6jqpi";
@@ -43,7 +43,6 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Capture image from USB webcam at a specified interval";
-    homepage = http://linux-uvc.berlios.de/;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = https://containerd.tools/;
+    homepage = https://containerd.io/;
     description = "A daemon to control runC";
     license = licenses.asl20;
     maintainers = with maintainers; [ offline vdemeester ];

--- a/pkgs/applications/window-managers/larswm/default.nix
+++ b/pkgs/applications/window-managers/larswm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://larswm.fnurt.net/;
+    homepage = http://www.fnurt.net/larswm;
     description = "9wm-like tiling window manager";
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Numix cursor theme";
-    homepage = https://numixproject.org;
+    homepage = https://numixproject.github.io;
     license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ offline ];

--- a/pkgs/development/compilers/orc/default.nix
+++ b/pkgs/development/compilers/orc/default.nix
@@ -20,10 +20,10 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The Oil Runtime Compiler";
-    homepage = http://code.entropywave.com/orc/;
+    homepage = https://gstreamer.freedesktop.org/projects/orc.html;
     # The source code implementing the Marsenne Twister algorithm is licensed
     # under the 3-clause BSD license. The rest is 2-clause BSD license.
-    license = licenses.bsd3;
+    license = with licenses; [ bsd3 bsd2 ];
     platforms = platforms.unix;
     maintainers = [ maintainers.fuuzetsu ];
   };

--- a/pkgs/development/interpreters/qnial/default.nix
+++ b/pkgs/development/interpreters/qnial/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An array language from Nial Systems";
-    homepage = http://www.nial.com;
+    homepage = https://github.com/vrthra/qnial;
     license = stdenv.lib.licenses.artistic1;
     maintainers = [ stdenv.lib.maintainers.vrthra ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/LASzip/default.nix
+++ b/pkgs/development/libraries/LASzip/default.nix
@@ -8,12 +8,12 @@ stdenv.mkDerivation rec {
     url = "https://github.com/LASzip/LASzip/archive/v${version}.tar.gz";
     sha256 = "b8e8cc295f764b9d402bc587f3aac67c83ed8b39f1cb686b07c168579c61fbb2";
   };
-  
+
   buildInputs = [cmake];
 
   meta = {
     description = "Turn quickly bulky LAS files into compact LAZ files without information loss";
-    homepage = https://www.laszip.org;
+    homepage = https://laszip.org;
     license = stdenv.lib.licenses.lgpl2;
     maintainers = [ stdenv.lib.maintainers.michelk ];
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/audio/jamomacore/default.nix
+++ b/pkgs/development/libraries/audio/jamomacore/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A C++ platform for building dynamic and reflexive systems with an emphasis on audio and media";
-    homepage = https://jamoma.org;
+    homepage = http://www.jamoma.org;
     license = stdenv.lib.licenses.bsd3;
     maintainers = [ stdenv.lib.maintainers.magnetophon ];
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/bwidget/default.nix
+++ b/pkgs/development/libraries/bwidget/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ tcl ];
 
   meta = {
-    homepage = http://tcl.activestate.com/software/tcllib/;
+    homepage = https://sourceforge.net/projects/tcllib;
     description = "High-level widget set for Tcl/Tk";
     license = stdenv.lib.licenses.tcltk;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/clipper/default.nix
+++ b/pkgs/development/libraries/clipper/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       The Clipper library performs line & polygon clipping - intersection, union, difference & exclusive-or,
       and line & polygon offsetting. The library is based on Vatti's clipping algorithm.
     '';
-    homepage = https://www.angusj.com/delphi/clipper.php;
+    homepage = https://sourceforge.net/projects/polyclipping;
     license = licenses.boost;
     maintainers = with maintainers; [ mpickering ];
     platforms = with platforms; unix;

--- a/pkgs/development/libraries/gtkimageview/default.nix
+++ b/pkgs/development/libraries/gtkimageview/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = http://trac.bjourne.webfactional.com/;
+    homepage = "https://wiki.gnome.org/Projects/GTK%2B/GtkImageView";
 
     description = "Image viewer widget for GTK+";
 


### PR DESCRIPTION
###### Motivation for this change
Update dead homepage meta data with dead links.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

