### PR TITLE
lib: Improve overrideExisting implementation

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -435,9 +435,12 @@ rec {
     useful for deep-overriding.
 
     Example:
-      x = { a = { b = 4; c = 3; }; }
-      overrideExisting x { a = { b = 6; d = 2; }; }
-      => { a = { b = 6; d = 2; }; }
+      overrideExisting {} { a = 1; }
+      => {}
+      overrideExisting { b = 2; } { a = 1; }
+      => { b = 2; }
+      overrideExisting { a = 3; b = 2; } { a = 1; }
+      => { a = 1; b = 2; }
   */
   overrideExisting = old: new:
     mapAttrs (name: value: new.${name} or value) old;

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -440,7 +440,7 @@ rec {
       => { a = { b = 6; d = 2; }; }
   */
   overrideExisting = old: new:
-    old // listToAttrs (map (attr: nameValuePair attr (attrByPath [attr] old.${attr} new)) (attrNames old));
+    mapAttrs (name: value: new.${name} or value) old;
 
   /* Get a package output.
      If no output is found, fallback to `.out` and then to the default.

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -236,6 +236,20 @@ runTests {
     };
   };
 
+  testOverrideExistingEmpty = {
+    expr = overrideExisting {} { a = 1; };
+    expected = {};
+  };
+
+  testOverrideExistingDisjoint = {
+    expr = overrideExisting { b = 2; } { a = 1; };
+    expected = { b = 2; };
+  };
+
+  testOverrideExistingOverride = {
+    expr = overrideExisting { a = 3; b = 2; } { a = 1; };
+    expected = { a = 1; b = 2; };
+  };
 
 # GENERATORS
 # these tests assume attributes are converted to lists


### PR DESCRIPTION
###### Motivation for this change
The original implementation was overcomplicated

@Profpatsch 

Because it was fun I did the proof for this, even though it's pretty easy to see why it works:

#### Proof of equivalence

The definition of `or` can be thought of as:
```
a.n or e == if a ? n then a.n else e
```

First we prove that `attrByPath [attr] old.${attr} new` == `new.${attr} or old.${attr}`
```nix

attrByPath [attr] old.${attr} new
# Def. attrByPath
let attr' = head [attr]; in
if new ? ${attr'} then attrByPath (tail [attr]) old.${attr} new.${attr'} else old.${attr}
# Def. head, tail
let attr' = attr; in
if new ? ${attr'} then attrByPath [] old.${attr} new.${attr'} else old.${attr}
# Substitution
if new ? ${attr} then attrByPath [] old.${attr} new.${attr} else old.${attr}
# Def. attrByPath
if new ? ${attr} then new.${attr} else old.${attr}
# Def. or
new.${attr} or old.${attr}
```

```nix
old // listToAttrs (map (attr: nameValuePair attr (attrByPath [attr] old.${attr} new)) (attrNames old))
# Via above proof
old // listToAttrs (map (attr: nameValuePair attr (new.${attr} or old.${attr})) (attrNames old))
# Def. nameValuePair
old // listToAttrs (map (attr: { name = attr; value = new.${attr} or old.${attr}; }) (attrNames old))
# Def. mapAttrs
old // mapAttrs (attr: value: new.${attr} or value) old
# By handwaving, it's much more work to prove that, but it's pretty obvious
mapAttrs (attr: value: new.${attr} or value) old
# Renaming
mapAttrs (name: value: new.${name} or value) old
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

