### PR TITLE
NewtonsoftJson: only build Newtonsoft.Json.csproj

### DIFF
--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -895,7 +895,7 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
        rm -rvf Tools
     '';
 
-    xBuildFiles = [ "Src/Newtonsoft.Json.sln" ];
+    xBuildFiles = [ "Src/Newtonsoft.Json/Newtonsoft.Json.csproj" ];
     outputFiles = [ "Src/Newtonsoft.Json/bin/Release/Net45/*" ];
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

This fixes the build of Newtonsoft.Json, which is blocking other
builds. The tests were not able to compile due to changes in NUnit.
Upgrading Newtonsoft.Json is currently not possible as the project
structure is now using dotnet-core and is incompatible with xbuild.

Example of failing build:

https://hydra.nixos.org/build/81003982

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

