### PR TITLE
Skaware summer 2018 release

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -1,0 +1,128 @@
+{ stdenv, fetchgit, writeScript, file }:
+let lib = stdenv.lib;
+in {
+  # : string
+  pname
+  # : string
+, version
+  # : string
+, sha256
+  # : string
+, description
+  # : list Platform
+, platforms ? lib.platforms.all
+  # : list string
+, outputs ? [ "bin" "lib" "dev" "doc" "out" ]
+  # TODO(Profpatsch): automatically infer most of these
+  # : list string
+, configureFlags
+  # mostly for moving and deleting files from the build directory
+  # : lines
+, postInstall
+  # : list Maintainer
+, maintainers ? []
+
+
+}:
+
+let
+
+  # File globs that can always be deleted
+  commonNoiseFiles = [
+    ".gitignore"
+    "Makefile"
+    "INSTALL"
+    "configure"
+    "patch-for-solaris"
+    "src/**/*"
+    "tools/**/*"
+    "package/**/*"
+    "config.mak"
+  ];
+
+  # File globs that should be moved to $doc
+  commonMetaFiles = [
+    "COPYING"
+    "AUTHORS"
+    "NEWS"
+    "CHANGELOG"
+    "README"
+    "README.*"
+  ];
+
+  globWith = stdenv.lib.concatMapStringsSep "\n";
+  rmNoise = globWith (f:
+    ''rm -rf ${f}'') commonNoiseFiles;
+  mvMeta = globWith
+    (f: ''mv ${f} "$DOCDIR" 2>/dev/null || true'')
+    commonMetaFiles;
+
+  # Move & remove actions, taking the package doc directory
+  commonFileActions = writeScript "common-file-actions.sh" ''
+    #!${stdenv.shell}
+    set -e
+    DOCDIR="$1"
+    shopt -s globstar extglob nullglob
+    ${rmNoise}
+    mkdir -p "$DOCDIR"
+    ${mvMeta}
+  '';
+
+
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+
+  src = fetchgit {
+    url = "git://git.skarnet.org/${pname}";
+    rev = "refs/tags/v${version}";
+    inherit sha256;
+  };
+
+  inherit outputs;
+
+  dontDisableStatic = true;
+  enableParallelBuilding = true;
+
+  configureFlags = configureFlags ++ [
+    "--enable-absolute-paths"
+    (if stdenv.isDarwin
+      then "--disable-shared"
+      else "--enable-shared")
+  ]
+    # On darwin, the target triplet from -dumpmachine includes version number,
+    # but skarnet.org software uses the triplet to test binary compatibility.
+    # Explicitly setting target ensures code can be compiled against a skalibs
+    # binary built on a different version of darwin.
+    # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
+    ++ (lib.optional stdenv.isDarwin
+         "--build=${stdenv.hostPlatform.system}");
+
+  # TODO(Profpatsch): ensure that there is always a $doc output!
+  postInstall = ''
+    echo "Cleaning & moving common files"
+    mkdir -p $doc/share/doc/${pname}
+    ${commonFileActions} $doc/share/doc/${pname}
+
+    ${postInstall}
+  '';
+
+  postFixup = ''
+    echo "Checking for remaining source files"
+    rem=$(find -mindepth 1 -xtype f -print0 \
+           | tee $TMP/remaining-files)
+    if [[ "$rem" != "" ]]; then
+      echo "ERROR: These files should be either moved or deleted:"
+      cat $TMP/remaining-files | xargs -0 ${file}/bin/file
+      exit 1
+    fi
+  '';
+
+  meta = {
+    homepage = "https://skarnet.org/software/${pname}/";
+    inherit description platforms;
+    license = stdenv.lib.licenses.isc;
+    maintainers = with lib.maintainers;
+      [ pmahoney Profpatsch ] ++ maintainers;
+  };
+
+}

