### PR TITLE
haskellPackages.shellFor: Fix ghc calls

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -174,8 +174,7 @@ let
     (optionalString (versionOlder "7.10" ghc.version && !isHaLVM) "-threaded")
   ];
 
-  isHaskellPkg = x: (x ? pname) && (x ? version) && (x ? env);
-  isSystemPkg = x: !isHaskellPkg x;
+  isHaskellPkg = x: x ? isHaskellLibrary;
 
   allPkgconfigDepends = pkgconfigDepends ++ libraryPkgconfigDepends ++ executablePkgconfigDepends ++
                         optionals doCheck testPkgconfigDepends ++ optionals doBenchmark benchmarkPkgconfigDepends;
@@ -192,7 +191,10 @@ let
                      optionals doCheck (testDepends ++ testHaskellDepends ++ testSystemDepends ++ testFrameworkDepends) ++
                      optionals doBenchmark (benchmarkDepends ++ benchmarkHaskellDepends ++ benchmarkSystemDepends ++ benchmarkFrameworkDepends);
 
-  allBuildInputs = propagatedBuildInputs ++ otherBuildInputs;
+
+  allBuildInputs = propagatedBuildInputs ++ otherBuildInputs ++ depsBuildBuild;
+  isHaskellPartition =
+    stdenv.lib.partition isHaskellPkg allBuildInputs;
 
   haskellBuildInputs = stdenv.lib.filter isHaskellPkg allBuildInputs;
   systemBuildInputs = stdenv.lib.filter isSystemPkg allBuildInputs;
@@ -428,6 +430,13 @@ stdenv.mkDerivation ({
     inherit pname version;
 
     compiler = ghc;
+
+
+    getBuildInputs = {
+      inherit propagatedBuildInputs otherBuildInputs allPkgconfigDepends;
+      haskellBuildInputs = isHaskellPartition.right;
+      systemBuildInputs = isHaskellPartition.wrong;
+    };
 
     isHaskellLibrary = isLibrary;
 

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -259,20 +259,46 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     shellFor = { packages, withHoogle ? false, ... } @ args:
       let
         selected = packages self;
-        packageInputs = builtins.map getBuildInputs selected;
-        haskellInputs =
-          builtins.filter
-            (input: pkgs.lib.all (p: input.outPath != p.outPath) selected)
-            (pkgs.lib.concatMap (p: p.haskellBuildInputs) packageInputs);
+
+        packageInputs = map getBuildInputs selected;
+
+        name = if pkgs.lib.length selected == 1
+          then "ghc-shell-for-${(pkgs.lib.head selected).name}"
+          else "ghc-shell-for-packages";
+
+        # If `packages = [ a b ]` and `a` depends on `b`, don't build `b`,
+        # because cabal will end up ignoring that built version, assuming
+        # new-style commands.
+        haskellInputs = pkgs.lib.filter
+          (input: pkgs.lib.all (p: input.outPath != p.outPath) selected)
+          (pkgs.lib.concatMap (p: p.haskellBuildInputs) packageInputs);
         systemInputs = pkgs.lib.concatMap (p: p.systemBuildInputs) packageInputs;
+
         withPackages = if withHoogle then self.ghcWithHoogle else self.ghcWithPackages;
+        ghcEnv = withPackages (p: haskellInputs);
+        nativeBuildInputs = pkgs.lib.concatMap (p: p.nativeBuildInputs) selected;
+
+        ghcCommand' = if ghc.isGhcjs or false then "ghcjs" else "ghc";
+        ghcCommand = "${ghc.targetPrefix}${ghcCommand'}";
+        ghcCommandCaps= pkgs.lib.toUpper ghcCommand';
+
         mkDrvArgs = builtins.removeAttrs args ["packages" "withHoogle"];
       in pkgs.stdenv.mkDerivation (mkDrvArgs // {
-        name = "ghc-shell-for-packages";
-        nativeBuildInputs = [(withPackages (_: haskellInputs))] ++ mkDrvArgs.nativeBuildInputs or [];
+        name = mkDrvArgs.name or name;
+
         buildInputs = systemInputs ++ mkDrvArgs.buildInputs or [];
+        nativeBuildInputs = [ ghcEnv ] ++ nativeBuildInputs ++ mkDrvArgs.nativeBuildInputs or [];
         phases = ["installPhase"];
         installPhase = "echo $nativeBuildInputs $buildInputs > $out";
+        LANG = "en_US.UTF-8";
+        LOCALE_ARCHIVE = pkgs.lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+        "NIX_${ghcCommandCaps}" = "${ghcEnv}/bin/${ghcCommand}";
+        "NIX_${ghcCommandCaps}PKG" = "${ghcEnv}/bin/${ghcCommand}-pkg";
+        # TODO: is this still valid?
+        "NIX_${ghcCommandCaps}_DOCDIR" = "${ghcEnv}/share/doc/ghc/html";
+        "NIX_${ghcCommandCaps}_LIBDIR" = if ghc.isHaLVM or false
+          then "${ghcEnv}/lib/HaLVM-${ghc.version}"
+          else "${ghcEnv}/lib/${ghcCommand}-${ghc.version}";
       });
 
     ghc = ghc // {

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -43,7 +43,7 @@ let
   mkDerivationImpl = pkgs.callPackage ./generic-builder.nix {
     inherit stdenv;
     nodejs = buildPackages.nodejs-slim;
-    inherit (self) buildHaskellPackages ghc;
+    inherit (self) buildHaskellPackages ghc shellFor;
     inherit (self.buildHaskellPackages) jailbreak-cabal;
     hscolour = overrideCabal self.buildHaskellPackages.hscolour (drv: {
       isLibrary = false;


### PR DESCRIPTION
###### Motivation for this change
This cost me a couple hours to figure out. The original error was
```
Got error while processing diagnostics: <command line>: cannot satisfy -package-id hnix-0.5.2-5hMz8sQY4ky2OCdjsvbD9J
```
from ghc-mod via [HIE](https://github.com/haskell/haskell-ide-engine). After a very long time of debugging, I finally figured out that the reason was that `shellFor` doesn't run any `shellHook` that sets up the correct `NIX_GHC*` env vars to have it find stuff. This PR just does a dirty fast fix by copying part of the logic in `generic-builder.nix`, please don't merge it like this.

Ping @peti @ryantm @basvandijk @domenkozar (Ping the people I annoyed for hours in #haskell-ide-engine because of this: @alanz @DanielG)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

