### PR TITLE
pulseaudio-modules-bt: init at unstable-2018-09-11

### DIFF
--- a/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
+++ b/pkgs/applications/audio/pulseaudio-modules-bt/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, runCommand
+, fetchFromGitHub
+, libpulseaudio
+, pulseaudio
+, pkgconfig
+, libtool
+, cmake
+, bluez
+, dbus
+, sbc
+}:
+
+let
+  pulseSources = runCommand "pulseaudio-sources" {} ''
+    mkdir $out
+    tar -xf ${pulseaudio.src}
+    mv pulseaudio*/* $out/
+  '';
+
+in stdenv.mkDerivation rec {
+  name = "pulseaudio-modules-bt-${version}";
+  version = "unstable-2018-09-11";
+
+  src = fetchFromGitHub {
+    owner = "EHfive";
+    repo = "pulseaudio-modules-bt";
+    rev = "9c6ad75382f3855916ad2feaa6b40e37356d80cc";
+    sha256 = "1iz4m3y6arsvwcyvqc429w252dl3apnhvl1zhyvfxlbg00d2ii0h";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    cmake
+  ];
+
+  buildInputs = [
+    libpulseaudio
+    pulseaudio
+    libtool
+    bluez
+    dbus
+    sbc
+  ];
+
+  NIX_CFLAGS_COMPILE = [
+    "-L${pulseaudio}/lib/pulseaudio"
+  ];
+
+  prePatch = ''
+    rm -r pa
+    ln -s ${pulseSources} pa
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/EHfive/pulseaudio-modules-bt;
+    description = "SBC, Sony LDAC codec (A2DP Audio) support for Pulseaudio";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ adisbladis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13706,6 +13706,8 @@ with pkgs;
 
   bluez5 = callPackage ../os-specific/linux/bluez { };
 
+  pulseaudio-modules-bt = callPackage ../applications/audio/pulseaudio-modules-bt { };
+
   bluez = bluez5;
 
   inherit (python3Packages) bedup;


### PR DESCRIPTION
###### Motivation for this change
I want to use LDAC

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] ~~macOS~~
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm using this way on NixOS:
```nix
  hardware.pulseaudio = {
    enable = true;
    # Replace built in pulseaudio modules with enhanced bluetooth ones
    package = with pkgs; pulseaudioFull.overrideAttrs(oldAttrs: {
      postInstall = oldAttrs.postInstall + ''

        cp -a ${pulseaudio-modules-bt}/* $out/
      '';
    });
  };
```