### PR TITLE
qmapshack: 1.11.1 -> 1.12.0

### DIFF
--- a/pkgs/applications/misc/qmapshack/default.nix
+++ b/pkgs/applications/misc/qmapshack/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, cmake, qtscript, qtwebkit, gdal, proj, routino, quazip }:
+{ stdenv, fetchurl, cmake, qtscript, qtwebengine, gdal, proj, routino, quazip }:
 
 stdenv.mkDerivation rec {
   name = "qmapshack-${version}";
-  version = "1.11.1";
+  version = "1.12.0";
 
   src = fetchurl {
     url = "https://bitbucket.org/maproom/qmapshack/downloads/${name}.tar.gz";
-    sha256 = "0yqilfldmfw8m18jbkffv4ar1px6kjs0zlgb216bnhahcr1y8r9y";
+    sha256 = "0d5p60kq9pa2hfql4nr8p42n88lr42jrsryrsllvaj45b8b6kvih";
   };
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ qtscript qtwebkit gdal proj routino quazip ];
+  buildInputs = [ qtscript qtwebengine gdal proj routino quazip ];
 
   cmakeFlags = [
     "-DROUTINO_XML_PATH=${routino}/share/routino"


### PR DESCRIPTION
###### Motivation for this change

Plowing through #45960 failures.

This is (with at least another failure) fallout from Qt 5.10 -> 5.11 from June.

Also, a fresher version!

It'll need cherry-picking to release-18.09


###### Things done


- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- 🌶️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

#44047 stops me from testing this :/.

Some of the binaries could be executed and ran (without Qt).

---

