### PR TITLE
youtube-dl:  2018.08.28 -> 2018.09.01, fix youtube download

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchurl, buildPythonPackage
 , zip, ffmpeg, rtmpdump, phantomjs2, atomicparsley, pycryptodome, pandoc
+, fetchpatch
 # Pandoc is required to build the package's man page. Release tarballs contain a
 # formatted man page already, though, it will still be installed. We keep the
 # manpage argument in place in case someone wants to use this derivation to
@@ -21,6 +22,15 @@ buildPythonPackage rec {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
     sha256 = "0h8x8agl4s5cnfzwmshbcg4pxcgg3iyb86w8krs21y2k9d1ng036";
   };
+
+  patches = [
+    # https://github.com/rg3/youtube-dl/pull/17464
+    (fetchpatch {
+      name = "youtube-js-player-fix.patch";
+      url = "https://github.com/rg3/youtube-dl/pull/17464/commits/6d7359775ae4eef1d1213aae81e092467a2c675c.patch";
+      sha256 = "12mwfmp7iwlawpx6r4rhz546b3anxrx6zc4nyjs8grbh5vxhj9yg";
+    })
+  ];
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ zip ] ++ lib.optional generateManPage pandoc;

--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -15,11 +15,11 @@
 buildPythonPackage rec {
 
   pname = "youtube-dl";
-  version = "2018.08.28";
+  version = "2018.09.01";
 
   src = fetchurl {
     url = "https://yt-dl.org/downloads/${version}/${pname}-${version}.tar.gz";
-    sha256 = "1swdp4czvm0752psbi8a4qw5i9x18s7nhivh7iw92274pmqxq9wi";
+    sha256 = "0h8x8agl4s5cnfzwmshbcg4pxcgg3iyb86w8krs21y2k9d1ng036";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Youtube made an update that breaks youtube-dl on many videos. Since that is a big breakage for many users (for example those using mpv to stream youtube), we should include the fix (unmerged upstream PR https://github.com/rg3/youtube-dl/pull/17464) as soon as possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

