### PR TITLE
default.nix: More thoroughly explain the macOS upgrade process

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,26 @@
 let requiredVersion = import ./lib/minver.nix; in
 
 if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.nixVersion == 1 then
+   let
+    fallback-paths = import ./nixos/modules/installer/tools/nix-fallback-paths.nix;
 
-  abort ''
+   in abort ''
 
     This version of Nixpkgs requires Nix >= ${requiredVersion}, please upgrade:
 
     - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.
 
-    - Alternatively, with Nix > 2.0 `nix upgrade-nix' can be used to imperatively
-      upgrade Nix. You may use `nix-env --version' to check which version you have.
+    - If you have a multi-user Nix installation on macOS, update Nix by running:
+
+          sudo -i nix-store -r ${fallback-paths.x86_64-darwin};
+          sudo -i ${fallback-paths.x86_64-darwin}/bin/nix-env --uninstall nix
+          sudo -i ${fallback-paths.x86_64-darwin}/bin/nix-env -i ${fallback-paths.x86_64-darwin}
+          sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+          sudo launchctl load /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+
+        if you have done that and still see this error message, also run:
+
+          ${fallback-paths.x86_64-darwin}/bin/nix-env -i ${fallback-paths.x86_64-darwin}
 
     - If you installed Nix using the install script (https://nixos.org/nix/install),
       it is safe to upgrade by running it again:


### PR DESCRIPTION
###### Motivation for this change

The install instructions broke an IRC user, `floop`'s setup and was pretty frustrating.

```
error: evaluation aborted with the following error message: '
This version of Nixpkgs requires Nix >= 2.0, please upgrade:

- If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.

- If you have a multi-user Nix installation on macOS, update Nix by running:

      sudo -i nix-store -r /nix/store/lc3ymlix73kaad5srjdgaxp9ngr1sg6g-nix-2.1.1;
      sudo -i /nix/store/lc3ymlix73kaad5srjdgaxp9ngr1sg6g-nix-2.1.1/bin/nix-env --uninstall nix
      sudo -i /nix/store/lc3ymlix73kaad5srjdgaxp9ngr1sg6g-nix-2.1.1/bin/nix-env -i /nix/store/lc3ymlix73kaad5srjdgaxp9ngr1sg6g-nix-2.1.1
      sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist
      sudo launchctl load /Library/LaunchDaemons/org.nixos.nix-daemon.plist

    if you have done that and still see this error message, also run:

      /nix/store/lc3ymlix73kaad5srjdgaxp9ngr1sg6g-nix-2.1.1/bin/nix-env -i /nix/store/lc3ymlix73kaad5srjdgaxp9ngr1sg6g-nix-2.1.1

- If you installed Nix using the install script (https://nixos.org/nix/install),
  it is safe to upgrade by running it again:

      curl https://nixos.org/nix/install | sh

For more information, please see the NixOS release notes at
https://nixos.org/nixos/manual or locally at
/home/grahamc/projects/nixpkgs/doc/manual/release-notes.

If you need further help, see https://nixos.org/nixos/support.html
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

