### PR TITLE
ocamlPackages.{tyxml,lwt}: always enable camlp4 support

### DIFF
--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip, pkgconfig, ncurses, libev, jbuilder
 , ocaml, findlib, cppo
 , ocaml-migrate-parsetree, ppx_tools_versioned, result
-, withP4 ? !stdenv.lib.versionAtLeast ocaml.version "4.07"
+, withP4 ? true
 , camlp4 ? null
 }:
 

--- a/pkgs/development/ocaml-modules/tyxml/default.nix
+++ b/pkgs/development/ocaml-modules/tyxml/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, ocaml, findlib, ocamlbuild, uutf, markup, ppx_tools_versioned, re
-, withP4 ? !stdenv.lib.versionAtLeast ocaml.version "4.07"
+, withP4 ? true
 , camlp4 ? null
 }:
 


### PR DESCRIPTION
###### Motivation for this change

camlp4 is now available for OCaml 4.07

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

