### PR TITLE
systrayhelper: init at 0.0.3

### DIFF
--- a/pkgs/tools/misc/systrayhelper/default.nix
+++ b/pkgs/tools/misc/systrayhelper/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, pkgconfig, libappindicator-gtk3, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "systrayhelper-${version}";
+  version = "0.0.3";
+  rev = "0953942245566bf358ba937af840947100380e15";
+
+  goPackagePath = "github.com/ssbc/systrayhelper";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "ssbc";
+    repo = "systrayhelper";
+    sha256 = "12xmzcw94in4m1hl4hbfdsbvkkaqrljgb67b95m1qwkkjak3q9g6";
+  };
+
+  goDeps = ./deps.nix;
+
+  # re date: https://github.com/NixOS/nixpkgs/pull/45997#issuecomment-418186178
+  # > .. keep the derivation deterministic. Otherwise, we would have to rebuild it every time.
+  buildFlagsArray = [ ''-ldflags=
+    -X main.version=v${version}
+    -X main.commit=${rev}
+    -X main.date="nix-byrev"
+    -s
+    -w
+  '' ];
+
+  nativeBuildInputs = [ pkgconfig libappindicator-gtk3 ];
+  buildInputs = [ libappindicator-gtk3 ];
+
+  meta = with stdenv.lib; {
+    description = "A systray utility written in go, using json over stdio for control and events";
+    homepage    = "https://github.com/ssbc/systrayhelper";
+    maintainers = with maintainers; [ cryptix ];
+    license     = licenses.mit;
+    # It depends on the inputs, i guess? not sure about solaris, for instance. go supports it though
+    # I hope nix can figure this out?! ¯\\_(ツ)_/¯
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/systrayhelper/deps.nix
+++ b/pkgs/tools/misc/systrayhelper/deps.nix
@@ -1,0 +1,102 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/getlantern/context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/context";
+      rev =  "624d99b1798d7c5375ea1d3ca4c5b04d58f7c775";
+      sha256 = "09yf9x6478a5z01hybr98zwa8ax3fx7l6wwsvdkxp3fdg9dqm13b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/getlantern/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/errors";
+      rev =  "e24b7f4ff7c70be59bbefca6b7695d68cda8b399";
+      sha256 = "1wshagslgl3r07gniq0g55cqgi1j1gk0yrri5ywjz7wm8da42qcr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/getlantern/golog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/golog";
+      rev =  "cca714f7feb5df8e455f409b549d384441ac4578";
+      sha256 = "0gnf30n38zkx356cqc6jdv1kbzy59ddqhqndwrxsm2n2zc3b5p7q";
+    };
+  }
+  {
+    goPackagePath  = "github.com/getlantern/hex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/hex";
+      rev =  "083fba3033ad473db3dd31c9bb368473d37581a7";
+      sha256 = "18q6rypmcqmcwlfzrrdcz08nff0a289saplvd9y3ifnfcqdw3j77";
+    };
+  }
+  {
+    goPackagePath  = "github.com/getlantern/hidden";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/hidden";
+      rev =  "d52a649ab33af200943bb599898dbdcfdbc94cb7";
+      sha256 = "0133qmp4sjq8da5di3459vc5g5nqbpqra0f558zd95js3fdmkmsi";
+    };
+  }
+  {
+    goPackagePath  = "github.com/getlantern/ops";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/ops";
+      rev =  "37353306c90844c8e0591956f56611f46299d202";
+      sha256 = "0q8j2963jqf3p7fcnsfinkvz71mfylrkk2xjar775zjx5a23sa5i";
+    };
+  }
+  {
+    goPackagePath  = "github.com/getlantern/systray";
+    fetch = {
+      type = "git";
+      url = "https://github.com/getlantern/systray";
+      rev =  "3fd1443dac5c8297999189fe28d5836b2b075b66";
+      sha256 = "1sb11n27zy8xmq0lvrpqikb53425jvwl5617cp201va6iwk1hgnh";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-stack/stack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-stack/stack";
+      rev =  "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a";
+      sha256 = "0wk25751ryyvxclyp8jdk5c3ar0cmfr8lrjb66qbg4808x66b96v";
+    };
+  }
+  {
+    goPackagePath  = "github.com/oxtoacart/bpool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/oxtoacart/bpool";
+      rev =  "4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6";
+      sha256 = "01kk6dhkz96yhp3p5v2rjwq8mbrwrdsn6glqw7jp4h7g5za7yi95";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "c059e472caf75dbe73903f6521a20abac245b17f";
+      sha256 = "07xg8ym776j2w0k8445ii82lx8yz358cp1z96r739y13i1anqdzi";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "d0be0721c37eeb5299f245a996a483160fc36940";
+      sha256 = "081wyvfnlf842dqg03raxfz6lldlxpmyh1prix9lmrrm65arxb12";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5462,6 +5462,8 @@ with pkgs;
 
   staruml = callPackage ../tools/misc/staruml { inherit (gnome2) GConf; libgcrypt = libgcrypt_1_5; };
 
+  systrayhelper = callPackage ../tools/misc/systrayhelper {};
+
   otter-browser = qt5.callPackage ../applications/networking/browsers/otter {};
 
   privoxy = callPackage ../tools/networking/privoxy {


### PR DESCRIPTION
###### Motivation for this change

systrayhelper offers a stdio json interface to create menu-items and send click events back over stdout.
It is used by some other applications I'd like to introduce to nixpkgs.

###### Things done

- [x] Tested using `nix.useSandbox` on my two nixos machines
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Questions:
* Is there a way to get the current date/time as a string? 

See `default.nix:19`, I'd like to do something like `-X main.date=$(date +%F)`

* Is meta.platform just informational?

I wasn't sure about restricting it. This should built on linux, darwin and possibly others where the libraries are available.
