### PR TITLE
pythonPackages.dask-*: init

### DIFF
--- a/pkgs/development/python-modules/dask-glm/default.nix
+++ b/pkgs/development/python-modules/dask-glm/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, cloudpickle
+, dask
+, numpy, toolz # dask[array]
+, multipledispatch
+, scipy
+, scikitlearn
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "0.1.0";
+  pname = "dask-glm";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5a38d17538558fe6a3457cd67eed0a90a5dff51a9eaebb496efb68fc432ed89a";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ cloudpickle dask numpy toolz multipledispatch scipy scikitlearn ];
+
+  checkPhase = ''
+    py.test dask_glm
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/dask/dask-glm/;
+    description = "Generalized Linear Models with Dask";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dask-image/default.nix
+++ b/pkgs/development/python-modules/dask-image/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, dask
+, numpy, toolz # dask[array]
+, scipy
+, pims
+, pytest
+, scikitimage
+}:
+
+buildPythonPackage rec {
+  version = "0.1.1";
+  pname = "dask-image";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e6294ac577a8fc0abec2b97a2c42d404f599feac61d6899bdf1bf2b7cfb0e015";
+  };
+
+  checkInputs = [ pytest scikitimage ];
+  propagatedBuildInputs = [ dask numpy toolz scipy pims ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dask/dask-image;
+    description = "Distributed image processing";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dask-jobqueue/default.nix
+++ b/pkgs/development/python-modules/dask-jobqueue/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, dask
+, distributed
+, docrep
+, pytest
+}:
+
+buildPythonPackage rec {
+  version = "0.4.0";
+  pname = "dask-jobqueue";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c73dae82b2a1d2a9f4ef17778f0de7a9237671a7fd3374aadd9d2bc07e92e848";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ dask distributed docrep ];
+
+  # do not run entire tests suite (requires slurm, sge, etc.)
+  checkPhase = ''
+    py.test dask_jobqueue/tests/test_jobqueue_core.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dask/dask-jobqueue;
+    description = "Deploy Dask on job schedulers like PBS, SLURM, and SGE";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dask-ml/default.nix
+++ b/pkgs/development/python-modules/dask-ml/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, dask
+, numpy, toolz # dask[array]
+, numba
+, pandas
+, scikitlearn
+, scipy
+, dask-glm
+, six
+, multipledispatch
+, packaging
+, pytest
+, xgboost
+, tensorflow
+, joblib
+, distributed
+}:
+
+buildPythonPackage rec {
+  version = "0.10.0";
+  pname = "dask-ml";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4b6ca548c7282c1b6983e696e4bdfa0a2d7b51b168928b9322ea7a4b9a9f20f9";
+  };
+
+  checkInputs = [ pytest xgboost tensorflow joblib distributed ];
+  propagatedBuildInputs = [ dask numpy toolz numba pandas scikitlearn scipy dask-glm six multipledispatch packaging ];
+
+  # dask-ml has some heavy test requirements
+  # and requires some very new packages
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dask/dask-ml;
+    description = "Scalable Machine Learn with Dask";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/dask-xgboost/default.nix
+++ b/pkgs/development/python-modules/dask-xgboost/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, xgboost
+, dask
+, distributed
+, pytest
+, scikitlearn
+, scipy
+}:
+
+buildPythonPackage rec {
+  version = "0.1.5";
+  pname = "dask-xgboost";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1860d06965fe68def1c83b9195130a92050fd4bc28bf2be689898a3a74ee1316";
+  };
+
+  checkInputs = [ pytest scikitlearn ];
+  propagatedBuildInputs = [ xgboost dask distributed ];
+
+  checkPhase = ''
+    py.test dask_xgboost/tests/test_core.py
+  '';
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dask/dask-xgboost;
+    description = "Interactions between Dask and XGBoost";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pytest
 , pytest-repeat
 , pytest-faulthandler
@@ -26,14 +26,12 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "1.22.1";
+  version = "1.23.1";
 
   # get full repository need conftest.py to run tests
-  src = fetchFromGitHub {
-    owner = "dask";
-    repo = pname;
-    rev = version;
-    sha256 = "0xvx55rhbhlyys3kjndihwq6y6260qzy9mr3miclh5qddaiw2d5z";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9d4693442efe40e05e4304fe6d8174989c6eb4bad1afe70480c98263ef8e1cdb";
   };
 
   checkInputs = [ pytest pytest-repeat pytest-faulthandler pytest-timeout mock joblib ];

