### PR TITLE
python3Packages.pyowm: fix python3 build

### DIFF
--- a/pkgs/development/python-modules/pyowm/default.nix
+++ b/pkgs/development/python-modules/pyowm/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, requests }:
+{ lib, buildPythonPackage, fetchPypi, requests, geojson }:
 
 buildPythonPackage rec {
   pname = "pyowm";
@@ -9,11 +9,13 @@ buildPythonPackage rec {
     sha256 = "ed175873823a2fedb48e453505c974ca39f3f75006ef1af54fdbcf72e6796849";
   };
 
-  propagatedBuildInputs = [ requests ];
+  propagatedBuildInputs = [ requests geojson ];
 
   # This may actually break the package.
   postPatch = ''
-    substituteInPlace setup.py --replace "requests>=2.18.2,<2.19" "requests"
+    substituteInPlace setup.py \
+      --replace "requests>=2.18.2,<2.19" "requests"  \
+      --replace "geojson>=2.3.0,<2.4" "geojson<2.5,>=2.3.0"
   '';
 
   # No tests in archive


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80714323

Version 2.9 requires `geojson==2.x'. To allow 2.4, the constraint
required some patching using `substituteInPlace'.

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

