### PR TITLE
nixos: xserver.displayManager: use slim for automatic logins

### DIFF
--- a/nixos/modules/services/x11/display-managers/auto.nix
+++ b/nixos/modules/services/x11/display-managers/auto.nix
@@ -41,12 +41,10 @@ in
 
   config = mkIf cfg.enable {
 
-    services.xserver.displayManager.lightdm = {
+    services.xserver.displayManager.slim = {
       enable = true;
-      autoLogin = {
-        enable = true;
-        user = cfg.user;
-      };
+      autoLogin = true;
+      defaultUser = cfg.user;
     };
 
     # lightdm by default doesn't allow auto login for root, which is

--- a/nixos/modules/services/x11/display-managers/auto.nix
+++ b/nixos/modules/services/x11/display-managers/auto.nix
@@ -47,20 +47,6 @@ in
       defaultUser = cfg.user;
     };
 
-    # lightdm by default doesn't allow auto login for root, which is
-    # required by some nixos tests. Override it here.
-    security.pam.services.lightdm-autologin.text = lib.mkForce ''
-        auth     requisite pam_nologin.so
-        auth     required  pam_succeed_if.so quiet
-        auth     required  pam_permit.so
-
-        account  include   lightdm
-
-        password include   lightdm
-
-        session  include   lightdm
-    '';
-
   };
 
 }

--- a/nixos/tests/flatpak.nix
+++ b/nixos/tests/flatpak.nix
@@ -10,8 +10,6 @@ import ./make-test.nix ({ pkgs, ... }:
   machine = { pkgs, ... }: {
     imports = [ ./common/x11.nix ];
     services.xserver.desktopManager.gnome3.enable = true; # TODO: figure out minimal environment where the tests work
-    # common/x11.nix enables the auto display manager (lightdm)
-    services.xserver.displayManager.gdm.enable = false;
     environment.gnome3.excludePackages = pkgs.gnome3.optionalPackages;
     services.flatpak.enable = true;
     environment.systemPackages = with pkgs; [ gnupg gnome-desktop-testing ostree python2 ];


### PR DESCRIPTION
###### Motivation for this change

`lightdm` is not that light for automatic logins: it runs two processes three threads each (while slim runs one of each) all of which stay in memory even after login is finished. Meanwhile, `auto` users usually want the display manager to get out of their way, not to pollute their system with six useless threads.  Moreover, the closure size of slim+theme in its default config in NixOS is 53M, while the similar closure size of lightdm+greeter+theme is 254M.

###### Things done

- [X] This is how it was before #30890.
- [X] Writing this from a system with this applied.