### PR TITLE
[18.09] set min version back to 1.11

### DIFF
--- a/lib/minver.nix
+++ b/lib/minver.nix
@@ -1,2 +1,2 @@
 # Expose the minimum required version for evaluating Nixpkgs
-"2.0"
+"1.11"

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -141,50 +141,6 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
    </listitem>
    <listitem>
     <para>
-     The minimum version of Nix required to evaluate Nixpkgs is now 2.0.
-    </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       For users of NixOS 18.03, NixOS 18.03 defaulted to Nix 2.0, but
-       supported using Nix 1.11 by setting <literal>nix.package =
-       pkgs.nix1;</literal>. If this option is set to a Nix 1.11 package, you
-       will need to either unset the option or upgrade it to Nix 2.0.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       For users of NixOS 17.09, you will first need to upgrade Nix by setting
-       <literal>nix.package = pkgs.nixStable2;</literal> and run
-       <command>nixos-rebuild switch</command> as the <literal>root</literal>
-       user.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       For users of a daemon-less Nix installation on Linux or macOS, you can
-       upgrade Nix by running <command>curl https://nixos.org/nix/install |
-       sh</command>, or prior to doing a channel update, running
-       <command>nix-env -iA nix</command>.
-      </para>
-      <para>
-       If you have already run a channel update and Nix is no longer able to
-       evaluate Nixpkgs, the error message printed should provide adequate
-       directions for upgrading Nix.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       For users of the Nix daemon on macOS, you can upgrade Nix by running
-       <command>sudo -i sh -c 'nix-channel --update &amp;&amp; nix-env -iA
-       nixpkgs.nix'; sudo launchctl stop org.nixos.nix-daemon; sudo launchctl
-       start org.nixos.nix-daemon</command>.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </listitem>
-   <listitem>
-    <para>
      <literal>lib.strict</literal> is removed. Use
      <literal>builtins.seq</literal> instead.
     </para>

--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ duplicity ];
 
-  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
+  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "lib/nautilus/extensions-3.0";
 
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas

