### PR TITLE
backblaze-b2: Fix autocompletion support

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -33,7 +33,7 @@ buildPythonApplication rec {
   postInstall = ''
     mv "$out/bin/b2" "$out/bin/backblaze-b2"
 
-    sed 's/^have b2 \&\&$/_have backblaze-b2 \&\&/'  -i contrib/bash_completion/b2
+    sed 's/^_have b2 \&\&$/_have backblaze-b2 \&\&/'  -i contrib/bash_completion/b2
     sed 's/^\(complete -F _b2\) b2/\1 backblaze-b2/' -i contrib/bash_completion/b2
 
     mkdir -p "$out/etc/bash_completion.d"


### PR DESCRIPTION
###### Motivation for this change
backblaze v1.3.6 [incorporates](https://github.com/Backblaze/B2_Command_Line_Tool#136-august-21-2018) a [fix](https://github.com/Backblaze/B2_Command_Line_Tool/pull/497) for autocompletion that replaced `have` function with `_have`. The postInstall hook therefore needs to be updated to replace `_have`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

