### PR TITLE
semodule-utils: init at 2.7

### DIFF
--- a/pkgs/os-specific/linux/semodule-utils/default.nix
+++ b/pkgs/os-specific/linux/semodule-utils/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, libsepol }:
+
+stdenv.mkDerivation rec {
+  name = "semodule-utils-${version}";
+  version = "2.7";
+
+  inherit (libsepol) se_release se_url;
+
+  src = fetchurl {
+    url = "${se_url}/${se_release}/${name}.tar.gz";
+    sha256 = "1fl60x4w8rn5bcwy68sy48aydwsn1a17d48slni4sfx4c8rqpjch";
+  };
+
+  buildInputs = [ libsepol ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "LIBSEPOLA=${stdenv.lib.getLib libsepol}/lib/libsepol.a"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "SELinux policy core utilities (packaging additions)";
+    license = licenses.gpl2;
+    inherit (libsepol.meta) homepage platforms;
+    maintainers = [ maintainers.e-user ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14510,6 +14510,8 @@ with pkgs;
 
   policycoreutils = callPackage ../os-specific/linux/policycoreutils { };
 
+  semodule-utils = callPackage ../os-specific/linux/semodule-utils { };
+
   powerdns = callPackage ../servers/dns/powerdns { };
 
   dnsdist = callPackage ../servers/dns/dnsdist { };


### PR DESCRIPTION
###### Motivation for this change

`semodule-utils` is distributed as part of SELinux upstream releases and its artifacts complement those of `policycoreutils`. The most important program provided is `semodule_package`, which is used to compile policy modules from intermediate files output by `checkmodule` from `policycoreutils`. 

This package is required to fix https://github.com/NixOS/nix/issues/2374.

I currently don't have a running installation of NixOS to run all the tests listed below.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

