### PR TITLE
kde-applications: 18.08.0 -> 18.08.1

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.08.0/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/applications/18.08.1/ -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1715 +3,1715 @@
 
 {
   akonadi = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-18.08.0.tar.xz";
-      sha256 = "06a1n84w4bfljyariyajzpn1sajkn4dwpsrr47pz38vf1m6dp7mz";
-      name = "akonadi-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-18.08.1.tar.xz";
+      sha256 = "0fipz3xnbgqk7f9pxfm3p38fniddb76scpb80fvb2v6gn0snlabi";
+      name = "akonadi-18.08.1.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-calendar-18.08.0.tar.xz";
-      sha256 = "1qlqvsv4gs50v9dd3nbw8wyq0vgvxvslhnk1hnqpyvh0skcwslh5";
-      name = "akonadi-calendar-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-calendar-18.08.1.tar.xz";
+      sha256 = "1knwr8s1qn13fan1pq31pr3dk219cmv96mwvd36ir0bd2l7vkmcs";
+      name = "akonadi-calendar-18.08.1.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-calendar-tools-18.08.0.tar.xz";
-      sha256 = "1d5kr7nxfy7y9ybi4qnfbfci5kc44ya916j9wgb18r6rfdhdwsxr";
-      name = "akonadi-calendar-tools-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-calendar-tools-18.08.1.tar.xz";
+      sha256 = "1l4idxwi9h0bff1cwwsm7s4m9bcw4vp4ip5r87vc7687hhphc27l";
+      name = "akonadi-calendar-tools-18.08.1.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadiconsole-18.08.0.tar.xz";
-      sha256 = "0qrwgjdmqa5jj8vcbs6n733v462sxnf4jcmh2khjddf2h5na6q86";
-      name = "akonadiconsole-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadiconsole-18.08.1.tar.xz";
+      sha256 = "031garrv2q3rv6qjjkzm3rmmd25f6j17sz2yv4hn3zgzydkjjskn";
+      name = "akonadiconsole-18.08.1.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-contacts-18.08.0.tar.xz";
-      sha256 = "0jqs0llpxq34j4glgzsfifk5yd24x6smky550s66bjzkyg3j2s2m";
-      name = "akonadi-contacts-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-contacts-18.08.1.tar.xz";
+      sha256 = "1p7192f7n6g7ihj05f7zzqpzl33sbvzsg479lkl120rmvzbjhfxn";
+      name = "akonadi-contacts-18.08.1.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-import-wizard-18.08.0.tar.xz";
-      sha256 = "00my9ja8clz758s3x2jjlsxlpc8zfs8vlq4vh9i2vmsacqwrfy24";
-      name = "akonadi-import-wizard-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-import-wizard-18.08.1.tar.xz";
+      sha256 = "0x80nfa04ffwdvv861ahpgrbnx48ad28ii5glcg5pp5a840jx72s";
+      name = "akonadi-import-wizard-18.08.1.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-mime-18.08.0.tar.xz";
-      sha256 = "0jj9l1zjh72crj8gfifpn73c5xiyycjgv0cm1qalf370cd1sdx80";
-      name = "akonadi-mime-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-mime-18.08.1.tar.xz";
+      sha256 = "04xf5kbf30y5g4amx1x3nvkfypid232l4jamx3lnhia5x4kn2q5g";
+      name = "akonadi-mime-18.08.1.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-notes-18.08.0.tar.xz";
-      sha256 = "0x2v8ylnli29ld6y9vqj18a4bph4zm34zymdmrp3swll1j6xib7q";
-      name = "akonadi-notes-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-notes-18.08.1.tar.xz";
+      sha256 = "1ib7a7y37mq0dj0arxg2f41a30d8i637359ixhcf9sgpcs3xysns";
+      name = "akonadi-notes-18.08.1.tar.xz";
     };
   };
   akonadi-search = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akonadi-search-18.08.0.tar.xz";
-      sha256 = "0fsn7mm1h9m9h3zm2z2fdghbw7m6wdbgfhg7b4iish2br375qh1s";
-      name = "akonadi-search-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akonadi-search-18.08.1.tar.xz";
+      sha256 = "0r7bwfjq9z6ky3riap5gnffzb9k7hwslfprk0jad63dl0djj4qzw";
+      name = "akonadi-search-18.08.1.tar.xz";
     };
   };
   akregator = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/akregator-18.08.0.tar.xz";
-      sha256 = "1s044m9l8z6safqcarjplmlksappjkx7iry3k8s2p6ld4w377w3c";
-      name = "akregator-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/akregator-18.08.1.tar.xz";
+      sha256 = "1js6fbz7hhj0pyjgaz5zhi5bbyw2l9v2gkpj8f8jw4ria2hiz4w8";
+      name = "akregator-18.08.1.tar.xz";
     };
   };
   analitza = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/analitza-18.08.0.tar.xz";
-      sha256 = "1sqr94mbblqry9a1nkmg6py2w0p1wlnbim99kadmp56ypf483rw7";
-      name = "analitza-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/analitza-18.08.1.tar.xz";
+      sha256 = "11zzrgjl2fjbpjagzpzff0aq83ss5037pj4g83wi3qqvlkhphzf2";
+      name = "analitza-18.08.1.tar.xz";
     };
   };
   ark = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ark-18.08.0.tar.xz";
-      sha256 = "0dp7lrc0nqwwshcsi1408lqyycqhxgx18bmnf1sq7ysh6d1w6i75";
-      name = "ark-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ark-18.08.1.tar.xz";
+      sha256 = "1k95qnjn4xgi0dnypfiwa86n0zwckkh5qnc54mv9g1xvvzah04cq";
+      name = "ark-18.08.1.tar.xz";
     };
   };
   artikulate = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/artikulate-18.08.0.tar.xz";
-      sha256 = "12bkfxpaz352823c639q3bal9j6fcaamypv2ql08rn44h9zdjvk8";
-      name = "artikulate-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/artikulate-18.08.1.tar.xz";
+      sha256 = "1cvd6sm45j2gg0ga7j3vyz89lrl1ghlwq6516rsxrvsy3vg7vdmy";
+      name = "artikulate-18.08.1.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/audiocd-kio-18.08.0.tar.xz";
-      sha256 = "0mh1cfz0dn28i9hqyjmz2cm50qkxzj0qkrvar59p03i2r8vqybf8";
-      name = "audiocd-kio-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/audiocd-kio-18.08.1.tar.xz";
+      sha256 = "11wz5glih8jf9l85ncfhg91nyvh7s6q25gfy0vnqk8k0a98h0ghi";
+      name = "audiocd-kio-18.08.1.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/baloo-widgets-18.08.0.tar.xz";
-      sha256 = "026lm8m7bp8q1akwgfvzsyyam7jknndif3vmij4x5ra7yy5xa0s9";
-      name = "baloo-widgets-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/baloo-widgets-18.08.1.tar.xz";
+      sha256 = "1ab86j0akmz8vqkg3xhx1qlp27ndsg183irhfap313maw88bzwxp";
+      name = "baloo-widgets-18.08.1.tar.xz";
     };
   };
   blinken = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/blinken-18.08.0.tar.xz";
-      sha256 = "0ivpv27vgzchm0r8zlb02w6l0a8xsi7q173660bjv1ynwalgn3bm";
-      name = "blinken-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/blinken-18.08.1.tar.xz";
+      sha256 = "0xzk8ddgr55sil00dl6b00m0x5az81yhd1cklr6mahjgg7w822br";
+      name = "blinken-18.08.1.tar.xz";
     };
   };
   bomber = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/bomber-18.08.0.tar.xz";
-      sha256 = "0z83hkvs7h0pg91sczmvkkn7yc8xfch5hl7l25b7kac4c9qznzix";
-      name = "bomber-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/bomber-18.08.1.tar.xz";
+      sha256 = "0x4z8fa2klhabr99al3iyyf9aq3pm8rk1gi6cjghjgwrrcav7an7";
+      name = "bomber-18.08.1.tar.xz";
     };
   };
   bovo = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/bovo-18.08.0.tar.xz";
-      sha256 = "0bbkm0c801rcvk8z0idbasn1m7cdd2mpbpb1ap9ghgv2vjbln7va";
-      name = "bovo-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/bovo-18.08.1.tar.xz";
+      sha256 = "1jwq9wjkdhy8bvkxg4lvb1m4qqw0zr84ws096nk6pccqk7xlkpr2";
+      name = "bovo-18.08.1.tar.xz";
     };
   };
   calendarsupport = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/calendarsupport-18.08.0.tar.xz";
-      sha256 = "0ps4963c2wbmlwp7aks16jw2pz74fqlxarhsnjj3r339575inzw2";
-      name = "calendarsupport-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/calendarsupport-18.08.1.tar.xz";
+      sha256 = "0hh8jr81hcqyhm9fp0s27g52077d9li8x8rrg3bd18lw3flib0fq";
+      name = "calendarsupport-18.08.1.tar.xz";
     };
   };
   cantor = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/cantor-18.08.0.tar.xz";
-      sha256 = "08sqr1nxn9a24z4jicmjn9zn64xv3yyy054rzblr2h2hi3n6fqdy";
-      name = "cantor-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/cantor-18.08.1.tar.xz";
+      sha256 = "05cvyrf17lvh85qrcg1yf8x2c9d3l9wgbvnlhw4idx06crhvwvbb";
+      name = "cantor-18.08.1.tar.xz";
     };
   };
   cervisia = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/cervisia-18.08.0.tar.xz";
-      sha256 = "1avc18vv2lb27w5ybiajsr65c65zpvbv43ihz4gcjv7awqf754w7";
-      name = "cervisia-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/cervisia-18.08.1.tar.xz";
+      sha256 = "1hir8ssr2yjjkly8kh8qdxqlgaa29q94kpsrk1crcdl67vrc8pph";
+      name = "cervisia-18.08.1.tar.xz";
     };
   };
   dolphin = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/dolphin-18.08.0.tar.xz";
-      sha256 = "1r3g3qssawhav3dx9a9qdd7dqcjj1ynm6ravj5wx39h4qdflrysy";
-      name = "dolphin-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/dolphin-18.08.1.tar.xz";
+      sha256 = "1f8w1315kg5mnz0jfdbynw5kapg529kwr3qc98nh83q4vfrjr7yj";
+      name = "dolphin-18.08.1.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/dolphin-plugins-18.08.0.tar.xz";
-      sha256 = "1j96bkc3xah4ca3a9asplpf152dp234r2bzs5wg25b3aw7zp5siv";
-      name = "dolphin-plugins-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/dolphin-plugins-18.08.1.tar.xz";
+      sha256 = "0wa09n3x255d3rn5sndvyybawj2aq0sm0fdvqz7sbnm1c67g6akd";
+      name = "dolphin-plugins-18.08.1.tar.xz";
     };
   };
   dragon = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/dragon-18.08.0.tar.xz";
-      sha256 = "020vnnzd7crvrv8dbcf41h04hpr2ayrfk6ayxhxpazrzic1sxxx6";
-      name = "dragon-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/dragon-18.08.1.tar.xz";
+      sha256 = "1r9zdia4r1g77c456zi1yv3vjrccww6lqrhplwg90bw8091isc7s";
+      name = "dragon-18.08.1.tar.xz";
     };
   };
   eventviews = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/eventviews-18.08.0.tar.xz";
-      sha256 = "1ca499dzqsy2n6c0s0vrwvjykc4vd5s4m2bkn0vdg2dbyyx9fncj";
-      name = "eventviews-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/eventviews-18.08.1.tar.xz";
+      sha256 = "0h5aqjncsmhgjqsj65j12bx4rb5rf4604fs6h04lda8jrk2qla3y";
+      name = "eventviews-18.08.1.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ffmpegthumbs-18.08.0.tar.xz";
-      sha256 = "1rbfbwnyync4j15qzdhn47gksr6jm97pgkld2x3p564gi98w0vrn";
-      name = "ffmpegthumbs-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ffmpegthumbs-18.08.1.tar.xz";
+      sha256 = "11gwrw3fm6di4z5a04jqxfvm176mh20h8pfpv0c0zq9qipr1khkc";
+      name = "ffmpegthumbs-18.08.1.tar.xz";
     };
   };
   filelight = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/filelight-18.08.0.tar.xz";
-      sha256 = "1wx6q0gq4zlg95a93sg7zqkbaka1pcn99jsjkdncq1z4lfphppk9";
-      name = "filelight-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/filelight-18.08.1.tar.xz";
+      sha256 = "03sz1bnz7w3b4227hvfidi225ci5i83z022fgkb632b0dp2l9m8p";
+      name = "filelight-18.08.1.tar.xz";
     };
   };
   granatier = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/granatier-18.08.0.tar.xz";
