### PR TITLE
hyperscrypt-font: init at 1.1

### DIFF
--- a/pkgs/data/fonts/hyperscrypt/default.nix
+++ b/pkgs/data/fonts/hyperscrypt/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchzip, lib }:
+
+let
+  version = "1.1";
+  pname = "HyperScrypt";
+in
+
+fetchzip rec {
+  name = "${lib.toLower pname}-font-${version}";
+  url = "https://gitlab.com/StudioTriple/Hyper-Scrypt/-/archive/${version}/Hyper-Scrypt-${version}.zip";
+  sha256 = "01pf5p2scmw02s0gxnibiwxbpzczphaaapv0v4s7svk9aw2gmc0m";
+  postFetch = ''
+    mkdir -p $out/share/fonts/{truetype,opentype}
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}.ttf
+    unzip -j $downloadedFile \*${pname}.otf -d $out/share/fonts/opentype/${pname}.otf
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://velvetyne.fr/fonts/hyper-scrypt/;
+    description = "A modern stencil typeface inspired by stained glass technique";
+    longDescription = ''
+      The Hyper Scrypt typeface was designed for the Hyper Chapelle
+      exhibition. It was commissioned by AAAAA Atelier to Studio
+      Triple's designer Jérémy Landes.  Hyper Scrypt is a modern
+      stencil typeface inspired by the stained glass technique used in
+      the Metz cathedral. It borrows the stained glass method, drawing
+      holes for the light with black lead. This creates a reverse
+      typeface, where the shapes of the letters are drawn by their
+      counters. Hyper Scrypt is at the intersection between 3 metals :
+      the sacred lead of stained glass, the lead of print characters
+      and the heavy metal. Despite its organic look inherited for the
+      molted metal, Hyper Scrypt is based upon a rigorous grid,
+      allowing some neat alignements between shapes in multi lines
+      layouts.
+      '';
+    license = licenses.ofl;
+    maintainers = with maintainers; [ leenaars ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14939,6 +14939,8 @@ with pkgs;
 
   hanazono = callPackage ../data/fonts/hanazono { };
 
+  hyperscrypt-font = callPackage ../data/fonts/hyperscrypt { };
+
   ia-writer-duospace = callPackage ../data/fonts/ia-writer-duospace { };
 
   ibm-plex = callPackage ../data/fonts/ibm-plex { };


### PR DESCRIPTION
###### Motivation for this change

Interesting Libre font by French font artist Jérémy Landes from StudioTriple.fr

###### Things done

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

