### PR TITLE
python3Packages.genanki: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/genanki/default.nix
+++ b/pkgs/development/python-modules/genanki/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, cached-property, frozendict, pystache, pyyaml, pytest, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "genanki";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xj8yd3acl8h457sh42balvcd0z4mg5idd4q63f7qlfzc5wgbb74";
+  };
+
+  propagatedBuildInputs = [
+		pytestrunner
+    cached-property
+    frozendict
+    pystache
+    pyyaml
+  ];
+
+  checkInputs = [ pytest ];
+
+  disabled = !isPy3k;
+
+  # relies on upstream anki
+	doCheck = false;
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/kerrickstaley/genanki;
+    description = "Generate Anki decks programmatically";
+    license = licenses.mit;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -286,6 +286,8 @@ in {
 
   fire = callPackage ../development/python-modules/fire { };
 
+  genanki = callPackage ../development/python-modules/genanki { };
+
   globus-sdk = callPackage ../development/python-modules/globus-sdk { };
 
   goocalendar = callPackage ../development/python-modules/goocalendar { };


### PR DESCRIPTION


###### Motivation for this change

Library to generate anki flashcards. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

