### PR TITLE
gnaf-loader: init at 2018-09-10

### DIFF
--- a/pkgs/tools/misc/gnaf-loader/default.nix
+++ b/pkgs/tools/misc/gnaf-loader/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, makeWrapper, postgis, python3Packages, gnused }:
+
+stdenv.mkDerivation {
+  name = "gnaf-loader-2018-09-10";
+
+  src = fetchFromGitHub {
+    owner = "minus34";
+    repo = "gnaf-loader";
+    rev = "8561cae34fad996cdbbe24189bc5cd3c4da29955";
+    sha256 = "1g1r1d0jz7as29hlamg9rdj8nh5hyq00haplppbvlz7a85wk4i1x";
+  };
+
+  nativeBuildInputs = [ makeWrapper gnused ];
+
+  buildInputs = with python3Packages; [ psycopg2 ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv load-gnaf.py $out
+    mv psma.py $out
+    mv postgres-scripts $out
+    sed \
+      -i \
+      '1s;^;#!/usr/bin/env python\n;' \
+      $out/load-gnaf.py
+    chmod u+x,g+x,o+x $out/load-gnaf.py
+    makeWrapper \
+      $out/load-gnaf.py \
+      $out/bin/load-gnaf.py \
+      --set PYTHONPATH "$PYTHONPATH" \
+      --set PATH '${stdenv.lib.makeBinPath [ postgis ]}'
+  '';
+
+  postFixup = ''
+    sed \
+      --regexp-extended \
+      --in-place \
+      's!log_file = .*!log_file = "./load-gnaf.log"!' \
+      $out/load-gnaf.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/minus34/gnaf-loader;
+    description = "A quick way to get started with PSMA's open GNAF & Admin Boundaries";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ cmcdragonkai ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2776,6 +2776,8 @@ with pkgs;
 
   gmvault = callPackage ../tools/networking/gmvault { };
 
+  gnaf-loader = callPackage ../tools/misc/gnaf-loader { };
+
   gnash = callPackage ../misc/gnash { };
 
   gnaural = callPackage ../applications/audio/gnaural {


### PR DESCRIPTION
###### Motivation for this change

I need some help with this. It's a python script that isn't a Python package. I thought I can use `stdenv.mkDerivation` but how do I get a python module dependency into it? It relies on `psycopg2`!

gnaf-loader is a script that loads the GNAF data into a PostgreSQL database. The GNAF database is a database of all postable addresses in Australia and it's used by a lot of GIS applications targeting Australia.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

