### PR TITLE
aws-vault: 4.1.0 -> 4.3.0, pass linker flag for specifying app version

### DIFF
--- a/pkgs/tools/admin/aws-vault/default.nix
+++ b/pkgs/tools/admin/aws-vault/default.nix
@@ -13,6 +13,12 @@ buildGoPackage rec {
     sha256 = "0cwzvw1rcvg7y3m8dahr9r05s4i9apnfw5xhiaf0rlkdh3vy33wp";
   };
 
+  # set the version. see: aws-vault's Makefile
+  buildFlagsArray = ''
+    -ldflags=
+    -X main.Version=v${version}
+  '';
+
   meta = with lib; {
     description = "A vault for securely storing and accessing AWS credentials in development environments";
     homepage = "https://github.com/99designs/aws-vault";

--- a/pkgs/tools/admin/aws-vault/default.nix
+++ b/pkgs/tools/admin/aws-vault/default.nix
@@ -2,7 +2,7 @@
 buildGoPackage rec {
   name = "${pname}-${version}";
   pname = "aws-vault";
-  version = "4.1.0";
+  version = "4.3.0";
 
   goPackagePath = "github.com/99designs/${pname}";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "99designs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "04cdynqmkbs7bkl2aay4sjxq49i90fg048lw0ssw1fpwldbvnl6j";
+    sha256 = "0cwzvw1rcvg7y3m8dahr9r05s4i9apnfw5xhiaf0rlkdh3vy33wp";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Among other things, brings in fixes for compilation issues:

- [v4.3.0](https://github.com/99designs/aws-vault/releases/tag/v4.3.0)
   > Update go-keychain to resolve Go 1.11 compilation issue
- [v4.2.1](https://github.com/99designs/aws-vault/releases/tag/v4.2.1)
   > compatibility with go 1.10
- [v4.2.0](https://github.com/99designs/aws-vault/releases/tag/v4.2.0)

The linker flag makes it so that you get back the correct version string when you specify `--version`:

```sh
$ aws-vault --version
v4.3.0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

