### PR TITLE
bluejeans-gui: init at 1.6.39

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, rpmextract, patchelf, libnotify, libcap, cairo, pango, fontconfig, udev, dbus
+, gtk2, atk, expat, gdk_pixbuf, freetype, nspr, glib, nss, gconf, libX11, libXrender, libXtst, libXdamage
+, libXi, libXext, libXfixes, libXcomposite, alsaLib, bash
+}:
+
+stdenv.mkDerivation rec {
+  name = "bluejeans-${version}";
+  version = "1.36.9";
+
+  src =
+    fetchurl {
+      url = "https://swdl.bluejeans.com/desktop/linux/1.36/${version}/bluejeans-${version}.x86_64.rpm";
+      sha256 = "0sbv742pzqd2cxn3kq10lfi16jah486i9kyrmi8l1rpb9fhyw2m1";
+    };
+
+  buildInputs = [ patchelf rpmextract ];
+
+  libPath =
+    stdenv.lib.makeLibraryPath
+       [ libnotify libcap cairo pango fontconfig gtk2 atk expat gdk_pixbuf dbus udev.lib
+         freetype nspr glib stdenv.cc stdenv.cc.cc.lib nss gconf libX11 libXrender libXtst libXdamage
+         libXi libXext libXfixes libXcomposite alsaLib
+       ];
+
+  buildCommand = ''
+    mkdir -p $out/bin/
+    cd $out
+    rpmextract $src
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      opt/bluejeans/bluejeans-bin
+    patchelf \
+      --set-rpath ${libPath} \
+      opt/bluejeans/bluejeans-bin
+    patchelf \
+      --replace-needed libudev.so.0 libudev.so.1 \
+      opt/bluejeans/bluejeans-bin
+    ln -s $out/opt/bluejeans/bluejeans $out/bin/bluejeans
+    substituteInPlace $out/bin/bluejeans \
+      --replace '#!/bin/bash' '#!${bash}/bin/bash'
+    chmod +x $out/bin/bluejeans
+  '';
+
+  meta = {
+    description = "Video, audio, and web conferencing that works together with the collaboration tools you use every day.";
+    license = stdenv.lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15586,6 +15586,12 @@ with pkgs;
 
   bluejeans = callPackage ../applications/networking/browsers/mozilla-plugins/bluejeans { };
 
+  bluejeans-gui = callPackage ../applications/networking/instant-messengers/bluejeans {
+    gconf = pkgs.gnome2.GConf;
+    inherit (pkgs.xorg) libX11 libXrender libXtst libXdamage
+                        libXi libXext libXfixes libXcomposite;
+  };
+
   bombono = callPackage ../applications/video/bombono {};
 
   bomi = libsForQt5.callPackage ../applications/video/bomi {


### PR DESCRIPTION
There's an existing `bluejeans` package, but that looks like a browser plugins. This is a standalone application.

I checked that it executes and was able to confirm that the video & sound works.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---