### PR TITLE
ghostscript: 9.22 -> 9.24 (security)

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -9,8 +9,9 @@ assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
 let
   version = "9.${ver_min}";
-  ver_min = "22";
-  sha256 = "1fyi4yvdj39bjgs10klr31cda1fbx1ar7a7b7yz7v68gykk65y61";
+  ver_min = "24";
+  # ghostscript*.tar.xz in https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9xx/SHA512SUMS
+  sha512 = "dcbeeb5d3dd5ccaf949dc4be68363c50b1d35e647be4790a50b1bbf5f259f1d9181f705be27bfca708c4d270f945ff4b24e3db10b57800c1ee0ea7a40931c547";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";
@@ -39,7 +40,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9${ver_min}/${name}.tar.xz";
-    inherit sha256;
+    inherit sha512;
   };
 
   outputs = [ "out" "man" "doc" ];
@@ -89,8 +90,8 @@ stdenv.mkDerivation rec {
 
     cp -r Resource "$out/share/ghostscript/${version}"
 
-    mkdir -p "$doc/share/ghostscript/${version}"
-    mv "$out/share/ghostscript/${version}"/{doc,examples} "$doc/share/ghostscript/${version}/"
+    mkdir -p "$doc/share/doc/ghostscript"
+    mv "$doc/share/doc/${version}" "$doc/share/doc/ghostscript/"
 
     ln -s "${fonts}" "$out/share/ghostscript/fonts"
   '' + stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, pkgconfig, zlib, expat, openssl, autoconf
-, libjpeg, libpng, libtiff, freetype, fontconfig, lcms2, libpaper, jbig2dec
+, libjpeg, libpng, libtiff, freetype, fontconfig, libpaper, jbig2dec
 , libiconv, ijs
 , x11Support ? false, xlibsWrapper ? null
 , cupsSupport ? false, cups ? null
@@ -43,6 +43,11 @@ stdenv.mkDerivation rec {
     inherit sha512;
   };
 
+  patches = [
+    ./urw-font-files.patch
+    ./doc-no-ref.diff
+  ];
+
   outputs = [ "out" "man" "doc" ];
 
   enableParallelBuilding = true;
@@ -50,16 +55,13 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig autoconf ];
   buildInputs =
     [ zlib expat openssl
-      libjpeg libpng libtiff freetype fontconfig lcms2 libpaper jbig2dec
+      libjpeg libpng libtiff freetype fontconfig libpaper jbig2dec
       libiconv ijs
     ]
     ++ lib.optional x11Support xlibsWrapper
     ++ lib.optional cupsSupport cups
     ;
-
-  patches = [
-    ./urw-font-files.patch
-  ];
+  # No lcms2; upstream "is in process of forking it" and thus won't use one from a library.
 
   preConfigure = ''
     # requires in-tree (heavily patched) openjpeg

--- a/pkgs/misc/ghostscript/doc-no-ref.diff
+++ b/pkgs/misc/ghostscript/doc-no-ref.diff
@@ -1,0 +1,7 @@
+Kill the reference from libgc.so to the documentation directory.
+It's bad for closure, and probably not really good for anything.
+--- a/base/gs.mak
++++ b/base/gs.mak
+@@ -538,1 +538,1 @@
+-	$(EXP)$(ECHOGS_XE) -a $(gconfigd_h) -x 23 define -s -u GS_DOCDIR -x 2022 $(GS_DOCDIR) -x 22
++	$(EXP)$(ECHOGS_XE) -a $(gconfigd_h) -x 23 define -s -u GS_DOCDIR -x 2022 /no-path-to-docs -x 22


### PR DESCRIPTION
The $doc stuff needed changes, probably because of ghostscript newly
reacting to some configure flags that stdenv passes.
 - share/ghostscript/9.22/doc was an ugly location for documentation,
   and I didn't like their new share/ghostscript/9.24 either,
   so that got changed to share/doc/ghostscript/9.24
 - their process no longer installs examples, apparently,
   but I don't expect that would be any problem for us

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

