### PR TITLE
kdecoration-viewer: Fixes build

### DIFF
--- a/pkgs/tools/misc/kdecoration-viewer/default.nix
+++ b/pkgs/tools/misc/kdecoration-viewer/default.nix
@@ -2,13 +2,13 @@
 , cmake, extra-cmake-modules, qtquickcontrols, kconfigwidgets, kdeclarative, kdecoration }:
 
 stdenv.mkDerivation rec {
-  name = "kdecoration-viewer-2015-08-20";
+  name = "kdecoration-viewer-2018-07-24";
 
   src = fetchFromGitHub {
     owner = "KDE";
     repo = "kdecoration-viewer";
-    rev = "d7174acee01475fbdb71cfd48ca49d487a141701";
-    sha256 = "1cc4xxv72a82p1w9r76090xba7g069r41bi4zx32k4gz3vyl1am6";
+    rev = "6e50b39c651bbf92fd7e7116d43bf57288254288";
+    sha256 = "01v6i081vx0mydqvnj05xli86m52v6bxxc3z1zlyyap9cfhag7lj";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

