### PR TITLE
pythonPackages.persistent: fix build

### DIFF
--- a/pkgs/development/python-modules/persistent/default.nix
+++ b/pkgs/development/python-modules/persistent/default.nix
@@ -1,12 +1,14 @@
 { buildPythonPackage
 , fetchPypi
 , zope_interface
+, sphinx, manuel
 }:
 
 buildPythonPackage rec {
   pname = "persistent";
   version = "4.4.2";
 
+  nativeBuildInputs = [ sphinx manuel ];
   propagatedBuildInputs = [ zope_interface ];
 
   src = fetchPypi {


### PR DESCRIPTION
###### Motivation for this change

https://hydra.nixos.org/build/80547563

ZHF #45960 . Documentation-related tests failed, the docs didn't build correctly because of missing dependencies sphinx and manuel. Add them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions

---

