### PR TITLE
watchexec: darwin support

### DIFF
--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -4,7 +4,7 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "watchexec-${version}";
-  version = "1.8.6";
+  version = "1.9.0";
   buildInputs = stdenv.lib.optional stdenv.isDarwin [ CoreServices ];
 
   preConfigure = ''
@@ -12,9 +12,9 @@ buildRustPackage rec {
   '';
 
   src = fetchFromGitHub {
-    owner = "mattgreen";
+    owner = "watchexec";
     repo = "watchexec";
-    rev = "${version}";
+    rev = version;
     sha256 = "1jib51dbr6s1iq21inm2xfsjnz1730nyd3af1x977iqivmwdisax";
   };
 
@@ -22,9 +22,9 @@ buildRustPackage rec {
 
   meta = with stdenv.lib; {
     description = "Executes commands in response to file modifications";
-    homepage = https://github.com/mattgreen/watchexec;
+    homepage = https://github.com/watchexec/watchexec;
     license = with licenses; [ asl20 ];
     maintainers = [ maintainers.michalrus ];
-    platforms = [ "x86_64-linux" "platforms.unix"];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -25,6 +25,6 @@ buildRustPackage rec {
     homepage = https://github.com/watchexec/watchexec;
     license = with licenses; [ asl20 ];
     maintainers = [ maintainers.michalrus ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -7,7 +7,7 @@ buildRustPackage rec {
   version = "1.9.0";
   buildInputs = stdenv.lib.optional stdenv.isDarwin [ CoreServices ];
 
-  preConfigure = ''
+  preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
     export NIX_LDFLAGS="-F${CoreFoundation}/Library/Frameworks -framework CoreFoundation $NIX_LDFLAGS"
   '';
 

--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -1,23 +1,30 @@
-{ stdenv, rustPlatform, fetchFromGitHub }:
+{ stdenv, lib, rustPlatform, fetchFromGitHub, CoreServices, CoreFoundation }:
 
-rustPlatform.buildRustPackage rec {
+with rustPlatform;
+
+buildRustPackage rec {
   name = "watchexec-${version}";
-  version = "1.9.0";
+  version = "1.8.6";
+  buildInputs = stdenv.lib.optional stdenv.isDarwin [ CoreServices ];
+
+  preConfigure = ''
+    export NIX_LDFLAGS="-F${CoreFoundation}/Library/Frameworks -framework CoreFoundation $NIX_LDFLAGS"
+  '';
 
   src = fetchFromGitHub {
-    owner = "watchexec";
+    owner = "mattgreen";
     repo = "watchexec";
-    rev = version;
-    sha256 = "0zp5s2dy5zbar0virvy1izjpvvgwbz7rvjmcy6bph6rb5c4bhm70";
+    rev = "${version}";
+    sha256 = "1jib51dbr6s1iq21inm2xfsjnz1730nyd3af1x977iqivmwdisax";
   };
 
-  cargoSha256 = "1li84kq9myaw0zwx69y72f3lx01s7i9p8yays4rwvl1ymr614y1l";
+  cargoSha256 = "0sm1jvx1y18h7y66ilphsqmkbdxc76xly8y7kxmqwdi4lw54i9vl";
 
   meta = with stdenv.lib; {
     description = "Executes commands in response to file modifications";
-    homepage = https://github.com/watchexec/watchexec;
+    homepage = https://github.com/mattgreen/watchexec;
     license = with licenses; [ asl20 ];
     maintainers = [ maintainers.michalrus ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" "platforms.unix"];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5807,7 +5807,9 @@ with pkgs;
 
   wal_e = callPackage ../tools/backup/wal-e { };
 
-  watchexec = callPackage ../tools/misc/watchexec { };
+  watchexec = callPackage ../tools/misc/watchexec {
+    inherit (darwin.apple_sdk.frameworks) CoreServices  CoreFoundation;
+  };
 
   watchman = callPackage ../development/tools/watchman {
     inherit (darwin.apple_sdk.frameworks) CoreServices;


### PR DESCRIPTION
###### Motivation for this change

`watchexec` wasn't building correctly on macOS. With help of @LnL7 it does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---