### PR TITLE
qtkeychain: Fixes Qt4 build.

### DIFF
--- a/pkgs/development/libraries/qtkeychain/0001-Fixes-build-with-Qt4.patch
+++ b/pkgs/development/libraries/qtkeychain/0001-Fixes-build-with-Qt4.patch
@@ -1,0 +1,25 @@
+From f72e5b67ee1137a0ccd57db5d077a197b01b3cdc Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Tue, 4 Sep 2018 23:19:29 -0400
+Subject: [PATCH] Fixes build with Qt4.
+
+---
+ keychain_unix.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/keychain_unix.cpp b/keychain_unix.cpp
+index 30b26c3..b27ebef 100644
+--- a/keychain_unix.cpp
++++ b/keychain_unix.cpp
+@@ -91,7 +91,7 @@ static bool isKwallet5Available()
+     // a wallet can be opened.
+ 
+     iface.setTimeout(500);
+-    QDBusMessage reply = iface.call(QStringLiteral("networkWallet"));
++    QDBusMessage reply = iface.call("networkWallet");
+     return reply.type() == QDBusMessage::ReplyMessage;
+ }
+ 
+-- 
+2.16.4
+

--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
     sha256 = "0h4wgngn2yl35hapbjs24amkjfbzsvnna4ixfhn87snjnq5lmjbc"; # v0.9.1
   };
 
+  patches = if withQt5 then null else [ ./0001-Fixes-build-with-Qt4.patch ];
+
   cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ]
     ++ stdenv.lib.optional stdenv.isDarwin [
        # correctly detect the compiler


### PR DESCRIPTION
###### Motivation for this change

Not 100% enthusiastic at "fixing" Qt4 build as this is. Why? Because the only use (AFAICT) of Qt4 qtkeychain was tomahawk, which has been marked broken and is abandoned upstream. Furthermore, tomahawk supposedly can be built using Qt5 instead (according to recent unreleased commits). Thus this is *untested*. I won't be mad, possibly glad if instead we remove the Qt4 attribute of qtkeychain.

Though, in the vein of ZHF #45960, I have this fixed cooked and ready. (I cooked it before I could realize this wouldn't be tested.)

It'll need to be cherry-picked to 18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✅ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- 🆖 Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build qtkeychain libsForQt5.qtkeychain