### PR TITLE
bullet: fix darwin build

### DIFF
--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, cmake, libGLU_combined, freeglut, darwin }:
+{ stdenv, fetchFromGitHub, cmake, libGLU_combined, freeglut
+, Cocoa,  OpenGL
+}:
 
 stdenv.mkDerivation rec {
   name = "bullet-${version}";
@@ -11,10 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "1msp7w3563vb43w70myjmqsdb97kna54dcfa7yvi9l3bvamb92w3";
   };
 
-  buildInputs = [ cmake ] ++
-    (if stdenv.isDarwin
-     then with darwin.apple_sdk.frameworks; [ Cocoa OpenGL ]
-     else [libGLU_combined freeglut]);
+  nativeBuildInputs = [ cmake ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ libGLU_combined freeglut ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
 
   patches = [ ./gwen-narrowing.patch ];
 
@@ -28,25 +29,26 @@ stdenv.mkDerivation rec {
     "-DBUILD_CPU_DEMOS=OFF"
     "-DINSTALL_EXTRA_LIBS=ON"
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    "-DMACOSX_DEPLOYMENT_TARGET=\"10.9\""
     "-DOPENGL_FOUND=true"
-    "-DOPENGL_LIBRARIES=${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework"
-    "-DOPENGL_INCLUDE_DIR=${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework"
-    "-DOPENGL_gl_LIBRARY=${darwin.apple_sdk.frameworks.OpenGL}/Library/Frameworks/OpenGL.framework"
-    "-DCOCOA_LIBRARY=${darwin.apple_sdk.frameworks.Cocoa}/Library/Frameworks/Cocoa.framework"
+    "-DOPENGL_LIBRARIES=${OpenGL}/Library/Frameworks/OpenGL.framework"
+    "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks/OpenGL.framework"
+    "-DOPENGL_gl_LIBRARY=${OpenGL}/Library/Frameworks/OpenGL.framework"
+    "-DCOCOA_LIBRARY=${Cocoa}/Library/Frameworks/Cocoa.framework"
+    "-DBUILD_BULLET2_DEMOS=OFF"
+    "-DBUILD_UNIT_TESTS=OFF"
   ];
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A professional free 3D Game Multiphysics Library";
     longDescription = ''
       Bullet 3D Game Multiphysics Library provides state of the art collision
       detection, soft body and rigid body dynamics.
     '';
     homepage = http://bulletphysics.org;
-    license = stdenv.lib.licenses.zlib;
-    maintainers = with stdenv.lib.maintainers; [ aforemny ];
-    platforms = with stdenv.lib.platforms; unix;
+    license = licenses.zlib;
+    maintainers = with maintainers; [ aforemny ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22213,7 +22213,9 @@ with pkgs;
     inherit (gnome2) gtksourceview;
   };
 
-  bullet = callPackage ../development/libraries/bullet {};
+  bullet = callPackage ../development/libraries/bullet {
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
+  };
 
   spdlog = callPackage ../development/libraries/spdlog { };
 


### PR DESCRIPTION
###### Motivation for this change

The examples fail with an opengl related issue:

    Undefined symbols for architecture x86_64:
      "SimpleOpenGL3App::SimpleOpenGL3App(char const*, int, int, bool)", referenced from:
          _main in main_opengl_single_example.o
      "_useShadowMap", referenced from:
          GL_ShapeDrawer::drawScene(btDiscreteDynamicsWorld const*, bool, int) in GL_ShapeDrawer.o
    ld: symbol(s) not found for architecture x86_64

And the tests need an extra dependencly, possibley related to
https://github.com/bulletphysics/bullet3/issues/819

    ld: library not found for -lBussIK

/cc ZHF #45961

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
