### PR TITLE
kodi: fix nfs support

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -189,7 +189,7 @@ in stdenv.mkDerivation rec {
         wrapProgram $out/bin/$p \
           --prefix PATH            ":" "${lib.makeBinPath [ python2 glxinfo xdpyinfo ]}" \
           --prefix LD_LIBRARY_PATH ":" "${lib.makeLibraryPath
-              [ curl systemd libmad libvdpau libcec libcec_platform rtmpdump libass ]}"
+              ([ curl systemd libmad libvdpau libcec libcec_platform rtmpdump libass ] ++ lib.optional nfsSupport libnfs)}"
       done
 
       substituteInPlace $out/share/xsessions/kodi.desktop \


### PR DESCRIPTION
Currently nfs support is broken in kodi on NixOS because libnfs is required to be in the LD_LIBRARY_PATH.

see: https://www.reddit.com/r/NixOS/comments/9aiquo/how_to_enable_nfs_support_in_kodi/

###### Motivation for this change
Fix nfs support in kodi. I would suggest this is change is minor enough it could be backported to 18.09 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

