### PR TITLE
scaleway-cli: 1.14 -> 1.17

### DIFF
--- a/pkgs/tools/admin/scaleway-cli/default.nix
+++ b/pkgs/tools/admin/scaleway-cli/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec{
   name = "scaleway-cli-${version}";
-  version = "1.14";
+  version = "1.17";
 
   goPackagePath = "github.com/scaleway/scaleway-cli";
 
@@ -10,7 +10,7 @@ buildGoPackage rec{
     owner = "scaleway";
     repo = "scaleway-cli";
     rev = "v${version}";
-    sha256 = "09rqw82clfdiixa9m3hphxh5v7w1gks3wicz1dvpay2sx28bpddr";
+    sha256 = "0v50wk6q8537880whi6w83dia9y934v0s2xr1z52cn3mrsjghsnd";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

