### PR TITLE
nixos/libinput: add TappingDrag option

### DIFF
--- a/nixos/modules/services/x11/hardware/libinput.nix
+++ b/nixos/modules/services/x11/hardware/libinput.nix
@@ -157,6 +157,17 @@ in {
           '';
       };
 
+      tappingDrag = mkOption {
+        type = types.bool;
+        default = true;
+        description =
+          ''
+            Enables or disables drag during tapping behavior ("tap-and-drag"). When enabled, a tap
+            followed by a finger held down causes a single button down only, all motions of that finger
+            thus translate into dragging motion. Tap-and-drag requires option Tapping to be enabled.
+          '';
+      };
+
       tappingDragLock = mkOption {
         type = types.bool;
         default = true;
@@ -228,6 +239,7 @@ in {
           Option "HorizontalScrolling" "${xorgBool cfg.horizontalScrolling}"
           Option "SendEventsMode" "${cfg.sendEventsMode}"
           Option "Tapping" "${xorgBool cfg.tapping}"
+          Option "TappingDrag" "${xorgBool cfg.tappingDrag}"
           Option "TappingDragLock" "${xorgBool cfg.tappingDragLock}"
           Option "DisableWhileTyping" "${xorgBool cfg.disableWhileTyping}"
           ${cfg.additionalOptions}


### PR DESCRIPTION
###### Motivation for this change
This change adds missing TappingDrag option of libinput.
Description can be found at libinput(4): https://www.mankier.com/4/libinput.

I think it should be disabled by default, but I preserved libinput behavior.
Documentation says "Most devices have tap-and-drag enabled by default."


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

