### PR TITLE
dconf module: add dconf to services.dbus.packages

### DIFF
--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -32,6 +32,8 @@ in
     environment.etc = optionals (cfg.profiles != {})
       (mapAttrsToList mkDconfProfile cfg.profiles);
 
+    services.dbus.packages = [ pkgs.gnome3.dconf ];
+
     environment.variables.GIO_EXTRA_MODULES = optional cfg.enable
       "${pkgs.gnome3.dconf.lib}/lib/gio/modules";
     # https://github.com/NixOS/nixpkgs/pull/31891


### PR DESCRIPTION
Some programs like eog seem to need dconf accessible on dbus.
Without this change I get

```
(eog:1738): dconf-WARNING **: 21:20:52.770: failed to commit changes to
dconf: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name
ca.desrt.dconf was not provided by any .service files
```

cc @lethalman @jtojnar as maintainers.
If this seem sensible to you, could you backport this to 18.09 ?

###### Things done

tested on nixos 18.09 beta, with xfce+i3.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) tested `tests.gnome3` and `tests.xfce`.
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

