### PR TITLE
pythonPackages.trio: fix build

### DIFF
--- a/pkgs/development/python-modules/sniffio/default.nix
+++ b/pkgs/development/python-modules/sniffio/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonPackage, lib, fetchPypi, glibcLocales, isPy3k, contextvars
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "sniffio";
+  version = "1.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dzb0nx3m1hpjgsv6s6w5ac2jcmywcz6gqnfkw8rwz1vkr1836rf";
+  };
+
+  # breaks with the following error:
+  # > TypeError: 'encoding' is an invalid keyword argument for this function
+  disabled = !isPy3k;
+
+  buildInputs = [ glibcLocales ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.7") [ contextvars ];
+
+  # no tests distributed with PyPI
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/python-trio/sniffio;
+    license = licenses.asl20;
+    description = "Sniff out which async library your code is running under";
+  };
+}

--- a/pkgs/development/python-modules/trio/default.nix
+++ b/pkgs/development/python-modules/trio/default.nix
@@ -8,6 +8,7 @@
 , pytest
 , pyopenssl
 , trustme
+, sniffio
 }:
 
 buildPythonPackage rec {
@@ -31,6 +32,7 @@ buildPythonPackage rec {
     async_generator
     idna
     outcome
+    sniffio
   ] ++ lib.optionals (pythonOlder "3.7") [ contextvars ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -574,6 +574,8 @@ in {
 
   trio = callPackage ../development/python-modules/trio {};
 
+  sniffio = callPackage ../development/python-modules/sniffio { };
+
   tokenserver = callPackage ../development/python-modules/tokenserver {};
 
   toml = callPackage ../development/python-modules/toml { };


### PR DESCRIPTION
###### Motivation for this change

Fixes the build for `python3Packages.trio' for the next ZHF iteration.
Please refer to the Hydra build for further reference: https://hydra.nixos.org/build/80617356

`python3Packages.sniffio` is needed for the build, otherwise the build
aborts with an error like this:

```
  Could not find a version that satisfies the requirement sniffio (from trio==0.6.0) (from versions: )
No matching distribution found for sniffio (from trio==0.6.0)
```

See #45960 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

