### PR TITLE
Add more deepin packages

### DIFF
--- a/pkgs/desktops/deepin/dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/dbus-factory/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, jq, libxml2, go-dbus-generator }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dbus-factory";
+  version = "3.1.17";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1llq8wzgikgpzj7z36fyzk8kjych2h9nzi3x6zv53z0xc1xn4256";
+  };
+
+  nativeBuildInputs = [
+    jq
+    libxml2
+    go-dbus-generator
+  ];
+
+  makeFlags = [ "GOPATH=$(out)/share/gocode" ];
+
+  meta = with stdenv.lib; {
+    description = "Generates static DBus bindings for Golang and QML at build-time";
+    homepage = https://github.com/linuxdeepin/dbus-factory;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/deepin-sound-theme/default.nix
+++ b/pkgs/desktops/deepin/deepin-sound-theme/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "deepin-sound-theme-${version}";
+  version = "15.10.3";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = "deepin-sound-theme";
+    rev = version;
+    sha256 = "1sw4nrn7q7wk1hpicm05apyc0mihaw42iqm52wb8ib8gm1qiylr9";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Deepin sound theme";
+    homepage = https://github.com/linuxdeepin/deepin-sound-theme;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -17,6 +17,7 @@ let
     };
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };
+    go-gir-generator = callPackage ./go-gir-generator { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
     qt5integration = callPackage ./qt5integration { };
 

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -3,6 +3,7 @@
 let
   packages = self: with self; {
 
+    dbus-factory = callPackage ./dbus-factory { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -10,6 +10,7 @@ let
     deepin-menu = callPackage ./deepin-menu { };
     deepin-mutter = callPackage ./deepin-mutter { };
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
+    deepin-sound-theme = callPackage ./deepin-sound-theme { };
     deepin-terminal = callPackage ./deepin-terminal {
       inherit (pkgs.gnome3) libgee vte;
       wnck = pkgs.libwnck3;

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -18,6 +18,7 @@ let
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };
     go-gir-generator = callPackage ./go-gir-generator { };
+    go-lib = callPackage ./go-lib { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
     qt5integration = callPackage ./qt5integration { };
 

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -17,6 +17,7 @@ let
     };
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };
+    go-dbus-generator = callPackage ./go-dbus-generator { };
     go-gir-generator = callPackage ./go-gir-generator { };
     go-lib = callPackage ./go-lib { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -17,6 +17,7 @@ let
     };
     dtkcore = callPackage ./dtkcore { };
     dtkwidget = callPackage ./dtkwidget { };
+    go-dbus-factory = callPackage ./go-dbus-factory { };
     go-dbus-generator = callPackage ./go-dbus-generator { };
     go-gir-generator = callPackage ./go-gir-generator { };
     go-lib = callPackage ./go-lib { };

--- a/pkgs/desktops/deepin/go-dbus-factory/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-factory/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "go-dbus-factory";
+  version = "0.0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0gj2xxv45gh7wr5ry3mcsi46kdsyq9nbd7znssn34kapiv40ixcx";
+  };
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "GoLang DBus factory for the Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/go-dbus-factory;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/go-dbus-generator/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-generator/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, go, go-lib }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "go-dbus-generator";
+  version = "0.6.6";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "17rzicqizyyrhjjf4rild7py1cyd07b2zdcd9nabvwn4gvj6lhfb";
+  };
+
+  nativeBuildInputs = [
+    go
+    go-lib
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "GOPATH=$(GGOPATH):${go-lib}/share/gocode"
+    "HOME=$(TMP)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Convert dbus interfaces to go-lang or qml wrapper code";
+    homepage = https://github.com/linuxdeepin/go-dbus-generator;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-gir-generator/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, go, gobjectIntrospection, libgudev }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "go-gir-generator";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0yi3lsgkxi8ghz2c7msf2df20jxkvzj8s47slvpzz4m57i82vgzl";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    go
+  ];
+
+  buildInputs = [
+    gobjectIntrospection
+    libgudev
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "HOME=$(TMP)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Generate static golang bindings for GObject";
+    homepage = https://github.com/linuxdeepin/go-gir-generator;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/go-lib/default.nix
+++ b/pkgs/desktops/deepin/go-lib/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, glib, xorg, gdk_pixbuf, pulseaudio,
+  mobile-broadband-provider-info
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "go-lib";
+  version = "1.2.16.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0nl35dm0bdca38qhnzdpsv6b0vds9ccvm4c86rs42a7c6v655b1q";
+  };
+
+  buildInputs = [
+    glib
+    xorg.libX11
+    gdk_pixbuf
+    pulseaudio
+    mobile-broadband-provider-info
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Go bindings for Deepin Desktop Environment development";
+    homepage = https://github.com/linuxdeepin/go-lib;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

- Add [deepin-sound-theme](https://github.com/linuxdeepin/deepin-sound-theme) (the freedesktop sound theme for Deepin)
- Add [go-gir-generator](https://github.com/linuxdeepin/go-gir-generator) (Project go-gir-generator implements GObject-introspection based bindings generator for Go)
- Add [go-lib](https://github.com/linuxdeepin/go-lib) (Deepin GoLang Library is a library containing many useful go routines for things such as glib, gettext, archive, graphic,etc.)
- Add [go-dbus-generator](https://github.com/linuxdeepin/go-dbus-generator) (DBus Generator is static dbus binding tool for multipble languages.)
- Add [go-dbus-factory](https://github.com/linuxdeepin/go-dbus-factory) (GoLang DBus factory for the Deepin Desktop Environment)
- Add [dbus-factory](https://github.com/linuxdeepin/dbus-factory) (DBus Factory is a project which generates static dbus bindings for Golang and QML at build-time.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).