### PR TITLE
spacy: Fix build

### DIFF
--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -37,7 +37,8 @@ buildPythonPackage rec {
       --replace "ftfy==" "ftfy>=" \
       --replace "msgpack-python==" "msgpack-python>=" \
       --replace "msgpack-numpy==" "msgpack-numpy>=" \
-      --replace "pathlib" "pathlib; python_version<\"3.4\""
+      --replace "thinc>=6.10.3,<6.11.0" "thinc>=6.10.3" \
+      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -35,7 +35,9 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace setup.py \
       --replace "msgpack-python==" "msgpack-python>=" \
-      --replace "msgpack-numpy==" "msgpack-numpy>="
+      --replace "msgpack-numpy==" "msgpack-numpy>=" \
+      --replace "plac>=0.9,<1.0" "plac>=0.9" \
+      --replace "hypothesis>=2,<3" "hypothesis>=2"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Fix `thinc` and `spacy` builds.

ZHF #45960

To make spacy usable again, the model packages need to be updated as well. I will do this in a separate PR if I have time later today or tomorrow.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

