### PR TITLE
musl: 1.1.19 -> 1.1.20

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -29,11 +29,11 @@ let
 in
 stdenv.mkDerivation rec {
   name    = "musl-${version}";
-  version = "1.1.19";
+  version = "1.1.20";
 
   src = fetchurl {
     url    = "https://www.musl-libc.org/releases/musl-${version}.tar.gz";
-    sha256 = "1nf1wh44bhm8gdcfr75ayib29b99vpq62zmjymrq7f96h9bshnfv";
+    sha256 = "0q8dsjxl41dccscv9a0r78bs7jap57mn4mni5pwbbip6s1qqggj4";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Announcement: http://www.openwall.com/lists/musl/2018/09/04/17
Release commit (adds release notes to WHATSNEW): https://git.musl-libc.org/cgit/musl/commit/?h=v1.1.20&id=0fa1e638e87cf257e9f96b4019b2076afd674a19


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


The hydra instance powering my musl build-fleet died a few weeks ago
and as a result I haven't tested the impact this has on all-the-things
(esp in terms of various cross-compilation scenarios).

Many of these fixes are worthy of having been picked but it always
seemed a release was happening soon... :D

See the notes and commit logs for more details.