### PR TITLE
texinfo: fix for the new perl

### DIFF
--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
+  # TODO: fix on mass rebuild
+  ${if interactive then "patches" else null} = optional (version == "6.5") ./perl.patch;
+
   # We need a native compiler to build perl XS extensions
   # when cross-compiling.
   depsBuildBuild = [ buildPackages.stdenv.cc perl ];

--- a/pkgs/development/tools/misc/texinfo/perl.patch
+++ b/pkgs/development/tools/misc/texinfo/perl.patch
@@ -1,0 +1,43 @@
+Adapted from http://svn.savannah.gnu.org/viewvc/texinfo/
+Author: gavin
+--- trunk/tp/Texinfo/Parser.pm  2018-06-04 19:51:36 UTC (rev 8006)
++++ trunk/tp/Texinfo/Parser.pm  2018-07-13 15:31:28 UTC (rev 8007)
+@@ -5531,11 +5531,11 @@
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1;
+       $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
+       $has_comment = 1 if (defined($4));
+     } else {
+       $self->line_error (sprintf($self->__(
+--- trunk/tp/Texinfo/Convert/XSParagraph/xspara.c       2018-07-13 15:31:28 UTC (rev 8007)
++++ trunk/tp/Texinfo/Convert/XSParagraph/xspara.c       2018-07-13 15:39:29 UTC (rev 8008)
+@@ -248,6 +248,11 @@
+ 
+   dTHX;
+ 
++#if PERL_VERSION > 27 || (PERL_VERSION == 27 && PERL_SUBVERSION > 8)
++  /* needed due to thread-safe locale handling in newer perls */
++  switch_to_global_locale();
++#endif
++
+   if (setlocale (LC_CTYPE, "en_US.UTF-8")
+       || setlocale (LC_CTYPE, "en_US.utf8"))
+     goto success;
+@@ -320,6 +325,10 @@
+     {
+ success: ;
+       free (utf8_locale);
++#if PERL_VERSION > 27 || (PERL_VERSION == 27 && PERL_SUBVERSION > 8)
++      /* needed due to thread-safe locale handling in newer perls */
++      sync_locale();
++#endif
+       /*
+       fprintf (stderr, "tried to set LC_CTYPE to UTF-8.\n");
+       fprintf (stderr, "character encoding is: %s\n",

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8743,13 +8743,9 @@ with pkgs;
   texinfo5 = callPackage ../development/tools/misc/texinfo/5.2.nix { };
   texinfo6 = callPackage ../development/tools/misc/texinfo/6.5.nix { };
   texinfo = texinfo6;
-  texinfoInteractive = appendToName "interactive" (texinfo.override {
-    interactive = true;
-    # doCheck = true -> some xlocale.h problem with perl 5.28.0
-    # (it's mistakenly trying to include the non-existent header)
-    perl = perl526;
-    buildPackages = buildPackages // { perl = buildPackages.perl526; };
-  });
+  texinfoInteractive = appendToName "interactive" (
+    texinfo.override { interactive = true; }
+  );
 
   texi2html = callPackage ../development/tools/misc/texi2html { };
 


### PR DESCRIPTION
###### Motivation for this change

Two `perl` versions are a bit too much.

###### Things done

- [X] It builds and passes its own tests.
- [X] Saves a bunch of space.

<strike>I think this should be stable enough for staging-next.</strike> Added a hack to prevent mass-rebuild, rebased onto master.

/cc @vcunat