### PR TITLE
safe-money: Fix dependencies for safe-money-*

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1130,4 +1130,12 @@ self: super: {
 
   # https://github.com/snapframework/xmlhtml/pull/37
   xmlhtml = doJailbreak super.xmlhtml;
+
+  # https://github.com/NixOS/nixpkgs/issues/46467
+  safe-money-aeson = super.safe-money-aeson.override { safe-money = self.safe-money_0_7; };
+  safe-money-store = super.safe-money-store.override { safe-money = self.safe-money_0_7; };
+  safe-money-cereal = super.safe-money-cereal.override { safe-money = self.safe-money_0_7; };
+  safe-money-serialise = super.safe-money-serialise.override { safe-money = self.safe-money_0_7; };
+  safe-money-xmlbf = super.safe-money-xmlbf.override { safe-money = self.safe-money_0_7; };
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super


### PR DESCRIPTION
###### Motivation for this change

`safe-money-*` all depend on `safe-money-0.7`, but hackage2nix made them incorrectly
depend on `safe-money-0.6`.   In `safe-money-0.7` the `safe-money` package was split up
into multiple packages. This is why this occurred.

We should be able to remove this 'hack' as soon as the new Stackage LTS
comes out, as safe-money-0.7 will then be the default version.

fixes #46467 
cc #45960 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

