### PR TITLE
pythonPackages.flask_ldap_login: Fix build

### DIFF
--- a/pkgs/development/python-modules/flask-ldap-login/default.nix
+++ b/pkgs/development/python-modules/flask-ldap-login/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
 , flask, flask_wtf, flask_testing, ldap
 , mock, nose }:
 
@@ -10,6 +10,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "085rik7q8xrp5g95346p6jcp9m2yr8kamwb2kbiw4q0b0fpnnlgq";
   };
+
+  patches = [
+    # Fix flask_wtf>=0.9.0 incompatibility. See https://github.com/ContinuumIO/flask-ldap-login/issues/41
+    (fetchpatch {
+      url = https://github.com/ContinuumIO/flask-ldap-login/commit/ed08c03c818dc63b97b01e2e7c56862eaa6daa43.patch;
+      sha256 = "19pkhbldk8jq6m10kdylvjf1c8m84fvvj04v5qda4cjyks15aq48";
+    })
+  ];
 
   checkInputs = [ nose mock flask_testing ];
   propagatedBuildInputs = [ flask flask_wtf ldap ];

--- a/pkgs/development/python-modules/flask-ldap-login/default.nix
+++ b/pkgs/development/python-modules/flask-ldap-login/default.nix
@@ -1,10 +1,11 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch
+{ stdenv, buildPythonPackage, isPy3k, fetchFromGitHub, fetchpatch
 , flask, flask_wtf, flask_testing, ldap
 , mock, nose }:
 
 buildPythonPackage rec {
   pname = "flask-ldap-login";
   version = "0.3.4";
+  disabled = isPy3k;
 
   src = fetchFromGitHub {
     owner = "ContinuumIO";

--- a/pkgs/development/python-modules/flask-ldap-login/default.nix
+++ b/pkgs/development/python-modules/flask-ldap-login/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch
 , flask, flask_wtf, flask_testing, ldap
 , mock, nose }:
 
 buildPythonPackage rec {
   pname = "flask-ldap-login";
-  version = "0.3.0";
+  version = "0.3.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "085rik7q8xrp5g95346p6jcp9m2yr8kamwb2kbiw4q0b0fpnnlgq";
+  src = fetchFromGitHub {
+    owner = "ContinuumIO";
+    repo = "flask-ldap-login";
+    rev = version;
+    sha256 = "1l6zahqhwn5g9fmhlvjv80288b5h2fk5mssp7amdkw5ysk570wzp";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
flask_ldap_login does currently not our version of flask_wtf.
There is however already a PR upstream to fix the issue, which we can use as a patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

