### PR TITLE
deepin-mutter: init at 3.20.34

### DIFF
--- a/pkgs/desktops/deepin/deepin-mutter/default.nix
+++ b/pkgs/desktops/deepin/deepin-mutter/default.nix
@@ -1,0 +1,61 @@
+{ stdenv, fetchFromGitHub, pkgconfig, intltool, libtool, gnome3, xorg,
+  libcanberra-gtk3, upower, xkeyboard_config, libxkbcommon,
+  libstartup_notification, libinput, cogl, clutter, systemd
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-mutter";
+  version = "3.20.34";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0s427fmj806ljpdg6jdvpfislk5m1xvxpnnyrq3l8b7pkhjvp8wd";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    intltool
+    libtool
+    gnome3.gnome-common
+  ];
+
+  buildInputs = [
+    gnome3.gtk
+    gnome3.gnome-desktop
+    gnome3.gsettings-desktop-schemas
+    gnome3.libgudev
+    gnome3.zenity
+    upower
+    xorg.libxkbfile
+    libxkbcommon
+    libcanberra-gtk3
+    libstartup_notification
+    libinput
+    xkeyboard_config
+    cogl
+    clutter
+    systemd
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--enable-native-backend"
+    "--enable-compile-warnings=minimum"
+  ];
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Base window manager for deepin, fork of gnome mutter";
+    homepage = https://github.com/linuxdeepin/deepin-mutter;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -8,6 +8,7 @@ let
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
     deepin-menu = callPackage ./deepin-menu { };
+    deepin-mutter = callPackage ./deepin-mutter { };
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
     deepin-terminal = callPackage ./deepin-terminal {
       inherit (pkgs.gnome3) libgee vte;

--- a/pkgs/development/libraries/clutter/default.nix
+++ b/pkgs/development/libraries/clutter/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, libGLU_combined, libX11, libXext, libXfixes
-, libXdamage, libXcomposite, libXi, libxcb, cogl, pango, atk, json-glib,
-gobjectIntrospection, gtk3, gnome3
+, libXdamage, libXcomposite, libXi, libxcb, cogl, pango, atk, json-glib
+, gobjectIntrospection, gtk3, gnome3, libinput, libgudev, libxkbcommon
 }:
 
 let
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   propagatedBuildInputs =
     [ libX11 libGLU_combined libXext libXfixes libXdamage libXcomposite libXi cogl pango
-      atk json-glib gobjectIntrospection libxcb
+      atk json-glib gobjectIntrospection libxcb libinput libgudev libxkbcommon
     ];
 
   configureFlags = [ "--enable-introspection" ]; # needed by muffin AFAIK

--- a/pkgs/development/libraries/cogl/default.nix
+++ b/pkgs/development/libraries/cogl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libGL, glib, gdk_pixbuf, xorg, libintl
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libGL, glib, gdk_pixbuf, xorg, libintl
 , pangoSupport ? true, pango, cairo, gobjectIntrospection, wayland, gnome3
 , mesa_noglu
 , gstreamerSupport ? true, gst_all_1 }:
@@ -13,6 +13,23 @@ in stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
     sha256 = "03f0ha3qk7ca0nnkkcr1garrm1n1vvfqhkz9lwjm592fnv6ii9rr";
   };
+
+  patches = [
+    # Some deepin packages need the following patches. They have been
+    # submitted by Fedora on the GNOME Bugzilla
+    # (https://bugzilla.gnome.org/787443). Upstream thinks the patch
+    # could be merged, but dev can not make a new release.
+
+    (fetchpatch {
+      url = https://bug787443.bugzilla-attachments.gnome.org/attachment.cgi?id=359589;
+      sha256 = "0f0d9iddg8zwy853phh7swikg4yzhxxv71fcag36f8gis0j5p998";
+    })
+
+    (fetchpatch {
+      url = https://bug787443.bugzilla-attachments.gnome.org/attachment.cgi?id=361056;
+      sha256 = "09fyrdci4727fg6qm5aaapsbv71sf4wgfaqz8jqlyy61dibgg490";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig libintl ];
 


### PR DESCRIPTION
###### Motivation for this change

- Add [deepin-mutter](https://github.com/linuxdeepin/deepin-mutter) (base window manager for deepin, fork of gnome mutter).
- `cogl`: Add GL_ARB_shader_texture_lod and copy_sub_image support, needed by `deepin-mutter`.
- `clutter`: enable evdev input, needed by `deepin-mutter`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).