### PR TITLE
Fixes the lldpd service not starting on NixOS 18.09

### DIFF
--- a/pkgs/tools/networking/lldpd/default.nix
+++ b/pkgs/tools/networking/lldpd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkgconfig, removeReferencesTo
+{ stdenv, lib, fetchurl, fetchpatch, pkgconfig, removeReferencesTo
 , libevent, readline, net_snmp }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,16 @@ stdenv.mkDerivation rec {
     url = "https://media.luffy.cx/files/lldpd/${name}.tar.gz";
     sha256 = "0lgiappbjm95r1m0xyxb6gzz4izcjixknbzq3s7pbqbsmhm642s5";
   };
+
+  patches = [
+    # Fixes #44507: The service fails to start due to a /bin/mkdir call.
+    # Should be included in the upstream release after 1.0.1.
+    # Please remove this patch when updating and ensure the NixOS service starts.
+    (fetchpatch {
+      url = "https://github.com/vincentbernat/lldpd/commit/90a50860ebdcdeb5b7dc85790b18bed23c97ec32.patch";
+      sha256 = "005i4ldc4mfzfmvbnid6849ax2i93mx8nkyf8vjv8k73bfpdza8z";
+    })
+  ];
 
   configureFlags = [
     "--localstatedir=/var"


### PR DESCRIPTION
Backports a patch that will be included in later versions, no longer calling /bin/mkdir.
Fixes #44507.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

