### PR TITLE
sound-juicer: fix build

### DIFF
--- a/pkgs/applications/audio/sound-juicer/default.nix
+++ b/pkgs/applications/audio/sound-juicer/default.nix
@@ -22,6 +22,8 @@ in stdenv.mkDerivation rec{
     gst_all_1.gst-libav
   ];
 
+  NIX_CFLAGS_COMPILE="-Wno-error=format-nonliteral";
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;


### PR DESCRIPTION
###### Motivation for this change
The build was failing.
https://hydra.nixos.org/build/80530105/nixlog/1

cc https://github.com/NixOS/nixpkgs/issues/45960 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

