### PR TITLE
Fix: Build solaar with pythonPackages

### DIFF
--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,5 +1,5 @@
-{fetchFromGitHub, stdenv, gtk3, python34Packages, gobjectIntrospection}:
-python34Packages.buildPythonApplication rec {
+{fetchFromGitHub, stdenv, gtk3, pythonPackages, gobjectIntrospection}:
+pythonPackages.buildPythonApplication rec {
   name = "solaar-unstable-${version}";
   version = "2018-02-02";
   namePrefix = "";
@@ -10,7 +10,7 @@ python34Packages.buildPythonApplication rec {
     sha256 = "0zy5vmjzdybnjf0mpp8rny11sc43gmm8172svsm9s51h7x0v83y3";
   };
 
-  propagatedBuildInputs = [python34Packages.pygobject3 python34Packages.pyudev gobjectIntrospection gtk3];
+  propagatedBuildInputs = [pythonPackages.pygobject3 pythonPackages.pyudev gobjectIntrospection gtk3];
   postInstall = ''
     wrapProgram "$out/bin/solaar" \
       --prefix PYTHONPATH : "$PYTHONPATH" \


### PR DESCRIPTION
###### Motivation for this change
Python34Packags led into build errors with pytest when trying to install solaar, changing to pythonPackages solved this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

