### PR TITLE
nats-streaming-server: init at 0.11.0

### DIFF
--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -1,0 +1,26 @@
+{  buildGoPackage, fetchFromGitHub, lib  }:
+
+with lib;
+
+buildGoPackage rec {
+  name = "nats-streaming-server-${version}";
+  version = "0.11.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/nats-io/nats-streaming-server";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "nats-io";
+    repo = "nats-streaming-server";
+	sha256 = "0skkx3f7dpbf6nqpsbsk8ssn8hl55s9k76a5y5ksyqar5bdxvds5";
+  };
+
+  meta = {
+    description = "NATS Streaming System Server";
+    license = licenses.asl20;
+    maintainers = [ maintainers.swdunlop ];
+    homepage = https://nats.io/;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13126,6 +13126,8 @@ with pkgs;
 
   nas = callPackage ../servers/nas { };
 
+  nats-streaming-server = callPackage ../servers/nats-streaming-server { };
+
   neard = callPackage ../servers/neard { };
 
   nginx = nginxStable;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

