### PR TITLE
python3Packages.gpgme: enable python3 support

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, libgpgerror, gnupg, pkgconfig, glib, pth, libassuan
-, file, which
+, file, which, ncurses
 , autoreconfHook
 , git
 , texinfo
 , qtbase ? null
-, withPython ? false, swig2 ? null, python ? null
+, pythonSupport ? false, swig2 ? null, python ? null
 }:
 
 let
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (qtbase != null) qtbase;
 
   nativeBuildInputs = [ file pkgconfig gnupg autoreconfHook git texinfo ]
-  ++ lib.optionals withPython [ python swig2 which ];
+  ++ lib.optionals pythonSupport [ python swig2 which ncurses ];
 
   postPatch =''
     substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-fixed-path=${gnupg}/bin"
     "--with-libgpg-error-prefix=${libgpgerror.dev}"
-  ] ++ lib.optional withPython "--enable-languages=python";
+  ] ++ lib.optional pythonSupport "--enable-languages=python";
 
   NIX_CFLAGS_COMPILE =
     # qgpgme uses Q_ASSERT which retains build inputs at runtime unless

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5672,7 +5672,7 @@ in {
 
   google_cloud_speech = callPackage ../development/python-modules/google_cloud_speech { };
 
-  gpgme = toPythonModule (pkgs.gpgme.override { withPython=true; });
+  gpgme = toPythonModule (pkgs.gpgme.override { pythonSupport=true; inherit python; });
 
   gphoto2 = callPackage ../development/python-modules/gphoto2 {
     inherit (pkgs) pkgconfig;


### PR DESCRIPTION
when calling python3Packages.gpgme, it was still picking python2.
Changed withPython into pythonSupport since it's the convention.

I had to enable ncurses too because of this error when configuring:

```
configure:19858: checking for Python include path
configure:19874: result: -I/nix/store/hy65mn4wjswqih75gfr6g4q3xgqdm325-python3-3.6.6/include/python3.6m
configure:19881: checking for Python library path
configure:19958: result: -L/nix/store/hy65mn4wjswqih75gfr6g4q3xgqdm325-python3-3.6.6/lib -lpython3.6m
configure:19965: checking for Python site-packages path
configure:19971: result: /nix/store/hy65mn4wjswqih75gfr6g4q3xgqdm325-python3-3.6.6/lib/python3.6/site-packages
configure:19978: checking python extra libraries
configure:19985: result: -lpthread -ldl -lcrypt -lncurses -lutil -lm
configure:19992: checking python extra linking flags
configure:19999: result: -Xlinker -export-dynamic
configure:20006: checking consistency of all components of python development environment
configure:20032: gcc -o conftest -g -O2  -I/nix/store/hy65mn4wjswqih75gfr6g4q3xgqdm325-python3-3.6.6/include/python3.6m  conftest.c  -L/nix/store/hy65mn4wjswqih75gfr6g4q3xgqdm325-python3-3.6.6/lib -lpython3.6m -Xlinker -export-dynamic -lpthread -ldl -lcrypt -lncurses -lutil -lm >&5
/nix/store/h0lbngpv6ln56hjj59i6l77vxq25flbz-binutils-2.30/bin/ld: cannot find -lncurses
collect2: error: ld returned 1 exit status
configure:20032: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "gpgme"
| #define PACKAGE_TARNAME "gpgme"
| #define PACKAGE_VERSION "1.11.1"
| #define PACKAGE_STRING "gpgme 1.11.1"
| #define PACKAGE_BUGREPORT "http://bugs.gnupg.org"
| #define PACKAGE_URL ""
| #define PACKAGE "gpgme"
| #define VERSION "1.11.1"
| #define STDC_HEADERS 1
| #define HAVE_SYS_TYPES_H 1
| #define HAVE_SYS_STAT_H 1
| #define HAVE_STDLIB_H 1
| #define HAVE_STRING_H 1
| #define HAVE_MEMORY_H 1
| #define HAVE_STRINGS_H 1
| #define HAVE_INTTYPES_H 1
| #define HAVE_STDINT_H 1
| #define HAVE_UNISTD_H 1
| #define __EXTENSIONS__ 1
| #define _ALL_SOURCE 1
| #define _GNU_SOURCE 1
| #define _POSIX_PTHREAD_SEMANTICS 1
| #define _TANDEM_SOURCE 1
| #define PACKAGE "gpgme"
| #define VERSION "1.11.1"
| #define HAVE_DLFCN_H 1
| #define LT_OBJDIR ".libs/"
| #define FIXED_SEARCH_PATH "/nix/store/cf1fwlgilrv4z45qw5zvqkkvb1bv6zyv-gnupg-2.2.9/bin"
| /* end confdefs.h.  */
| 
| 		#include <Python.h>
| int
| main ()
| {
| Py_Initialize();
|   ;
|   return 0;
| }
| 
configure:20049: result: no
configure:20062: WARNING:
  Could not link test program to Python. Maybe the main Python library has been
  installed in some non-standard library path. If so, pass it to configure,
  via the LDFLAGS environment variable.
  Example: ./configure LDFLAGS="-L/usr/non-standard-path/python/lib"
  ============================================================================
   You probably have to install the development version of the Python package
   for your distribution.  The exact name of this package varies among them.
  ============================================================================
	   

```

###### Motivation for this change
Need python3 bindings for my mail agent "alot"

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

