### PR TITLE
pythonPackages.pycaption: fix build

### DIFF
--- a/pkgs/development/python-modules/pycaption/default.nix
+++ b/pkgs/development/python-modules/pycaption/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   prePatch = ''
     substituteInPlace setup.py \
       --replace 'beautifulsoup4>=4.2.1,<4.5.0' \
-                'beautifulsoup4>=4.2.1,<=4.6.0'
+                'beautifulsoup4>=4.2.1,<=4.6.3'
   '';
 
   # don't require enum34 on python >= 3.4


### PR DESCRIPTION
###### Motivation for this change

The `beaitufulsoup4` package distributed by `nixpkgs` is now at `4.6.3`.

Additionally it fixes `gnomecaption` which depends on the broken
`pycaption` package.

See https://hydra.nixos.org/build/81000247
See https://hydra.nixos.org/build/80723223

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

