### PR TITLE
gnome-builder: add ctags

### DIFF
--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, ctags
 , desktop-file-utils
 , docbook_xsl
 , docbook_xml_dtd_43
@@ -58,6 +59,7 @@ in stdenv.mkDerivation {
   ];
 
   buildInputs = [
+    ctags
     flatpak
     gnome3.devhelp
     gnome3.libgit2-glib


### PR DESCRIPTION
Gnome Builder uses Ctags for autocompletion.

From looking at [this](https://gitlab.gnome.org/GNOME/gnome-builder/blob/master/data/gsettings/meson.build#L7) adding it as a build input should be sufficient.

cc @jameysharp  @jtojnar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

