### PR TITLE
elpy: fix build dep

### DIFF
--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -178,7 +178,7 @@ let
       for file in elpy.el elpy-pkg.el; do
         substituteInPlace $file \
             --replace "company \"0.8.2\"" "company \"${company.version}\"" \
-            --replace "find-file-in-project \"3.3\"" "find-file-in-project \"${melpaPackages.find-file-in-project.version}\"" \
+            --replace "find-file-in-project \"3.3\"" "find-file-in-project \"${(melpaPackages self).find-file-in-project.version}\"" \
             --replace "highlight-indentation \"0.5.0\"" "highlight-indentation \"${highlight-indentation.version}\"" \
             --replace "pyvenv \"1.3\"" "pyvenv \"${pyvenv.version}\"" \
             --replace "yasnippet \"0.8.0\"" "yasnippet \"${yasnippet.version}\""


### PR DESCRIPTION
###### Motivation for this change
cc @matthewbauer closed #46372 a bit faster than i expected. This is a follow-up fix on elpy, which i missed on my tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

