### PR TITLE
add various elementary thirdparty applications

### DIFF
--- a/pkgs/applications/audio/vocal/default.nix
+++ b/pkgs/applications/audio/vocal/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, pkgconfig, vala, gtk3, libxml2, granite, webkitgtk, clutter-gtk
+, clutter-gst, libunity, libnotify, sqlite, gst_all_1, libsoup, json-glib, gnome3, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "vocal";
+  version = "2.2.0";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "needle-and-thread";
+    repo = pname;
+    rev = version;
+    sha256 = "09cm4azyaa9fmfymygf25gf0klpm5p04k6bc1i90jhw0f1im8sgl";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gobjectIntrospection
+    libxml2
+    ninja
+    pkgconfig
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = with gst_all_1; [
+    clutter-gst
+    clutter-gtk
+    gnome3.libgee
+    granite
+    gst-plugins-base
+    gst-plugins-good
+    gstreamer
+    json-glib
+    libnotify
+    libunity
+    sqlite
+    webkitgtk
+  ];
+
+  meta = with stdenv.lib; {
+    description = "The podcast client for the modern free desktop";
+    longDescription = ''
+      Vocal is a powerful, fast, and intuitive application that helps users find new podcasts, manage their libraries, and enjoy the best that indepedent audio and video publishing has to offer. Vocal features full support for both episode downloading and streaming, native system integration, iTunes store search and top 100 charts (with international results support), iTunes link parsing, OPML importing and exporting, and so much more. Plus, it has great smart features like automatically keeping your library clean from old files, and the ability to set custom skip intervals.
+    '';
+    homepage = https://github.com/needle-and-thread/vocal;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/editors/quilter/default.nix
+++ b/pkgs/applications/editors/quilter/default.nix
@@ -1,0 +1,73 @@
+{ stdenv, fetchFromGitHub, fetchpatch, vala, pkgconfig, meson, ninja, python3
+, granite, gtk3, desktop-file-utils, gnome3, gtksourceview, webkitgtk, gtkspell3
+, discount, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "quilter";
+  version = "1.6.3";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "lainsce";
+    repo = pname;
+    rev = version;
+    sha256 = "1wa0i6dgg6fgb7q9z33v9qmn1a1dn3ik58v1f3a49dvd5xyf8q6q";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    discount
+    granite
+    gtk3
+    gtksourceview
+    gtkspell3
+    webkitgtk
+    gnome3.libgee
+  ];
+
+  patches = [
+    # Fix build with vala 0.42 - Drop these in next release
+    (fetchpatch {
+      url = "https://github.com/lainsce/quilter/commit/a58838213cd7f2d33048c7b34b96dc8875612624.patch";
+      sha256 = "1a4w1zql4zfk8scgrrssrm9n3sh5fsc1af5zvrqk8skbv7f2c80n";
+    })
+    (fetchpatch {
+      url = "https://github.com/lainsce/quilter/commit/d1800ce830343a1715bc83da3339816554896be5.patch";
+      sha256 = "0xl5iz8bgx5661vbbq8qa1wkfvw9d3da67x564ckjfi05zq1vddz";
+    })
+    # Correct libMarkdown dependency discovery: See https://github.com/lainsce/quilter/pull/170
+    (fetchpatch {
+      url = "https://github.com/lainsce/quilter/commit/8b1f3a60bd14cb86c1c62f9917c5f0c12bc4e459.patch";
+      sha256 = "1kjc6ygf9yjvqfa4xhzxiava3338swp9wbjhpfaa3pyz3ayh188n";
+    })
+    # post_install script cleanups: See https://github.com/lainsce/quilter/pull/171
+    (fetchpatch {
+      url = "https://github.com/lainsce/quilter/commit/55bf3b10cd94fcc40b0867bbdb1931a09f577922.patch";
+      sha256 = "1330amichaif2qfrh4qkxwqbcpr87ipik7vzjbjdm2bv3jz9353r";
+    })
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Focus on your writing - designed for elementary OS";
+    homepage    = https://github.com/lainsce/quilter;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, vala, pkgconfig, meson, ninja, python3, granite
+, gtk3, gnome3, gtksourceview, json-glib, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "notejot";
+  version = "1.4.5";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "lainsce";
+    repo = pname;
+    rev = version;
+    sha256 = "0mjig4y2rb6v2dyzya44mfz0dxgp5wnjs3kdavf9ha2jzjjr5xyb";
+  };
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.libgee
+    granite
+    gtk3
+    gtksourceview
+    json-glib
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Stupidly-simple sticky notes applet";
+    homepage    = https://github.com/lainsce/notejot;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/ftp/taxi/default.nix
+++ b/pkgs/applications/networking/ftp/taxi/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, vala, pkgconfig, meson, ninja, python3, granite
+, gtk3, gnome3, libsoup, libsecret, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "taxi";
+  version = "0.0.1";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "Alecaddd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "01c552w68576pnsyqbwy3hjhbww6vys3r3s0wxjdiscjqj1aawqg";
+  };
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.libgee
+    granite
+    gtk3
+    libsecret
+    libsoup
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The FTP Client that drives you anywhere";
+    homepage    = https://github.com/Alecaddd/taxi;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/weather/meteo/default.nix
+++ b/pkgs/applications/networking/weather/meteo/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitLab, vala, python3, pkgconfig, meson, ninja, granite, gtk3
+, gnome3, json-glib, libsoup, clutter, clutter-gtk, libchamplain, webkitgtk
+, libappindicator, desktop-file-utils, appstream, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "meteo";
+  version = "0.8.5";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitLab {
+    owner = "bitseater";
+    repo = pname;
+    rev = version;
+    sha256 = "1mc2djhkg0nzcjmy87l1wqwni48vgpqh8s1flr90pipk12a1mh7n";
+  };
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    clutter
+    clutter-gtk
+    gnome3.geocode-glib
+    gtk3
+    json-glib
+    libappindicator
+    libchamplain
+    libsoup
+    webkitgtk
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Know the forecast of the next hours & days";
+    homepage    = https://gitlab.com/bitseater/meteo;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/office/aesop/default.nix
+++ b/pkgs/applications/office/aesop/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, vala, pkgconfig, meson, ninja, python3, granite, gtk3, gnome3
+, desktop-file-utils, json-glib, libsoup, poppler, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "aesop";
+  version = "1.0.5";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "lainsce";
+    repo = pname;
+    rev = version;
+    sha256 = "17hjg4qcy8q9xl170yapbhn9vdsn3jf537jsggq51pp0fnhvsnqs";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.libgee
+    granite
+    gtk3
+    json-glib
+    libsoup
+    poppler
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The simplest PDF viewer around";
+    homepage    = https://github.com/lainsce/aesop;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchFromGitHub, vala, pkgconfig, libxml2, cmake, ninja, gtk3, granite, gnome3
+, gobjectIntrospection, sqlite, poppler, poppler_utils, html2text, unzip, unar, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "bookworm";
+  version = "1.0.0";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "babluboy";
+    repo = pname;
+    rev = version;
+    sha256 = "0nv1nxird0s0qfhh8fr82mkj4qimhklw1bwcjwmvjdsvsxxs9520";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gobjectIntrospection
+    libxml2
+    ninja
+    pkgconfig
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = with gnome3; [
+    glib
+    granite
+    gtk3
+    html2text
+    libgee
+    poppler
+    sqlite
+    webkitgtk
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${stdenv.lib.makeBinPath [ unzip unar poppler_utils html2text ]}"
+    )
+  '';
+
+   meta = with stdenv.lib; {
+     description = "A simple, focused eBook reader";
+     longDescription = ''
+       Read the books you love without having to worry about different format complexities like epub, pdf, mobi, cbr, etc.
+     '';
+     homepage = https://babluboy.github.io/bookworm/;
+     license = licenses.gpl3Plus;
+     platforms = platforms.linux;
+   };
+ }

