### PR TITLE
gradient_halide: init at 2018-08-31

### DIFF
--- a/pkgs/development/compilers/gradient-halide/default.nix
+++ b/pkgs/development/compilers/gradient-halide/default.nix
@@ -1,0 +1,62 @@
+{ llvmPackages, lib, fetchFromGitHub, cmake
+, libpng, libjpeg, mesa_noglu, eigen3_3, openblas
+}:
+
+llvmPackages.stdenv.mkDerivation rec {
+
+  pversion = "2018-08-31";
+  name = "gradient-halide-${pversion}";
+
+  src = fetchFromGitHub {
+    owner = "jrk";
+    repo = "gradient-halide";
+    rev = "f630dd26eb141349d147f20ace39793d5bc717d2";
+    sha256 = "0qhk1plc4697p1livf9xz2c5aqaq6v9sx1pr0ia6x7sjkmggc9rc";
+  };
+
+  patches = [ ./nix.patch ];
+
+  # clang fails to compile intermediate code because
+  # of unused "--gcc-toolchain" option
+  postPatch = ''
+    sed -i "s/-Werror//" src/CMakeLists.txt
+  '';
+
+  cmakeFlags = [ "-DWARNINGS_AS_ERRORS=OFF" ];
+
+  # To handle the lack of 'local' RPATH; required, as they call one of
+  # their built binaries requiring their libs, in the build process.
+  preBuild = ''
+    export LD_LIBRARY_PATH="$(pwd)/lib:$LD_LIBRARY_PATH"
+  '';
+
+  enableParallelBuilding = true;
+
+  # Note: only openblas and not atlas part of this Nix expression
+  # see pkgs/development/libraries/science/math/liblapack/3.5.0.nix
+  # to get a hint howto setup atlas instead of openblas
+  buildInputs = [ llvmPackages.llvm libpng libjpeg mesa_noglu eigen3_3 openblas ];
+
+  nativeBuildInputs = [ cmake ];
+
+  # No install target for cmake available.
+  # Calling install target in Makefile causes complete rebuild
+  # and the library rpath is broken, because libncursesw.so.6 is missing.
+  # Another way is using "make halide_archive", but the tarball is not easy
+  # to disassemble.
+  installPhase = ''
+    find
+    mkdir -p "$out/lib" "$out/bin"
+    cp bin/HalideTrace* "$out/bin"
+    cp lib/libHalide.so "$out/lib"
+    cp -r include "$out"
+  '';
+
+  meta = with lib; {
+    description = "Differentiable version of the Halide C++ image and array processing framework";
+    homepage = "https://halide-lang.org";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.bcdarwin ];
+  };
+}

--- a/pkgs/development/compilers/gradient-halide/nix.patch
+++ b/pkgs/development/compilers/gradient-halide/nix.patch
@@ -1,0 +1,55 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 40a685b7e..c452efd09 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,10 +49,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+ set(LLVM_VERSION "${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR}")
+
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-as${CMAKE_EXECUTABLE_SUFFIX}" LLVM_AS)
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-nm${CMAKE_EXECUTABLE_SUFFIX}" LLVM_NM)
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}" CLANG)
+-file(TO_NATIVE_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-config${CMAKE_EXECUTABLE_SUFFIX}" LLVM_CONFIG)
++find_program(LLVM_AS llvm-as HINTS ${LLVM_TOOLS_BINARY_DIR})
++find_program(LLVM_NM llvm-nm HINTS ${LLVM_TOOLS_BINARY_DIR})
++find_program(CLANG clang HINTS ${LLVM_TOOLS_BINARY_DIR})
++find_program(LLVM_CONFIG llvm-config HINTS ${LLVM_TOOLS_BINARY_DIR})
+
+ # LLVM doesn't appear to expose --system-libs via its CMake interface,
+ # so we must shell out to llvm-config to find this info
+diff --git a/apps/linear_algebra/CMakeLists.txt b/apps/linear_algebra/CMakeLists.txt
+index 132c80e6a..36ce865f2 100644
+--- a/apps/linear_algebra/CMakeLists.txt
++++ b/apps/linear_algebra/CMakeLists.txt
+@@ -26,7 +26,7 @@ if (CBLAS_FOUND)
+   #  Atlas requires also linking against its provided libcblas for cblas symbols
+   set(ATLAS_EXTRA_LIBS cblas) # XXX fragile
+   set(OpenBLAS_EXTRA_LIBS)
+-  set(BLAS_VENDORS OpenBLAS ATLAS)
++  set(BLAS_VENDORS OpenBLAS)
+
+   # TODO
+   # there are more vendors we could add here that support the cblas interface
+@@ -41,6 +41,7 @@ if (CBLAS_FOUND)
+       message(STATUS " ${BLAS_VENDOR}: Missing")
+     else()
+       message(STATUS " ${BLAS_VENDOR}: Found")
++      set(BLAS_LIBRARIES "${BLAS_LIBRARIES}" CACHE FILEPATH "BLAS library to use")
+       list(APPEND BLAS_VENDORS ${NAME})
+     endif()
+   endforeach()
+diff --git a/apps/linear_algebra/tests/CMakeLists.txt b/apps/linear_algebra/tests/CMakeLists.txt
+index 4b95eb3bb..1daa97437 100644
+--- a/apps/linear_algebra/tests/CMakeLists.txt
++++ b/apps/linear_algebra/tests/CMakeLists.txt
+@@ -19,6 +19,6 @@ target_compile_options(test_halide_blas PRIVATE -Wno-unused-variable)
+ target_link_libraries(test_halide_blas
+   PRIVATE
+    halide_blas
+-   cblas # XXX fragile
++   ${BLAS_LIBRARIES}
+    Halide
+ )
+--
+2.15.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3049,6 +3049,8 @@ with pkgs;
 
   pxz = callPackage ../tools/compression/pxz { };
 
+  gradient_halide = callPackage ../development/compilers/gradient-halide {};
+
   hans = callPackage ../tools/networking/hans { };
 
   h2 = callPackage ../servers/h2 { };


### PR DESCRIPTION
Halide extended with autodiff as described in [Differentiable Programming for
Image Processing and Deep Learning in Halide](https://people.csail.mit.edu/tzumao/gradient_halide/gradient_halide.pdf).

Gradient Halide is implemented in a separate repository from stock Halide, hence this package. At the moment, I've simply copied the existing Halide expression since there are minimal differences. It seems like I should factor the two expressions but I'm not sure of the appropriate directory structure. Of course, hopefully the two repositories will soon merge and this will be irrelevant anyway.

The tests seem to be getting built but I couldn't immediately figure out how to run them when building, but I've compiled and run a couple examples against the library.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [NA] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

