### PR TITLE
pythonPackages.joblib: Disable flaky test

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -18,7 +18,9 @@ buildPythonPackage rec {
   checkInputs = [ sphinx numpydoc pytest ];
 
   checkPhase = ''
-    py.test -k 'not test_disk_used and not test_nested_parallel_warnings' joblib/test
+    py.test -k 'not test_disk_used and \
+                not test_nested_parallel_warnings and \
+                not test_nested_parallelism_limit' joblib/test
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
This should fix the darwin build of joblib.
Please backport to 18.09. (ZHF-darwin: #45961)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

