### PR TITLE
pythonPackages.libusb1: Fix darwin build

### DIFF
--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, python, libusb1 }:
+{ stdenv, lib, buildPythonPackage, fetchPypi, python, libusb1, pytest }:
 
 buildPythonPackage rec {
   pname = "libusb1";
@@ -17,8 +17,12 @@ buildPythonPackage rec {
 
   buildInputs = [ libusb1 ];
 
+  checkInputs = [ pytest ];
+
   checkPhase = ''
-    ${python.interpreter} -m usb1.testUSB1
+    # USBPollerThread is unreliable. Let's not test it.
+    # See: https://github.com/vpelletier/python-libusb1/issues/16
+    py.test -k 'not testUSBPollerThreadExit' usb1/testUSB1.py
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "a49917a2262cf7134396f6720c8be011f14aabfc5cdc53f880cc672c0f39d271";
   };
 
-  postPatch = lib.optionalString stdenv.isLinux ''
+  postPatch = ''
     substituteInPlace usb1/libusb1.py --replace \
       "ctypes.util.find_library(base_name)" \
       "'${libusb1}/lib/libusb-1.0${stdenv.hostPlatform.extensions.sharedLibrary}'"


### PR DESCRIPTION
###### Motivation for this change
This should fix the darwin build.
Please backport to 18.09 (ZHF-18.09 #45961)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

