### PR TITLE
mako: init at 1.1

### DIFF
--- a/pkgs/applications/misc/mako/default.nix
+++ b/pkgs/applications/misc/mako/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, scdoc, systemd, pango, cairo
+, wayland, wayland-protocols }:
+
+stdenv.mkDerivation rec {
+  name = "mako-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "mako";
+    rev = "v${version}";
+    sha256 = "18krsyp9g6f689024dn1mq8dyj4yg8c3kcy5s88q1gm8py6c4493";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig scdoc ];
+  buildInputs = [ systemd pango cairo wayland wayland-protocols ];
+
+  meta = with stdenv.lib; {
+    description = "A lightweight Wayland notification daemon";
+    homepage = https://wayland.emersion.fr/mako/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dywedir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17446,6 +17446,8 @@ with pkgs;
 
   makeself = callPackage ../applications/misc/makeself { };
 
+  mako = callPackage ../applications/misc/mako { };
+
   mapmap = libsForQt5.callPackage ../applications/video/mapmap { };
 
   marathon = callPackage ../applications/networking/cluster/marathon { };


### PR DESCRIPTION
`mako` currently works on Sway 1.0 alpha.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

