### PR TITLE
treewide: Use http/https for homepages

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = git://github.com/QuickChick/QuickChick.git;
+    homepage = https://github.com/QuickChick/QuickChick;
     description = "Randomized property-based testing plugin for Coq; a clone of Haskell QuickCheck";
     maintainers = with maintainers; [ jwiegley ];
     platforms = coq.meta.platforms;

--- a/pkgs/development/coq-modules/category-theory/default.nix
+++ b/pkgs/development/coq-modules/category-theory/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = git://github.com/jwiegley/category-theory.git;
+    homepage = https://github.com/jwiegley/category-theory;
     description = "A formalization of category theory in Coq for personal study and practical work";
     maintainers = with maintainers; [ jwiegley ];
     platforms = coq.meta.platforms;

--- a/pkgs/development/coq-modules/coq-haskell/default.nix
+++ b/pkgs/development/coq-modules/coq-haskell/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = git://github.com/jwiegley/coq-haskell.git;
+    homepage = https://github.com/jwiegley/coq-haskell;
     description = "A library for formalizing Haskell types and functions in Coq";
     maintainers = with maintainers; [ jwiegley ];
     platforms = coq.meta.platforms;

--- a/pkgs/development/python-modules/urlgrabber/default.nix
+++ b/pkgs/development/python-modules/urlgrabber/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ pycurl ];
 
   meta = with stdenv.lib; {
-    homepage = "urlgrabber.baseurl.org";
+    homepage = http://urlgrabber.baseurl.org;
     license = licenses.lgpl2Plus;
     description = "Python module for downloading files";
     maintainers = with maintainers; [ qknight ];


### PR DESCRIPTION
###### Motivation for this change

The URLs wouldn't be clickable otherwise. Not sure if this should be ported to staging-18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

