### PR TITLE
libxshmfence: 1.2 -> 1.3 fixes memfd_create usage w/musl

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1160,11 +1160,11 @@ let
   }) // {inherit kbproto libX11 ;};
 
   libxshmfence = (mkDerivation "libxshmfence" {
-    name = "libxshmfence-1.2";
+    name = "libxshmfence-1.3";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/lib/libxshmfence-1.2.tar.bz2;
-      sha256 = "032b0nlkdrpbimdld4gqvhqx53rzn8fawvf1ybhzn7lcswgjs6yj";
+      url = mirror://xorg/individual/lib/libxshmfence-1.3.tar.bz2;
+      sha256 = "032b0nlkdrpbimdld4gqvhqx53rzn8fawvf1ybhzn8lcswgjs6yj";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ xproto ];

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -53,7 +53,7 @@ mirror://xorg/individual/proto/inputproto-2.3.2.tar.bz2
 mirror://xorg/individual/proto/kbproto-1.0.7.tar.bz2
 mirror://xorg/X11R7.7/src/everything/libAppleWM-1.4.1.tar.bz2
 mirror://xorg/individual/lib/libdmx-1.1.3.tar.bz2
-mirror://xorg/individual/lib/libxshmfence-1.2.tar.bz2
+mirror://xorg/individual/lib/libxshmfence-1.3.tar.bz2
 mirror://xorg/individual/lib/libfontenc-1.1.3.tar.bz2
 mirror://xorg/individual/lib/libFS-1.0.7.tar.bz2
 mirror://xorg/individual/lib/libICE-1.0.9.tar.bz2


### PR DESCRIPTION
I think needed for newer glibc versions as well, FWIW.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---