### PR TITLE
nixpkgs module: Fix defaulting of `localSystem` and `system`

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -36,7 +36,11 @@ let
     _file = ./eval-config.nix;
     key = _file;
     config = {
-      nixpkgs.localSystem = lib.mkDefault { inherit system; };
+      # Explicit `nixpkgs.system` or `nixpkgs.localSystem` should override
+      # this.  Since the latter defaults to the former, the former should
+      # default to the argument. That way this new default could propagate all
+      # they way through, but has the last priority behind everything else.
+      nixpkgs.system = lib.mkDefault system;
       _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
     };
   };


### PR DESCRIPTION
Take two of #40708 (4fe2898).

That PR attempted to bidirectionally default `config.nixpkgs.system` and `config.nixpkgs.localSystem.system` to each be updated by the other. But this is not possible with the way the module system works. Divergence in certain cases in inevitable.

This PR is more conservative and just has `system` default `localSystem` and `localSystem` make the final call as-is. This solves a number of issues.

 - `localSystem` completely overrides `system`, just like with nixpkgs proper. There is no need to specify `localSystem.system` to clobber the  old system.

 - `config.nixpkgs.localSystem` is exactly what is passed to nixpkgs. No spooky steps.

 - `config.nixpkgs.localSystem` is elaborated just as nixpkgs would so that all attributes are available, not just the ones the user specified.

The remaining issue is just that `config.nixpkgs.system` doesn't update based on `config.nixpkgs.localSystem.system`. It should never be referred to lest it is a bogus stale value because `config.nixpkgs.localSystem` overwrites it.

Fixes #46320

----

Backport: https://github.com/NixOS/nixpkgs/pull/46343