### PR TITLE
altcoins.btc1d: fix darwin build

### DIFF
--- a/pkgs/applications/altcoins/btc1.nix
+++ b/pkgs/applications/altcoins/btc1.nix
@@ -1,6 +1,8 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, openssl, db48, boost
-, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
-, withGui }:
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, hexdump, openssl, db48
+, boost, zlib, miniupnpc, qt4, utillinux, protobuf, qrencode, libevent
+, AppKit
+, withGui ? !stdenv.isDarwin
+}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec{
@@ -12,11 +14,10 @@ stdenv.mkDerivation rec{
     sha256 = "0v0g2wb4nsnhddxzb63vj2bc1mgyj05vqm5imicjfz8prvgc0si8";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook ];
-  buildInputs = [ openssl db48 boost zlib
-                  miniupnpc protobuf libevent]
-                  ++ optionals stdenv.isLinux [ utillinux ]
-                  ++ optionals withGui [ qt4 qrencode ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook hexdump ];
+  buildInputs = [ openssl db48 boost zlib miniupnpc protobuf libevent ]
+    ++ optionals withGui [ qt4 qrencode ]
+    ++ optional stdenv.isDarwin AppKit;
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
                      ++ optionals withGui [ "--with-gui=qt4" ];

--- a/pkgs/applications/altcoins/default.nix
+++ b/pkgs/applications/altcoins/default.nix
@@ -32,8 +32,11 @@ rec {
     boost = boost165; withGui = false;
   };
 
-  btc1 = callPackage ./btc1.nix { boost = boost165; withGui = true; };
-  btc1d = callPackage ./btc1.nix { boost = boost165; withGui = false; };
+  btc1 = callPackage ./btc1.nix {
+    inherit (darwin.apple_sdk.frameworks) AppKit;
+    boost = boost165;
+  };
+  btc1d = btc1.override { withGui = false; };
 
   cryptop = python3.pkgs.callPackage ./cryptop { };
 


### PR DESCRIPTION
The gui build doesn't work yet.

###### Motivation for this change

Only hexdump was needed from utillinux which is also available on darwin
through the unixtools meta package.

/cc ZHF #45961

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
