### PR TITLE
plasma-applet-volumewin7mixer: init at v23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2531,6 +2531,11 @@
     github = "mdaiter";
     name = "Matthew S. Daiter";
   };
+  mdevlamynck = {
+    email = "matthias.devlamynck@mailoo.org";
+    github = "mdevlamynck";
+    name = "Matthias Devlamynck";
+  };
   meditans = {
     email = "meditans@gmail.com";
     github = "meditans";

--- a/pkgs/applications/misc/plasma-applet-volumewin7mixer/cmake.patch
+++ b/pkgs/applications/misc/plasma-applet-volumewin7mixer/cmake.patch
@@ -1,0 +1,20 @@
+diff -Naur org.kde.plasma.volumewin7mixer/CMakeLists.txt org.kde.plasma.volumewin7mixer.patch/CMakeLists.txt
+--- org.kde.plasma.volumewin7mixer/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
++++ org.kde.plasma.volumewin7mixer.patch/CMakeLists.txt	2016-04-19 11:23:35.137866949 +0200
+@@ -0,0 +1,15 @@
++# Set minimum CMake version (required for CMake 3.0 or later)
++cmake_minimum_required(VERSION 2.8.12)
++
++# Use Extra CMake Modules (ECM) for common functionality.
++# See http://api.kde.org/ecm/manual/ecm.7.html
++# and http://api.kde.org/ecm/manual/ecm-kde-modules.7.html
++find_package(ECM REQUIRED NO_MODULE)
++# Needed by find_package(KF5Plasma) below.
++set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_MODULE_PATH})
++
++# Locate plasma_install_package macro.
++find_package(KF5Plasma REQUIRED)
++
++# Add installatation target ("make install").
++plasma_install_package(package org.kde.plasma.volumewin7mixer)
+

--- a/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
+++ b/pkgs/applications/misc/plasma-applet-volumewin7mixer/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, cmake, extra-cmake-modules, plasma-framework, kwindowsystem, plasma-pa, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "plasma-applet-volumewin7mixer-${version}";
+  version = "23";
+
+  src = fetchFromGitHub {
+    owner = "Zren";
+    repo = "plasma-applet-volumewin7mixer";
+    rev = "v${version}";
+    sha256 = "1j2bq343lnhwqz26qfsvg7vjxv84ibzbc4y86rjkh07nqjwb3xsc";
+  };
+
+  patches = [ ./cmake.patch ];
+  postPatch = '' rm build '';
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ plasma-framework kwindowsystem plasma-pa ];
+
+  meta = with stdenv.lib; {
+    description = "A fork of the default volume plasmoid with a Windows 7 theme (vertical sliders).";
+    homepage = "https://github.com/Zren/plasma-applet-volumewin7mixer";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mdevlamynck ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20470,6 +20470,8 @@ with pkgs;
     pantheon-terminal = callPackage ../desktops/pantheon/apps/pantheon-terminal { };
   };
 
+  plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
+
   redshift = callPackage ../applications/misc/redshift {
     inherit (python3Packages) python pygobject3 pyxdg wrapPython;
     inherit (darwin.apple_sdk.frameworks) CoreLocation ApplicationServices Foundation Cocoa;


### PR DESCRIPTION
###### Motivation for this change

Adds a volume mixer applet for plasma https://github.com/Zren/plasma-applet-volumewin7mixer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

