### PR TITLE
ultimate-oldschool-pc-font-pack: init at 1.0

### DIFF
--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation rec {
+  name = "ultimate-oldschool-pc-font-pack-${version}";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "http://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
+    sha256 = "7666cf23176e34ea03a218b5c1500f4ad729d97150ab7bdb7cf2adf4c99a9a7a";
+  };
+
+  buildInputs = [ unzip ];
+
+  dontBuild = true;
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/truetype
+    cp 'Px437 (TrueType - DOS charset)'/*.ttf $out/share/fonts/truetype
+    cp 'PxPlus (TrueType - extended charset)'/*.ttf $out/share/fonts/truetype
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";
+    homepage = "http://int10h.org/oldschool-pc-fonts/";
+    platforms = platforms.unix;
+    license = licenses.cc-by-sa-40;
+    maintainers = [ maintainers.endgame ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15336,6 +15336,8 @@ with pkgs;
 
   ucs-fonts = callPackage ../data/fonts/ucs-fonts { };
 
+  ultimate-oldschool-pc-font-pack = callPackage ../data/fonts/ultimate-oldschool-pc-font-pack { };
+
   uni-vga = callPackage ../data/fonts/uni-vga { };
 
   unifont = callPackage ../data/fonts/unifont { };


### PR DESCRIPTION
I'm not sure I've got everything 100% right; I haven't packaged fonts before. Also, I've only packaged the TTF fonts — is there anywhere useful I can put the bitmap `.FON` files?

###### Motivation for this change

I like my terminals to look like they came from 1990.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

