### PR TITLE
seaview: init at 4.7

### DIFF
--- a/pkgs/applications/science/biology/seaview/default.nix
+++ b/pkgs/applications/science/biology/seaview/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, coreutils, fltk, libjpeg }:
+
+stdenv.mkDerivation rec {
+  version = "4.7";
+  name = "seaview-${version}";
+
+  src = fetchurl {
+    url = "ftp://pbil.univ-lyon1.fr/pub/mol_phylogeny/seaview/archive/seaview_${version}.tar.gz";
+    sha256 = "0fhyq7dcn0izhwcfin9ajsr7kmmsqm9f1np1rmhzg4digfwqb29n";
+  };
+
+  buildInputs = [ fltk libjpeg ];
+
+  patchPhase = "sed -i 's#PATH=/bin:/usr/bin rm#'${coreutils}/bin/rm'#' seaview.cxx";
+  installPhase = "mkdir -p $out/bin; cp seaview $out/bin";
+
+  meta = with stdenv.lib; {
+    description = "GUI for molecular phylogeny";
+    longDescription = ''
+      SeaView is a multiplatform, graphical user interface for multiple sequence alignment and molecular phylogeny.
+        - SeaView reads and writes various file formats (NEXUS, MSF, CLUSTAL, FASTA, PHYLIP, MASE, Newick) of DNA and protein sequences and of phylogenetic trees.
+        - SeaView drives programs muscle or Clustal Omega for multiple sequence alignment, and also allows to use any external alignment algorithm able to read and write FASTA-formatted files.
+        - Seaview drives the Gblocks program to select blocks of evolutionarily conserved sites.
+        - SeaView computes phylogenetic trees by
+          + parsimony, using PHYLIP's dnapars/protpars algorithm,
+          + distance, with NJ or BioNJ algorithms on a variety of evolutionary distances,
+          + maximum likelihood, driving program PhyML 3.1.
+        - Seaview can use the Transfer Bootstrap Expectation method to compute the bootstrap support of PhyML and distance trees.
+        - SeaView prints and draws phylogenetic trees on screen, SVG, PDF or PostScript files.
+        - SeaView allows to download sequences from EMBL/GenBank/UniProt using the Internet.
+
+      Seaview is published in:
+
+          Gouy M., Guindon S. & Gascuel O. (2010) SeaView version 4 : a multiplatform graphical user interface for sequence alignment and phylogenetic tree building. Molecular Biology and Evolution 27(2):221-224.
+    '';
+    homepage = http://doua.prabi.fr/software/seaview;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.iimog ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20726,6 +20726,8 @@ with pkgs;
 
   strelka = callPackage ../applications/science/biology/strelka { };
 
+  seaview = callPackage ../applications/science/biology/seaview { };
+
   varscan = callPackage ../applications/science/biology/varscan { };
 
   hmmer = callPackage ../applications/science/biology/hmmer { };


### PR DESCRIPTION
###### Motivation for this change

Add package for seaview, a GUI for molecular phylogeny

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

