### PR TITLE
nixos/tests/opensmtpd: prevent non-deterministic failure

### DIFF
--- a/nixos/tests/opensmtpd.nix
+++ b/nixos/tests/opensmtpd.nix
@@ -102,10 +102,16 @@ import ./make-test.nix {
   testScript = ''
     startAll;
 
-    $client->waitForUnit("network.target");
+    $client->waitForUnit("network-online.target");
     $smtp1->waitForUnit('opensmtpd');
     $smtp2->waitForUnit('opensmtpd');
     $smtp2->waitForUnit('dovecot2');
+
+    # To prevent sporadic failures during daemon startup, make sure
+    # services are listening on their ports before sending requests
+    $smtp1->waitForOpenPort(25);
+    $smtp2->waitForOpenPort(25);
+    $smtp2->waitForOpenPort(143);
 
     $client->succeed('send-a-test-mail');
     $smtp1->waitUntilFails('smtpctl show queue | egrep .');


### PR DESCRIPTION
###### Motivation for this change

A sporadic test failure [occured on Hydra](https://hydra.nixos.org/build/80798731) because a request was sent to smtpd after the systemd unit was started, but before the daemon was actually listening. Fix by checking for open ports first.

cc ZHF #45960

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

