### PR TITLE
backblaze-b2: 1.1.0 -> 1.3.6

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -4,19 +4,30 @@
 
 buildPythonApplication rec {
   pname = "backblaze-b2";
-  version = "1.1.0";
+  version = "1.3.6";
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
     rev = "v${version}";
-    sha256 = "0697rcdsmxz51p4b8m8klx2mf5xnx6vx56vcf5jmzidh8mc38a6z";
+    sha256 = "12axb0c56razfhrx1l62sjvdrbg6vz0yyqph2mxyjza1ywpb93b5";
   };
 
   propagatedBuildInputs = [ arrow futures logfury requests six tqdm ];
 
   checkPhase = ''
     python test_b2_command_line.py test
+  '';
+
+  postPatch = ''
+    # b2 uses an upper bound on arrow, because arrow 0.12.1 is not
+    # compatible with Python 2.6:
+    #
+    # https://github.com/crsmithdev/arrow/issues/517
+    #
+    # However, since we use Python 2.7, newer versions of arrow are fine.
+
+    sed -i 's/,<0.12.1//g' requirements.txt
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Many useful changes since 1.1.0: https://github.com/Backblaze/B2_Command_Line_Tool#release-history

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

