### PR TITLE
mage: init at 1.7.1

### DIFF
--- a/pkgs/development/tools/build-managers/mage/default.nix
+++ b/pkgs/development/tools/build-managers/mage/default.nix
@@ -1,0 +1,31 @@
+{  buildGoPackage, fetchFromGitHub, lib  }:
+
+with lib;
+
+buildGoPackage rec {
+  name = "mage-${version}";
+  version = "1.2.4";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/magefile/mage";
+  subPackages = [ "." ];
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "magefile";
+    repo = "mage";
+    sha256 = "1870pgxsbhj54z8ks26pzidzsr2mfl1g226gw9j6s3xjdbbslylk";
+  };
+  
+  # ex: from pkgs/development/tools/dep/default.nix
+  # buildFlagsArray = ("-ldflags=-s -w -X main.commitHash=${rev} -X main.version=${version}");
+  buildFlagsArray = ("-ldflags=-X github.com/magefile/mage/mage.gitTag=${rev}");
+
+  meta = {
+    description = "A Make/Rake-like Build Tool Using Go";
+    license = licenses.asl20;
+    maintainers = [ maintainers.swdunlop ];
+    homepage = https://magefile.org/;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/build-managers/mage/default.nix
+++ b/pkgs/development/tools/build-managers/mage/default.nix
@@ -1,25 +1,26 @@
-{  buildGoPackage, fetchFromGitHub, lib  }:
+{ buildGoPackage, fetchFromGitHub, lib }:
 
 with lib;
 
 buildGoPackage rec {
   name = "mage-${version}";
-  version = "1.2.4";
-  rev = "v${version}";
+  version = "1.7.1";
 
   goPackagePath = "github.com/magefile/mage";
   subPackages = [ "." ];
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "magefile";
     repo = "mage";
-    sha256 = "1870pgxsbhj54z8ks26pzidzsr2mfl1g226gw9j6s3xjdbbslylk";
+    rev = "v${version}";
+    sha256 = "0n4k5dy338rxwzj654smxzlanmd0zws6mdzv0wc4byqjhr7mqhg2";
   };
-  
-  # ex: from pkgs/development/tools/dep/default.nix
-  # buildFlagsArray = ("-ldflags=-s -w -X main.commitHash=${rev} -X main.version=${version}");
-  buildFlagsArray = ("-ldflags=-X github.com/magefile/mage/mage.gitTag=${rev}");
+
+  buildFlagsArray = [ 
+    "-ldflags="
+    "-X github.com/magefile/mage/mage.commitHash=v${version}"
+    "-X github.com/magefile/mage/mage.gitTag=v${version}"
+  ];
 
   meta = {
     description = "A Make/Rake-like Build Tool Using Go";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8470,6 +8470,8 @@ with pkgs;
 
   go-md2man = callPackage ../development/tools/misc/md2man {};
 
+  mage = callPackage ../development/tools/build-managers/mage { };
+
   minify = callPackage ../development/web/minify { };
 
   minizinc = callPackage ../development/tools/minizinc { };


### PR DESCRIPTION
###### Motivation for this change

add mage, a make-like tool using Go

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