-      sha256 = "06nzgpwvgvbh6hf5yxmcxigh3n72qa0mbiv7k56157yyvxigk62q";
-      name = "granatier-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/granatier-18.08.1.tar.xz";
+      sha256 = "062qh639n1k919n67k2xn5h829gr0ncczif9mffw8ggvqqrzh560";
+      name = "granatier-18.08.1.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/grantlee-editor-18.08.0.tar.xz";
-      sha256 = "06m2n5rcgp63xgnr5jdzly7fda8zx5r3ki07ldxz1xivd985zmfp";
-      name = "grantlee-editor-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/grantlee-editor-18.08.1.tar.xz";
+      sha256 = "0wl8ii23wh1xakf6vcsv7n259kw0b3lpz7qnfmhz8nwj3k890g9q";
+      name = "grantlee-editor-18.08.1.tar.xz";
     };
   };
   grantleetheme = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/grantleetheme-18.08.0.tar.xz";
-      sha256 = "1mk80hfra4nmrcb0ff3n7l33pbw6j5lypb3ip7g4c1p8qik6imfv";
-      name = "grantleetheme-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/grantleetheme-18.08.1.tar.xz";
+      sha256 = "1ydi89smsim4lvgwclm9xsnldimsy45b69qsipz9vhhck4pccd7n";
+      name = "grantleetheme-18.08.1.tar.xz";
     };
   };
   gwenview = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/gwenview-18.08.0.tar.xz";
-      sha256 = "1nv9a7pj0h2m3wxzy03jw3pi5ps3xqvq9sx7mblq8p4klga2pcnl";
-      name = "gwenview-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/gwenview-18.08.1.tar.xz";
+      sha256 = "0p32v9y2gz5q4j1vz0yqw90qg8l7nbyzxqn7pqwrzbhlycsx7mp9";
+      name = "gwenview-18.08.1.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/incidenceeditor-18.08.0.tar.xz";
-      sha256 = "1s88i1l30b30an8lwc8sdlzfm1cvmb9n5786bs9y0jfgw01wdl7j";
-      name = "incidenceeditor-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/incidenceeditor-18.08.1.tar.xz";
+      sha256 = "0da1jba66pvjar5wxcx2q9dhfwj2mlwk17h0j9xc9kgxj2y0bzx9";
+      name = "incidenceeditor-18.08.1.tar.xz";
     };
   };
   juk = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/juk-18.08.0.tar.xz";
-      sha256 = "1lzw9ih4771vdxqngc0ja57v9y6wlgf8dbmnjax74ryi232py1d9";
-      name = "juk-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/juk-18.08.1.tar.xz";
+      sha256 = "17mylgsw11nc64y0if3imrs2hsxwfdflnn1a4f5p64awrzid04mc";
+      name = "juk-18.08.1.tar.xz";
     };
   };
   k3b = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/k3b-18.08.0.tar.xz";
-      sha256 = "1lm9140xc5mq1szyc4vkms6b3qhl4b3yn74kqp942b8k9djn17md";
-      name = "k3b-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/k3b-18.08.1.tar.xz";
+      sha256 = "1vv7pr1i3vj778m763mv1bzrq29kaqm02hnllhgq4dcci3hafn6a";
+      name = "k3b-18.08.1.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kaccounts-integration-18.08.0.tar.xz";
-      sha256 = "0wvqhf9br8nqqacyn6j4k2323w6nixkfzlajkmx872d31d7aqf11";
-      name = "kaccounts-integration-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kaccounts-integration-18.08.1.tar.xz";
+      sha256 = "18nbj4vyakhxvzy35j4b7iap06lp7zwhfpylfpnshjbcrb724qzs";
+      name = "kaccounts-integration-18.08.1.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kaccounts-providers-18.08.0.tar.xz";
-      sha256 = "1zxyqwdrf9pp5b1vnd8p4wz21ciavffjxd68vcjjyj8bba30c51l";
-      name = "kaccounts-providers-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kaccounts-providers-18.08.1.tar.xz";
+      sha256 = "0ygiyv5fxf6b62sfibm621cz5cxin6qa1mnjpdxfj72xj8p7dbd7";
+      name = "kaccounts-providers-18.08.1.tar.xz";
     };
   };
   kaddressbook = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kaddressbook-18.08.0.tar.xz";
-      sha256 = "1wgqqnikv9qyrb4nvkm7h91r1iqfkmbpdp67lcw4jkglqghnn2qc";
-      name = "kaddressbook-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kaddressbook-18.08.1.tar.xz";
+      sha256 = "0917d7m2nvgadkns8im7fzzqp2m5i21m4nrw75hv6bil7v0cshnn";
+      name = "kaddressbook-18.08.1.tar.xz";
     };
   };
   kajongg = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kajongg-18.08.0.tar.xz";
-      sha256 = "0dfrwzq1p9ikff52qi50ckb769pfij7gzn61r6pdkkfjgy86364y";
-      name = "kajongg-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kajongg-18.08.1.tar.xz";
+      sha256 = "0apjydg0q9yvvnlirhhvri2bqwzrkrq85fzphi49pr5ki3ah03dz";
+      name = "kajongg-18.08.1.tar.xz";
     };
   };
   kalarm = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kalarm-18.08.0.tar.xz";
-      sha256 = "0415yq61q700slmm6vskd92pc2sp1027flghgans80i29617zgaq";
-      name = "kalarm-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kalarm-18.08.1.tar.xz";
+      sha256 = "1558nls14a22pwjnk59fpgmb4ddrdvzf3rdhl0nf6kkgr0ma0p1w";
+      name = "kalarm-18.08.1.tar.xz";
     };
   };
   kalarmcal = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kalarmcal-18.08.0.tar.xz";
-      sha256 = "0ss56dy451lbbq872sarqcyapf4g6kgw78s88hgs7z5mlyj8xnll";
-      name = "kalarmcal-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kalarmcal-18.08.1.tar.xz";
+      sha256 = "02shp4m85frjs4kp5n2kv3nz5frjfrckm7zkjlnwn6lrg6jz7q0f";
+      name = "kalarmcal-18.08.1.tar.xz";
     };
   };
   kalgebra = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kalgebra-18.08.0.tar.xz";
-      sha256 = "0fv4v7xnspqjbc7x6n2gcyjssm15apszbvj4gs1w2lwlbbr3i224";
-      name = "kalgebra-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kalgebra-18.08.1.tar.xz";
+      sha256 = "1996vbcvbpkvmya291w2kxfjwkm3baqflx04drrglildsrn6q07w";
+      name = "kalgebra-18.08.1.tar.xz";
     };
   };
   kalzium = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kalzium-18.08.0.tar.xz";
-      sha256 = "0bjpiir1xxwvhs4xgnvbhphw24iif9g4kj9zg61bqcvq5zxf821x";
-      name = "kalzium-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kalzium-18.08.1.tar.xz";
+      sha256 = "0sp89xi94xpix1gpz1s7qya1ki7lbbx93yr17bmhlp4dhyfqbzw5";
+      name = "kalzium-18.08.1.tar.xz";
     };
   };
   kamera = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kamera-18.08.0.tar.xz";
-      sha256 = "169vsxnpcgxws27hcap2l5wjbfyxxi30321c8r3p8fm2klvbc8nw";
-      name = "kamera-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kamera-18.08.1.tar.xz";
+      sha256 = "03p94azchdgr19mbgpgkvb3rlddik3bjl6iy3j0yd99frlns15ck";
+      name = "kamera-18.08.1.tar.xz";
     };
   };
   kamoso = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kamoso-18.08.0.tar.xz";
-      sha256 = "1a8azx7rdbzznh9qwzg0x6w50vb5bc6cmd442j2hhdwkl15dqpwd";
-      name = "kamoso-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kamoso-18.08.1.tar.xz";
+      sha256 = "11hm8q2v3x1rhm2smiqm9gmscbpdkyfb6x4sl0xrnm36m7ps54qb";
+      name = "kamoso-18.08.1.tar.xz";
     };
   };
   kanagram = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kanagram-18.08.0.tar.xz";
-      sha256 = "02v3xlkfphkk86y8yrw10lq7f4wc7gmh02ms2w00aqrllkpja4vn";
-      name = "kanagram-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kanagram-18.08.1.tar.xz";
+      sha256 = "0mq8qrvvn30axhizzlzhzp5vl9q1ys7s7p5v525flyyz9fs011dz";
+      name = "kanagram-18.08.1.tar.xz";
     };
   };
   kapman = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kapman-18.08.0.tar.xz";
-      sha256 = "03fhxn8zckidkab56fzgwai0d1ac5k3il32w881gq5z012ms013h";
-      name = "kapman-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kapman-18.08.1.tar.xz";
+      sha256 = "0grq9yllpaa267lx654n39mj7ll0g2pj6s42fq7b7236naqyna3d";
+      name = "kapman-18.08.1.tar.xz";
     };
   };
   kapptemplate = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kapptemplate-18.08.0.tar.xz";
-      sha256 = "10fyvwxf6xmn8jdc4p3m3jpb8ykaga1jmwx2hzhf8c6a3rrcxvvb";
-      name = "kapptemplate-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kapptemplate-18.08.1.tar.xz";
+      sha256 = "1dp9831hzmh9gd3qwvfyb2ihindl5c42jvmmrhnmfbz1j199z98w";
+      name = "kapptemplate-18.08.1.tar.xz";
     };
   };
   kate = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kate-18.08.0.tar.xz";
-      sha256 = "1licprflzcsrfap7klr1ia2kl2z2cp16zgznphrqkkn9n6x7xz67";
-      name = "kate-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kate-18.08.1.tar.xz";
+      sha256 = "1jsdk6jfff36fcb1x0vxl0iqa1xrl0400bm7fhp1gv9m553pkysa";
+      name = "kate-18.08.1.tar.xz";
     };
   };
   katomic = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/katomic-18.08.0.tar.xz";
-      sha256 = "07d9irgqrawll18fi3b2mrjj416gpkn43bsriifkraqf8yrn3m4s";
-      name = "katomic-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/katomic-18.08.1.tar.xz";
+      sha256 = "0cd8l7hn89xr5spq107nqxz7dx12drvv70siqx896d8lfpkmh96d";
+      name = "katomic-18.08.1.tar.xz";
     };
   };
   kbackup = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kbackup-18.08.0.tar.xz";
-      sha256 = "14nmk7dwrmkfv7kz4r64vzy46n48g3l1iqj0937qnpbqk12yvak9";
-      name = "kbackup-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kbackup-18.08.1.tar.xz";
+      sha256 = "15x75biiwixiw0j329pcxhh5sfyqm82x2rdfb0nqp0zz01cwicv6";
+      name = "kbackup-18.08.1.tar.xz";
     };
   };
   kblackbox = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kblackbox-18.08.0.tar.xz";
-      sha256 = "0nd4nsx7yyiy1g1g4v0gaw0m6r3kb07gnn8236bch6xxy9xcdzhb";
-      name = "kblackbox-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kblackbox-18.08.1.tar.xz";
+      sha256 = "00xd6k9ndm1jbr1j2mhi8xfcxqdiwzwnb1cvr35a22r414lbc3cw";
+      name = "kblackbox-18.08.1.tar.xz";
     };
   };
   kblocks = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kblocks-18.08.0.tar.xz";
-      sha256 = "1pnxzfp3bd089bjbdsi0iwjpw60p36lb110yb61cv0vb54g1sia1";
-      name = "kblocks-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kblocks-18.08.1.tar.xz";
+      sha256 = "0y9hfxb9rpijpkm1r697v1w5q3gny8pa3ax5y0qq6695j2h7c52p";
+      name = "kblocks-18.08.1.tar.xz";
     };
   };
   kblog = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kblog-18.08.0.tar.xz";
-      sha256 = "00q7266lx29bfgzhfmb192l8h3qwgpj3yyfc0lykkbhjf6d9w783";
-      name = "kblog-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kblog-18.08.1.tar.xz";
+      sha256 = "0ickxhz7y098zx88308774kkz8wf6v51ydlnbmnayb8lyaw8ms8i";
+      name = "kblog-18.08.1.tar.xz";
     };
   };
   kbounce = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kbounce-18.08.0.tar.xz";
