### PR TITLE
texFunctions: Fix lhs2tex helper derivation

### DIFF
--- a/pkgs/tools/typesetting/tex/nix/default.nix
+++ b/pkgs/tools/typesetting/tex/nix/default.nix
@@ -95,7 +95,7 @@ rec {
 
           deps = import (pkgs.runCommand "lhs2tex-includes"
             { src = key; }
-            "${pkgs.stdenv.bash}/bin/bash ${./find-lhs2tex-includes.sh}");
+            "${pkgs.bash}/bin/bash ${./find-lhs2tex-includes.sh}");
 
         in pkgs.lib.concatMap (x: if builtins.pathExists x then [{key = x;}] else [])
                               (map (x: dirOf key + ("/" + x)) deps);
@@ -134,7 +134,7 @@ rec {
       name = "tex";
       builder = ./lhs2tex.sh;
       inherit source flags;
-      buildInputs = [ pkgs.lhs2tex pkgs.perl ];
+      buildInputs = [ pkgs.haskellPackages.lhs2tex pkgs.perl ];
       copyIncludes = ./copy-includes.pl;
       includes = map (x: [x.key (baseNameOf (toString x.key))])
         (findLhs2TeXIncludes {rootFile = source;});


### PR DESCRIPTION
The package lhs2tex function was moved to haskellPackages.lhs2tex
quite some time ago, and  stdenv.bash does not exist anymore either.
This simply seems to have been a case of code rot of code that
wasn't used in quite a long time.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

