### PR TITLE
zsh-history-substring-search: init at 1.0.1

### DIFF
--- a/pkgs/shells/zsh/zsh-history-substring-search/default.nix
+++ b/pkgs/shells/zsh/zsh-history-substring-search/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchFromGitHub, zsh }:
+
+stdenv.mkDerivation rec {
+  name = "zsh-history-substring-search-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "zsh-users";
+    repo = "zsh-history-substring-search";
+    rev = "v${version}";
+    sha256 = "0lgmq1xcccnz5cf7vl0r0qj351hwclx9p80cl0qczxry4r2g5qaz";
+  };
+
+  installPhase = ''
+    install -D zsh-history-substring-search.zsh \
+      "$out/share/zsh-history-substring-search/zsh-history-substring-search.zsh"
+  '';
+
+  meta = with lib; {
+    description = "Fish shell history-substring-search for Zsh";
+    homepage = https://github.com/zsh-users/zsh-history-substring-search;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6209,6 +6209,8 @@ with pkgs;
 
   zsh-git-prompt = callPackage ../shells/zsh/zsh-git-prompt { };
 
+  zsh-history-substring-search = callPackage ../shells/zsh/zsh-history-substring-search { };
+
   zsh-navigation-tools = callPackage ../tools/misc/zsh-navigation-tools { };
 
   zsh-syntax-highlighting = callPackage ../shells/zsh/zsh-syntax-highlighting { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

