### PR TITLE
pythonPackages.mahotas: fix build, move expression

### DIFF
--- a/pkgs/development/python-modules/mahotas/default.nix
+++ b/pkgs/development/python-modules/mahotas/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage, fetchFromGitHub, nose, pillow, scipy, numpy, imread, stdenv }:
+
+buildPythonPackage rec {
+  pname = "mahotas";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "luispedro";
+    repo = "mahotas";
+    rev = "v${version}";
+    sha256 = "1d2hciag5sxw00qj7qz7lbna477ifzmpgl0cv3xqzjkhkn5m4d7r";
+  };
+
+  # remove this as soon as https://github.com/luispedro/mahotas/issues/97 is fixed
+  patches = [ ./disable-impure-tests.patch ];
+
+  propagatedBuildInputs = [ numpy imread pillow scipy ];
+  checkInputs = [ nose ];
+
+  checkPhase= ''
+    python setup.py test
+  '';
+
+  disabled = stdenv.isi686; # Failing tests
+
+  meta = with stdenv.lib; {
+    description = "Computer vision package based on numpy";
+    homepage = http://mahotas.readthedocs.io/;
+    maintainers = with maintainers; [ luispedro ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/mahotas/disable-impure-tests.patch
+++ b/pkgs/development/python-modules/mahotas/disable-impure-tests.patch
@@ -1,0 +1,34 @@
+diff --git a/mahotas/tests/test_colors.py b/mahotas/tests/test_colors.py
+index 8a8183b..0d34c9f 100644
+--- a/mahotas/tests/test_colors.py
++++ b/mahotas/tests/test_colors.py
+@@ -2,7 +2,9 @@ import mahotas
+ import numpy as np
+ from mahotas.tests.utils import luispedro_jpg
+ from mahotas.colors import rgb2xyz, rgb2lab, xyz2rgb, rgb2grey, rgb2sepia
++from nose.tools import nottest
+ 
++@nottest
+ def test_colors():
+     f = luispedro_jpg()
+     lab = rgb2lab(f)
+diff --git a/mahotas/tests/test_features_shape.py b/mahotas/tests/test_features_shape.py
+index 462f467..2381793 100644
+--- a/mahotas/tests/test_features_shape.py
++++ b/mahotas/tests/test_features_shape.py
+@@ -2,6 +2,7 @@ import mahotas.features.shape
+ import numpy as np
+ import mahotas as mh
+ from mahotas.features.shape import roundness, eccentricity
++from nose.tools import nottest
+ 
+ def test_eccentricity():
+     D = mh.disk(32, 2)
+@@ -29,6 +30,7 @@ def test_zeros():
+     I[8:4:12] = 1
+     assert eccentricity(I) == 0
+ 
++@nottest
+ def test_ellipse_axes():
+     Y,X = np.mgrid[:1024,:1024]
+     Y = Y/1024.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1712,35 +1712,7 @@ in {
 
   idna = callPackage ../development/python-modules/idna { };
 
-  mahotas = buildPythonPackage rec {
-    name = "python-mahotas-${version}";
-    version = "1.4.2";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/luispedro/mahotas/archive/v${version}.tar.gz";
-      sha256 = "1mvsxh0pa5vdvbknlv1m68n7gw2cv4pyqgqp3r770rnmf6nxbp7m";
-    };
-
-    buildInputs = with self; [
-      nose
-      pillow
-      scipy
-    ];
-    propagatedBuildInputs = with self; [
-      numpy
-      imread
-    ];
-
-    disabled = stdenv.isi686; # Failing tests
-
-    meta = with stdenv.lib; {
-      description = "Computer vision package based on numpy";
-      homepage = http://mahotas.readthedocs.io/;
-      maintainers = with maintainers; [ luispedro ];
-      license = licenses.mit;
-      platforms = platforms.linux;
-    };
-  };
+  mahotas = callPackage ../development/python-modules/mahotas { };
 
   MDP = callPackage ../development/python-modules/mdp {};
 


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80828287

Moves `mahotas` out of `python-packages.nix` into its own file and fixes
broken test cases by skipping them using nosetest's `@nottest`
annotation.

These tests broke from time to time in a sandbox and are therefore
considered impure.

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

