### PR TITLE
statsd: mark broken, disable nixos test

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -399,7 +399,7 @@ in rec {
   tests.slurm = callTest tests/slurm.nix {};
   tests.smokeping = callTest tests/smokeping.nix {};
   tests.snapper = callTest tests/snapper.nix {};
-  tests.statsd = callTest tests/statsd.nix {};
+  #tests.statsd = callTest tests/statsd.nix {}; # statsd is broken: #45946
   tests.strongswan-swanctl = callTest tests/strongswan-swanctl.nix {};
   tests.sudo = callTest tests/sudo.nix {};
   tests.systemd = callTest tests/systemd.nix {};

--- a/pkgs/development/node-packages/default-v8.nix
+++ b/pkgs/development/node-packages/default-v8.nix
@@ -77,6 +77,12 @@ nodePackages // {
     '';
   };
 
+  statsd = nodePackages.statsd.override {
+    # broken with node v8, dead upstream,
+    # see #45946 and https://github.com/etsy/statsd/issues/646
+    meta.broken = true;
+  };
+
   webdrvr = nodePackages.webdrvr.override {
     buildInputs = [ pkgs.phantomjs ];
 


### PR DESCRIPTION
###### Motivation for this change

It's broken with node v8 and the upstream project is dead (last commit Nov. 2016), see #45946 and https://github.com/etsy/statsd/issues/646, so mark it broken and disable the NixOS test.

Alternatives considered (but decided against): 

- revert to node v6 ? Not worth the work and overhead for a dead project.
- drop it completely: Not yet, because some other nixos modules seem to reference the term `statsd`, and we need time to figure out whether they actually  depend on our `statsd` package/module.

Needs backporting ZHF #45960 

closes #45946

---
cc @Ma27 
