### PR TITLE
prettyping: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3888,6 +3888,11 @@
     github = "StillerHarpo";
     name = "Florian Engel";
   };
+  stites = {
+    email = "sam@stites.io";
+    github = "stites";
+    name = "Sam Stites";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/pkgs/development/tools/prettyping/default.nix
+++ b/pkgs/development/tools/prettyping/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation rec {
+  name = "prettyping-${version}";
+  version = "1.0.1";
+
+  src = fetchgit {
+    url = "https://github.com/denilsonsa/prettyping";
+    rev = "e8d7538b8742b27cffe28e9dfe13d1d1a12288e3";
+    sha256 = "05vfaq9y52z40245j47yjk1xaiwrazv15sgjq64w91dfyahjffxf";
+    fetchSubmodules = false;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    chmod +x $src/prettyping
+    install $src/prettyping $out/bin/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A wrapper around the standard ping tool, making the output prettier, more colorful, more compact, and easier to read.";
+    longDescription = ''
+      `prettyping` runs the standard ping in background and parses its output, showing ping responses in a graphical way at the terminal (by using colors and Unicode characters). Don’t have support for UTF-8 in your terminal? No problem, you can disable it and use standard ASCII characters instead. Don’t have support for colors? No problem, you can also disable them.
+    '';
+    homepage = http://denilson.sa.nom.br/prettyping/;
+    license = licenses.mit;
+    maintainers = [ maintainers.stites ];
+    platforms = platforms.all;
+  };
+}
+
+


### PR DESCRIPTION
###### Motivation for this change
Another great script (recently cameo'd in [CLI: Improved](https://remysharp.com/2018/08/23/cli-improved), _Remy Sharp_).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions: Ubuntu 17.01
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
 
Heads-up, this will conflict with #46111 since both update maintainers.nix at the same place. 
