### PR TITLE
mitmproxy: 3.0.4 -> 4.0.4, fix tests

### DIFF
--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -1,17 +1,28 @@
-{ stdenv, fetchFromGitHub, python3Packages, glibcLocales }:
+{ stdenv, fetchFromGitHub, python3Packages, glibcLocales, fetchpatch }:
 
 with python3Packages;
 
 buildPythonPackage rec {
   pname = "mitmproxy";
-  version = "3.0.4";
+  version = "4.0.4";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "10l761ds46r1p2kjxlgby9vdxbjjlgq72s6adjypghi41s3qf034";
+    sha256 = "14i9dkafvyl15rq2qa8xldscn5lmkk2g52kbi2hl63nzx9yibx6r";
   };
+
+  patches = [
+    (fetchpatch {
+      # Tests failed due to expired test certificates,
+      # https://github.com/mitmproxy/mitmproxy/issues/3316
+      # TODO: remove on next update
+      name = "test-certificates.patch";
+      url = "https://github.com/mitmproxy/mitmproxy/commit/1b6a8d6acd3d70f9b9627ad4ae9def08103f8250.patch";
+      sha256 = "03y79c25yir7d8xj79czdc81y3irqq1i3ks9ca0mv1az8b7xsvfv";
+    })
+  ];
 
   postPatch = ''
     # remove dependency constraints
@@ -23,8 +34,7 @@ buildPythonPackage rec {
   checkPhase = ''
     export HOME=$(mktemp -d)
     export LC_CTYPE=en_US.UTF-8
-    # test_echo resolves hostnames
-    pytest -k 'not test_echo and not test_find_unclaimed_URLs '
+    pytest -k 'not test_find_unclaimed_URLs'
   '';
 
   propagatedBuildInputs = [
@@ -38,6 +48,7 @@ buildPythonPackage rec {
   checkInputs = [
     beautifulsoup4 flask pytest
     requests glibcLocales
+    asynctest parver pytest-asyncio
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960 . Previous version was [broken](https://hydra.nixos.org/job/nixpkgs/trunk/mitmproxy.x86_64-linux), tests failed: 

- update to latest release
- add missing checkInputs
- apply upstream patch to fix some tests that failed due to expired test ssl certs
- re-enable a previously disabled test case

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @fpletz @kamilchm 
