### PR TITLE
androidndk: fix eval

### DIFF
--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -1,4 +1,4 @@
-{ lib
+{ lib, stdenv
 , makeWrapper
 , runCommand, wrapBintoolsWith, wrapCCWith
 , buildAndroidndk, androidndk, targetAndroidndkPkgs

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -281,7 +281,7 @@ rec {
     inherit (buildPackages)
       makeWrapper;
     inherit (pkgs)
-      lib hostPlatform targetPlatform
+      lib stdenv
       runCommand wrapBintoolsWith wrapCCWith;
     # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
     # but for splicing messing up on infinite recursion for the variants we
@@ -297,7 +297,7 @@ rec {
     inherit (buildPackages)
       makeWrapper;
     inherit (pkgs)
-      lib hostPlatform targetPlatform
+      lib stdenv
       runCommand wrapBintoolsWith wrapCCWith;
     # buildPackages.foo rather than buildPackages.buildPackages.foo would work,
     # but for splicing messing up on infinite recursion for the variants we


### PR DESCRIPTION
###### Motivation for this change

fixup from https://github.com/NixOS/nixpkgs/pull/45820

/cc @Ericson2314


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

