### PR TITLE
pdsh: set default module to ssh, remove obsolete fixes

### DIFF
--- a/pkgs/tools/networking/pdsh/default.nix
+++ b/pkgs/tools/networking/pdsh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, readline, rsh, ssh, pam }:
+{ stdenv, fetchurl, perl, readline, rsh, ssh }:
 
 stdenv.mkDerivation rec {
   name = "pdsh-2.33";
@@ -8,12 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0bwlkl9inj66iwvafg00pi3sk9n673phdi0kcc59y9nn55s0hs3k";
   };
 
-  buildInputs = [perl readline ssh pam];
-
-  /* pdsh uses pthread_cancel(), which requires libgcc_s.so.1 to be
-     loadable at run-time. Adding the flag below ensures that the
-     library can be found. Obviously, though, this is a hack. */
-  NIX_LDFLAGS="-lgcc_s";
+  buildInputs = [ perl readline ssh ];
 
   preConfigure = ''
     configureFlagsArray=(
@@ -22,11 +17,11 @@ stdenv.mkDerivation rec {
       "--with-machines=/etc/pdsh/machines"
       ${if readline == null then "--without-readline" else "--with-readline"}
       ${if ssh == null then "--without-ssh" else "--with-ssh"}
-      ${if pam == null then "--without-pam" else "--with-pam"}
       ${if rsh == false then "--without-rsh" else "--with-rsh"}
       "--with-dshgroups"
       "--with-xcpu"
       "--disable-debug"
+      '--with-rcmd-rank-list=ssh,krb4,exec,xcpu,rsh'
     )
   '';
 


### PR DESCRIPTION
###### Motivation for this change
Having `rsh` the default connection mechanism seems outdated (and unsafe).

CC @peti for review and testing

###### Things done

* Set default remote module to ssh
* Remove `-lgcc_s` hack (seems not needed anymore?).
* Remove `pam` dependency, is not recognized by configure
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

