### PR TITLE
cgit: use full path of groff in man2html

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, openssl, zlib, asciidoc, libxml2, libxslt
 , docbook_xsl, pkgconfig, luajit
-, gzip, bzip2, xz
+, groff, gzip, bzip2, xz
 , python, wrapPython, pygments, markdown
 }:
 
@@ -32,6 +32,9 @@ stdenv.mkDerivation rec {
         -e 's|"bzip2"|"${bzip2.bin}/bin/bzip2"|' \
         -e 's|"xz"|"${xz.bin}/bin/xz"|' \
         -i ui-snapshot.c
+
+    substituteInPlace filters/html-converters/man2html \
+      --replace 'groff' '${groff}/bin/groff'
   '';
 
   # Give cgit a git source tree and pass configuration parameters (as make


### PR DESCRIPTION
###### Motivation for this change

groff may not be installed system-wide or may be outside cgit's path
(e.g. when running cgit using uwsgi). As a result, the man2html filter
fails. Replace groff by its full path in man2html.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

