### PR TITLE
openblas: fix pkg-config alias name

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -140,7 +140,7 @@ stdenv.mkDerivation rec {
     # Write pkgconfig aliases. Upstream report:
     # https://github.com/xianyi/OpenBLAS/issues/1740
     for alias in blas cblas lapack; do
-      cat <<EOF > $out/lib/pkgconfig/openblas-$alias.pc
+      cat <<EOF > $out/lib/pkgconfig/$alias.pc
 Name: $alias
 Version: ${version}
 Description: $alias provided by the OpenBLAS package.


### PR DESCRIPTION
###### Motivation for this change

Fixup for #45257 (which I already had locally but forgot to push to that PR before merging).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

