### PR TITLE
Sickbeard/Sickgear/Sickrage: Init and module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -289,7 +289,7 @@
       stanchion = 262;
       riak-cs = 263;
       infinoted = 264;
-      # keystone = 265; # unused, removed 2017-12-13
+      sickbeard = 265;
       # glance = 266; # unused, removed 2017-12-13
       couchpotato = 267;
       gogs = 268;
@@ -579,7 +579,7 @@
       stanchion = 262;
       riak-cs = 263;
       infinoted = 264;
-      # keystone = 265; # unused, removed 2017-12-13
+      sickbeard = 265;
       # glance = 266; # unused, removed 2017-12-13
       couchpotato = 267;
       gogs = 268;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -393,6 +393,7 @@
   ./services/misc/rogue.nix
   ./services/misc/serviio.nix
   ./services/misc/safeeyes.nix
+  ./services/misc/sickbeard.nix
   ./services/misc/siproxd.nix
   ./services/misc/snapper.nix
   ./services/misc/sonarr.nix

--- a/nixos/modules/services/misc/sickbeard.nix
+++ b/nixos/modules/services/misc/sickbeard.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  name = "sickbeard";
+
+  cfg = config.services.sickbeard;
+  sickbeard = cfg.package;
+
+in
+{
+
+  ###### interface
+
+  options = {
+    services.sickbeard = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to enable the sickbeard server.";
+      };
+      package = mkOption {
+        type = types.package;
+        default = pkgs.sickbeard;
+        example = literalExample "pkgs.sickrage";
+        description =''
+          Enable <literal>pkgs.sickrage</literal> or <literal>pkgs.sickgear</literal>
+          as an alternative to SickBeard
+        '';
+      };
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/${name}";
+        description = "Path where to store data files.";
+      };
+      configFile = mkOption {
+        type = types.path;
+        default = "${cfg.dataDir}/config.ini";
+        description = "Path to config file.";
+      };
+      port = mkOption {
+        type = types.ints.u16;
+        default = 8081;
+        description = "Port to bind to.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = name;
+        description = "User to run the service as";
+      };
+      group = mkOption {
+        type = types.str;
+        default = name;
+        description = "Group to run the service as";
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    users.users = optionalAttrs (cfg.user == name) (singleton {
+      name = name;
+      uid = config.ids.uids.sickbeard;
+      group = cfg.group;
+      description = "sickbeard user";
+      home = cfg.dataDir;
+      createHome = true;
+    });
+
+    users.groups = optionalAttrs (cfg.group == name) (singleton {
+      name = name;
+      gid = config.ids.gids.sickbeard;
+    });
+
+    systemd.services.sickbeard = {
+      description = "Sickbeard Server";
+      wantedBy    = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${sickbeard}/SickBeard.py --datadir ${cfg.dataDir} --config ${cfg.configFile} --port ${toString cfg.port}";
+      };
+    };
+  };
+}

--- a/pkgs/servers/sickbeard/default.nix
+++ b/pkgs/servers/sickbeard/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, python2, makeWrapper }:
+
+let
+  pythonEnv = python2.withPackages(ps: with ps; [ cheetah ]);
+in python2.pkgs.buildPythonApplication rec {
+  name = "sickbeard-${version}";
+  version = "2016-03-21";
+
+  src = fetchFromGitHub {
+    owner = "midgetspy";
+    repo = "Sick-Beard";
+    rev = "171a607e41b7347a74cc815f6ecce7968d9acccf";
+    sha256 = "16bn13pvzl8w6nxm36ii724x48z1cnf8y5fl0m5ig1vpqfypk5vq";
+  };
+
+  dontBuild = true;
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pythonEnv ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R {autoProcessTV,cherrypy,data,lib,sickbeard,SickBeard.py} $out/
+
+    makeWrapper $out/SickBeard.py $out/bin/sickbeard
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PVR & episode guide that downloads and manages all your TV shows";
+    license     = licenses.gpl3;
+    homepage    = https:/github.com/midgetspy/Sick-Beard;
+    maintainers = with stdenv.lib.maintainers; [ ];
+  };
+}

