### PR TITLE
kubernetes: 1.10.5 -> 1.11.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -452,6 +452,14 @@ inherit (pkgs.nixos {
     </para>
    </listitem>
    <listitem>
+     <para>
+     The Kubernetes package has been bumped to major version 1.11.
+     Please consult the
+     <link xlink:href="https://github.com/kubernetes/kubernetes/blob/release-1.11/CHANGELOG-1.11.md">release notes</link>
+     for details on new features and api changes.
+    </para>
+   </listitem>
+   <listitem>
     <para>
      The option
      <varname>services.kubernetes.apiserver.admissionControl</varname> was


### PR DESCRIPTION
###### Motivation for this change

Since https://github.com/NixOS/nixpkgs/pull/45670 will not make it to 18.09, I'm PR'ing the kubernetes package separately. I'd like it if this could be backported to NixOS 18.09.

Even though this PR has no module updates, the main purpose of issue #43882 was to upgrade to v1.11, thus:
closes #43882 

@srhb ping

###### Things done

NixOS tests for rbac and dns runs clean.

I've also tested this with a three node cluster in Google Cloud and it turns out that the existing kubernetes module works seamlessly with the 1.11.3 package, although some of the k8s components yield warnings for deprecated flags.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