--- a/pkgs/applications/misc/qpdfview/default.nix
+++ b/pkgs/applications/misc/qpdfview/default.nix
@@ -21,16 +21,11 @@ stdenv.mkDerivation {
   src = fetchurl {
     inherit (s) url sha256;
   };
-  qmakeFlags = [
-    "*.pro"
-    "TARGET_INSTALL_PATH=${placeholder "out"}/bin"
-    "PLUGIN_INSTALL_PATH=${placeholder "out"}/lib/qpdfview"
-    "DATA_INSTALL_PATH=${placeholder "out"}/share/qpdfview"
-    "MANUAL_INSTALL_PATH=${placeholder "out"}/share/man/man1"
-    "ICON_INSTALL_PATH=${placeholder "out"}/share/icons/hicolor/scalable/apps"
-    "LAUNCHER_INSTALL_PATH=${placeholder "out"}/share/applications"
-    "APPDATA_INSTALL_PATH=${placeholder "out"}/share/appdata"
-  ];
+
+  # TODO: revert this once placeholder is supported
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags *.pro TARGET_INSTALL_PATH=$out/bin PLUGIN_INSTALL_PATH=$out/lib/qpdfview DATA_INSTALL_PATH=$out/share/qpdfview MANUAL_INSTALL_PATH=$out/share/man/man1 ICON_INSTALL_PATH=$out/share/icons/hicolor/scalable/apps LAUNCHER_INSTALL_PATH=$out/share/applications APPDATA_INSTALL_PATH=$out/share/appdata"
+  '';
 
   meta = {
     inherit (s) version;

--- a/pkgs/desktops/gnome-3/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/apps/file-roller/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ glib gtk json-glib libarchive file gnome3.defaultIconTheme libnotify nautilus ];
 
-  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
+  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "lib/nautilus/extensions-3.0";
 
   postPatch = ''
     chmod +x postinstall.py # patchShebangs requires executable file

--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib gtk3 gjs pango gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme libunistring ];
 
   mesonFlags = [
-    "-Ddbus_service_dir=${placeholder "out"}/share/dbus-1/services"
+    "-Ddbus_service_dir=share/dbus-1/services"
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -37,9 +37,11 @@ stdenv.mkDerivation rec {
     "-DENABLE_VALA_BINDINGS=ON"
     "-DENABLE_INTROSPECTION=ON"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
-    "-DINCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
   ];
 
+  postPatch = ''
+    cmakeFlags="-DINCLUDE_INSTALL_DIR=$dev/include $cmakeFlags"
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dudev_dir=${placeholder "out"}/lib/udev"
+    "-Dudev_dir=lib/udev"
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/libgee/default.nix
+++ b/pkgs/desktops/gnome-3/core/libgee/default.nix
@@ -6,8 +6,6 @@ in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
-  outputs = [ "out" "dev" ];
-
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${gnome3.versionBranch version}/${name}.tar.xz";
     sha256 = "0c26x8gi3ivmhlbqcmiag4jwrkvcy28ld24j55nqr3jikb904a5v";
@@ -15,11 +13,10 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  patches = [ ./fix_introspection_paths.patch ];
+
   nativeBuildInputs = [ pkgconfig autoconf vala gobjectIntrospection ];
   buildInputs = [ glib ];
-
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/libgee/fix_introspection_paths.patch
+++ b/pkgs/desktops/gnome-3/core/libgee/fix_introspection_paths.patch
@@ -1,0 +1,13 @@
+--- fix_introspection_paths.patch/configure	2014-01-07 17:43:53.521339338 +0000
++++ fix_introspection_paths.patch/configure-fix	2014-01-07 17:45:11.068635069 +0000
+@@ -12085,8 +12085,8 @@
+        INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+        INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+        INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+-       INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+-       INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
++       INTROSPECTION_GIRDIR="${datadir}/gir-1.0"
++       INTROSPECTION_TYPELIBDIR="${libdir}/girepository-1.0"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+        INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
 
   mesonFlags = [
-    "-Dwith-nautilusdir=${placeholder "out"}/lib/nautilus/extensions-3.0"
+    "-Dwith-nautilusdir=lib/nautilus/extensions-3.0"
     # https://bugs.launchpad.net/ubuntu/+source/totem/+bug/1712021
     # https://bugzilla.gnome.org/show_bug.cgi?id=784236
     # https://github.com/mesonbuild/meson/issues/1994

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_GIO_2_0_GIOMODULEDIR = "${placeholder "out"}/lib/gio/modules";
+  PKG_CONFIG_GIO_2_0_GIOMODULEDIR = "lib/gio/modules";
 
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -63,9 +63,9 @@ stdenv.mkDerivation rec {
 
   # Uncomment when switching back to meson
   # mesonFlags = [
-  #   "-Dgio_module_dir=${placeholder "out"}/lib/gio/modules"
-  #   "-Dsystemduserunitdir=${placeholder "out"}/lib/systemd/user"
-  #   "-Ddbus_service_dir=${placeholder "out"}/share/dbus-1/services"
+  #   "-Dgio_module_dir=lib/gio/modules"
+  #   "-Dsystemduserunitdir=lib/systemd/user"
+  #   "-Ddbus_service_dir=share/dbus-1/services"
   #   "-Dtmpfilesdir=no"
   # ] ++ stdenv.lib.optionals (!gnomeSupport) [
   #   "-Dgcr=false" "-Dgoa=false" "-Dkeyring=false" "-Dhttp=false"

--- a/pkgs/development/libraries/libwnck/3.x.nix
+++ b/pkgs/development/libraries/libwnck/3.x.nix
@@ -19,8 +19,8 @@ in stdenv.mkDerivation rec{
   nativeBuildInputs = [ pkgconfig intltool gobjectIntrospection ];
   propagatedBuildInputs = [ libX11 gtk3 ];
 
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${placeholder "dev"}/share/gir-1.0";
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "${placeholder "out"}/lib/girepository-1.0";
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "$(dev)/share/gir-1.0";
+  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR = "$(out)/lib/girepository-1.0";
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -34,7 +34,7 @@ in stdenv.mkDerivation rec {
     "-Denable_gstreamer=true"
   ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "lib/systemd/user";
 
   FONTCONFIG_FILE = fontsConf; # Fontconfig error: Cannot load default config file
 

--- a/pkgs/development/libraries/science/math/sympow/default.nix
+++ b/pkgs/development/libraries/science/math/sympow/default.nix
@@ -34,11 +34,13 @@ stdenv.mkDerivation rec {
     makeWrapper "$out/share/sympow/sympow" "$out/bin/sympow" \
       --run 'export SYMPOW_LOCAL="$HOME/.local/share/sympow"' \
       --run 'if [ ! -d "$SYMPOW_LOCAL" ]; then
-        mkdir -p "$SYMPOW_LOCAL" 
-        cp -r ${placeholder "out"}/share/sympow/* "$SYMPOW_LOCAL"
+        mkdir -p "$SYMPOW_LOCAL"
+        cp -r @out@/share/sympow/* "$SYMPOW_LOCAL"
         chmod -R +xw "$SYMPOW_LOCAL"
     fi' \
       --run 'cd "$SYMPOW_LOCAL"'
+    substituteInPlace $out/bin/sympow --subst-var out
+
     runHook postInstall
   '';
 

--- a/pkgs/development/libraries/spice-gtk/default.nix
+++ b/pkgs/development/libraries/spice-gtk/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext libsoup autoreconfHook vala gobjectIntrospection ];
 
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
+  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "$(out)/share/polkit-1/actions";
 
   configureFlags = [
     "--with-gtk3"

--- a/pkgs/os-specific/linux/dbus-broker/default.nix
+++ b/pkgs/os-specific/linux/dbus-broker/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ dbus glib linuxHeaders systemd ];
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "lib/systemd/system";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "lib/systemd/user";
 
   postInstall = ''
     install -Dm644 ../README $out/share/doc/dbus-broker/README

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -38,9 +38,11 @@ in stdenv.mkDerivation rec {
     [ "--enable-gss"
       "--with-statedir=/var/lib/nfs"
       "--with-krb5=${kerberosEnv}"
-      "--with-systemd=${placeholder "out"}/etc/systemd/system"
+      "--with-systemd=$(out)/etc/systemd/system"
       "--enable-libmount-mount"
-      "--with-pluginpath=${placeholder "lib"}/lib/libnfsidmap" # this installs libnfsidmap
+      # need an absolute path to lib output here.
+      # TODO: use ${placeholder lib} when nix 1.1 is no longer supported
+      "--with-pluginpath=@lib@/lib/libnfsidmap" # this installs libnfsidmap
     ]
     ++ lib.optional (stdenv ? glibc) "--with-rpcgen=${stdenv.glibc.bin}/bin/rpcgen";
 
@@ -72,6 +74,11 @@ in stdenv.mkDerivation rec {
 
       sed '1i#include <stdint.h>' -i support/nsm/rpc.c
     '';
+
+  # TODO: remove when placeholders are allowed (see configureFlags)
+  postConfigure = ''
+    substituteInPlace support/include/config.h --replace '@lib@' "$lib"
+  '';
 
   makeFlags = [
     "sbindir=$(out)/bin"

--- a/pkgs/os-specific/linux/selinux-sandbox/default.nix
+++ b/pkgs/os-specific/linux/selinux-sandbox/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "-m 4755" "-m 755"
     substituteInPlace sandboxX.sh \
       --replace "#!/bin/sh" "#!${bash}/bin/sh" \
-      --replace "/usr/share/sandbox/start" "${placeholder "out"}/share/sandbox/start" \
+      --replace "/usr/share/sandbox/start" "$out/share/sandbox/start" \
       --replace "/usr/bin/cut" "${coreutils}/bin/cut" \
       --replace "/usr/bin/Xephyr" "${xorgserver}/bin/Xepyhr" \
       --replace "secon" "${policycoreutils}/bin/secon"

--- a/pkgs/servers/rpcbind/default.nix
+++ b/pkgs/servers/rpcbind/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
              ++ stdenv.lib.optional useSystemd systemd;
 
   configureFlags = [
-    "--with-systemdsystemunitdir=${if useSystemd then "${placeholder "out"}/etc/systemd/system" else "no"}"
+    "--with-systemdsystemunitdir=${if useSystemd then "$(out)/etc/systemd/system" else "no"}"
     "--enable-warmstarts"
     "--with-rpcuser=rpc"
   ];

--- a/pkgs/tools/graphics/gmic/default.nix
+++ b/pkgs/tools/graphics/gmic/default.nix
@@ -32,10 +32,14 @@ in stdenv.mkDerivation rec {
     "-DBUILD_LIB_STATIC=OFF"
     "-DBUILD_PLUGIN=${if withGimpPlugin then "ON" else "OFF"}"
     "-DENABLE_DYNAMIC_LINKING=ON"
-  ] ++ stdenv.lib.optional withGimpPlugin "-DPLUGIN_INSTALL_PREFIX=${placeholder "gimpPlugin"}/${gimp.targetPluginDir}";
+  ];
 
   postPatch = ''
     cp ${CMakeLists} CMakeLists.txt
+  '';
+
+  preConfigure = stdenv.lib.optionalString withGimpPlugin ''
+    cmakeFlags="$cmakeFlags -DPLUGIN_INSTALL_PREFIX=$gimpPlugin/${gimp.targetPluginDir}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -29,11 +29,11 @@ stdenv.mkDerivation rec {
     glib-compile-schemas $out/share/glib-2.0/schemas
   '';
 
-  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
-  PKG_CONFIG_SYSTEMD_TMPFILESDIR = "${placeholder "out"}/lib/tmpfiles.d";
-  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR= "${placeholder "out"}/share/bash-completion/completions";
-  PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "lib/systemd/system";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "lib/systemd/user";
+  PKG_CONFIG_SYSTEMD_TMPFILESDIR = "lib/tmpfiles.d";
+  PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR= "share/bash-completion/completions";
+  PKG_CONFIG_UDEV_UDEVDIR = "lib/udev";
 
   postFixup = ''
     wrapProgram "$out/libexec/colord-session" \


### PR DESCRIPTION
###### Motivation for this change

This reverts the minver.nix change as well as commits that introduced 2.0 language features. Need more feedback on whether this is okay. My impression was that this was the original intention, to make things easier on users. As a rule, we should make sure it is always be possible to upgrade yearly, so 17.03 -> 18.03 should work and 17.09 -> 18.09 should also work. Eventually we may want to make one of the biyearly releases a LTS.

Fixes #46387

*Note*: this just effects the release-18.09 branch. The minver is still 2.0 in master.

For reference, if you ever need to check for nix 1.0 support, just do ```nix-shell -p nix1 --run 'nix-env -qaP	-f.'```.