### PR TITLE
noti: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3888,6 +3888,11 @@
     github = "StillerHarpo";
     name = "Florian Engel";
   };
+  stites = {
+    email = "sam@stites.io";
+    github = "stites";
+    name = "Sam Stites";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "noti-${version}";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "variadico";
+    repo = "noti";
+    rev = "${version}";
+    sha256 = "1chsqfqk0pnhx5k2nr4c16cpb8m6zv69l1jvv4v4903zgfzcm823";
+  };
+
+  goPackagePath = "github.com/variadico/noti";
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-X ${goPackagePath}/internal/command.Version=${version}")
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/man/man{1,5}/
+    cp $src/docs/man/noti.1      $out/share/man/man1/
+    cp $src/docs/man/noti.yaml.5 $out/share/man/man5/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Monitor a process and trigger a notification.";
+    longDescription = ''
+      Monitor a process and trigger a notification.
+
+      Never sit and wait for some long-running process to finish. Noti can alert you when it's done. You can receive messages on your computer or phone.
+    '';
+    homepage = https://github.com/variadico/noti;
+    license = licenses.mit;
+    maintainers = [ maintainers.stites ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1462,6 +1462,8 @@ with pkgs;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };
 
+  noti = callPackage ../tools/misc/noti { };
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   nwipe = callPackage ../tools/security/nwipe { };


### PR DESCRIPTION
###### Motivation for this change
Add a new, works-out-of-the-box notifier

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions: Ubunt17.04
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

First-time submitter! let me know if I should move this package somewhere else, or if anything is wrong. 
