### PR TITLE
idea: move meta to each package

### DIFF
--- a/pkgs/development/libraries/boost/1.55.nix
+++ b/pkgs/development/libraries/boost/1.55.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl, ... } @ args:
+{ stdenv, callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
   version = "1.55.0";
@@ -8,5 +8,14 @@ callPackage ./generic.nix (args // rec {
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_55_0.tar.bz2";
     sha256 = "0lkv5dzssbl5fmh2nkaszi8x9qbj80pr4acf9i26sj3rvlih1w7z";
+  };
+
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.remove "aarch64-linux" stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
   };
 })

--- a/pkgs/development/libraries/boost/1.59.nix
+++ b/pkgs/development/libraries/boost/1.59.nix
@@ -37,4 +37,13 @@ callPackage ./generic.nix (args // rec {
     ./cygwin-1.45.0-jam-cygwin.patch
     ./cygwin-1.50.0-jam-pep3149.patch
   ];
+
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.60.nix
+++ b/pkgs/development/libraries/boost/1.60.nix
@@ -8,4 +8,12 @@ callPackage ./generic.nix (args // rec {
     sha256 = "0fzx6dwqbrkd4bcd8pjv0fpapwmrxxwr8yx9g67lihlsk3zzysk8";
   };
 
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.62.nix
+++ b/pkgs/development/libraries/boost/1.62.nix
@@ -9,4 +9,12 @@ callPackage ./generic.nix (args // rec {
     sha256 = "36c96b0f6155c98404091d8ceb48319a28279ca0333fba1ad8611eb90afb2ca0";
   };
 
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.63.nix
+++ b/pkgs/development/libraries/boost/1.63.nix
@@ -9,4 +9,12 @@ callPackage ./generic.nix (args // rec {
     sha256 = "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0";
   };
 
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.64.nix
+++ b/pkgs/development/libraries/boost/1.64.nix
@@ -9,4 +9,12 @@ callPackage ./generic.nix (args // rec {
     sha256 = "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332";
   };
 
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.65.nix
+++ b/pkgs/development/libraries/boost/1.65.nix
@@ -9,4 +9,12 @@ callPackage ./generic.nix (args // rec {
     sha256 = "9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81";
   };
 
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.66.nix
+++ b/pkgs/development/libraries/boost/1.66.nix
@@ -8,4 +8,13 @@ callPackage ./generic.nix (args // rec {
     # SHA256 from http://www.boost.org/users/history/version_1_66_0.html
     sha256 = "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9";
   };
+
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.67.nix
+++ b/pkgs/development/libraries/boost/1.67.nix
@@ -14,4 +14,13 @@ callPackage ./generic.nix (args // rec {
     # SHA256 from http://www.boost.org/users/history/version_1_66_0.html
     sha256 = "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba";
   };
+
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/1.68.nix
+++ b/pkgs/development/libraries/boost/1.68.nix
@@ -8,4 +8,13 @@ callPackage ./generic.nix (args // rec {
     # SHA256 from http://www.boost.org/users/history/version_1_68_0.html
     sha256 = "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7";
   };
+
+  meta = {
+    homepage = http://boost.org/;
+    description = "Collection of C++ libraries";
+    license = stdenv.lib.licenses.boost;
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ peti wkennington ];
+  };
 })

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -16,7 +16,7 @@
 , mpi ? null
 
 # Attributes inherit from specific versions
-, version, src
+, version, src, meta
 , ...
 }:
 
@@ -84,7 +84,7 @@ in
 stdenv.mkDerivation {
   name = "boost-${version}";
 
-  inherit src;
+  inherit src meta;
 
   patchFlags = optionalString (stdenv.hostPlatform.libc == "msvcrt") "-p0";
   patches = patches
@@ -94,15 +94,6 @@ stdenv.mkDerivation {
           + "boost-mingw.patch";
       sha256 = "0s32kwll66k50w6r5np1y5g907b7lcpsjhfgr7rsw7q5syhzddyj";
     });
