### PR TITLE
python.pkgs.pytest-fixture-config: disable tests

### DIFF
--- a/pkgs/development/python-modules/pytest-fixture-config/default.nix
+++ b/pkgs/development/python-modules/pytest-fixture-config/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, setuptools-git, pytest, six }:
+, setuptools-git, pytest }:
 
 buildPythonPackage rec {
   pname = "pytest-fixture-config";
@@ -14,11 +14,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pytest ];
 
-  checkInputs = [ six ];
-
-  checkPhase = ''
-    py.test
-  '';
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Simple configuration objects for Py.test fixtures. Allows you to skip tests when their required config variables aren’t set.";


### PR DESCRIPTION
###### Motivation for this change

Tests seem to fail on all recent versions even outside of our build
system. The upstream CI tests seem to somehow succeed but I wasn't able
to reproduce that locally. For not it is probably best to disable them.


/cc @dotlambda, @FRidh (re: https://github.com/NixOS/nixpkgs/pull/45792#issuecomment-417417604 ), ZHF #45960 (should be pickable as is)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

