### PR TITLE
android-file-transfer: 3.4 -> 3.5

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "android-file-transfer-${version}";
-  version = "3.4";
+  version = "3.5";
   src = fetchFromGitHub {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
     rev = "v${version}";
-    sha256 = "1xwl0vk57174gdjhgqkzrirwzd2agdm84q30dq9q376ixgxjrifc";
+    sha256 = "036hca41ikgnw4maykjdp53l31rm01mgamy9y56i5qqh84cwmls2";
   };
   buildInputs = [ cmake fuse readline pkgconfig qtbase ];
   buildPhase = ''
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
   meta = with stdenv.lib; {
     description = "Reliable MTP client with minimalistic UI";
-    homepage = http://whoozle.github.io/android-file-transfer-linux/;
+    homepage = https://whoozle.github.io/android-file-transfer-linux/;
     license = licenses.lgpl21;
     maintainers = [ maintainers.xaverdh ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @xaverdh
