### PR TITLE
earlyoom: fix version number

### DIFF
--- a/pkgs/os-specific/linux/earlyoom/default.nix
+++ b/pkgs/os-specific/linux/earlyoom/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "earlyoom-${version}";
-  version = "0.11";
+  name = "earlyoom-${VERSION}";
+  VERSION = "0.11";
 
   src = fetchFromGitHub {
     owner = "rfjakob";

--- a/pkgs/os-specific/linux/earlyoom/default.nix
+++ b/pkgs/os-specific/linux/earlyoom/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "earlyoom-${VERSION}";
+  # This environment variable is read by make to set the build version.
   VERSION = "0.11";
 
   src = fetchFromGitHub {
     owner = "rfjakob";
     repo = "earlyoom";
-    rev = "08b7ed8e72feed2eec2e558ba2cfacbf6d469594";
+    rev = "v${VERSION}";
     sha256 = "1k3xslb70fzk80wlka32l0k2v45qn1xgwyjkjiz85gv6v4mv92vl";
   };
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp earlyoom $out/bin
+    install -D earlyoom $out/bin/earlyoom
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
Before:
```
$ nix run nixpkgs.earlyoom -c earlyoom -h
earlyoom (unknown version)
Usage: earlyoom [-m PERCENT] [-s PERCENT] [-k|-i] [-h]
-m ... set available memory minimum to PERCENT of total (default 10 %)
-s ... set free swap minimum to PERCENT of total (default 10 %)
-k ... use kernel oom killer instead of own user-space implementation
-i ... user-space oom killer should ignore positive oom_score_adj values
-d ... enable debugging messages
-v ... print version information and exit
-h ... this help text
```
After:
```
$ nix run nixpkgs.earlyoom -c earlyoom -h
earlyoom 0.11
Usage: earlyoom [-m PERCENT] [-s PERCENT] [-k|-i] [-h]
-m ... set available memory minimum to PERCENT of total (default 10 %)
-s ... set free swap minimum to PERCENT of total (default 10 %)
-k ... use kernel oom killer instead of own user-space implementation
-i ... user-space oom killer should ignore positive oom_score_adj values
-d ... enable debugging messages
-v ... print version information and exit
-h ... this help text
```

earlyoom's Makefile attempts to detect the current version using git,
but we don't keep .git in its source, so this fails. We can however
set the VERSION environment variable to override this, as we now do.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): no change
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

