### PR TITLE
opentracker: 2016-10-02 -> 2018-05-26

### DIFF
--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation {
   name = "opentracker-2018-05-26";
 
   src = fetchgit {
-    url = "git://erdgeist.org/opentracker";
+    url = "https://erdgeist.org/gitweb/opentracker";
     rev = "6411f1567f64248b0d145493c2e61004d2822623";
     sha256 = "110nfb6n4clykwdzpk54iccsfjawq0krjfqhg114i1z0ri5dyl8j";
   };
@@ -12,9 +12,9 @@ stdenv.mkDerivation {
   buildInputs = [ libowfat zlib ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/doc
-    cp opentracker $out/bin
-    cp opentracker.conf.sample $out/share/doc
+    runHook preInstall
+    install -D opentracker $out/bin/opentracker
+    install -D opentracker.conf.sample $out/share/doc/opentracker.conf.sample
     runHook postInstall
   '';
 

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchgit, libowfat, zlib }:
 
 stdenv.mkDerivation {
-  name = "opentracker-2016-10-02";
+  name = "opentracker-2018-05-26";
 
   src = fetchgit {
     url = "git://erdgeist.org/opentracker";
-    rev = "0ebc0ed6a3e3b7acc9f9e338cc23cea5f4f22f61";
-    sha256 = "0qi0a8fygjwgs3yacramfn53jdabfgrlzid7q597x9lr94anfpyl";
+    rev = "6411f1567f64248b0d145493c2e61004d2822623";
+    sha256 = "110nfb6n4clykwdzpk54iccsfjawq0krjfqhg114i1z0ri5dyl8j";
   };
 
   buildInputs = [ libowfat zlib ];


### PR DESCRIPTION
###### Motivation for this change

Opentracker version was lacking behind.

Also bittorrent test where this was used was failing. This PR doesn't fix the test though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

