### PR TITLE
lollypop: wrap search provider

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -1,10 +1,14 @@
-{ stdenv, fetchgit, meson, ninja, pkgconfig, wrapGAppsHook
-, appstream-glib, desktop-file-utils, gobjectIntrospection
-, python36Packages, gnome3, glib, gst_all_1 }:
+{ stdenv, fetchgit, meson, ninja, pkgconfig
+, python3, gtk3, gst_all_1, libsecret, libsoup
+, appstream-glib, desktop-file-utils, gnome3
+, gobjectIntrospection, wrapGAppsHook }:
 
-stdenv.mkDerivation rec  {
+python3.pkgs.buildPythonApplication rec  {
   version = "0.9.522";
   name = "lollypop-${version}";
+
+  format = "other";
+  doCheck = false;
 
   src = fetchgit {
     url = "https://gitlab.gnome.org/World/lollypop";
@@ -13,26 +17,30 @@ stdenv.mkDerivation rec  {
     sha256 = "0f2brwv884cvmxj644jcj9sg5hix3wvnjy2ndg0fh5cxyqz0kwn5";
   };
 
-  nativeBuildInputs = with python36Packages; [
+  nativeBuildInputs = with python3.pkgs; [
     appstream-glib
     desktop-file-utils
     gobjectIntrospection
     meson
     ninja
-    python36Packages.python
     pkgconfig
     wrapGAppsHook
-    wrapPython
   ];
 
-  buildInputs = [ glib ] ++ (with gnome3; [
-    gsettings-desktop-schemas gtk3 libsecret libsoup totem-pl-parser
-  ]) ++ (with gst_all_1; [
-    gst-libav gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly
+  buildInputs = with gst_all_1; [
+    gnome3.totem-pl-parser
+    gst-libav
+    gst-plugins-bad
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-ugly
     gstreamer
-  ]);
+    gtk3
+    libsecret
+    libsoup
+  ];
 
-  pythonPath = with python36Packages; [
+  pythonPath = with python3.pkgs; [
     beautifulsoup4
     gst-python
     pillow
@@ -42,11 +50,14 @@ stdenv.mkDerivation rec  {
     pylast
   ];
 
-  postFixup = "wrapPythonPrograms";
-
   postPatch = ''
-    chmod +x ./meson_post_install.py
-    patchShebangs ./meson_post_install.py
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+  '';
+
+  preFixup = ''
+    buildPythonPath "$out/libexec/lollypop-sp $pythonPath"
+    patchPythonScript "$out/libexec/lollypop-sp"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
The gnome search provider was not wrapped at `$out/libexec/lollypop-sp`.

Also #43742 died of staleness :smile: 

> @jtojnar 
> Maybe using python.pkgs.buildPythonApplication would be better

I've made this change :+1: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

