### PR TITLE
qt5.qtwebkit: Fixes modules src being subtly broken.

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -34,7 +34,18 @@ let
   qtCompatVersion = "5.11";
 
   mirror = "http://download.qt.io";
-  srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; };
+  srcs = import ./srcs.nix { inherit fetchurl; inherit mirror; } // {
+    # Community port of the now unmaintained upstream qtwebkit.
+    qtwebkit = {
+      src = fetchFromGitHub {
+        owner = "annulen";
+        repo = "webkit";
+        rev = "4ce8ebc4094512b9916bfa5984065e95ac97c9d8";
+        sha256 = "05h1xnxzbf7sp3plw5dndsvpf6iigh0bi4vlj4svx0hkf1giakjf";
+      };
+      version = "5.212-alpha-01-26-2018";
+    };
+  };
 
   patches = {
     qtbase = [
@@ -102,15 +113,7 @@ let
       qtwayland = callPackage ../modules/qtwayland.nix {};
       qtwebchannel = callPackage ../modules/qtwebchannel.nix {};
       qtwebengine = callPackage ../modules/qtwebengine.nix {};
-      qtwebkit = callPackage ../modules/qtwebkit.nix {
-        src = fetchFromGitHub {
-          owner = "annulen";
-          repo = "webkit";
-          rev = "4ce8ebc4094512b9916bfa5984065e95ac97c9d8";
-          sha256 = "05h1xnxzbf7sp3plw5dndsvpf6iigh0bi4vlj4svx0hkf1giakjf";
-        };
-        version = "5.212-alpha-01-26-2018";
-      };
+      qtwebkit = callPackage ../modules/qtwebkit.nix {};
       qtwebsockets = callPackage ../modules/qtwebsockets.nix {};
       qtx11extras = callPackage ../modules/qtx11extras.nix {};
       qtxmlpatterns = callPackage ../modules/qtxmlpatterns.nix {};

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -5,8 +5,6 @@
 , bison2, flex, gdb, gperf, perl, pkgconfig, python2, ruby
 , darwin
 , flashplayerFix ? false
-, src ? null
-, version ? null
 }:
 
 let
@@ -34,9 +32,6 @@ qtModule {
   ] ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ cmake ];
 
   cmakeFlags = optionals (lib.versionAtLeast qtbase.version "5.11.0") [ "-DPORT=Qt" ];
-
-  inherit src;
-  inherit version;
 
   __impureHostDeps = optionals (stdenv.isDarwin) [
     "/usr/lib/libicucore.dylib"

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -8,7 +8,7 @@ args:
 
 let
   inherit (args) name;
-  version = if (args.version or null) == null then srcs."${name}".version else args.version;
+  version = args.version or srcs."${name}".version;
   src = args.src or srcs."${name}".src;
 in
 


### PR DESCRIPTION
b785d4813e5d0f428b9563b3cea7cc6953fc24db introduced breakage in Qt
modules for 5.6 and 5.9, especially visible is Qt Webkit.

This was manifested by having a non-sensical build log where it is using
the top-level `src` attribute as source instead of Qt Webkit's own
source.

Were it not for the `src` top-level attribute (which is a legit
package), the error would have been made obvious by passing `null` to
`src`.

 This partially reverts newly introduced way `src` can be passed to a
qtModule, instead relying on extending the `srcs` attrset.

For ZHF #45960

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - ⬜ macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ⬜ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ⬜ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @bkchr 