### PR TITLE
[WIP] nixos: add environment.gnome3.enableExtensions

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -141,6 +141,16 @@ in
       description = "Which packages gnome should exclude from the default environment";
     };
 
+    environment.gnome3.enableExtensions = mkOption {
+      default = null;
+      example = literalExample "with pkgs.gnomeExtensions; [ dash-to-dock ]";
+      type = with types; nullOr (listOf package);
+      description = ''
+        Which GNOME Shell Extensions to enable. If null, extensions are managed
+        imperatively via your browser and/or GNOME Tweaks.
+      '';
+    };
+
   };
 
   config = mkMerge [
@@ -308,6 +318,16 @@ in
         # Do not use the default environment, it provides a broken PATH
         environment = mkForce {};
       };
+
+    services.xserver.desktopManager.gnome3.extraGSettingsOverrides =
+      let
+        extensions = config.environment.gnome3.enableExtensions;
+        extensionUuids = builtins.toJSON (map (x: x.uuid) extensions);
+      in
+        lib.optionalString (extensions != null) ''
+          [org.gnome.shell]
+          enabled-extensions=${extensionUuids}
+        '';
 
       # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-36/elements/core/meta-gnome-core-shell.bst
       environment.systemPackages = with pkgs.gnome3; [

--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -329,6 +329,15 @@ in
           enabled-extensions=${extensionUuids}
         '';
 
+     # Add a lock file, it prevents users from modifying / overriding the
+     # system (default) settings.
+     # FIXME: It doesn't work! Users can still change these settings.
+     # Ref. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/desktop_migration_and_administration_guide/custom-default-values-system-settings
+     environment.etc."dconf/db/local.d/locks/00-org-gnome-shell-enabled-extensions".text = ''
+       # Prevent this key from being overridden by users (enforcing declarative style)
+       /org/gnome/shell/enabled-extensions
+     '';
+
       # Adapt from https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-36/elements/core/meta-gnome-core-shell.bst
       environment.systemPackages = with pkgs.gnome3; [
         adwaita-icon-theme


### PR DESCRIPTION
###### Motivation for this change
I'd like to enable/disable GNOME3 extensions from configuration.nix. However, when testing this I learned that services.xserver.desktopManager.gnome3.extraGSettingsOverrides, which this is built upon, only provides _default_ values for the system. Users are still able to change settings. And once they have made a change, any change to the system default will be ignored. This is marked WIP since I'd like for this setting to be truly declarative. The first 4 commits would be nice to merge anyway, so one can play with this locally at least.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
