### PR TITLE
qesteidutil: Fixes build from Qt upgrade.

### DIFF
--- a/pkgs/tools/security/qesteidutil/default.nix
+++ b/pkgs/tools/security/qesteidutil/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, fetchpatch
 , cmake, ccid, qttools, qttranslations
 , pkgconfig, pcsclite, hicolor-icon-theme 
 }:
@@ -18,6 +18,13 @@ stdenv.mkDerivation rec {
     sha256 = "0zly83sdqsf9lxnfw4ir2a9vmmfba181rhsrz61ga2zzpm2wf0f0";
     fetchSubmodules = true;
   };
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/open-eid/qesteidutil/commit/868e8245f2481e29e1154e168ac92d32e93a5425.patch;
+      sha256 = "0pwrkd8inf0qaf7lcchmj558k6z34ah672zcb722aa5ybbif0lkn";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cmake ccid qttools pcsclite qttranslations


### PR DESCRIPTION
###### Motivation for this change

Plowing through #45960 failures.

This is (with at least another failure) fallout from Qt 5.10 -> 5.11 from June.

The patch does not strictly address the issue, but has been judged (by me) to be fine; the actual intended fix is minimal, and the value of having one fewer failure is good. If it is judged not to be fine, cutting the fix and keeping the header changes in a custom patch can be done.

It'll need cherry-picking to release-18.09


###### Things done


- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- 🌶️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

#44047 stops me from testing this :/.

---

