### PR TITLE
Cleanup homepage links

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -546,6 +546,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Public Domain";
   };
 
+  purdueBsd = {
+    fullName = " Purdue BSD-Style License"; # also know as lsof license
+    url = https://enterprise.dejacode.com/licenses/public/purdue-bsd;
+  };
+
   qpl = spdx {
     spdxId = "QPL-1.0";
     fullName = "Q Public License 1.0";

--- a/pkgs/development/libraries/ilixi/default.nix
+++ b/pkgs/development/libraries/ilixi/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Lightweight C++ GUI toolkit for embedded Linux systems";
-    homepage = http://ilixi.org/;
+    homepage = https://github.com/ilixi/ilixi;
     license = licenses.lgpl3;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/iso-codes/default.nix
+++ b/pkgs/development/libraries/iso-codes/default.nix
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ gettext python3 ];
 
   meta = with stdenv.lib; {
-    homepage = http://pkg-isocodes.alioth.debian.org/;
+    homepage = https://salsa.debian.org/iso-codes-team/iso-codes;
     description = "Various ISO codes packaged as XML files";
-    maintainers = [ ];
+    license = licenses.lgpl21;
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/libLAS/default.nix
+++ b/pkgs/development/libraries/libLAS/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "LAS 1.0/1.1/1.2 ASPRS LiDAR data translation toolset";
-    homepage = https://www.liblas.org;
+    homepage = https://liblas.org;
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.michelk ];

