### PR TITLE
rustc: enable parallel building

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -162,9 +162,7 @@ stdenv.mkDerivation {
 
   configurePlatforms = [];
 
-  # https://github.com/NixOS/nixpkgs/pull/21742#issuecomment-272305764
-  # https://github.com/rust-lang/rust/issues/30181
-  # enableParallelBuilding = false;
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = https://www.rust-lang.org/;


### PR DESCRIPTION
###### Motivation for this change

The upstream issue is closed, all mentions of the issue on NixOS GitHub are old, I rebuilt it several times with this enabled, no issues.

`rustc` is on the critical path to `firefox`, without this `firefox` is always the very last package to be built on my machine when doing a mass rebuild because `rustc` take ages to build on a moderately slow single core.

###### Things done

- [X] Rebuilt >3 times without issues. Good enough for me.
