### PR TITLE
appimage-run: Support type-1 Appimages

### DIFF
--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeScript, buildFHSUserEnv, coreutils
+{ stdenv, writeScript, buildFHSUserEnv, coreutils, file, libarchive
 , extraPkgs ? pkgs: [] }:
 
 buildFHSUserEnv {
@@ -131,7 +131,14 @@ buildFHSUserEnv {
     export APPDIR="$SQUASHFS_ROOT/squashfs-root"
     if [ ! -x "$APPDIR" ]; then
       cd "$SQUASHFS_ROOT"
-      "$APPIMAGE" --appimage-extract 2>/dev/null
+
+      if ${file}/bin/file --mime-type --brief --keep-going "$APPIMAGE" | grep -q iso; then
+        # is type-1 appimage
+        ${libarchive}/bin/bsdtar -x -C "$SQUASHFS_ROOT" -f "$APPIMAGE"
+      else
+        # is type-2 appimage
+        "$APPIMAGE" --appimage-extract 2>/dev/null
+      fi
     fi
 
     cd "$APPDIR"


### PR DESCRIPTION
###### Motivation for this change

This attempts to detect older appimages and extract them
in the same manner as new ones, without changing filesystem paths

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

