### PR TITLE
pdftag: 1.0.4 -> 1.0.5

### DIFF
--- a/pkgs/tools/graphics/pdftag/default.nix
+++ b/pkgs/tools/graphics/pdftag/default.nix
@@ -4,23 +4,17 @@
 stdenv.mkDerivation rec {
   pname = "pdftag";
   name = "${pname}-${version}";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "arrufat";
     repo = pname;
-    rev = version;
-    sha256 = "17zk42h0n33b4p8fqlq2riqwcdi8y9m5n0ccydnk6a4x8rli97b3";
+    rev = "v${version}";
+    sha256 = "1paj8hs27akzsivn01a30fl3zx5gfn1h89wxg2m72fd806hk0hql";
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook ];
-  buildInputs = [ gtk3 poppler vala ];
-
-  patchPhase = ''substituteInPlace meson.build \
-    --replace "install_dir: '/usr" "install_dir: '$out"
-  '';
-
-  preInstall = "mkdir -p $out/share/licenses/${pname}";
+  nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook vala ];
+  buildInputs = [ gtk3 poppler ];
 
   meta = with stdenv.lib; {
     description = "Edit metadata found in PDFs";


### PR DESCRIPTION
###### Motivation for this change

New release that removes hard coded path and unnecessary license install, also see https://github.com/NixOS/nixpkgs/pull/45666

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

