### PR TITLE
gitAndTools.git-extras: install zsh completion

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-extras/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "DESTDIR=$(out) PREFIX=" ];
 
+  postInstall = ''
+    install -D etc/git-extras-completion.zsh $out/share/zsh/site-functions/_git_extras
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://github.com/tj/git-extras;
     description = "GIT utilities -- repo summary, repl, changelog population, author commit percentages and more";


### PR DESCRIPTION
because there are so many freaking commands !

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

