### PR TITLE
mkspiffs: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1610,6 +1610,11 @@
     github = "hamhut1066";
     name = "Hamish Hutchings";
   };
+  haslersn = {
+    email = "haslersn@fius.informatik.uni-stuttgart.de";
+    github = "haslersn";
+    name = "Sebastian Hasler";
+  };
   havvy = {
     email = "ryan.havvy@gmail.com";
     github = "havvy";

--- a/pkgs/tools/filesystems/mkspiffs/default.nix
+++ b/pkgs/tools/filesystems/mkspiffs/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchgit, git,  }:
+
+stdenv.mkDerivation rec {
+  name = "mkspiffs-${version}";
+  version = "0.2.3";
+
+  src = fetchgit {
+    url = "https://github.com/igrr/mkspiffs";
+    rev = version;
+    deepClone = true;
+    sha256 = "0lgw8iyz57qc2l9nvn054cpsl3piik4n63gw7bp7rpci03xazi9j";
+  };
+
+  nativeBuildInputs = [ git ];
+  installPhase = ''
+    make dist
+    mkdir -p $out/bin
+    cp mkspiffs $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool to build and unpack SPIFFS images";
+    license = licenses.mit;
+    homepage = https://github.com/igrr/mkspiffs;
+    maintainers = with maintainers; [ haslersn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1447,6 +1447,8 @@ with pkgs;
 
   metabase = callPackage ../servers/metabase { };
 
+  mkspiffs = callPackage ../tools/filesystems/mkspiffs { };
+
   monetdb = callPackage ../servers/sql/monetdb { };
 
   mp3blaster = callPackage ../applications/audio/mp3blaster { };


### PR DESCRIPTION
###### Motivation for this change

There wasn't a derivation for mkspiffs yet, so I made one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

