### PR TITLE
zsh: apply upstream fix from 5.6.1

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation {
     sha256 = "1vik7s3q5hvazvgw4jm4b90qlk6zcry0s314xw1liarspkd721g3";
   };
 
+  postPatch = ''
+    sed -i -e 's,#include "builtin.pro",\0\n#include <math.h>,' Src/builtin.c
+  '';
+
   buildInputs = [ ncurses pcre ];
 
   configureFlags = [

--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses, pcre }:
+{ stdenv, fetchurl, fetchpatch, ncurses, pcre }:
 
 let
   version = "5.6";
@@ -18,6 +18,13 @@ stdenv.mkDerivation {
     sha256 = "1vik7s3q5hvazvgw4jm4b90qlk6zcry0s314xw1liarspkd721g3";
   };
 
+  patches = [
+    (fetchpatch {
+      url = https://github.com/zsh-users/zsh/commit/0d5275c6b94e798e813092f37bd40429bd9b0f8b.patch;
+      sha256 = "0jair5rymyfhikzymyw8c070fyb5p7gsjxcqysmkq8q99d3g75r9";
+      excludes = [ "ChangeLog" ];
+    })
+  ];
   postPatch = ''
     sed -i -e 's,#include "builtin.pro",\0\n#include <math.h>,' Src/builtin.c
   '';


### PR DESCRIPTION
5.6.1 is tagged on GitHub but not available
on sf.net for whatever reason.

Attempting to build from github doesn't work
without some changes to the expression so instead
grab this fix introduced in update to 5.6.

Add missing include of math.h while visiting this,
needed for new (5.6) use of isnan/isinf .




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---