### PR TITLE
ocamlPackages.ppx_import: 1.4 -> 1.5

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,21 +1,24 @@
-{stdenv, fetchFromGitHub, buildOcaml, opaline,
- cppo, ounit, ppx_deriving}:
+{ stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild, opaline
+, cppo, ounit, ppx_deriving
+}:
 
-buildOcaml rec {
-  name = "ppx_import";
+if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+then throw "ppx_import is not available for OCaml ${ocaml.version}"
+else
 
-  version = "1.4";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-ppx_import-${version}";
 
-  minimumSupportedOcamlVersion = "4.02";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "ocaml-ppx";
     repo = "ppx_import";
     rev = "v${version}";
-    sha256 = "14c2lp7r9080c4hsb1y1drbxxx3v44b7ib5wfh3kkh3f1jfsjwbk";
+    sha256 = "1lf5lfp6bl5g4gdszaa6k6pkyh3qyhbarg5m1j0ai3i8zh5qg09d";
   };
 
-  buildInputs = [ cppo ounit ppx_deriving opaline ];
+  buildInputs = [ ocaml findlib ocamlbuild cppo ounit ppx_deriving opaline ];
 
   doCheck = true;
   checkTarget = "test";
@@ -25,5 +28,7 @@ buildOcaml rec {
   meta = with stdenv.lib; {
     description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";
     license = licenses.mit;
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.07.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

