### PR TITLE
pythonmagick: fix build

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -355,6 +355,11 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "Independent JPEG Group License";
   };
 
+  imagemagick = spdx {
+    fullName = "ImageMagick License";
+    spdxId = "imagemagick";
+  };
+
   inria-compcert = {
     fullName  = "INRIA Non-Commercial License Agreement for the CompCert verified compiler";
     url       = "http://compcert.inria.fr/doc/LICENSE";

--- a/pkgs/applications/graphics/PythonMagick/default.nix
+++ b/pkgs/applications/graphics/PythonMagick/default.nix
@@ -1,6 +1,6 @@
 # This expression provides Python bindings to ImageMagick. Python libraries are supposed to be called via `python-packages.nix`.
 
-{stdenv, fetchurl, python, boost, pkgconfig, imagemagick}:
+{ stdenv, fetchurl, python, pkgconfig, imagemagick, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "pythonmagick-${version}";
@@ -11,10 +11,18 @@ stdenv.mkDerivation rec {
     sha256 = "137278mfb5079lns2mmw73x8dhpzgwha53dyl00mmhj2z25varpn";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [python boost imagemagick];
+  postPatch = ''
+    rm configure
+  '';
 
-  meta = {
+  configureFlags = [ "--with-boost=${python.pkgs.boost}" ];
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ python python.pkgs.boost imagemagick ];
+
+  meta = with stdenv.lib; {
     homepage = http://www.imagemagick.org/script/api.php;
+    license = licenses.imagemagick;
+    description = "PythonMagick provides object oriented bindings for the ImageMagick Library.";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The original build broke with the following linker issue:

```
  CXXLD    _PythonMagick.la
/nix/store/h0lbngpv6ln56hjj59i6l77vxq25flbz-binutils-2.30/bin/ld: cannot find -l-L/nix/store/4gh6ynzsd5ndx37hmkl62xa8z30k43y1-imagemagick-6.9.9-34/lib
collect2: error: ld returned 1 exit status
```

This happens since `BOOST_PYTHON_LIB` wasn't set properly, however
`_PythonMagick.la` was linked with `-l$(BOOST_PYTHON_LIB)
$(MAGICK_LIBS)`. With an empty `BOOST_PYTHON_LIB` the linker got
confused.

To work around this, the `boost` library directory needs to be specified
explicitly. To ensure that the changes take effect, the original
`configure` script shipped with `$src` needs to be removed and recreated
using the `autoreconfHook`.

Additionally the `imagemagick` license (https://spdx.org/licenses/ImageMagick.html)
needs to be added to `lib/licenses.nix` to document the proper license
of `pythonmagick` in the meta section.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