-      sha256 = "0x07lxqip9l2k9mdpan03yh17ammkd1f242l2p3qq3j1s71bpznm";
-      name = "kbounce-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kbounce-18.08.1.tar.xz";
+      sha256 = "1k2qmdhm3sllxhsz6hhs94fndm1lrifhh7md2lmws2l2977ymkpi";
+      name = "kbounce-18.08.1.tar.xz";
     };
   };
   kbreakout = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kbreakout-18.08.0.tar.xz";
-      sha256 = "1jrix92p48zcpgwvfxn484bw1k8ynfacm4iww14splx2d9skj489";
-      name = "kbreakout-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kbreakout-18.08.1.tar.xz";
+      sha256 = "06mxh67pyg7fv8x152kd79xzrfnlw22x4x3iklhbngsk1cqsg62r";
+      name = "kbreakout-18.08.1.tar.xz";
     };
   };
   kbruch = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kbruch-18.08.0.tar.xz";
-      sha256 = "1gkij27hl847bc2jdnjqvigncdmb11spj2rsy825rsnpiqxbqv8f";
-      name = "kbruch-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kbruch-18.08.1.tar.xz";
+      sha256 = "0m4m1xqp2aqkqs7cgj8z5c6b3s64d330bfgsq7mnm2wakmc69x9g";
+      name = "kbruch-18.08.1.tar.xz";
     };
   };
   kcachegrind = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcachegrind-18.08.0.tar.xz";
-      sha256 = "13nqcxh21apxpzg51alsgn34hps21nr7aqyh60kd4fbmmsxrqll0";
-      name = "kcachegrind-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcachegrind-18.08.1.tar.xz";
+      sha256 = "0llqmziq0h6wx3inxc2rmph1qs68fb34q09fvhfasg43l8y8a6cm";
+      name = "kcachegrind-18.08.1.tar.xz";
     };
   };
   kcalc = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcalc-18.08.0.tar.xz";
-      sha256 = "04bdbdyc9lky6i0dkm6w9f2k3gvr9zq5b9yc6qhl4smdiivlqjb6";
-      name = "kcalc-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcalc-18.08.1.tar.xz";
+      sha256 = "139pjh31k9cy608h7yl9kxq48x6dsm5c0gcbndqc6nsjwd88ck04";
+      name = "kcalc-18.08.1.tar.xz";
     };
   };
   kcalcore = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcalcore-18.08.0.tar.xz";
-      sha256 = "0sdzx0ygq89np2cj22v06m9j00nwbqn97rm43nffgixwvrlf1wy5";
-      name = "kcalcore-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcalcore-18.08.1.tar.xz";
+      sha256 = "0kf92imqm9lqisfy3i25qn0g588p35w23xl0vmx75i67pzr3jcjn";
+      name = "kcalcore-18.08.1.tar.xz";
     };
   };
   kcalutils = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcalutils-18.08.0.tar.xz";
-      sha256 = "12s2anmwi3q95kjl197jis90vi5gzpxs0b4xj4m6n4lzmnyjvfxl";
-      name = "kcalutils-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcalutils-18.08.1.tar.xz";
+      sha256 = "1z346k9aniv3bq9c1dak3x5hzymi71ygns773r4agzm4kdn8ghwh";
+      name = "kcalutils-18.08.1.tar.xz";
     };
   };
   kcharselect = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcharselect-18.08.0.tar.xz";
-      sha256 = "1gfzzzk5admdclw75qhnsf3271p2lr0fgqzxvclcxppwmv5j56aq";
-      name = "kcharselect-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcharselect-18.08.1.tar.xz";
+      sha256 = "06r9q03rs00zqs0dpb0wxa9663pc2i51hsf83c0z9jnkpq6sjijb";
+      name = "kcharselect-18.08.1.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcolorchooser-18.08.0.tar.xz";
-      sha256 = "1sxlx6cnpm0yfbrbk1pqaf0lsf1mgzdnkszr30hwz6z5lvvzj73l";
-      name = "kcolorchooser-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcolorchooser-18.08.1.tar.xz";
+      sha256 = "027afkj0mllvnwdrrfjnpp4769dp5ixrdmd17r59q2hja0wz6cpf";
+      name = "kcolorchooser-18.08.1.tar.xz";
     };
   };
   kcontacts = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcontacts-18.08.0.tar.xz";
-      sha256 = "0cil96cd383gvqa2dw1lhaw3vi3m04y4rpjqmiapzwnn4ck0v1ii";
-      name = "kcontacts-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcontacts-18.08.1.tar.xz";
+      sha256 = "1y0drw7n9mhyq84brqxz4rr666pqj5ww94f2i8k34chdzkcqsr52";
+      name = "kcontacts-18.08.1.tar.xz";
     };
   };
   kcron = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kcron-18.08.0.tar.xz";
-      sha256 = "14lkaz1b6hnpwvxnnx3mgv3fg86vm1g45fggfx25x6x72kiihhzq";
-      name = "kcron-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kcron-18.08.1.tar.xz";
+      sha256 = "1blalii8b6i8b1cknwcarbj84m6rrffsjamgnzyz6l81l43b0j9m";
+      name = "kcron-18.08.1.tar.xz";
     };
   };
   kdav = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdav-18.08.0.tar.xz";
-      sha256 = "13jwc4623f9mx64i7fb3ha5gwbqgfd54dirbvcyyglrzipxmgja1";
-      name = "kdav-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdav-18.08.1.tar.xz";
+      sha256 = "046h72gvcc9wxq0rn5ribf3lr03q6zq6acz2c3kxsbdw6kbypb2x";
+      name = "kdav-18.08.1.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdebugsettings-18.08.0.tar.xz";
-      sha256 = "1ddqcfq2icsk2xmfr02jawdgxyydhx4yyhrfd7pk8cfw66rm23br";
-      name = "kdebugsettings-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdebugsettings-18.08.1.tar.xz";
+      sha256 = "0n6lvccm803g9ilwwdka0srvak14i8lk5g149c6qmd73wywqdk84";
+      name = "kdebugsettings-18.08.1.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kde-dev-scripts-18.08.0.tar.xz";
-      sha256 = "1glnm91wn3xdd6zqqy2p178f05z5wn3gr1i6jyqb0zkl8ansy3yi";
-      name = "kde-dev-scripts-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kde-dev-scripts-18.08.1.tar.xz";
+      sha256 = "1y162wn5mpi0c3wa8vjb2al2mizz292jzj22wvdzp19vliy32j95";
+      name = "kde-dev-scripts-18.08.1.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kde-dev-utils-18.08.0.tar.xz";
-      sha256 = "1dk510kgjgvycdyzr5mwq9z1b3xr8hlpm4ahfwlfn299gl563fwf";
-      name = "kde-dev-utils-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kde-dev-utils-18.08.1.tar.xz";
+      sha256 = "1w5r7w7s5iaaxaxicd42nh2dhmc7anfqpv9n92rrk1hwpmjbphg5";
+      name = "kde-dev-utils-18.08.1.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdeedu-data-18.08.0.tar.xz";
-      sha256 = "1ph3bw4xgmgh28j9vnj9v1amgisy3f44whpwwhzin9zgzz0cw3gw";
-      name = "kdeedu-data-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdeedu-data-18.08.1.tar.xz";
+      sha256 = "0gpg1haawwi1d1p1pwzx2127kkdpg4i833312cl637v5qgvg7xhc";
+      name = "kdeedu-data-18.08.1.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdegraphics-mobipocket-18.08.0.tar.xz";
-      sha256 = "0p3bci612qbqnbps4g4yb2kd1rs6kx2ppcls6vpfb035c28ygf7a";
-      name = "kdegraphics-mobipocket-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdegraphics-mobipocket-18.08.1.tar.xz";
+      sha256 = "13jw2gn3wc946zdgr2hi1nsd6m518idn4q5wq0ym715mfbfs17zn";
+      name = "kdegraphics-mobipocket-18.08.1.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdegraphics-thumbnailers-18.08.0.tar.xz";
-      sha256 = "0dwfphz70y0g43a9nxfda78qwsv7y4llx1f51x6n8jl64kpxnijw";
-      name = "kdegraphics-thumbnailers-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdegraphics-thumbnailers-18.08.1.tar.xz";
+      sha256 = "0h9h5d81bjmjcgbxh3sy776rddpxxcwyj0jjix67q37kndbap4k0";
+      name = "kdegraphics-thumbnailers-18.08.1.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdenetwork-filesharing-18.08.0.tar.xz";
-      sha256 = "0l5f9ffwsk0s9r87kid9k1a7j2v4lcdzbn2w4qb2pg22k92k8p67";
-      name = "kdenetwork-filesharing-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdenetwork-filesharing-18.08.1.tar.xz";
+      sha256 = "1bfqk57d1xfqbig1r8cymlp0pgsfmrix5nr4m1a015rmpqnvb92d";
+      name = "kdenetwork-filesharing-18.08.1.tar.xz";
     };
   };
   kdenlive = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdenlive-18.08.0.tar.xz";
-      sha256 = "06d0viqma7kivzv3hbsiirkfhbj28mdr2nr3f5ic56381q3ps923";
-      name = "kdenlive-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdenlive-18.08.1.tar.xz";
+      sha256 = "1ampvjlxn3q8l3mi4nap4lq3hgxzmp6ic88hzmkdj41vpm01flpf";
+      name = "kdenlive-18.08.1.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdepim-addons-18.08.0.tar.xz";
-      sha256 = "05141013jdaascsb7ihbmd4f1lh1r6ah5w39wp5vky6ma35zv2l1";
-      name = "kdepim-addons-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdepim-addons-18.08.1.tar.xz";
+      sha256 = "0fgggq0dl4qy0wha4jjarxgjly54s9fpqkm2macfq2bgvdbsjrgj";
+      name = "kdepim-addons-18.08.1.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdepim-apps-libs-18.08.0.tar.xz";
-      sha256 = "0zpx3nilrsvgmgx5visppyx3kn2g5k8fnhfy649k6wa35p846495";
-      name = "kdepim-apps-libs-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdepim-apps-libs-18.08.1.tar.xz";
+      sha256 = "0v4vvrjh1amlrvmf61cjfb2yr1j4j0qypf5349spnnlwjjrxn2hw";
+      name = "kdepim-apps-libs-18.08.1.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdepim-runtime-18.08.0.tar.xz";
-      sha256 = "0b1jbksxks32s8gjzrjhh4nja089j5dq75yaiil99w11f7nfpkar";
-      name = "kdepim-runtime-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdepim-runtime-18.08.1.tar.xz";
+      sha256 = "0133d86z1fggzg15jk2p8pg42zcv3khikpgdlyvz4si3canmvkwj";
+      name = "kdepim-runtime-18.08.1.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdesdk-kioslaves-18.08.0.tar.xz";
-      sha256 = "1fpg4sdbgzvlc9z7wwxxbp466fhybphvmcdpplbr7ws3588792cb";
-      name = "kdesdk-kioslaves-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdesdk-kioslaves-18.08.1.tar.xz";
+      sha256 = "1nn4bzywd42ijbzlcnkdlr84n1p6argrd1gz91yyyrhqark7ma76";
+      name = "kdesdk-kioslaves-18.08.1.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdesdk-thumbnailers-18.08.0.tar.xz";
-      sha256 = "047rnzn2lsbhfll0fp4vdf4jsyixg7vmpl2xyvi1y85df5nvv2pc";
-      name = "kdesdk-thumbnailers-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdesdk-thumbnailers-18.08.1.tar.xz";
+      sha256 = "1c133n4qf9jkgzhccipspwk3r8mbja0k8556ng0wxnhayzmv2sx9";
+      name = "kdesdk-thumbnailers-18.08.1.tar.xz";
     };
   };
   kdf = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdf-18.08.0.tar.xz";
-      sha256 = "1flv6qjb936fcj5crshy26qy9y2p7j9i3hlidr9lsk81wsyjkqqg";
-      name = "kdf-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdf-18.08.1.tar.xz";
+      sha256 = "1m5hwfhzvikh7isakbvzyc3y98zdky4iz8vdsi7nnyb6d8n2hbrr";
+      name = "kdf-18.08.1.tar.xz";
     };
   };
   kdialog = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdialog-18.08.0.tar.xz";
-      sha256 = "04xhp4pdn7gv69gwydz9afml27qj9mrqz2hnrhcsf29pw3vq0hli";
-      name = "kdialog-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdialog-18.08.1.tar.xz";
+      sha256 = "0s8a3y8sjhyq8lf3i8r6ligg1s9nbhxsd34vncw3lkbq60xkyhrr";
+      name = "kdialog-18.08.1.tar.xz";
     };
   };
   kdiamond = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kdiamond-18.08.0.tar.xz";
