### PR TITLE
strongswan: set the right dir for TLS CA cert

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -78,7 +78,10 @@ stdenv.mkDerivation rec {
          "--with-tss=trousers"
          "--enable-aikgen"
          "--enable-sqlite" ]
-    ++ optional enableNetworkManager "--enable-nm";
+    ++ optionals enableNetworkManager [
+         "--enable-nm"
+         "--with-nm-ca-dir=/etc/ssl/certs"
+    ];
 
   postInstall = ''
     # this is needed for l2tp


### PR DESCRIPTION
###### Motivation for this change

This fixes an issue where the strongswan NM client is not able to
connect to a VPN. By default it tries to load the trust CA from
/usr/share/ca-certificates which doesn't exist in NixOS and most modern
distros.

See debian-related issue:
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835095

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Since playing around with this I am having issues with the error: `Could not activate connection:  The VPN service  'org.freedesktop.NetworkManager.strongswan' was not installed.`. Even when reverting back to nixos-unstable. I think that there is some state file somewhere that locks the version.