### PR TITLE
profile-sync-daemon: 5.53 -> 6.33

### DIFF
--- a/nixos/modules/services/desktops/profile-sync-daemon.nix
+++ b/nixos/modules/services/desktops/profile-sync-daemon.nix
@@ -4,22 +4,7 @@ with lib;
 
 let
   cfg = config.services.psd;
-
-  configFile = ''
-    ${optionalString (cfg.users != [ ]) ''
-      USERS="${concatStringsSep " " cfg.users}"
-    ''}
-
-    ${optionalString (cfg.browsers != [ ]) ''
-      BROWSERS="${concatStringsSep " " cfg.browsers}"
-    ''}
-
-    ${optionalString (cfg.volatile != "") "VOLATILE=${cfg.volatile}"}
-    ${optionalString (cfg.daemonFile != "") "DAEMON_FILE=${cfg.daemonFile}"}
-  '';
-
 in {
-
   options.services.psd = with types; {
     enable = mkOption {
       type = bool;
@@ -28,32 +13,6 @@ in {
         Whether to enable the Profile Sync daemon.
       '';
     };
-
-    users = mkOption {
-      type = listOf str;
-      default = [ ];
-      example = [ "demo" ];
-      description = ''
-        A list of users whose browser profiles should be sync'd to tmpfs.
-      '';
-    };
-
-    browsers = mkOption {
-      type = listOf str;
-      default = [ ];
-      example = [ "chromium" "firefox" ];
-      description = ''
-        A list of browsers to sync. Available choices are:
-
-        chromium chromium-dev conkeror.mozdev.org epiphany firefox
-        firefox-trunk google-chrome google-chrome-beta google-chrome-unstable
-        heftig-aurora icecat luakit midori opera opera-developer opera-beta
-        qupzilla palemoon rekonq seamonkey
-
-        An empty list will enable all browsers.
-      '';
-    };
-
     resyncTimer = mkOption {
       type = str;
       default = "1h";
@@ -66,80 +25,53 @@ in {
         omitted.
       '';
     };
-
-    volatile = mkOption {
-      type = str;
-      default = "/run/psd-profiles";
-      description = ''
-        The directory where browser profiles should reside(this should be
-        mounted as a tmpfs). Do not include a trailing backslash.
-      '';
-    };
-
-    daemonFile = mkOption {
-      type = str;
-      default = "/run/psd";
-      description = ''
-        Where the pid and backup configuration files will be stored.
-      '';
-    };
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = cfg.users != [];
-        message = "services.psd.users must contain at least one user";
-      }
-    ];
-
     systemd = {
-      services = {
-        psd = {
-          description = "Profile Sync daemon";
-          wants = [ "psd-resync.service" "local-fs.target" ];
-          wantedBy = [ "multi-user.target" ];
-          preStart = "mkdir -p ${cfg.volatile}";
-
-          path = with pkgs; [ glibc rsync gawk ];
-
-          unitConfig = {
-            RequiresMountsFor = [ "/home/" ];
+      user = {
+        services = {
+          psd = {
+            enable = true;
+            description = "Profile Sync daemon";
+            wants = [ "psd-resync.service" "local-fs.target" ];
+            wantedBy = [ "default.target" ];
+            path = with pkgs; [ rsync kmod gawk nettools profile-sync-daemon ];
+            unitConfig = {
+              RequiresMountsFor = [ "/home/" ];
+            };
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = "yes";
+              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon sync";
+              ExecStop = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
+            };
           };
 
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = "yes";
-            ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon sync";
-            ExecStop = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
+          psd-resync = {
+            enable = true;
+            description = "Timed profile resync";
+            after = [ "psd.service" ];
+            wants = [ "psd-resync.timer" ];
+            partOf = [ "psd.service" ];
+            wantedBy = [ "default.target" ];
+            path = with pkgs; [ rsync kmod gawk nettools profile-sync-daemon ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";
+            };
           };
         };
 
-        psd-resync = {
-          description = "Timed profile resync";
-          after = [ "psd.service" ];
-          wants = [ "psd-resync.timer" ];
-          partOf = [ "psd.service" ];
+        timers.psd-resync = {
+          description = "Timer for profile sync daemon - ${cfg.resyncTimer}";
+          partOf = [ "psd-resync.service" "psd.service" ];
 
-          path = with pkgs; [ glibc rsync gawk ];
-
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";
+          timerConfig = {
+            OnUnitActiveSec = "${cfg.resyncTimer}";
           };
-        };
-      };
-
-      timers.psd-resync = {
-        description = "Timer for profile sync daemon - ${cfg.resyncTimer}";
-        partOf = [ "psd-resync.service" "psd.service" ];
-
-        timerConfig = {
-          OnUnitActiveSec = "${cfg.resyncTimer}";
         };
       };
     };
-
-    environment.etc."psd.conf".text = configFile;
-
   };
 }

--- a/pkgs/tools/misc/profile-sync-daemon/default.nix
+++ b/pkgs/tools/misc/profile-sync-daemon/default.nix
@@ -1,15 +1,24 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, utillinux}:
 
 stdenv.mkDerivation rec {
-  version = "5.53";
+  version = "6.33";
   name = "profile-sync-daemon-${version}";
 
   src = fetchurl {
     url = "http://github.com/graysky2/profile-sync-daemon/archive/v${version}.tar.gz";
-    sha256 = "0m7h9l7dndqgb5k3grpc00f6dpg73p6h4q5sgkf8bvyzvcbdafwx";
+    sha256 = "0dzs51xbszzmcg82n2dil6nljj4gn0aw9rqjmhyi4a5frc8g6xmb";
   };
 
-  installPhase = "PREFIX=\"\" DESTDIR=$out make install-systemd-all";
+  installPhase = ''
+    PREFIX=\"\" DESTDIR=$out make install
+    substituteInPlace $out/bin/profile-sync-daemon \
+      --replace "/usr/" "$out/" \
+      --replace "sudo " "/run/wrappers/bin/sudo "
+    # $HOME detection fails (and is unnecessary)
+    sed -i '/^HOME/d' $out/bin/profile-sync-daemon
+    substituteInPlace $out/bin/psd-overlay-helper \
+      --replace "PATH=/usr/bin:/bin" "PATH=${utillinux.bin}/bin"
+  '';
 
   preferLocalBuild = true;
 


### PR DESCRIPTION
Outdated package


This change is somewhat major in that the service transitioned from being a
systemd system service to a systemd user service. Hence I thought it was
appropriate to do away with the NixOS module altogether as modules are not
user-centric. I would suggest the following be used as a template, in
`/etc/nixos/configuration.nix`:

```nix
services.logind.extraConfig = "RuntimeDirectorySize=50%";
systemd = {
  user = {
    services = {
      psd = {
        description = "Profile Sync daemon";
        wants = [ "psd-resync.service" "local-fs.target" ];
        wantedBy = [ "multi-user.target" ];

        path = with pkgs; [ rsync kmod gawk nettools profile-sync-daemon ];

        unitConfig = {
          RequiresMountsFor = [ "/home/" ];
        };

        serviceConfig = {
          Type = "oneshot";
          RemainAfterExit = "yes";
          ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon sync";
          ExecStop = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
        };
      };

      psd-resync = {
        description = "Timed profile resync";
        after = [ "psd.service" ];
        wants = [ "psd-resync.timer" ];
        partOf = [ "psd.service" ];

        path = with pkgs; [ rsync kmod gawk nettools profile-sync-daemon ];

        serviceConfig = {
          Type = "oneshot";
          ExecStart = "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";
        };
      };
    };

    timers.psd-resync = {
      description = "Timer for profile sync daemon";
      partOf = [ "psd-resync.service" "psd.service" ];

      timerConfig = {
        OnUnitActiveSec = "1h";
      };
    };
  };
};
```

Note that the `VOLATILE` configuration option previously used to specify the
cache location has been deprecated (which is arguably a poor choice), and now
cache is stored in `$XDG_RUNTIME_DIR`. This is quite small on NixOS, so that's
what the `logind` line changes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---