### PR TITLE
pants: fix build

### DIFF
--- a/pkgs/development/tools/build-managers/pants/default.nix
+++ b/pkgs/development/tools/build-managers/pants/default.nix
@@ -17,6 +17,7 @@ in buildPythonApplication rec {
 
   prePatch = ''
     sed -E -i "s/'([[:alnum:].-]+)[=><][[:digit:]=><.,]*'/'\\1'/g" setup.py
+    substituteInPlace setup.py --replace "requests[security]<2.19,>=2.5.0" "requests[security]<2.20,>=2.5.0"
   '';
 
   # Unnecessary, and causes some really weird behavior around .class files, which


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80727495

`pants' works with requests==2.19 to build successfully and `nixpkgs' currently uses `requests==2.19.1`.
Patching the version constraint in `setup.py' accordingly fixes the problem.

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

