### PR TITLE
nixos: doc: implement #12542

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -252,7 +252,7 @@ in rec {
     ''; # */
 
   # Generate the NixOS manual.
-  manual = runCommand "nixos-manual"
+  manualHTML = runCommand "nixos-manual-html"
     { inherit sources;
       nativeBuildInputs = [ buildPackages.libxml2.bin buildPackages.libxslt.bin ];
       meta.description = "The NixOS manual in HTML format";
@@ -281,6 +281,11 @@ in rec {
       echo "doc manual $dst" >> $out/nix-support/hydra-build-products
     ''; # */
 
+  # Alias for backward compatibility. TODO(@oxij): remove eventually.
+  manual = manualHTML;
+
+  # Index page of the NixOS manual.
+  manualHTMLIndex = "${manualHTML}/share/doc/nixos/index.html";
 
   manualEpub = runCommand "nixos-manual-epub"
     { inherit sources;

--- a/nixos/doc/manual/development/building-parts.xml
+++ b/nixos/doc/manual/development/building-parts.xml
@@ -34,7 +34,7 @@ $ nix-build -A system</screen>
    </varlistentry>
    <varlistentry>
     <term>
-     <varname>system.build.manual.manual</varname>
+     <varname>system.build.manual.manualHTML</varname>
     </term>
     <listitem>
      <para>

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -28,7 +28,7 @@ rec {
       modules = configurations ++
         [ ../modules/virtualisation/qemu-vm.nix
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
-          { key = "no-manual"; services.nixosManual.enable = false; }
+          { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
         ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
       extraArgs = { inherit nodes; };

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde.nix
@@ -30,7 +30,7 @@ with lib;
       Version=1.0
       Type=Application
       Name=NixOS Manual
-      Exec=firefox ${config.system.build.manual.manual}/share/doc/nixos/index.html
+      Exec=firefox ${config.system.build.manual.manualHTMLIndex}
       Icon=text-html
     '';
 

--- a/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
+++ b/nixos/modules/installer/cd-dvd/system-tarball-sheevaplug.nix
@@ -137,7 +137,7 @@ in
   # Setting vesa, we don't get the nvidia driver, which can't work in arm.
   services.xserver.videoDrivers = [ "vesa" ];
 
-  services.nixosManual.enable = false;
+  documentation.nixos.enable = false;
 
   # Include the firmware for various wireless cards.
   networking.enableRalinkFirmware = true;

--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -22,7 +22,7 @@ with lib;
   config = {
 
     # Enable in installer, even if the minimal profile disables it.
-    services.nixosManual.enable = mkForce true;
+    documentation.nixos.enable = mkForce true;
 
     # Show the manual.
     services.nixosManual.showManual = true;

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -12,7 +12,7 @@ with lib;
   i18n.supportedLocales = [ (config.i18n.defaultLocale + "/UTF-8") ];
 
   documentation.enable = mkDefault false;
-  services.nixosManual.enable = mkDefault false;
+  documentation.nixos.enable = mkDefault false;
 
   sound.enable = mkDefault false;
 }

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -276,6 +276,7 @@ with lib;
 
     (mkRenamedOptionModule [ "programs" "info" "enable" ] [ "documentation" "info" "enable" ])
     (mkRenamedOptionModule [ "programs" "man"  "enable" ] [ "documentation" "man"  "enable" ])
+    (mkRenamedOptionModule [ "services" "nixosManual" "enable" ] [ "documentation" "nixos" "enable" ])
 
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"

--- a/nixos/modules/services/misc/nixos-manual.nix
+++ b/nixos/modules/services/misc/nixos-manual.nix
@@ -39,8 +39,6 @@ let
       in scrubbedEval.options;
   };
 
-  entry = "${manual.manual}/share/doc/nixos/index.html";
-
   helpScript = pkgs.writeScriptBin "nixos-help"
     ''
       #! ${pkgs.runtimeShell} -e
@@ -61,7 +59,7 @@ let
           fi
         fi
       fi
-      exec "$browser" ${entry}
+      exec "$browser" ${manual.manualHTMLIndex}
     '';
 
   desktopItem = pkgs.makeDesktopItem {
@@ -121,7 +119,7 @@ in
     environment.systemPackages = []
       ++ optionals config.services.xserver.enable [ desktopItem pkgs.nixos-icons ]
       ++ optional  config.documentation.man.enable manual.manpages
-      ++ optionals config.documentation.doc.enable [ manual.manual helpScript ];
+      ++ optionals config.documentation.doc.enable [ manual.manualHTML helpScript ];
 
     boot.extraTTYs = mkIf cfg.showManual ["tty${toString cfg.ttyNumber}"];
 
@@ -130,7 +128,7 @@ in
         { description = "NixOS Manual";
           wantedBy = [ "multi-user.target" ];
           serviceConfig =
-            { ExecStart = "${cfg.browser} ${entry}";
+            { ExecStart = "${cfg.browser} ${manual.manualHTMLIndex}";
               StandardInput = "tty";
               StandardOutput = "tty";
               TTYPath = "/dev/tty${toString cfg.ttyNumber}";

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -128,7 +128,8 @@ in rec {
 
   channel = import lib/make-channel.nix { inherit pkgs nixpkgs version versionSuffix; };
 
-  manual = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manual);
+  manualHTML = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manualHTML);
+  manual = manualHTML; # TODO(@oxij): remove eventually
   manualEpub = (buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manualEpub));
   manpages = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.manpages);
   manualGeneratedSources = buildFromConfig ({ ... }: { }) (config: config.system.build.manual.generatedSources);

--- a/nixos/tests/misc.nix
+++ b/nixos/tests/misc.nix
@@ -14,7 +14,7 @@ import ./make-test.nix ({ pkgs, ...} : rec {
     { swapDevices = mkOverride 0
         [ { device = "/root/swapfile"; size = 128; } ];
       environment.variables.EDITOR = mkOverride 0 "emacs";
-      services.nixosManual.enable = mkOverride 0 true;
+      documentation.nixos.enable = mkOverride 0 true;
       systemd.tmpfiles.rules = [ "d /tmp 1777 root root 10d" ];
       fileSystems = mkVMOverride { "/tmp2" =
         { fsType = "tmpfs";


### PR DESCRIPTION
###### Motivation for this change

NixOS `documentation` subtree was born out of 2/3s of #12542, this implements the leftover 1/3. This patchset consists of option renames, code movements, a bit of cleanup, and one new assert.

In short, nothing substantial.

This simply makes the `configuration.nix(5)` manual cleaner and the `services.nixosManual` service is now actually a service, not an amalgamation of different things.

###### Known issues

`services.nixosManual.showManual` should be renamed to `services.nixosManual.enable`, but since `services.nixosManual.enable` meant a completely different thing before and there's no `configVersion`-thing yet I left it as is.

###### Things done

- [X] It builds.

Don't merge sooner than 2018-09-09 23:59 UTC.