### PR TITLE
qtchan: Fixes build from Qt upgrade.

### DIFF
--- a/pkgs/applications/networking/browsers/qtchan/default.nix
+++ b/pkgs/applications/networking/browsers/qtchan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, qt, makeWrapper }:
+{ stdenv, fetchFromGitHub, fetchpatch, qt, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "qtchan-${version}";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "0n94jd6b1y8v6x5lkinr9rzm4bjg9xh9m7zj3j73pgq829gpmj3a";
   };
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/siavash119/qtchan/commit/718abeee5cf4aca8c99b35b26f43909362a29ee6.patch;
+      sha256 = "11b72l5njvfsyapd479hp4yfvwwb1mhq3f077hwgg0waz5l7n00z";
+    })
+  ];
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ qt.qmake makeWrapper ];


### PR DESCRIPTION
Uses an upstream fix.

###### Motivation for this change

Plowing through #45960 failures.

This is (with at least another failure) fallout from Qt 5.10 -> 5.11 from June.

It'll need cherry-picking to release-18.09

###### Things done


- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

#44047 wasn't an issue since this (wrongly?) wraps with qt plugin path...

---

