### PR TITLE
pythonPackages: cleanup gmpy[2], add phe

### DIFF
--- a/pkgs/development/python-modules/gmpy/default.nix
+++ b/pkgs/development/python-modules/gmpy/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage, fetchurl, isPyPy, gmp } :
+
+let
+  pname = "gmpy";
+  version = "1.17";
+in
+
+buildPythonPackage {
+  inherit pname version;
+
+  disabled = isPyPy;
+
+  src = fetchurl {
+    url = "mirror://pypi/g/gmpy/${pname}-${version}.zip";
+    sha256 = "1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14";
+  };
+
+  buildInputs = [ gmp ];
+
+  meta = {
+    description = "GMP or MPIR interface to Python 2.4+ and 3.x";
+    homepage = http://code.google.com/p/gmpy/;
+  };
+}

--- a/pkgs/development/python-modules/gmpy2/default.nix
+++ b/pkgs/development/python-modules/gmpy2/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchurl, isPyPy, gmp, mpfr, libmpc } :
+
+let
+  pname = "gmpy2";
+  version = "2.0.8";
+in
+
+buildPythonPackage {
+  inherit pname version;
+
+  disabled = isPyPy;
+
+  src = fetchurl {
+    url = "mirror://pypi/g/gmpy2/${pname}-${version}.zip";
+    sha256 = "0grx6zmi99iaslm07w6c2aqpnmbkgrxcqjrqpfq223xri0r3w8yx";
+  };
+
+  buildInputs = [ gmp mpfr libmpc ];
+
+  meta = with stdenv.lib; {
+    description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x";
+    homepage = http://code.google.com/p/gmpy/;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/development/python-modules/phe/default.nix
+++ b/pkgs/development/python-modules/phe/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy, isPy3k, click, gmpy2, numpy } :
+
+let
+  pname = "phe";
+  version = "1.4.0";
+in
+
+buildPythonPackage {
+  inherit pname version;
+
+  # https://github.com/n1analytics/python-paillier/issues/51
+  disabled = isPyPy || ! isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0wzlk7d24kp0f5kpm0kvvc88mm42144f5cg9pcpb1dsfha75qy5m";
+  };
+
+  buildInputs = [ click gmpy2 numpy ];
+
+  # 29/233 tests fail
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A library for Partially Homomorphic Encryption in Python";
+    homepage = https://github.com/n1analytics/python-paillier;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3732,6 +3732,8 @@ in {
     };
   };
 
+  phe = callPackage ../development/python-modules/phe { };
+
   phpserialize = callPackage ../development/python-modules/phpserialize { };
 
   plaid-python = callPackage ../development/python-modules/plaid-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2624,25 +2624,7 @@ in {
 
   GeoIP = callPackage ../development/python-modules/GeoIP { };
 
-  gmpy = buildPythonPackage rec {
-    name = "gmpy-1.17";
-    disabled = isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/g/gmpy/${name}.zip";
-      sha256 = "1a79118a5332b40aba6aa24b051ead3a31b9b3b9642288934da754515da8fa14";
-    };
-
-    buildInputs = [
-      pkgs.gcc
-      pkgs.gmp
-    ];
-
-    meta = {
-      description = "GMP or MPIR interface to Python 2.4+ and 3.x";
-      homepage = http://code.google.com/p/gmpy/;
-    };
-  };
+  gmpy = callPackage ../development/python-modules/gmpy { };
 
   gmpy2 = buildPythonPackage rec {
     name = "gmpy2-2.0.6";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2626,28 +2626,7 @@ in {
 
   gmpy = callPackage ../development/python-modules/gmpy { };
 
-  gmpy2 = buildPythonPackage rec {
-    name = "gmpy2-2.0.6";
-    disabled = isPyPy;
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/g/gmpy2/${name}.zip";
-      sha256 = "5041d0ae24407c24487106099f5bcc4abb1a5f58d90e6712cc95321975eddbd4";
-    };
-
-    buildInputs = [
-      pkgs.gcc
-      pkgs.gmp
-      pkgs.mpfr
-      pkgs.libmpc
-    ];
-
-    meta = {
-      description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x";
-      homepage = http://code.google.com/p/gmpy/;
-      license = licenses.gpl3Plus;
-    };
-  };
+  gmpy2 = callPackage ../development/python-modules/gmpy2 { };
 
   gmusicapi = with pkgs; buildPythonPackage rec {
     name = "gmusicapi-10.1.0";


### PR DESCRIPTION
###### Motivation for this change

This cleans up the `gmpy`, and `gmpy2` python packages and moves them into separate files.
Additionally, this adds `phe`, a library for Partially Homomorphic Encryption in Python".


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

