### PR TITLE
zfs-unstable: 2018-09-02 -> 0.8.0-rc1

### DIFF
--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -180,10 +180,10 @@ in {
     incompatibleKernelVersion = null;
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "2018-09-02";
+    version = "0.8.0-rc1";
 
-    rev = "c197a77c3cf36531e4cf79e524e1ccf7ec00cc4c";
-    sha256 = "0rk835nnl4w5km8qxcr1wdpr9xasssnrmsxhjlqjy0ry3qcb2197";
+    rev = "b8a90418f3a9c23b89c5d2c729a4dd0fea644508";
+    sha256 = "041b7h8gbb042x9mhg8y87bgq9y793bawglc7b0fg871k6190drx";
     isUnstable = true;
 
     extraPatches = [


### PR DESCRIPTION
###### Motivation for this change

zfs 0.8.0-rc1 was released.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - `nix-build nixos/tests/zfs.nix -A unstable `
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

