### PR TITLE
zfs-unstable:  2018-08-13 -> 2018-09-02

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -180,10 +180,10 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2018-08-13";
+    version = "2018-09-02";
 
-    rev = "64e96969a88c21aebb2f8d982a8c345e55a2ae6c";
-    sha256 = "164fvsf9zqvq3vafnvjxafjl8gihmfqfsjwsmky16i90a6hs96gf";
+    rev = "c197a77c3cf36531e4cf79e524e1ccf7ec00cc4c";
+    sha256 = "0rk835nnl4w5km8qxcr1wdpr9xasssnrmsxhjlqjy0ry3qcb2197";
     isUnstable = true;
 
     extraPatches = [


### PR DESCRIPTION
###### Motivation for this change

I encountered a kernel panic when shutting down the system using zfs-unstable in combination with encryption and a volume with `sync=disabled` (which is suggested in https://nixos.wiki/wiki/NixOS_on_ZFS#Encrypted_ZFS ).

The bug was reported (https://github.com/zfsonlinux/zfs/issues/7753) to zfs, they invesigated it on a NixOS VM and a fix was merged (https://github.com/zfsonlinux/zfs/pull/7795).

This PR pushes zfs-unstable to the current master. I've run the tests with `nix-build zfs.nix -A unstable` in nixpkgs/nixos/tests.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

