### PR TITLE
lidarr: init at 0.3.1.471

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -329,6 +329,7 @@
       # kvm = 302; # unused
       # render = 303; # unused
       zeronet = 304;
+      lidarr = 305;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -618,6 +619,7 @@
       kvm = 302; # default udev rules from systemd requires these
       render = 303; # default udev rules from systemd requires these
       zeronet = 304;
+      lidarr = 305;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -363,6 +363,7 @@
   ./services/misc/jackett.nix
   ./services/misc/logkeys.nix
   ./services/misc/leaps.nix
+  ./services/misc/lidarr.nix
   ./services/misc/mantisbt.nix
   ./services/misc/mathics.nix
   ./services/misc/matrix-synapse.nix

--- a/nixos/modules/services/misc/lidarr.nix
+++ b/nixos/modules/services/misc/lidarr.nix
@@ -1,0 +1,42 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.lidarr;
+in
+{
+  options = {
+    services.lidarr = {
+      enable = mkEnableOption "Lidarr";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.lidarr = {
+      description = "Lidarr";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = "lidarr";
+        Group = "lidarr";
+        PermissionsStartOnly = "true";
+        ExecStart = "${pkgs.lidarr}/bin/Lidarr";
+        Restart = "on-failure";
+
+        StateDirectory = "/var/lib/lidarr/";
+        StateDirectoryMode = "0770";
+      };
+    };
+
+    users.users.lidarr = {
+      uid = config.ids.uids.lidarr;
+      home = "/var/lib/lidarr";
+      group = "lidarr";
+    };
+
+    users.groups.lidarr.gid = config.ids.gids.lidarr;
+  };
+}

--- a/pkgs/servers/lidarr/default.nix
+++ b/pkgs/servers/lidarr/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "lidarr-${version}";
+  version = "0.3.1.471";
+
+  src = fetchurl {
+    url = "https://github.com/lidarr/Lidarr/releases/download/v${version}/Lidarr.develop.${version}.linux.tar.gz";
+    sha256 = "1x8q5yivkz8rwpkz0gdi73iaszb253bm1c3rdzar7xgrqr3g11nm";
+  };
+
+  buildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r * $out/bin/
+
+    # Mark all executable files as non-executable
+    find $out/bin -type f -executable | xargs chmod -x
+
+    makeWrapper "${mono}/bin/mono" $out/bin/Lidarr \
+      --add-flags "$out/bin/Lidarr.exe" \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [
+          curl sqlite libmediainfo ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Usenet/BitTorrent music downloader";
+    homepage = https://lidarr.audio/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.etu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3821,6 +3821,8 @@ with pkgs;
 
   libwebsockets = callPackage ../development/libraries/libwebsockets { };
 
+  lidarr = callPackage ../servers/lidarr { };
+
   limesuite = callPackage ../applications/misc/limesuite { };
 
   limesurvey = callPackage ../servers/limesurvey { };


### PR DESCRIPTION
###### Motivation for this change
Fork of sonarr (as radarr) but for music instead of series and movies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

