### PR TITLE
pythonPackages.cozy: Disable on python2

### DIFF
--- a/pkgs/development/python-modules/cozy/default.nix
+++ b/pkgs/development/python-modules/cozy/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchFromGitHub, lib,
+{ buildPythonPackage, isPy3k, fetchFromGitHub, lib,
   z3, ply, python-igraph, oset, ordered-set, dictionaries }:
 
 buildPythonPackage {
@@ -28,6 +28,8 @@ buildPythonPackage {
   postInstall = ''
     $out/bin/cozy --help
   '';
+
+  disabled = !isPy3k;
 
   meta = {
     description = "The collection synthesizer";


### PR DESCRIPTION
###### Motivation for this change
Cozy does not support python2.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

