### PR TITLE
patchwork: Init at 3.10.1

### DIFF
--- a/pkgs/applications/networking/scuttlebutt/patchwork/default.nix
+++ b/pkgs/applications/networking/scuttlebutt/patchwork/default.nix
@@ -1,0 +1,107 @@
+{ stdenv, lib, fetchurl, glibc, zlib, fuse, cairo, atk,
+  pythonPackages, p7zip, udev, dbus, gtk3, pango,
+  gdk_pixbuf, glib, libX11, libXScrnSaver, libXcomposite, libXcursor,
+  libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst,
+  libxcb, gnome2, nss, nspr, alsaLib, cups, fontconfig, expat, makeDesktopItem}:
+
+let
+  rpath = lib.makeLibraryPath [
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus 
+    expat
+    fontconfig
+    fuse
+    gdk_pixbuf
+    glib
+    gtk3
+    gnome2.GConf
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libxcb
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    nspr
+    nss
+    pango
+    stdenv.cc.cc 
+    udev
+    zlib.out
+  ];
+
+in stdenv.mkDerivation rec {
+  name = "Patchwork-${version}";
+  version = "3.10.1";
+
+  src = fetchurl {
+    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/${name}-linux-x86_64.AppImage";
+    sha256 = "18dvzh2bfmq320s2qi6cqn0qc32y9yl2wdwj518aq8bds78yqqx2";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "Patchwork";
+    exec = "patchwork";
+    icon = "$out/share/patchwork/";
+    comment = "Decentralized messanging and sharing app"; 
+    desktopName = "Patchwork";
+    genericName = "Patchwork";
+    categories = "Network;";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase"];
+
+  buildIntputs = [ pythonPackages.binwalk p7zip ];
+
+  binwalk = "${pythonPackages.binwalk}/bin/binwalk";
+
+  unpackPhase = ''
+    export HOME=$(pwd) # binwalk seems unhappy without this...
+    ${binwalk} $src --quiet -D 'squashfs:.squashfs:7z x %e'
+    '';
+
+  installPhase = ''
+    # 
+    # appName is kind of a hack. Binwalk extracted
+    # the retrieved squashfs in a directory named after the
+    # AppImage name (_$imagename.extracted to be exact),
+    # which itself depends of its name in the nix store.
+    #
+    # I did not find a way to extract the data without this
+    # weird folder name.
+    # 
+    # So we are basically looking for the name of the AppImage drv here (without the .drv)
+    # to predict this directory name.
+    # 
+    appName=$(basename -s .drv $src)
+    mkdir -p $out/{libexec,bin,share/patchwork}
+    cd _$appName.extracted
+    cp ssb-patchwork.png $out/share/patchwork/patchwork.png
+    cp -r app/* $out/libexec/
+    chmod a+x $out/libexec/ssb-patchwork
+    ln -s $out/libexec/ssb-patchwork $out/bin/patchwork
+  '';
+
+  fixupPhase = ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${rpath}:$out/libexec \
+      $out/libexec/ssb-patchwork 
+  '';
+
+  meta = {
+    description = "A decentralized messaging and sharing app built on top of Secure Scuttlebutt (SSB)";
+    homepage    = https://github.com/ssbc/patchwork;
+    license     = lib.licenses.agpl3;
+    maintainers = with lib.maintainers; [ cryptix ninjatrappeur ];
+    platforms   = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4521,6 +4521,8 @@ with pkgs;
 
   patchutils = callPackage ../tools/text/patchutils { };
 
+  patchwork = callPackage ../applications/networking/scuttlebutt/patchwork { };
+
   parted = callPackage ../tools/misc/parted { };
 
   pell = callPackage ../applications/misc/pell { };


### PR DESCRIPTION
###### Motivation for this change

Add patchwork, a decentralized messaging and sharing app built on top of Secure Scuttlebutt (SSB).

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Hi,

As you can see, this software is distributed using a "new" (at least to me) archive type called [AppImage](https://appimage.org/). As its name states, it runs everywhere, it can install any software on any linux distribution, which sounds great.

Sadly, it does not run on nixos at all :(

I did not wanted to debug the "executable archive" by itself. Instead, I've looked for a way to extract the actual package from the archive in order to install it in a more "traditional" way.

I am extracting the actual package contained in various squashfs embedded in the AppImage using binwalk.

It's a bit hack-ish, but it has the certain advantage to work. I'm open to any improvement on the process.

I've setup a notification to watch any new release of this software: I plan to maintain this package.

Have a nice day!
