### PR TITLE
pythonPackages.locustio: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/development/python-modules/locustio/default.nix
+++ b/pkgs/development/python-modules/locustio/default.nix
@@ -1,8 +1,8 @@
 { buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , mock
 , unittest2
-, msgpack-python
+, msgpack
 , requests
 , flask
 , gevent
@@ -11,18 +11,16 @@
 
 buildPythonPackage rec {
   pname = "locustio";
-  version = "0.8.1";
+  version = "0.9.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "64583987ba1c330bb071aee3e29d2eedbfb7c8b342fa064bfb74fafcff660d61";
+  src = fetchFromGitHub {
+    owner = "locustio";
+    repo = "locust";
+    rev = "${version}";
+    sha256 = "1645d63ig4ymw716b6h53bhmjqqc13p9r95k1xfx66ck6vdqnisd";
   };
 
-  patchPhase = ''
-    sed -i s/"pyzmq=="/"pyzmq>="/ setup.py
-  '';
-
-  propagatedBuildInputs = [ msgpack-python requests flask gevent pyzmq ];
+  propagatedBuildInputs = [ msgpack requests flask gevent pyzmq ];
   buildInputs = [ mock unittest2 ];
 
   meta = {


### PR DESCRIPTION
Fixing build issue. Additionally fetching from github becuase pypi
packge does not come with README which is a buildtime dependency.

###### Motivation for this change

18.09 Zero Hydra Failures #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

