### PR TITLE
kakoune-lsp-client: init 5.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2947,6 +2947,11 @@
     github = "np";
     name = "Nicolas Pouillard";
   };
+  nrdxp = {
+    email = "34083928+nrdxp@users.noreply.github.com";
+    github = "nrdxp";
+    name = "Timothy DeHerrera";
+  };
   nslqqq = {
     email = "nslqqq@gmail.com";
     name = "Nikita Mikhailov";

--- a/pkgs/development/tools/misc/kakoune-lsp-client/default.nix
+++ b/pkgs/development/tools/misc/kakoune-lsp-client/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "kakoune-lsp-client-${version}";
+  version = "5.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ul";
+    repo = "kak-lsp";
+    rev = "v" + version;
+    sha256 = "0jgdpxcjvzk6zp3kak6bhvhzmgmaga74ia1c3y2i5z39w6gjbycj";
+  };
+
+  cargoSha256 = "0pa16923n2nkxxz991dgh9ilydpi4lfb9j23aciylmss909dv29f";
+
+  postInstall = ''
+    install -Dm644 -t "$out/etc/kak-lsp" kak-lsp.toml
+    install -Dm644 -t "$out/lib/systemd/user" kak-lsp.service
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Language Server Protocol client for Kakoune implemented in Rust";
+    homepage = https://github.com/ul/kak-lsp;
+    license = with licenses; [ unlicense ];
+    maintainers = with maintainers; [ nrdxp ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3438,6 +3438,8 @@ with pkgs;
 
   kakoune = callPackage ../applications/editors/kakoune { };
 
+  kakoune-lsp-client = callPackage ../development/tools/misc/kakoune-lsp-client { };
+
   kbdd = callPackage ../applications/window-managers/kbdd { };
 
   kdbplus = pkgsi686Linux.callPackage ../applications/misc/kdbplus { };


### PR DESCRIPTION
###### Motivation for this change

Adding initial working package for Kakoune's Language Server Protocol client version 5.2.1

upstream
https://github.com/ul/kak-lsp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions -- (Arch Linux)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

