### PR TITLE
quantum-espresso, siesta init packages for density functional theory calculations

### DIFF
--- a/pkgs/applications/science/chemistry/quantum-espresso/default.nix
+++ b/pkgs/applications/science/chemistry/quantum-espresso/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl
+, gfortran, fftw, openblas
+, mpi ? null
+}:
+
+stdenv.mkDerivation rec {
+  version = "6.3";
+  name = "quantum-espresso-${version}";
+
+  src = fetchurl {
+    url = "https://gitlab.com/QEF/q-e/-/archive/qe-${version}/q-e-qe-${version}.tar.gz";
+    sha256 = "1738z3nhkzcrgnhnfg1r4lipbwvcrcprwhzjbjysnylmzbzwhrs0";
+  };
+
+  passthru = {
+    inherit mpi;
+  };
+
+  preConfigure = ''
+    patchShebangs configure
+  '';
+
+  # remove after 6.3 version:
+  # makefile needs to ignore install directory easier than applying patch
+  preInstall = ''
+    printf "\n.PHONY: install\n" >> Makefile
+  '';
+
+  buildInputs = [ fftw openblas gfortran ]
+    ++ (stdenv.lib.optionals (mpi != null) [ mpi ]);
+
+configureFlags = if (mpi != null) then [ "LD=${mpi}/bin/mpif90" ] else [ "LD=${gfortran}/bin/gfortran" ];
+
+  makeFlags = [ "all" ];
+
+  meta = with stdenv.lib; {
+    description = "Electronic-structure calculations and materials modeling at the nanoscale";
+    longDescription = ''
+        Quantum ESPRESSO is an integrated suite of Open-Source computer codes for
+        electronic-structure calculations and materials modeling at the
+        nanoscale. It is based on density-functional theory, plane waves, and
+        pseudopotentials.
+      '';
+    homepage = https://www.quantum-espresso.org/;
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/applications/science/chemistry/siesta/default.nix
+++ b/pkgs/applications/science/chemistry/siesta/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchurl
+, gfortran, openblas
+, mpi ? null, scalapack
+}:
+
+stdenv.mkDerivation rec {
+  version = "4.1-b3";
+  name = "siesta-${version}";
+
+  src = fetchurl {
+    url = "https://launchpad.net/siesta/4.1/4.1-b3/+download/siesta-4.1-b3.tar.gz";
+    sha256 = "1450jsxj5aifa0b5fcg7mxxq242fvqnp4zxpgzgbkdp99vrp06gm";
+  };
+
+  passthru = {
+    inherit mpi;
+  };
+
+  buildInputs = [ openblas gfortran ]
+    ++ (stdenv.lib.optionals (mpi != null) [ mpi scalapack ]);
+
+  enableParallelBuilding = true;
+
+  # Must do manualy becuase siesta does not do the regular
+  # ./configure; make; make install
+  configurePhase = ''
+    cd Obj
+    sh ../Src/obj_setup.sh
+    cp gfortran.make arch.make
+  '';
+
+  preBuild = if (mpi != null) then ''
+    makeFlagsArray=(
+        CC="mpicc" FC="mpifort"
+        FPPFLAGS="-DMPI" MPI_INTERFACE="libmpi_f90.a" MPI_INCLUDE="."
+        COMP_LIBS="" LIBS="-lopenblas -lscalapack"
+    );
+  '' else ''
+    makeFlagsArray=(
+      COMP_LIBS="" LIBS="-lopenblas"
+    );
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a siesta $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A first-principles materials simulation code using DFT";
+    longDescription = ''
+         SIESTA is both a method and its computer program
+         implementation, to perform efficient electronic structure
+         calculations and ab initio molecular dynamics simulations of
+         molecules and solids. SIESTA's efficiency stems from the use
+         of strictly localized basis sets and from the implementation
+         of linear-scaling algorithms which can be applied to suitable
+         systems. A very important feature of the code is that its
+         accuracy and cost can be tuned in a wide range, from quick
+         exploratory calculations to highly accurate simulations
+         matching the quality of other approaches, such as plane-wave
+         and all-electron methods.
+      '';
+    homepage = https://www.quantum-espresso.org/;
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20625,6 +20625,12 @@ with pkgs;
 
   pymol = callPackage ../applications/science/chemistry/pymol { };
 
+  quantum-espresso = callPackage ../applications/science/chemistry/quantum-espresso { };
+
+  quantum-espresso-mpi = callPackage ../applications/science/chemistry/quantum-espresso {
+     mpi = openmpi;
+  };
+
   ### SCIENCE/GEOMETRY
 
   drgeo = callPackage ../applications/science/geometry/drgeo {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20631,6 +20631,12 @@ with pkgs;
      mpi = openmpi;
   };
 
+  siesta = callPackage ../applications/science/chemistry/siesta { };
+
+  siesta-mpi = callPackage ../applications/science/chemistry/siesta {
+     mpi = openmpi;
+  };
+
   ### SCIENCE/GEOMETRY
 
   drgeo = callPackage ../applications/science/geometry/drgeo {


### PR DESCRIPTION
###### Motivation for this change

Wanted to add two material science codes for calculating the electronic structure of materials. quantum-espresso has a serial and mpi version while siesta is serial for now. This is becuase siesta requires scalapack for mpi version.

###### Things done

siesta: init at 4.1-b3
quantum-espresso: init at 6.3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

