### PR TITLE
deepin-image-viewer: init at 1.2.23

### DIFF
--- a/pkgs/desktops/deepin/deepin-image-viewer/default.nix
+++ b/pkgs/desktops/deepin/deepin-image-viewer/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, qttools, qtsvg,
+  qtx11extras, dtkcore, dtkwidget, qt5integration, freeimage, libraw,
+  libexif
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-image-viewer";
+  version = "1.2.23";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1n1b3j65in6v7q5bxgkiam8qy56kjn9prld3sjrbc2mqzff8sm3q";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+    qttools
+  ];
+
+  buildInputs = [
+    qtsvg
+    qtx11extras
+    dtkcore
+    dtkwidget
+    qt5integration
+    freeimage
+    libraw
+    libexif
+  ];
+
+  postPatch = ''
+    patchShebangs .
+    sed -i qimage-plugins/freeimage/freeimage.pro \
+           qimage-plugins/libraw/libraw.pro \
+      -e "s,\$\$\[QT_INSTALL_PLUGINS\],$out/$qtPluginPrefix,"
+    sed -i viewer/com.deepin.ImageViewer.service \
+      -e "s,/usr,$out,"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Image Viewer for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/deepin-image-viewer;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -8,6 +8,7 @@ let
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };
     deepin-gtk-theme = callPackage ./deepin-gtk-theme { };
     deepin-icon-theme = callPackage ./deepin-icon-theme { };
+    deepin-image-viewer = callPackage ./deepin-image-viewer { };
     deepin-menu = callPackage ./deepin-menu { };
     deepin-mutter = callPackage ./deepin-mutter { };
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };

--- a/pkgs/development/libraries/freeimage/default.nix
+++ b/pkgs/development/libraries/freeimage/default.nix
@@ -1,44 +1,18 @@
 { stdenv, fetchurl, unzip, darwin }:
 
 stdenv.mkDerivation {
-  name = "freeimage-3.17.0";
+  name = "freeimage-3.18.0";
 
   src = fetchurl {
-    url = mirror://sourceforge/freeimage/FreeImage3170.zip;
-    sha256 = "12bz57asdcfsz3zr9i9nska0fb6h3z2aizy412qjqkixkginbz7v";
+    url = mirror://sourceforge/freeimage/FreeImage3180.zip;
+    sha256 = "1z9qwi9mlq69d5jipr3v2jika2g0kszqdzilggm99nls5xl7j4zl";
   };
-
-  patches = let
-    patchURL = https://anonscm.debian.org/cgit/debian-science/packages/freeimage.git/plain/debian/patches;
-  in [
-    (fetchurl {
-      url = patchURL + "/Fix-CVE-2015-0852.patch";
-      sha256 = "1vxdck4i5qi5j6i3cjja0gfy79mmbf0lq2qdrnqdsl4kclbvw2c8";
-    })
-    (fetchurl {
-      url = patchURL + "/Fix-CVE-2016-5684.patch";
-      sha256 = "14ffgqbnwg28r6sjvm3z89zbnnm9ghbc81hdhrzxlyk3vwvd6cw3";
-    })
-    (fetchurl {
-      url = https://raw.githubusercontent.com/buildroot/buildroot/2018.05/package/libfreeimage/0005-Manage-powf64-with-glibc.patch;
-      sha256 = "1lis479ad5cfkhqm044nk4x97wfwm3hry3bvij1w5xkndnlfppc2";
-    })
-  ];
 
   buildInputs = [ unzip ] ++ stdenv.lib.optional stdenv.isDarwin darwin.cctools;
 
   prePatch = if stdenv.isDarwin
              then ''
-    sed -e 's/gcc-4.0/clang/g' \
-        -e 's/g++-4.0/clang++/g' \
-        -e 's/COMPILERFLAGS = -Os -fexceptions -fvisibility=hidden -DNO_LCMS/COMPILERFLAGS = -Os -fexceptions -fvisibility=hidden -DNO_LCMS -D__ANSI__/' \
-        -e "s|PREFIX = /usr/local|PREFIX = $out|" \
-        -e 's|-Wl,-syslibroot /Developer/SDKs/MacOSX10.5.sdk||g' \
-        -e 's|-Wl,-syslibroot /Developer/SDKs/MacOSX10.6.sdk||g' \
-        -e 's|-isysroot /Developer/SDKs/MacOSX10.6.sdk||g' \
-        -e 's|-isysroot /Developer/SDKs/MacOSX10.5.sdk||g' \
-        -e 's| $(STATICLIB)-ppc $(STATICLIB)-i386||g' \
-        -e 's| $(SHAREDLIB)-ppc $(SHAREDLIB)-i386||g' \
+    sed -e "s|PREFIX = /usr/local|PREFIX = $out|" \
         -e 's|	install -d -m 755 -o root -g wheel $(INCDIR) $(INSTALLDIR)||' \
         -e 's| -m 644 -o root -g wheel||g' \
         -i ./Makefile.osx


### PR DESCRIPTION
###### Motivation for this change

Add [deepin-image-viewer](https://github.com/linuxdeepin/deepin-image-viewer) (Image Viewer for Deepin Desktop Environment).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).