### PR TITLE
hdaps-gl: init at 0.0.5

### DIFF
--- a/pkgs/tools/misc/hdaps-gl/default.nix
+++ b/pkgs/tools/misc/hdaps-gl/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip, freeglut, libGL, libGLU }:
+
+let version = "0.0.5"; in
+stdenv.mkDerivation {
+      name = "hdaps-gl-${version}";
+      src = fetchzip {
+            url = "mirror://sourceforge/project/hdaps/hdaps-gl/hdaps-gl-${version}/hdaps-gl-${version}.tar.gz";
+            sha256 = "16fk4k0lvr4c95vd6c7qdylcqa1h5yjp3xm4xwipdjbp0bvsgxq4";
+      };
+
+      buildInputs = [ freeglut libGL libGLU ];
+
+      # the Makefile has no install target
+      installPhase = ''
+            install -Dt $out/bin ./hdaps-gl
+      '';
+
+      meta = with stdenv.lib; {
+            description = "GL-based laptop model that rotates in real-time via hdaps";
+            homepage = https://sourceforge.net/projects/hdaps/;
+            license = licenses.gpl2;
+            platforms = platforms.linux;
+            maintainers = [ maintainers.symphorien ];
+      };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3072,6 +3072,8 @@ with pkgs;
 
   hdapsd = callPackage ../os-specific/linux/hdapsd { };
 
+  hdaps-gl = callPackage ../tools/misc/hdaps-gl { };
+
   hddtemp = callPackage ../tools/misc/hddtemp { };
 
   hdf4 = callPackage ../tools/misc/hdf4 {


### PR DESCRIPTION
###### Motivation for this change
use hdaps-gl

Note to testers: this will segfault if used on a glibc < 2.26 system because of a mismatch between opengl drivers requiring an old glibc and hdaps-gl's glibc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

