### PR TITLE
pythonPackages.authres: fix broken homepage

### DIFF
--- a/pkgs/development/python-modules/authres/default.nix
+++ b/pkgs/development/python-modules/authres/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
       Authentication-Results Headers generation and parsing for
       Python/Python3.
     '';
-    homepage = https://launchpad.net/authres;
+    homepage = https://launchpad.net/authentication-results-python;
     license = licenses.bsd3;
     maintainers = with maintainers; [ leenaars ];
   };


### PR DESCRIPTION
###### Motivation for this change

Homepage moved, thanks to repology for reporting. 

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