--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, writeScript, file }:
+{ stdenv, fetchurl, writeScript, file }:
 let lib = stdenv.lib;
 in {
   # : string
@@ -72,9 +72,8 @@ let
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
 
-  src = fetchgit {
-    url = "git://git.skarnet.org/${pname}";
-    rev = "refs/tags/v${version}";
+  src = fetchurl {
+    url = "https://skarnet.org/software/${pname}/${pname}-${version}.tar.gz";
     inherit sha256;
   };
 

--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "nsss";
   version = "0.0.1.0";
-  sha256 = "0pw7qk4j4q4sl3h01bbqcr44ppxkdvaw08xlhsnnkiv9jypfwx7w";
+  sha256 = "0f285bvpvhk40cqjpkc1jb36il0fkzzzjmc89gbbq3awl3w4r1i0";
 
   description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions.";
 

--- a/pkgs/development/libraries/nsss/default.nix
+++ b/pkgs/development/libraries/nsss/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, skawarePackages }:
+
+with skawarePackages;
+
+buildPackage {
+  pname = "nsss";
+  version = "0.0.1.0";
+  sha256 = "0pw7qk4j4q4sl3h01bbqcr44ppxkdvaw08xlhsnnkiv9jypfwx7w";
+
+  description = "An implementation of a subset of the pwd.h, group.h and shadow.h family of functions.";
+
+  # TODO: nsss support
+  configureFlags = [
+    "--libdir=\${lib}/lib"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+  ];
+
+  postInstall = ''
+    # remove all nsss executables from build directory
+    rm $(find -name "nsssd-*" -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libnsss.* libnsssd.*
+
+    mv doc $doc/share/doc/nsss/html
+    mv examples $doc/share/doc/nsss/examples
+  '';
+
+}

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.6.4.0";
+  version = "2.7.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/skalibs";
     rev = "refs/tags/v${version}";
-    sha256 = "13icrwxxb7k3cj37dl07h0apk6lwyrg1qrwjwh4l82i8f32bnjz2";
+    sha256 = "068pkbl91mi35amlhv491dwrbzyfifrlxijss0g2vf693xvx6lxm";
   };
 
   outputs = [ "lib" "dev" "doc" "out" ];

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "skalibs";
   version = "2.7.0.0";
-  sha256 = "068pkbl91mi35amlhv491dwrbzyfifrlxijss0g2vf693xvx6lxm";
+  sha256 = "0mnprdf4w4ami0db22rwd111m037cdmn2p8xa4i8cbwxcrv4sjcn";
 
   description = "A set of general-purpose C programming libraries";
 

--- a/pkgs/development/libraries/skalibs/default.nix
+++ b/pkgs/development/libraries/skalibs/default.nix
@@ -1,51 +1,30 @@
-{ stdenv, fetchgit }:
+{ stdenv, skawarePackages }:
 
-let
+with skawarePackages;
 
+buildPackage {
+  pname = "skalibs";
   version = "2.7.0.0";
+  sha256 = "068pkbl91mi35amlhv491dwrbzyfifrlxijss0g2vf693xvx6lxm";
 
-in stdenv.mkDerivation rec {
-
-  name = "skalibs-${version}";
-
-  src = fetchgit {
-    url = "git://git.skarnet.org/skalibs";
-    rev = "refs/tags/v${version}";
-    sha256 = "068pkbl91mi35amlhv491dwrbzyfifrlxijss0g2vf693xvx6lxm";
-  };
+  description = "A set of general-purpose C programming libraries";
 
   outputs = [ "lib" "dev" "doc" "out" ];
 
-  dontDisableStatic = true;
-
-  enableParallelBuilding = true;
-
   configureFlags = [
-    "--enable-force-devr"       # assume /dev/random works
+    # assume /dev/random works
+    "--enable-force-devr"
     "--libdir=\${lib}/lib"
     "--dynlibdir=\${lib}/lib"
     "--includedir=\${dev}/include"
     "--sysdepdir=\${lib}/lib/skalibs/sysdeps"
-  ]
-  ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
-  # On darwin, the target triplet from -dumpmachine includes version number, but
-  # skarnet.org software uses the triplet to test binary compatibility.
-  # Explicitly setting target ensures code can be compiled against a skalibs
-  # binary built on a different version of darwin.
-  # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
-  ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.hostPlatform.system}");
+  ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/skalibs
+    rm -rf sysdeps.cfg
+    rm libskarnet.*
+
     mv doc $doc/share/doc/skalibs/html
   '';
-
-  meta = {
-    homepage = http://skarnet.org/software/skalibs/;
-    description = "A set of general-purpose C programming libraries";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
-  };
 
 }

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -1,25 +1,19 @@
-{ stdenv, fetchurl, skalibs }:
+{ stdenv, skawarePackages }:
 
-let
+with skawarePackages;
 
+buildPackage {
+  pname = "s6-linux-utils";
   version = "2.5.0.0";
+  sha256 = "0wbxwki2alyym6dm44s5ajp9ndw6sgrqvizkznz71c30i0dlxrnf";
 
-in stdenv.mkDerivation rec {
-
-  name = "s6-linux-utils-${version}";
-
-  src = fetchurl {
-    url = "https://www.skarnet.org/software/s6-linux-utils/${name}.tar.gz";
-    sha256 = "04q2z71dkzahd2ppga2zikclz2qk014c23gm7rigqxjc8rs1amvq";
-  };
+  description = "A set of minimalistic Linux-specific system utilities";
+  platforms = stdenv.lib.platforms.linux;
 
   outputs = [ "bin" "dev" "doc" "out" ];
 
-  dontDisableStatic = true;
-
   # TODO: nsss support
   configureFlags = [
-    "--enable-absolute-paths"
     "--bindir=\${bin}/bin"
     "--includedir=\${dev}/include"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
@@ -29,16 +23,10 @@ in stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/s6-networking/
-    mv doc $doc/share/doc/s6-networking/html
-  '';
+    # remove all s6 executables from build directory
+    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
 
-  meta = {
-    homepage = http://www.skarnet.org/software/s6-linux-utils/;
-    description = "A set of minimalistic Linux-specific system utilities";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
-  };
+    mv doc $doc/share/doc/s6-linux-utils/html
+  '';
 
 }

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.4.0.2";
+  version = "2.5.0.0";
 
 in stdenv.mkDerivation rec {
 
@@ -10,13 +10,14 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.skarnet.org/software/s6-linux-utils/${name}.tar.gz";
-    sha256 = "0245rmk7wfyyfsi4g7f0niprwlvqlwkbyjxflb8kkbvhwfdavqip";
+    sha256 = "04q2z71dkzahd2ppga2zikclz2qk014c23gm7rigqxjc8rs1amvq";
   };
 
   outputs = [ "bin" "dev" "doc" "out" ];
 
   dontDisableStatic = true;
 
+  # TODO: nsss support
   configureFlags = [
     "--enable-absolute-paths"
     "--bindir=\${bin}/bin"

--- a/pkgs/os-specific/linux/s6-linux-utils/default.nix
+++ b/pkgs/os-specific/linux/s6-linux-utils/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "s6-linux-utils";
   version = "2.5.0.0";
-  sha256 = "0wbxwki2alyym6dm44s5ajp9ndw6sgrqvizkznz71c30i0dlxrnf";
+  sha256 = "04q2z71dkzahd2ppga2zikclz2qk014c23gm7rigqxjc8rs1amvq";
 
   description = "A set of minimalistic Linux-specific system utilities";
   platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -1,28 +1,18 @@
-{ stdenv, fetchgit, skalibs }:
+{ stdenv, skawarePackages }:
 
-let
+with skawarePackages;
 
+buildPackage {
+  pname = "execline";
   version = "2.5.0.1";
+  sha256 = "0d4gvixz7xja03hnwc2bf13xrgh1jq27ij4m1jlrpgrzhfpqz37q";
 
-in stdenv.mkDerivation rec {
-
-  name = "execline-${version}";
-
-  src = fetchgit {
-    url = "git://git.skarnet.org/execline";
-    rev = "refs/tags/v${version}";
-    sha256 = "0d4gvixz7xja03hnwc2bf13xrgh1jq27ij4m1jlrpgrzhfpqz37q";
-  };
+  description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
-  dontDisableStatic = true;
-
-  enableParallelBuilding = true;
-
   # TODO: nsss support
   configureFlags = [
-    "--enable-absolute-paths"
     "--libdir=\${lib}/lib"
     "--dynlibdir=\${lib}/lib"
     "--bindir=\${bin}/bin"
@@ -31,22 +21,15 @@ in stdenv.mkDerivation rec {
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"
     "--with-dynlib=${skalibs.lib}/lib"
-  ]
-  ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
-  ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.hostPlatform.system}");
+  ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/execline
+    # remove all execline executables from build directory
+    rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libexecline.*
+
     mv doc $doc/share/doc/execline/html
     mv examples $doc/share/doc/execline/examples
   '';
-
-  meta = {
-    homepage = http://skarnet.org/software/execline/;
-    description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
-  };
 
 }

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "execline";
   version = "2.5.0.1";
-  sha256 = "0d4gvixz7xja03hnwc2bf13xrgh1jq27ij4m1jlrpgrzhfpqz37q";
+  sha256 = "0j8hwdw8wn0rv8njdza8fbgmvyjg7hqp3qlbw00i7fwskr7d21wd";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.5.0.0";
+  version = "2.5.0.1";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/execline";
     rev = "refs/tags/v${version}";
-    sha256 = "19vd8252g5bmzm4i9gybpj7i2mhsflcgfl4ns5k3g1vv7f69i1dn";
+    sha256 = "0d4gvixz7xja03hnwc2bf13xrgh1jq27ij4m1jlrpgrzhfpqz37q";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
@@ -20,6 +20,7 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # TODO: nsss support
   configureFlags = [
     "--enable-absolute-paths"
     "--libdir=\${lib}/lib"

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -1,47 +1,35 @@
-{ stdenv, fetchurl, skalibs }:
+{ stdenv, skawarePackages }:
 
-with stdenv.lib;
+with skawarePackages;
 
-stdenv.mkDerivation rec {
-  name = "s6-portable-utils-${version}";
+let
+  pname = "s6-portable-utils";
+
+in buildPackage {
+  pname = pname;
   version = "2.2.1.2";
+  sha256 = "1zfanja5mbyafmzw28dlx1bb3fixa7lidbs62sxf849ly3z0zqp2";
 
-  src = fetchurl {
-    url = "https://www.skarnet.org/software/s6-portable-utils/${name}.tar.gz";
-    sha256 = "0if77z07rfygd1yk9d2abxkdbx3dg52vcjhb20isb8kvqxhkg8ih";
-  };
+  description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 
   outputs = [ "bin" "dev" "doc" "out" ];
 
-  dontDisableStatic = true;
-
   configureFlags = [
-    "--enable-absolute-paths"
     "--bindir=\${bin}/bin"
     "--includedir=\${dev}/include"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"
     "--with-dynlib=${skalibs.lib}/lib"
-  ]
-  # On darwin, the target triplet from -dumpmachine includes version number, but
-  # skarnet.org software uses the triplet to test binary compatibility.
-  # Explicitly setting target ensures code can be compiled against a skalibs
-  # binary built on a different version of darwin.
-  # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
-  ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.hostPlatform.system}");
+  ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/s6-portable-utils/
-    mv doc $doc/share/doc/s6-portable-utils/html
+    # remove all s6 executables from build directory
+    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
+    rm seekablepipe
+
+    mv doc $doc/share/doc/${pname}/html
   '';
 
-  meta = {
-    homepage = http://www.skarnet.org/software/s6-portable-utils/;
-    description = "A set of tiny general Unix utilities optimized for simplicity and small size";
-    platforms = platforms.all;
-    license = licenses.isc;
-    maintainers = with maintainers; [ pmahoney Profpatsch ];
-  };
 
 }

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -8,7 +8,7 @@ let
 in buildPackage {
   pname = pname;
   version = "2.2.1.2";
-  sha256 = "1zfanja5mbyafmzw28dlx1bb3fixa7lidbs62sxf849ly3z0zqp2";
+  sha256 = "0if77z07rfygd1yk9d2abxkdbx3dg52vcjhb20isb8kvqxhkg8ih";
 
   description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 

--- a/pkgs/tools/misc/s6-portable-utils/default.nix
+++ b/pkgs/tools/misc/s6-portable-utils/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "s6-portable-utils-${version}";
-  version = "2.2.1.1";
+  version = "2.2.1.2";
 
   src = fetchurl {
     url = "https://www.skarnet.org/software/s6-portable-utils/${name}.tar.gz";
-    sha256 = "0ca5iiq3n6isj64jb81xpwjzjx1q8jg145nnnn91ra2qqk93kqka";
+    sha256 = "0if77z07rfygd1yk9d2abxkdbx3dg52vcjhb20isb8kvqxhkg8ih";
   };
 
   outputs = [ "bin" "dev" "doc" "out" ];

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -1,27 +1,17 @@
-{ stdenv, fetchgit, skalibs }:
+{ stdenv, skawarePackages }:
 
-let
+with skawarePackages;
 
+buildPackage {
+  pname = "s6-dns";
   version = "2.3.0.1";
+  sha256 = "0flxkrnff2c28514k2nxv2y41k38pbiwd8dxlqaxgs2cl27i0ggb";
 
-in stdenv.mkDerivation rec {
-
-  name = "s6-dns-${version}";
-
-  src = fetchgit {
-    url = "git://git.skarnet.org/s6-dns";
-    rev = "refs/tags/v${version}";
-    sha256 = "0flxkrnff2c28514k2nxv2y41k38pbiwd8dxlqaxgs2cl27i0ggb";
-  };
+  description = "A suite of DNS client programs and libraries for Unix systems";
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
-  dontDisableStatic = true;
-
-  enableParallelBuilding = true;
-
   configureFlags = [
-    "--enable-absolute-paths"
     "--libdir=\${lib}/lib"
     "--libexecdir=\${lib}/libexec"
     "--dynlibdir=\${lib}/lib"
@@ -31,21 +21,15 @@ in stdenv.mkDerivation rec {
     "--with-include=${skalibs.dev}/include"
     "--with-lib=${skalibs.lib}/lib"
     "--with-dynlib=${skalibs.lib}/lib"
-  ]
-  ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
-  ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.hostPlatform.system}");
+  ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/s6-dns/
+    # remove all s6-dns executables from build directory
+    rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libs6dns.*
+    rm libskadns.*
+
     mv doc $doc/share/doc/s6-dns/html
   '';
-
-  meta = {
-    homepage = http://www.skarnet.org/software/s6-dns/;
-    description = "A suite of DNS client programs and libraries for Unix systems";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
-  };
 
 }

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.3.0.0";
+  version = "2.3.0.1";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-dns";
     rev = "refs/tags/v${version}";
-    sha256 = "1hczdg3dzi9z6f0wicm2qa2239fiax915zp66xspdz6qd23nqrxb";
+    sha256 = "0flxkrnff2c28514k2nxv2y41k38pbiwd8dxlqaxgs2cl27i0ggb";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/tools/networking/s6-dns/default.nix
+++ b/pkgs/tools/networking/s6-dns/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "s6-dns";
   version = "2.3.0.1";
-  sha256 = "0flxkrnff2c28514k2nxv2y41k38pbiwd8dxlqaxgs2cl27i0ggb";
+  sha256 = "16ymalc4yxbwc0kapwmissxlw2bdk4sx3b33zp1gwx3n6hkcgh8c";
 
   description = "A suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -21,7 +21,7 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 buildPackage {
   pname = "s6-networking";
   version = "2.3.0.3";
-  sha256 = "06kv2l31ch0zw538bpivgnwymb056x5hpmqafglffgkbq3izp7wc";
+  sha256 = "1kfjl7da6wkmyq1mvq9irkbzk2wbi0axjfbcw5cym5y11mqswsjs";
 
   description = "A suite of small networking utilities for Unix systems";
 

--- a/pkgs/tools/networking/s6-networking/default.nix
+++ b/pkgs/tools/networking/s6-networking/default.nix
@@ -9,7 +9,7 @@
 let
   inherit (stdenv) lib;
 
-  version = "2.3.0.2";
+  version = "2.3.0.3";
 
   sslSupportEnabled = sslSupport != false;
   sslLibs = {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-networking";
     rev = "refs/tags/v${version}";
-    sha256 = "1qrhca8yjaysrqf7nx3yjfyfi9yly3rxpgrd2sqj0a0ckk73rv42";
+    sha256 = "06kv2l31ch0zw538bpivgnwymb056x5hpmqafglffgkbq3izp7wc";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
@@ -35,6 +35,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # TODO: nsss support
   configureFlags = [
     "--enable-absolute-paths"
     "--libdir=\${lib}/lib"

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "s6-rc";
   version = "0.4.1.0";
-  sha256 = "1as7jhlp4cvh1bzvcli1hk1pbdzkac8gys1h379blymfy8hmp805";
+  sha256 = "1xl37xi509pcm5chcvn8l7gb952sr5mkpxhpkbsxhsllj791bfa2";
 
   description = "A service manager for s6-based systems";
   platforms = stdenv.lib.platforms.linux;

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "0.4.0.1";
+  version = "0.4.1.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6-rc";
     rev = "refs/tags/v${version}";
-    sha256 = "10gkkdbvkb4s2yshx425v9diwm7vvbl320a2bm0c3wz71xr94wsw";
+    sha256 = "1as7jhlp4cvh1bzvcli1hk1pbdzkac8gys1h379blymfy8hmp805";
   };
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];

--- a/pkgs/tools/system/s6-rc/default.nix
+++ b/pkgs/tools/system/s6-rc/default.nix
@@ -1,27 +1,18 @@
-{ stdenv, execline, fetchgit, skalibs, s6 }:
+{ stdenv, skawarePackages }:
 
-let
+with skawarePackages;
 
+buildPackage {
+  pname = "s6-rc";
   version = "0.4.1.0";
+  sha256 = "1as7jhlp4cvh1bzvcli1hk1pbdzkac8gys1h379blymfy8hmp805";
 
-in stdenv.mkDerivation rec {
-
-  name = "s6-rc-${version}";
-
-  src = fetchgit {
-    url = "git://git.skarnet.org/s6-rc";
-    rev = "refs/tags/v${version}";
-    sha256 = "1as7jhlp4cvh1bzvcli1hk1pbdzkac8gys1h379blymfy8hmp805";
-  };
+  description = "A service manager for s6-based systems";
+  platforms = stdenv.lib.platforms.linux;
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
-  dontDisableStatic = true;
-
-  enableParallelBuilding = true;
-
   configureFlags = [
-    "--enable-absolute-paths"
     "--libdir=\${lib}/lib"
     "--libexecdir=\${lib}/libexec"
     "--dynlibdir=\${lib}/lib"
@@ -37,22 +28,15 @@ in stdenv.mkDerivation rec {
     "--with-dynlib=${skalibs.lib}/lib"
     "--with-dynlib=${execline.lib}/lib"
     "--with-dynlib=${s6.out}/lib"
-  ]
-  ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
-  ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.hostPlatform.system}");
+  ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/s6-rc/
+    # remove all s6 executables from build directory
+    rm $(find -name "s6-rc-*" -type f -mindepth 1 -maxdepth 1 -executable)
+    rm s6-rc libs6rc.*
+
     mv doc $doc/share/doc/s6-rc/html
     mv examples $doc/share/doc/s6-rc/examples
   '';
-
-  meta = {
-    homepage = http://skarnet.org/software/s6-rc/;
-    description = "A service manager for s6-based systems";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
-  };
 
 }

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -5,7 +5,7 @@ with skawarePackages;
 buildPackage {
   pname = "s6";
   version = "2.7.2.0";
-  sha256 = "07j4is7kxkynschwbf83q5rw1872kg3ij2vhxyfp3bg71k5pw1az";
+  sha256 = "02canrzmhr66gi16ldyylk378jlmyfl73vn72ayr12h2wyxgqm5g";
 
   description = "skarnet.org's small & secure supervision software suite";
 

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -2,7 +2,7 @@
 
 let
 
-  version = "2.7.1.1";
+  version = "2.7.2.0";
 
 in stdenv.mkDerivation rec {
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
   src = fetchgit {
     url = "git://git.skarnet.org/s6";
     rev = "refs/tags/v${version}";
-    sha256 = "0dncw3h9wc4cgc9q8zjwicgbcqcn6722yhk8g9bvrhs7h4fkfqav";
+    sha256 = "07j4is7kxkynschwbf83q5rw1872kg3ij2vhxyfp3bg71k5pw1az";
   };
 
   # NOTE lib: cannot split lib from bin at the moment,
@@ -24,6 +24,7 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # TODO: nsss support
   configureFlags = [
     "--enable-absolute-paths"
     "--libdir=\${out}/lib"

--- a/pkgs/tools/system/s6/default.nix
+++ b/pkgs/tools/system/s6/default.nix
@@ -1,32 +1,21 @@
-{ stdenv, execline, fetchgit, skalibs }:
+{ stdenv, skawarePackages }:
 
-let
+with skawarePackages;
 
+buildPackage {
+  pname = "s6";
   version = "2.7.2.0";
+  sha256 = "07j4is7kxkynschwbf83q5rw1872kg3ij2vhxyfp3bg71k5pw1az";
 
-in stdenv.mkDerivation rec {
-
-  name = "s6-${version}";
-
-  src = fetchgit {
-    url = "git://git.skarnet.org/s6";
-    rev = "refs/tags/v${version}";
-    sha256 = "07j4is7kxkynschwbf83q5rw1872kg3ij2vhxyfp3bg71k5pw1az";
-  };
+  description = "skarnet.org's small & secure supervision software suite";
 
   # NOTE lib: cannot split lib from bin at the moment,
   # since some parts of lib depend on executables in bin.
   # (the `*_startf` functions in `libs6`)
-
   outputs = [ /*"bin" "lib"*/ "out" "dev" "doc" ];
-
-  dontDisableStatic = true;
-
-  enableParallelBuilding = true;
 
   # TODO: nsss support
   configureFlags = [
-    "--enable-absolute-paths"
     "--libdir=\${out}/lib"
     "--libexecdir=\${out}/libexec"
     "--dynlibdir=\${out}/lib"
@@ -39,22 +28,15 @@ in stdenv.mkDerivation rec {
     "--with-lib=${execline.lib}/lib"
     "--with-dynlib=${skalibs.lib}/lib"
     "--with-dynlib=${execline.lib}/lib"
-  ]
-  ++ (if stdenv.isDarwin then [ "--disable-shared" ] else [ "--enable-shared" ])
-  ++ (stdenv.lib.optional stdenv.isDarwin "--build=${stdenv.hostPlatform.system}");
+  ];
 
   postInstall = ''
-    mkdir -p $doc/share/doc/s6/
+    # remove all s6 executables from build directory
+    rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libs6.*
+
     mv doc $doc/share/doc/s6/html
     mv examples $doc/share/doc/s6/examples
   '';
-
-  meta = {
-    homepage = http://www.skarnet.org/software/s6/;
-    description = "skarnet.org's small & secure supervision software suite";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ pmahoney Profpatsch ];
-  };
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12000,6 +12000,8 @@ with pkgs;
   skalibs = skawarePackages.skalibs;
 
   skawarePackages = recurseIntoAttrs {
+    buildPackage = callPackage ../build-support/skaware/build-skaware-package.nix { };
+
     skalibs = callPackage ../development/libraries/skalibs { };
     execline = callPackage ../tools/misc/execline { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2385,7 +2385,7 @@ with pkgs;
 
   exempi = callPackage ../development/libraries/exempi { };
 
-  execline = callPackage ../tools/misc/execline { };
+  execline = skawarePackages.execline;
 
   exif = callPackage ../tools/graphics/exif { };
 
@@ -5061,13 +5061,13 @@ with pkgs;
 
   s3gof3r = callPackage ../tools/networking/s3gof3r { };
 
-  s6-dns = callPackage ../tools/networking/s6-dns { };
+  s6-dns = skawarePackages.s6-dns;
 
-  s6-linux-utils = callPackage ../os-specific/linux/s6-linux-utils { };
+  s6-linux-utils = skawarePackages.s6-linux-utils;
 
-  s6-networking = callPackage ../tools/networking/s6-networking { };
+  s6-networking = skawarePackages.s6-networking;
 
-  s6-portable-utils = callPackage ../tools/misc/s6-portable-utils { };
+  s6-portable-utils = skawarePackages.s6-portable-utils;
 
   sablotron = callPackage ../tools/text/xml/sablotron { };
 
@@ -11997,7 +11997,19 @@ with pkgs;
 
   shibboleth-sp = callPackage ../development/libraries/shibboleth-sp { };
 
-  skalibs = callPackage ../development/libraries/skalibs { };
+  skalibs = skawarePackages.skalibs;
+
+  skawarePackages = recurseIntoAttrs {
+    skalibs = callPackage ../development/libraries/skalibs { };
+    execline = callPackage ../tools/misc/execline { };
+
+    s6 = callPackage ../tools/system/s6 { };
+    s6-dns = callPackage ../tools/networking/s6-dns { };
+    s6-linux-utils = callPackage ../os-specific/linux/s6-linux-utils { };
+    s6-networking = callPackage ../tools/networking/s6-networking { };
+    s6-portable-utils = callPackage ../tools/misc/s6-portable-utils { };
+    s6-rc = callPackage ../tools/system/s6-rc { };
+  };
 
   skydive = callPackage ../tools/networking/skydive { };
 
@@ -13407,9 +13419,9 @@ with pkgs;
     boost = boost159;
   };
 
-  s6 = callPackage ../tools/system/s6 { };
+  s6 = skawarePackages.s6;
 
-  s6-rc = callPackage ../tools/system/s6-rc { };
+  s6-rc = skawarePackages.s6-rc;
 
   supervise = callPackage ../tools/system/supervise { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11305,6 +11305,8 @@ with pkgs;
 
   nss_wrapper = callPackage ../development/libraries/nss_wrapper { };
 
+  nsss = skawarePackages.nsss;
+
   ntbtls = callPackage ../development/libraries/ntbtls { };
 
   ntk = callPackage ../development/libraries/audio/ntk { };
@@ -12011,6 +12013,9 @@ with pkgs;
     s6-networking = callPackage ../tools/networking/s6-networking { };
     s6-portable-utils = callPackage ../tools/misc/s6-portable-utils { };
     s6-rc = callPackage ../tools/system/s6-rc { };
+
+    nsss = callPackage ../development/libraries/nsss { };
+
   };
 
   skydive = callPackage ../tools/networking/skydive { };


### PR DESCRIPTION
###### Motivation for this change

https://www.mail-archive.com/skaware@list.skarnet.org/msg01217.html

Each package in the skaware stack is structured pretty much exactly the same way, so there was tremendous duplication in the way those packages were defined. This removes most of that duplication.

The commits are incremental and are best reviewed one-by-one.

The nsss package is added, most of the stack supports optionally using this library, this is not yet added (if we want to run the tests for nsss there is a circular dependency on `s6` to make things harder).

cc other maintainer @pmahoney 

Closes #45066.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all new binary files (usually in `./result/bin/`)

