### PR TITLE
weechatScripts.weechat-matrix-bridge: don't export `olm.lua' as script

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-matrix-bridge/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
       --replace "__NIX_LIB_PATH__" "$out/lib/?.so"
   '';
 
-  passthru.scripts = [ "olm.lua" "matrix.lua" ];
+  passthru.scripts = [ "matrix.lua" ];
 
   installPhase = ''
     mkdir -p $out/{share,lib}


### PR DESCRIPTION
###### Motivation for this change

Loading olm.lua as weechat script with `/script load olm.lua' causes
errors like this:

```
/nix/store/43jbh7yxh8j4gjfzbvpd9clncah5dip1-weechat-matrix-bridge-2018-05-29/lib/ffi.so: undefined symbol: lua_tointeger
```

As `olm.lua' is loaded by `matrix.lua' it doesn't need to be included
manually by the weechat configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

