### PR TITLE
stdenv, neovim: Use `lib.warn` for deprecation warnings for 18.09

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -30,7 +30,7 @@ let
 
   /* for compatibility with passing extraPythonPackages as a list; added 2018-07-11 */
   compatFun = funOrList: (if builtins.isList funOrList then
-    (_: builtins.trace "passing a list as extraPythonPackages to the neovim wrapper is deprecated, pass a function as to python.withPackages instead" funOrList)
+    (_: lib.warn "passing a list as extraPythonPackages to the neovim wrapper is deprecated, pass a function as to python.withPackages instead" funOrList)
     else funOrList);
   extraPythonPackagesFun = compatFun extraPythonPackages;
   extraPython3PackagesFun = compatFun extraPython3Packages;

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -123,7 +123,7 @@ let
       inherit (hostPlatform)
         isDarwin isLinux isSunOS isCygwin isFreeBSD isOpenBSD
         isi686 isx86_64 is64bit isAarch32 isAarch64 isMips isBigEndian;
-      isArm = builtins.trace
+      isArm = lib.warn
         "`stdenv.isArm` is deprecated after 18.03. Please use `stdenv.isAarch32` instead"
         hostPlatform.isAarch32;
 


### PR DESCRIPTION
###### Motivation for this change

Backport of #46104

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

