### PR TITLE
Keras: fix build by updating expected dependencies.

### DIFF
--- a/pkgs/development/python-modules/keras/default.nix
+++ b/pkgs/development/python-modules/keras/default.nix
@@ -25,6 +25,14 @@ buildPythonPackage rec {
     keras-applications keras-preprocessing
   ];
 
+  # Keras 2.2.2 expects older versions of keras_applications
+  # and keras_preprocessing. These substitutions can be removed
+  # for for the next Keras release.
+  postPatch = ''
+    substituteInPlace setup.py --replace "keras_applications==1.0.4" "keras_applications==1.0.5"
+    substituteInPlace setup.py --replace "keras_preprocessing==1.0.2" "keras_preprocessing==1.0.3"
+  '';
+
   # Couldn't get tests working
   doCheck = false;
 


### PR DESCRIPTION
Keras: fix build by updating expected dependencies.

###### Motivation for this change    
Keras expects keras_preprocessing 1.0.2 and 1.0.4. 1.0.3 and 1.0.5
are respectively in nixpkgs.
    
ZHF #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