-      sha256 = "14c5i2fj9scvkqffz95lrqj49vfg7yh7gfc4s3zzg2sl91j7hwzq";
-      name = "kdiamond-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kdiamond-18.08.1.tar.xz";
+      sha256 = "0vcqdadb9kbmxnycaba6g9hiiyxqybqiw1i4zldlw5x4gnj7dcv2";
+      name = "kdiamond-18.08.1.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/keditbookmarks-18.08.0.tar.xz";
-      sha256 = "1zsfmcyb9s782k6knlv56mrssazdid6i70g74is46s59sgfdd9fl";
-      name = "keditbookmarks-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/keditbookmarks-18.08.1.tar.xz";
+      sha256 = "10nzhsyia1q0m26icqb20qh8s8n6r5vlb5q498gw8dv3rzsmh6sf";
+      name = "keditbookmarks-18.08.1.tar.xz";
     };
   };
   kfind = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kfind-18.08.0.tar.xz";
-      sha256 = "1bvln7iq2ikcrzaa53wskpqwzmndjvc84a2jdjqzirmh6pqzlf3h";
-      name = "kfind-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kfind-18.08.1.tar.xz";
+      sha256 = "15w4cdvz35yyfyfaxb4mnxynlbryixydkwmx7lkmhlwnk3zjmskr";
+      name = "kfind-18.08.1.tar.xz";
     };
   };
   kfloppy = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kfloppy-18.08.0.tar.xz";
-      sha256 = "1clz5651d11pm77mi57nzr274zwshx2qhglfn6jxiif9yz6s9dfp";
-      name = "kfloppy-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kfloppy-18.08.1.tar.xz";
+      sha256 = "07v3q4jiw728s9akwhy27hczp4hxhp7f8c6g59gdqm0ply0vgxk6";
+      name = "kfloppy-18.08.1.tar.xz";
     };
   };
   kfourinline = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kfourinline-18.08.0.tar.xz";
-      sha256 = "1agmzlwy4izrmi58cf08cg34h155inmws3ghp524jz1li6rqvzfr";
-      name = "kfourinline-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kfourinline-18.08.1.tar.xz";
+      sha256 = "03g8g0s2214fqkqp4lyh9m8f382s8xwzi0yqz0yigyq1w5igcl9p";
+      name = "kfourinline-18.08.1.tar.xz";
     };
   };
   kgeography = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kgeography-18.08.0.tar.xz";
-      sha256 = "0nj3lg8q84wvh1pypix619bdr9xm6s9s5vywciq8ggskqa2qrdc5";
-      name = "kgeography-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kgeography-18.08.1.tar.xz";
+      sha256 = "1pqs2sk88idzc8xr85qy689palkf5y5l4pfqkd9xfkb87041rl93";
+      name = "kgeography-18.08.1.tar.xz";
     };
   };
   kget = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kget-18.08.0.tar.xz";
-      sha256 = "0vpphsfgqa4h1bsj0k6lz591ymd5zy3ng86fl4l1qv36kh5b3sr4";
-      name = "kget-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kget-18.08.1.tar.xz";
+      sha256 = "1ax6sdkpvzg37sp05fx083h0nn78a2zpfpr2l74j3qwq2yssy298";
+      name = "kget-18.08.1.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kgoldrunner-18.08.0.tar.xz";
-      sha256 = "13i3b8z2pbvh90ykv365s30az9r33is8wp8ys33kz88z26260rsv";
-      name = "kgoldrunner-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kgoldrunner-18.08.1.tar.xz";
+      sha256 = "1wbdranw0fq8qynn13d0wkb7fckfzqbz2g920gyx2igw0bblcj0y";
+      name = "kgoldrunner-18.08.1.tar.xz";
     };
   };
   kgpg = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kgpg-18.08.0.tar.xz";
-      sha256 = "12d6vqfcrgmqajk383p9gx9l49digm51km00slwkb15yjzgsjckx";
-      name = "kgpg-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kgpg-18.08.1.tar.xz";
+      sha256 = "1i3g7x18khnyvwnvgpnv6xdfbv29w65x8d8ml60zb8siipbnlwb5";
+      name = "kgpg-18.08.1.tar.xz";
     };
   };
   khangman = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/khangman-18.08.0.tar.xz";
-      sha256 = "0vcyak1pqq894d10jn4s8948fz8py6kjhgrbvjk2ksp28fzsb1q2";
-      name = "khangman-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/khangman-18.08.1.tar.xz";
+      sha256 = "1nc9lbjxlwr4aqsl6idjyhqxd5wampcz7a6zgq6py03n8mr811qy";
+      name = "khangman-18.08.1.tar.xz";
     };
   };
   khelpcenter = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/khelpcenter-18.08.0.tar.xz";
-      sha256 = "1ykw91s1w5953646ylxm49bq0bjgxd8yp29r09644q12qmi1w9ay";
-      name = "khelpcenter-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/khelpcenter-18.08.1.tar.xz";
+      sha256 = "1k60yqnpkplj0k0b8h27zyhviqs6ddwhygmv7cpmnwa1d7kvhdwi";
+      name = "khelpcenter-18.08.1.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kidentitymanagement-18.08.0.tar.xz";
-      sha256 = "1rrdxbil0z0vmv0h0d6jdlwa3sfs3nncq39wmydhwx09phk7db85";
-      name = "kidentitymanagement-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kidentitymanagement-18.08.1.tar.xz";
+      sha256 = "0w1lmfcjq2fb65l3vd9qzq037j7r3dd49aqh8bnrwkjslshy7iwz";
+      name = "kidentitymanagement-18.08.1.tar.xz";
     };
   };
   kig = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kig-18.08.0.tar.xz";
-      sha256 = "0kgsar7sp3a7x72gnagi2hwajbl1yaaj493qjnwzlwidjjrlzmhb";
-      name = "kig-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kig-18.08.1.tar.xz";
+      sha256 = "1haf21widyfi0afixyfczk944l048w8dvlmgkwvfqhmgiiz52g72";
+      name = "kig-18.08.1.tar.xz";
     };
   };
   kigo = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kigo-18.08.0.tar.xz";
-      sha256 = "1ws0diq3kb8f15v30cj0hc0ii4d14dca7fb3p8vvm8r4ly7gqbdr";
-      name = "kigo-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kigo-18.08.1.tar.xz";
+      sha256 = "1dmb3cmbi473wpkbnv895nyxxhqmp09ihghvxir77khjpmask04a";
+      name = "kigo-18.08.1.tar.xz";
     };
   };
   killbots = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/killbots-18.08.0.tar.xz";
-      sha256 = "165g1zll7wq6gyz1lzaf1x17j2nagd66lj015qxifjpn9fd475mm";
-      name = "killbots-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/killbots-18.08.1.tar.xz";
+      sha256 = "184glirpf8jzy91769d13rck3vnh96s171h6sfqab755857wj960";
+      name = "killbots-18.08.1.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kimagemapeditor-18.08.0.tar.xz";
-      sha256 = "1r3hngzvidv1yz7kd7l8l78gqdhjvw9smciv1vkzf7dk9qarlyfq";
-      name = "kimagemapeditor-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kimagemapeditor-18.08.1.tar.xz";
+      sha256 = "1w0yinp58f7x4ss2m069736faagwil7ay8gd5w79a5frqizsj36d";
+      name = "kimagemapeditor-18.08.1.tar.xz";
     };
   };
   kimap = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kimap-18.08.0.tar.xz";
-      sha256 = "12lslmprwmibijlpwng4acmmhdfhm1dgvqsazbyvsr8jagkryxmq";
-      name = "kimap-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kimap-18.08.1.tar.xz";
+      sha256 = "0na135np2li231kzxfjy4wb5bbgkkyll66x8jd4y0lxvc4cwipfd";
+      name = "kimap-18.08.1.tar.xz";
     };
   };
   kio-extras = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kio-extras-18.08.0.tar.xz";
-      sha256 = "1k5azz26zwsflnsgv4r0i8z8jph060wpksyqfpkz0vfsf3lv0k3n";
-      name = "kio-extras-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kio-extras-18.08.1.tar.xz";
+      sha256 = "03q68bc53q656pw733g2j2wkbag6hbqpwszkap2h4pn011cihgyw";
+      name = "kio-extras-18.08.1.tar.xz";
     };
   };
   kiriki = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kiriki-18.08.0.tar.xz";
-      sha256 = "1fciiq490iwcz86g9pqp8g0s40zf7a3zan132iqmscpl71hsv01b";
-      name = "kiriki-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kiriki-18.08.1.tar.xz";
+      sha256 = "1kc2flpfqvfijrazvnk7mk03myy7f7lqia1r9lxg1g3xx095jqhz";
+      name = "kiriki-18.08.1.tar.xz";
     };
   };
   kiten = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kiten-18.08.0.tar.xz";
-      sha256 = "1gzgfj0p0s5yjhwx6hldc8s0cs6p2bn5gd8sy29sicg13wjvhkmj";
-      name = "kiten-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kiten-18.08.1.tar.xz";
+      sha256 = "1i1pgfxvcqh5jbbk39b6rlc0s67z2naw5glxhkg3nrvxy9yxw9n2";
+      name = "kiten-18.08.1.tar.xz";
     };
   };
   kitinerary = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kitinerary-18.08.0.tar.xz";
-      sha256 = "14jwlkfy9z6q2pnjmlcy5gihc75n6qnsck05zycs4qsxa4srpn0l";
-      name = "kitinerary-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kitinerary-18.08.1.tar.xz";
+      sha256 = "0bv1nwwi2mc0l3vfvx29d46l7b876qf4bch9g84zmdcas37w786l";
+      name = "kitinerary-18.08.1.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kjumpingcube-18.08.0.tar.xz";
-      sha256 = "001a2ayl74hi89j8i3553qx0cs8w7f4myskq3qa01rg3w4pb3wl2";
-      name = "kjumpingcube-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kjumpingcube-18.08.1.tar.xz";
+      sha256 = "1qfzydbpd86zsb0yfy5xdaqlbh1awm70lg1nzbqn99rl47vsm85b";
+      name = "kjumpingcube-18.08.1.tar.xz";
     };
   };
   kldap = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kldap-18.08.0.tar.xz";
-      sha256 = "1825146vi1lq1383qmn8ix70d2rc2cfwp95vpn4divf9aqwmc4x0";
-      name = "kldap-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kldap-18.08.1.tar.xz";
+      sha256 = "1knf61whi1raj66z55a8535rj911na15zkq0vcb8djz6cg3xw29r";
+      name = "kldap-18.08.1.tar.xz";
     };
   };
   kleopatra = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kleopatra-18.08.0.tar.xz";
-      sha256 = "1wwjn2p2vblr6fdfcy1s5gf3h5cnclc4lj5vsi5cxyp7d86ij49c";
-      name = "kleopatra-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kleopatra-18.08.1.tar.xz";
+      sha256 = "0g65qxz6v1glh86fvgpb89ay1221qbnz97mnzw8fb26aar838s8y";
+      name = "kleopatra-18.08.1.tar.xz";
     };
   };
   klettres = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/klettres-18.08.0.tar.xz";
-      sha256 = "1g84swzlynyl7r2ln52n7w9q0yf6540dd9hj3j0zsp1y2hb9fns8";
-      name = "klettres-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/klettres-18.08.1.tar.xz";
+      sha256 = "0k5c9j9w0d95fzs7103nx13cxz9q5ivn34wq8px0ma9jaig1w1j9";
+      name = "klettres-18.08.1.tar.xz";
     };
   };
   klickety = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/klickety-18.08.0.tar.xz";
-      sha256 = "1jrxabmnv0s38i255x7xycn12fgpkmr4p1y0ydk5x98zrv4vn8y0";
-      name = "klickety-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/klickety-18.08.1.tar.xz";
+      sha256 = "1zx7f4hpcgfrfbgmmhfj9p9l604bzhg06zznfgq40774m4d5m992";
+      name = "klickety-18.08.1.tar.xz";
     };
   };
   klines = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/klines-18.08.0.tar.xz";
-      sha256 = "14ks53xh6hhlrmiqa7a1f7z42i035qw3v72dpbc8bw20vg53bzpy";
-      name = "klines-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/klines-18.08.1.tar.xz";
+      sha256 = "1wwvzvwshxj03s3ywpg65lfj32xcd3yj4y7fhdms8xjn0b341grc";
+      name = "klines-18.08.1.tar.xz";
     };
   };
   kmag = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmag-18.08.0.tar.xz";
