### PR TITLE
pythonPackages.geopandas: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -1,23 +1,23 @@
 { stdenv, buildPythonPackage, fetchFromGitHub
 , pandas, shapely, fiona, descartes, pyproj
-, pytest }:
+, pytest, Rtree }:
 
 buildPythonPackage rec {
   pname = "geopandas";
-  version = "0.3.0";
+  version = "0.4.0";
   name = pname + "-" + version;
 
   src = fetchFromGitHub {
     owner = "geopandas";
     repo = "geopandas";
     rev = "v${version}";
-    sha256 = "0maafafr7sjjmlg2f19bizg06c8a5z5igmbcgq6kgmi7rklx8xxz";
+    sha256 = "025zpgck5pnmidvzk0805pr345rd7k6z66qb2m34gjh1814xjkhv";
   };
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest Rtree ];
 
   checkPhase = ''
-    py.test geopandas
+    py.test geopandas -m "not web"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Additionally fix issue with tests failing for 18.09 release.

Tests required url fetch. Disabled with "not web".

###### Motivation for this change

Fix build in 27 and 36. #45960

###### Things done

pythonPackages.geopandas: 0.3.0 -> 0.4.0

fix build. Tests now pass.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

