### PR TITLE
sage: re-add pkg-config aliases

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -21,7 +21,7 @@ let
 
       sagelib = self.callPackage ./sagelib.nix {
         inherit flint ecl arb;
-        inherit sage-src pynac singular;
+        inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
         linbox = nixpkgs.linbox.override { withSage = true; };
       };
 
@@ -41,13 +41,13 @@ let
       };
 
       sage-env = self.callPackage ./sage-env.nix {
-        inherit sage-src python rWrapper ecl singular palp flint pynac pythonEnv;
+        inherit sage-src python rWrapper openblas-cblas-pc ecl singular palp flint pynac pythonEnv;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
       };
 
       sage-with-env = self.callPackage ./sage-with-env.nix {
         inherit pythonEnv;
-        inherit sage-src pynac singular;
+        inherit sage-src openblas-blas-pc openblas-cblas-pc openblas-lapack-pc pynac singular;
         pkg-config = nixpkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
         three = nodePackages_8_x.three;
       };
@@ -59,6 +59,10 @@ let
       };
     };
   };
+
+  openblas-blas-pc = callPackage ./openblas-pc.nix { name = "blas"; };
+  openblas-cblas-pc = callPackage ./openblas-pc.nix { name = "cblas"; };
+  openblas-lapack-pc = callPackage ./openblas-pc.nix { name = "lapack"; };
 
   sage-src = callPackage ./sage-src.nix {};
 

--- a/pkgs/applications/science/math/sage/openblas-pc.nix
+++ b/pkgs/applications/science/math/sage/openblas-pc.nix
@@ -1,0 +1,17 @@
+{ openblasCompat
+, writeTextFile
+, name
+}:
+
+writeTextFile {
+  name = "openblas-${name}-pc-${openblasCompat.version}";
+  destination = "/lib/pkgconfig/${name}.pc";
+  text = ''
+    Name: ${name}
+    Version: ${openblasCompat.version}
+
+    Description: ${name} for SageMath, provided by the OpenBLAS package.
+    Cflags: -I${openblasCompat}/include
+    Libs: -L${openblasCompat}/lib -lopenblas
+  '';
+}

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -37,7 +37,7 @@
 , lcalc
 , rubiks
 , flintqs
-, openblasCompat
+, openblas-cblas-pc
 , flint
 , gmp
 , mpfr
@@ -98,9 +98,9 @@ writeTextFile rec {
     export PKG_CONFIG_PATH='${lib.concatStringsSep ":" (map (pkg: "${pkg}/lib/pkgconfig") [
         # This is only needed in the src/sage/misc/cython.py test and I'm not sure if there's really a use-case
         # for it outside of the tests. However since singular and openblas are runtime dependencies anyways
-        # it doesn't really hurt to include.
+        # and openblas-cblas-pc is tiny, it doesn't really hurt to include.
         singular
-        openblasCompat
+        openblas-cblas-pc
       ])
     }'
     export SAGE_ROOT='${sage-src}'

--- a/pkgs/applications/science/math/sage/sage-with-env.nix
+++ b/pkgs/applications/science/math/sage/sage-with-env.nix
@@ -4,6 +4,9 @@
 , sage-env
 , sage-src
 , openblasCompat
+, openblas-blas-pc
+, openblas-cblas-pc
+, openblas-lapack-pc
 , pkg-config
 , three
 , singular
@@ -29,6 +32,9 @@ let
     makeWrapper
     pkg-config
     openblasCompat # lots of segfaults with regular (64 bit) openblas
+    openblas-blas-pc
+    openblas-cblas-pc
+    openblas-lapack-pc
     singular
     three
     pynac

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -3,6 +3,9 @@
 , buildPythonPackage
 , arb
 , openblasCompat
+, openblas-blas-pc
+, openblas-cblas-pc
+, openblas-lapack-pc
 , brial
 , cliquer
 , cypari2
@@ -56,7 +59,9 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     iml
     perl
-    openblasCompat
+    openblas-blas-pc
+    openblas-cblas-pc
+    openblas-lapack-pc
     jupyter_core
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Those were removed because they were added to openblas itself. There was
an error with that however and it will take some time until the fix
makes its way through staging. For the time being, reverting this part
of 26d5d030fe498b64a307af35ff96ff215ccd967a will fix the sage build.
This commit should be reverted once
408eacbc896ecc6d0e25238963ecbd412d78ce3c is in master.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

