### PR TITLE
pdf2htmlEX: mark as broken

### DIFF
--- a/pkgs/tools/typesetting/pdf2htmlEX/default.nix
+++ b/pkgs/tools/typesetting/pdf2htmlEX/default.nix
@@ -43,5 +43,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl3Plus;
     maintainers = [ maintainers.taktoa ];
     platforms   = with platforms; linux;
+    broken      = true; # 2018-09-08
   };
 }


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/81003667

The build is currently broken on Hydra due to the following error:

```
CairoFontEngine.cc:681:17: error: 'void Object::free()' is private within this context
```

This issue is was also reported in AUR (https://aur.archlinux.org/packages/pdf2htmlex/)
and in the upstream issue tracker (https://github.com/coolwanglu/pdf2htmlEX/issues/753) with
no answer until now.

The current README.md states that the project is no longer under active
development and it seems as there are currently no active maintainers
who could fix this:

* https://github.com/coolwanglu/pdf2htmlEX/commit/5d0a2239fcf6ef60a1140edb917fad69d751d6e3
* https://github.com/coolwanglu/pdf2htmlEX/issues/772

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

