### PR TITLE
nixos/switch-to-configuration: support shells which aren't POSIX compliant

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -419,7 +419,7 @@ while (my $f = <$listActiveUsers>) {
     my ($uid, $name) = ($+{uid}, $+{user});
     print STDERR "reloading user units for $name...\n";
 
-    system("su", "-l", $name, "-c", "XDG_RUNTIME_DIR=/run/user/$uid @systemd@/bin/systemctl --user daemon-reload");
+    system("su", "-l", $name, "-c", "export XDG_RUNTIME_DIR=/run/user/$uid; @systemd@/bin/systemctl --user daemon-reload");
 }
 
 close $listActiveUsers;


### PR DESCRIPTION
`fish' doesn't support the `ENVVAR=foo my cmd' notation which breaks
`nixos-rebuild switch':

```
fish: Unsupported use of '='. To run '/nix/store/dzn7zyf1dhxlvrbpgn yn7di58zvfblrq-systemd-239/bin/systemctl'
with a modified environment, please use
'env XDG_RUNTIME_DIR=/run/user/1000 /nix/store/dzn7zyf1dhxlvrbpgnyn7di58zvfblrq-systemd-239/bin/systemctl…'
```

The issue can be solved by adding an `export' statement and run the
command after that.

Fixes #45897

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

