### PR TITLE
arrayfire: init at 3.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1902,6 +1902,11 @@
     github = "jluttine";
     name = "Jaakko Luttinen";
   };
+  jmagoon = {
+    email = "js.magoon@gmail.com";
+    github = "jmagoon";
+    name = "Jon Magoon";
+  };
   jmettes = {
     email = "jonathan@jmettes.com";
     github = "jmettes";

--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -1,0 +1,26 @@
+{  stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "3.6.1";
+  name = "arrayfire-${version}";
+  src = fetchurl {
+    url = "http://arrayfire.s3.amazonaws.com/3.6.1/ArrayFire-v3.6.1_Linux_x86_64.sh";
+    sha256 = "14qsdbq2yz5bmj5zg4y8sb9pybz2h41zsc3fqv9nhmfmllb004gc";
+  };
+
+  phases = "installPhase";
+
+  installPhase = ''
+    bash ${src} --include-subdirs --prefix=$out
+    cd $out && mv arrayfire/* .
+    rm -rf arrayfire
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Multiplatform library for parallel GPU computation";
+    homepage = http://www.arrayfire.com/;
+    maintainers = with maintainers; [ "jmagoon" ];
+    license = licenses.cc-by-40;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/arrayfire/default.nix
+++ b/pkgs/development/libraries/arrayfire/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   version = "3.6.1";
   name = "arrayfire-${version}";
   src = fetchurl {
-    url = "http://arrayfire.s3.amazonaws.com/3.6.1/ArrayFire-v3.6.1_Linux_x86_64.sh";
+    url = "http://arrayfire.s3.amazonaws.com/${version}/ArrayFire-v${version}_Linux_x86_64.sh";
     sha256 = "14qsdbq2yz5bmj5zg4y8sb9pybz2h41zsc3fqv9nhmfmllb004gc";
   };
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Multiplatform library for parallel GPU computation";
     homepage = http://www.arrayfire.com/;
-    maintainers = with maintainers; [ "jmagoon" ];
+    maintainers = with maintainers; [ jmagoon ];
     license = licenses.cc-by-40;
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8897,6 +8897,8 @@ with pkgs;
 
   armadillo = callPackage ../development/libraries/armadillo {};
 
+  arrayfire = callPackage ../development/libraries/arrayfire {};
+
   arrow-cpp = callPackage ../development/libraries/arrow-cpp {};
 
   assimp = callPackage ../development/libraries/assimp { };


### PR DESCRIPTION
###### Motivation for this change
Added the Arrayfire package, a C++ library that wraps GPU computation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

