### PR TITLE
fetchNuGet: Add support for sha512

### DIFF
--- a/pkgs/build-support/fetchnuget/default.nix
+++ b/pkgs/build-support/fetchnuget/default.nix
@@ -5,6 +5,7 @@ attrs @
 , version
 , url ? "https://www.nuget.org/api/v2/package/${baseName}/${version}"
 , sha256 ? ""
+, sha512 ? ""
 , md5 ? ""
 , ...
 }:
@@ -13,7 +14,7 @@ if md5 != "" then
 else
   buildDotnetPackage ({
     src = fetchurl {
-      inherit url sha256;
+      inherit url sha256 sha512;
       name = "${baseName}.${version}.zip";
     };
 


### PR DESCRIPTION
###### Motivation for this change

The goal is helping to package dotnet projects similar to `node2nix` or `pypi2nix`

After `dotnet restore`, produces the file `project.assets.json` listing each nuget package with `sha512`.   `fetchurl` supports `sha512`, so it is  just forwarded.
Using this, an expression can be created containing all nuget dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

There are no packages yet which would use sha512 in fetchNuGet, so I have tested this way:

```
nix repl .
Added 9404 variables.

nix-repl> :b dotnetPackages.Fake 
```
Which still builds and uses the cache.

I have tested with the same version and sha512 [here](https://github.com/baracoder/dotnet2nix/blob/3493bf1608e6b939e022efa5b219c7b34575630b/default.nix#L9-L50)

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] ~~Tested execution of all binary files (usually in `./result/bin/`)~~
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

