### PR TITLE
pyre: 0.9.0 -> 0.11.0

### DIFF
--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -1,24 +1,30 @@
-{ stdenv, fetchFromGitHub, ocamlPackages, makeWrapper, writeScript }:
+{ stdenv, fetchFromGitHub, ocamlPackages, makeWrapper, writeScript
+, jbuilder, python3, rsync, fetchpatch }:
 let
   # Manually set version - the setup script requires
   # hg and git + keeping the .git directory around.
-  version = "0.0.10";
+  pyre-version = "0.0.11";
   versionFile = writeScript "version.ml" ''
     cat > "./version.ml" <<EOF
+    open Core
     let build_info () =
-    "pyre-nixpkgs ${version}"
+    "pyre-nixpkgs ${pyre-version}"
     let version () =
-    "${version}"
+    "${pyre-version}"
+
+    let log_version_banner () =
+      Log.info "Running as pid: %d" (Pid.to_int (Unix.getpid ()));
+      Log.info "Version: %s" (version ());
     EOF
   '';
-in stdenv.mkDerivation {
-  name = "pyre-${version}";
+ pyre-bin = stdenv.mkDerivation {
+  name = "pyre-${pyre-version}";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "pyre-check";
-    rev = "v${version}";
-    sha256 = "17fk2izq434jsr8dfz828754356qdwa6zv0lbzm6z1kgq4jg7brv";
+    rev = "v${pyre-version}";
+    sha256 = "0ig7bx2kfn2kbxw74wysh5365yp5gyby42l9l29iclrzdghgk32l";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -33,6 +39,8 @@ in stdenv.mkDerivation {
     ppx_deriving_yojson
     ocamlbuild
     ppxlib
+    jbuilder
+    ounit
     # python36Packages.python36Full # TODO
   ];
 
@@ -41,13 +49,15 @@ in stdenv.mkDerivation {
     export HOME=.
 
     # "external" because https://github.com/facebook/pyre-check/pull/8/files
-    sed "s/%VERSION%/external ${version}/" Makefile.template > Makefile
+    sed "s/%VERSION%/external ${pyre-version}/" Makefile.template > Makefile
+    sed "s/%VERSION%/external/" dune.in > dune
 
     cp ${versionFile} ./scripts/generate-version-number.sh
 
     mkdir $(pwd)/build
     export OCAMLFIND_DESTDIR=$(pwd)/build
     export OCAMLPATH=$OCAMLPATH:$(pwd)/build
+
     make release
   '';
 
@@ -60,7 +70,7 @@ in stdenv.mkDerivation {
   # Improvement for a future version.
   installPhase = ''
     mkdir -p $out/bin
-    cp _build/all/main.native $out/bin/pyre.bin
+    cp ./_build/default/main.exe $out/bin/pyre.bin
   '';
 
   meta = with stdenv.lib; {
@@ -70,4 +80,54 @@ in stdenv.mkDerivation {
     platforms = with platforms; linux;
     maintainers = with maintainers; [ teh ];
   };
+};
+typeshed = stdenv.mkDerivation {
+  name = "typeshed";
+  # typeshed doesn't have versions, it seems to be synchronized with
+  # mypy relases. I'm assigning a random version here (same as pyre).
+  version = pyre-version;
+  src = fetchFromGitHub {
+    owner = "python";
+    repo = "typeshed";
+    rev = "a08c6ea";
+    sha256 = "0wy8yh43vhyyc4g7iqnmlj66kz5in02y5qc0c4jdckhpa3mchaqk";
+  };
+  phases = [ "unpackPhase" "installPhase" ];
+  installPhase = "cp -r $src $out";
+};
+in python3.pkgs.buildPythonApplication rec {
+  pname = "pyre-check";
+  version = pyre-version;
+  src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "pyre-check";
+    rev = "v${pyre-version}";
+    sha256 = "0ig7bx2kfn2kbxw74wysh5365yp5gyby42l9l29iclrzdghgk32l";
+  };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/facebook/pyre-check/commit/b473d2ed9fc11e7c1cd0c7b8c42f521e5cdc2003.patch";
+      sha256 = "05xvyp7j4n6z92bxf64rxfq5pvaadxgx1c8c5qziy75vdz72lkcy";
+    })
+    ./pyre-bdist-wheel.patch
+  ];
+
+  # The build-pypi-package script does some funky stuff with build
+  # directories - easier to patch it a bit than to replace it
+  # completely though:
+  postPatch = ''
+    mkdir ./build
+    substituteInPlace scripts/build-pypi-package.sh \
+        --replace 'NIX_BINARY_FILE' '${pyre-bin}/bin/pyre.bin' \
+        --replace 'BUILD_ROOT="$(mktemp -d)"' "BUILD_ROOT=$(pwd)/build"
+  '';
+
+  buildInputs = [ pyre-bin rsync ];
+  propagatedBuildInputs = with python3.pkgs; [ docutils typeshed ];
+  buildPhase = ''
+    bash scripts/build-pypi-package.sh --version ${pyre-version} --bundle-typeshed ${typeshed}
+    cp -r build/dist dist
+  '';
+
+  doCheck = false; # can't open file 'nix_run_setup':
 }

