### PR TITLE
sks,nixos/sks: Various minor improvements

### DIFF
--- a/nixos/modules/services/security/sks.nix
+++ b/nixos/modules/services/security/sks.nix
@@ -53,6 +53,21 @@ in {
         type = types.ints.u16;
         description = "HKP port to listen on.";
       };
+
+      webroot = mkOption {
+        type = types.path;
+        default = "${sksPkg.webSamples}/OpenPKG";
+        defaultText = "\${pkgs.sks.webSamples}/OpenPKG";
+        description = ''
+	  Source directory (will be symlinked) for the files the built-in
+	  webserver should serve. SKS (''${pkgs.sks.webSamples}) provides the
+	  following examples: "HTML5", "OpenPKG", and "XHTML+ES". The index
+	  file can be named index.html, index.htm, index.xhtm, or index.xhtml.
+	  Files with the extensions .css, .es, .js, .jpg, .jpeg, .png, or .gif
+	  are supported. Subdirectories and filenames with anything other than
+          alphanumeric characters and the '.' character will be ignored.
+        '';
+      };
     };
   };
 
@@ -78,6 +93,7 @@ in {
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         preStart = ''
+          ln -sfT "${cfg.webroot}" web
           mkdir -p ${home}/dump
           ${sksPkg}/bin/sks build ${home}/dump/*.gpg -n 10 -cache 100 || true #*/
           ${sksPkg}/bin/sks cleandb || true

--- a/nixos/modules/services/security/sks.nix
+++ b/nixos/modules/services/security/sks.nix
@@ -55,17 +55,18 @@ in {
       };
 
       webroot = mkOption {
-        type = types.path;
+        type = types.nullOr types.path;
         default = "${sksPkg.webSamples}/OpenPKG";
         defaultText = "\${pkgs.sks.webSamples}/OpenPKG";
         description = ''
-	  Source directory (will be symlinked) for the files the built-in
-	  webserver should serve. SKS (''${pkgs.sks.webSamples}) provides the
-	  following examples: "HTML5", "OpenPKG", and "XHTML+ES". The index
-	  file can be named index.html, index.htm, index.xhtm, or index.xhtml.
-	  Files with the extensions .css, .es, .js, .jpg, .jpeg, .png, or .gif
-	  are supported. Subdirectories and filenames with anything other than
-          alphanumeric characters and the '.' character will be ignored.
+          Source directory (will be symlinked, if not null) for the files the
+          built-in webserver should serve. SKS (''${pkgs.sks.webSamples})
+          provides the following examples: "HTML5", "OpenPKG", and "XHTML+ES".
+          The index file can be named index.html, index.htm, index.xhtm, or
+          index.xhtml. Files with the extensions .css, .es, .js, .jpg, .jpeg,
+          .png, or .gif are supported. Subdirectories and filenames with
+          anything other than alphanumeric characters and the '.' character
+          will be ignored.
         '';
       };
     };
@@ -95,7 +96,8 @@ in {
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         preStart = ''
-          ln -sfT "${cfg.webroot}" web
+          ${lib.optionalString (cfg.webroot != null)
+            "ln -sfT \"${cfg.webroot}\" web"}
           mkdir -p dump
           ${sksPkg}/bin/sks build dump/*.gpg -n 10 -cache 100 || true #*/
           ${sksPkg}/bin/sks cleandb || true

--- a/pkgs/servers/sks/adapt-to-nixos.patch
+++ b/pkgs/servers/sks/adapt-to-nixos.patch
@@ -1,0 +1,27 @@
+--- a/version.ml	2018-09-08 15:56:18.919154257 +0200
++++ b/version.ml	2018-09-08 15:56:07.544028575 +0200
+@@ -24,16 +24,6 @@
+ 
+ let run () =
+   let bdb_version = Bdb.version () in
+-  let dbstats_dir =
+-    let split = Str.regexp_string "." in
+-    let major_minor_string major minor =
+-      sprintf "Further details about the BDB environment can be seen by \
+-	  executing\ndb%s.%s_stat -x in the KDB and Ptree directories\n" major minor
+-    in
+-    match Str.split split bdb_version with
+-    | major :: minor :: _ -> major_minor_string major minor
+-    | [] | _ :: []        -> major_minor_string "X"   "Y"
+-  in
+   printf "SKS version %s%s\n"
+     Common.version Common.version_suffix;
+ 	
+@@ -44,5 +34,6 @@
+          requirement for recon of SKS %s\n"
+       Common.compatible_version_string;
+ 	
+-  printf "%s" dbstats_dir
++  printf "Further details about the BDB environment can be seen by executing\n\
++    db_stat -x in the KDB and PTree directories\n"
+ 

--- a/pkgs/servers/sks/default.nix
+++ b/pkgs/servers/sks/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "00q5ma5rvl10rkc6cdw8d69bddgrmvy0ckqj3hbisy65l4idj2zm";
   };
 
+  outputs = [ "out" "webSamples" ];
+
   buildInputs = [ ocaml zlib db perl camlp4 ];
 
   makeFlags = [ "PREFIX=$(out)" "MANDIR=$(out)/share/man" ];
@@ -25,6 +27,9 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkPhase = "./sks unit_test";
+
+  # Copy the web examples for the NixOS module
+  postInstall = "cp -R sampleWeb $webSamples";
 
   meta = with stdenv.lib; {
     description = "An easily deployable & decentralized OpenPGP keyserver";

--- a/pkgs/servers/sks/default.nix
+++ b/pkgs/servers/sks/default.nix
@@ -11,6 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "00q5ma5rvl10rkc6cdw8d69bddgrmvy0ckqj3hbisy65l4idj2zm";
   };
 
+  # pkgs.db provides db_stat, not db$major.$minor_stat
+  patches = [ ./adapt-to-nixos.patch ];
+
   outputs = [ "out" "webSamples" ];
 
   buildInputs = [ ocaml zlib db perl camlp4 ];


### PR DESCRIPTION
###### Motivation for this change

Module:
- Add a webroot option (serve a website by default, makes the setup easier)
- Explicitly set a group (instead of using 65534/nogroup)
- Move pkgs.sks from environment.systemPackages to the "sks" user and add pkgs.db

Package:
- Adapt the output of "sks version" to NixOS
- Copy the example webpages to $webSamples

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

