### PR TITLE
xsettingsd: git-2015-06-14 -> 1.0.0

### DIFF
--- a/pkgs/tools/X11/xsettingsd/default.nix
+++ b/pkgs/tools/X11/xsettingsd/default.nix
@@ -1,39 +1,38 @@
-{ stdenv, fetchFromGitHub, scons, libX11, pkgconfig }:
+{ stdenv, fetchFromGitHub, scons, pkgconfig, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "xsettingsd-${version}";
-  version = "git-2015-06-14";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "derat";
     repo = "xsettingsd";
-    rev = "b4999f5e9e99224caf97d09f25ee731774ecd7be";
-    sha256 = "18cp6a66ji483lrvf0vq855idwmcxd0s67ijpydgjlsr70c65j7s";
+    rev = "v${version}";
+    sha256 = "05m4jlw0mgwp24cvyklncpziq1prr2lg0cq9c055sh4n9d93d07v";
   };
 
   patches = [
     ./SConstruct.patch
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libX11 scons ];
+  nativeBuildInputs = [ scons pkgconfig ];
+
+  buildInputs = [ libX11 ];
+
   buildPhase = ''
-    mkdir -p "$out"
-    scons \
-      -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES \
-      "prefix=$out"
+    scons -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES
   '';
   
   installPhase = ''
-    mkdir -p "$out"/bin
-    install xsettingsd "$out"/bin
-    install dump_xsettings "$out"/bin
+    install -D -t "$out"/bin xsettingsd dump_xsettings
+    install -D -t "$out"/usr/share/man/man1 xsettingsd.1 dump_xsettings.1
   '';
 
   meta = with stdenv.lib; {
     description = "Provides settings to X11 applications via the XSETTINGS specification";
     homepage = https://github.com/derat/xsettingsd;
-    license = licenses.bsd2;
+    license = licenses.bsd3;
     platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

- Update to version [1.0.0](https://github.com/derat/xsettingsd/releases/tag/v1.0.0)
- Install man pages
- Fix license
- Add maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).