### PR TITLE
nullidentdmod: Init at 1.3

### DIFF
--- a/pkgs/servers/identd/nullidentdmod/default.nix
+++ b/pkgs/servers/identd/nullidentdmod/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
+  name = "nullidentdmod-${version}";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "Acidhub";
+    repo = "nullidentdmod";
+    rev = "v${version}";
+    sha256 = "1ahwm5pyidc6m07rh5ls2lc25kafrj233nnbcybprgl7bqdq1b0k";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    install -Dm755 nullidentdmod $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple identd that just replies with a random string or customized userid";
+    license = licenses.gpl2;
+    homepage = http://acidhub.click/NullidentdMod;
+    maintainers = with maintainers; [ das_j ];
+    platforms = platforms.linux; # Must be run by systemd
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13285,6 +13285,8 @@ with pkgs;
 
   newrelic-sysmond = callPackage ../servers/monitoring/newrelic-sysmond { };
 
+  nullidentdmod = callPackage ../servers/identd/nullidentdmod {};
+
   riemann = callPackage ../servers/monitoring/riemann { };
   riemann-dash = callPackage ../servers/monitoring/riemann-dash { };
 


### PR DESCRIPTION
###### Motivation for this change

I'd like to send fake idents from my system to prevent attackers from spying on my local users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

