### PR TITLE
weechat: fix quoting for ${}  syntax

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -133,13 +133,13 @@ in if configure == null then weechat else
 
       scripts = builtins.concatStringsSep ";" (lib.foldl (scripts: drv: scripts ++ mkScript drv)
         [ ] (config.scripts or []));
-    in "${scripts}\n${init}";
+    in "${scripts};${init}";
 
     mkWeechat = bin: (writeScriptBin bin ''
       #!${stdenv.shell}
       export WEECHAT_EXTRA_LIBDIR=${pluginsDir}
       ${lib.concatMapStringsSep "\n" (p: lib.optionalString (p ? extraEnv) p.extraEnv) plugins}
-      exec ${weechat}/bin/${bin} "$@" --run-command "${init}"
+      exec ${weechat}/bin/${bin} "$@" --run-command ${lib.escapeShellArg init}
     '') // {
       inherit (weechat) name meta;
       unwrapped = weechat;


### PR DESCRIPTION
###### Motivation for this change

In my previous PR I missed that ${sec.foobar} (syntax to retrieve
secrets in a weechat runtime) breaks the shell evaluation.

Furthermore `;` shall be used rather than `\n` to concat scripts and the
init config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

