### PR TITLE
networking.hostId: fix cmd in description

### DIFF
--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -341,7 +341,7 @@ in
         You should try to make this ID unique among your machines. You can
         generate a random 32-bit ID using the following commands:
 
-        <literal>cksum /etc/machine-id | while read c rest; do printf "%x" $c; done</literal>
+        <literal>head -c 8 /etc/machine-id</literal>
 
         (this derives it from the machine-id that systemd generates) or
 


### PR DESCRIPTION
Pad the hex literal with leading zeros to the required length of 8 bytes (32 bit).

#### Question to reviewers:
As `/etc/machine-id` is already a random, lower-case hex string, why not just use `head -c 8 /etc/machine-id`?