### PR TITLE
solarus[-quest-editor]: 1.4.5 -> 1.5.3

### DIFF
--- a/pkgs/development/tools/solarus-quest-editor/default.nix
+++ b/pkgs/development/tools/solarus-quest-editor/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchFromGitHub, cmake, luajit,
+{ stdenv, fetchFromGitLab, cmake, luajit,
   SDL2, SDL2_image, SDL2_ttf, physfs,
   openal, libmodplug, libvorbis, solarus,
-  qtbase, qttools }:
+  qtbase, qttools, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "solarus-quest-editor-${version}";
-  version = "1.4.5";
+  version = "1.5.3";
     
-  src = fetchFromGitHub {
-    owner = "christopho";
+  src = fetchFromGitLab {
+    owner = "solarus-games";
     repo = "solarus-quest-editor";
-    rev = "61f0fa7a5048994fcd9c9f3a3d1255d0be2967df";
-    sha256 = "1fpq55nvs5k2rxgzgf39c069rmm73vmv4gr5lvmqzgsz07rkh07f";
+    rev = "v1.5.3";
+    sha256 = "1b9mg04yy4pnrl745hbc82rz79k0f8ci3wv7gvsm3a998q8m98si";
   };
   
   buildInputs = [ cmake luajit SDL2
@@ -19,7 +19,18 @@ stdenv.mkDerivation rec {
     openal libmodplug libvorbis
     solarus qtbase qttools ];
     
-  patches = [ ./patches/fix-install.patch ];
+  patches = [
+    ./patches/fix-install.patch
+
+    # Next two patches should be fine to remove for next release.
+    # This commit fixes issues AND adds features *sighs*
+    ./patches/partial-f285beab62594f73e57190c49848c848487214cf.patch
+
+    (fetchpatch {
+      url = https://gitlab.com/solarus-games/solarus-quest-editor/commit/8f308463030c18cd4f7c8a6052028fff3b7ca35a.patch;
+      sha256 = "1jq48ghhznrp47q9lq2rhh48a1z4aylyy4qaniaqyfyq3vihrchr";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "The editor for the Zelda-like ARPG game engine, Solarus";

--- a/pkgs/development/tools/solarus-quest-editor/patches/partial-f285beab62594f73e57190c49848c848487214cf.patch
+++ b/pkgs/development/tools/solarus-quest-editor/patches/partial-f285beab62594f73e57190c49848c848487214cf.patch
@@ -1,0 +1,33 @@
+From f285beab62594f73e57190c49848c848487214cf Mon Sep 17 00:00:00 2001
+From: stdgregwar <gregoirehirt@gmail.com>
+Date: Sun, 1 Jul 2018 00:00:41 +0200
+Subject: [PATCH] Shader previewer base
+
+
+diff --git a/include/widgets/tileset_view.h b/include/widgets/tileset_view.h
+index 615f432..799a4c6 100644
+--- a/include/widgets/tileset_view.h
++++ b/include/widgets/tileset_view.h
+@@ -23,6 +23,7 @@
+ #include "pattern_separation.h"
+ #include <QGraphicsView>
+ #include <QPointer>
++#include <QMenu>
+ 
+ class QAction;
+ 
+diff --git a/src/widgets/text_editor.cpp b/src/widgets/text_editor.cpp
+index 4f2ff68..90080a9 100644
+--- a/src/widgets/text_editor.cpp
++++ b/src/widgets/text_editor.cpp
+@@ -26,6 +26,7 @@
+ #include <QList>
+ #include <QPlainTextEdit>
+ #include <QScrollBar>
++#include <QAction>
+ #include <QTextStream>
+ #include <QUndoStack>
+ 
+-- 
+2.18.0
+

--- a/pkgs/games/solarus/default.nix
+++ b/pkgs/games/solarus/default.nix
@@ -1,21 +1,23 @@
-{ stdenv, fetchFromGitHub, cmake, luajit,
+{ stdenv, fetchFromGitLab, cmake, luajit,
   SDL2, SDL2_image, SDL2_ttf, physfs,
-  openal, libmodplug, libvorbis}:
+  openal, libmodplug, libvorbis,
+  qtbase, qttools }:
 
 stdenv.mkDerivation rec {
   name = "solarus-${version}";
-  version = "1.4.5";
+  version = "1.5.3";
 
-  src = fetchFromGitHub {
-    owner = "christopho";
+  src = fetchFromGitLab {
+    owner = "solarus-games";
     repo = "solarus";
-    rev = "d9fdb9fdb4e1b9fc384730a9279d134ae9f2c70e";
-    sha256 = "0xjx789d6crm322wmkqyq9r288vddsha59yavhy78c4r01gs1p5v";
+    rev = "v1.5.3";
+    sha256 = "035hkdw3a1ryasj5wfa1xla1xmpnc3hjp4s20sl9ywip41675vaz";
   };
 
   buildInputs = [ cmake luajit SDL2
     SDL2_image SDL2_ttf physfs
-    openal libmodplug libvorbis ];
+    openal libmodplug libvorbis
+    qtbase qttools ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20157,7 +20157,7 @@ with pkgs;
     lua = lua5_1;
   };
 
-  solarus = callPackage ../games/solarus { };
+  solarus = libsForQt5.callPackage ../games/solarus { };
 
   solarus-quest-editor = libsForQt5.callPackage ../development/tools/solarus-quest-editor { };
 


### PR DESCRIPTION
###### Motivation for this change

#45960 has solarus-quest-editor failing.

This is (with at least another failure) fallout from Qt 5.10 -> 5.11 from June.

The update may not be strictly necessary to fix the issue, but:

 * It needed to be updated.
 * It allows using patches from upstream.

It'll need cherry-picking to release-18.09


###### Things done


- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- 🌶️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

#44047 stops me from testing this :/.

---

