### PR TITLE
nixos/release.nix: disable blivet test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -249,7 +249,7 @@ in rec {
   tests.beegfs = callTest tests/beegfs.nix {};
   tests.bittorrent = callTest tests/bittorrent.nix {};
   tests.bind = callTest tests/bind.nix {};
-  tests.blivet = callTest tests/blivet.nix {};
+  #tests.blivet = callTest tests/blivet.nix {};   # broken since 2017-07024
   tests.boot = callSubTests tests/boot.nix {};
   tests.boot-stage1 = callTest tests/boot-stage1.nix {};
   tests.borgbackup = callTest tests/borgbackup.nix {};


### PR DESCRIPTION
###### Motivation for this change

- test has been broken since 2017-07-24
- no attempts to fix it
- it tests a really outdated blivet version (Oct 2014)

This drops the test from `release.nix` so it is no longer run on Hydra. It does *not* remove the test.

---
cc @aszlig 
