### PR TITLE
jbake: fix sandbox build

### DIFF
--- a/pkgs/development/tools/jbake/default.nix
+++ b/pkgs/development/tools/jbake/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ makeWrapper jre ];
 
+  postPatch = "patchShebangs .";
+
   installPhase = ''
     mkdir -p $out
     cp -vr * $out


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80999410

Without a sandbox the `checkPhase` breaks with the following error:

```
/nix/store/i6vl5lwlz5jbkg4r6p340dwmj6fha3xq-stdenv-linux/setup: bin/jbake: /usr/bin/env: bad interpreter: No such file or directory
jbake did not return correct version
```

Running `patchShebangs` before fixes the issue.

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

