### PR TITLE
gildas: fix build failures

### DIFF
--- a/pkgs/applications/science/astronomy/gildas/default.nix
+++ b/pkgs/applications/science/astronomy/gildas/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./wrapper.patch ./return-error-code.patch ./clang.patch ./aarch64.patch ./gag-font-bin-rule.patch ];
 
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang "-Wno-unused-command-line-argument";
+
   configurePhase=''
     substituteInPlace admin/wrapper.sh --replace '%%OUT%%' $out
     substituteInPlace admin/wrapper.sh --replace '%%PYTHONHOME%%' ${python27Env}

--- a/pkgs/applications/science/astronomy/gildas/default.nix
+++ b/pkgs/applications/science/astronomy/gildas/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gtk2-x11 lesstif cfitsio python27Env ];
 
-  patches = [ ./wrapper.patch ./return-error-code.patch ./clang.patch ./aarch64.patch ];
+  patches = [ ./wrapper.patch ./return-error-code.patch ./clang.patch ./aarch64.patch ./gag-font-bin-rule.patch ];
 
   configurePhase=''
     substituteInPlace admin/wrapper.sh --replace '%%OUT%%' $out

--- a/pkgs/applications/science/astronomy/gildas/gag-font-bin-rule.patch
+++ b/pkgs/applications/science/astronomy/gildas/gag-font-bin-rule.patch
@@ -1,0 +1,13 @@
+diff -ruN gildas-src-aug18a/kernel/etc/Makefile gildas-src-aug18a.gag-font-bin-rule/kernel/etc/Makefile
+--- gildas-src-aug18a/kernel/etc/Makefile	2016-09-09 09:39:37.000000000 +0200
++++ gildas-src-aug18a.gag-font-bin-rule/kernel/etc/Makefile	2018-09-04 12:03:11.000000000 +0200
+@@ -29,7 +29,8 @@
+ 
+ SEDEXE=sed -e 's?source tree?executable tree?g'
+ 
+-$(datadir)/gag-font.bin: hershey-font.dat $(bindir)/hershey
++$(datadir)/gag-font.bin: hershey-font.dat $(bindir)/hershey \
++	$(gagintdir)/etc/gag.dico.gbl $(gagintdir)/etc/gag.dico.lcl
+ ifeq ($(GAG_ENV_KIND)-$(GAG_TARGET_KIND),cygwin-mingw)
+ 	$(bindir)/hershey `cygpath -w $(datadir)`/gag-font.bin
+ else


### PR DESCRIPTION
###### Motivation for this change

Fix build failures on Hydra (#45960).

Please backport to 18.09 when merging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
