### PR TITLE
pythonPackages.ncclient: refactor + init pythonPackages.selectors2

### DIFF
--- a/pkgs/development/python-modules/ncclient/default.nix
+++ b/pkgs/development/python-modules/ncclient/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , paramiko
+, selectors2
 , lxml
 , libxml2
 , libxslt
@@ -21,7 +22,7 @@ buildPythonPackage rec {
   checkInputs = [ nose rednose ];
 
   propagatedBuildInputs = [
-    paramiko lxml libxml2 libxslt
+    paramiko lxml libxml2 libxslt selectors2
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/selectors2/default.nix
+++ b/pkgs/development/python-modules/selectors2/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, nose, psutil, mock }:
+
+buildPythonPackage rec {
+  version = "2.0.1";
+  pname = "selectors2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "81b77c4c6f607248b1d6bbdb5935403fef294b224b842a830bbfabb400c81884";
+  };
+
+  checkInputs = [ nose psutil mock ];
+
+  checkPhase = ''
+    # https://github.com/NixOS/nixpkgs/pull/46186#issuecomment-419450064
+    # Trick to disable certain tests that depend on timing which
+    # will always fail on hydra
+    export TRAVIS=""
+    nosetests tests/test_selectors2.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.github.com/SethMichaelLarson/selectors2;
+    description = "Back-ported, durable, and portable selectors";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -536,6 +536,8 @@ in {
 
   seekpath = callPackage ../development/python-modules/seekpath { };
 
+  selectors2 = callPackage ../development/python-modules/selectors2 { };
+
   serversyncstorage = callPackage ../development/python-modules/serversyncstorage {};
 
   simpleeval = callPackage ../development/python-modules/simpleeval { };


### PR DESCRIPTION
###### Motivation for this change

18.09 Zero Hydra Failures #45960

###### Things done

ncclient fails to build due to new dependency. adding selectors2 as dependency of ncclient. Added recently 20 days ago in August. https://github.com/ncclient/ncclient/commit/8ef20f282877097c8f51604679277db49c39f80c

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

