### PR TITLE
dbus-sharp-2_0: fix build

### DIFF
--- a/pkgs/development/libraries/dbus-sharp/default.nix
+++ b/pkgs/development/libraries/dbus-sharp/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, pkgconfig, mono, autoreconfHook }:
+{stdenv, fetchFromGitHub, pkgconfig, mono48, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "dbus-sharp-${version}";
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ mono ];
+
+  # Use msbuild when https://github.com/NixOS/nixpkgs/pull/43680 is merged
+  # See: https://github.com/NixOS/nixpkgs/pull/46060
+  buildInputs = [ mono48 ];
 
   dontStrip = true;
 


### PR DESCRIPTION
This is a reported [issue](https://github.com/mono/dbus-sharp/issues/64) which is fixed either by downgrading mono or by using msbuild.
The use of msbuild would have been preferred here if it [was in nixpkgs](https://github.com/NixOS/nixpkgs/issues/29817).

###### Motivation for this change
This build failure
```
Failure adding assembly dbus-sharp.dll to the cache: Strong name cannot be verified for delay-signed assembly
```

ZHF: https://github.com/NixOS/nixpkgs/issues/45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

