### PR TITLE
libxnd, libndtypes: refactor add support for darwin

### DIFF
--- a/pkgs/development/libraries/libndtypes/default.nix
+++ b/pkgs/development/libraries/libndtypes/default.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation rec {
     sha256 = "0dpvv13mrid8l5zkjlz18qvirz3nr0v98agx9bcvkqbiahlfgjli";
   };
 
-  makeFlags = [ "CONFIGURE_LDFLAGS='-shared'" ];
+  # Override linker with cc (symlink to either gcc or clang)
+  # Library expects to use cc for linking
+  configureFlags = [ "LD=${stdenv.cc.targetPrefix}cc" ];
 
   meta = {
     description = "Dynamic types for data description and in-memory computations";

--- a/pkgs/development/libraries/libxnd/default.nix
+++ b/pkgs/development/libraries/libxnd/default.nix
@@ -17,10 +17,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libndtypes ];
 
-  configureFlags = [ "XND_INCLUDE='-I${libndtypes}/include'"
-                     "XND_LINK='-L${libndtypes}/lib'" ];
-
-  makeFlags = [ "CONFIGURE_LDFLAGS='-shared'" ];
+  # Override linker with cc (symlink to either gcc or clang)
+  # Library expects to use cc for linking
+  configureFlags = [ "LD=${stdenv.cc.targetPrefix}cc" ];
 
   meta = {
     description = "General container that maps a wide range of Python values directly to memory";


### PR DESCRIPTION
###### Motivation for this change

Prior build instructions were hacks because I did not understand that the configure script was choosing `ld` as the linker instead of using `gcc` to properly link. This commit fixes these issues and simplifies the build. 

###### Things done

libxnd: refactor
libndtypes: refactor

Please ensure that this build works on darwin.


- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

