### PR TITLE
 dtkwidget: init at 2.0.9.3 

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -11,6 +11,7 @@ let
       wnck = pkgs.libwnck3;
     };
     dtkcore = callPackage ./dtkcore { };
+    dtkwidget = callPackage ./dtkwidget { };
 
   };
 

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -23,17 +23,24 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    sed -i src/src.pro src/dtk_module.prf \
-      -e "s,\$\''${QT_HOST_DATA}/mkspecs,$out/mkspecs,"
+    # Only define QT_HOST_DATA if it is empty
+    sed '/QT_HOST_DATA=/a }' -i src/dtk_module.prf
+    sed '/QT_HOST_DATA=/i isEmpty(QT_HOST_DATA) {' -i src/dtk_module.prf
 
-    sed -i tools/script/dtk-translate.py \
-      -e "s,#!env,#!/usr/bin/env,"
+    # Fix shebang
+    sed -i tools/script/dtk-translate.py -e "s,#!env,#!/usr/bin/env,"
+  '';
+
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags QT_HOST_DATA=$out"
   '';
 
   postFixup = ''
     chmod +x $out/lib/dtk2/*.py
     wrapPythonProgramsIn "$out/lib/dtk2" "$out $pythonPath"
   '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Deepin tool kit core modules";

--- a/pkgs/desktops/deepin/dtkwidget/default.nix
+++ b/pkgs/desktops/deepin/dtkwidget/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, qtmultimedia,
+  qtsvg, qtx11extras, librsvg, libstartup_notification, gsettings-qt,
+  dde-qt-dbus-factory, dtkcore
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dtkwidget";
+  version = "2.0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1ngspvjvws1d2nkyqjh9y45ilahkd1fqwxnlmazgik4355mb76bv";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    qttools
+  ];
+
+  buildInputs = [
+    qtmultimedia
+    qtsvg
+    qtx11extras
+    librsvg
+    libstartup_notification
+    gsettings-qt
+    dde-qt-dbus-factory
+    dtkcore
+  ];
+
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags \
+      INCLUDE_INSTALL_DIR=$out/include \
+      LIB_INSTALL_DIR=$out/lib \
+      QT_HOST_DATA=$out"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Deepin graphical user interface library";
+    homepage = https://github.com/linuxdeepin/dtkwidget;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

- Add [dtkwidget](https://github.com/linuxdeepin/dtkwidget) (Deepin graphical user interface library).
- dtkcore: only define QT_HOST_DATA if it is empty, enable parallel building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).