### PR TITLE
openbsm: fix linux build

### DIFF
--- a/pkgs/development/libraries/openbsm/default.nix
+++ b/pkgs/development/libraries/openbsm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0b98359hd8mm585sh145ss828pg2y8vgz38lqrb7nypapiyqdnd1";
   };
 
-  patches = [ ./bsm-add-audit_token_to_pid.patch ];
+  patches = lib.optional stdenv.isDarwin [ ./bsm-add-audit_token_to_pid.patch ];
 
   meta = {
     homepage = http://www.openbsm.org/;


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80705916

To fix the linux build the patch `bsm-add-audit_token_to_pid.patch`
mustn't be applied during Linux builds, only for Darwin as it's an
Apple-only fix.

The compiler failure occurred because `audit_token_t` is part of
`<mach/mach.h>` which is not available on Linux.

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

