### PR TITLE
treewide: fix `config.allowAliases = false` evaluation

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -3,7 +3,7 @@
 , kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
 , kio, kcrash
 , boost, libraw, fftw, eigen, exiv2, libheif, lcms2, gsl, openexr, giflib
-, openjpeg, opencolorio, vc, poppler_qt5, curl, ilmbase
+, openjpeg, opencolorio, vc, poppler, curl, ilmbase
 , qtmultimedia, qtx11extras
 , python3
 }:
@@ -23,7 +23,7 @@ mkDerivation rec {
     karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
     ki18n kitemmodels kitemviews kwindowsystem kio kcrash
     boost libraw fftw eigen exiv2 lcms2 gsl openexr libheif giflib
-    openjpeg opencolorio poppler_qt5 curl ilmbase
+    openjpeg opencolorio poppler curl ilmbase
     qtmultimedia qtx11extras
     python3
   ] ++ lib.optional (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) vc;

--- a/pkgs/applications/graphics/qcomicbook/default.nix
+++ b/pkgs/applications/graphics/qcomicbook/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools, qtx11extras, poppler_qt5 }:
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools, qtx11extras, poppler }:
 
 stdenv.mkDerivation rec {
   name = "qcomicbook-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    qtbase qttools qtx11extras poppler_qt5
+    qtbase qttools qtx11extras poppler
   ];
 
   postInstall = ''

--- a/pkgs/applications/window-managers/xmonad/log-applet/default.nix
+++ b/pkgs/applications/window-managers/xmonad/log-applet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, glib, dbus-glib
-, desktopSupport, xlibs
+, desktopSupport, xorg
 , gtk2
 , gtk3, gnome3, mate
 , libxfce4util, xfce4-panel
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "042307grf4zvn61gnflhsj5xsjykrk9sjjsprprm4iij0qpybxcw";
   };
 
-  buildInputs = [ glib dbus-glib xlibs.xcbutilwm ]
+  buildInputs = [ glib dbus-glib xorg.xcbutilwm ]
     ++ stdenv.lib.optionals (desktopSupport == "gnomeflashback") [ gtk3 gnome3.gnome-panel ]
     ++ stdenv.lib.optionals (desktopSupport == "mate") [ gtk3 mate.mate-panel ]
     ++ stdenv.lib.optionals (desktopSupport == "xfce4") [ gtk2 libxfce4util xfce4-panel ]

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -2,7 +2,7 @@
 , gtk3, gobjectIntrospection, libappindicator-gtk3, librsvg
 , evdev, pygobject3, pylibacl, pytest, bluez
 , linuxHeaders
-, libX11, libXext, libXfixes, libusb1, libudev
+, libX11, libXext, libXfixes, libusb1, udev
 }:
 
 buildPythonApplication rec {
@@ -34,7 +34,7 @@ buildPythonApplication rec {
     substituteInPlace scc/device_monitor.py --replace "find_library('bluetooth')" "'libbluetooth.so.3'"
   '';
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [ libX11 libXext libXfixes libusb1 libudev bluez ];
+  LD_LIBRARY_PATH = lib.makeLibraryPath [ libX11 libXext libXfixes libusb1 udev bluez ];
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH")

--- a/pkgs/misc/vim-plugins/default.nix
+++ b/pkgs/misc/vim-plugins/default.nix
@@ -111,7 +111,7 @@ self = generated // (with generated; {
     '';
   });
 
-  command_T = command_T.overrideAttrs(old: {
+  command-t = command-t.overrideAttrs(old: {
     buildInputs = [ ruby rake ];
     buildPhase = ''
       rake make
@@ -166,7 +166,7 @@ self = generated // (with generated; {
 		dependencies = ["gitv"];
 	});
 
-  taglist = taglist.overrideAttrs(old: {
+  taglist-vim = taglist-vim.overrideAttrs(old: {
     setSourceRoot = ''
       export sourceRoot=taglist
       mkdir taglist
@@ -309,7 +309,7 @@ self = generated // (with generated; {
     '';
   });
 
-  yankring = yankring.overrideAttrs(old: {
+  YankRing-vim = YankRing-vim.overrideAttrs(old: {
     sourceRoot = ".";
   });
 

--- a/pkgs/tools/X11/ncview/default.nix
+++ b/pkgs/tools/X11/ncview/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl
-, netcdf, x11, xorg, udunits, expat
+, netcdf, xlibsWrapper, xorg, udunits, expat
 }:
 
 let
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     sha256 = "1gliziyxil2fcz85hj6z0jq33avrxdcjs74d500lhxwvgd8drfp8";
   };
 
-  buildInputs = [ netcdf x11 xorg.libXaw udunits expat ];
+  buildInputs = [ netcdf xlibsWrapper xorg.libXaw udunits expat ];
 
   meta = with stdenv.lib; {
     description = "Visual browser for netCDF format files";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17241,7 +17241,6 @@ with pkgs;
 
   krita = libsForQt5.callPackage ../applications/graphics/krita {
     openjpeg = openjpeg_1;
-    poppler_qt5 = libsForQt5.poppler;
   };
 
   krusader = libsForQt5.callPackage ../applications/misc/krusader { };


### PR DESCRIPTION
###### Motivation for this change

Our configuration options should evaluate!

###### Things done

tested evaluation with 
```
nix-env -qa woeusb-3.2.2 -f . --attr-path --arg config '{ allowBroken = true; allowUnfree = true; allowAliases = false;}'
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---