### PR TITLE
Paperwork 1.2.4

### DIFF
--- a/pkgs/applications/office/paperwork/backend.nix
+++ b/pkgs/applications/office/paperwork/backend.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, lib, fetchFromGitHub
+{ buildPythonPackage, lib, fetchFromGitLab
 
 , isPy3k, isPyPy
 
@@ -10,17 +10,25 @@
 
 buildPythonPackage rec {
   pname = "paperwork-backend";
-  version = "1.2.2";
+  version = "1.2.4";
 
-  src = fetchFromGitHub {
-    owner = "openpaperwork";
-    repo = "paperwork-backend";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    repo = "paperwork";
+    group = "World";
+    owner = "OpenPaperwork";
     rev = version;
-    sha256 = "1rvf06vphm32601ja1bfkfkfpgjxiv0lh4yxjy31jll0bfnsf7pf";
+    sha256 = "0wjjiw99aswmppnhzq3jir0p5p78r3m8hjinhdirkgm6h7skq5p4";
   };
+
+  sourceRoot = "source/paperwork-backend";
 
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;
+
+  patchPhase = ''
+    echo 'version = "${version}"' > paperwork_backend/_version.py
+  '';
 
   preCheck = "\"$out/bin/paperwork-shell\" chkdeps paperwork_backend";
 

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -1,20 +1,14 @@
-{ lib, python3Packages, fetchFromGitHub, gtk3, cairo
+{ lib, python3Packages, fetchFromGitLab, gtk3, cairo
 , aspellDicts, buildEnv
 , gnome3, hicolor-icon-theme, librsvg
 , xvfb_run, dbus, libnotify
 }:
 
 python3Packages.buildPythonApplication rec {
+  inherit (python3Packages.paperwork-backend) version src;
   name = "paperwork-${version}";
-  # Don't forget to also update paperwork-backend when updating this!
-  version = "1.2.2";
 
-  src = fetchFromGitHub {
-    repo = "paperwork";
-    owner = "openpaperwork";
-    rev = version;
-    sha256 = "1nb5sna2s952xb7c89qccg9qp693pyqj8g7xz16ll16ydfqnzsdk";
-  };
+  sourceRoot = "source/paperwork-gtk";
 
   # Patch out a few paths that assume that we're using the FHS:
   postPatch = ''
@@ -39,6 +33,12 @@ python3Packages.buildPythonApplication rec {
 
     sed -i -e 's/"logo"/"logo-icon-name"/g' \
       src/paperwork/frontend/aboutdialog/aboutdialog.glade
+
+    cat - ../AUTHORS.py > src/paperwork/_version.py <<EOF
+    # -*- coding: utf-8 -*-
+    version = "${version}"
+    authors_code=""
+    EOF
   '';
 
   ASPELL_CONF = "dict-dir ${buildEnv {

--- a/pkgs/development/python-modules/pyocr/default.nix
+++ b/pkgs/development/python-modules/pyocr/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage rec {
   checkPhase = "pytest";
 
   meta = {
-    inherit (src) homepage;
+    inherit (src.meta) homepage;
     description = "A Python wrapper for Tesseract and Cuneiform";
     license = lib.licenses.gpl3Plus;
   };

--- a/pkgs/development/python-modules/pyocr/paths.patch
+++ b/pkgs/development/python-modules/pyocr/paths.patch
@@ -1,28 +1,28 @@
-diff --git a/src/pyocr/cuneiform.py b/src/pyocr/cuneiform.py
-index a461d92..1f2b914 100644
---- a/src/pyocr/cuneiform.py
-+++ b/src/pyocr/cuneiform.py
+Index: current/src/pyocr/cuneiform.py
+===================================================================
+--- current.orig/src/pyocr/cuneiform.py
++++ current/src/pyocr/cuneiform.py
 @@ -27,13 +27,9 @@ from . import error
  from . import util
  
  
 -# CHANGE THIS IF CUNEIFORM IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 -CUNEIFORM_CMD = 'cuneiform'
-+CUNEIFORM_CMD = '@NIX_CUNEIFORM_CMD@'
++CUNEIFORM_CMD = '@cuneiform@/bin/cuneiform'
  
 -CUNEIFORM_DATA_POSSIBLE_PATHS = [
 -    "/usr/local/share/cuneiform",
 -    "/usr/share/cuneiform",
 -]
-+CUNEIFORM_DATA_POSSIBLE_PATHS = ['@NIX_CUNEIFORM_DATA@']
++CUNEIFORM_DATA_POSSIBLE_PATHS = ['@cuneiform@/share/cuneiform']
  
  LANGUAGES_LINE_PREFIX = "Supported languages: "
  LANGUAGES_SPLIT_RE = re.compile("[^a-z]")
-diff --git a/src/pyocr/libtesseract/tesseract_raw.py b/src/pyocr/libtesseract/tesseract_raw.py
-index b4e7bda..47505f7 100644
---- a/src/pyocr/libtesseract/tesseract_raw.py
-+++ b/src/pyocr/libtesseract/tesseract_raw.py
-@@ -1,55 +1,13 @@
+Index: current/src/pyocr/libtesseract/tesseract_raw.py
+===================================================================
+--- current.orig/src/pyocr/libtesseract/tesseract_raw.py
++++ current/src/pyocr/libtesseract/tesseract_raw.py
+@@ -1,52 +1,13 @@
  import ctypes
  import logging
  import os
@@ -56,7 +56,13 @@ index b4e7bda..47505f7 100644
 -        # Jflesch> Don't they have the equivalent of LD_LIBRARY_PATH on
 -        # Windows ?
 -        "../vs2010/DLL_Release/libtesseract302.dll",
+-        # prefer the most recent first
+-        "libtesseract305.dll",
+-        "libtesseract304.dll",
+-        "libtesseract303.dll",
 -        "libtesseract302.dll",
+-        "libtesseract400.dll",  # Tesseract 4 is still in alpha stage
+-        "libtesseract.dll",
 -        "C:\\Program Files (x86)\\Tesseract-OCR\\libtesseract-4.dll",
 -        "C:\\Program Files (x86)\\Tesseract-OCR\\libtesseract-3.dll",
 -    ]
@@ -66,27 +72,18 @@ index b4e7bda..47505f7 100644
 -        "libtesseract.so.3",
 -    ]
 -
--
--g_libtesseract = None
--
--for libname in libnames:
--    try:
--        g_libtesseract = ctypes.cdll.LoadLibrary(libname)
--        break
--    except OSError:
--        pass
-+g_libtesseract = ctypes.cdll.LoadLibrary('@NIX_LIBTESSERACT_PATH@')
++libnames = [ "@tesseract@/lib/libtesseract.so" ]
  
+ g_libtesseract = None
  
- class PageSegMode(object):
-@@ -326,12 +284,11 @@ def init(lang=None):
+@@ -346,12 +307,11 @@ def init(lang=None):
      try:
          if lang:
              lang = lang.encode("utf-8")
 -        prefix = None
 -        if TESSDATA_PREFIX:
 -            prefix = TESSDATA_PREFIX.encode("utf-8")
-+        prefix = os.getenv('TESSDATA_PREFIX', '@NIX_TESSDATA_PREFIX@')
++        prefix = os.getenv('TESSDATA_PREFIX', '@tesseract@/share/tessdata')
 +        os.environ['TESSDATA_PREFIX'] = prefix
          g_libtesseract.TessBaseAPIInit3(
              ctypes.c_void_p(handle),
@@ -95,17 +92,17 @@ index b4e7bda..47505f7 100644
              ctypes.c_char_p(lang)
          )
          g_libtesseract.TessBaseAPISetVariable(
-diff --git a/src/pyocr/tesseract.py b/src/pyocr/tesseract.py
-index c935881..7139ffe 100755
---- a/src/pyocr/tesseract.py
-+++ b/src/pyocr/tesseract.py
-@@ -31,8 +31,7 @@ from .builders import DigitBuilder  # backward compatibility
+Index: current/src/pyocr/tesseract.py
+===================================================================
+--- current.orig/src/pyocr/tesseract.py
++++ current/src/pyocr/tesseract.py
+@@ -31,8 +31,7 @@ from .builders import DigitBuilder  # ba
  from .error import TesseractError  # backward compatibility
  from .util import digits_only
  
 -# CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 -TESSERACT_CMD = 'tesseract.exe' if os.name == 'nt' else 'tesseract'
-+TESSERACT_CMD = '@NIX_TESSERACT_CMD@'
++TESSERACT_CMD = '@tesseract@/bin/tesseract'
  
  TESSDATA_EXTENSION = ".traineddata"
  

--- a/pkgs/development/python-modules/pypillowfight/default.nix
+++ b/pkgs/development/python-modules/pypillowfight/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Library containing various image processing algorithms";
-    inherit (src) homepage;
+    inherit (src.meta) homepage;
     license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/development/python-modules/pypillowfight/default.nix
+++ b/pkgs/development/python-modules/pypillowfight/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchFromGitLab, nose, pillow
+, isPy3k, isPyPy
+}:
+buildPythonPackage rec {
+  name = "pypillowfight-${version}";
+  version = "0.2.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "OpenPaperwork";
+    repo = "libpillowfight";
+    rev = version;
+    sha256 = "0wbzfhbzim61fmkm7p7f2rwslacla1x00a6xp50haawjh9zfwc4y";
+  };
+
+  prePatch = ''
+    echo '#define INTERNAL_PILLOWFIGHT_VERSION "${version}"' > src/pillowfight/_version.h
+  '';
+
+  # Disable tests because they're designed to only work on Debian:
+  # https://github.com/jflesch/libpillowfight/issues/2#issuecomment-268259174
+  doCheck = false;
+
+  # Python 2.x is not supported, see:
+  # https://github.com/jflesch/libpillowfight/issues/1
+  disabled = !isPy3k && !isPyPy;
+
+  # This is needed by setup.py regardless of whether tests are enabled.
+  buildInputs = [ nose ];
+  propagatedBuildInputs = [ pillow ];
+
+  meta = with stdenv.lib; {
+    description = "Library containing various image processing algorithms";
+    inherit (src) homepage;
+    license = licenses.gpl3Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -288,13 +288,13 @@ with pkgs;
 
   # gitlab example
   fetchFromGitLab = {
-    owner, repo, rev, domain ? "gitlab.com", name ? "source",
+    owner, repo, rev, domain ? "gitlab.com", name ? "source", group ? null,
     ... # For hash agility
   }@args: fetchzip ({
     inherit name;
-    url = "https://${domain}/api/v4/projects/${owner}%2F${repo}/repository/archive.tar.gz?sha=${rev}";
-    meta.homepage = "https://${domain}/${owner}/${repo}/";
-  } // removeAttrs args [ "domain" "owner" "repo" "rev" ]) // { inherit rev; };
+    url = "https://${domain}/api/v4/projects/${lib.optionalString (group != null) group+"%2F"}${owner}%2F${repo}/repository/archive.tar.gz?sha=${rev}";
+    meta.homepage = "https://${domain}/${lib.optionalString (group != null) group+"/"}${owner}/${repo}/";
+  } // removeAttrs args [ "domain" "owner" "group" "repo" "rev" ]) // { inherit rev; };
 
   # gitweb example, snapshot support is optional in gitweb
   fetchFromRepoOrCz = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3918,35 +3918,7 @@ in {
     };
   };
 
-  pypillowfight = buildPythonPackage rec {
-    name = "pypillowfight-${version}";
-    version = "0.2.1";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "jflesch";
-      repo = "libpillowfight";
-      rev = version;
-      sha256 = "1rwmajsy9qhl3qhhy5mw0xmr3n8abxcq8baidpn0sxv6yjg2369z";
-    };
-
-    # Disable tests because they're designed to only work on Debian:
-    # https://github.com/jflesch/libpillowfight/issues/2#issuecomment-268259174
-    doCheck = false;
-
-    # Python 2.x is not supported, see:
-    # https://github.com/jflesch/libpillowfight/issues/1
-    disabled = !isPy3k && !isPyPy;
-
-    # This is needed by setup.py regardless of whether tests are enabled.
-    buildInputs = [ self.nose ];
-    propagatedBuildInputs = [ self.pillow ];
-
-    meta = {
-      description = "Library containing various image processing algorithms";
-      homepage = "https://github.com/jflesch/libpillowfight";
-      license = licenses.gpl3Plus;
-    };
-  };
+  pypillowfight = callPackage ../development/python-modules/pypillowfight { };
 
   pyprind = callPackage ../development/python-modules/pyprind { };
 


### PR DESCRIPTION
###### Motivation for this change
update (most of these updates could be made standalone. tell me if you want to split.)

###### Things done

The new home for paperwork is the gnome gitlab instance, but they have an unusual namespacing. Instead of the "traditional" owner/repo url, there are three levels: group/owner/repo: https://gitlab.gnome.org/World/OpenPaperwork/paperwork

I have adapted `fetchFromGitLab` to take an optional `group` argument.

I have checked that I can still scan/ocr succesfully with paperwork.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`) (just paperwork)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

cc @aszlig as maintainer.

