### PR TITLE
papi: init at 5.6.0

### DIFF
--- a/pkgs/development/libraries/science/benchmark/papi/default.nix
+++ b/pkgs/development/libraries/science/benchmark/papi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  version = "5.6.0";
+  name = "papi-${version}";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/icl/papi/get/papi-5-6-0-t.tar.gz";
+    sha256 = "13mngf9kl0y2wfxqvkad0smdaag7k8fvw82b4312gx62nwhc1i6r";
+  };
+
+  buildInputs = [ stdenv ];
+
+  preConfigure = ''
+    cd src
+  '';
+
+  doCheck = true;
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    homepage = https://icl.utk.edu/papi/;
+    description = "PAPI provides the tool designer and application engineer with a consistent interface and methodology for use of the performance counter hardware found in most major microprocessors";
+    license = licenses.bsdOriginal;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20590,6 +20590,10 @@ with pkgs;
   tetgen = callPackage ../applications/science/geometry/tetgen { }; # AGPL3+
   tetgen_1_4 = callPackage ../applications/science/geometry/tetgen/1.4.nix { }; # MIT
 
+  ### SCIENCE/BENCHMARK
+
+  papi = callPackage ../development/libraries/science/benchmark/papi { };
+
   ### SCIENCE/BIOLOGY
 
   alliance = callPackage ../applications/science/electronics/alliance { };


### PR DESCRIPTION
papi is a high resolution performance counter.

###### Motivation for this change

wanted to add a library I use for evaluating software performance.

###### Things done

papi: init at 5.6.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

