### PR TITLE
clang_complete (vimPlugin): fix multiple clang outputs

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -439,7 +439,10 @@ self = rec {
     # $ eval echo $(nix-instantiate --eval --expr 'with (import <nixpkgs>) {}; clang.default_cxx_stdlib_compile')
     preFixup = ''
       substituteInPlace "$out"/share/vim-plugins/clang_complete/plugin/clang_complete.vim \
-        --replace "let g:clang_library_path = '' + "''" + ''" "let g:clang_library_path='${llvmPackages.clang.cc}/lib/libclang.so'"
+        --replace "let g:clang_library_path = '' + "''" + ''" "let g:clang_library_path='${llvmPackages.clang.cc.lib}/lib/libclang.so'"
+
+      substituteInPlace "$out"/share/vim-plugins/clang_complete/plugin/libclang.py \
+        --replace "/usr/lib/clang" "${llvmPackages.clang.cc}/lib/clang"
     '';
   };
 

--- a/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/clang_complete
+++ b/pkgs/misc/vim-plugins/vim2nix/additional-nix-code/clang_complete
@@ -7,5 +7,8 @@
     # $ eval echo $(nix-instantiate --eval --expr 'with (import <nixpkgs>) {}; clang.default_cxx_stdlib_compile')
     preFixup = ''
       substituteInPlace "$out"/share/vim-plugins/clang_complete/plugin/clang_complete.vim \
-        --replace "let g:clang_library_path = '' + "''" + ''" "let g:clang_library_path='${llvmPackages.clang.cc}/lib/libclang.so'"
+        --replace "let g:clang_library_path = '' + "''" + ''" "let g:clang_library_path='${llvmPackages.clang.cc.lib}/lib/libclang.so'"
+
+      substituteInPlace "$out"/share/vim-plugins/clang_complete/plugin/libclang.py \
+        --replace "/usr/lib/clang" "${llvmPackages.clang.cc}/lib/clang"
     '';


### PR DESCRIPTION
###### Motivation for this change

Clang-specific headers and `libclang.so` now go to different outputs. `clang_complete` vim plugin must know the location of both. The fix slightly modifies `preFixup` phase so that this information is provided.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

