### PR TITLE
top-level, stdenv: Make `system` and `stdenv.system` describe the hostPlatform

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -283,6 +283,14 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
       from your config without any issues.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      <literal>stdenv.system</literal> and <literal>system</literal> in nixpkgs now refer to the host platform instead of the build platform.
+      For native builds this is not change, let alone a breaking one.
+      For cross builds, it is a breaking change, and <literal>stdenv.buildPlatform.system</literal> can be used instead for the old behavior.
+      They should be using that anyways for clarity.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -127,6 +127,9 @@ let
         "`stdenv.isArm` is deprecated after 18.03. Please use `stdenv.isAarch32` instead"
         hostPlatform.isAarch32;
 
+      # The derivation's `system` is `buildPlatform.system`.
+      inherit (buildPlatform) system;
+
       # Whether we should run paxctl to pax-mark binaries.
       needsPax = isLinux;
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -89,7 +89,7 @@ let
     targetPlatform = lib.warn
       "top-level `targetPlatform` is deprecated since 18.09. Please use `stdenv.targetPlatform`."
       super.stdenv.targetPlatform;
-    inherit (super.stdenv.buildPlatform) system;
+    inherit (super.stdenv.hostPlatform) system;
   };
 
   splice = self: super: import ./splice.nix lib self (buildPackages != null);


### PR DESCRIPTION
###### Motivation for this change

Intuitively, one cares mainly about the host platform: Platforms differ in meaningful ways but compilation is morally a pure process and probably doesn't care, or those difference are already abstracted away. @Dezgeg also empirically confirmed that > 95% of checks are indeed of the host platform.

Yet these attributes in the old cross infrastructure were defined to be the build platform, for expediency. And this was never before changed. (For native builds build and host coincide, so it isn't clear what the
intention was.)

Fixing this doesn't affect native builds, since again they coincide. It also doesn't affect cross builds of anything in Nixpkgs, as these are no longer used. It could affect external cross builds, but I deem that
unlikely as anyone thinking about cross would use more explicit attributes for clarity, all the more so because the rarity of inspecting the build platform.

CC @dezgeg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

