### PR TITLE
Dell laptop fan control service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -272,6 +272,7 @@
   ./services/hardware/illum.nix
   ./services/hardware/interception-tools.nix
   ./services/hardware/irqbalance.nix
+  ./services/hardware/i8kmon.nix
   ./services/hardware/lcd.nix
   ./services/hardware/lirc.nix
   ./services/hardware/nvidia-optimus.nix

--- a/nixos/modules/services/hardware/i8kmon.nix
+++ b/nixos/modules/services/hardware/i8kmon.nix
@@ -1,0 +1,137 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.i8kmon;
+
+in {
+
+  options = {
+
+    services.i8kmon = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable i8kmon, fan controller for Dell laptops.
+          *ATTENTION* Use at your own risk, as misconfiguration can lead to hardware damage.
+        '';
+      };
+
+      state0 = mkOption {
+        type = types.str;
+        default = "{0 0} \-1 60 \-1 65";
+        description = ''
+          {LEFTFANSTATE RIGHTFANSTATE} LOWONAC HIGHONAC LOWONBATTERY HIGHONBATTERY
+          LEFTFANSTATE 0 disabled, 1 enabled, - fan missing
+          RIGHTFANSTATE 0 disabled, 1 enabled, - fan missing
+	  LOWON{AC,BATTERY} low threshold on state 0, must be '\-1'.
+          HIGHON{AC,BATTERY} maximum threshold on state 0.
+          Read the i8kmon manpage for more information about these values.
+        '';
+      };
+
+      state1 = mkOption {
+        type = types.str;
+        default = "{1 0} 50 70 55 75";
+        description = ''
+          {LEFTFANSTATE RIGHTFANSTATE} LOWONAC HIGHONAC LOWONBATTERY HIGHONBATTERY
+          LEFTFANSTATE 0 disabled, 1 enabled, - fan missing
+          RIGHTFANSTATE 0 disabled, 1 enabled, - fan missing
+	  LOWON{AC,BATTERY} low threshold on state 1.
+          HIGHON{AC,BATTERY} maximum threshold on state 1.
+          Read the i8kmon manpage for more information about these values.
+        '';
+      };
+
+      state2 = mkOption {
+        type = types.str;
+        default = "{1 1} 60 80 65 85";
+        description = ''
+          {LEFTFANSTATE RIGHTFANSTATE} LOWONAC HIGHONAC LOWONBATTERY HIGHONBATTERY
+          LEFTFANSTATE 0 disabled, 1 enabled, - fan missing
+          RIGHTFANSTATE 0 disabled, 1 enabled, - fan missing
+	  LOWON{AC,BATTERY} low threshold on state 2.
+          HIGHON{AC,BATTERY} maximum threshold on state 2.
+          Read the i8kmon manpage for more information about these values.
+        '';
+      };
+
+      state3 = mkOption {
+        type = types.str;
+        default = "{2 2} 70 128 75 128";
+        description = ''
+          {LEFTFANSTATE RIGHTFANSTATE} LOWONAC HIGHONAC LOWONBATTERY HIGHONBATTERY
+          LEFTFANSTATE 0 disabled, 1 enabled, - fan missing
+          RIGHTFANSTATE 0 disabled, 1 enabled, - fan missing
+	  LOWON{AC,BATTERY} low threshold on state 3.
+          HIGHON{AC,BATTERY} maximum threshold on state 3, must be '128'.
+          Read the i8kmon manpage for more information about these values.
+        '';
+      };
+
+      leftspeed = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          STATE0SPEED STATE1SPEED STATE2SPEED STATE3SPEED
+          Speed values of the left fan at the states 0 - 3.
+          Example: '0 1000 2000 3000'
+          If the values are not given, i8kmon will probe these values (turns fan on at maximum).
+        '';
+      };
+
+      rightspeed = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          STATE0SPEED STATE1SPEED STATE2SPEED STATE3SPEED
+          Speed values of the right fan at the states 0 - 3.
+          Example: '0 1000 2000 3000'
+          If the values are not given, i8kmon will probe these values (turns fan on at maximum).
+        '';
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ pkgs.dell-bios-fan-control pkgs.i8kutils ];
+
+    environment.etc = {
+      "i8kmon.conf" = {
+        source = pkgs.writeText "i8kmon.conf" ''
+          set config(0) {${cfg.state0}}
+          set config(1) {${cfg.state1}}
+          set config(2) {${cfg.state2}}
+          set config(3) {${cfg.state3}}
+
+          ${lib.optionalString (cfg.leftspeed != null) ''set status(leftspeed) "${cfg.leftspeed}"''}
+          ${lib.optionalString (cfg.rightspeed != null) ''set status(rightspeed) "${cfg.rightspeed}"''}
+        '';
+      };
+    };
+
+    systemd.services.i8kmon = {
+      description = "i8kmon";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        ConditionPathExists = [ "/proc/i8k" ];
+      };
+      serviceConfig = {
+        ExecStartPre = "${pkgs.dell-bios-fan-control}/bin/dell-bios-fan-control 0";
+        ExecStopPost = "${pkgs.dell-bios-fan-control}/bin/dell-bios-fan-control 1";
+        ExecStart = "${pkgs.i8kutils}/bin/i8kmon -nc";
+        Restart = "always";
+        RestartSec = 5;
+      };
+    };
+
+  };
+
+}

