### PR TITLE
pythonPackages.pymatgen: 2018.8.10 -> 2018.9.1

### DIFF
--- a/pkgs/development/python-modules/pymatgen/default.nix
+++ b/pkgs/development/python-modules/pymatgen/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, buildPythonPackage, fetchPypi, glibcLocales, numpy, pydispatcher, sympy, requests, monty, ruamel_yaml, six, scipy, tabulate, enum34, matplotlib, palettable, spglib, pandas }:
+{ stdenv, buildPythonPackage, fetchPypi, glibcLocales, numpy, pydispatcher, sympy, requests, monty, ruamel_yaml, six, scipy, tabulate, enum34, matplotlib, palettable, spglib, pandas, networkx }:
 
 buildPythonPackage rec {
   pname = "pymatgen";
-  version = "2018.8.10";
+  version = "2018.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9bb3b170ca8654c956fa2efdd31107570c0610f7585d90e4a541eb99cee41603";
+    sha256 = "dee5dbd8008081de9f27759c20c550d09a07136eeebfe941e3d05fd88ccace18";
   };
 
   nativeBuildInputs = [ glibcLocales ];
-  propagatedBuildInputs = [ numpy pydispatcher sympy requests monty ruamel_yaml six scipy tabulate enum34 matplotlib palettable spglib pandas ];
-  
+  propagatedBuildInputs = [ numpy pydispatcher sympy requests monty ruamel_yaml six scipy tabulate enum34 matplotlib palettable spglib pandas networkx ];
+
   # No tests in pypi tarball.
   doCheck = false;
 
@@ -22,4 +22,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ psyanticy ];
   };
 }
-


### PR DESCRIPTION
Also 2018.8.10 does not build in previous state because auto updating
from pypi did not account for a new requirement `networkx`. This has
been added.

Contributes to #45960

###### Motivation for this change

pymatgen does not build in current state. 

###### Things done

pythonPackages.pymatgen: 2018.8.10 -> 2018.9.1
Added networkx as dependency

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

