### PR TITLE
Fix idris gcc builds on darwin and disable broken package

### DIFF
--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -1,5 +1,5 @@
 # Build an idris package
-{ stdenv, lib, idrisPackages, gmp }:
+{ gccStdenv, lib, idrisPackages, gmp }:
   { idrisDeps ? []
   , noPrelude ? false
   , noBase ? false
@@ -19,7 +19,8 @@ let
     };
   };
 in
-stdenv.mkDerivation ({
+# We use gcc stdenv to get gcc calls on Darwin to work
+gccStdenv.mkDerivation ({
   name = "idris-${name}-${version}";
 
   buildInputs = [ idris-with-packages gmp ] ++ extraBuildInputs;

--- a/pkgs/development/idris-modules/lens.nix
+++ b/pkgs/development/idris-modules/lens.nix
@@ -1,4 +1,5 @@
-{ build-idris-package
+{ stdenv
+, build-idris-package
 , fetchFromGitHub
 , bifunctors
 , lib
@@ -21,5 +22,6 @@ build-idris-package  {
     homepage = https://github.com/HuwCampbell/idris-lens;
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.brainrape ];
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/45960

The `lens` package is really weird: It succeeds on linux without problems, but fails on darwin with [an error that indicates a missing standard library constructor](https://hydra.nixos.org/build/80235644/nixlog/1/tail). I therefore marked it as broken on darwin.

The other change this PR has is to use `gccStdenv` to build all idris packages instead of the normal stdenv. This is because of [such errors](https://hydra.nixos.org/build/80313988/nixlog/1/tail), both the clang warnings and the gcc missing error. Since gcc seems to be the standard to use in a Makefile for idris packages, it makes sense to use `gccStdenv` here I think.

This fixes the build for `curses`, `eternal` and `mhd` on darwin

Ping @mpickering @brainrape 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

