### PR TITLE
git, gpgme: use default texinfo

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -4,7 +4,6 @@
 args @ {config, lib, pkgs}: with args; with pkgs;
 let
   gitBase = callPackage ./git {
-    texinfo = texinfo5;
     svnSupport = false;         # for git-svn support
     guiSupport = false;         # requires tcl/tk
     sendEmailSupport = false;   # requires plenty of perl libraries

--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -2,7 +2,7 @@
 , file, which
 , autoreconfHook
 , git
-, texinfo5
+, texinfo
 , qtbase ? null
 , withPython ? false, swig2 ? null, python ? null
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     [ libgpgerror glib libassuan pth ]
     ++ lib.optional (qtbase != null) qtbase;
 
-  nativeBuildInputs = [ file pkgconfig gnupg autoreconfHook git texinfo5 ]
+  nativeBuildInputs = [ file pkgconfig gnupg autoreconfHook git texinfo ]
   ++ lib.optionals withPython [ python swig2 which ];
 
   postPatch =''


### PR DESCRIPTION
###### Motivation for this change

I don't see any issues with building against `texinfo6` or in generated infopages. No more `texinfo5` on my system.

###### Things done

- [X] Built the whole system on top of this revision.
- [X] Writing from that system. No issues.

Merge at will. I would also backport to 18.09, since this reduces common closure size somewhat because of the change to `git`.