### PR TITLE
sickrage: init at v2018.07.21-1

### DIFF
--- a/pkgs/servers/sickrage/default.nix
+++ b/pkgs/servers/sickrage/default.nix
@@ -1,0 +1,21 @@
+{stdenv, fetchurl, pkgs, ...}:
+    stdenv.mkDerivation rec {
+        version = "v2018.07.21-1";
+        name = "sickrage-${version}";
+        src = fetchurl {
+            url = "https://github.com/SickRage/SickRage/archive/${version}.tar.gz";
+            sha256 = "0dc9502853e0f004a9643bbe81527d3a9cfc6a6aa92a87e49d43fa10d21e89e5";
+        };
+        buildInputs = with pkgs; [python27];
+        installPhase = ''
+            mkdir $out
+            cp -R * $out
+        '';
+        meta = {
+            description = "Automatic Video Library Manager for TV Shows";
+            longDescription = "It watches for new episodes of your favorite shows, and when they are posted it does its magic.";
+            homepage = "https://sickrage.github.io/";
+            licence = stdenv.lib.licenses.gpl3;
+            maintainers = "sterfield@gmail.com";
+        };
+    }

--- a/pkgs/servers/sickrage/default.nix
+++ b/pkgs/servers/sickrage/default.nix
@@ -15,7 +15,7 @@
             description = "Automatic Video Library Manager for TV Shows";
             longDescription = "It watches for new episodes of your favorite shows, and when they are posted it does its magic.";
             homepage = "https://sickrage.github.io/";
-            licence = stdenv.lib.licenses.gpl3;
-            maintainers = "sterfield@gmail.com";
+            license = stdenv.lib.licenses.gpl3;
+            maintainers = ["sterfield@gmail.com"];
         };
     }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1264,6 +1264,8 @@ with pkgs;
 
   emby = callPackage ../servers/emby { };
 
+  sickrage = callPackage ../servers/sickrage {};
+
   enca = callPackage ../tools/text/enca { };
 
   ent = callPackage ../tools/misc/ent { };


### PR DESCRIPTION
###### Motivation for this change
Sickrage is an "Automatic Video Library Manager for TV Shows.". It's the latest version as of now.
This is my first package and a rather simple one (all python libs are embedded in the code).

It's currently built against Nixos master branch and working fine. The NixOS module will follow.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

