### PR TITLE
linux_rpi: add support for 64-bit Raspberry Pi 3

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -18,6 +18,7 @@ stdenv.lib.overrideDerivation (buildLinux (args // rec {
   defconfig = {
     "armv6l-linux" = "bcmrpi_defconfig";
     "armv7l-linux" = "bcm2709_defconfig";
+    "aarch64-linux" = "bcmrpi3_defconfig";
   }.${stdenv.hostPlatform.system} or (throw "linux_rpi not supported on '${stdenv.hostPlatform.system}'");
 
   features = {
@@ -31,9 +32,17 @@ stdenv.lib.overrideDerivation (buildLinux (args // rec {
     sed -i $buildRoot/.config -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
   '';
 
-  postFixup = ''
-    # Make copies of the DTBs named after the upstream names so that U-Boot finds them.
-    # This is ugly as heck, but I don't know a better solution so far.
+  # Make copies of the DTBs named after the upstream names so that U-Boot finds them.
+  # This is ugly as heck, but I don't know a better solution so far.
+  postFixup = if stdenv.hostPlatform.system == "aarch64-linux" then ''
+    rm $out/dtbs/broadcom/bcm283*.dtb
+    copyDTB() {
+      cp -v "$out/dtbs/broadcom/$1" "$out/dtbs/broadcom/$2"
+    }
+
+    copyDTB bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
+    copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
+  '' else ''
     rm $out/dtbs/bcm283*.dtb
     copyDTB() {
       cp -v "$out/dtbs/$1" "$out/dtbs/$2"

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,10 +1,10 @@
-{ stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, ... } @ args:
+{ stdenv, lib, buildPackages, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
   modDirVersion = "4.14.50";
   tag = "1.20180619";
 in
-stdenv.lib.overrideDerivation (buildLinux (args // rec {
+lib.overrideDerivation (buildLinux (args // rec {
   version = "${modDirVersion}-${tag}";
   inherit modDirVersion;
 
@@ -34,20 +34,13 @@ stdenv.lib.overrideDerivation (buildLinux (args // rec {
 
   # Make copies of the DTBs named after the upstream names so that U-Boot finds them.
   # This is ugly as heck, but I don't know a better solution so far.
-  postFixup = if stdenv.hostPlatform.system == "aarch64-linux" then ''
-    rm $out/dtbs/broadcom/bcm283*.dtb
+  postFixup = ''
+    dtbDir=${if stdenv.isAarch64 then "$out/dtbs/broadcom" else "$out/dtbs"}
+    rm $dtbDir/bcm283*.dtb
     copyDTB() {
-      cp -v "$out/dtbs/broadcom/$1" "$out/dtbs/broadcom/$2"
+      cp -v "$dtbDir/$1" "$dtbDir/$2"
     }
-
-    copyDTB bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
-    copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
-  '' else ''
-    rm $out/dtbs/bcm283*.dtb
-    copyDTB() {
-      cp -v "$out/dtbs/$1" "$out/dtbs/$2"
-    }
-
+  '' + lib.optionalString (lib.elem stdenv.hostPlatform.system ["armv6l-linux"]) ''
     copyDTB bcm2708-rpi-0-w.dtb bcm2835-rpi-zero.dtb
     copyDTB bcm2708-rpi-0-w.dtb bcm2835-rpi-zero-w.dtb
     copyDTB bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
@@ -57,7 +50,9 @@ stdenv.lib.overrideDerivation (buildLinux (args // rec {
     copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-b-plus.dtb
     copyDTB bcm2708-rpi-b-plus.dtb bcm2835-rpi-zero.dtb
     copyDTB bcm2708-rpi-cm.dtb bcm2835-rpi-cm.dtb
+  '' + lib.optionalString (lib.elem stdenv.hostPlatform.system ["armv7l-linux"]) ''
     copyDTB bcm2709-rpi-2-b.dtb bcm2836-rpi-2-b.dtb
+  '' + lib.optionalString (lib.elem stdenv.hostPlatform.system ["armv7l-linux" "aarch64-linux"]) ''
     copyDTB bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
     copyDTB bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
     copyDTB bcm2710-rpi-cm3.dtb bcm2837-rpi-cm3.dtb


### PR DESCRIPTION
###### Motivation for this change

The Raspberry Pi vendor kernel has a config for a 64-bit Raspberry Pi 3 kernel, but this is currently not supported in NixOS. I need this config to use a driver that is not included in the upstream kernel.

The device trees are different for this config, so this requires a different `postFixup` phase for aarch64.

This kernel boots correctly and I have not found any issues with it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

