### PR TITLE
Sickrage: nixos module 

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -393,6 +393,7 @@
   ./services/misc/serviio.nix
   ./services/misc/safeeyes.nix
   ./services/misc/siproxd.nix
+  ./services/misc/sickrage.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix
   ./services/misc/spice-vdagentd.nix

--- a/nixos/modules/services/misc/sickrage.nix
+++ b/nixos/modules/services/misc/sickrage.nix
@@ -1,0 +1,48 @@
+{config, pkgs, lib, ...}:
+
+with lib;
+
+let cfg = config.services.sickrage;
+in {
+  options.services.sickrage = {
+    enable = mkOption {
+      description = "Activate Sickrage server";
+      type = types.bool;
+      visible = true;
+      default = false;
+    };
+    port = mkOption {
+      description = "Sickrage's listening port";
+      type = types.int;
+      visible = true;
+      default = 8001;
+    };
+  };
+
+
+  config = mkIf cfg.enable {
+    systemd.services.sickrage = {
+      enable = true;
+      after = ["network.target"];
+      description = "Sickrage server";
+      serviceConfig = {
+        Type = "forking";
+        User = "sickrage";
+        Group = "nogroup";
+        RuntimeDirectory = "sickrage";
+        StateDirectory = "sickrage";     
+        PIDFile = "/run/sickrage/sickrage.pid";
+        ExecStart = "/nix/store/niz2pzmfs0f0wkg64lbdrn2h8q7gzkyj-sickrage-v2018.07.18-2/SickBeard.py --daemon --datadir=/var/lib/sickrage --pidfile=/run/sickrage/sickrage.pid --port=${toString cfg.port}";
+      };
+      wantedBy = ["multi-user.target"];
+    };
+    users = {
+      users = {
+        sickrage = {
+         isSystemUser = true;
+         name = "sickrage";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
###### Motivation for this change
This is the Nixos module for the [sickrage package pushed recently](https://github.com/NixOS/nixpkgs/pull/46214).

Simple configuration with dynamic users and port that can be changed through options.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

