### PR TITLE
afew: add manpage

### DIFF
--- a/pkgs/applications/networking/mailreaders/afew/default.nix
+++ b/pkgs/applications/networking/mailreaders/afew/default.nix
@@ -9,11 +9,21 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0105glmlkpkjqbz350dxxasvlfx9dk0him9vwbl86andzi106ygz";
   };
 
-  buildInputs = with pythonPackages; [ setuptools_scm ];
+  nativeBuildInputs = with pythonPackages; [ sphinx setuptools_scm ];
 
   propagatedBuildInputs = with pythonPackages; [
     pythonPackages.notmuch chardet dkimpy
   ] ++ stdenv.lib.optional (!pythonPackages.isPy3k) subprocess32;
+
+  postBuild =  ''
+    make -C docs man
+  '';
+
+  postInstall = ''
+    mandir="$out/share/man/man1"
+    mkdir -p "$mandir"
+    cp docs/build/man/* "$mandir"
+  '';
 
   makeWrapperArgs = [
     ''--prefix PATH ':' "${notmuch}/bin"''


### PR DESCRIPTION
###### Motivation for this change

Generate the `afew` manpage which was previously missing.
(I did not add a separate `man` output, not worth it for a single 9kB manpage.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] impact on closure size: +9kB
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainers @andir @flokli @garbas
