### PR TITLE
libratbag: init at v0.9.903

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2808,6 +2808,11 @@
     github = "muflax";
     name = "Stefan Dorn";
   };
+  mvnetbiz = {
+    email = "mvnetbiz@gmail.com";
+    github = "mvnetbiz";
+    name = "Matt Votava";
+  };
   myrl = {
     email = "myrl.0xf@gmail.com";
     github = "myrl";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -275,6 +275,7 @@
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/pcscd.nix
   ./services/hardware/pommed.nix
+  ./services/hardware/ratbagd.nix
   ./services/hardware/sane.nix
   ./services/hardware/sane_extra_backends/brscan4.nix
   ./services/hardware/tcsd.nix

--- a/nixos/modules/services/hardware/ratbagd.nix
+++ b/nixos/modules/services/hardware/ratbagd.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.ratbagd;
+in
+{
+  ###### interface
+
+  options = {
+    services.ratbagd = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable ratbagd for configuring gaming mice.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    # Give users access to the "ratbagctl" tool
+    environment.systemPackages = [ pkgs.libratbag ];
+
+    services.dbus.packages = [ pkgs.libratbag ];
+
+    systemd.packages = [ pkgs.libratbag ];
+  };
+}

--- a/pkgs/os-specific/linux/libratbag/default.nix
+++ b/pkgs/os-specific/linux/libratbag/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig
+, glib, systemd, udev, libevdev, gitMinimal, check, valgrind, swig, python3 }:
+
+stdenv.mkDerivation rec {
+  name = "libratbag-${version}";
+  version = "0.9.903";
+
+  src = fetchFromGitHub {
+    owner  = "libratbag";
+    repo   = "libratbag";
+    rev    = "v${version}";
+    sha256 = "0cr5skrb7a5mgj7dkm647ib8336hb88bf11blaf6xldafi8b0jlj";
+  };
+
+
+  # todo: python should be in buildInputs, but right now meson propagates
+  # its own python. see: https://github.com/NixOS/nixpkgs/pull/46020
+  nativeBuildInputs = [
+    (python3.withPackages (ps: with ps; [ evdev pygobject3 ]))
+    meson ninja pkgconfig gitMinimal swig check valgrind
+  ];
+
+  buildInputs = [ glib systemd udev libevdev ];
+
+  mesonFlags = [
+    "-Dsystemd-unit-dir=./lib/systemd/system/"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Configuration library for gaming mice";
+    homepage    = https://github.com/libratbag/libratbag;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ mvnetbiz ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, meson, ninja, pkgconfig, gettext, fetchFromGitHub, python3
+, wrapGAppsHook, gtk3, glib, desktop-file-utils, appstream-glib, gnome3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "piper-${version}";
+  version = "0.2.902";
+
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner  = "libratbag";
+    repo   = "piper";
+    rev    =  version;
+    sha256 = "1ny0vf8ym9v040cb5h084k5wwn929fnhq9infbdq8f8vvy61magb";
+  };
+
+  nativeBuildInputs = [ meson ninja gettext pkgconfig wrapGAppsHook desktop-file-utils appstream-glib ];
+  buildInputs = [ gtk3 glib gnome3.defaultIconTheme python3 ];
+  propagatedBuildInputs = with python3.pkgs; [ lxml evdev pygobject3 ];
+
+  postPatch = ''
+    chmod +x meson_install.sh # patchShebangs requires executable file
+    patchShebangs meson_install.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GTK frontend for ratbagd mouse config daemon";
+    homepage    = https://github.com/libratbag/piper;
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ mvnetbiz ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17746,6 +17746,8 @@ with pkgs;
 
   pijul = callPackage ../applications/version-management/pijul {};
 
+  piper = callPackage ../os-specific/linux/piper { };
+
   plank = callPackage ../applications/misc/plank { };
 
   planner = callPackage ../applications/office/planner { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15022,6 +15022,8 @@ with pkgs;
 
   libertinus = callPackage ../data/fonts/libertinus { };
 
+  libratbag = callPackage ../os-specific/linux/libratbag { };
+
   libre-baskerville = callPackage ../data/fonts/libre-baskerville { };
 
   libre-bodoni = callPackage ../data/fonts/libre-bodoni { };


### PR DESCRIPTION
###### Motivation for this change
Libratbag is a daemon and utility for configuring DPI, buttons, etc. of programmable gaming mice.

###### Things done
Added package for libratbag and service module ratbagd.
Added piper: gtk frontend app for ratbagctl
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

