### PR TITLE
mosquitto: ipv6 and tls cert store fixes

### DIFF
--- a/nixos/modules/services/networking/mosquitto.nix
+++ b/nixos/modules/services/networking/mosquitto.nix
@@ -70,7 +70,7 @@ in
 
         cafile = mkOption {
           type = types.nullOr types.path;
-          default = null;
+          default = "/etc/ssl/certs/ca-certificates.crt";
           description = "Path to PEM encoded CA certificates.";
         };
 

--- a/nixos/modules/services/networking/mosquitto.nix
+++ b/nixos/modules/services/networking/mosquitto.nix
@@ -48,8 +48,8 @@ in
       enable = mkEnableOption "Enable the MQTT Mosquitto broker.";
 
       host = mkOption {
-        default = "127.0.0.1";
-        example = "0.0.0.0";
+        default = "::1";
+        example = "::";
         type = types.string;
         description = ''
           Host to listen on without SSL.
@@ -87,7 +87,7 @@ in
         };
 
         host = mkOption {
-          default = "0.0.0.0";
+          default = "::";
           example = "localhost";
           type = types.string;
           description = ''


### PR DESCRIPTION
###### Motivation for this change

This fixes mosquitto not listening by default on IPv6 and not finding the cert store by default.

I propose backporting this to 18.09 (cc @vcunat, @samueldr)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - N/A macOS
   - N/A other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- N/A Tested execution of all binary files (usually in `./result/bin/`)
- N/A Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

