### PR TITLE
parmetis: init at 4.0.3

### DIFF
--- a/pkgs/development/libraries/science/math/parmetis/default.nix
+++ b/pkgs/development/libraries/science/math/parmetis/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchurl
+, cmake
+, mpi
+}:
+
+stdenv.mkDerivation rec {
+  name = "parmetis-${version}";
+  version = "4.0.3";
+
+  src = fetchurl {
+    url = "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-${version}.tar.gz";
+    sha256 = "0pvfpvb36djvqlcc3lq7si0c5xpb2cqndjg8wvzg35ygnwqs5ngj";
+  };
+
+  buildInputs = [ cmake mpi ];
+
+  # metis and GKlib are packaged with distribution
+  # AUR https://aur.archlinux.org/packages/parmetis/ has reported that
+  # it easier to build with the included packages as opposed to using the metis
+  # package. Compilation time is short.
+  configurePhase = ''
+    make config metis_path=$PWD/metis gklib_path=$PWD/metis/GKlib prefix=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured graphs, meshes, and for computing fill-reducing orderings of sparse matrices";
+    homepage = http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview;
+    platforms = platforms.all;
+    license = licenses.cc-by-nc-sa-20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20806,6 +20806,10 @@ with pkgs;
 
   petsc = callPackage ../development/libraries/science/math/petsc { };
 
+  parmetis = callPackage ../development/libraries/science/math/parmetis {
+    mpi = openmpi;
+  };
+
   scs = callPackage ../development/libraries/science/math/scs {
     liblapack = liblapackWithoutAtlas;
   };


### PR DESCRIPTION
###### Motivation for this change

Parallel implementation of metis. Useful for petsc package #28368 compilation

###### Things done

parmetis: init at 4.0.3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

