### PR TITLE
govendor: init at 1.0.9

### DIFF
--- a/pkgs/development/tools/govendor/default.nix
+++ b/pkgs/development/tools/govendor/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "govendor-${version}";
+  version = "1.0.9";
+
+  goPackagePath = "github.com/kardianos/govendor";
+
+  src = fetchFromGitHub {
+    owner = "kardianos";
+    repo = "govendor";
+    rev = "v${version}";
+    sha256 = "0g02cd25chyijg0rzab4xr627pkvk5k33mscd6r0gf1v5xvadcfq";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/kardianos/govendor";
+    description = "Go vendor tool that works with the standard vendor file";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ zimbatm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14460,6 +14460,8 @@ with pkgs;
 
   govers = callPackage ../development/tools/govers { };
 
+  govendor = callPackage ../development/tools/govendor { };
+
   gotools = callPackage ../development/tools/gotools { };
 
   gotop = callPackage ../tools/system/gotop { };


### PR DESCRIPTION
###### Motivation for this change

needed govendor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

