### PR TITLE
uefitool: init at 0.25.1

### DIFF
--- a/pkgs/applications/misc/uefitool/default.nix
+++ b/pkgs/applications/misc/uefitool/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, qmake, zip }:
+
+stdenv.mkDerivation rec {
+  name = "UEFITool-${version}";
+  version = "0.25.1";
+
+  src = fetchurl {
+    url = "https://github.com/LongSoft/UEFITool/archive/${version}.tar.gz";
+    sha256 = "0bgffna9sbgr1nw517jv5lj5lppg9pany415gjzmd8gj0m28fvsw";
+  };
+
+  nativeBuildInputs = [ qmake zip ];
+
+  enableParallelBuilding = true;
+
+  qmakeFlags = [
+    "QMAKE_CXXFLAGS+=-flto"
+    "QMAKE_LFLAGS+=-flto"
+    "CONFIG+=optimize_size"
+    "-recursive" "subdirs.pro"
+  ];
+
+  # Subprojects use a bespoke layout, so create a meta-project to
+  # build them all in one go.
+  preConfigure = ''
+    cat >subdirs.pro <<EOF
+    TEMPLATE = subdirs
+    SUBDIRS = uefitool uefipatch uefireplace
+    uefitool.file = uefitool.pro
+    uefipatch.file = UEFIPatch/uefipatch.pro
+    uefireplace.file = UEFIReplace/uefireplace.pro
+    EOF
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp UEFITool UEFIPatch/UEFIPatch UEFIReplace/UEFIReplace $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "UEFI firmware image viewer and editor";
+    homepage = https://github.com/LongSoft/UEFITool;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tadfisher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18927,6 +18927,8 @@ with pkgs;
 
   testssl = callPackage ../applications/networking/testssl { };
 
+  uefitool = libsForQt5.callPackage ../applications/misc/uefitool { };
+
   umurmur = callPackage ../applications/networking/umurmur { };
 
   udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };


### PR DESCRIPTION
###### Motivation for this change

Add the UEFITool application for examining and modifying UEFI firmware images.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

