### PR TITLE
dhcpcd: No need to hack around broken patchShebangs anymore

### DIFF
--- a/pkgs/tools/networking/dhcpcd/default.nix
+++ b/pkgs/tools/networking/dhcpcd/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ udev ];
+  buildInputs = [
+    udev
+    runtimeShellPackage # So patchShebangs finds a bash suitable for the installed scripts
+  ];
 
   preConfigure = "patchShebangs ./configure";
 
@@ -28,11 +31,6 @@ stdenv.mkDerivation rec {
 
   # Check that the udev plugin got built.
   postInstall = stdenv.lib.optional (udev != null) "[ -e $out/lib/dhcpcd/dev/udev.so ]";
-
-  # TODO shlevy remove once patchShebangs is fixed
-  postFixup = ''
-    find $out -type f -print0 | xargs --null sed -i 's|${stdenv.shellPackage}|${runtimeShellPackage}|'
-  '';
 
   meta = {
     description = "A client for the Dynamic Host Configuration Protocol (DHCP)";


### PR DESCRIPTION
###### Motivation for this change

Now that https://github.com/NixOS/nixpkgs/pull/43833 has landed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

