### PR TITLE
pythonPackages.pymetar: 0.21 -> 1.0 

### DIFF
--- a/pkgs/development/python-modules/pymetar/default.nix
+++ b/pkgs/development/python-modules/pymetar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, isPy3k, fetchPypi }:
+{ stdenv, python, buildPythonPackage, isPy3k, fetchPypi }:
 
 buildPythonPackage rec {
   pname = "pymetar";
@@ -10,6 +10,16 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1n4k5aic4sgp43ki6j3zdw9b21r3biqqws8ah57b77n44b8wzrap";
   };
+
+  checkPhase = ''
+    cd testing/smoketest
+    tar xzf reports.tgz
+    mkdir logs
+    patchShebangs runtests.sh
+    substituteInPlace runtests.sh --replace "break" "exit 1"  # fail properly
+    export PYTHONPATH="$PYTHONPATH:$out/${python.sitePackages}"
+    ./runtests.sh
+  '';
 
   meta = with stdenv.lib; {
     description = "A command-line tool to show the weather report by a given station ID";

--- a/pkgs/development/python-modules/pymetar/default.nix
+++ b/pkgs/development/python-modules/pymetar/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "A command-line tool to show the weather report by a given station ID";
     homepage = http://www.schwarzvogel.de/software/pymetar.html;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ erosennin ];
   };
 }

--- a/pkgs/development/python-modules/pymetar/default.nix
+++ b/pkgs/development/python-modules/pymetar/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "pymetar";
-  version = "0.21";
+  version = "1.0";
 
-  disabled = isPy3k;
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1sh3nm5ilnsgpnzbb2wv4xndnizjayw859qp72798jadqpcph69k";
+    sha256 = "1n4k5aic4sgp43ki6j3zdw9b21r3biqqws8ah57b77n44b8wzrap";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

