### PR TITLE
scalapack: init at 2.0.2

### DIFF
--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, fetchurl
+, gfortran
+, cmake
+, blas
+, liblapack
+, mpi
+}:
+
+stdenv.mkDerivation rec {
+  name = "scalapack-${version}";
+  version = "2.0.2";
+
+  src = fetchurl {
+    url = "http://www.netlib.org/scalapack/scalapack-${version}.tgz";
+    sha256 = "0p1r61ss1fq0bs8ynnx7xq4wwsdvs32ljvwjnx6yxr8gd6pawx0c";
+  };
+
+  buildInputs = [ cmake mpi liblapack blas gfortran ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.netlib.org/scalapack/;
+    description = "Library of high-performance linear algebra routines for parallel distributed memory machines";
+    license = licenses.bsdOriginal;
+    platforms = platforms.all;
+    maintainers = [ maintainers.costrouc ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20777,6 +20777,10 @@ with pkgs;
 
   planarity = callPackage ../development/libraries/science/math/planarity { };
 
+  scalapack = callPackage ../development/libraries/science/math/scalapack {
+    mpi = openmpi;
+  };
+
   rankwidth = callPackage ../development/libraries/science/math/rankwidth { };
 
   fenics = callPackage ../development/libraries/science/math/fenics {


### PR DESCRIPTION
Added scalapack with flexibility to choose blas, lapack, and mpi
implementation.

###### Motivation for this change

Nixpkgs is perfect for scientific computing. Scalapack is a major dependency for many scientific codes.

###### Things done

scalapack: init at 2.0.2

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

