### PR TITLE
vowpalwabbit: fix build against boost-python.

### DIFF
--- a/pkgs/development/python-modules/vowpalwabbit/default.nix
+++ b/pkgs/development/python-modules/vowpalwabbit/default.nix
@@ -9,13 +9,20 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "0b517371fc64f1c728a0af42a31fa93def27306e9b4d25d6e5fd01bcff1b7304";
   };
+
+  # Should be fixed in next Python release after 8.5.0:
+  # https://github.com/JohnLangford/vowpal_wabbit/pull/1533
+  patches = [
+    ./vowpal-wabbit-find-boost.diff
+  ];
+
   # vw tries to write some explicit things to home
   # python installed: The directory '/homeless-shelter/.cache/pip/http'
   preInstall = ''
     export HOME=$PWD
   '';
 
-  buildInputs = [ boost.dev zlib.dev clang ncurses pytest docutils pygments ];
+  buildInputs = [ python.pkgs.boost zlib.dev clang ncurses pytest docutils pygments ];
   propagatedBuildInputs = [ numpy scipy scikitlearn ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/vowpalwabbit/default.nix
+++ b/pkgs/development/python-modules/vowpalwabbit/default.nix
@@ -1,5 +1,5 @@
-{ lib, buildPythonPackage, fetchPypi, python, boost, zlib, clang, ncurses
-, pytest, docutils, pygments, numpy, scipy, scikitlearn }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, python, boost, zlib, clang
+, ncurses, pytest, docutils, pygments, numpy, scipy, scikitlearn }:
 
 buildPythonPackage rec {
   pname = "vowpalwabbit";
@@ -24,6 +24,11 @@ buildPythonPackage rec {
 
   buildInputs = [ python.pkgs.boost zlib.dev clang ncurses pytest docutils pygments ];
   propagatedBuildInputs = [ numpy scipy scikitlearn ];
+
+  # Python ctypes.find_library uses DYLD_LIBRARY_PATH.
+  preConfigure = lib.optionalString stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH="${python.pkgs.boost}/lib"
+  '';
 
   checkPhase = ''
     # check-manifest requires a git clone, not a tarball

--- a/pkgs/development/python-modules/vowpalwabbit/default.nix
+++ b/pkgs/development/python-modules/vowpalwabbit/default.nix
@@ -40,6 +40,7 @@ buildPythonPackage rec {
     description = "Vowpal Wabbit is a fast machine learning library for online learning, and this is the python wrapper for the project.";
     homepage    = https://github.com/JohnLangford/vowpal_wabbit;
     license     = licenses.bsd3;
+    broken      = stdenv.isAarch64;
     maintainers = with maintainers; [ teh ];
   };
 }

--- a/pkgs/development/python-modules/vowpalwabbit/vowpal-wabbit-find-boost.diff
+++ b/pkgs/development/python-modules/vowpalwabbit/vowpal-wabbit-find-boost.diff
@@ -1,0 +1,16 @@
+--- vowpalwabbit-8.5.0.orig/setup.py	2018-09-03 14:27:22.833621339 +0200
++++ vowpalwabbit-8.5.0/setup.py	2018-09-03 14:37:18.076127914 +0200
+@@ -25,12 +25,7 @@
+     """Find correct boost-python library information """
+     if system == 'Linux':
+         # use version suffix if present
+-        boost_lib = 'boost_python-py{v[0]}{v[1]}'.format(v=sys.version_info)
+-        if sys.version_info.major == 3:
+-            for candidate in ['-py36', '-py35', '-py34', '3']:
+-                boost_lib = 'boost_python{}'.format(candidate)
+-                if find_library(boost_lib):
+-                    exit
++        boost_lib = 'boost_python{v[0]}{v[1]}'.format(v=sys.version_info)
+         if not find_library(boost_lib):
+             boost_lib = "boost_python"
+     elif system == 'Darwin':

--- a/pkgs/development/python-modules/vowpalwabbit/vowpal-wabbit-find-boost.diff
+++ b/pkgs/development/python-modules/vowpalwabbit/vowpal-wabbit-find-boost.diff
@@ -1,8 +1,11 @@
---- vowpalwabbit-8.5.0.orig/setup.py	2018-09-03 14:27:22.833621339 +0200
-+++ vowpalwabbit-8.5.0/setup.py	2018-09-03 14:37:18.076127914 +0200
-@@ -25,12 +25,7 @@
+--- vowpalwabbit-8.5.0.orig/setup.py	2018-09-03 20:32:39.000000000 +0200
++++ vowpalwabbit-8.5.0/setup.py	2018-09-03 20:34:09.000000000 +0200
+@@ -23,18 +23,11 @@
+ 
+ def find_boost():
      """Find correct boost-python library information """
-     if system == 'Linux':
+-    if system == 'Linux':
++    if system == 'Linux' or system == 'Darwin':
          # use version suffix if present
 -        boost_lib = 'boost_python-py{v[0]}{v[1]}'.format(v=sys.version_info)
 -        if sys.version_info.major == 3:
@@ -13,4 +16,19 @@
 +        boost_lib = 'boost_python{v[0]}{v[1]}'.format(v=sys.version_info)
          if not find_library(boost_lib):
              boost_lib = "boost_python"
-     elif system == 'Darwin':
+-    elif system == 'Darwin':
+-        boost_lib = 'boost_python-mt' if sys.version_info[0] == 2 else 'boost_python3-mt'
+     elif system == 'Cygwin':
+         boost_lib = 'boost_python-mt' if sys.version_info[0] == 2 else 'boost_python3-mt'
+     else:
+--- vowpalwabbit-8.5.0.orig/src/Makefile	2018-09-03 20:32:40.000000000 +0200
++++ vowpalwabbit-8.5.0/src/Makefile	2018-09-03 21:42:30.000000000 +0200
+@@ -37,7 +37,7 @@
+   NPROCS:=$(shell grep -c ^processor /proc/cpuinfo)
+ endif
+ ifeq ($(UNAME), Darwin)
+-  LIBS = -lboost_program_options-mt -lboost_serialization-mt -l pthread -l z
++  LIBS = -lboost_program_options -lboost_serialization -l pthread -l z
+   # On Macs, the location isn't always clear
+   #	brew uses /usr/local
+   #	but /opt/local seems to be preferred by some users


### PR DESCRIPTION
Patch setup.py to look for libboost_python{Major}{Minor}. This fixes the build in unstable and 18.09.

###### Motivation for this change

Going through the list of #45960 I found that the Vowpal Wabbit Python module does not compile. This fixes compilation with Python 2.7 and 3.6.

Note: for some reason, boost is added to the build environment without boost-python, unless I explicitly add `python.pkgs.boost` as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

