### PR TITLE
WIP: haskell: Make linkWithGold use gold also for compiling Setup.hs

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -17,6 +17,7 @@ in
 , buildDepends ? [], setupHaskellDepends ? [], libraryHaskellDepends ? [], executableHaskellDepends ? []
 , buildTarget ? ""
 , buildTools ? [], libraryToolDepends ? [], executableToolDepends ? [], testToolDepends ? [], benchmarkToolDepends ? []
+, extraSetupCompileFlags ? []
 , configureFlags ? []
 , buildFlags ? []
 , description ? ""
@@ -170,7 +171,7 @@ let
     (optionalString (isGhcjs || isHaLVM || versionOlder "7.8" ghc.version) "-j$NIX_BUILD_CORES")
     # https://github.com/haskell/cabal/issues/2398
     (optionalString (versionOlder "7.10" ghc.version && !isHaLVM) "-threaded")
-  ];
+  ] ++ extraSetupCompileFlags;
 
   isHaskellPkg = x: (x ? pname) && (x ? version) && (x ? env);
   isSystemPkg = x: !isHaskellPkg x;

--- a/pkgs/development/haskell-modules/lib.nix
+++ b/pkgs/development/haskell-modules/lib.nix
@@ -226,8 +226,9 @@ rec {
   /* Use the gold linker. It is a linker for ELF that is designed
      "to run as fast as possible on modern systems"
    */
-  linkWithGold = drv : appendConfigureFlag drv
-    "--ghc-option=-optl-fuse-ld=gold --ld-option=-fuse-ld=gold --with-ld=ld.gold";
+  linkWithGold = drv : overrideCabal (appendConfigureFlag drv
+    "--ghc-option=-optl-fuse-ld=gold --ld-option=-fuse-ld=gold --with-ld=ld.gold")
+    (old: { extraSetupCompileFlags = [ "-optl-fuse-ld=gold" ]; });
 
   /* link executables statically against haskell libs to reduce
      closure size


### PR DESCRIPTION
###### Motivation for this change

`linkWithGold` only uses `ld.gold` for the final link, not for building `Setup.hs` (which currently takes up to ~3 seconds on my machine for each Haskell package, which can add up to some time.)

###### This doesn't work yet

This is WIP because it segfaults.

If I try it on the `hello` Haskell package, I get a segfault when running `./Setup`:

```
niklas@ares:/tmp/nix-build-hello-1.0.0.2.drv-1/hello-1.0.0.2$ ./Setup 
Segmentation fault (core dumped)
```

`gdb` shows:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00007ffff7ad0c81 in frame_dummy ()
   from /nix/store/254rgj92dhkyg7sydb7al65gflnyjd7b-gmp-6.1.2/lib/libgmp.so.10
#2  0x0000000000000000 in ?? ()
```

and when I compile with `integer-simple`:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x000000000040ac7d in frame_dummy ()
#2  0x0000000000000000 in ?? ()
```

Not sure what's going on, why does the `Setup` segfault if linked with `ld.gold`?

CC @basvandijk @peti 