### PR TITLE
vimPlugins.ncm2: init at 2018-09-03 

### DIFF
--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -50,14 +50,14 @@ self = generated // (with generated; {
   LanguageClient-neovim = let
     LanguageClient-neovim-src = fetchgit {
       url = "https://github.com/autozimu/LanguageClient-neovim";
-      rev = "5015aa164dc9ad96a0f5fbadaf92a888d16bc0d9";
-      sha256 = "1b3916al2y4hxmmlhqxw4cdliyd42xahc7wmgm8yq1gbvzbhdafg";
+      rev = "59f0299e8f7d7edd0653b5fc005eec74c4bf4aba";
+      sha256 = "0x6729w7v3bxlpvm8jz1ybn23qa0zqfgxl88q2j0bbs6rvp0w1jq";
     };
     LanguageClient-neovim-bin = rustPlatform.buildRustPackage {
       name = "LanguageClient-neovim-bin";
       src = LanguageClient-neovim-src;
 
-      cargoSha256 = "1vafyi650qdaq1f7fc8d4nzrv1i6iz28fs5z66hsnz4xkwb3qq9w";
+      cargoSha256 = "1afmz14j7ma2nrsx0njcqbh2wa430dr10hds78c031286ppgwjls";
       buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
 
       # FIXME: Use impure version of CoreFoundation because of missing symbols.
@@ -67,7 +67,7 @@ self = generated // (with generated; {
       '';
     };
   in buildVimPluginFrom2Nix {
-    name = "LanguageClient-neovim-2018-06-12";
+    name = "LanguageClient-neovim-2018-09-07";
     src = LanguageClient-neovim-src;
 
     dependencies = [];

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -164,7 +164,15 @@ self = generated // (with generated; {
 
   gitv = gitv.overrideAttrs(old: {
 		dependencies = ["gitv"];
-	});
+  });
+
+  ncm2 = ncm2.overrideAttrs(old: {
+    dependencies = ["nvim-yarp"];
+  });
+
+  ncm2-ultisnips = ncm2-ultisnips.overrideAttrs(old: {
+    dependencies = ["ultisnips"];
+  });
 
   taglist = taglist.overrideAttrs(old: {
     setSourceRoot = ''

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -788,6 +788,56 @@
     };
   };
 
+  ncm2 = buildVimPluginFrom2Nix {
+    name = "ncm2-2018-09-03";
+    src = fetchFromGitHub {
+      owner = "ncm2";
+      repo = "ncm2";
+      rev = "08f026d84b50e8db3d3a4124da63c8c3e0e5e558";
+      sha256 = "07d411p3shm27qmir8hsw88mx3wdmz3am4qi0fqzkhkpkgli70jw";
+    };
+  };
+
+  ncm2-bufword = buildVimPluginFrom2Nix {
+    name = "ncm2-bufword-2018-07-28";
+    src = fetchFromGitHub {
+      owner = "ncm2";
+      repo = "ncm2-bufword";
+      rev = "86a92eb3fb217f9ea1e93f890b7e5e0eb1671ca9";
+      sha256 = "02f43rr9apgcjpz4ipnin4v3cvdlx931a0787x87iyr8a0aljg3y";
+    };
+  };
+
+  ncm2-path = buildVimPluginFrom2Nix {
+    name = "ncm2-path-2018-08-01";
+    src = fetchFromGitHub {
+      owner = "ncm2";
+      repo = "ncm2-path";
+      rev = "875ae47e171abc2ba6710bb835727bed46d7b329";
+      sha256 = "09vhggrb1nigr8p53gd9ibn3b84dh9yix2ndj2453wnq8ny9x2dc";
+    };
+  };
+
+  ncm2-tmux = buildVimPluginFrom2Nix {
+    name = "ncm2-tmux-2018-07-30";
+    src = fetchFromGitHub {
+      owner = "ncm2";
+      repo = "ncm2-tmux";
+      rev = "4f60ee1be57531295075d808e0006c83894096d1";
+      sha256 = "1ihbm65b9bc0y068w6r0k8f9lsc3603npb55chcchpj7z75539yh";
+    };
+  };
+
+  ncm2-ultisnips = buildVimPluginFrom2Nix {
+    name = "ncm2-ultisnips-2018-08-01";
+    src = fetchFromGitHub {
+      owner = "ncm2";
+      repo = "ncm2-ultisnips";
+      rev = "15432d7933cfb855599442a67d6f39ddb706c737";
+      sha256 = "0ixajh08fd5dgdz4h1sdxgiaind1nksk1d4lwyb6n4ijf672pms2";
+    };
+  };
+
   neco-look = buildVimPluginFrom2Nix {
     name = "neco-look-2018-01-21";
     src = fetchFromGitHub {
@@ -955,6 +1005,16 @@
       repo = "nvim-completion-manager";
       rev = "45a026afb8b309b3b80f2c1b5910f72a54a9b563";
       sha256 = "0znwgry4ill0nxm096hc8s9vf20rf9xcq3dz8y8h7xlqzzsycl7a";
+    };
+  };
+
+  nvim-yarp = buildVimPluginFrom2Nix {
+    name = "nvim-yarp-2018-07-27";
+    src = fetchFromGitHub {
+      owner = "roxma";
+      repo = "nvim-yarp";
+      rev = "52317ced0e16f226f0d44878917d0b5f4657b4d4";
+      sha256 = "1xj1n9x1nxjbbpp29x5kkwr0bxziwzn8n2b8z9467hj9w646zyrj";
     };
   };
 

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -174,6 +174,11 @@ morhetz/gruvbox
 mpickering/hlint-refactor-vim
 nathanaelkane/vim-indent-guides
 nbouscal/vim-stylish-haskell
+ncm2/ncm2
+ncm2/ncm2-bufword
+ncm2/ncm2-path
+ncm2/ncm2-tmux
+ncm2/ncm2-ultisnips
 neoclide/vim-easygit
 neovimhaskell/haskell-vim
 nixprime/cpsm
@@ -202,6 +207,7 @@ Rip-Rip/clang_complete
 rodjek/vim-puppet
 roxma/nvim-cm-racer
 roxma/nvim-completion-manager
+roxma/nvim-yarp
 rust-lang/rust.vim
 ryanoasis/vim-devicons
 Rykka/riv.vim


### PR DESCRIPTION
###### Motivation for this change

This is the new version of nvim-completion-manager. Should we remove the old plugin?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

