### PR TITLE
python.pkgs.nipype: Futures is python 2 only. Also fix building.

### DIFF
--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -18,6 +18,8 @@
 , psutil
 , pydot
 , pytest
+, pytest_xdist
+, pytest-forked
 , scipy
 , simplejson
 , traits
@@ -47,8 +49,6 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
       --replace "/usr/bin/env bash" "${bash}/bin/bash"
-
-    rm pytest.ini
   '';
 
   propagatedBuildInputs = [
@@ -56,7 +56,6 @@ buildPythonPackage rec {
     dateutil
     funcsigs
     future
-    futures
     networkx
     nibabel
     numpy
@@ -70,9 +69,10 @@ buildPythonPackage rec {
     xvfbwrapper
   ] ++ stdenv.lib.optional (!isPy3k) [
     configparser
+    futures
   ];
 
-  checkInputs = [ pytest mock pytestcov codecov which glibcLocales ];
+  checkInputs = [ pytest mock pytestcov pytest_xdist pytest-forked codecov which glibcLocales ];
 
   checkPhase = ''
     LC_ALL="en_US.UTF-8" py.test -v --doctest-modules nipype


### PR DESCRIPTION
###### Motivation for this change
It seems like this commit: https://github.com/NixOS/nixpkgs/commit/ac21188b6eef7b2ff363a536f7608b74ff31ad27 may have broken nipype for Python 3.

@FRidh I'm not sure why the `rm pytest.ini` command was added, but that file seemed not to exist. There is a `nipype/pytest.ini` file, but removing it led to testing errors.

###### Things done

Tested build for python 2 and 3.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

