### PR TITLE
mxnet: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchgit, cmake
-, opencv, gtest, openblas, liblapack
+{ stdenv, lib, fetchurl, bash, cmake
+, opencv, gtest, openblas, liblapack, perl
 , cudaSupport ? false, cudatoolkit, nvidia_x11
 , cudnnSupport ? false, cudnn
 }:
@@ -8,16 +8,17 @@ assert cudnnSupport -> cudaSupport;
 
 stdenv.mkDerivation rec {
   name = "mxnet-${version}";
-  version = "1.1.0";
+  version = "1.2.1";
 
-  # Submodules needed
-  src = fetchgit {
-    url = "https://github.com/apache/incubator-mxnet";
-    rev = "refs/tags/${version}";
-    sha256 = "1qgns0c70a1gfyil96h17ms736nwdkp9kv496gvs9pkzqzvr6cpz";
+  # Fetching from git does not work at the time (1.2.1) due to an
+  # incorrect hash in one of the submodules. The provided tarballs
+  # contain all necessary sources.
+  src = fetchurl {
+    url = "https://github.com/apache/incubator-mxnet/releases/download/${version}/apache-mxnet-src-${version}-incubating.tar.gz";
+    sha256 = "053zbdgs4j8l79ipdz461zc7wyfbfcflmi5bw7lj2q08zm1glnb2";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake perl ];
 
   buildInputs = [ opencv gtest openblas liblapack ]
               ++ lib.optionals cudaSupport [ cudatoolkit nvidia_x11 ]
@@ -29,6 +30,11 @@ stdenv.mkDerivation rec {
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
     ] else [ "-DUSE_CUDA=OFF" ])
     ++ lib.optional (!cudnnSupport) "-DUSE_CUDNN=OFF";
+
+  postPatch = ''
+    substituteInPlace 3rdparty/mkldnn/tests/CMakeLists.txt \
+      --replace "/bin/bash" "${bash}/bin/bash"
+  '';
 
   installPhase = ''
     install -Dm755 libmxnet.so $out/lib/libmxnet.so


### PR DESCRIPTION
Update and fix the build:

- Perl is a build-time requirement.
- Fix hardcoded /bin/bash invocation.

###### Motivation for this change

Build fails in 18.09, ZHF #45960.

(I plan to look at the Python mxnet module afterwards.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

