### PR TITLE
elf-header: Init at <libc version> 

### DIFF
--- a/pkgs/development/libraries/elf-header/default.nix
+++ b/pkgs/development/libraries/elf-header/default.nix
@@ -1,0 +1,43 @@
+{ stdenvNoCC, lib, glibc, musl }:
+
+let
+   libc =
+     if stdenvNoCC.targetPlatform.isMusl
+     then musl
+     else glibc;
+   headerPath =
+     if stdenvNoCC.targetPlatform.isMusl
+     then "musl-${libc.version}/include/elf.h"
+     else "glibc-${libc.version}/elf/elf.h";
+in
+
+stdenvNoCC.mkDerivation {
+  name = "elf-header";
+  inherit (libc) version;
+
+  src = null;
+
+  unpackPhase = "true";
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/include";
+    tar -xf \
+        ${lib.escapeShellArg libc.src} \
+        ${lib.escapeShellArg headerPath} \
+        --to-stdout \
+      | sed -e '/features\.h/d' \
+      > "$out/include/elf.h"
+  '';
+
+  meta = libc.meta // {
+    description = "The datastructures of ELF according to the target platform's libc";
+    longDescription = ''
+	  The Executable and Linkable Format (ELF, formerly named Extensible Linking
+	  Format), is usually defined in a header like this.
+	'';
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.ericson2314 ];
+  };
+}

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -139,6 +139,8 @@ stdenv.mkDerivation ({
   # prevent a retained dependency on the bootstrap tools in the stdenv-linux
   # bootstrap.
   BASH_SHELL = "/bin/sh";
+
+  passthru = { inherit version; };
 }
 
 // (removeAttrs args [ "withLinuxHeaders" "withGd" ]) //

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -5,8 +5,6 @@
 , withGd ? false
 }:
 
-assert stdenv.cc.isGNU;
-
 callPackage ./common.nix { inherit stdenv; } {
     name = "glibc" + stdenv.lib.optionalString withGd "-gd";
 
@@ -96,7 +94,8 @@ callPackage ./common.nix { inherit stdenv; } {
       mv $bin/bin/getconf_ $bin/bin/getconf
     '';
 
-    separateDebugInfo = true;
+    # Hack to get around eval issue.
+    separateDebugInfo = !stdenv.isDarwin;
 
     meta.description = "The GNU C Library";
   }

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -2,8 +2,6 @@
 , fetchurl, perl
 }:
 
-assert stdenvNoCC.hostPlatform.isLinux;
-
 let
   common = { version, sha256, patches ? null }: stdenvNoCC.mkDerivation {
     name = "linux-headers-${version}";
@@ -13,7 +11,7 @@ let
       inherit sha256;
     };
 
-    ARCH = stdenvNoCC.hostPlatform.platform.kernelArch;
+    ARCH = stdenvNoCC.hostPlatform.platform.kernelArch or (throw "missing kernelArch");
 
     # It may look odd that we use `stdenvNoCC`, and yet explicit depend on a cc.
     # We do this so we have a build->build, not build->host, C compiler.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9513,6 +9513,14 @@ with pkgs;
     installLocales = config.glibc.locales or false;
   };
 
+  # Provided by libc on Operating Systems that use the Extensible Linker Format.
+  elf-header =
+    if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf"
+    then null
+    else elf-header-real;
+
+  elf-header-real = callPackage ../development/libraries/elf-header { };
+
   glibc_memusage = callPackage ../development/libraries/glibc {
     installLocales = false;
     withGd = true;


### PR DESCRIPTION
###### Motivation for this change

This is used to build software working with ELF on platforms that don't provide that header as part of their libc. This is used for Darwin->Linux cross compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

