### PR TITLE
qt5dxcb-plugin: init at 1.1.11

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -13,6 +13,7 @@ let
     };
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };
+    qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
 
   };
 

--- a/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
+++ b/pkgs/desktops/deepin/qt5dxcb-plugin/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtx11extras, libSM, mtdev, cairo }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "qt5dxcb-plugin";
+  version = "1.1.11";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "157p2cqs9fvd4n4fmxj6mh4cxlc35bkl4rnf832wk2gvjnxdfrfy";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    qtx11extras
+    libSM
+    mtdev
+    cairo
+  ];
+
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags INSTALL_PATH=$out/$qtPluginPrefix/platforms"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Qt platform theme integration plugin for DDE";
+    homepage = https://github.com/linuxdeepin/qt5dxcb-plugin;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [qt5dxcb-plugin](https://github.com/linuxdeepin/qt5dxcb-plugin) (Qt platform integration plugin for Deepin Desktop Environment)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).