-      sha256 = "00ni6clpgwcr6b2yanmgplsb5jqmqxjiymd3572fkj7q8m17ak7f";
-      name = "kmag-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmag-18.08.1.tar.xz";
+      sha256 = "1a1xml73yhfrqzw37apgmf1f88x58ws09vfdrp8zchawskcm3yi2";
+      name = "kmag-18.08.1.tar.xz";
     };
   };
   kmahjongg = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmahjongg-18.08.0.tar.xz";
-      sha256 = "0lflx8jxk2yv7bsywwmbk5l54gyhbyv65996fg82z6lw9hrr5wrb";
-      name = "kmahjongg-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmahjongg-18.08.1.tar.xz";
+      sha256 = "1rdimx9kdm9n3g4856672z0spwsj5ihd40yx17vbzc3lhyqnk0w1";
+      name = "kmahjongg-18.08.1.tar.xz";
     };
   };
   kmail = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmail-18.08.0.tar.xz";
-      sha256 = "1xj2z4ix9zba6k3cdnakr7f0nfij1z925j3vp0gimkgyvbcb28vr";
-      name = "kmail-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmail-18.08.1.tar.xz";
+      sha256 = "12097jncdx5zdsr99lmsvhiymarymgbd004vmxm6rni0hq1aqzkl";
+      name = "kmail-18.08.1.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmail-account-wizard-18.08.0.tar.xz";
-      sha256 = "1hc6zqys2qncljvsl9j48ns77kkq5zabj5a2kzg953dgcdv5x25r";
-      name = "kmail-account-wizard-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmail-account-wizard-18.08.1.tar.xz";
+      sha256 = "0jzqqn07q0jsggss2r5pjgp0fhfgngvv0rjzyh12lzsn4l8iyd6z";
+      name = "kmail-account-wizard-18.08.1.tar.xz";
     };
   };
   kmailtransport = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmailtransport-18.08.0.tar.xz";
-      sha256 = "0dfws0pzq3jf1h6j5qzjm96fz1ci4v57j4s9fbry10vyn4racpq8";
-      name = "kmailtransport-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmailtransport-18.08.1.tar.xz";
+      sha256 = "196cjbnzqcp1ayqpn4vy8ah55nskhv07xrfrm8h0baxj90jd01xn";
+      name = "kmailtransport-18.08.1.tar.xz";
     };
   };
   kmbox = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmbox-18.08.0.tar.xz";
-      sha256 = "11dh1lgjhiy4bvpvrk1rw23fgjil45ch3lazqc4jp21d1skrr1v4";
-      name = "kmbox-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmbox-18.08.1.tar.xz";
+      sha256 = "0sjl64cjr2dxvjklpdl2p25vjbvzi0w42m5s3fzlqam9avmckfia";
+      name = "kmbox-18.08.1.tar.xz";
     };
   };
   kmime = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmime-18.08.0.tar.xz";
-      sha256 = "0kci9b2c67hzbl4hjwkkzk9j7g1l5wy1d8qrm1jwk8s7ccndindw";
-      name = "kmime-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmime-18.08.1.tar.xz";
+      sha256 = "00jxsnwkx4c9x1cm7w6r5z39d4962d0w6b8irdczix4r660xf56x";
+      name = "kmime-18.08.1.tar.xz";
     };
   };
   kmines = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmines-18.08.0.tar.xz";
-      sha256 = "0z0fidlcp0kf9vmdgfyzrwi9yk5mfwhkzlqlbfy1631xisz158yn";
-      name = "kmines-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmines-18.08.1.tar.xz";
+      sha256 = "0csjr16s6jjj6z0963kc5jqwywjf9mvsa8c7x751h76kci1x53b0";
+      name = "kmines-18.08.1.tar.xz";
     };
   };
   kmix = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmix-18.08.0.tar.xz";
-      sha256 = "084l5dpms26jwd894xnqr054hxjzlxcp2wm2rq37y3cbriia2xgh";
-      name = "kmix-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmix-18.08.1.tar.xz";
+      sha256 = "1i5wgdmr8sml9cqjlgmi2i4v8lgksa7pnp91cgj75bmcy68sv0gj";
+      name = "kmix-18.08.1.tar.xz";
     };
   };
   kmousetool = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmousetool-18.08.0.tar.xz";
-      sha256 = "0lcr8hpflaw5lrfydwi5sf069hfb19qifb7wh7qxh7j1b2z8w4gf";
-      name = "kmousetool-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmousetool-18.08.1.tar.xz";
+      sha256 = "0drpzdsry3xj4wm50850wf9rg3banbfaspbrmj1vwinbyz6f7pwz";
+      name = "kmousetool-18.08.1.tar.xz";
     };
   };
   kmouth = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmouth-18.08.0.tar.xz";
-      sha256 = "0naqn9pl7jldfna9l3i3kdv8rkw0nky4ppsvqghlrb9jf4dy8lfm";
-      name = "kmouth-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmouth-18.08.1.tar.xz";
+      sha256 = "0ywadz614w308vsss7b25xx4ddqyabr15miz9x7izffh67dhvm97";
+      name = "kmouth-18.08.1.tar.xz";
     };
   };
   kmplot = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kmplot-18.08.0.tar.xz";
-      sha256 = "0lvw351iz2gdzkphrf8hxgqbjqi4pqvxqk2zjbly4fzwbgk261bd";
-      name = "kmplot-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kmplot-18.08.1.tar.xz";
+      sha256 = "1287pk524lfqvadq2rc8226v9qiwqh80fj1gjhsw6y3vhj88dpvg";
+      name = "kmplot-18.08.1.tar.xz";
     };
   };
   knavalbattle = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/knavalbattle-18.08.0.tar.xz";
-      sha256 = "0b21z3qqhsyafsa6rx9mc560hrw0046npqjmi5jpmczl6y9mr78q";
-      name = "knavalbattle-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/knavalbattle-18.08.1.tar.xz";
+      sha256 = "0jxzgv06mysjalm0gfig3h6a9b84nkrq1qchi47h9x8cfaspba9r";
+      name = "knavalbattle-18.08.1.tar.xz";
     };
   };
   knetwalk = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/knetwalk-18.08.0.tar.xz";
-      sha256 = "04yfxxihfdqhrs126796k498v8valhd73q2bagcx59lj7iymxszj";
-      name = "knetwalk-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/knetwalk-18.08.1.tar.xz";
+      sha256 = "1bg4jaijvhb312cpwrfr4chmxj3fcj3k9caw5xwzrgdgw7prrbax";
+      name = "knetwalk-18.08.1.tar.xz";
     };
   };
   knotes = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/knotes-18.08.0.tar.xz";
-      sha256 = "0dvjafmf57z10lx8fb4y4na73qq3dfmqfa2w01b3sdzns0nzaqig";
-      name = "knotes-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/knotes-18.08.1.tar.xz";
+      sha256 = "1cihancavh5z5781gy6h8cikwbsw2p5hb2wbwakzjs3ld31nsjcv";
+      name = "knotes-18.08.1.tar.xz";
     };
   };
   kolf = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kolf-18.08.0.tar.xz";
-      sha256 = "0bcd4k7v5sid98h95xbqm5l0dcjkv367mdgzhr6yizlqpyg6c132";
-      name = "kolf-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kolf-18.08.1.tar.xz";
+      sha256 = "1ngzjmlhx471rfy486fpglpihydskrvwiqnl6xrp6fw1wg9pbd6b";
+      name = "kolf-18.08.1.tar.xz";
     };
   };
   kollision = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kollision-18.08.0.tar.xz";
-      sha256 = "029pwgwmsm9m284m1sbi2zzhhwbz6rlq68jd783ir6cq2z3llvjp";
-      name = "kollision-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kollision-18.08.1.tar.xz";
+      sha256 = "0is63m9zw8s53pf73c2a7f2wkvrsg70wk49x6rpzb28jmsgm1xi2";
+      name = "kollision-18.08.1.tar.xz";
     };
   };
   kolourpaint = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kolourpaint-18.08.0.tar.xz";
-      sha256 = "0p08xc8ai1cllbdwmv46xzcpv70mn6zwd4f62xsh71hhpg8fbqpi";
-      name = "kolourpaint-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kolourpaint-18.08.1.tar.xz";
+      sha256 = "101vz981kl006q8kirs9d9bsp1bpjzcl22bbswgjny6niqlzd5lm";
+      name = "kolourpaint-18.08.1.tar.xz";
     };
   };
   kompare = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kompare-18.08.0.tar.xz";
-      sha256 = "0md4qw29q5mnsz0k4a3dl6fdgff33w4kg59qy02kp3pvqav9r1zx";
-      name = "kompare-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kompare-18.08.1.tar.xz";
+      sha256 = "0ksdf5c6a3rhq0r8g8hiai53pzk37jiicislfik6y8f71rq0crqv";
+      name = "kompare-18.08.1.tar.xz";
     };
   };
   konqueror = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/konqueror-18.08.0.tar.xz";
-      sha256 = "12zw4bgmmc35vghi8phm93x9lmhfgpxxfvz0grxa4gxcxqjyzzcq";
-      name = "konqueror-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/konqueror-18.08.1.tar.xz";
+      sha256 = "0bz9vyagcrm7yihrx464hkf30y5rx6p9cvx8hq0sblvb7m4308y7";
+      name = "konqueror-18.08.1.tar.xz";
     };
   };
   konquest = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/konquest-18.08.0.tar.xz";
-      sha256 = "0pvx4ss8dpxd6q4jnxim3pwyxjvhcy1xihn7s3513hy0h4wabv6s";
-      name = "konquest-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/konquest-18.08.1.tar.xz";
+      sha256 = "1y3afkna2xg47qk9iwh3gsxbp1plf5y7k87svk8nzbh6aa8pillx";
+      name = "konquest-18.08.1.tar.xz";
     };
   };
   konsole = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/konsole-18.08.0.tar.xz";
-      sha256 = "1p119ky78zxi8l08xnfklrg21c6124q1fbjvbybf6l0qq3mzwy77";
-      name = "konsole-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/konsole-18.08.1.tar.xz";
+      sha256 = "05i9mkw4ygpy6ilqkkm5s7m9kva9ds0gr5gszci7z52m7y67s27d";
+      name = "konsole-18.08.1.tar.xz";
     };
   };
   kontact = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kontact-18.08.0.tar.xz";
-      sha256 = "0027zinl9s92vxhlzv9mak9fgzygqw5ml6i6x659pl3mc889fr7j";
-      name = "kontact-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kontact-18.08.1.tar.xz";
+      sha256 = "136sfr6gwf2cdlc54hc5p1wzcrjpnan0rzmzs21cwpp9gsvmsjvq";
+      name = "kontact-18.08.1.tar.xz";
     };
   };
   kontactinterface = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kontactinterface-18.08.0.tar.xz";
-      sha256 = "0mcvpmvczqpsqj83vqfv9zwz7jj3az65nq45xg1l476j8sva278n";
-      name = "kontactinterface-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kontactinterface-18.08.1.tar.xz";
+      sha256 = "1w96wyr5kinaghnaima1pcq5hz8qyzvvyjpsk3dg8h3is86npvkb";
+      name = "kontactinterface-18.08.1.tar.xz";
     };
   };
   kopete = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kopete-18.08.0.tar.xz";
-      sha256 = "0g79zv187pj7c2p33qsnkpmvrxpcx1iiy9lcrdz3acgzgvpfh5dk";
-      name = "kopete-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kopete-18.08.1.tar.xz";
+      sha256 = "0i38hvnp1qiwva6gd3p7zs962bhi5fviysr8wzm7296f1hv1rz4k";
+      name = "kopete-18.08.1.tar.xz";
     };
   };
   korganizer = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/korganizer-18.08.0.tar.xz";
-      sha256 = "0qifd6l93jjj7sxf3kllm3dq13p738zlvbpxg24wzc3gllyq4ip1";
-      name = "korganizer-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/korganizer-18.08.1.tar.xz";
+      sha256 = "0wdpcjar64f8bii3xbbj08dfnd0290xwdvlr09p1pfmlllp09l0v";
+      name = "korganizer-18.08.1.tar.xz";
     };
   };
   kpat = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kpat-18.08.0.tar.xz";