-
-  meta = {
-    homepage = http://boost.org/;
-    description = "Collection of C++ libraries";
-    license = stdenv.lib.licenses.boost;
-
-    platforms = (if versionOlder version "1.59" then remove "aarch64-linux" else id) platforms.unix;
-    maintainers = with maintainers; [ peti wkennington ];
-  };
 
   preConfigure = ''
     if test -f tools/build/src/tools/clang-darwin.jam ; then


### PR DESCRIPTION
> nix edit boost

currently edits generic.nix, leaving the user a bit confused about where
a specific boost version is defined. This is because Nix internally uses
`builtins.unsafeGetAttrPos "description" package.meta` to find the file
a package is from.

Additionally, I think it is possible for OfBorg to ping maintainers if the
maintainers are listed closer to the expressions being modified.

A con is obviously the duplication of meta fields.

A pro is the simplification of the meta: not having to do version comparisons in a generic location, for example.

cc @vcunat @peti @dezgeg @edolstra @Ericson2314 @dtzWill 

What do y'all think? This PR is for Boost-only, but we could easily apply the same idea and improve the experience for many other packages with a "generic" home:

```
"position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89"
      "position": "pkgs/development/libraries/boost/generic.nix:89",
      "position": "pkgs/development/libraries/botan/generic.nix:46",
      "position": "pkgs/development/libraries/botan/generic.nix:46",

      "position": "pkgs/servers/nosql/cassandra/generic.nix:65"
      "position": "pkgs/servers/nosql/cassandra/generic.nix:65"
      "position": "pkgs/servers/nosql/cassandra/generic.nix:65"
      "pkgs/development/libraries/celt/generic.nix:17"
      "position": "pkgs/development/libraries/celt/generic.nix:17"
      "position": "pkgs/development/libraries/celt/generic.nix:17"
      "position": "pkgs/tools/filesystems/ceph/generic.nix:171"
      "position": "pkgs/tools/filesystems/ceph/generic.nix:171"
      "position": "pkgs/development/libraries/db/generic.nix:48"
      "position": "pkgs/development/libraries/db/generic.nix:48"
      "position": "pkgs/development/libraries/db/generic.nix:48"
      "position": "pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix:4"
      "position": "pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix:4"
      "position": "pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix:4"
      "position": "pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix:4"
      "position": "pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix:4"

      "position": "pkgs/development/interpreters/elixir/generic-builder.nix:65"
      "position": "pkgs/development/interpreters/elixir/generic-builder.nix:65"
      "position": "pkgs/development/interpreters/elixir/generic-builder.nix:65"

      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/interpreters/erlang/generic-builder.nix:107"
      "position": "pkgs/development/libraries/ffmpeg/generic.nix:196"
      "position": "pkgs/development/libraries/ffmpeg/generic.nix:196"
      "position": "pkgs/development/libraries/ffmpeg/generic.nix:196"
      "position": "pkgs/misc/gnuk/generic.nix:48"
      "position": "pkgs/misc/gnuk/generic.nix:48",
      "position": "pkgs/misc/gnuk/generic.nix:48",
 21 58.8M   21 12.8M    0     0   170k      0  0:05:53  0:01:17  0:04:36  205k      "description": "A generic backend for GNUstep",
      "position": "pkgs/development/libraries/gnutls/generic.nix:71"
      "position": "pkgs/development/libraries/gnutls-kdh/generic.nix:78"
      "position": "pkgs/development/go-modules/generic/default.nix:79"
      "position": "pkgs/development/go-modules/generic/default.nix:79"
      "position": "pkgs/development/go-modules/generic/default.nix:79"
 "position": "pkgs/development/go-modules/generic/default.nix:79"
      "position": "pkgs/development/go-modules/generic/default.nix:79"
      "position": "pkgs/development/go-modules/generic/default.nix:79"
      "position": "pkgs/development/go-modules/generic/default.nix:79"
      "position": "pkgs/development/compilers/mono/generic.nix:90",
      "position": "pkgs/development/compilers/mono/generic.nix:90",
      "position": "pkgs/development/compilers/mono/generic-cmake.nix:87",
      "position": "pkgs/development/compilers/mono/generic-cmake.nix:87",
      "position": "pkgs/development/compilers/mono/generic-cmake.nix:87",
      "position": "pkgs/development/compilers/mono/generic-cmake.nix:87",
```

(and more)