### PR TITLE
qt5integration: init at 0.3.5

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -14,6 +14,7 @@ let
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
+    qt5integration = callPackage ./qt5integration { };
 
   };
 

--- a/pkgs/desktops/deepin/qt5integration/default.nix
+++ b/pkgs/desktops/deepin/qt5integration/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, mtdev, gsettings-qt
+, lxqt, qtx11extras, qtmultimedia, qtsvg, fontconfig, freetype
+, qt5dxcb-plugin, qtstyleplugins, dtkcore, dtkwidget
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "qt5integration";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0qf9ndsg8pz2n68y68a30d1hxr3ri8k4j00dxlbcf5cn5mbnny1b";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    dtkcore
+    dtkwidget
+    qt5dxcb-plugin
+    mtdev
+    lxqt.libqtxdg
+    qtstyleplugins
+    qtx11extras
+    qtmultimedia
+    qtsvg
+  ];
+
+  postPatch = ''
+    sed -i dstyleplugin/dstyleplugin.pro \
+           platformthemeplugin/qt5deepintheme-plugin.pro \
+           iconengineplugins/svgiconengine/svgiconengine.pro \
+           imageformatplugins/svg/svg.pro \
+      -e "s,\$\$\[QT_INSTALL_PLUGINS\],$out/$qtPluginPrefix,"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Qt platform theme integration plugins for DDE";
+    homepage = https://github.com/linuxdeepin/qt5integration;
+    license = with licenses; [ gpl3 lgpl2Plus bsd2 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [qt5integration](https://github.com/linuxdeepin/qt5integration) (Qt platform theme integration plugins for Deepin Desktop Environment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).