### PR TITLE
 deepin-shortcut-viewer: init at 1.3.5 

### DIFF
--- a/pkgs/desktops/deepin/deepin-shortcut-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-shortcut-viewer/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, dtkcore, dtkwidget,
+  qt5integration
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-shortcut-viewer";
+  version = "1.3.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "13vz8kjdqkrhgpvdgrvwn62vwzbyqp88hjm5m4rcqg3bh56709ma";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    dtkcore
+    dtkwidget
+    qt5integration
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Pop-up shortcut viewer for Deepin applications";
+    homepage = https://github.com/linuxdeepin/deepin-shortcut-viewer;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/deepin-terminal/default.nix
+++ b/pkgs/desktops/deepin/deepin-terminal/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, pkgconfig, gtk3, vala, cmake,
   ninja, vte, libgee, wnck, zssh, gettext, librsvg, libsecret,
-  json-glib, gobjectIntrospection, deepin-menu }:
+  json-glib, gobjectIntrospection, deepin-menu, deepin-shortcut-viewer
+}:
 
 stdenv.mkDerivation rec {
   name = "deepin-terminal-${version}";
@@ -27,12 +28,27 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    pkgconfig vala cmake ninja gettext
-    # For setup hook
-    gobjectIntrospection
+    pkgconfig
+    vala
+    cmake
+    ninja
+    gettext
+    gobjectIntrospection # For setup hook
   ];
 
-  buildInputs = [ gtk3 vte libgee wnck librsvg libsecret json-glib deepin-menu ];
+  buildInputs = [
+    gtk3
+    vte
+    libgee
+    wnck
+    librsvg
+    libsecret
+    json-glib
+    deepin-menu
+    deepin-shortcut-viewer
+  ];
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "The default terminal emulation for Deepin";

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -8,6 +8,7 @@ let
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
     deepin-menu = callPackage ./deepin-menu { };
+    deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
     deepin-terminal = callPackage ./deepin-terminal {
       inherit (pkgs.gnome3) libgee vte;
       wnck = pkgs.libwnck3;


### PR DESCRIPTION
###### Motivation for this change

- Add [deepin-shortcut-viewer](https://github.com/linuxdeepin/deepin-shortcut-viewer) (pop-up shortcut viewer for Deepin applications).

- deepin-terminal: add dependency on `deepin-shortcut-viewer`, and enable parallel building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).