### PR TITLE
chessx: fix build

### DIFF
--- a/pkgs/games/chessx/default.nix
+++ b/pkgs/games/chessx/default.nix
@@ -1,30 +1,41 @@
-{ stdenv, pkgconfig, zlib, qtbase, qtsvg, qttools, qtmultimedia, qmake, fetchurl }:
+{ stdenv, pkgconfig, zlib, qtbase, qtsvg, qttools, qtmultimedia, qmake, fetchurl, makeWrapper
+, lib
+}:
+
 stdenv.mkDerivation rec {
   name = "chessx-${version}";
   version = "1.4.6";
+
   src = fetchurl {
     url = "mirror://sourceforge/chessx/chessx-${version}.tgz";
     sha256 = "1vb838byzmnyglm9mq3khh3kddb9g4g111cybxjzalxxlc81k5dd";
   };
+
   buildInputs = [
-   qtbase
-   qtsvg
-   qttools
-   qtmultimedia
-   zlib
+    qtbase
+    qtsvg
+    qttools
+    qtmultimedia
+    zlib
   ];
-  nativeBuildInputs = [ pkgconfig qmake ];
+
+  nativeBuildInputs = [ pkgconfig qmake makeWrapper ];
 
   # RCC: Error in 'resources.qrc': Cannot find file 'i18n/chessx_da.qm'
   enableParallelBuilding = false;
 
   installPhase = ''
-      runHook preInstall
-      mkdir -p "$out/bin"
-      mkdir -p "$out/share/applications"
-      cp -pr release/chessx "$out/bin"
-      cp -pr unix/chessx.desktop "$out/share/applications"
-      runHook postInstall
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    mkdir -p "$out/share/applications"
+    cp -pr release/chessx "$out/bin"
+    cp -pr unix/chessx.desktop "$out/share/applications"
+
+    wrapProgram $out/bin/chessx \
+      --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-5.${lib.versions.minor qtbase.version}/plugins
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
@@ -32,5 +43,6 @@ stdenv.mkDerivation rec {
     description = "ChessX allows you to browse and analyse chess games";
     license = licenses.gpl2;
     maintainers = [maintainers.luispedro];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19730,7 +19730,7 @@ with pkgs;
 
   chessdb = callPackage ../games/chessdb { };
 
-  chessx = libsForQt5.callPackage ../games/chessx { };
+  chessx = libsForQt59.callPackage ../games/chessx { };
 
   chocolateDoom = callPackage ../games/chocolate-doom { };
 


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80998335.

Upstream doesn't support QT 5.11 ATM which broke compilation:

```
src/dialogs/savedialog.cpp: In constructor ‘SaveDialog::SaveDialog(QWidget*, Qt::WindowFlags)’:
src/dialogs/savedialog.cpp:37:34: error: invalid use of incomplete type ‘class QButtonGroup’
     group = new QButtonGroup(this);
```

The Arch community recommends to use an older QT version to fix
this (https://aur.archlinux.org/packages/chessx/).

Furthermore the `QT_PLUGIN_PATH` wasn't set properly which broke the
runtime since QT coudln't find the `xcb` plugin:

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized.
Reinstalling the application may fix this problem.
```

Finally, some minor style fixes were made for consistent indentation.

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

