### PR TITLE
gnu-pw-mgr: 2.3.3 -> 2.4.2

### DIFF
--- a/pkgs/tools/security/gnu-pw-mgr/default.nix
+++ b/pkgs/tools/security/gnu-pw-mgr/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "gnu-pw-mgr-${version}";
-  version = "2.3.3";
+  version = "2.4.2";
   src = fetchurl {
     url = "http://ftp.gnu.org/gnu/gnu-pw-mgr/${name}.tar.xz";
-    sha256 = "04xh38j7l0sfnb01kp05xc908pvqfc0lph94k7n9bi46zy3qy7ma";
+    sha256 = "1yvdzc5w37qrjrkby5699ygj9bhkvgi3zk9k9jcjry1j6b7wdl17";
   };
 
   buildInputs = [ gnulib ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

