### PR TITLE
terraform-landscape: 0.1.18 -> 0.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-landscape/Gemfile.lock
+++ b/pkgs/applications/networking/cluster/terraform-landscape/Gemfile.lock
@@ -2,12 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     colorize (0.8.1)
-    commander (4.4.5)
+    commander (4.4.6)
       highline (~> 1.7.2)
     diffy (3.2.1)
     highline (1.7.10)
     polyglot (0.3.5)
-    terraform_landscape (0.1.18)
+    terraform_landscape (0.2.0)
       colorize (~> 0.7)
       commander (~> 4.4)
       diffy (~> 3.0)

--- a/pkgs/applications/networking/cluster/terraform-landscape/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-landscape/default.nix
@@ -1,19 +1,18 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerApp, ruby }:
+let
+  version = (import ./gemset.nix).terraform_landscape.version;
+in bundlerApp {
+  pname = "terraform_landscape";
 
-bundlerEnv rec {
-  name = "terraform-landscape-${version}";
-
-  version = (import gemset).terraform_landscape.version;
   inherit ruby;
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+  gemdir = ./.;
+  exes = [ "landscape" ];
 
   meta = with lib; {
     description = "Improve Terraform's plan output to be easier to read and understand";
     homepage    = https://github.com/coinbase/terraform-landscape;
     license     = with licenses; apsl20;
-    maintainers = with maintainers; [ mbode ];
+    maintainers = with maintainers; [ mbode manveru ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/cluster/terraform-landscape/gemset.nix
+++ b/pkgs/applications/networking/cluster/terraform-landscape/gemset.nix
@@ -1,5 +1,7 @@
 {
   colorize = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "133rqj85n400qk6g3dhf2bmfws34mak1wqihvh3bgy9jhajw580b";
@@ -9,14 +11,18 @@
   };
   commander = {
     dependencies = ["highline"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0sry6raysvg9qsx5nqqw09n8r8hvcsqzvci7xp2qk7jq3s9mgvnn";
+      sha256 = "11sd2sb0id2dbxkv4pvymdiia1xxhms45kh4nr8mryqybad0fwwf";
       type = "gem";
     };
-    version = "4.4.5";
+    version = "4.4.6";
   };
   diffy = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "119imrkn01agwhx5raxhknsi331y5i4yda7r0ws0an6905ximzjg";
@@ -25,6 +31,8 @@
     version = "3.2.1";
   };
   highline = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "01ib7jp85xjc4gh4jg0wyzllm46hwv8p0w1m4c75pbgi41fps50y";
@@ -33,6 +41,8 @@
     version = "1.7.10";
   };
   polyglot = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1bqnxwyip623d8pr29rg6m8r0hdg08fpr2yb74f46rn1wgsnxmjr";
@@ -42,15 +52,19 @@
   };
   terraform_landscape = {
     dependencies = ["colorize" "commander" "diffy" "treetop"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0476q2kx88w9srj7rlzl6skrza3pdgyym7zksw78infsb2105lg9";
+      sha256 = "1mlpbsmysyhhbjx40gbwxr4mx7d3qpblbf5ms2v607b8a3saapzj";
       type = "gem";
     };
-    version = "0.1.18";
+    version = "0.2.0";
   };
   treetop = {
     dependencies = ["polyglot"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0g31pijhnv7z960sd09lckmw9h8rs3wmc8g4ihmppszxqm99zpv7";


### PR DESCRIPTION
###### Motivation for this change

Avoids conflicts, because this had the `bundler` executable (amongst others) in $PATH, while only `landscape` should be available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

