### PR TITLE
wolfssl: enable all features

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "00mpq1z8j37a873dbk9knb835m3qlwqnd1rslirqkc44hpz1i64j";
   };
 
+  configureFlags = [ "--enable-all" ];
+
   outputs = [ "out" "dev" "doc" "lib" ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Some websites won't load properly due to missing features. Simply enabling all features fixes this. This also matches how curl is currently tested with wolfssl on travis (see https://github.com/curl/curl/blob/66b3c186fa9a06d313501c80f02e7125acb78c3d/.travis.yml#L222 noting that --enable-tls13 is redundant in the more recent version of wolfssl used in nix, see https://github.com/wolfSSL/wolfssl/blob/v3.15.3-stable/configure.ac#L123 ).

For example, without the "--enable-all" configure flag, the user gets an error message when trying to load nixos.org (here, using curl built against wolfssl), presumably due to a missing feature:

```
curl: (51)      subject alt name(s) or common name do not match "nixos.org"
```

This commit fixes this problem.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

No package currently depends on wolfssl, so for testing I recompiled curl against wolfssl using the following shell.nix:

```nix
with import <nixpkgs> {};
let
  curlwolfssl = (curl.override {
    openssl = wolfssl;
  }).overrideDerivation (oldAttrs: {
    configureFlags =
      # --with-ca-fallback does not work with wolfssl
      (builtins.filter (x: x != "--with-ca-fallback") oldAttrs.configureFlags)
      ++ ["--with-wolfssl=${wolfssl}" "--without-ssl"];
  });
in
{
  my-env = stdenv.mkDerivation {
    name = "my-env";
    buildInputs = [
      curlwolfssl
    ];
  };
}
```

I tested the resulting curl binary and compared its output against my local curl binary provided by Fedora:

```bash
curl -2 https://nixos.org
curl --cacert /etc/ssl/certs/ca-bundle.crt https://nixos.org > 1.txt
/usr/bin/curl https://nixos.org > 2.txt
diff 1.txt 2.txt
```

The first line gives an error message "curl: (35) CyaSSL does not support SSLv2" confirming that CyaSSL - which is the old name for wolfssl still referred to by curl - is indeed used. Diff of output of local curl and this new curl shows identical outputs as expected.