### PR TITLE
thinc: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -6,6 +6,7 @@
 , pytest
 , cython
 , cymem
+, darwin
 , msgpack-numpy
 , msgpack-python
 , preshed
@@ -39,6 +40,10 @@ buildPythonPackage rec {
       --replace "plac>=0.9,<1.0" "plac>=0.9" \
       --replace "hypothesis>=2,<3" "hypothesis>=2"
   '';
+
+  buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    Accelerate CoreFoundation CoreGraphics CoreVideo
+  ]);
 
   propagatedBuildInputs = [
    cython


### PR DESCRIPTION
###### Motivation for this change

thinc uses Accelerate on macOS as a blas library. Add the necessary
dependencies to allow building on **unsandboxed** Darwin machines.

With this change, spacy should also build on Darwin.

ZHF #45961

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
