### PR TITLE
Feature/git annex remote google

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3234,6 +3234,11 @@
     github = "polyrod";
     name = "Maurizio Di Pietro";
   };
+  poelzi = {
+    email = "nix@poelzi.org";
+    github = "poelzi";
+    name = "Daniel Poelzleithner";
+  };
   pradeepchhetri = {
     email = "pradeep.chhetri89@gmail.com";
     github = "pradeepchhetri";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -56,6 +56,8 @@ let
 
   git-annex-remote-rclone = callPackage ./git-annex-remote-rclone { };
 
+  git-annex-remote-googledrive = callPackage ./git-annex-remote-googledrive { };
+
   # support for bugzilla
   git-bz = callPackage ./git-bz { };
 

--- a/pkgs/applications/version-management/git-and-tools/git-annex-remote-googledrive/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-remote-googledrive/default.nix
@@ -1,0 +1,22 @@
+#{ stdenv, pythonPackages, fetchPypi, rclone, makeWrapper }:
+{ stdenv, lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "git-annex-remote-googledrive";
+  version = "0.11.1";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "1vaycxmxhx8g797nzrnkmz5vbmjy4x7x3b7a2xb7yz6grgcxqgld";
+  };
+
+  buildInputs = [ ];
+  propagatedBuildInputs = [ python3.pkgs.pydrive python3.pkgs.annexremote python3.pkgs.tenacity ];
+
+  meta = with stdenv.lib; {
+    description = "Git annex remote for GoogleDrive";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ poelzi ];
+  };
+
+}

--- a/pkgs/development/python-modules/annexremote/default.nix
+++ b/pkgs/development/python-modules/annexremote/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "annexremote";
+  version = "1.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2be77ae9b9edd0d2818ab6dff7070a05aed2fcc1e5065638aa03eba991b67f17";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Lykos153/AnnexRemote;
+    description = "Helper module to easily develop special remotes for git annex";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ poelzi ];
+  };
+}

--- a/pkgs/development/python-modules/pydrive/default.nix
+++ b/pkgs/development/python-modules/pydrive/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, oauth2client, pyyaml, google_api_python_client }:
+
+buildPythonPackage rec {
+  pname = "PyDrive";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "83890dcc2278081c6e3f6a8da1f8083e25de0bcc8eb7c91374908c5549a20787";
+  };
+
+  propagatedBuildInputs = [ oauth2client pyyaml google_api_python_client ];
+
+  # does not work due missing secrets file
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/googledrive/PyDrive;
+    description = "PyDrive is a wrapper library of google-api-python-client that simplifies many common Google Drive API tasks";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ poelzi ];
+  };
+}

--- a/pkgs/development/python-modules/tenacity/default.nix
+++ b/pkgs/development/python-modules/tenacity/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, pbr, six }:
+
+buildPythonPackage rec {
+  pname = "tenacity";
+  version = "5.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4c10be4f8fbeb1cae24b9315103d8aca3f2b1ef001d455cbb1671d3d79924be6";
+  };
+
+  propagatedBuildInputs = [ pbr six ];
+
+  # does not work due missing secrets file
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/jd/tenacity;
+    description = "Retrying library for Python";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ poelzi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -420,6 +420,8 @@ in {
 
   pydbus = callPackage ../development/python-modules/pydbus { };
 
+  pydrive = callPackage ../development/python-modules/pydrive { };
+
   pydocstyle = callPackage ../development/python-modules/pydocstyle { };
 
   pyexiv2 = disabledIf isPy3k (toPythonModule (callPackage ../development/python-modules/pyexiv2 {}));

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13600,6 +13600,8 @@ in {
 
   texttable = callPackage ../development/python-modules/texttable { };
 
+  tenacity = callPackage ../development/python-modules/tenacity { };
+
   tiros = callPackage ../development/python-modules/tiros { };
 
   tifffile = callPackage ../development/python-modules/tifffile { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -176,6 +176,8 @@ in {
 
   aioamqp = callPackage ../development/python-modules/aioamqp { };
 
+  annexremote = callPackage ../development/python-modules/annexremote { };
+
   ansicolor = callPackage ../development/python-modules/ansicolor { };
 
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };


### PR DESCRIPTION
###### Motivation for this change

add git-annex-remote-googledrive. This remote has more features then the rclone remote and allows you to export a repository to google drive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

