### PR TITLE
perlPackages: ZHF 18.09

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2620,6 +2620,7 @@ let
     prePatch = ''
       # Attempts to use network.
       rm t/01-proxy-http.t
+      rm t/01-proxy-proc-safeexec.t
     '';
     meta = {
       description = "A generic connection to a hierarchical-structured data set";
@@ -9988,10 +9989,10 @@ let
     };
   };
   Mojolicious = buildPerlPackage rec {
-    name = "Mojolicious-7.93";
+    name = "Mojolicious-7.88";
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SR/SRI/${name}.tar.gz";
-      sha256 = "00c30fc566fee0823af0a75bdf4f170531655df14beca6d51f0e453a43aaad5d";
+      sha256 = "4c4c9c05131fcd175cd6370e15d2586baec1a3ec882cb6971e1f5f52b5e0d785";
     };
     meta = {
       homepage = https://mojolicious.org/;
@@ -11645,6 +11646,8 @@ let
       sha256 = "91c177f30f82302eaf3173356eef05c21bc82163df752acb469177bd14a72db9";
     };
     buildInputs = [ pkgs.zookeeper_mt ];
+    # fix "error: format not a string literal and no format arguments [-Werror=format-security]"
+    hardeningDisable = stdenv.lib.optional (stdenv.lib.versionAtLeast perl.version "5.28") "format";
     NIX_CFLAGS_COMPILE = "-I${pkgs.zookeeper_mt}/include";
     NIX_CFLAGS_LINK = "-L${pkgs.zookeeper_mt.out}/lib -lzookeeper_mt";
     meta = {


### PR DESCRIPTION
###### Motivation for this change

ZHF 18.09 https://github.com/NixOS/nixpkgs/issues/45960

###### Things done

 * ```perlXXXPackages.MojoIOLoopForkCall``` fixed by undoing https://github.com/NixOS/nixpkgs/commit/471b3f1dec0a077748083d181660c0c6ddd21086 (not sure if we have do this)

 * ```perlXXXPackages.Connector``` tests fail in sandbox, got passed without sandbox

 * ```perl528Packages.MojoIOLoopForkCall``` failed with `-Werror=format-security`, hardening disabled

