### PR TITLE
pythonPackages.tifffile: fix python 2 build

### DIFF
--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchPypi, buildPythonPackage, isPy27, pythonOlder
-, numpy, nose, enum34, futures }:
+, numpy, nose, enum34, futures, pathlib }:
 
 buildPythonPackage rec {
   pname = "tifffile";
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ numpy ]
-    ++ lib.optional isPy27 futures
+    ++ lib.optional isPy27 [ futures pathlib ]
     ++ lib.optional (pythonOlder "3.0") enum34;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
/cc #45960

###### Motivation for this change
fix python 2 build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
