### PR TITLE
treewide: Fix variables in homepages

### DIFF
--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -18,7 +18,7 @@ fetchzip rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://dotcolon.net/font/{pname}/";
+    homepage = "http://dotcolon.net/font/${pname}/";
     description = "Serif font designed by Sora Sagano";
     longDescription = ''
       Medio is a serif font designed by Sora Sagano, based roughly

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -18,7 +18,7 @@ fetchzip rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://dotcolon.net/font/{pname}/";
+    homepage = "http://dotcolon.net/font/${pname}/";
     description = "Geometric sans serif designed by Sora Sagano";
     longDescription = ''
      Penna is a geometric sans serif designed by Sora Sagano,

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -18,7 +18,7 @@ fetchzip rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://dotcolon.net/font/{pname}/";
+    homepage = "http://dotcolon.net/font/${pname}/";
     description = "A weighted sans serif font";
     platforms = platforms.all;
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -18,7 +18,7 @@ fetchzip rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = "http://dotcolon.net/font/{pname}/";
+    homepage = "http://dotcolon.net/font/${pname}/";
     description = "Roman body font designed for main text by Sora Sagano";
     longDescription = ''
       Seshat is a Roman body font designed for the main text. By


### PR DESCRIPTION
###### Motivation for this change

The URLs would be wrong otherwise. Not sure if this should be ported to staging-18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

