### PR TITLE
texlive: Adds patch for missing synctex header. (Fixes zathura build)

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -32,6 +32,11 @@ let
         url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/texlive-poppler-0.64.patch?h=packages/texlive-bin;
         sha256 = "0443d074zl3c5raba8jyhavish706arjcd80ibb84zwnwck4ai0w";
       })
+      (fetchurl {
+        name = "synctex-missing-header.patch";
+        url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/synctex-missing-header.patch?h=packages/texlive-bin&id=da56abf0f8a1e85daca0ec0f031b8fa268519e6b;
+        sha256 = "1c4aq8lk8g3mlfq3mdjnxvmhss3qs7nni5rmw0k054dmj6q1xj5n";
+      })
     ];
 
     configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

This seems like a known issue as other distributions (ArchLinux here)
have patches fixing the issue.

This hopefully fixes more than one dependant builds for ZHF 18.09. #45960 

~~This is marked **WIP** because I'll be using ofborg's output to figure out other affected packages, and see if there are issues... Though I expect the list to be a bit big since texlive is deeply entrenched.~~

With a superficial look, it seems to only fix zathura builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

* * *


### zathura notes

My current tests are that zathura builds, and starts. It seems that zathura could have other issues than that, making it subtly broken, while building. (Alternatively, I could be using it wrong.)

In the console:

```
error: Can not copy to temporary file: Operation not supported
```

In zathura's gui

```
Could not read file from GIO and copy it to a temporary file.
```

I expect fully that those are *irrelevant* to the change from this PR.

---

