### PR TITLE
pythonPackages:ordered-set: refactor

### DIFF
--- a/pkgs/development/python-modules/ordered-set/default.nix
+++ b/pkgs/development/python-modules/ordered-set/default.nix
@@ -1,10 +1,10 @@
-{ buildPythonPackage, fetchPypi, lib, pytest }:
+{ buildPythonPackage, fetchPypi, lib, pytest, pytestrunner }:
 
 buildPythonPackage rec {
   pname = "ordered-set";
   version = "3.0.1";
 
-  buildInputs = [ pytest ];
+  buildInputs = [ pytest pytestrunner ];
 
   src = fetchPypi {
     inherit pname version;
@@ -21,6 +21,3 @@ buildPythonPackage rec {
     maintainers = [ lib.maintainers.MostAwesomeDude ];
   };
 }
-
-
-


### PR DESCRIPTION
missing dependency for doing tests (pytestrunner) added three months
ago June https://github.com/LuminosoInsight/ordered-set/commit/c0b9308988a0c5953d98aecef63bb61f3a758609.

###### Motivation for this change

18.09 Zero Hydra Failures #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

