### PR TITLE
cargo-update: fix darwin build

### DIFF
--- a/pkgs/tools/package-management/cargo-update/default.nix
+++ b/pkgs/tools/package-management/cargo-update/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, defaultCrateOverrides, fetchFromGitHub, cmake, libssh2, libgit2, openssl, zlib }:
+{ stdenv, callPackage, defaultCrateOverrides, fetchFromGitHub, cmake, curl, libssh2, libgit2, openssl, zlib }:
 
 ((callPackage ./cargo-update.nix {}).cargo_update {}).override {
   crateOverrides = defaultCrateOverrides // {
@@ -13,7 +13,9 @@
         sha256 = "1bvrdgcw2akzd78wgvsisvghi8pvdk3szyg9s46qxv4km9sf88s7";
       };
 
-      buildInputs = [ cmake libssh2 libgit2 openssl zlib ];
+      nativeBuildInputs = [ cmake ];
+      buildInputs = [ libssh2 libgit2 openssl zlib ]
+        ++ stdenv.lib.optional stdenv.isDarwin curl;
 
       meta = with stdenv.lib; {
         description = "A cargo subcommand for checking and applying updates to installed executables";


### PR DESCRIPTION
###### Motivation for this change

On darwin libcurl is also needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

