### PR TITLE
nixos/lizardfs: init module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -336,6 +336,7 @@
       solr = 309;
       alerta = 310;
       minetest = 311;
+      mfs = 312;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -632,6 +633,7 @@
       solr = 309;
       alerta = 310;
       minetest = 311;
+      mfs = 312;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -469,6 +469,7 @@
   ./services/network-filesystems/glusterfs.nix
   ./services/network-filesystems/kbfs.nix
   ./services/network-filesystems/ipfs.nix
+  ./services/network-filesystems/lizardfs.nix
   ./services/network-filesystems/netatalk.nix
   ./services/network-filesystems/nfsd.nix
   ./services/network-filesystems/openafs/client.nix

--- a/nixos/modules/services/network-filesystems/lizardfs.nix
+++ b/nixos/modules/services/network-filesystems/lizardfs.nix
@@ -1,0 +1,261 @@
+{ config, pkgs, lib, ... }:
+with lib;
+let
+  cfg = config.services.lizardfs;
+
+  # default ports
+  cgiservPort = 9425;
+  masterMetaloggerPort = 9419;
+  masterChunkserverPort = 9420;
+
+  masterGoals = pkgs.writeText "mfsgoals.cfg" cfg.master.goals;
+  masterExports = pkgs.writeText "mfsexports.cfg" cfg.master.exports;
+
+  masterConfig = pkgs.writeText "mfsmaster.cfg" ''
+    DATA_PATH = /var/lib/mfs
+    CUSTOM_GOALS_FILENAME = ${masterGoals}
+    EXPORTS_FILENAME = ${masterExports}
+    ${cfg.master.config}
+  '';
+
+  metaloggerConfig = pkgs.writeText "mfsmetalogger.cfg" ''
+    MASTER_HOST = ${cfg.metalogger.masterHost}
+    MASTER_PORT = ${toString cfg.metalogger.masterPort}
+    DATA_PATH = /var/lib/mfs
+    ${cfg.metalogger.config}
+  '';
+
+  createChunkserverHdds = serv:
+    nameValuePair serv.name (pkgs.writeText "mfshdd-${serv.name}.cfg" ''
+      ${concatStringsSep "\n" serv.storageDirectories}
+    '');
+
+  chunkserverHdds = listToAttrs (map createChunkserverHdds cfg.chunkservers.servers);
+
+  createChunkserverConfig = serv:
+    nameValuePair serv.name (pkgs.writeText "mfschunkserver-${serv.name}.cfg" ''
+        MASTER_HOST = ${cfg.chunkservers.masterHost}
+        MASTER_PORT = ${toString cfg.chunkservers.masterPort}
+        HDD_CONF_FILENAME = ${chunkserverHdds."${serv.name}"}
+        CSSERV_LISTEN_PORT = ${toString serv.port}
+        DATA_PATH = /var/lib/mfs-${serv.name}
+        ${serv.config}
+      '');
+
+  chunkserverConfigs = listToAttrs (map createChunkserverConfig cfg.chunkservers.servers);
+in
+{
+  options = {
+    services.lizardfs = {
+      enable = mkOption {
+        default = false;
+        type = with types; bool;
+        description = ''
+          LizardFS configuration.
+        '';
+      };
+      cgiserv = {
+        enable = mkOption {
+          default = false;
+          type = with types; bool;
+          description = ''
+            Start LizardFS cgi server daemon.
+          '';
+        };
+        host = mkOption {
+          default = "0.0.0.0";
+          type = with types; str;
+          description = ''
+            Hostname/IP to bind to.
+          '';
+        };
+        port = mkOption {
+          default = cgiservPort;
+          type = with types; int;
+          description = ''
+            CGI server port.
+          '';
+        };
+      };
+      master = {
+        enable = mkOption {
+          default = false;
+          type = with types; bool;
+          description = ''
+            Start LizardFS master service.
+          '';
+        };
+        config = mkOption {
+          default = "";
+          type = with types; str;
+          description = ''
+            LizardFS master config. See mfsmaster.cfg(5) for details.
+          '';
+        };
+        exports = mkOption {
+          default = null;
+          type = with types; str;
+          description = ''
+            LizardFS master exports.
+          '';
+        };
+        goals = mkOption {
+          default = "";
+          type = with types; str;
+          description = ''
+            LizardFS master goals.
+          '';
+        };
+      };
+      metalogger = {
+        enable = mkOption {
+          default = false;
+          type = with types; bool;
+          description = ''
+            Start LizardFS metadata logger service.
+          '';
+        };
+        config = mkOption {
+          default = "";
+          type = types.str;
+          description = "Text to be put in mfsmetalogger.cfg. See mfsmetalogger.cfg(5) for details.";
+        };
+        masterHost = mkOption {
+          default = null;
+          type = with types; string;
+          description = ''
+            Master host for metalogger to connect to.
+          '';
+        };
+        masterPort = mkOption {
+          default = masterMetaloggerPort;
+          type = with types; int;
+          description = ''
+            Master port for metalogger to connect to.
+          '';
+        };
+      };
+      chunkservers = {
+        servers = mkOption {
+          default = [];
+          type = types.listOf (types.submodule {
+            options = {
+              name = mkOption {
+                default = null;
+                type = types.str;
+                description = "Chunkserver name for systemd.";
+              };
+              port = mkOption {
+                default = 9422;
+                type = types.int;
+                description = "Port to listen on.";
+              };
+              storageDirectories = mkOption {
+                default = null;
+                type = types.listOf types.str;
+                description = "List of LizardFS storage directories.";
+              };
+              config = mkOption {
+                default = "";
+                type = types.str;
+                description = "Text to be put in mfschunkserver.cfg. See mfschunkserver.cfg(5) for details.";
+              };
+            };
+          });
+          description = ''
+            List of LizardFS chunkservers to run on this node.
+          '';
+        };
+        masterHost = mkOption {
+          default = null;
+          type = with types; string;
+          description = ''
+            Master host for chunkservers to connect to.
+          '';
+        };
+        masterPort = mkOption {
+          default = masterChunkserverPort;
+          type = with types; int;
+          description = ''
+            Master port for chunkservers to connect to.
+          '';
+        };
+      };
+    };
+  };
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.lizardfs ]; # admin tools
+
+    users.users.mfs = {
+      group = "mfs";
+      description = "LizardFS daemon user";
+      uid = config.ids.uids.mfs;
+    };
+
+    users.groups.mfs.gid = config.ids.gids.mfs;
+
+    systemd.tmpfiles.rules = [ "d /var/lib/mfs 0770 mfs mfs -" ] ++
+      (map (serv: "d /var/lib/mfs-${serv.name} 0770 mfs mfs -") cfg.chunkservers.servers);
+
+    systemd.services =
+      let
+        createChunkserverService = serv:
+          nameValuePair "lizardfs-chunkserver-${serv.name}" {
+            description = "LizardFS Chunkserver for ${serv.name}";
+            documentation = [ "man:mfschunkserver" ];
+            after = [ "network.target" ];
+            wantedBy = [ "multi-user.target" ];
+            restartIfChanged = false;
+            serviceConfig = {
+              Type = "forking";
+              ExecStart = ''${pkgs.lizardfs}/bin/mfschunkserver  -c ${chunkserverConfigs."${serv.name}"} start'';
+              ExecStop = ''${pkgs.lizardfs}/bin/mfschunkserver  -c ${chunkserverConfigs."${serv.name}"} stop'';
+              ExecReload = ''${pkgs.lizardfs}/bin/mfschunkserver  -c ${chunkserverConfigs."${serv.name}"} reload'';
+              Restart = "on-abort";
+            };
+          };
+        in listToAttrs (
+          (map createChunkserverService cfg.chunkservers.servers)
+          ++ optional cfg.cgiserv.enable (nameValuePair "lizardfs-cgiserv" {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" ];
+            description = "LizardFS CGI server daemon";
+            documentation = [ "man:lizardfs-cgiserver" ];
+            restartIfChanged = false;
+            serviceConfig = {
+              ExecStart = "${pkgs.lizardfs}/bin/lizardfs-cgiserver -H ${cfg.cgiserv.host} -P ${toString cfg.cgiserv.port}";
+              Restart = "on-abort";
+              User = "nobody";
+            };
+          })
+          ++ optional cfg.master.enable (nameValuePair "lizardfs-master" {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" ];
+            description = "LizardFS master server daemon";
+            documentation = [ "man:mfsmaster" ];
+            restartIfChanged = false;
+            serviceConfig = {
+              Type = "forking";
+              TimeoutSec = 0;
+              ExecStart = ''${pkgs.lizardfs}/bin/mfsmaster -c ${masterConfig} start'';
+              ExecStop = ''${pkgs.lizardfs}/bin/mfsmaster -c ${masterConfig} stop'';
+              ExecReload = ''${pkgs.lizardfs}/bin/mfsmaster -c ${masterConfig} reload'';
+              Restart = "no";
+            };
+          })
+          ++ optional cfg.metalogger.enable (nameValuePair "lizardfs-metalogger" {
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" ];
+            description = "LizardFS metalogger server daemon";
+            documentation = [ "man:mfsmetalogger" ];
+            restartIfChanged = false;
+            serviceConfig = {
+              Type = "forking";
+              ExecStart = ''${pkgs.lizardfs}/bin/mfsmetalogger -c ${metaloggerConfig} start'';
+              ExecStop = ''${pkgs.lizardfs}/bin/mfsmetalogger -c ${metaloggerConfig} stop'';
+              ExecReload = ''${pkgs.lizardfs}/bin/mfsmetalogger -c ${metaloggerConfig} reload'';
+              Restart = "on-abort";
+            };
+          }));
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

LizardFS is packaged in NixOS, but there isn't a simple way to configure it, e.g. with chunkservers.

###### Things done

- Allows running multiple chunkservers on one machine
- CGI server, master server, and metaloggers supported

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

