### PR TITLE
go_1_11: Allow only one of GOARM={5,6,7}

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation rec {
            else if stdenv.targetPlatform.isAarch32 then "arm"
            else if stdenv.targetPlatform.isAarch64 then "arm64"
            else throw "Unsupported system";
-  GOARM = stdenv.targetPlatform.parsed.cpu.version or "";
+  GOARM = toString (stdenv.lib.intersectLists [(stdenv.targetPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
   GO386 = 387; # from Arch: don't assume sse2 on i686
   CGO_ENABLED = 1;
   GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";


### PR DESCRIPTION
###### Motivation for this change
According to https://github.com/golang/go/wiki/GoArm GOARM is allowed to be just one of 5,6 or 7.
It is recommended to aways set it in order to support cross compilation.

Fixes go and packages broken by the upgrade to go 1.11 on aarch

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

