### PR TITLE
nixos/accountservice: Don't restart account-daemon on upgrades

### DIFF
--- a/nixos/modules/services/desktops/accountsservice.nix
+++ b/nixos/modules/services/desktops/accountsservice.nix
@@ -40,6 +40,7 @@ with lib;
     systemd.packages = [ pkgs.accountsservice ];
 
     systemd.services.accounts-daemon = {
+      restartIfChanged = false;
 
       wantedBy = [ "graphical.target" ];
 


### PR DESCRIPTION
###### Motivation for this change
If account-daemon restarts in a gnome3 session it totally breaks and becomes unusable.

What happens for me if account-daemon restarts is that I see the screen flash like the login animation from gdm. All programs are still up. But the mouse is frozen and I can't even switch to a tty with my keyboard. The only thing that it actually responds to seems to be Ctrl+Alt+Delete which triggers a reboot. And this indicates that I'm actually in a tty but I see an image of my gnome-session.

This is a problem when doing `nixos-rebuild switch` etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jtojnar 