--- a/pkgs/development/libraries/libmowgli/default.nix
+++ b/pkgs/development/libraries/libmowgli/default.nix
@@ -3,15 +3,16 @@
 stdenv.mkDerivation rec {
   name = "libmowgli-${version}";
   version = "2.1.3";
-  
+
   src = fetchurl {
     url = "https://github.com/atheme/libmowgli-2/archive/v${version}.tar.gz";
     sha256 = "0xx4vndmwz40pxa5gikl8z8cskpdl9a30i2i5fjncqzlp4pspymp";
   };
-  
-  meta = {
+
+  meta = with stdenv.lib; {
     description = "A development framework for C providing high performance and highly flexible algorithms";
-    homepage = http://www.atheme.org/projects/mowgli.shtml;
-    platforms = stdenv.lib.platforms.unix;
+    homepage = https://github.com/atheme/libmowgli-2;
+    license = licenses.isc;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libtar/default.nix
+++ b/pkgs/development/libraries/libtar/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C library for manipulating POSIX tar files";
-    homepage = http://www.feep.net/libtar/;
+    homepage = http://repo.or.cz/libtar;
     license = licenses.bsd3;
     platforms = with platforms; linux ++ darwin;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -21,9 +21,8 @@ stdenv.mkDerivation rec {
       use minimal CPU and memory resources, and provide fast
       throughput in both directions.
     '';
-    homepage = https://libwebsockets.org/trac/libwebsockets;
+    homepage = https://libwebsockets.org;
     license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/openslp/default.nix
+++ b/pkgs/development/libraries/openslp/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   ];
 
   meta = with stdenv.lib; {
-    homepage = http://openslp.org/;
+    homepage = http://www.openslp.org/;
     description = "An open-source implementation of the IETF Service Location Protocol";
     maintainers = with maintainers; [ ttuegel ];
     license = licenses.bsd3;

--- a/pkgs/development/libraries/poker-eval/default.nix
+++ b/pkgs/development/libraries/poker-eval/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://pokersource.org/poker-eval/;
+    homepage = http://pokersource.sourceforge.net;
     description = "Poker hand evaluator";
     license = stdenv.lib.licenses.gpl3;
     maintainers = [stdenv.lib.maintainers.mtreskin];

--- a/pkgs/development/libraries/soqt/default.nix
+++ b/pkgs/development/libraries/soqt/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
 
   meta = {
-    homepage = http://www.coin3d.org/;
+    homepage = https://bitbucket.org/Coin3D/coin/wiki/Home;
     license = stdenv.lib.licenses.gpl2Plus;
     description = "Glue between Coin high-level 3D visualization library and Qt";
 

--- a/pkgs/development/libraries/soxt/default.nix
+++ b/pkgs/development/libraries/soxt/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ coin3d motif xlibsWrapper libGLU_combined ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.coin3d.org/;
+    homepage = https://bitbucket.org/Coin3D/coin/wiki/Home;
     license = licenses.bsd3;
     description = "A GUI binding for using Open Inventor with Xt/Motif";
     maintainers = with maintainers; [ tmplt ];

--- a/pkgs/development/libraries/tcllib/default.nix
+++ b/pkgs/development/libraries/tcllib/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ tcl ];
 
   meta = {
-    homepage = http://tcl.activestate.com/software/tcllib/;
+    homepage = https://sourceforge.net/projects/tcllib/;
     description = "Tcl-only library of standard routines for Tcl";
     license = stdenv.lib.licenses.tcltk;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/vrpn/default.nix
+++ b/pkgs/development/libraries/vrpn/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       set of physical devices (tracker, etc.) used in a virtual-reality
       (VR) system.
     '';
-    homepage    = http://www.vrpn.org/;
+    homepage    = https://github.com/vrpn/vrpn;
     license     = licenses.boost; # see https://github.com/vrpn/vrpn/wiki/License
     platforms   = platforms.linux;
     maintainers = with maintainers; [ ludo ];

--- a/pkgs/development/tools/analysis/splint/default.nix
+++ b/pkgs/development/tools/analysis/splint/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://splint.org/;
+    homepage = http://www.splint.org/;
     description = "Annotation-assisted lightweight static analyzer for C";
 
     longDescription = ''

--- a/pkgs/development/tools/misc/dfu-util/default.nix
+++ b/pkgs/development/tools/misc/dfu-util/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       phones. With dfu-util you are able to download firmware to your device or
       upload firmware from it.
     '';
-    homepage = http://dfu-util.gnumonks.org/;
+    homepage = http://dfu-util.sourceforge.net;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = [ maintainers.fpletz ];

--- a/pkgs/development/tools/misc/lsof/default.nix
+++ b/pkgs/development/tools/misc/lsof/default.nix
@@ -51,15 +51,16 @@ stdenv.mkDerivation rec {
     cp lsof $out/bin
   '';
 
-  meta = {
-    homepage = ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/;
+  meta = with stdenv.lib; {
+    homepage = https://people.freebsd.org/~abe/;
     description = "A tool to list open files";
     longDescription = ''
       List open files. Can show what process has opened some file,
       socket (IPv6/IPv4/UNIX local), or partition (by opening a file
       from it).
     '';
-    maintainers = [ stdenv.lib.maintainers.dezgeg ];
-    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ maintainers.dezgeg ];
+    platforms = platforms.unix;
+    license = licenses.purdueBsd;
   };
 }

--- a/pkgs/games/gnugo/default.nix
+++ b/pkgs/games/gnugo/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "GNU Go - A computer go player";
-    homepage = http://http://www.gnu.org/software/gnugo/;
+    homepage = http://www.gnu.org/software/gnugo/;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/games/rogue/default.nix
+++ b/pkgs/games/rogue/default.nix
@@ -17,10 +17,11 @@ stdenv.mkDerivation {
   # Fix build for recent ncurses versions
   NIX_CFLAGS_COMPILE = [ "-DNCURSES_INTERNALS=1" ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://rogue.rogueforge.net/rogue-5-4/;
     description = "The final version of the original Rogue game developed for the UNIX operating system";
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.eelco ];
+    platforms = platforms.all;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/games/urbanterror/default.nix
+++ b/pkgs/games/urbanterror/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
       tactical shooter; somewhat realism based, but the motto is "fun over
       realism". This results in a very unique, enjoyable and addictive game.
     '';
-    homepage = http://www.urbanterror.net;
+    homepage = http://www.urbanterror.info;
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ astsmtl fpletz ];
     platforms = platforms.linux;

--- a/pkgs/misc/talkfilters/default.nix
+++ b/pkgs/misc/talkfilters/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Converts English text into text that mimics a stereotyped or humorous dialect";
-    homepage = "http://http://www.hyperrealm.com/${pname}";
+    homepage = http://www.hyperrealm.com/talkfilters/talkfilters.html;
     license = stdenv.lib.licenses.gpl2;
     maintainers = with stdenv.lib.maintainers; [ ikervagyok ];
     platforms = with stdenv.lib.platforms; unix;

--- a/pkgs/os-specific/linux/i2c-tools/default.nix
+++ b/pkgs/os-specific/linux/i2c-tools/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Set of I2C tools for Linux";
-    homepage = http://www.lm-sensors.org/wiki/I2CTools;
+    homepage = https://i2c.wiki.kernel.org/index.php/I2C_Tools;
     license = licenses.gpl2;
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;

--- a/pkgs/os-specific/linux/pmount/default.nix
+++ b/pkgs/os-specific/linux/pmount/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # fails 1 out of 1 tests with "Error: could not open fstab-type file: No such file or directory"
 
   meta = {
-    homepage = http://pmount.alioth.debian.org/;
+    homepage = https://bazaar.launchpad.net/~fourmond/pmount/main/files;
     description = "Mount removable devices as normal user";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Update dead homepage meta data with dead links. Added some license on the fly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

