### PR TITLE
deepin-gettext-tools: init at 1.0.8

### DIFF
--- a/pkgs/desktops/deepin/deepin-gettext-tools/default.nix
+++ b/pkgs/desktops/deepin/deepin-gettext-tools/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, gettext, python3Packages, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-gettext-tools";
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "03cwa82dd14a31v44jd3z0kpiri6g21ar4f48s8ph78nvjy55880";
+  };
+
+  nativeBuildInputs = [
+    python3Packages.wrapPython
+  ];
+
+  buildInputs = [
+    gettext
+    perlPackages.perl
+    perlPackages.XMLLibXML
+    perlPackages.ConfigTiny
+    python3Packages.python
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postPatch = ''
+    sed -e 's/sudo cp/cp/' -i src/generate_mo.py
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+    wrapPythonProgramsIn "$out/lib/${pname}"
+    wrapProgram $out/bin/deepin-desktop-ts-convert --set PERL5LIB $PERL5LIB
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Deepin Internationalization utilities";
+    homepage = https://github.com/linuxdeepin/deepin-gettext-tools;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -4,6 +4,7 @@ let
   packages = self: with self; {
 
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
+    deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
     deepin-terminal = callPackage ./deepin-terminal {


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-gettext-tools](https://github.com/linuxdeepin/deepin-gettext-tools) (Deepin Internationalization utilities).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).