### PR TITLE
lib/generators.nix: broaden toINI usage

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -101,7 +101,7 @@ rec {
    */
   toINI = {
     # apply transformations (e.g. escapes) to section names
-    mkSectionName ? (name: libStr.escape [ "[" "]" ] name),
+    mkSectionName ? (name: "[" + (libStr.escape [ "[" "]" ] name) + "]"),
     # format a setting line from key and value
     mkKeyValue    ? mkKeyValueDefault {} "="
   }: attrsOfAttrs:
@@ -111,7 +111,7 @@ rec {
           libStr.concatStringsSep sep
             (libAttr.mapAttrsToList mapFn attrs);
         mkSection = sectName: sectValues: ''
-          [${mkSectionName sectName}]
+          ${mkSectionName sectName}
         '' + toKeyValue { inherit mkKeyValue; } sectValues;
     in
       # map input to ini sections


### PR DESCRIPTION
###### Motivation for this change
In home-manager, we generate configurations for different programs, like mbsync with this kind of config
```
IMAPAccount gmail
CertificateFile "/etc/ssl/certs/ca-certificates.crt"
Host "imap.gmail.com"
SSLType "IMAPS"
```
or with toml like (like in the MUA alot)

I would like to reuse the toINI function in nixpkgs to generate these config via overriding
mkSectionName and mkKeyValue but overriding mkSectionName doesn't get rid of the [ ] as I would like to to generate the previous example.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