--- a/pkgs/tools/misc/hashit/default.nix
+++ b/pkgs/tools/misc/hashit/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, cmake, vala, python3, gnome3, gtk3, granite, gobjectIntrospection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "hashit";
+  version = "0.2.0";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "artemanufrij";
+    repo = pname;
+    rev = version;
+    sha256 = "1d2g7cm7hhs354waidak9xkhhcvqlwnsl9d0bar9p82gfnpjdg7v";
+  };
+
+  nativeBuildInputs = [
+    gobjectIntrospection
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    granite
+    gtk3
+    gnome3.libgee
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A simple app for checking usual checksums";
+    homepage    = https://github.com/artemanufrij/hashit;
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17873,6 +17873,8 @@ with pkgs;
     gmime = gmime3;
   };
 
+  notejot = callPackage ../applications/misc/notejot { };
+
   notmuch-mutt = callPackage ../applications/networking/mailreaders/notmuch/mutt.nix { };
 
   muchsync = callPackage ../applications/networking/mailreaders/notmuch/muchsync.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19146,6 +19146,8 @@ with pkgs;
 
   vnstat = callPackage ../applications/networking/vnstat { };
 
+  vocal = callPackage ../applications/audio/vocal { };
+
   vogl = libsForQt5.callPackage ../development/tools/vogl { };
 
   volnoti = callPackage ../applications/misc/volnoti { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15701,6 +15701,8 @@ with pkgs;
 
   browsh = callPackage ../applications/networking/browsers/browsh { };
 
+  bookworm = callPackage ../applications/office/bookworm { };
+
   chromium = callPackage ../applications/networking/browsers/chromium {
     channel = "stable";
     pulseSupport = config.pulseaudio or true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15498,6 +15498,8 @@ with pkgs;
 
   autopanosiftc = callPackage ../applications/graphics/autopanosiftc { };
 
+  aesop = callPackage ../applications/office/aesop { };
+
   avidemux = libsForQt5.callPackage ../applications/video/avidemux { };
 
   avrdudess = callPackage ../applications/misc/avrdudess { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18279,6 +18279,8 @@ with pkgs;
 
   quirc = callPackage ../tools/graphics/quirc {};
 
+  quilter = callPackage ../applications/editors/quilter { };
+
   quiterss = libsForQt5.callPackage ../applications/networking/newsreaders/quiterss {};
 
   falkon = libsForQt5.callPackage ../applications/networking/browsers/falkon { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17793,6 +17793,8 @@ with pkgs;
 
   typora = callPackage ../applications/editors/typora { };
 
+  taxi = callPackage ../applications/networking/ftp/taxi { };
+
   librep = callPackage ../development/libraries/librep { };
 
   rep-gtk = callPackage ../development/libraries/rep-gtk { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16853,6 +16853,8 @@ with pkgs;
     inherit (gnome2) gnome_python;
   };
 
+  hashit = callPackage ../tools/misc/hashit { };
+
   hello = callPackage ../applications/misc/hello { };
   hello-unfree = callPackage ../applications/misc/hello-unfree { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17451,6 +17451,8 @@ with pkgs;
 
   mediathekview = callPackage ../applications/video/mediathekview { };
 
+  meteo = callPackage ../applications/networking/weather/meteo { };
+
   meld = callPackage ../applications/version-management/meld { };
 
   meme = callPackage ../applications/graphics/meme { };


### PR DESCRIPTION
###### Motivation for this change
Get some more of elementary's 'thirdparty' applications in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

