### PR TITLE
libuv: Disable temperamental shutdown_close_pipe test on Aarch32.

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation rec {
         "multiple_listen" "delayed_accept"
         "shutdown_close_tcp" "shutdown_eof" "shutdown_twice" "callback_stack"
         "tty_pty"
+      ] ++ stdenv.lib.optionals stdenv.isAarch32 [
+        # I observe this test failing with some regularity on ARMv7:
+        # https://github.com/libuv/libuv/issues/1871
+        "shutdown_close_pipe"
       ];
     tdRegexp = lib.concatStringsSep "\\|" toDisable;
     in lib.optionalString doCheck ''


### PR DESCRIPTION
###### Motivation for this change
One `libuv` test fails more often than not on my ARMv7 machine. I filed [an upstream ticket](https://github.com/libuv/libuv/issues/1871), but it's not clear what the problem is, and it doesn't seem upstream is going to look at it. Since nobody else is complaining about this, I am assuming it is limited only to ARMv7, and have restricted the change to this arch. I also see that many tests are already disabled in libuv for spurious failures, so I'm hoping a change like this isn't too controversial.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

