### PR TITLE
nextcloud: 13.0.6 -> 14.0.0

### DIFF
--- a/pkgs/servers/nextcloud/default.nix
+++ b/pkgs/servers/nextcloud/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name= "nextcloud-${version}";
-  version = "13.0.6";
+  name = "nextcloud-${version}";
+  version = "14.0.0";
 
   src = fetchurl {
     url = "https://download.nextcloud.com/server/releases/${name}.tar.bz2";
-    sha256 = "1m38k5jafz2lniy6fmq17xffkgaqs6rl4w789sqpniva1fb9xz4h";
+    sha256 = "0iwg7g2ydrs0ah5hxl9m5hqaz5wmymmdhiy997zbpap7hr1c2rgr";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

There is a new major version of Nextcloud available.  This is based on top of https://github.com/NixOS/nixpkgs/pull/46236 which hasn't been merged yet.

###### Things done

Note: There's no binaries to test but I'm using this right now on my personal server.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

