### PR TITLE
kodiPlugins: add YATP, drop exodus

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -181,26 +181,6 @@ let self = rec {
     // (mkController "ps")
     // (mkController "snes");
 
-  exodus = mkKodiPlugin rec {
-
-    plugin = "exodus";
-    namespace = "plugin.video.exodus";
-    version = "3.1.13";
-
-    src = fetchurl {
-      url = "https://offshoregit.com/${plugin}/${namespace}/${namespace}-${version}.zip";
-      sha256 = "1zyay7cinljxmpzngzlrr4pnk2a7z9wwfdcsk6a4p416iglyggdj";
-    };
-
-    buildInputs = [ unzip ];
-
-    meta = {
-      description = "A streaming plugin for Kodi";
-      platforms = platforms.all;
-      maintainers = with maintainers; [ edwtjo ];
-    };
-  };
-
   hyper-launcher = let
     pname = "hyper-launcher";
     version = "1.5.2";

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -1,6 +1,7 @@
 { stdenv, callPackage, fetchurl, fetchFromGitHub, unzip
 , cmake, kodiPlain, libcec_platform, tinyxml
-, steam, libusb, pcre-cpp, jsoncpp, libhdhomerun, zlib }:
+, steam, libusb, pcre-cpp, jsoncpp, libhdhomerun, zlib
+, python2Packages }:
 
 with stdenv.lib;
 
@@ -461,5 +462,32 @@ let self = rec {
       license = licenses.cc-by-nc-sa-30;
     };
   };
+
+  yatp = python2Packages.toPythonModule (mkKodiPlugin rec {
+    plugin = "yatp";
+    namespace = "plugin.video.yatp";
+    version = "3.3.2";
+
+    src = fetchFromGitHub {
+      owner = "romanvm";
+      repo = "kodi.yatp";
+      rev = "v.${version}";
+      sha256 = "12g1f57sx7dy6wy7ljl7siz2qs1kxcmijcg7xx2xpvmq61x9qa2d";
+    };
+
+    patches = [ ./yatp/dont-monkey.patch ];
+
+    propagatedBuildInputs = [
+      simpleplugin
+      python2Packages.requests
+      python2Packages.libtorrentRasterbar
+    ];
+
+    meta = {
+      homepage = src.meta.homepage;
+      description = "Yet Another Torrent Player: libtorrent-based torrent streaming for Kodi";
+      license = licenses.gpl3;
+    };
+  });
 
 }; in self

--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -251,6 +251,25 @@ let self = rec {
 
   };
 
+  simpleplugin = mkKodiPlugin rec {
+    plugin = "simpleplugin";
+    namespace = "script.module.simpleplugin";
+    version = "2.3.2";
+
+    src = fetchFromGitHub {
+      owner = "romanvm";
+      repo = namespace;
+      rev = "v.${version}";
+      sha256 = "0myar8dqjigb75pcc8zx3i5z79p1ifgphgb82s5syqywk0zaxm3j";
+    };
+
+    meta = {
+      homepage = src.meta.homepage;
+      description = "Simpleplugin API";
+      license = licenses.gpl3;
+    };
+  };
+
   svtplay = mkKodiPlugin rec {
 
     plugin = "svtplay";

--- a/pkgs/applications/video/kodi/yatp/dont-monkey.patch
+++ b/pkgs/applications/video/kodi/yatp/dont-monkey.patch
@@ -1,0 +1,29 @@
+diff --git a/plugin.video.yatp/server.py b/plugin.video.yatp/server.py
+index 1adcbb5..488b72c 100644
+--- a/plugin.video.yatp/server.py
++++ b/plugin.video.yatp/server.py
+@@ -20,24 +20,8 @@ addon = Addon()
+ _ = addon.initialize_gettext()
+ addon.log_notice('Starting Torrent Server...')
+ 
+-# A monkey-patch to set the necessary librorrent version
+-librorrent_addon = Addon('script.module.libtorrent')
+-orig_custom_version = librorrent_addon.get_setting('custom_version', False)
+-orig_set_version = librorrent_addon.get_setting('set_version', False)
+-librorrent_addon.set_setting('custom_version', 'true')
+-if addon.libtorrent_version == '1.0.9':
+-    librorrent_addon.set_setting('set_version', '4')
+-elif addon.libtorrent_version == '1.1.0':
+-    librorrent_addon.set_setting('set_version', '5')
+-elif addon.libtorrent_version == '1.1.1':
+-    librorrent_addon.set_setting('set_version', '6')
+-else:
+-    librorrent_addon.set_setting('set_version', '0')
+-
+ from libs.server import wsgi_app
+ 
+-librorrent_addon.set_setting('custom_version', orig_custom_version)
+-librorrent_addon.set_setting('set_version', orig_set_version)
+ # ======
+ 
+ if addon.enable_limits:

--- a/pkgs/development/python-modules/requests/default.nix
+++ b/pkgs/development/python-modules/requests/default.nix
@@ -11,8 +11,6 @@ buildPythonPackage rec {
     sha256 = "ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a";
   };
 
-  outputs = [ "out" "dev" ];
-
   nativeBuildInputs = [ pytest ];
   propagatedBuildInputs = [ urllib3 idna chardet certifi ];
   # sadly, tests require networking

--- a/pkgs/development/tools/glslviewer/default.nix
+++ b/pkgs/development/tools/glslviewer/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     libXi libX11
   ] ++ (with python2Packages; [ python setuptools wrapPython ])
     ++ stdenv.lib.optional stdenv.isDarwin Cocoa;
-  pythonPath = with python2Packages; [ requests.dev ];
+  pythonPath = with python2Packages; [ requests ];
 
   # Makefile has /usr/local/bin hard-coded for 'make install'
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change

Continuation of #46196. A mass rebuild.

###### Things done

- [X] Builds and works without issues

Note: after adding `yatp` into `kodiWithPlugins` you have to enable YATP manually in Kodi UI.

Merge at will.