### PR TITLE
pythonPackages.phonopy: refactor

### DIFF
--- a/pkgs/development/python-modules/phonopy/default.nix
+++ b/pkgs/development/python-modules/phonopy/default.nix
@@ -10,9 +10,12 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ numpy pyyaml matplotlib h5py ];
-  
+
   checkPhase = ''
-    cd test/phonopy
+    cd test
+    # dynamic structure factor test ocassionally fails do to roundoff
+    # see issue https://github.com/atztogo/phonopy/issues/79
+    rm spectrum/test_dynamic_structure_factor.py
     ${python.interpreter} -m unittest discover -b
     cd ../..
   '';
@@ -24,4 +27,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ psyanticy ];
   };
 }
-


### PR DESCRIPTION
Fixing phonopy not building. Tests were moved on Jul 30.

###### Motivation for this change

Fixing #45960 phonopy not building.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

