### PR TITLE
top-level: Deprecate top-level `{build,host,target}Platform`

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -47,13 +47,9 @@
 
    <para>
     In Nixpkgs, these three platforms are defined as attribute sets under the
-    names <literal>buildPlatform</literal>, <literal>hostPlatform</literal>,
-    and <literal>targetPlatform</literal>. All three are always defined as
-    attributes in the standard environment, and at the top level. That means
-    one can get at them just like a dependency in a function that is imported
-    with <literal>callPackage</literal>:
-<programlisting>{ stdenv, buildPlatform, hostPlatform, fooDep, barDep, .. }: ...buildPlatform...</programlisting>
-    , or just off <varname>stdenv</varname>:
+    names <literal>buildPlatform</literal>, <literal>hostPlatform</literal>, and
+    <literal>targetPlatform</literal>. They are always defined as attributes in
+    the standard environment. That means one can access them like:
 <programlisting>{ stdenv, fooDep, barDep, .. }: ...stdenv.buildPlatform...</programlisting>
     .
    </para>

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -79,11 +79,17 @@ let
 
   # The old identifiers for cross-compiling. These should eventually be removed,
   # and the packages that rely on them refactored accordingly.
-  platformCompat = self: super: let
-    inherit (super.stdenv) buildPlatform hostPlatform targetPlatform;
-  in {
-    inherit buildPlatform hostPlatform targetPlatform;
-    inherit (buildPlatform) system;
+  platformCompat = self: super: {
+    buildPlatform = lib.warn
+      "top-level `buildPlatform` is deprecated since 18.09. Please use `stdenv.buildPlatform`."
+      super.stdenv.buildPlatform;
+    hostPlatform = lib.warn
+      "top-level `hostPlatform` is deprecated since 18.09. Please use `stdenv.hostPlatform`."
+      super.stdenv.hostPlatform;
+    targetPlatform = lib.warn
+      "top-level `targetPlatform` is deprecated since 18.09. Please use `stdenv.targetPlatform`."
+      super.stdenv.targetPlatform;
+    inherit (super.stdenv.buildPlatform) system;
   };
 
   splice = self: super: import ./splice.nix lib self (buildPackages != null);


### PR DESCRIPTION
OK @dezgeg, I'm starting with these since these are the ones we agree on. I'll backport to 18.09 too, if you approve of this.

###### Motivation for this change

I don't know when we can/should remove them, but this at least gets people to stop using them. The preferred alternatives also date back to 17.09 so writing forward-compatable code without extra conditions is easy.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

