### PR TITLE
nixos/nginx: populate extraDomains with vhosts using useACMEHost

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -619,7 +619,13 @@ in
             user = cfg.user;
             group = lib.mkDefault cfg.group;
             webroot = vhostConfig.acmeRoot;
-            extraDomains = genAttrs vhostConfig.serverAliases (alias: null);
+            extraDomains = genAttrs vhostConfig.serverAliases (alias: null) //
+              (let
+                 otherVhosts = filterAttrs(n: v: v.useACMEHost == vhostConfig.serverName) virtualHosts;
+                 otherVhostDomains = concatLists (mapAttrsToList (name: vhost: [vhost.serverName] ++ vhost.serverAliases)
+                                                                 otherVhosts);
+               in
+                 genAttrs otherVhostDomains (alias: null));
             postRun = ''
               systemctl reload nginx
             '';

--- a/nixos/modules/services/web-servers/nginx/vhost-options.nix
+++ b/nixos/modules/services/web-servers/nginx/vhost-options.nix
@@ -62,7 +62,6 @@ with lib;
         This is useful if you have many subdomains and want to avoid hitting the
         <link xlink:href="https://letsencrypt.org/docs/rate-limits/">rate limit</link>.
         Alternately, you can generate a certificate through <option>enableACME</option>.
-        <emphasis>Note that this option does not create any certificates, nor it does add subdomains to existing ones – you will need to create them manually using  <xref linkend="opt-security.acme.certs"/>.</emphasis>
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

To reduce the number of issued certificates for LE, a solution is to
request one certificate for several domains. This can be done if all
domains are part of the same virual host definition (with
serverAliases) or by using useACMEHost instead of enableACME
attribute. In the later case, the user still had to add the
appropriate domains to the extraDomains attribute of the certificate.
We do that for them.

This has been tested with the following configuration:

    security.acme.production = false;
    services.nginx = {
     enable = true;
     recommendedTlsSettings   = true;

     virtualHosts."exo.89.145.160.62.nip.io" = {
       forceSSL = true;
       enableACME = true;
       serverAliases = [ "exo3.89.145.160.62.nip.io" ];
     };
     virtualHosts."exo2.89.145.160.62.nip.io" = {
       forceSSL = true;
       useACMEHost = "exo.89.145.160.62.nip.io";
       serverAliases = [ "exo4.89.145.160.62.nip.io" ];
     };
     virtualHosts."exo5.89.145.160.62.nip.io" = {
       forceSSL = true;
       enableACME = true;
     };
     virtualHosts."exo6.89.145.160.62.nip.io" = {
       forceSSL = true;
       enableACME = true;
       serverAliases = [ "exo7.89.145.160.62.nip.io" ];
     };
    };

And I get certificates with the following subject alt names:

 - DNS:exo.89.145.160.62.nip.io, DNS:exo2.89.145.160.62.nip.io,
   DNS:exo3.89.145.160.62.nip.io, DNS:exo4.89.145.160.62.nip.io
 - DNS:exo5.89.145.160.62.nip.io
 - DNS:exo6.89.145.160.62.nip.io, DNS:exo7.89.145.160.62.nip.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

