### PR TITLE
nanorc: Init at 2018-09-05

### DIFF
--- a/pkgs/applications/editors/nano/nanorc/default.nix
+++ b/pkgs/applications/editors/nano/nanorc/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nanorc-${version}";
+  version = "2018-09-05";
+
+  src = fetchFromGitHub {
+    owner = "scopatz";
+    repo = "nanorc";
+    rev = "1e589cb729d24fba470228d429e6dde07973d597";
+    sha256 = "136yxr38lzrfv8bar0c6c56rh54q9s94zpwa19f425crh44drppl";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share
+
+    install *.nanorc $out/share/
+  '';
+
+  meta = {
+    description = "Improved Nano Syntax Highlighting Files";
+    homepage = https://github.com/scopatz/nanorc;
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ nequissimus ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17843,6 +17843,8 @@ with pkgs;
 
   nanoblogger = callPackage ../applications/misc/nanoblogger { };
 
+  nanorc = callPackage ../applications/editors/nano/nanorc { };
+
   navipowm = callPackage ../applications/misc/navipowm { };
 
   navit = libsForQt5.callPackage ../applications/misc/navit { };


### PR DESCRIPTION
###### Motivation for this change
Better syntax highlighting for nano

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