-      sha256 = "0dm9alimp2ibf5fpgbafiaz3lh9irvq2539jp6l61jqcv7801fml";
-      name = "kpat-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kpat-18.08.1.tar.xz";
+      sha256 = "0cmdfmd8pcwwwq4hjcfjscdl36p9gmw9shmqimjnqm60i5ivlz65";
+      name = "kpat-18.08.1.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kpimtextedit-18.08.0.tar.xz";
-      sha256 = "0ciivvpfcsjzpc620zalx7k5ybh6bf53y19lvr1dgad29j6j871q";
-      name = "kpimtextedit-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kpimtextedit-18.08.1.tar.xz";
+      sha256 = "0v47hb9nvx3bq3ybsqng6546qxk5yi66kd0mm2g7bdx9iq060x0j";
+      name = "kpimtextedit-18.08.1.tar.xz";
     };
   };
   kpkpass = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kpkpass-18.08.0.tar.xz";
-      sha256 = "1wgycyx8nn9kaqbxvlps44g1nzr2qpr6mb7m22q5qcykly0i5wzl";
-      name = "kpkpass-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kpkpass-18.08.1.tar.xz";
+      sha256 = "11d125rd35p44phksxrbzaixasgrsa4z9ym98h69ylyk2mm8h9lk";
+      name = "kpkpass-18.08.1.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kqtquickcharts-18.08.0.tar.xz";
-      sha256 = "0ykf5xfzjsanj5rmn5qrhhqfb93i19mrwzsqq8pngaimcqb70cdk";
-      name = "kqtquickcharts-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kqtquickcharts-18.08.1.tar.xz";
+      sha256 = "1qki34i42hzr0zg0hydg4axsakfl7fydl23sn2xlvxyixw8yvcwi";
+      name = "kqtquickcharts-18.08.1.tar.xz";
     };
   };
   krdc = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/krdc-18.08.0.tar.xz";
-      sha256 = "03j3cn088mr8cd6vjkv19k5ayrhgh9mbyr0lkj9rr16z6861avmr";
-      name = "krdc-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/krdc-18.08.1.tar.xz";
+      sha256 = "05fkpwcl1ivprvqy8x1h8akc2fxqnfh80vbis1k1gy8wanizigg9";
+      name = "krdc-18.08.1.tar.xz";
     };
   };
   kreversi = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kreversi-18.08.0.tar.xz";
-      sha256 = "18qqfaxb34b0z6cdz9h2z0hkmr1vv85j7ra8gzhy35k40dgvhgqm";
-      name = "kreversi-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kreversi-18.08.1.tar.xz";
+      sha256 = "1srn6czbhmlglnmnkg9pl9qs1b98ckfralydivk14y40m24s4j0b";
+      name = "kreversi-18.08.1.tar.xz";
     };
   };
   krfb = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/krfb-18.08.0.tar.xz";
-      sha256 = "1zaran8lbhrnlr2nz12xis4b7q0krynzqyix14diiiysrfsmnwqm";
-      name = "krfb-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/krfb-18.08.1.tar.xz";
+      sha256 = "0p4jyl8dya1xvhisv30h86hnjyjc9sqaqj0d2zx447nqm479k9kw";
+      name = "krfb-18.08.1.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kross-interpreters-18.08.0.tar.xz";
-      sha256 = "1g3fgva8h0s1ld38m38iawjr04bsh572lazizr9a460nwk60nmsi";
-      name = "kross-interpreters-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kross-interpreters-18.08.1.tar.xz";
+      sha256 = "1vkai4v553anbbdb38rccfg65zww93gw2v05kmr0hk62n13lqbh2";
+      name = "kross-interpreters-18.08.1.tar.xz";
     };
   };
   kruler = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kruler-18.08.0.tar.xz";
-      sha256 = "0fv3186xhyvfi9zz48r4facy9x8m8y53qfl7x1rs0y1hq2d2k3nh";
-      name = "kruler-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kruler-18.08.1.tar.xz";
+      sha256 = "13gksm8mpnlvsi5v4a4fpbqb4mxq3l6giycwryi0qrh6bw33xak9";
+      name = "kruler-18.08.1.tar.xz";
     };
   };
   kshisen = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kshisen-18.08.0.tar.xz";
-      sha256 = "11q717m7m37902bchbgpdgsward4w2c9bwjns3xs4c3pyx1w7mg4";
-      name = "kshisen-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kshisen-18.08.1.tar.xz";
+      sha256 = "07w7rps4wh8ibhjnk1s80x9p1mvnl5yw37fnjz3byknk2a10lcm4";
+      name = "kshisen-18.08.1.tar.xz";
     };
   };
   ksirk = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ksirk-18.08.0.tar.xz";
-      sha256 = "1wxf1g5vfcnvz9n28ja17iawc1997vhz6p75bq84jmls51pxjkzn";
-      name = "ksirk-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ksirk-18.08.1.tar.xz";
+      sha256 = "0rqjxfrnbbmcx07l0rlyfv8mlka5hm4a59q8zsk6x2vii18yhi49";
+      name = "ksirk-18.08.1.tar.xz";
     };
   };
   ksmtp = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ksmtp-18.08.0.tar.xz";
-      sha256 = "13jkxrlycgk9qqw5v16i1rax8lwany7fd1n6m2875saxmjm9qi0s";
-      name = "ksmtp-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ksmtp-18.08.1.tar.xz";
+      sha256 = "0kznmx1qbv3kf0cqxwqgfwy1k79awrf6v46ni97h2fwrw90af9w9";
+      name = "ksmtp-18.08.1.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ksnakeduel-18.08.0.tar.xz";
-      sha256 = "0ixbv4b9ngb82f4s58hzjvmmifkjy5v59g76kpb5dv9nqb9x8833";
-      name = "ksnakeduel-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ksnakeduel-18.08.1.tar.xz";
+      sha256 = "0l0b94mx948zas3q27qn2dpvwfiqyd08zv2izl947prwg4mvmb0q";
+      name = "ksnakeduel-18.08.1.tar.xz";
     };
   };
   kspaceduel = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kspaceduel-18.08.0.tar.xz";
-      sha256 = "0qw3lkiwwrzicyqqr6fs78ljhn5z4vsvcvcn9l5j18qkmi2fd2dk";
-      name = "kspaceduel-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kspaceduel-18.08.1.tar.xz";
+      sha256 = "1fjk0i2f72kzzg321w96989nqw0zfvv9iyv28ywg2pjb62nj9z2x";
+      name = "kspaceduel-18.08.1.tar.xz";
     };
   };
   ksquares = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ksquares-18.08.0.tar.xz";
-      sha256 = "01g9jkd5cq1ga9k9brr8yiny3idmj88c4n1cm2qi10d9n1vd4fja";
-      name = "ksquares-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ksquares-18.08.1.tar.xz";
+      sha256 = "0m30yw3hwh9jmwfwabnmjg2l19q4c4b8qcxp2ywp2xzxggvs3ssd";
+      name = "ksquares-18.08.1.tar.xz";
     };
   };
   ksudoku = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ksudoku-18.08.0.tar.xz";
-      sha256 = "0fc7d6bs0ba51nypx4bn5hylfx9h6xlam7wjw1i7fr2yr8fdv9id";
-      name = "ksudoku-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ksudoku-18.08.1.tar.xz";
+      sha256 = "1ma0009prjmi59jym0qbfqan7iyp3h4pa7q5sdqykk77mlqm1z81";
+      name = "ksudoku-18.08.1.tar.xz";
     };
   };
   ksystemlog = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ksystemlog-18.08.0.tar.xz";
-      sha256 = "1m5y8rawhi03vnpdw75npdd7hc830a5b2kkrz1112g959psv00ah";
-      name = "ksystemlog-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ksystemlog-18.08.1.tar.xz";
+      sha256 = "0c05gzqn51mg7ag6nyir1z3jdy5wd4bfka8lx2gigf6kjqyq4yny";
+      name = "ksystemlog-18.08.1.tar.xz";
     };
   };
   kteatime = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kteatime-18.08.0.tar.xz";
-      sha256 = "18pm15s7q4xwzi61m2l8k6qplf948lq36iv9nh5sf4p6vp6syay2";
-      name = "kteatime-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kteatime-18.08.1.tar.xz";
+      sha256 = "0przpgn2kwvnmfsqxncb1wx4xxr696j6zpgwwx3bhqfd89dc0bgm";
+      name = "kteatime-18.08.1.tar.xz";
     };
   };
   ktimer = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktimer-18.08.0.tar.xz";
-      sha256 = "0g81daqdmfsmbnzjq74zxrbnjxjbi6nd6kl0acmjg7832l30m4js";
-      name = "ktimer-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktimer-18.08.1.tar.xz";
+      sha256 = "0bwkxl619d4gar2piyk63lds85sz43gghg02cifsjvdvjfqfqbhp";
+      name = "ktimer-18.08.1.tar.xz";
     };
   };
   ktnef = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktnef-18.08.0.tar.xz";
-      sha256 = "007gjmjyi5r8110w4fv7n5gl67ddn1dg0pb119qr3r82iba8qiqi";
-      name = "ktnef-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktnef-18.08.1.tar.xz";
+      sha256 = "184isgr9c5amwrlzlkji9q0dhl06936r2axdn5kjy2shbn7j7hz2";
+      name = "ktnef-18.08.1.tar.xz";
     };
   };
   ktouch = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktouch-18.08.0.tar.xz";
-      sha256 = "0pgckza5cn52aapa39d12dighx698jzb877iiml2n9870whifkms";
-      name = "ktouch-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktouch-18.08.1.tar.xz";
+      sha256 = "1z23i7h6s31b3az6fk22whp1zs7np20wji5bcwvck1cv5a0nlpvc";
+      name = "ktouch-18.08.1.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-accounts-kcm-18.08.0.tar.xz";
-      sha256 = "16k7dprj75g2lgsmnnmn9n6zgwnp64zsjci5y2vk0cp8ndlr1j54";
-      name = "ktp-accounts-kcm-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-accounts-kcm-18.08.1.tar.xz";
+      sha256 = "1pnq61vjvzs3lnxf52ski36arxyy5930gdh3858d7nq66dqcvw19";
+      name = "ktp-accounts-kcm-18.08.1.tar.xz";
     };
   };
   ktp-approver = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-approver-18.08.0.tar.xz";
-      sha256 = "1nh75yzprhbn0af33qsrs81vxk1brlxjf1jal7p8fpr47qdwhzvd";
-      name = "ktp-approver-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-approver-18.08.1.tar.xz";
+      sha256 = "0sxp79rscfph5iscbpcqyp08szfipnsb0a3k4idlxfxp8bxv1kr2";
+      name = "ktp-approver-18.08.1.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-auth-handler-18.08.0.tar.xz";
-      sha256 = "0akmbrn9z0ind3jmz2azixyvr9glai66j6dynszn59svvjxp0fiz";
-      name = "ktp-auth-handler-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-auth-handler-18.08.1.tar.xz";
+      sha256 = "18lnffiq0wh02j140ya3474sbq6nbb5yj6yavhm1dl0y0pap4mxl";
+      name = "ktp-auth-handler-18.08.1.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-call-ui-18.08.0.tar.xz";
-      sha256 = "0z23vcvz6nyc6klqqys4ivh33j21kww4fgcm5dvvlf940cc9gr3h";
-      name = "ktp-call-ui-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-call-ui-18.08.1.tar.xz";
+      sha256 = "1mqgwblz86qbdfhlzncc5wzvqwhki4kx5afbihgynjr13d4jjldp";
+      name = "ktp-call-ui-18.08.1.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-common-internals-18.08.0.tar.xz";
-      sha256 = "1sj1k8x8d2lk8xsqckjzg6zz01gqh3yj52yar56lngn1cjnnf6ak";
-      name = "ktp-common-internals-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-common-internals-18.08.1.tar.xz";
+      sha256 = "1r4ac7q8hpsldwagz4hsslsx962vxq8hmlhjs5r5h5c89r2qhpil";
+      name = "ktp-common-internals-18.08.1.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-contact-list-18.08.0.tar.xz";
-      sha256 = "0yx64rz6k5dv6s4wsadjqc0fcx6j7blhy15cbnh8r2pbwf0ilk2w";
-      name = "ktp-contact-list-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-contact-list-18.08.1.tar.xz";
+      sha256 = "09zfmqhpm907x1fcd3v7cvbgxx8sy1krjyidand77adl8ayiq59c";
+      name = "ktp-contact-list-18.08.1.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-contact-runner-18.08.0.tar.xz";
-      sha256 = "0i4zc6bksnb4iajz91wbw140dh7p0rg3hzhi563pn3siy9id442s";
-      name = "ktp-contact-runner-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-contact-runner-18.08.1.tar.xz";
+      sha256 = "0cv65v2kkfqg6kny3zl3k0kg5af3wbi42jjni0r37rsgaknmg45x";
+      name = "ktp-contact-runner-18.08.1.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-desktop-applets-18.08.0.tar.xz";
-      sha256 = "0i5sniidcgkvq2scf76pkshrj89gvkzjjslgqaxvqrgvyagsaski";
-      name = "ktp-desktop-applets-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-desktop-applets-18.08.1.tar.xz";
+      sha256 = "04pkknx46zkn5v7946s23n4m1gr28w1cwpsyz8mkww8xfxk52x2y";
+      name = "ktp-desktop-applets-18.08.1.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-filetransfer-handler-18.08.0.tar.xz";
-      sha256 = "15mifrbxxr8lvq7nflxwsz46ywnqmjv1d3irzq1xfcpl47907qhg";
-      name = "ktp-filetransfer-handler-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-filetransfer-handler-18.08.1.tar.xz";
+      sha256 = "07m25ydhpa92d6pqgrhj6mvhirsf6c1i1xnxjmybrmf8v4cy1z8v";
+      name = "ktp-filetransfer-handler-18.08.1.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-kded-module-18.08.0.tar.xz";
-      sha256 = "12rnnf2nm2kn2904b475qh9ql50yx583jga31389l012whm4gqqf";
-      name = "ktp-kded-module-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-kded-module-18.08.1.tar.xz";
+      sha256 = "0f8m3avph7w8yrlgpwsf6ykgbzzj7mrh973v2w6gw2iwz2ps0bbm";
+      name = "ktp-kded-module-18.08.1.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-send-file-18.08.0.tar.xz";
-      sha256 = "0m8p8w4hqanccf7g0za5yh30z2nxv8dxi09mg1fniypqaw4cp2n7";
-      name = "ktp-send-file-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-send-file-18.08.1.tar.xz";
+      sha256 = "1d9k2xmyrxk4s6dr1a0dgi4j4j5y5f73r57aldr5k821w425ssmg";
+      name = "ktp-send-file-18.08.1.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktp-text-ui-18.08.0.tar.xz";
-      sha256 = "04ygny9m823h30hi5qgjz1nk7dj44hdqa9ga0ai9cazxnavvsx57";
-      name = "ktp-text-ui-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktp-text-ui-18.08.1.tar.xz";
+      sha256 = "07ydrwsg2xv6vxsp6n2li6d5dfc92bdikdjqq266dqb35mb6wbx4";
+      name = "ktp-text-ui-18.08.1.tar.xz";
     };
   };
   ktuberling = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/ktuberling-18.08.0.tar.xz";
