### PR TITLE
dde-calendar: init at 1.2.5

### DIFF
--- a/pkgs/desktops/deepin/dde-calendar/default.nix
+++ b/pkgs/desktops/deepin/dde-calendar/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools,
+  deepin-gettext-tools, dtkcore, dtkwidget
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-calendar";
+  version = "1.2.5";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1a5zxpz7zncw6mrzv8zmn0j1vk0c8fq0m1xhmnwllffzybrhn4y7";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    qttools
+    deepin-gettext-tools
+  ];
+
+  buildInputs = [
+    dtkcore
+    dtkwidget
+  ];
+
+  postPatch = ''
+    patchShebangs .
+    sed -i translate_desktop.sh \
+      -e "s,/usr/bin/deepin-desktop-ts-convert,deepin-desktop-ts-convert,"
+    sed -i com.deepin.Calendar.service \
+      -e "s,/usr,$out,"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Calendar for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/dde-calendar;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -4,6 +4,7 @@ let
   packages = self: with self; {
 
     dbus-factory = callPackage ./dbus-factory { };
+    dde-calendar = callPackage ./dde-calendar { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };


### PR DESCRIPTION
###### Motivation for this change

Add [dde-callendar](https://github.com/linuxdeepin/dde-calendar) (calendar for Deepin Desktop Environment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).