### PR TITLE
leo-editor: 5.6 -> 5.7.3, fix build

### DIFF
--- a/pkgs/applications/editors/leo-editor/default.nix
+++ b/pkgs/applications/editors/leo-editor/default.nix
@@ -1,29 +1,20 @@
-{ stdenv, python3, libsForQt56, fetchFromGitHub, makeWrapper, makeDesktopItem }:
+{ stdenv, python3, fetchFromGitHub, makeWrapper, makeDesktopItem }:
 
-let
-  packageOverrides = self: super: {
-    pyqt56 = libsForQt56.callPackage ../../../development/python-modules/pyqt/5.x.nix {
-      pythonPackages = self;
-    };
-  };
-
-  pythonPackages = (python3.override { inherit packageOverrides; }).pkgs;
-in
 stdenv.mkDerivation rec {
   name = "leo-editor-${version}";
-  version = "5.6";
+  version = "5.7.3";
 
   src = fetchFromGitHub {
     owner = "leo-editor";
     repo = "leo-editor";
     rev = version;
-    sha256 = "1k6q3gvaf05bi0mzkmmb1p6wrgxwri7ivn38p6f0m0wfd3f70x2j";
+    sha256 = "0ri6l6cxwva450l05af5vs1lsgrz6ciwd02njdgphs9pm1vwxbl9";
   };
 
   dontBuild = true;
 
   nativeBuildInputs = [ makeWrapper python3 ];
-  propagatedBuildInputs = with pythonPackages; [ pyqt56 docutils ];
+  propagatedBuildInputs = with python3.pkgs; [ pyqt5 docutils ];
 
   desktopItem = makeDesktopItem rec {
     name = "leo-editor";


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960. 
Previous version depended on qt56.qtwebengine which is [broken](https://hydra.nixos.org/job/nixpkgs/trunk/leo-editor.x86_64-linux).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

