### PR TITLE
mark long-failing packages broken for 18.09

### DIFF
--- a/pkgs/development/compilers/clasp/default.nix
+++ b/pkgs/development/compilers/clasp/default.nix
@@ -70,5 +70,6 @@ stdenv.mkDerivation rec {
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
     homepage = "https://github.com/drmeister/clasp";
+    broken = true; # 2018-09-08, no successful build since 2018-01-03
   };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -189,6 +189,7 @@ EOF
     description = "A web engine based on the Chromium web browser";
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.unix;
+    broken = qt56; # 2018-09-13, no successful build since 2018-04-25
   };
 
 }

--- a/pkgs/development/tools/haskell/leksah/default.nix
+++ b/pkgs/development/tools/haskell/leksah/default.nix
@@ -14,4 +14,8 @@ in stdenv.mkDerivation {
       --prefix PATH : "${leksahEnv}/bin" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
   '';
+
+  meta = {
+    broken = true; # 2018-09-13, no successful hydra build since 2017-08-19
+  };
 }

--- a/pkgs/games/btanks/default.nix
+++ b/pkgs/games/btanks/default.nix
@@ -32,5 +32,6 @@ stdenv.mkDerivation rec {
     homepage = https://sourceforge.net/projects/btanks/;
     description = "Fast 2d tank arcade game";
     license = stdenv.lib.licenses.gpl2Plus;
+    broken = true; # 2018-09-13, no successful build since 2018-03-16
   };
 }

--- a/pkgs/os-specific/darwin/maloader/default.nix
+++ b/pkgs/os-specific/darwin/maloader/default.nix
@@ -33,5 +33,6 @@ stdenv.mkDerivation {
     homepage = https://github.com/shinh/maloader;
     license = stdenv.lib.licenses.bsd2;
     platforms = stdenv.lib.platforms.linux;
+    broken = true; # 2018-09-08, no succesful build since 2017-08-21
   };
 }

--- a/pkgs/servers/kippo/default.nix
+++ b/pkgs/servers/kippo/default.nix
@@ -95,5 +95,6 @@ in stdenv.mkDerivation rec {
       license = licenses.bsd3;
       platforms = platforms.linux;
       maintainers = with maintainers; [ tomberek ];
+      broken = true; # 2018-09-12, failed on hydra since 2017-12-11
     };
 }

--- a/pkgs/servers/web-apps/frab/default.nix
+++ b/pkgs/servers/web-apps/frab/default.nix
@@ -48,5 +48,6 @@ stdenv.mkDerivation rec {
     description = "Web-based conference planning and management system";
     homepage = https://github.com/frab/frab;
     license = licenses.mit;
+    broken = true; # 2018-09-08; no successful hydra build since 2018-02-14
   };
 }


### PR DESCRIPTION
###### Motivation for this change

While looking at Hydra failures for ZHF #45960, I found some packages that have been failing for a long time. Great opportunity to start a little clean-up for 18.09.

I propose a simple rule:
A package that has not had a successful Hydra build since 2018-03-01 (before 18.03 was branched off) deserves neither immediate investigation nor more Hydra resources, and will be marked broken right away. It would have been fixed by now if there was demand for it.

Of course, whoever is interested can fix and resurrect them later... If that doesn't happen, these packages should be removed for 19.03.

I'll keep adding more packages to this list as I find them, and merge when the list is long enough :smile:

###### How you can help

- Drop a comment if you find more packages that should be on this list
- Also tell me if I'm wrong and a package should NOT be marked broken
- Committers, feel free to add commits to this PR

---

cc @samueldr @vcunat 