### PR TITLE
vkquake: fix build

### DIFF
--- a/pkgs/games/quakespasm/vulkan.nix
+++ b/pkgs/games/quakespasm/vulkan.nix
@@ -1,4 +1,5 @@
-{ stdenv, SDL2, fetchFromGitHub, makeWrapper, gzip, libvorbis, libmad, vulkan-loader }:
+{ stdenv, SDL2, fetchFromGitHub, makeWrapper, gzip, libvorbis, libmad, vulkan-headers, vulkan-loader }:
+
 stdenv.mkDerivation rec {
   name = "vkquake-${version}";
   majorVersion = "1.00";
@@ -13,8 +14,12 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "source/Quake";
 
+  nativeBuildInputs = [
+    makeWrapper vulkan-headers
+  ];
+
   buildInputs = [
-    makeWrapper gzip SDL2 libvorbis libmad vulkan-loader.dev
+    gzip SDL2 libvorbis libmad vulkan-loader
   ];
 
   buildFlags = [ "DO_USERDIRS=1" ];


### PR DESCRIPTION
###### Motivation for this change

`vulkan-loader.dev` doesn't generate `include/vulkan.h` which this needs. Not sure when that changed.

Added `vulkan-headers` to `nativeBuildInputs` and moved `makeWrapper` there as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

