### PR TITLE
pythonPackages.jupyterlab_launcher: refactor

### DIFF
--- a/pkgs/development/python-modules/jupyterlab_launcher/default.nix
+++ b/pkgs/development/python-modules/jupyterlab_launcher/default.nix
@@ -1,7 +1,8 @@
-{ lib, buildPythonPackage, fetchPypi, jsonschema, notebook }:
+{ lib, buildPythonPackage, fetchPypi, jsonschema, notebook, pythonOlder }:
 buildPythonPackage rec {
   pname = "jupyterlab_launcher";
   version = "0.13.1";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;


### PR DESCRIPTION
jupyterlab_launcher does not support python version < 3.5. Disabled
for older versions. See https://pypi.org/project/jupyterlab-launcher/#description

###### Motivation for this change

18.09 Zero Hydra Failures #45960 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

