### PR TITLE
Chordbook: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3511,6 +3511,11 @@
     github = "rprospero";
     name = "Adam Washington";
   };
+  rschardt = {
+    email = "robert.schardt@gmx.de";
+    github = "rschardt";
+    name = "Robert Schardt";
+  };
   rszibele = {
     email = "richard@szibele.com";
     github = "rszibele";

--- a/pkgs/servers/web-apps/chordbook/default.nix
+++ b/pkgs/servers/web-apps/chordbook/default.nix
@@ -16,7 +16,6 @@ haskell.lib.buildStackProject {
   buildInputs = [ 
     postgresql100 
     zlib
-    ghc
   ];
 
   meta = with lib; {

--- a/pkgs/servers/web-apps/chordbook/default.nix
+++ b/pkgs/servers/web-apps/chordbook/default.nix
@@ -1,0 +1,28 @@
+### Chordbook-Package
+{ nixpkgs ? import <nixpkgs>, lib }:
+with (import <nixpkgs> { });
+
+haskell.lib.buildStackProject {
+
+  name = "Chordbook";
+
+  src = fetchFromGitLab {
+    owner = "bob-project";	
+    repo = "Chordbook";
+    rev = "1baf136ddc248011145c7709ffbed046f506e5fd";
+    sha256 = "02xqfwnzqby1sjbxwx5hm4lx6l94pjd99fzazszfcc4hayk96bk7";
+  };                                                                                              
+
+  buildInputs = [ 
+    postgresql100 
+    zlib
+    ghc
+  ];
+
+  meta = with lib; {
+    homepage = https://gitlab.com/bob-project/Chordbook;
+    description = "a digital chordbook for memorizing chords";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ rschardt ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -647,6 +647,8 @@ with pkgs;
 
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
+  chordbook = callPackage ../servers/web-apps/chordbook { };
+
   djmount = callPackage ../tools/filesystems/djmount { };
 
   dgsh = callPackage ../shells/dgsh { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to learn how to add a stack-application to nixpkgs and i would be happy if people could use my code as a template or if they are interested in the application itself. 
 
The Chordbook-Application is a hobby-project of mine. 
It is a web-application which allows to memorize Guitar-Chords and i also want to extend it with features as i progress with my guitar training. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

