### PR TITLE
18.09: kubernetes: 1.10.5 -> 1.11.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -408,6 +408,14 @@ inherit (pkgs.nixos {
     </para>
    </listitem>
    <listitem>
+     <para>
+     The Kubernetes package has been bumped to major version 1.11.
+     Please consult the
+     <link xlink:href="https://github.com/kubernetes/kubernetes/blob/release-1.11/CHANGELOG-1.11.md">release notes</link>
+     for details on new features and api changes.
+    </para>
+   </listitem>
+   <listitem>
     <para>
      The option
      <varname>services.kubernetes.apiserver.admissionControl</varname> was


### PR DESCRIPTION
Backport of #46573 to 18.09. The module revamp did not make the cut for this release. See the comments on that PR for compatibility, namely that 1.11 works with our current modules (with the same issues that 1.10 has) and keeps us up to date.

@samueldr I assume this is still an acceptable backport, as long as we don't touch the module, right?

(cherry picked from commit a49f56c3b1a5dc88c1dfbb0412a790033ac0f6c3)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

