### PR TITLE
nixos: initrd/luks: make uuid specified devices discoverable

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -11,19 +11,30 @@ let
       exit 1
     }
 
+    dev_exist() {
+      local target="$1"
+      if [ -e $target ]; then
+        return 0
+      else
+        local uuid=$(echo -n $target | sed -e 's,UUID=\(.*\),\1,g')
+        local dev=$(blkid --uuid $uuid)
+        return $?
+      fi
+    }
+
     wait_target() {
         local name="$1"
         local target="$2"
         local secs="''${3:-10}"
         local desc="''${4:-$name $target to appear}"
 
-        if [ ! -e $target ]; then
+        if ! dev_exist $target; then
             echo -n "Waiting $secs seconds for $desc..."
             local success=false;
             for try in $(seq $secs); do
                 echo -n "."
                 sleep 1
-                if [ -e $target ]; then
+                if dev_exist $target; then
                     success=true
                     break
                 fi


### PR DESCRIPTION
###### Motivation for this change

Previously it was possible to use uuid specifiers in ```encrypted.blkDev="UUID=XXXXXXXX-YYY-..."```. Perhaps it was by accident and not design but this ability was recently lost. This PR makes the system initrd accept resolvable UUIDs for encrypted block devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