--- a/pkgs/servers/sickbeard/sickgear.nix
+++ b/pkgs/servers/sickbeard/sickgear.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, python2, makeWrapper }:
+
+let
+  pythonEnv = python2.withPackages(ps: with ps; [ cheetah ]);
+in python2.pkgs.buildPythonApplication rec {
+  name = "sickgear-${version}";
+  version = "0.17.5";
+
+  src = fetchFromGitHub {
+    owner = "SickGear";
+    repo = "SickGear";
+    rev = "release_${version}";
+    sha256 = "1lx060klgxz8gjanfjvya6p6kd8842qbpp1qhhiw49a25r8gyxpk";
+  };
+
+  dontBuild = true;
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ pythonEnv ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R {autoProcessTV,gui,lib,sickbeard,SickBeard.py} $out/
+
+    makeWrapper $out/SickBeard.py $out/bin/sickgear
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The most reliable stable TV fork of the great Sick-Beard to fully automate TV enjoyment with innovation";
+    license     = licenses.gpl3;
+    homepage    = https:/github.com/SickGear/SickGear;
+    maintainers = with stdenv.lib.maintainers; [ ];
+  };
+}

--- a/pkgs/servers/sickbeard/sickrage.nix
+++ b/pkgs/servers/sickbeard/sickrage.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, python2, makeWrapper }:
+
+python2.pkgs.buildPythonApplication rec {
+  name = "sickrage-${version}";
+  version = "v2018.07.21-1";
+
+  src = fetchFromGitHub {
+    owner = "SickRage";
+    repo = "SickRage";
+    rev = "${version}"; 
+    sha256 = "0lzklpsxqrb73inbv8almnhbnb681pmi44gzc8i4sjwmdksiiif9";
+  };
+
+  dontBuild = true;
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ python2 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -R {gui,lib,locale,sickbeard,sickrage,SickBeard.py} $out/
+
+    makeWrapper $out/SickBeard.py $out/bin/sickrage
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Automatic Video Library Manager for TV Shows";
+    longDescription = "It watches for new episodes of your favorite shows, and when they are posted it does its magic.";
+    license     = licenses.gpl3;
+    homepage    = https://sickrage.github.io;
+    maintainers = [ "sterfield@gmail.com" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13525,6 +13525,8 @@ with pkgs;
       # see also openssl, which has/had this same trick
   };
 
+  sickbeard = callPackage ../servers/sickbeard { };
+
   sipcmd = callPackage ../applications/networking/sipcmd { };
 
   sipwitch = callPackage ../servers/sip/sipwitch { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13527,6 +13527,8 @@ with pkgs;
 
   sickbeard = callPackage ../servers/sickbeard { };
 
+  sickgear = callPackage ../servers/sickbeard/sickgear.nix { };
+
   sipcmd = callPackage ../applications/networking/sipcmd { };
 
   sipwitch = callPackage ../servers/sip/sipwitch { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13529,6 +13529,8 @@ with pkgs;
 
   sickgear = callPackage ../servers/sickbeard/sickgear.nix { };
 
+  sickrage = callPackage ../servers/sickbeard/sickrage.nix { };
+
   sipcmd = callPackage ../applications/networking/sipcmd { };
 
   sipwitch = callPackage ../servers/sip/sipwitch { };


### PR DESCRIPTION
###### Motivation for this change
This is an attempt to unify #46538, #46214 and #46340. Added packages for sickbeard, sickgear and sickrage, and added a nixos module to specify which package to use.
@sterfield: I hope it's ok that I didn't merge your commit - since I made some changes to your package based on comments from @worldofpeace on #46514. I kept you as the maintainer for Sickrage though

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

