### PR TITLE
qutebrowser: Fix patching of standarddir.py

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -58,7 +58,7 @@ in python3Packages.buildPythonApplication rec {
   ];
 
   postPatch = ''
-    sed -i "s,/usr/share/qutebrowser,$out/share/qutebrowser,g" qutebrowser/utils/standarddir.py
+    sed -i "s,/usr/share/,$out/share/,g" qutebrowser/utils/standarddir.py
   '' + lib.optionalString withPdfReader ''
     sed -i "s,/usr/share/pdf.js,${pdfjs},g" qutebrowser/browser/pdfjs.py
   '';


### PR DESCRIPTION
The original patch was broken since https://github.com/qutebrowser/qutebrowser/commit/a85e19a5e1ae6792159fe0922ee5ba57815df132 because an `APPNAME` variable was introduced there.

I haven't done any testing at all, as I'm not a NixOS user (I'm the upstream maintainer).

cc @abbradar who introduced the patching in 9b4a7984a4803ed5ab9c9515682778444370eb01