### PR TITLE
bunny: 1.2 -> 1.3

### DIFF
--- a/pkgs/tools/package-management/bunny/default.nix
+++ b/pkgs/tools/package-management/bunny/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "bunny-${version}";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitLab {
     owner = "tim241";
     repo = "bunny";
     rev = version;
-    sha256 = "13qsgv4n4c96pgm2l5kvwxpk97x2jpk3wp2m56vdj07hcgywgj3h";
+    sha256 = "0nh2h5kj9b0nkb6yrzf4if7anfdmy9vijzy4bl3s7qck0nzbpy8s";
   };
 
   dontBuild = true;


### PR DESCRIPTION
###### Motivation for this change
Newer version came out. This makes it available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

