### PR TITLE
sickgear: init at 0.17.5

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -329,6 +329,7 @@
       # kvm = 302; # unused
       # render = 303; # unused
       zeronet = 304;
+      sickgear = 306;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -618,6 +619,7 @@
       kvm = 302; # default udev rules from systemd requires these
       render = 303; # default udev rules from systemd requires these
       zeronet = 304;
+      sickgear = 306;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -588,6 +588,7 @@
   ./services/networking/skydns.nix
   ./services/networking/shadowsocks.nix
   ./services/networking/shairport-sync.nix
+  ./services/networking/sickgear.nix
   ./services/networking/shout.nix
   ./services/networking/sniproxy.nix
   ./services/networking/smokeping.nix

--- a/nixos/modules/services/networking/sickgear.nix
+++ b/nixos/modules/services/networking/sickgear.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.sickgear;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+    services.sickgear = {
+      enable = mkOption {
+        default = false;
+        description = "Whether to enable the sickgear server.";
+      };
+      dataDir = mkOption {
+        default = "/var/lib/sickgear";
+        description = "Path where to store data files.";
+      };
+      configFile = mkOption {
+        default = "/var/lib/sickgear/config.ini";
+        description = "Path to config file.";
+      };
+      port = mkOption {
+        default = 8081;
+        description = "Port to bind to.";
+      };
+      user = mkOption {
+        default = "sickgear";
+        description = "User to run the service as";
+      };
+      group = mkOption {
+        default = "sickgear";
+        description = "Group to run the service as";
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.users.sickgear = {
+          uid = config.ids.uids.sickgear;
+          group = "sickgear";
+          description = "sickgear user";
+          home = "/var/lib/sickgear/";
+          createHome = true;
+    };
+
+    users.groups.sickgear = {
+      gid = config.ids.gids.sickgear;
+    };
+
+    systemd.services.sickgear = {
+        description = "sickgear server";
+        wantedBy    = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          User = "${cfg.user}";
+          Group = "${cfg.group}";
+          ExecStart = "${pkgs.sickgear}/bin/sickgear --datadir ${cfg.dataDir} --config ${cfg.configFile} --port ${toString cfg.port}";
+        };
+    };
+  };
+}

--- a/pkgs/servers/sickgear/default.nix
+++ b/pkgs/servers/sickgear/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, python2, makeWrapper }:
+
+let
+  pythonEnv = python2.withPackages(ps: with ps; [ cheetah ]);
+in python2.pkgs.buildPythonApplication rec {
+  name = "sickgear-${version}";
+  version = "0.17.5";
+
+  src = fetchFromGitHub {
+    owner = "SickGear";
+    repo = "SickGear";
+    rev = "release_${version}";
+    sha256 = "1lx060klgxz8gjanfjvya6p6kd8842qbpp1qhhiw49a25r8gyxpk";
+  };
+
+  dontBuild = true;
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pythonEnv ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R * $out/
+
+    mkdir -p $out/bin
+    makeWrapper $out/SickBeard.py $out/bin/sickgear
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The most reliable stable TV fork of the great Sick-Beard to fully automate TV enjoyment with innovation";
+    license     = licenses.gpl3;
+    homepage    = https:/github.com/SickGear/SickGear;
+    maintainers = with stdenv.lib.maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13523,6 +13523,8 @@ with pkgs;
       # see also openssl, which has/had this same trick
   };
 
+  sickgear = callPackage ../servers/sickgear {};
+
   sipcmd = callPackage ../applications/networking/sipcmd { };
 
   sipwitch = callPackage ../servers/sip/sipwitch { };


### PR DESCRIPTION
###### Motivation for this change
Added [sickgear](https://github.com/SickGear/SickGear) package and nixos module. I can add myself as a maintainer on the next version bump and once #46514 is merged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

