### PR TITLE
dtkwm: init at 2.0.9

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -17,6 +17,7 @@ let
       wnck = pkgs.libwnck3;
     };
     dtkcore = callPackage ./dtkcore { };
+    dtkwm = callPackage ./dtkwm { };
     dtkwidget = callPackage ./dtkwidget { };
     go-dbus-factory = callPackage ./go-dbus-factory { };
     go-dbus-generator = callPackage ./go-dbus-generator { };

--- a/pkgs/desktops/deepin/dtkwm/default.nix
+++ b/pkgs/desktops/deepin/dtkwm/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qtx11extras, dtkcore }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dtkwm";
+  version = "2.0.9";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "0vkx6vlz83pgawhdwqkwpq3dy8whxmjdzfpgrvm2m6jmspfk9bab";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    dtkcore
+    qtx11extras
+  ];
+
+  preConfigure = ''
+    qmakeFlags="$qmakeFlags \
+      QT_HOST_DATA=$out \
+      INCLUDE_INSTALL_DIR=$out/include \
+      LIB_INSTALL_DIR=$out/lib"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Deepin graphical user interface library";
+    homepage = https://github.com/linuxdeepin/dtkwm;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [dtkwm](https://github.com/linuxdeepin/dtkwm) (Deepint Tool Kit (Dtk) is the base development tool of all C++/Qt Developer work on Deepin).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).