### PR TITLE
puredata: 0.48-0 -> 0.48-2

### DIFF
--- a/pkgs/applications/audio/puredata/default.nix
+++ b/pkgs/applications/audio/puredata/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation  rec {
   name = "puredata-${version}";
-  version = "0.48-0";
+  version = "0.48-2";
 
   src = fetchurl {
     url = "http://msp.ucsd.edu/Software/pd-${version}.src.tar.gz";
-    sha256 = "0wy9kl2v00fl27x4mfzhbca415hpaisp6ls8a6mkl01qbw20krny";
+    sha256 = "0p86hncgzkrl437v2wch2fg9iyn6mnrgbn811sh9pwmrjj2f06v8";
   };
 
   nativeBuildInputs = [ autoreconfHook gettext makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

