### PR TITLE
deepin-menu: init at 3.3.10

### DIFF
--- a/pkgs/desktops/deepin/deepin-menu/default.nix
+++ b/pkgs/desktops/deepin/deepin-menu/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, dtkcore, dtkwidget,
+  qt5integration }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-menu";
+  version = "3.3.10";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1666821c2irs2hjgr3kvivij6c2fgjva8323kplrz75w2lz518xb";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    dtkcore
+    dtkwidget
+    qt5integration
+  ];
+
+  postPatch = ''
+    sed -i deepin-menu.pro -e "s,/usr,$out,"
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Deepin menu service";
+    homepage = https://github.com/linuxdeepin/deepin-menu;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, gtk3, vala, cmake, ninja, vte, libgee, wnck, zssh, gettext, librsvg, libsecret, json-glib, gobjectIntrospection }:
+{ stdenv, fetchurl, fetchFromGitHub, pkgconfig, gtk3, vala, cmake,
+  ninja, vte, libgee, wnck, zssh, gettext, librsvg, libsecret,
+  json-glib, gobjectIntrospection, deepin-menu }:
 
 stdenv.mkDerivation rec {
   name = "deepin-terminal-${version}";
@@ -30,7 +32,7 @@ stdenv.mkDerivation rec {
     gobjectIntrospection
   ];
 
-  buildInputs = [ gtk3 vte libgee wnck librsvg libsecret json-glib ];
+  buildInputs = [ gtk3 vte libgee wnck librsvg libsecret json-glib deepin-menu ];
 
   meta = with stdenv.lib; {
     description = "The default terminal emulation for Deepin";
@@ -41,7 +43,7 @@ stdenv.mkDerivation rec {
      '';
     homepage = https://github.com/linuxdeepin/deepin-terminal;
     license = licenses.gpl3;
-    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
   };
 }

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -7,6 +7,7 @@ let
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
+    deepin-menu = callPackage ./deepin-menu { };
     deepin-terminal = callPackage ./deepin-terminal {
       inherit (pkgs.gnome3) libgee vte;
       wnck = pkgs.libwnck3;


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-menu](https://github.com/linuxdeepin/deepin-menu) (unified menu service for Deepin Desktop Environment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

