### PR TITLE
nixos: sound: warn about changes to defaults

### DIFF
--- a/nixos/modules/services/audio/alsa.nix
+++ b/nixos/modules/services/audio/alsa.nix
@@ -1,5 +1,5 @@
 # ALSA sound support.
-{ config, lib, pkgs, ... }:
+{ config, options, lib, pkgs, ... }:
 
 with lib;
 
@@ -83,7 +83,18 @@ in
 
   ###### implementation
 
-  config = mkIf config.sound.enable {
+  config = mkMerge [{
+
+    warnings = optional (options.sound.enable.highestPrio > 1000) ''
+      You don't have `sound.enable` explicitly enabled of disabled. It was
+      enabled by default before a43e33d0e48b2284ac3a2222d7f1965cef66f5e2 and
+      became disabled by default after e349ccc77febd45abbd14be14f7de123ec4a4da2.
+
+      Which means that if you output sound via ALSA it will still works, but
+      your system will no longer save and restore ALSA state between reboots.
+    '';
+
+  } (mkIf config.sound.enable {
 
     environment.systemPackages = [ alsaUtils ];
 
@@ -129,6 +140,6 @@ in
       ];
     };
 
-  };
+  })];
 
 }


### PR DESCRIPTION
###### Motivation for this change

I still think that change needs to be reverted, but if there's no will for that let's at the very least warn users about the problem that change introduced. Without this most ALSA users switching from releases before 18.03 will get sound, but won't get ALSA state save/restore. That would be very confusing.

All modules and tests that want to be completely headless disable this option explicitly. I.e. you won't see this warning unless you are affected.

###### Things done

- [X] Tested to work as expected.

Please backport to 18.09.