### PR TITLE
calaos_installer: fix darwin install

### DIFF
--- a/pkgs/misc/calaos/installer/default.nix
+++ b/pkgs/misc/calaos/installer/default.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
 
   qmakeFlags = [ "REVISION=${version}" ];
 
-  installPhase = ''
+  installPhase = if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+    cp -a calaos_installer.app $out/Applications
+  '' else ''
     mkdir -p $out/bin
     cp -a calaos_installer $out/bin
   '';


### PR DESCRIPTION
###### Motivation for this change

On darwin this builds an application instead of a binary.

/cc ZHF #45961


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