-      sha256 = "1m9mdv7hdsrnzjcdnmqrl82mafa9psbr5k7b6m3llh95f61b4jpn";
-      name = "ktuberling-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/ktuberling-18.08.1.tar.xz";
+      sha256 = "176fdw99ni02nz3kv62dbiw7887a5kvmxsm8bg3viwyymcs8aay8";
+      name = "ktuberling-18.08.1.tar.xz";
     };
   };
   kturtle = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kturtle-18.08.0.tar.xz";
-      sha256 = "0mwhnsbwj92zrgyjdfi18pxsfyaxa8pzdmh5k20m0jrh76gkhjr0";
-      name = "kturtle-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kturtle-18.08.1.tar.xz";
+      sha256 = "1r3w5hbzw2f4794j690wgm7x3dfxfyqnaylhjcrxqmqydkc54w2c";
+      name = "kturtle-18.08.1.tar.xz";
     };
   };
   kubrick = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kubrick-18.08.0.tar.xz";
-      sha256 = "1affzpwq45r1cqb9ra8w24rrszvvzxiik4ng6jf54dik8sk7wrnn";
-      name = "kubrick-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kubrick-18.08.1.tar.xz";
+      sha256 = "0nwd0n8rx7dzbwjvkhnmvb2g4g7lasng7745klcdwk40ww223b60";
+      name = "kubrick-18.08.1.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kwalletmanager-18.08.0.tar.xz";
-      sha256 = "10yri44d68n6hc4dn78wgqzw394krwjqr6azwd6qgxjp6asc8n69";
-      name = "kwalletmanager-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kwalletmanager-18.08.1.tar.xz";
+      sha256 = "08hr7ii6dybbmipppay2gxiwak8rqbrxrwbjz0206cyav16bbp7q";
+      name = "kwalletmanager-18.08.1.tar.xz";
     };
   };
   kwave = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kwave-18.08.0.tar.xz";
-      sha256 = "0aimhn8hgjnwhv0j2hiyiqgh5bslm7rs13yc8sk0kh1vix6909mp";
-      name = "kwave-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kwave-18.08.1.tar.xz";
+      sha256 = "1gsxzpf8ij7bw6s4dbdl8kvyz21wy76dxi4wqwdggi29gvxzpi76";
+      name = "kwave-18.08.1.tar.xz";
     };
   };
   kwordquiz = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/kwordquiz-18.08.0.tar.xz";
-      sha256 = "1aghybg72anwj6vz3s3zr5i5wflackvfwl9n39mvxddm4ajnw1km";
-      name = "kwordquiz-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/kwordquiz-18.08.1.tar.xz";
+      sha256 = "0bkxvw2g64r2k87m05mdxwh25lbixcga406x9i64z5dmgpsb7d9m";
+      name = "kwordquiz-18.08.1.tar.xz";
     };
   };
   libgravatar = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libgravatar-18.08.0.tar.xz";
-      sha256 = "0yqd99lax1w5r1fy4rmbv9lk988zvq2yydkrdgh8vymxjljg5xa4";
-      name = "libgravatar-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libgravatar-18.08.1.tar.xz";
+      sha256 = "0axmf5ph5ahs4124fi016hjj559472k2apgfsbnf9q80d6y25lgf";
+      name = "libgravatar-18.08.1.tar.xz";
     };
   };
   libkcddb = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkcddb-18.08.0.tar.xz";
-      sha256 = "1ns90vcbp21mwsbvndmk97fpd8n7152iw783q7bqfy1n3ggzkz5x";
-      name = "libkcddb-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkcddb-18.08.1.tar.xz";
+      sha256 = "1qy3zid9n7irkiz6vizmhwljrg3wcxxgcch58nmacg7fdxwcnnn1";
+      name = "libkcddb-18.08.1.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkcompactdisc-18.08.0.tar.xz";
-      sha256 = "0pgn65knay7fgk2zdgqd29wfhqk9x4zlpp4ywjwb2zsvzz51j9f8";
-      name = "libkcompactdisc-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkcompactdisc-18.08.1.tar.xz";
+      sha256 = "075i81gpb4c1wgzbv6nnvhgkz2sww0y5zqh8sxw67r46rz4rjwak";
+      name = "libkcompactdisc-18.08.1.tar.xz";
     };
   };
   libkdcraw = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkdcraw-18.08.0.tar.xz";
-      sha256 = "0xpkkgxsmvrldnprzqrxaz67jb5cv6vndg8flbkagvp0s7mnw56x";
-      name = "libkdcraw-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkdcraw-18.08.1.tar.xz";
+      sha256 = "0fp01s9fw3m9li5v8cd2zmvy6xrysdqddzcal1xm5df2qj6xnk1d";
+      name = "libkdcraw-18.08.1.tar.xz";
     };
   };
   libkdegames = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkdegames-18.08.0.tar.xz";
-      sha256 = "1jl3snqyg3p3l4hddg7ag2mkgi49qvzml8p82zdn3sf5fhka1g70";
-      name = "libkdegames-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkdegames-18.08.1.tar.xz";
+      sha256 = "05xqmg0g08gd45d1q1wblyj5002fvcs72iazif6j7lj9zy60x3qw";
+      name = "libkdegames-18.08.1.tar.xz";
     };
   };
   libkdepim = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkdepim-18.08.0.tar.xz";
-      sha256 = "1gfwfmr5iqkwb490d3mm32892q47pc73b6c8zygm7mn5cjb5376l";
-      name = "libkdepim-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkdepim-18.08.1.tar.xz";
+      sha256 = "0rq7y5r15d1r8s9v1mip780xyh11011j1w2id0cbll9a3fhjfgy9";
+      name = "libkdepim-18.08.1.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkeduvocdocument-18.08.0.tar.xz";
-      sha256 = "1i5vmjfczd71654cpxd11djwk852aqg5lkn98pa8qvjy7v85jynn";
-      name = "libkeduvocdocument-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkeduvocdocument-18.08.1.tar.xz";
+      sha256 = "1nchaip5rcgvazbn3bsiycsa5wcvqj3c0xz48isaz1rmirw4dkan";
+      name = "libkeduvocdocument-18.08.1.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkexiv2-18.08.0.tar.xz";
-      sha256 = "0cdh5wd2lvm9m4nyz2yv5ksszk1pc8ajzwq9c467m74lvb1p2had";
-      name = "libkexiv2-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkexiv2-18.08.1.tar.xz";
+      sha256 = "0v0g626hjpksb8kxgp0kzx84a6hf3qq66if2hxh82kis5xdzbj4l";
+      name = "libkexiv2-18.08.1.tar.xz";
     };
   };
   libkgapi = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkgapi-18.08.0.tar.xz";
-      sha256 = "1aax7djyp1104b8sbrpfhf5c8j30g3hac973lpblfqg0yhkd9lw0";
-      name = "libkgapi-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkgapi-18.08.1.tar.xz";
+      sha256 = "0rsfk8n4z67m371vnglin16l33ankv0i60l07c8znr7jllkyzf7r";
+      name = "libkgapi-18.08.1.tar.xz";
     };
   };
   libkgeomap = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkgeomap-18.08.0.tar.xz";
-      sha256 = "00hjz7amg2rf5s74465s44ac6kd33q4mvsa9ynpljisll5avlhan";
-      name = "libkgeomap-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkgeomap-18.08.1.tar.xz";
+      sha256 = "1mnf43bpklyxh1schphndc7izknnzn3ymwppq4anysb9k603s7n4";
+      name = "libkgeomap-18.08.1.tar.xz";
     };
   };
   libkipi = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkipi-18.08.0.tar.xz";
-      sha256 = "1g34ryzr4vx5657c4j4w3b57n5ir6miwp1k60qk7av73qsik7a7d";
-      name = "libkipi-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkipi-18.08.1.tar.xz";
+      sha256 = "166njf2w6qy30xiccagnpsb7ggcvqmdkp1djahfwmvjwqqxqq9ic";
+      name = "libkipi-18.08.1.tar.xz";
     };
   };
   libkleo = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkleo-18.08.0.tar.xz";
-      sha256 = "0vscfz794yp9hnrn4r4phbip2mqi3jvi41m5mpjd5pw11644d66c";
-      name = "libkleo-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkleo-18.08.1.tar.xz";
+      sha256 = "1q1s335rmh2k2hmx4k67ik9wy2wa4n271fv21k6sg0l3h58z3fc6";
+      name = "libkleo-18.08.1.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkmahjongg-18.08.0.tar.xz";
-      sha256 = "0xzv7vawwq0gm10h9mfrsy5m5zpk1n3s338al0h9vskvhznphy83";
-      name = "libkmahjongg-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkmahjongg-18.08.1.tar.xz";
+      sha256 = "0vvmm0mp2s5bl28vn7nq49b3izfy1myxx7c55qq6h3pmml70alp9";
+      name = "libkmahjongg-18.08.1.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libkomparediff2-18.08.0.tar.xz";
-      sha256 = "0nx66198vn6zrv012i4p2ghc2slxqccfb3fhd9zszzpnyd08zs27";
-      name = "libkomparediff2-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libkomparediff2-18.08.1.tar.xz";
+      sha256 = "114w3xcd31i0y5fk4cr9d075mmvx746hsnm6grc8mkhi6diplxs1";
+      name = "libkomparediff2-18.08.1.tar.xz";
     };
   };
   libksane = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libksane-18.08.0.tar.xz";
-      sha256 = "09wx6haaw0rjcjdh2c05b2zrpz57zlhx9x9jy9hw28byrf71i0k0";
-      name = "libksane-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libksane-18.08.1.tar.xz";
+      sha256 = "0vi0kph8klnm3br9f9ifs5zgnncw83wrvk3kmxc412i28216qgf1";
+      name = "libksane-18.08.1.tar.xz";
     };
   };
   libksieve = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/libksieve-18.08.0.tar.xz";
-      sha256 = "0xnjw2q1hlmrlzdi776459v5w3l88bxpzzpqc93xmq39xh7xqq7b";
-      name = "libksieve-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/libksieve-18.08.1.tar.xz";
+      sha256 = "06agi9wkj455sx0inn6hiahmqlfjaa3ffr8i7zfs2rfzw78qvg20";
+      name = "libksieve-18.08.1.tar.xz";
     };
   };
   lokalize = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/lokalize-18.08.0.tar.xz";
