### PR TITLE
Walabot SDK and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -288,6 +288,7 @@
   ./services/hardware/usbmuxd.nix
   ./services/hardware/thermald.nix
   ./services/hardware/undervolt.nix
+  ./services/hardware/walabot.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
   ./services/logging/fluentd.nix

--- a/nixos/modules/services/hardware/walabot.nix
+++ b/nixos/modules/services/hardware/walabot.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.walabot;
+in {
+  options = {
+    hardware.walabot = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable hardware support for a "Walabot Makers" device.
+
+          This creates the statefull database needed by the `walabot-api` in
+          `/var/lib/walabot/` and installs the necessary udev rule.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.walabot-hardware = {
+      description = "Installs the Walabot SDK database";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.Type = "oneshot";
+      script = ''
+        if [ ! -d "/var/lib/walabot" ]; then
+          mkdir -p /var/lib
+          cp -r ${pkgs.walabot-sdk}/var/lib/walabot /var/lib/
+
+          chmod 777 /var/lib/walabot/DB/
+          chmod 666 /var/lib/walabot/DB/*
+        fi
+      '';
+    };
+
+    services.udev.packages = lib.singleton (pkgs.writeTextFile {
+      name = "walabot-udev-rules";
+      destination = "/etc/udev/rules.d/50-walabot.rules";
+      text = ''
+        SUBSYSTEM=="usb", ATTR{idVendor}=="2c9c", ATTR{idProduct}="1000", MODE="0666"
+      '';
+    });
+  };
+}

--- a/pkgs/development/libraries/walabot-sdk/default.nix
+++ b/pkgs/development/libraries/walabot-sdk/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, dpkg }:
+
+stdenv.mkDerivation rec {
+  name = "walabot-sdk-${version}";
+  version = "1.0.34";
+
+  src = fetchurl {
+    url = "https://s3.eu-central-1.amazonaws.com/walabot/WalabotInstaller/Latest/walabot_maker_${version}_linux_x64.deb";
+    sha256 = "08zab14z6f4i9161b3il1v4888lds9xfh48b9a2hd1n8wg7s44wh";
+  };
+
+  sourceRoot = ".";
+  unpackCmd = "${dpkg}/bin/dpkg -x \"$src\" .";
+
+  buildPhase = ":"; # nothing to build
+
+  installPhase = ''
+    mkdir $out
+    cp -r usr/{include,lib} var $out/
+  '';
+
+  preFixup = let
+    libPath = stdenv.lib.makeLibraryPath [ stdenv.cc.cc.lib ];
+  in ''
+    patchelf --set-rpath "${libPath}" $out/lib/libWalabotAPI.so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://walabot.com/;
+    description = "Library for the Walabot";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.geistesk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12425,6 +12425,8 @@ with pkgs;
     stdenv = overrideCC stdenv gcc6; # upstream code incompatible with gcc7
   };
 
+  walabot-sdk = callPackage ../development/libraries/walabot-sdk { };
+
   wavpack = callPackage ../development/libraries/wavpack { };
 
   wayland = callPackage ../development/libraries/wayland { };


### PR DESCRIPTION
###### Motivation for this change
This PR adds the proprietary SDK for the [Walabot Makers](https://walabot.com/makers). Because of the nature of the library, which is only available as a pre-compiled shared library, a database must be present under `/var/lib/walabot`. The `walabot` NixOS-module creates this directory and populates it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`) (*none present*)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

