### PR TITLE
nixos-artwork: Keeps new wallpaper compatible with old path.

### DIFF
--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl }:
 
 let
-  mkNixBackground = { name, src, description }:
+  mkNixBackground = { name, src, description, installPhase ? "" }:
 
     stdenv.mkDerivation {
       inherit name src;
@@ -11,6 +11,7 @@ let
       installPhase = ''
         mkdir -p $out/share/artwork/gnome
         ln -s $src $out/share/artwork/gnome/${src.name}
+        ${installPhase}
       '';
 
       meta = with stdenv.lib; {
@@ -70,6 +71,10 @@ rec {
       url = https://raw.githubusercontent.com/NixOS/nixos-artwork/783c38b22de09f6ee33aacc817470a4513392d83/wallpapers/nix-wallpaper-simple-dark-gray_bottom.png;
       sha256 = "13hi4jwp5ga06dpdw5l03b4znwn58fdjlkqjkg824isqsxzv6k15";
     };
+    # Keeps this compatible with `Gnome_Dark.png`.
+    installPhase = ''
+      ln -s $out/share/artwork/gnome/nix-wallpaper-simple-dark-gray_bottom.png $out/share/artwork/gnome/Gnome_Dark.png
+    '';
   };
 
   simple-light-gray = mkNixBackground {


### PR DESCRIPTION
See:

 * https://github.com/NixOS/nixpkgs/commit/bc5b26b4ab6ddaf8e08acfa7d06a054ddac43358#commitcomment-30385181

cc @grahamc 

This will need a backport to 18.09 too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I have *only* verified the contents of `result` after a `nix-build`

```
~/tmp/nixpkgs/nixpkgs $ ls -l result/share/artwork/gnome/
lrwxrwxrwx 1 root root 133 Dec 31  1969 result/share/artwork/gnome/Gnome_Dark.png -> /nix/store/gzy4psym7619fdjz11ywlllaxfjhzmdl-simple-dark-gray-2018-08-28/share/artwork/gnome/nix-wallpaper-simple-dark-gray_bottom.png
lrwxrwxrwx 1 root root  85 Dec 31  1969 result/share/artwork/gnome/nix-wallpaper-simple-dark-gray_bottom.png -> /nix/store/qb82wpjaf3j6pswhk73rkcd43si2nb1w-nix-wallpaper-simple-dark-gray_bottom.png
```

It is as expected. The symlinks are fine.

---

