### PR TITLE
prettyping: init 1.0.1

### DIFF
--- a/pkgs/tools/networking/prettyping/default.nix
+++ b/pkgs/tools/networking/prettyping/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "${program}-${version}";
+  program = "prettyping";
+  version = "1.0.1";
+  src = fetchFromGitHub {
+    owner = "denilsonsa";
+    repo = program;
+    rev = "v${version}";
+    sha256 = "05vfaq9y52z40245j47yjk1xaiwrazv15sgjq64w91dfyahjffxf";
+  };
+
+  installPhase = ''
+    install -Dt $out/bin prettyping
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/denilsonsa/prettyping;
+    description = "A wrapper around the standard ping tool with the objective of making the output prettier, more colorful, more compact, and easier to read";
+    license = with licenses; [ mit ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ qoelet ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4738,6 +4738,8 @@ with pkgs;
 
   pptpd = callPackage ../tools/networking/pptpd {};
 
+  prettyping = callPackage ../tools/networking/prettyping { };
+
   prey-bash-client = callPackage ../tools/security/prey { };
 
   profile-cleaner = callPackage ../tools/misc/profile-cleaner { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

