### PR TITLE
Fix for pytorch-0.4.1 cuda-enabled build.

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -79,12 +79,12 @@ let
 in
 stdenv.mkDerivation rec {
   name = "openblas-${version}";
-  version = "0.3.1";
+  version = "0.3.3";
   src = fetchFromGitHub {
     owner = "xianyi";
     repo = "OpenBLAS";
     rev = "v${version}";
-    sha256 = "1dkwp4gz1hzpmhzks9y9ipb4c5h0r6c7yff62x3s8x9z6f8knaqc";
+    sha256 = "0cpkvfvc14xm9mifrm919rp8vrq70gpl7r2sww4f0izrl39wklwx";
   };
 
   inherit blas64;
@@ -118,20 +118,7 @@ stdenv.mkDerivation rec {
     ] ++ stdenv.lib.optional (stdenv.hostPlatform.libc == "musl") "NO_AFFINITY=1"
     ++ mapAttrsToList (var: val: var + "=" + val) config;
 
-    patches = [
-      # Backport of https://github.com/xianyi/OpenBLAS/pull/1667, which
-      # is causing problems and was already accepted upstream.
-      (fetchpatch {
-        url = "https://github.com/xianyi/OpenBLAS/commit/5f2a3c05cd0e3872be3c5686b9da6b627658eeb7.patch";
-        sha256 = "1qvxhk92likrshw6z6hjqxvkblwzgsbzis2b2f71bsvx9174qfk1";
-      })
-      # Double "MAX_ALLOCATING_THREADS", fix with Go and Octave
-      # https://github.com/xianyi/OpenBLAS/pull/1663 (see also linked issue)
-      (fetchpatch {
-        url = "https://github.com/xianyi/OpenBLAS/commit/a49203b48c4a3d6f86413fc8c4b1fbfaa1946463.patch";
-        sha256 = "0v6kjkbgbw7hli6xkism48wqpkypxmcqvxpx564snll049l2xzq2";
-      })
-    ];
+    patches = [];
 
   doCheck = true;
   checkTarget = "tests";

--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -42,6 +42,22 @@ in buildPythonPackage rec {
     export CUDNN_INCLUDE_DIR=${cudnn}/include
   '';
 
+  preFixup = ''
+    function join_by { local IFS="$1"; shift; echo "$*"; }
+    function strip2 {
+      IFS=':'
+      read -ra RP <<< $(patchelf --print-rpath $1)
+      IFS=' '
+      RP_NEW=$(join_by : ''${RP[@]:2})
+      patchelf --set-rpath \$ORIGIN:''${RP_NEW} "$1"
+    }
+
+    for f in $(find ''${out} -name 'libcaffe2*.so')
+    do
+      strip2 $f
+    done
+  '';
+
   buildInputs = [
      cmake
      numpy.blas
@@ -56,7 +72,7 @@ in buildPythonPackage rec {
   ] ++ lib.optional (pythonOlder "3.5") typing;
 
   checkPhase = ''
-    ${cudaStubEnv}python test/run_test.py --exclude distributed autograd distributions jit sparse torch utils nn
+    ${cudaStubEnv}python test/run_test.py --exclude dataloader sparse torch utils
   '';
 
   meta = {


### PR DESCRIPTION
As reported at #46032 pytorch build currently fails. The reason, I believe, is ongoing pytorch and libcaffe merge and related dependencies problems. Basically this patch fixes hard-coded dependency inside build directory.

Also openblas was updated because autograd tests failed with older version, see https://github.com/pytorch/pytorch/issues/11133. Patches were merged into upstream and no longer necessary.

- Built on platform(s)
   - [ X] NixOS


