### PR TITLE
environment.noXlibs: change defaults

### DIFF
--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -22,7 +22,7 @@ with lib;
 
   config = mkIf config.environment.noXlibs {
     programs.ssh.setXAuthLocation = false;
-    security.pam.services.su.forwardXAuth = lib.mkForce false;
+    security.pam.services.su.forwardXAuth = lib.mkDefault false;
     services.openssh.forwardX11 = lib.mkDefault false;
     
     services.udisks2.enable = lib.mkDefault false;

--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -9,7 +9,7 @@ with lib;
   options = {
     environment.noXlibs = mkOption {
       type = types.bool;
-      default = false;
+      default = !config.services.xserver.enable && !config.services.xrdp.enable;
       description = ''
         Switch off the options in the default configuration that
         require X11 libraries. This includes client-side font
@@ -23,8 +23,10 @@ with lib;
   config = mkIf config.environment.noXlibs {
     programs.ssh.setXAuthLocation = false;
     security.pam.services.su.forwardXAuth = lib.mkForce false;
-
-    fonts.fontconfig.enable = false;
+    services.openssh.forwardX11 = lib.mkDefault false;
+    
+    services.udisks2.enable = lib.mkDefault false;
+    security.polkit.enable = lib.mkDefault false;
 
     nixpkgs.overlays = singleton (const (super: {
       dbus = super.dbus.override { x11Support = false; };

--- a/nixos/modules/config/no-x-libs.nix
+++ b/nixos/modules/config/no-x-libs.nix
@@ -27,6 +27,7 @@ with lib;
     
     services.udisks2.enable = lib.mkDefault false;
     security.polkit.enable = lib.mkDefault false;
+    nixpkgs.config.cairo.gl = lib.mkDefault false;
 
     nixpkgs.overlays = singleton (const (super: {
       dbus = super.dbus.override { x11Support = false; };


### PR DESCRIPTION
###### Motivation for this change

1. change default value from ```false``` to ```(!config.services.xserver.enable && !config.services.xrdp.enable)```
2. if ```noXLibs```, disable by default ```udisks2``` and ```polkit```, as they are huge closures (https://github.com/NixOS/nixpkgs/issues/45222#issuecomment-413931249) useful for desktop
3. remove ```fontconfig``` as irrelevant here, it is used by ```rrdtool``` (```collectd```'s graphs) and other imaging tools/libraries

---
```9.needs: community feedback```
Please, do not merge quickly, I'd like to collect user's practices around ```environment.noXlibs``` to make it better.
Here is just how I am using it