### PR TITLE
taskjuggler: 3.5.0 -> 3.6.0

### DIFF
--- a/pkgs/applications/misc/taskjuggler/Gemfile.lock
+++ b/pkgs/applications/misc/taskjuggler/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
-    mime-types (2.6.1)
-    taskjuggler (3.5.0)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
+    mini_mime (1.0.1)
+    taskjuggler (3.6.0)
       mail (>= 2.4.3)
       term-ansicolor (>= 1.0.7)
-    term-ansicolor (1.3.2)
+    term-ansicolor (1.6.0)
       tins (~> 1.0)
-    tins (1.6.0)
+    tins (1.16.3)
 
 PLATFORMS
   ruby
@@ -18,4 +18,4 @@ DEPENDENCIES
   taskjuggler
 
 BUNDLED WITH
-   1.10.5
+   1.14.6

--- a/pkgs/applications/misc/taskjuggler/default.nix
+++ b/pkgs/applications/misc/taskjuggler/default.nix
@@ -1,16 +1,21 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerApp, ruby }:
 
-bundlerEnv {
-  name = "taskjuggler-3.5.0";
+bundlerApp {
+  pname = "taskjuggler";
 
   inherit ruby;
   gemdir = ./.;
 
+  exes = [
+    "tj3" "tj3client" "tj3d" "tj3man" "tj3ss_receiver" "tj3ss_sender"
+    "tj3ts_receiver" "tj3ts_sender" "tj3ts_summary" "tj3webd"
+  ];
+
   meta = {
-    broken = true; # needs ruby 2.0
     description = "A modern and powerful project management tool";
     homepage    = http://taskjuggler.org/;
     license     = lib.licenses.gpl2;
     platforms   = lib.platforms.unix;
+    maintainers = [ lib.maintainers.manveru ];
   };
 }

--- a/pkgs/applications/misc/taskjuggler/gemset.nix
+++ b/pkgs/applications/misc/taskjuggler/gemset.nix
@@ -1,47 +1,55 @@
 {
-  "mail" = {
-    version = "2.6.3";
+  mail = {
+    dependencies = ["mini_mime"];
+    groups = ["default"];
+    platforms = [];
     source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "10dyifazss9mgdzdv08p47p344wmphp5pkh5i73s7c04ra8y6ahz";
       type = "gem";
-      sha256 = "1nbg60h3cpnys45h7zydxwrl200p7ksvmrbxnwwbpaaf9vnf3znp";
     };
-    dependencies = [
-      "mime-types"
-    ];
+    version = "2.7.0";
   };
-  "mime-types" = {
-    version = "2.6.1";
+  mini_mime = {
+    groups = ["default"];
+    platforms = [];
     source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1q4pshq387lzv9m39jv32vwb8wrq3wc4jwgl4jk209r4l33v09d3";
       type = "gem";
-      sha256 = "1vnrvf245ijfyxzjbj9dr6i1hkjbyrh4yj88865wv9bs75axc5jv";
     };
+    version = "1.0.1";
   };
-  "taskjuggler" = {
-    version = "3.5.0";
+  taskjuggler = {
+    dependencies = ["mail" "term-ansicolor"];
+    groups = ["default"];
+    platforms = [];
     source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0ky3cydl3szhdyxsy4k6zxzjlbll7mlq025aj6xd5jmh49k3pfbp";
       type = "gem";
-      sha256 = "0r84rlc7a6w7p9nc9mgycbs5h0hq0kzscjq7zj3296xyf0afiwj2";
     };
-    dependencies = [
-      "mail"
-      "term-ansicolor"
-    ];
+    version = "3.6.0";
   };
-  "term-ansicolor" = {
-    version = "1.3.2";
+  term-ansicolor = {
+    dependencies = ["tins"];
+    groups = ["default"];
+    platforms = [];
     source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "1b1wq9ljh7v3qyxkk8vik2fqx2qzwh5lval5f92llmldkw7r7k7b";
       type = "gem";
-      sha256 = "0ydbbyjmk5p7fsi55ffnkq79jnfqx65c3nj8d9rpgl6sw85ahyys";
     };
-    dependencies = [
-      "tins"
-    ];
-  };
-  "tins" = {
     version = "1.6.0";
+  };
+  tins = {
+    groups = ["default"];
+    platforms = [];
     source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0g95xs4nvx5n62hb4fkbkd870l9q3y9adfc4h8j21phj9mxybkb8";
       type = "gem";
-      sha256 = "02qarvy17nbwvslfgqam8y6y7479cwmb1a6di9z18hzka4cf90hz";
     };
+    version = "1.16.3";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18794,7 +18794,7 @@ with pkgs;
   teamspeak_client = libsForQt5.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };
 
-  uaskjuggler = callPackage ../applications/misc/taskjuggler { };
+  taskjuggler = callPackage ../applications/misc/taskjuggler { };
 
   tasknc = callPackage ../applications/misc/tasknc { };
 


### PR DESCRIPTION
###### Motivation for this change

Seems to be fine with Ruby 2.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