--- a/pkgs/development/tools/pyre/pyre-bdist-wheel.patch
+++ b/pkgs/development/tools/pyre/pyre-bdist-wheel.patch
@@ -1,0 +1,43 @@
+diff --git a/scripts/build-pypi-package.sh b/scripts/build-pypi-package.sh
+index 1035591..bb8cbae 100755
+--- a/scripts/build-pypi-package.sh
++++ b/scripts/build-pypi-package.sh
+@@ -98,7 +98,7 @@ rsync -avm --filter='- tests/' --filter='+ */' --filter='-! *.py' "${SCRIPTS_DIR
+ sed -i -e "/__version__/s/= \".*\"/= \"${PACKAGE_VERSION}\"/" "${BUILD_ROOT}/${MODULE_NAME}/version.py"
+ 
+ # Copy binary files.
+-BINARY_FILE="${SCRIPTS_DIRECTORY}/../_build/default/main.exe"
++BINARY_FILE="NIX_BINARY_FILE"
+ if [[ ! -f "${BINARY_FILE}" ]]; then
+   echo "The binary file ${BINARY_FILE} does not exist."
+   echo "Have you run 'make' in the toplevel directory?"
+@@ -146,7 +146,7 @@ def find_typeshed_files(base):
+         result.append((target, files))
+     return result
+ 
+-with open('README.md') as f:
++with open('README.md', encoding='utf8') as f:
+     long_description = f.read()
+ 
+ setup(
+@@ -205,20 +205,3 @@ fi
+ 
+ # Build.
+ python3 setup.py bdist_wheel
+-
+-# Move artifact outside the build directory.
+-mkdir -p "${SCRIPTS_DIRECTORY}/dist"
+-files_count="$(find "${BUILD_ROOT}/dist/" -type f | wc -l | tr -d ' ')"
+-[[ "${files_count}" == '1' ]] || \
+-  die "${files_count} files created in ${BUILD_ROOT}/dist, but only one was expected"
+-source_file="$(find "${BUILD_ROOT}/dist/" -type f)"
+-destination="$(basename "${source_file}")"
+-destination="${destination/%-any.whl/-${WHEEL_DISTRIBUTION_PLATFORM}.whl}"
+-mv "${source_file}" "${SCRIPTS_DIRECTORY}/dist/${destination}"
+-
+-# Cleanup.
+-cd "${SCRIPTS_DIRECTORY}"
+-rm -rf "${BUILD_ROOT}"
+-
+-printf '\nAll done. Build artifact available at:\n  %s\n' "${SCRIPTS_DIRECTORY}/dist/${destination}"
+-exit 0


### PR DESCRIPTION
###### Motivation for this change

The ocaml pyre binary can't really be used standalone any more, so this wraps into the full python binary.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

