### PR TITLE
pythonPackages.zodb: fix tests

### DIFF
--- a/pkgs/development/python-modules/zodb/default.nix
+++ b/pkgs/development/python-modules/zodb/default.nix
@@ -4,7 +4,6 @@
 , zope_testrunner
 , transaction
 , six
-, wheel
 , zope_interface
 , zodbpickle
 , zconfig
@@ -24,21 +23,27 @@ buildPythonPackage rec {
     };
 
     patches = [
-      ./ZODB-5.3.0-fix-tests.patch
+      ./ZODB-5.3.0-fix-tests.patch # still needeed with 5.4.0
+      # Upstream patch to fix tests with persistent 4.4,
+      # cannot fetchpatch because only one hunk of the upstream commit applies.
+      # TODO remove on next release
+      ./fix-tests-with-persistent-4.4.patch
     ];
 
     propagatedBuildInputs = [
-      manuel
       transaction
-      zope_testrunner
       six
-      wheel
       zope_interface
       zodbpickle
       zconfig
       persistent
       zc_lockfile
       BTrees
+    ];
+
+    checkInputs = [
+      manuel
+      zope_testrunner
     ];
 
     meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/zodb/fix-tests-with-persistent-4.4.patch
+++ b/pkgs/development/python-modules/zodb/fix-tests-with-persistent-4.4.patch
@@ -1,0 +1,26 @@
+From 2d0ae7199501795617a82a32bafe19b4b5ae89c3 Mon Sep 17 00:00:00 2001
+From: Jason Madden <jamadden@gmail.com>
+Date: Wed, 22 Aug 2018 10:43:19 -0500
+Subject: [PATCH] Fix tests with, and depend on, persistent 4.4.
+
+Fixes #213.
+---
+ src/ZODB/tests/util.py | 5 +++++
+ 3 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/ZODB/tests/util.py b/src/ZODB/tests/util.py
+index 4ffde92c1..e9bf547fa 100644
+--- a/src/ZODB/tests/util.py
++++ b/src/ZODB/tests/util.py
+@@ -37,6 +37,11 @@
+      r"\1"),
+     (re.compile('b(".*?")'),
+      r"\1"),
++    # Persistent 4.4 changes the repr of persistent subclasses,
++    # and it is slightly different with the C extension and
++    # pure-Python module
++    (re.compile('ZODB.tests.testcrossdatabasereferences.'),
++     ''),
+     # Python 3 adds module name to exceptions.
+     (re.compile("ZODB.interfaces.BlobError"),
+      r"BlobError"),


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960 

Tests failed after `persistent` was updated to 4.4. Apply an upstream patch to fix them.
This should also fix `vulnix`.

###### Things done

- [x] built in a sandbox on NixOS x64_64-linux
- [x] passes nix-review

---