--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, slicerator
+, scikitimage
+, six
+, numpy
+, tifffile
+, pytest
+, nose
+}:
+
+buildPythonPackage rec {
+  version = "0.4.1";
+  pname = "PIMS";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6a53a155e900b44e71127a1e1fccbfbaed7eec3c2b52497c40c23a05f334c9dd";
+  };
+
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [ slicerator six numpy tifffile scikitimage ];
+
+  # not everything packaged with pypi release
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/soft-matter/pims;
+    description = "Python Image Sequence: Load video and sequential images in many formats with a simple, consistent interface";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/slicerator/default.nix
+++ b/pkgs/development/python-modules/slicerator/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, python
+, six
+}:
+
+buildPythonPackage rec {
+  version = "0.9.8";
+  pname = "slicerator";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b91dd76a415fd8872185cbd6fbf1922fe174359053d4694983fc719e4a0f5667";
+  };
+
+  propagatedBuildInputs = [ six ];
+
+  checkPhase = ''
+    ${python.interpreter} run_tests.py
+  '';
+
+  # run_tests.py not packaged with pypi release
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/soft-matter/slicerator;
+    description = "A lazy-loading, fancy-sliceable iterable";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1996,6 +1996,8 @@ in {
 
   dask-ml = callPackage ../development/python-modules/dask-ml { };
 
+  dask-xgboost = callPackage ../development/python-modules/dask-xgboost { };
+
   datrie = callPackage ../development/python-modules/datrie { };
 
   heapdict = callPackage ../development/python-modules/heapdict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1984,6 +1984,8 @@ in {
 
   dask = callPackage ../development/python-modules/dask { };
 
+  dask-ml = callPackage ../development/python-modules/dask-ml { };
+
   datrie = callPackage ../development/python-modules/datrie { };
 
   heapdict = callPackage ../development/python-modules/heapdict { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -386,6 +386,8 @@ in {
 
   phonopy = callPackage ../development/python-modules/phonopy { };
 
+  pims = callPackage ../development/python-modules/pims { };
+
   plantuml = callPackage ../tools/misc/plantuml { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1984,6 +1984,8 @@ in {
 
   dask = callPackage ../development/python-modules/dask { };
 
+  dask-glm = callPackage ../development/python-modules/dask-glm { };
+
   dask-ml = callPackage ../development/python-modules/dask-ml { };
 
   datrie = callPackage ../development/python-modules/datrie { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1986,6 +1986,8 @@ in {
 
   dask-glm = callPackage ../development/python-modules/dask-glm { };
 
+  dask-jobqueue = callPackage ../development/python-modules/dask-jobqueue { };
+
   dask-ml = callPackage ../development/python-modules/dask-ml { };
 
   datrie = callPackage ../development/python-modules/datrie { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -568,6 +568,8 @@ in {
 
   slackclient = callPackage ../development/python-modules/slackclient { };
 
+  slicerator = callPackage ../development/python-modules/slicerator { };
+
   spglib = callPackage ../development/python-modules/spglib { };
 
   statistics = callPackage ../development/python-modules/statistics { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1990,6 +1990,8 @@ in {
 
   dask-glm = callPackage ../development/python-modules/dask-glm { };
 
+  dask-image = callPackage ../development/python-modules/dask-image { };
+
   dask-jobqueue = callPackage ../development/python-modules/dask-jobqueue { };
 
   dask-ml = callPackage ../development/python-modules/dask-ml { };


### PR DESCRIPTION
###### Motivation for this change

Have been doing a lot of work with dask. Wanted to add most used dask modules.

###### Things done

pythonPackages.dask-xgboost: init at 0.1.5
pythonPackages.dask-image: init at 01.1
pythonPackages.slicerator: init at 0.9.8
pythonPackages.pims: init at 0.4.1
pythonPackages.dask-jobqueue: init at 0.4.0
pythonPackages.dask-glm: init at 0.1.0
pythonPackages.dask-ml: init at 0.10.0
pythonPackages.distributed: refactor fix broken build (did not register version properly)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

