### PR TITLE
roccat-tools: init at 5.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -346,6 +346,11 @@
     github = "ashgillman";
     name = "Ashley Gillman";
   };
+  ashkitten = {
+    email = "ashlea@protonmail.com";
+    github = "ashkitten";
+    name = "ash lea";
+  };
   aske = {
     email = "aske@fmap.me";
     github = "aske";

--- a/pkgs/applications/misc/roccat-tools/default.nix
+++ b/pkgs/applications/misc/roccat-tools/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, callPackage, fetchurl, pkgconfig, cmake, pcre, gtk2, gtk3, dbus-glib, libgudev, lua5_1 }:
+
+let
+  libgaminggear = callPackage ./libgaminggear.nix {};
+in
+  stdenv.mkDerivation rec {
+  name = "roccat-tools-${version}";
+  version = "5.7.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/roccat/${name}.tar.bz2";
+    sha256 = "15gxplcm62167xhk65k8v6gg3j6jr0c5a64wlz72y1vfq0ai7qm6";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libgaminggear cmake pcre gtk2 gtk3 dbus-glib libgudev lua5_1 ];
+
+  patchPhase = ''
+    substituteInPlace roccateventhandler/CMakeLists.txt --replace '/etc/xdg' "$out/etc/xdg"
+    substituteInPlace libroccat/roccat_helper.c --replace '"/", "/var", "lib"' 'g_get_user_config_dir()'
+  '';
+
+  cmakeFlags = [
+    "-DLIBDIR=lib"
+    "-DUDEVDIR=lib/udev"
+    "-DLUA_FIND_VERSION=5.1"
+    "-DLUA_FIND_VERSION_EXACT=1"
+    "-DCMAKE_MODULE_PATH=${libgaminggear}/lib/cmake"
+  ];
+
+  meta = {
+    description = "Userland tools for roccat devices";
+    homepage = http://roccat.sourceforge.net;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ stdenv.lib.maintainers.ashkitten ];
+  };
+}

--- a/pkgs/applications/misc/roccat-tools/libgaminggear.nix
+++ b/pkgs/applications/misc/roccat-tools/libgaminggear.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, pkgconfig, cmake, pcre, gtk2, gtk3, libcanberra, libnotify, sqlite }:
+
+stdenv.mkDerivation rec {
+    name = "libgaminggear-${version}";
+    version = "0.15.1";
+
+    src = fetchurl {
+        url = "mirror://sourceforge/libgaminggear/${name}.tar.bz2";
+        sha256 = "0jf5i1iv8j842imgiixbhwcr6qcwa93m27lzr6gb01ri5v35kggz";
+    };
+
+    nativeBuildInputs = [ pkgconfig ];
+    buildInputs = [ cmake pcre gtk2 gtk3 libcanberra libnotify sqlite ];
+
+    patchPhase = ''
+        substituteInPlace configuration/FindGAMINGGEAR.cmake.in --replace '@GFX_PLUGIN_DIR@' 'lib/gaminggear_plugins'
+    '';
+
+    cmakeFlags = [
+        "-DINSTALL_LIBDIR=lib"
+        "-DINSTALL_CMAKE_MODULESDIR=lib/cmake"
+        "-DINSTALL_PKGCONFIGDIR=lib/pkgconfig"
+    ];
+
+    meta = {
+        description = "Supplementary libraries for roccat-tools";
+        homepage = http://roccat.sourceforge.net;
+        license = stdenv.lib.licenses.gpl2;
+        platforms = stdenv.lib.platforms.linux;
+        maintainers = [ stdenv.lib.maintainers.ashkitten ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5004,6 +5004,8 @@ with pkgs;
 
   rlwrap = callPackage ../tools/misc/rlwrap { };
 
+  roccat-tools = callPackage ../applications/misc/roccat-tools { };
+
   rockbox_utility = libsForQt5.callPackage ../tools/misc/rockbox-utility { };
 
   rosegarden = libsForQt5.callPackage ../applications/audio/rosegarden { };


### PR DESCRIPTION
###### Motivation for this change

i made the package for myself and figured it's nice to share.

 i'm new to all this stuff so i didn't make a 25-way split package like [the aur](https://aur.archlinux.org/pkgbase/roccat-tools/). if that's a thing yall want i guess let me know how to do it and i will?

i also patched it to put its files in `$XDG_CONFIG_HOME` instead of `/var/lib`, because i'm not sure how i'd make it work with `/var/lib` and it seemed like a weird place anyways.

i don't own all the devices this supports, so i wasn't able to test everything, though it seemed to work fine with my ryosmkfx and tyon.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
