### PR TITLE
pacman: substitute paths in repo-add

### DIFF
--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ perl libarchive openssl zlib bzip2 lzma ];
 
+  postFixup = ''
+    substituteInPlace $out/bin/repo-add \
+      --replace bsdtar "${libarchive}/bin/bsdtar"
+  '';
+
   meta = with lib; {
     description = "A simple library-based package manager";
     homepage = https://www.archlinux.org/pacman/;


### PR DESCRIPTION
###### Motivation for this change

The `repo-add` script assumes `bsdtar` and `openssl` are in the path, causing it to fail on NixOS.

###### Things done

This PR substitutes those instances with the absolute paths.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

