### PR TITLE
broken darwin packages (c)

### DIFF
--- a/pkgs/development/libraries/csfml/default.nix
+++ b/pkgs/development/libraries/csfml/default.nix
@@ -25,7 +25,6 @@ stdenv.mkDerivation {
     '';
     license = licenses.zlib;
     maintainers = [ maintainers.jpdoyle ];
-
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/physics/cernlib/default.nix
+++ b/pkgs/development/libraries/physics/cernlib/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://cernlib.web.cern.ch;
     description = "Legacy collection of libraries and modules for data analysis in high energy physics";
+    broken = stdenv.isDarwin;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers; [ veprbl ];
     license = stdenv.lib.licenses.gpl2;

--- a/pkgs/development/tools/cargo-web/default.nix
+++ b/pkgs/development/tools/cargo-web/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchFromGitHub, openssl, pkgconfig, rustPlatform }:
+{ stdenv, fetchFromGitHub, openssl, pkgconfig, rustPlatform
+, CoreServices, Security
+}:
 
 rustPlatform.buildRustPackage rec {
   name = "cargo-web-${version}";
@@ -14,12 +16,14 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "157av9zkirr00w9v11mh7yp8w36sy7rw6i80i5jmi0mgrdvcg5si";
 
   nativeBuildInputs = [ openssl pkgconfig ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security ];
 
   meta = with stdenv.lib; {
     description = "A Cargo subcommand for the client-side Web";
     homepage = https://github.com/koute/cargo-web;
     license = with licenses; [asl20 /* or */ mit];
     maintainers = [ maintainers.kevincox ];
+    broken = stdenv.isDarwin;  # test with CoreFoundation 10.11
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7181,7 +7181,9 @@ with pkgs;
 
   cargo-vendor = callPackage ../build-support/rust/cargo-vendor { };
 
-  cargo-web = callPackage ../development/tools/cargo-web { };
+  cargo-web = callPackage ../development/tools/cargo-web {
+    inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+  };
 
   carnix = (callPackage ../build-support/rust/carnix.nix { }).carnix { };
 


### PR DESCRIPTION
###### Motivation for this change

Mark various packages linux only or broken on darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

