### PR TITLE
makefile2graph: init at 2018-01-03

### DIFF
--- a/pkgs/development/tools/analysis/makefile2graph/default.nix
+++ b/pkgs/development/tools/analysis/makefile2graph/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, makeWrapper, bash, gnumake }:
+
+stdenv.mkDerivation rec {
+  name = "makefile2graph-2018-01-03";
+
+  src = fetchFromGitHub {
+    owner = "lindenb";
+    repo = "makefile2graph";
+    rev = "61fb95a5ba91c20236f5e4deb11127c34b47091f";
+    sha256 = "07hq40bl48i8ka35fcciqcafpd8k9rby1wf4vl2p53v0665xaghr";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  fixupPhase = ''
+    substituteInPlace $out/bin/makefile2graph \
+      --replace '/bin/sh' ${bash}/bin/bash \
+      --replace 'make2graph' "$out/bin/make2graph"
+    wrapProgram $out/bin/makefile2graph \
+      --set PATH ${stdenv.lib.makeBinPath [ gnumake ]}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/lindenb/makefile2graph";
+    description = "Creates a graph of dependencies from GNU-Make; Output is a graphiz-dot file or a Gexf-XML file";
+    maintainers = with maintainers; [ cmcdragonkai ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3912,6 +3912,8 @@ with pkgs;
 
   makerpm = callPackage ../development/tools/makerpm { };
 
+  makefile2graph = callPackage ../development/tools/analysis/makefile2graph { };
+
   # See https://github.com/NixOS/nixpkgs/issues/15849. I'm switching on isLinux because
   # it looks like gnulib is broken on non-linux, so it seems likely that this would cause
   # trouble on bsd and/or cygwin as well.


### PR DESCRIPTION
###### Motivation for this change

This adds makefile2graph, the ability to generate graphs from makefiles!

While doing this, I found the tests doesn't work properly because of a bunch of assumptions, so I didn't run them. It would require substitutions on the source first.

Furthermore I found that replace substitution `make` was conflicting on substitutions on `make2graph`. So I separated them into 1 substitution, and the other was a `wrapProgram`. Any advice on simplifying this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

