### PR TITLE
gocode: c7fddb39 -> 00e7f5ac

### DIFF
--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -1,20 +1,47 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "gocode-${version}";
-  version = "20170903-${stdenv.lib.strings.substring 0 7 rev}";
-  rev = "c7fddb39ecbc9ebd1ebe7d2a3af473ed0fffffa1";
+  version = "20180727-${stdenv.lib.strings.substring 0 7 rev}";
+  rev = "00e7f5ac290aeb20a3d8d31e737ae560a191a1d5";
 
-  goPackagePath = "github.com/nsf/gocode";
+  goPackagePath = "github.com/mdempsky/gocode";
 
   # we must allow references to the original `go` package,
   # because `gocode` needs to dig into $GOROOT to provide completions for the
   # standard packages.
   allowGoReference = true;
 
-  src = fetchgit {
+  src = fetchFromGitHub {
+    owner = "mdempsky";
+    repo = "gocode";
     inherit rev;
-    url = "https://github.com/nsf/gocode";
-    sha256 = "0qx8pq38faig41xkl1a4hrgp3ziyjyn6g53vn5wj7cdgm5kk67nb";
+    sha256 = "0vrwjq4r90za47hm88yx5h2mvkv7y4yaj2xbx3skg62wq2drsq31";
+  };
+
+  preBuild = ''
+    # getting an error building the testdata because they contain invalid files
+    # on purpose as part of the testing.
+    rm -r go/src/$goPackagePath/internal/suggest/testdata
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An autocompletion daemon for the Go programming language";
+    longDescription = ''
+      Gocode is a helper tool which is intended to be integrated with your
+      source code editor, like vim, neovim and emacs. It provides several
+      advanced capabilities, which currently includes:
+
+        - Context-sensitive autocompletion
+
+      It is called daemon, because it uses client/server architecture for
+      caching purposes. In particular, it makes autocompletions very fast.
+      Typical autocompletion time with warm cache is 30ms, which is barely
+      noticeable.
+    '';
+    homepage = https://github.com/mdempsky/gocode;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ kalbasit ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Also, switch to the now-maintained fork of gocode available at github.com/mdempsky/gocode because github.com/nsf/gocode is now unmaintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

