### PR TITLE
hcloud: Add autocomplete support for bash and zsh

### DIFF
--- a/pkgs/development/tools/hcloud/default.nix
+++ b/pkgs/development/tools/hcloud/default.nix
@@ -14,6 +14,19 @@ buildGoPackage rec {
 
   buildFlagsArray = [ "-ldflags=" "-w -X github.com/hetznercloud/cli/cli.Version=${version}" ];
 
+  postInstall = ''
+    mkdir -p \
+      $bin/etc/bash_completion.d \
+      $bin/share/zsh/vendor-completions
+
+    # Add bash completions
+    $bin/bin/hcloud completion bash > "$bin/etc/bash_completion.d/hcloud"
+
+    # Add zsh completions
+    echo "#compdef hcloud" > "$bin/share/zsh/vendor-completions/_hcloud"
+    $bin/bin/hcloud completion zsh >> "$bin/share/zsh/vendor-completions/_hcloud"
+  '';
+
   meta = {
     description = "A command-line interface for Hetzner Cloud, a provider for cloud virtual private servers";
     homepage = https://github.com/hetznercloud/cli;


### PR DESCRIPTION
###### Motivation for this change

Currently one would need to manually run the command to generate
completion and insert it into `.bashrc`/`.zshrc` to get the
autocompletion to work. This patch will automatically generate
both docs and save them to correct position so it should continue
to work even if user changes the shell at a later stage.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't personally use zsh so I didn't test that but I found the correct path in [`restic/default.nix`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/backup/restic/default.nix#L30) so I think we should be fine. If anyone has any issues please let me know and I'll remove zsh support (better yet, much obliged if you do use zsh and can verify it works as expected :blush: ).