### PR TITLE
ceres-solver: fix darwin build

### DIFF
--- a/pkgs/development/libraries/ceres-solver/default.nix
+++ b/pkgs/development/libraries/ceres-solver/default.nix
@@ -2,7 +2,7 @@
 , eigen
 , fetchurl
 , cmake
-, google-gflags ? null
+, google-gflags
 , glog
 , runTests ? false
 }:
@@ -21,7 +21,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ eigen glog ]
-    ++ stdenv.lib.optional (google-gflags != null) google-gflags;
+    ++ stdenv.lib.optional runTests google-gflags;
+
+  # The Basel BUILD file conflicts with the cmake build directory on
+  # case-insensitive filesystems, eg. darwin.
+  preConfigure = ''
+    rm BUILD
+  '';
 
   doCheck = runTests;
 


### PR DESCRIPTION
The Basel BUILD file conflicts with the cmake build directory on
case-insensitive filesystems, eg. darwin.

/cc ZHF #45961

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

