### PR TITLE
any-nix-shell: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1610,6 +1610,11 @@
     github = "hamhut1066";
     name = "Hamish Hutchings";
   };
+  haslersn = {
+    email = "haslersn@fius.informatik.uni-stuttgart.de";
+    github = "haslersn";
+    name = "Sebastian Hasler";
+  };
   havvy = {
     email = "ryan.havvy@gmail.com";
     github = "havvy";

--- a/pkgs/shells/any-nix-shell/default.nix
+++ b/pkgs/shells/any-nix-shell/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "any-nix-shell-${version}";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "haslersn";
+    repo = "any-nix-shell";
+    rev = "v${version}";
+    sha256 = "1fb4c2xkvk3hwy6km02h7j6wsmpachi66n286p2grzgk5k88pijr";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r bin $out
+    wrapProgram $out/bin/any-nix-shell --prefix PATH ":" $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "fish and zsh support for nix-shell";
+    license = licenses.mit;
+    homepage = https://github.com/haslersn/any-nix-shell;
+    maintainers = with maintainers; [ haslersn ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6243,6 +6243,8 @@ with pkgs;
   runtimeShell = "${runtimeShellPackage}${runtimeShellPackage.shellPath}";
   runtimeShellPackage = bash;
 
+  any-nix-shell = callPackage ../shells/any-nix-shell { };
+
   bash = lowPrio (callPackage ../shells/bash/4.4.nix { });
 
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed


### PR DESCRIPTION
###### Motivation for this change

any-nix-shell adds fish and zsh support for nix-shell. More supported shells can be added in the future.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

