### PR TITLE
ZHF 18.09: fix crypsetup build with python enabled.

### DIFF
--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -19,6 +19,9 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs tests
+    ${stdenv.lib.optionalString enablePython ''
+      patchShebangs ./python/pycryptsetup-test.py
+    ''}
 
     # O_DIRECT is filesystem dependent and fails in a sandbox (on tmpfs)
     # and on several filesystem types (btrfs, zfs) without sandboxing.


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/81028247.

###### Motivation for this change
 /cc ZHF #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

