### PR TITLE
nbd: add which to buildInputs

### DIFF
--- a/pkgs/tools/networking/nbd/default.nix
+++ b/pkgs/tools/networking/nbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, glib }:
+{ stdenv, fetchurl, pkgconfig, glib, which }:
 
 stdenv.mkDerivation rec {
   name = "nbd-3.18";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs =
-    [ pkgconfig glib ]
+    [ pkgconfig glib which ]
     ++ stdenv.lib.optional (stdenv ? glibc) stdenv.glibc.linuxHeaders;
 
   postInstall = ''

--- a/pkgs/tools/networking/nbd/default.nix
+++ b/pkgs/tools/networking/nbd/default.nix
@@ -8,9 +8,10 @@ stdenv.mkDerivation rec {
     sha256 = "0cb0sjiv0j9sh9dk24nrjm7sa0axbrcp2av5hc91g1ryzk764dyq";
   };
 
-  buildInputs =
-    [ pkgconfig glib which ]
+  buildInputs = [ glib ]
     ++ stdenv.lib.optional (stdenv ? glibc) stdenv.glibc.linuxHeaders;
+
+  nativeBuildInputs = [ pkgconfig which ];
 
   postInstall = ''
     mkdir -p "$out/share/doc/${name}"


### PR DESCRIPTION
###### Motivation for this change
The `nbd` build complains numerously about not being able to find the `which` package during its testing phase:
```
make  check-TESTS
make[3]: Entering directory '/build/nbd-3.18/tests/run'
./simple_test: line 9: which: not found
./cfg1
5442: Requests: 0
** Message: 01:01:44.884: 5442: Throughput read test (without flushes) complete. Took 0.080 seconds to complete, 50.222Mib/s
PASS: cfg1
./simple_test: line 9: which: not found
./cfgmulti
5463: Requests: 0
** Message: 01:01:45.988: 5463: Throughput read test (without flushes) complete. Took 0.079 seconds to complete, 50.925Mib/s
5469: Requests: 0
** Message: 01:01:46.068: 5469: Throughput read test (without flushes) complete. Took 0.077 seconds to complete, 52.084Mib/s
PASS: cfgmulti
./simple_test: line 9: which: not found
./cfgnew
5490: Requests: 0
** Message: 01:01:47.178: 5490: Throughput read test (without flushes) complete. Took 0.084 seconds to complete, 47.414Mib/s
PASS: cfgnew
./simple_test: line 9: which: not found
./cfgsize
```
and so on.

I'm not sure why the build doesn't fail under these conditions, but anyway, simply adding `which` to its `buildInputs` fixes this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

