### PR TITLE
patch-shebangs: respect cross compilation for 18.09

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -5,10 +5,32 @@
 # rewritten to /nix/store/<hash>/bin/python.  Interpreters that are
 # already in the store are left untouched.
 
-fixupOutputHooks+=('if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then patchShebangs "$prefix"; fi')
+fixupOutputHooks+=(patchShebangsAuto)
+
+# Run patch shebangs on a directory.
+# patchShebangs [--build | --host] directory
+
+# Flags:
+# --build : Lookup commands available at build-time
+# --host  : Lookup commands available at runtime
+
+# Example use cases,
+# $ patchShebangs --host /nix/store/...-hello-1.0/bin
+# $ patchShebangs --build configure
 
 patchShebangs() {
+    local pathName
+
+    if [ "$1" = "--host" ]; then
+        pathName=HOST_PATH
+        shift
+    elif [ "$1" = "--build" ]; then
+        pathName=PATH
+        shift
+    fi
+
     local dir="$1"
+
     header "patching script interpreter paths in $dir"
     local f
     local oldPath
@@ -27,6 +49,14 @@ patchShebangs() {
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
         read -r oldPath arg0 args <<< "$oldInterpreterLine"
 
+        if [ -z "$pathName" ]; then
+            if [[ "$f" = "$NIX_STORE"* ]]; then
+                pathName=HOST_PATH
+            else
+                pathName=PATH
+            fi
+        fi
+
         if $(echo "$oldPath" | grep -q "/bin/env$"); then
             # Check for unsupported 'env' functionality:
             # - options: something starting with a '-'
@@ -35,14 +65,17 @@ patchShebangs() {
                 echo "unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)"
                 exit 1
             fi
-            newPath="$(command -v "$arg0" || true)"
+
+            newPath="$(PATH="${!pathName}" command -v "$arg0" || true)"
         else
             if [ "$oldPath" = "" ]; then
                 # If no interpreter is specified linux will use /bin/sh. Set
                 # oldpath="/bin/sh" so that we get /nix/store/.../sh.
                 oldPath="/bin/sh"
             fi
-            newPath="$(command -v "$(basename "$oldPath")" || true)"
+
+            newPath="$(PATH="${!pathName}" command -v "$(basename "$oldPath")" || true)"
+
             args="$arg0 $args"
         fi
 
@@ -64,4 +97,18 @@ patchShebangs() {
     done
 
     stopNest
+}
+
+patchShebangsAuto () {
+    if [ -z "$dontPatchShebangs" -a -e "$prefix" ]; then
+
+        # Dev output will end up being run on the build platform. An
+        # example case of this is sdl2-config. Otherwise, we can just
+        # use the runtime path (--host).
+        if [ "$output" != out ] && [ "$output" = "${!outputDev}" ]; then
+            patchShebangs --build "$prefix"
+        else
+            patchShebangs --host "$prefix"
+        fi
+    fi
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -500,11 +500,11 @@ activatePackage() {
     # the transition, we do include everything in thatcase.
     #
     # TODO(@Ericson2314): Don't special-case native compilation
-    if [[ ( -z "${strictDeps-}" ||  "$hostOffset" -le -1 ) && -d "$pkg/bin" ]]; then
+    if [[ ( -z "${strictDeps-}" || "$hostOffset" -le -1 ) && -d "$pkg/bin" ]]; then
         addToSearchPath _PATH "$pkg/bin"
     fi
 
-    if [[ "$hostOffset" -eq 0 && -d "$pkg/bin" ]]; then
+    if [[ ( -z "${strictDeps-}" || "$hostOffset" -eq 0 ) && -d "$pkg/bin" ]]; then
         addToSearchPath HOST_PATH "$pkg/bin"
     fi
 

--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ udev ];
+  buildInputs = [
+    udev
+    runtimeShellPackage # So patchShebangs finds a bash suitable for the installed scripts
+  ];
 
   preConfigure = "patchShebangs ./configure";
 
@@ -28,11 +31,6 @@ stdenv.mkDerivation rec {
 
   # Check that the udev plugin got built.
   postInstall = stdenv.lib.optional (udev != null) "[ -e $out/lib/dhcpcd/dev/udev.so ]";
-
-  # TODO shlevy remove once patchShebangs is fixed
-  postFixup = ''
-    find $out -type f -print0 | xargs --null sed -i 's|${stdenv.shellPackage}|${runtimeShellPackage}|'
-  '';
 
   meta = {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";


### PR DESCRIPTION
###### Motivation for this change

This is a version of https://github.com/NixOS/nixpkgs/pull/43833 made more conservative to *only* affect cross builds (well, anything enabling `strictDeps`). I hope that makes it conservative enough to land in 18.09. Sorry I didn't make this earlier, pre-fork.

The idea is that if `strictDeps` isn't defined, `HOST_PATH` is defined exactly the same as `PATH`. This means that `patchShebangs`, `patchShebangs --build`, and `patchShebangs --host` are all defined the same as each other and as `patchShebangs` is today.

I still like @matthewbauer's version for `staging` and 19.03 and beyond. The breakage it creates points us to things worth fixing, just not as part of the 18.09 deadline!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

