### PR TITLE
openmpi: 3.1.0->3.1.2

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -10,14 +10,14 @@
 
 let
   majorVersion = "3.1";
-  minorVersion = "0";
+  minorVersion = "2";
 
 in stdenv.mkDerivation rec {
   name = "openmpi-${majorVersion}.${minorVersion}";
 
   src = fetchurl {
     url = "http://www.open-mpi.org/software/ompi/v${majorVersion}/downloads/${name}.tar.bz2";
-    sha256 = "0v7hrmf1z5d1rmm0z5gi79l536j3z5s5b0kf9q5rr1fc4i0h8p5j";
+    sha256 = "1ibniapqki763agpfh65y284las083fqmj8m5b2pi8ilgy2fsm66";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, python, buildPythonPackage, mpi, openssh }:
+{ stdenv, fetchPypi, fetchpatch, python, buildPythonPackage, mpi, openssh }:
 
 buildPythonPackage rec {
   pname = "mpi4py";
@@ -12,6 +12,13 @@ buildPythonPackage rec {
   passthru = {
     inherit mpi;
   };
+
+  patches = [ (fetchpatch {
+    # Disable tests failing with 3.1.x and MPI_THREAD_MULTIPLE
+    url = "https://bitbucket.org/mpi4py/mpi4py/commits/c2b6b7e642a182f9b00a2b8e9db363214470548a/raw";
+    sha256 = "0n6bz3kj4vcqb6q7d0mlj5vl6apn7i2bvfc9mpg59vh3wy47119q";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace test/test_spawn.py --replace \
@@ -37,8 +44,6 @@ buildPythonPackage rec {
     # Needed to run the tests reliably. See:
     # https://bitbucket.org/mpi4py/mpi4py/issues/87/multiple-test-errors-with-openmpi-30
     export OMPI_MCA_rmaps_base_oversubscribe=yes
-    export OMPI_MCA_osc=sm
-    export OMPI_MCA_btl=self,vader
   '';
 
   setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -37,6 +37,8 @@ buildPythonPackage rec {
     # Needed to run the tests reliably. See:
     # https://bitbucket.org/mpi4py/mpi4py/issues/87/multiple-test-errors-with-openmpi-30
     export OMPI_MCA_rmaps_base_oversubscribe=yes
+    export OMPI_MCA_osc=sm
+    export OMPI_MCA_btl=self,vader
   '';
 
   setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];


### PR DESCRIPTION
###### Motivation for this change
Update openmpi 

###### Things done
Added an upstream patch from `mpi4py` to skip broken tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

