### PR TITLE
et-book: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1847,6 +1847,11 @@
     github = "jerith666";
     name = "Matt McHenry";
   };
+  jethro = {
+    email = "jethrokuan95@gmail.com";
+    github = "jethrokuan";
+    name = "Jethro Kuan";
+  };
   jfb = {
     email = "james@yamtime.com";
     github = "tftio";

--- a/pkgs/data/fonts/et-book/default.nix
+++ b/pkgs/data/fonts/et-book/default.nix
@@ -14,8 +14,8 @@ fetchFromGitHub rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Font for ET Book";
-    license = licenses.free;
+    description = "The typeface used in Edward Tufte’s books.";
+    license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ jethro ];
   };

--- a/pkgs/data/fonts/et-book/default.nix
+++ b/pkgs/data/fonts/et-book/default.nix
@@ -1,16 +1,16 @@
 { stdenv, fetchFromGitHub }:
 
 fetchFromGitHub rec {
-  rev = "1.0";
-  name = "et-book-${rev}";
-  owner = "jethrokuan";
+  rev = "7e8f02dadcc23ba42b491b39e5bdf16e7b383031";
+  name = "et-book-${builtins.substring 0 6 rev}";
+  owner = "edwardtufte";
   repo = "et-book";
   sha256 = "1bfb1l8k7fzgk2l8cikiyfn5x9m0fiwrnsbc1483p8w3qp58s5n2";
 
   postFetch = ''
     tar -xzf $downloadedFile
     mkdir -p $out/share/fonts/truetype
-    cp -t $out/share/fonts/truetype ${name}/*.ttf
+    cp -t $out/share/fonts/truetype et-book-${rev}/source/4-ttf/*.ttf
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/fonts/et-book/default.nix
+++ b/pkgs/data/fonts/et-book/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub }:
+
+fetchFromGitHub rec {
+  rev = "1.0";
+  name = "et-book-${rev}";
+  owner = "jethrokuan";
+  repo = "et-book";
+  sha256 = "1bfb1l8k7fzgk2l8cikiyfn5x9m0fiwrnsbc1483p8w3qp58s5n2";
+
+  postFetch = ''
+    tar -xzf $downloadedFile
+    mkdir -p $out/share/fonts/truetype
+    cp -t $out/share/fonts/truetype ${name}/*.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Font for ET Book";
+    license = licenses.free;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ jethro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -151,6 +151,8 @@ with pkgs;
 
   ebook2cw = callPackage ../applications/misc/ebook2cw { };
 
+  etBook = callPackage ../data/fonts/et-book { };
+
   fetchbower = callPackage ../build-support/fetchbower {
     inherit (nodePackages) bower2nix;
   };


### PR DESCRIPTION
###### Motivation for this change

ET Bembo is a relatively popular font, surprised to see it yet to be packaged in Nixpkgs. The revision given is bogus, this font has not been updated for many years.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

