### PR TITLE
pythonPackages.markerlib: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/markerlib/default.nix
+++ b/pkgs/development/python-modules/markerlib/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, nose
+}:
+
+buildPythonPackage rec {
+  version = "0.6.0";
+  pname = "markerlib";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2fdb3939441f5bf4f090b1979a34f84a11d33eed6c0e3995de88ae5c06b6e3ae";
+  };
+
+  buildInputs = [ setuptools ];
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/dholth/markerlib/;
+    description = "A compiler for PEP 345 environment markers";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -334,6 +334,8 @@ in {
 
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
+  markerlib = callPackage ../development/python-modules/markerlib { };
+
   monty = callPackage ../development/python-modules/monty { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

pythonPackages.markerlib: init at 0.6.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

