### PR TITLE
pirate-get: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/tools/networking/pirate-get/default.nix
+++ b/pkgs/tools/networking/pirate-get/default.nix
@@ -4,13 +4,13 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "pirate-get";
-  version = "0.3.1";
+  version = "0.3.2";
 
   doCheck = false;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9d7cc4b15dd8c6a82f9e03a666372e38613ccafdc846ad4c1226ba936beea68d";
+    sha256 = "1iirip12zrxm2nqsib5wfqqnlfmhh432y3kkyih9crk4q2p914df";
   };
 
   propagatedBuildInputs = [ colorama veryprettytable beautifulsoup4 pyperclip ];


### PR DESCRIPTION
###### Motivation for this change
Version bump

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s)
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [x] Determined the impact on package closure size (1.05x increase)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

