### PR TITLE
gnu-smalltalk: fix build

### DIFF
--- a/pkgs/development/compilers/gnu-smalltalk/default.nix
+++ b/pkgs/development/compilers/gnu-smalltalk/default.nix
@@ -34,6 +34,8 @@ in stdenv.mkDerivation rec {
 
   configureFlags = stdenv.lib.optional (!emacsSupport) "--without-emacs";
 
+  hardeningDisable = [ "format" ];
+
   installFlags = stdenv.lib.optional emacsSupport "lispdir=$(out)/share/emacs/site-lisp";
 
   # For some reason the tests fail if executated with nix-build, but pass if


### PR DESCRIPTION
###### Motivation for this change

One more fix for ZHF #45960. Disable format hardening to get it to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

