### PR TITLE
gobject-introspection: Fix macos shared lib paths

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
+++ b/pkgs/development/libraries/gobject-introspection/absolute_shlib_path.patch
@@ -87,8 +87,8 @@
 +                    m = pattern.search(line)
                  if m:
                      del patterns[library]
--                    shlibs.append(m.group(1))
-+                    shlibs.append(os.path.join(options.fallback_libpath, m.group(1)))
+-                    shlibs.append(_sanitize_install_name(m.group(1)))
++                    shlibs.append(os.path.join(options.fallback_libpath, _sanitize_install_name(m.group(1))))
                      break
  
          if len(patterns) > 0:

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   patches = [
+    ./macos-shared-library.patch
     (substituteAll {
       src = ./absolute_shlib_path.patch;
       inherit nixStoreDir;

--- a/pkgs/development/libraries/gobject-introspection/macos-shared-library.patch
+++ b/pkgs/development/libraries/gobject-introspection/macos-shared-library.patch
@@ -1,0 +1,36 @@
+diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
+index c93d20c..4d4915d 100644
+--- a/giscanner/shlibs.py
++++ b/giscanner/shlibs.py
+@@ -43,6 +43,22 @@ def _resolve_libtool(options, binary, libraries):
+ 
+     return shlibs
+ 
++def _sanitize_install_name(install_name):
++    '''
++    On macOS, the dylib can be built with install_name as @rpath/libfoo.so
++    instead of the absolute path to the library, so handle that. The name
++    can also be @loader_path or @executable_path.
++    '''
++    if not install_name.startswith('@'):
++        return install_name
++    if install_name.startswith('@rpath/'):
++        return install_name[7:]
++    if install_name.startswith('@loader_path/'):
++        return install_name[13:]
++    if install_name.startswith('@executable_path/'):
++        return install_name[17:]
++    raise RuntimeError('Unknown install_name {!r}'.format(install_name))
++
+ 
+ # Assume ldd output is something vaguely like
+ #
+@@ -121,7 +137,7 @@ def _resolve_non_libtool(options, binary, libraries):
+                 m = pattern.search(line)
+                 if m:
+                     del patterns[library]
+-                    shlibs.append(m.group(1))
++                    shlibs.append(_sanitize_install_name(m.group(1)))
+                     break
+ 
+         if len(patterns) > 0:


### PR DESCRIPTION
This applies the proposed upstream patch (described in https://gitlab.gnome.org/GNOME/gobject-introspection/issues/222) before applying the current nixpkgs patches (which had to be updated slightly to apply on top of the upsteam patch).

I tested this fix by building `haskellPackages.gi-atk` and `haskellPackages.gi-gdkpixbuf` build on macos (both of which had were broken by #40599).  I also checked the `@rpath` was gone in:

```
$ cat $(nix-build ./default.nix -A atk.dev --system x86_64-darwin)/share/gir-1.0/Atk-1.0.gir | grep shared-library
             shared-library="/nix/store/25659xy1p1naj0c0rc1xf9bfj4l1ryij-atk-2.28.1/lib/libatk-1.0.0.dylib"
```

###### Things done:

- [ ] Tested using sandboxing (`nix-build --option build-use-chroot true` or [nix.useChroot](http://nixos.org/nixos/manual/options.html#opt-nix.useChroot) on NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] OS X
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### More

Fixes issue #<insert id>

cc @<maintainer>


---

_Please note, that points are not mandatory, but rather desired._
