### PR TITLE
castxml: Fix build

### DIFF
--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "1hjh8ihjyp1m2jb5yypp5c45bpbz8k004f4p1cjw4gc7pxhjacdj";
   };
 
+  cmakeFlags = [
+    "-DCLANG_RESOURCE_DIR=${llvmPackages.clang-unwrapped}"
+    "-DSPHINX_MAN=${if withMan then "ON" else "OFF"}"
+  ];
+
   buildInputs = [
     cmake
     llvmPackages.clang-unwrapped
@@ -24,11 +29,6 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
 
   propagatedbuildInputs = [ llvmPackages.libclang ];
-
-  preConfigure = ''
-    cmakeFlagsArray+=(
-     ${if withMan then "-DSPHINX_MAN=ON" else ""}
-  )'';
 
   # 97% tests passed, 96 tests failed out of 2866
   # mostly because it checks command line and nix append -isystem and all


### PR DESCRIPTION
###### Motivation for this change
This should fix the castxml build.
Please backport to 18.09 (ZHF-18.09 #45961)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

