### PR TITLE
cargo-tree: 0.19.0 -> 0.20.0

### DIFF
--- a/pkgs/tools/package-management/cargo-tree/default.nix
+++ b/pkgs/tools/package-management/cargo-tree/default.nix
@@ -1,17 +1,17 @@
 { stdenv, lib, rustPlatform, fetchFromGitHub, pkgconfig, cmake, curl, libiconv, darwin }:
 rustPlatform.buildRustPackage rec {
   name = "cargo-tree-${version}";
-  version = "0.19.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "sfackler";
     repo = "cargo-tree";
     rev = "v${version}";
 
-    sha256 = "16vsw392qs3ag2brvcan19km7ds0s9s7505p3hnfjvjrzgdliir3";
+    sha256 = "197kbr7q7aqzv5l8xilz60m50rbkmfwfswyd6ka7w83j5bi88jw3";
   };
 
-  cargoSha256 = "0g6afhqqdf76axbcs5wj9gydsabd3d5ja8qd8z8y6wbp7n0y4h6a";
+  cargoSha256 = "1v84cj42ch49jrigrkivg99hzxa79jii8s3fddjk23hi1xx1c35y";
 
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ curl ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];


### PR DESCRIPTION
###### Motivation for this change

It was outdated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).