### PR TITLE
brlaser: cleanup and mark linux only

### DIFF
--- a/pkgs/misc/cups/drivers/brlaser/default.nix
+++ b/pkgs/misc/cups/drivers/brlaser/default.nix
@@ -1,7 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, zlib, cups }:
 
 stdenv.mkDerivation rec {
-
   name = "brlaser-${version}";
   version = "4";
 
@@ -12,11 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1yy4mpf68c82h245srh2sd1yip29w6kx14gxk4hxkv496gf55lw5";
   };
 
-  buildInputs = [ cmake zlib cups ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib cups ];
 
-  preConfigure = ''
-    cmakeFlags="$cmakeFlags -DCUPS_SERVER_BIN=$out/lib/cups/ -DCUPS_DATA_DIR=$out/share/cups/"
-  '';
+  cmakeFlags = [ "-DCUPS_SERVER_BIN=$out/lib/cups" "-DCUPS_DATA_DIR=$out/share/cups" ];
 
   meta = with stdenv.lib; {
     description = "A CUPS driver for Brother laser printers";
@@ -37,7 +35,7 @@ stdenv.mkDerivation rec {
       '';
     homepage = https://github.com/pdewacht/brlaser;
     license = licenses.gpl2;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ StijnDW ];
   };
 }


### PR DESCRIPTION
The test binaries depend use open_memstream which isn't available on
darwin.

    error: use of undeclared identifier 'open_memstream'

/cc ZHF #45961

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

