### PR TITLE
libguestfs-appliance: do not build on Hydra

### DIFF
--- a/pkgs/development/libraries/libguestfs/appliance.nix
+++ b/pkgs/development/libraries/libguestfs/appliance.nix
@@ -4,4 +4,8 @@ fetchzip {
   name = "libguestfs-appliance-1.38.0";
   url = "http://libguestfs.org/download/binaries/appliance/appliance-1.38.0.tar.xz";
   sha256 = "15rxwj5qjflizxk7slpbrj9lcwkd2lgm52f5yv101qba4yyn3g76";
+
+  meta = {
+    hydraPlatforms = []; # Hydra fails with "Output limit exceeded"
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

Hydra fails with "Output limit exceeded"
https://hydra.nixos.org/build/80720522

ZHF #45960