### PR TITLE
nixos/initrd-network: multiple DHCP fixes

### DIFF
--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -12,10 +12,9 @@ let
     ''
       #! /bin/sh
       if [ "$1" = bound ]; then
+        ip address add "$ip/$mask" dev "$interface"
         if [ -n "$mtu" ]; then
-          ip address add "$ip/$mask" dev "$interface" mtu "$mtu"
-        else
-          ip address add "$ip/$mask" dev "$interface"
+          ip link set mtu "$mtu" dev "$interface"
         fi
         if [ -n "$staticroutes" ]; then
           echo "$staticroutes" \


### PR DESCRIPTION
 * acquire DHCP on the interfaces with ```networking.interface.$name.useDHCP == true``` or on all interfaces if ```networking.useDHCP == true``` (was only "eth0", it is ```udhcpc```'s default behaviour)
 * respect ```mtu``` if it was in DHCP answer (it happens in the wild, on some hostings)
 * acquire and set up ```staticroutes``` (unlike others clients, ```udhcpc``` does not do the query by default); this supersedes https://github.com/NixOS/nixpkgs/pull/41829

Shortly, it makes ```initrd-network``` closer to network in stage-2
It fixes the practical cases where ```initrd-network``` has problems while stage-2 works well.