-      sha256 = "17h634abxzg3kx182qxdx6gyz0knl61yn32nlf76l0cv0bqc2xz5";
-      name = "lokalize-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/lokalize-18.08.1.tar.xz";
+      sha256 = "1k5vn3jnvqvdc4bn1hdfjjp3snfcpc5i3925kns760vpvdm4a9in";
+      name = "lokalize-18.08.1.tar.xz";
     };
   };
   lskat = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/lskat-18.08.0.tar.xz";
-      sha256 = "05ckhh8270hjj94ks9zg6pypa2dm1d2r4l219gq456rrhyj9zv13";
-      name = "lskat-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/lskat-18.08.1.tar.xz";
+      sha256 = "11snjlsmcsh4nkcfdzjdl0jia8g350xj2hgilqk5b9jir0j8rsyp";
+      name = "lskat-18.08.1.tar.xz";
     };
   };
   mailcommon = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/mailcommon-18.08.0.tar.xz";
-      sha256 = "06j66326wbvgnmacmbhvszbhdcw6h3pzxwcnbbz66n0zz2y4m5gd";
-      name = "mailcommon-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/mailcommon-18.08.1.tar.xz";
+      sha256 = "1791ph0r5b9a0k2qgjrbxsz8drg23v5bdn832d695yy9q9rgxvwx";
+      name = "mailcommon-18.08.1.tar.xz";
     };
   };
   mailimporter = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/mailimporter-18.08.0.tar.xz";
-      sha256 = "0gywzd882mkjf9q07wg2hi4js4gqvyjxf3y0lgq22k5bd5gpfxbs";
-      name = "mailimporter-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/mailimporter-18.08.1.tar.xz";
+      sha256 = "1rnmhfi54a9vlmvqjv2hsj967q886dkbv6nqn5imz11s8a97anb9";
+      name = "mailimporter-18.08.1.tar.xz";
     };
   };
   marble = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/marble-18.08.0.tar.xz";
-      sha256 = "1ylcdnf0rw0a51jcy183p9xcir4j7jlm6dmhk4k13zvzv16pcwvf";
-      name = "marble-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/marble-18.08.1.tar.xz";
+      sha256 = "1vc6l68fvqdncvpmd8995v4hawi4w4zn3yjfpnghgvmvs30bak4p";
+      name = "marble-18.08.1.tar.xz";
     };
   };
   mbox-importer = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/mbox-importer-18.08.0.tar.xz";
-      sha256 = "08n46q2xxvjbbcr4754x7qw4p3yffmrpvzxi7k2i48ifxhs2awqj";
-      name = "mbox-importer-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/mbox-importer-18.08.1.tar.xz";
+      sha256 = "1sqn11404xc9k76kz9zmm526dkzlk1ywnf15128plvyj6576wwaq";
+      name = "mbox-importer-18.08.1.tar.xz";
     };
   };
   messagelib = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/messagelib-18.08.0.tar.xz";
-      sha256 = "0d1bb0n9izwlk9fbwyf1hvwkrng1b6im574fxpkgk73ivb72ppfx";
-      name = "messagelib-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/messagelib-18.08.1.tar.xz";
+      sha256 = "17z8c60dnhwzgpls3b6hsvyjgjpjybw7cfkc05xn1yihi5gr2rxs";
+      name = "messagelib-18.08.1.tar.xz";
     };
   };
   minuet = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/minuet-18.08.0.tar.xz";
-      sha256 = "0gvla9ig912wrg6vvdmqv2hyybr08a45crx69l31hcd13h9pmyg6";
-      name = "minuet-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/minuet-18.08.1.tar.xz";
+      sha256 = "06jwrra25v2al0jw7dvp7h41jmw48d784ky74xi9lx4ma4h4vsvg";
+      name = "minuet-18.08.1.tar.xz";
     };
   };
   okular = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/okular-18.08.0.tar.xz";
-      sha256 = "11wwh0vb1l2dw2zhcg6f92y7vb5i5kaqwi8kszz8sd874ydpp8pn";
-      name = "okular-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/okular-18.08.1.tar.xz";
+      sha256 = "1in053a3ir4qw2fabrv69g6kxr2hmdwq360kikmwdgsb6a7a8sjk";
+      name = "okular-18.08.1.tar.xz";
     };
   };
   palapeli = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/palapeli-18.08.0.tar.xz";
-      sha256 = "1a1k44q62raw1kxkyg8cspvwxzr1islbwzcb7sj63cmzsmwfhkg1";
-      name = "palapeli-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/palapeli-18.08.1.tar.xz";
+      sha256 = "17c6xlmjz8nnnvp4xa27yzrx2vrsjlznjm2awj70z923js5kzfhl";
+      name = "palapeli-18.08.1.tar.xz";
     };
   };
   parley = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/parley-18.08.0.tar.xz";
-      sha256 = "1cy58fs1jaz1zga4dwfr80m0p6cgzc5ip26ds2x2lpygx7pbjcc6";
-      name = "parley-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/parley-18.08.1.tar.xz";
+      sha256 = "1bwj806qm2g3n57f1svaz6x5y238xl0b3pmp4cg29a9c090gcj0r";
+      name = "parley-18.08.1.tar.xz";
     };
   };
   picmi = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/picmi-18.08.0.tar.xz";
-      sha256 = "1x2ya0vwxwc56rfskl3l83nw0vpdh1lzshh0sdal3rfw0s8w895x";
-      name = "picmi-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/picmi-18.08.1.tar.xz";
+      sha256 = "0bc3zs5ql1yfriq3pbxc0cb010n8rygqglpz8c2qinnsgf9wb305";
+      name = "picmi-18.08.1.tar.xz";
     };
   };
   pimcommon = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/pimcommon-18.08.0.tar.xz";
-      sha256 = "1j6pj7f52ya0jgzq97g65zl3mpv7hn002flv35qlg5srzdllm3pd";
-      name = "pimcommon-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/pimcommon-18.08.1.tar.xz";
+      sha256 = "0h8g374bdnf9nm43flz9wg1ddcdppqxng1vq58vqlviiy32qf86p";
+      name = "pimcommon-18.08.1.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/pim-data-exporter-18.08.0.tar.xz";
-      sha256 = "1spbkwv9kqzky958nymr5plz8rgzxbn6xzgy7k9pkpvynd1a54hz";
-      name = "pim-data-exporter-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/pim-data-exporter-18.08.1.tar.xz";
+      sha256 = "01spb3lfs3rsl1h6d6lrszssj1rnbv1p21np75x4rm7qxzdn7wy7";
+      name = "pim-data-exporter-18.08.1.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/pim-sieve-editor-18.08.0.tar.xz";
-      sha256 = "0nqv530rlamlngxwy3cpbyjj75akx3k9lcifgymlbm4ipp9k125c";
-      name = "pim-sieve-editor-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/pim-sieve-editor-18.08.1.tar.xz";
+      sha256 = "09npw10dgzk7z3022d1np4qvmbwb07lxjj2nd4k1hxnkcjaz242d";
+      name = "pim-sieve-editor-18.08.1.tar.xz";
     };
   };
   poxml = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/poxml-18.08.0.tar.xz";
-      sha256 = "04sy8v3n12asz8hfh107y5irhxzlpkzgc3zjw8qfygflzg9a48cz";
-      name = "poxml-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/poxml-18.08.1.tar.xz";
+      sha256 = "1zazxxh4j8ihlb5v33b5wgj4ddqqhd809lzhxq28dq0mg7wvqcm8";
+      name = "poxml-18.08.1.tar.xz";
     };
   };
   print-manager = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/print-manager-18.08.0.tar.xz";
-      sha256 = "1mi2aqsh5irlnlgkajkkxhazyafhpndrxckcc2kmrh00d4cxhivn";
-      name = "print-manager-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/print-manager-18.08.1.tar.xz";
+      sha256 = "0ixamp14m3p13j1c6nc9x6043600k2anfw12mn1yg4f8q5fb6dnf";
+      name = "print-manager-18.08.1.tar.xz";
     };
   };
   rocs = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/rocs-18.08.0.tar.xz";
-      sha256 = "1c3i11mg6xs64wjyph51hqr6j428hh71ljdq4ajhysql7l5kbhhx";
-      name = "rocs-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/rocs-18.08.1.tar.xz";
+      sha256 = "1kchipj3q29zfp60l81q52m6gb4fcmawcl42rvzr4mxf4h7dw72n";
+      name = "rocs-18.08.1.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/signon-kwallet-extension-18.08.0.tar.xz";
-      sha256 = "024ay0z9inbf7k54iq5v78cxh4q8x1ypvd8r3w80dyygjw2dw743";
-      name = "signon-kwallet-extension-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/signon-kwallet-extension-18.08.1.tar.xz";
+      sha256 = "1wf9xffjxyqn5vwwnp4wbn22lby5vc396snc3imdp1bx4z5ffck4";
+      name = "signon-kwallet-extension-18.08.1.tar.xz";
     };
   };
   spectacle = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/spectacle-18.08.0.tar.xz";
-      sha256 = "1gc2qza529jld1zngzs98zmd3734h13phviswqpg93qnbr9hxskr";
-      name = "spectacle-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/spectacle-18.08.1.tar.xz";
+      sha256 = "0xvw6l0712gmb3dvq9hnyp7r160rvmvmm3mvgapj4z5c00m8a1d7";
+      name = "spectacle-18.08.1.tar.xz";
     };
   };
   step = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/step-18.08.0.tar.xz";
-      sha256 = "15hjbisv3adsn0vavlcl3iy3vz6mf1fv0qj4ykmxckblcyhm1mgg";
-      name = "step-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/step-18.08.1.tar.xz";
+      sha256 = "1b7cvrhdbfkqg72phbgbl15v8c4nr6b1b9fw8i1vam028a97bq8z";
+      name = "step-18.08.1.tar.xz";
     };
   };
   svgpart = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/svgpart-18.08.0.tar.xz";
-      sha256 = "0q71nn1xsdh7ag60szl836lif9ywnv3dlv8w0sn3zfa7yv0cbraa";
-      name = "svgpart-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/svgpart-18.08.1.tar.xz";
+      sha256 = "07mm5vzd5lslr5x7r71ac3hp3s779i89nz4d84550pk0qdn3qpmb";
+      name = "svgpart-18.08.1.tar.xz";
     };
   };
   sweeper = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/sweeper-18.08.0.tar.xz";
-      sha256 = "1j87cb9bbfn42f2xn9k6j8ailgn18b5ribjf4sgglx2h1l3vpq51";
-      name = "sweeper-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/sweeper-18.08.1.tar.xz";
+      sha256 = "1vmdk38j03qj0l5gc27dc242j0cj7k2c5zfq2xrvjb44rxfirdy4";
+      name = "sweeper-18.08.1.tar.xz";
     };
   };
   syndication = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/syndication-18.08.0.tar.xz";
-      sha256 = "17j3ks7bmr3p71lvrm8bzbfai5sw3frwrwl0ckbg1rwhkbsi3d71";
-      name = "syndication-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/syndication-18.08.1.tar.xz";
+      sha256 = "0lirbr8zb1j5kalki6v98wmcg5z25xj1wamszd81h9wlkgk5aqd0";
+      name = "syndication-18.08.1.tar.xz";
     };
   };
   umbrello = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/umbrello-18.08.0.tar.xz";
-      sha256 = "0rs92l6disjha8w5nx05qjbidib4a9yyab7f4cd4sjnjfcw3i1px";
-      name = "umbrello-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/umbrello-18.08.1.tar.xz";
+      sha256 = "16p283jz5v5j40i1i7c9fk36bhs2k30rk17l3nikmf0qd7j5n6ir";
+      name = "umbrello-18.08.1.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "18.08.0";
+    version = "18.08.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.08.0/src/zeroconf-ioslave-18.08.0.tar.xz";
-      sha256 = "05j8k8la4gcydazzhhxq8700w1l4q57yylcar1wzs108icp03rkm";
-      name = "zeroconf-ioslave-18.08.0.tar.xz";
+      url = "${mirror}/stable/applications/18.08.1/src/zeroconf-ioslave-18.08.1.tar.xz";
+      sha256 = "0m1yhm17chz49xs6nh1n8dqdkbnr8kkig9p2f9nmvypnfagygpsi";
+      name = "zeroconf-ioslave-18.08.1.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

