### PR TITLE
Allow doCheck config of buildGoPackage

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -170,6 +170,7 @@ go.stdenv.mkDerivation (
     runHook postBuild
   '';
 
+  doCheck = args.doCheck or false;
   checkPhase = args.checkPhase or ''
     runHook preCheck
 


### PR DESCRIPTION
###### Motivation for this change
Golang derivations created with `buildGoPackage` do not run tests upon `nix-build`. This PR exposes a `doCheck` arg that gets propagated to the derivation (it is `false` by default)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
  - Unsure how to do this? But the change is backwards-compatible
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