--- a/pkgs/tools/system/dell-bios-fan-control/default.nix
+++ b/pkgs/tools/system/dell-bios-fan-control/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "dell-bios-fan-control-${version}";
+  version = "2018-05-21";
+
+  src = fetchFromGitHub {
+    owner = "TomFreudenberg";
+    repo = "dell-bios-fan-control";
+    rev = "a2c81a2918b15b97bdb1c6bf41233e4c2786d416";
+    sha256 = "1d1cc4j6cz900mcf55kqfywzddv809yp0lsfwg8j890bv1s7riwa";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+   
+    cp dell-bios-fan-control $out/bin/
+  '';
+
+  meta = {
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ bkchr ];
+    platforms = stdenv.lib.platforms.linux;
+    description = "A user space utility to set control of fans by bios on some Dell laptops";
+  };
+}

--- a/pkgs/tools/system/i8kutils/default.nix
+++ b/pkgs/tools/system/i8kutils/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, tcl, bash, acpi, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "i8kutils-${version}";
+  version = "2018-06-03";
+
+  src = fetchFromGitHub {
+    owner = "vitorafsr";
+    repo = "i8kutils";
+    rev = "ade7dc70fe00b6067916a0f235ec2b5cffb41dec";
+    sha256 = "1qa7ga8apavqsyxas8rh11d3bbkavlxxr90hl95h0k5sg9v583na";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace i8kmon \
+      --replace '/usr/bin/env tclsh' ${tcl}/bin/tclsh \
+      --replace /usr/bin/i8kfan $out/bin/i8kfan \
+      --replace i8kctl $out/bin/i8kctl
+    substituteInPlace i8kfan \
+      --replace /bin/bash ${bash}/bin/bash \
+      --replace /usr/bin/i8kctl $out/bin/i8kctl
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,etc/modprobe.d,share/man1}
+   
+    cp i8kmon i8kfan i8kctl $out/bin/
+    cp dell-smm-hwmon.conf $out/etc/modprobe.d
+    cp i8kmon.1 $out/share/man1/
+  '';
+
+  preFixup = ''
+    wrapProgram "$out/bin/i8kmon" \
+      --prefix PATH : "${acpi}/bin/"
+  '';
+
+  meta = {
+    license = stdenv.lib.licenses.gpl3;
+    maintainers = with stdenv.lib.maintainers; [ bkchr ];
+    platforms = stdenv.lib.platforms.linux;
+    description = "User-space programs for controlling the fans on some Dell laptops.";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22205,6 +22205,8 @@ with pkgs;
 
   thinkfan = callPackage ../tools/system/thinkfan { };
 
+  dell-bios-fan-control = callPackage ../tools/system/dell-bios-fan-control { };
+
   tup = callPackage ../development/tools/build-managers/tup { };
 
   trufflehog = callPackage ../tools/security/trufflehog { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22205,6 +22205,8 @@ with pkgs;
 
   thinkfan = callPackage ../tools/system/thinkfan { };
 
+  i8kutils = callPackage ../tools/system/i8kutils { };
+
   dell-bios-fan-control = callPackage ../tools/system/dell-bios-fan-control { };
 
   tup = callPackage ../development/tools/build-managers/tup { };


### PR DESCRIPTION
###### Motivation for this change
Adds the i8kmon service for controlling the fans of Dell laptops.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

