### PR TITLE
linphone: enable gtk ui

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -4,6 +4,7 @@
 , mediastreamer-openh264, bctoolbox, makeWrapper, fetchFromGitHub, cmake
 , libmatroska, bcunit, doxygen, gdk_pixbuf, glib, cairo, pango, polarssl
 , python, graphviz, belcard
+, withGui ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "0az2ywrpx11sqfb4s4r2v726avcjf4k15bvrqj7xvhz7hdndmh0j";
   };
 
-  cmakeFlags = "-DENABLE_GTK_UI=ON";
+  cmakeFlags = stdenv.lib.optional withGui [ "-DENABLE_GTK_UI=ON" ];
 
   postPatch = ''
     touch coreapi/liblinphone_gitversion.h

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
     sha256 = "0az2ywrpx11sqfb4s4r2v726avcjf4k15bvrqj7xvhz7hdndmh0j";
   };
 
+  cmakeFlags = "-DENABLE_GTK_UI=ON";
+
+  postPatch = ''
+    touch coreapi/liblinphone_gitversion.h
+  '';
+
   buildInputs = [
     readline openldap cyrus_sasl libupnp zlib libxml2 gtk2 libnotify speex ffmpeg libX11
     polarssl libsoup udev ortp mediastreamer sqlite belle-sip libosip libexosip


### PR DESCRIPTION
###### Motivation for this change

Linphone voip client currently depends on Gtk, yet the Gtk-based UI is *not* currently available.  This passes `ENABLE_GTK_UI=ON` to actually enable it.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

