### PR TITLE
prometheus-alertmanager module: implement meshing

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -99,6 +99,14 @@ in {
           Open port in firewall for incoming connections.
         '';
       };
+
+      meshPeers = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Initial peers for HA mesh cluster.
+        '';
+      };
     };
   };
 
@@ -111,11 +119,12 @@ in {
       after    = [ "network.target" ];
       script = ''
         ${pkgs.prometheus-alertmanager.bin}/bin/alertmanager \
-        --config.file ${alertmanagerYml} \
-        --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
-        --log.level ${cfg.logLevel} \
-        ${optionalString (cfg.webExternalUrl != null) ''--web.external-url ${cfg.webExternalUrl} \''}
-        ${optionalString (cfg.logFormat != null) "--log.format ${cfg.logFormat}"}
+          --config.file ${alertmanagerYml} \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          --log.level ${cfg.logLevel} \
+          ${optionalString (cfg.webExternalUrl != null) ''--web.external-url ${cfg.webExternalUrl}''} \
+          ${optionalString (cfg.logFormat != null) "--log.format ${cfg.logFormat}"} \
+          ${toString (map (peer: "--mesh.peer ${peer}:6783") cfg.meshPeers)}
       '';
 
       serviceConfig = {

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -115,6 +115,22 @@ in {
           Initial peers for HA mesh cluster.
         '';
       };
+
+      meshNickName = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Nick name of this alertmanager instance. Defaults to the hostname.
+        '';
+      };
+
+      meshPassword = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Password for the alertmanager mesh. Disables encryption if null.
+        '';
+      };
     };
   };
 
@@ -140,6 +156,8 @@ in {
           --storage.path ${cfg.stateDir} \
           ${optionalString (cfg.webExternalUrl != null) ''--web.external-url ${cfg.webExternalUrl}''} \
           ${optionalString (cfg.logFormat != null) "--log.format ${cfg.logFormat}"} \
+          ${optionalString (cfg.meshNickName != null) "--mesh.nickname ${cfg.meshNickName}"} \
+          ${optionalString (cfg.meshPassword != null) "--mesh.password ${cfg.meshPassword}"} \
           ${toString (map (peer: "--mesh.peer ${peer}:6783") cfg.meshPeers)}
       '';
 


### PR DESCRIPTION
###### Motivation for this change

Allow meshing in the prometheus alertmanager module.

This has been used in production for quite some time and we just missed upstreaming it.
Therefore, and due to it being a rather small change, I propose backporting to 18.09 (cc @vcunat, @samueldr)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - N/A macOS
   - N/A other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- N/A Tested execution of all binary files (usually in `./result/bin/`)
- N/A Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

