### PR TITLE
findutils: disable a bogus test

### DIFF
--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -10,7 +10,14 @@ stdenv.mkDerivation rec {
     sha256 = "178nn4dl7wbcw499czikirnkniwnx36argdnqgz4ik9i6zvwkm6y";
   };
 
-  patches = [ ./memory-leak.patch ./no-install-statedir.patch ];
+  patches = [
+    ./memory-leak.patch
+    ./no-install-statedir.patch
+
+    # don't run getdtablesize tests, they will impurely fail depending
+    # on the value of sysconf(_SC_OPEN_MAX)
+    ./disable-getdtablesize-test.patch
+  ];
 
   buildInputs = [ coreutils ]; # bin/updatedb script needs to call sort
 

--- a/pkgs/tools/misc/findutils/disable-getdtablesize-test.patch
+++ b/pkgs/tools/misc/findutils/disable-getdtablesize-test.patch
@@ -1,0 +1,25 @@
+diff --git a/tests/test-dup2.c b/tests/test-dup2.c
+--- a/tests/test-dup2.c
++++ b/tests/test-dup2.c
+@@ -157,8 +157,6 @@ main (void)
+       ASSERT (close (255) == 0);
+       ASSERT (close (256) == 0);
+     }
+-  ASSERT (dup2 (fd, bad_fd - 1) == bad_fd - 1);
+-  ASSERT (close (bad_fd - 1) == 0);
+   errno = 0;
+   ASSERT (dup2 (fd, bad_fd) == -1);
+   ASSERT (errno == EBADF);
+diff --git a/tests/test-getdtablesize.c b/tests/test-getdtablesize.c
+index a0325af..a83f8ec 100644
+--- a/tests/test-getdtablesize.c
++++ b/tests/test-getdtablesize.c
+@@ -29,8 +29,6 @@ int
+ main (int argc, char *argv[])
+ {
+   ASSERT (getdtablesize () >= 3);
+-  ASSERT (dup2 (0, getdtablesize() - 1) == getdtablesize () - 1);
+-  ASSERT (dup2 (0, getdtablesize()) == -1);
+ 
+   return 0;
+ }


### PR DESCRIPTION
findutils fails to pass checkPhase on my Linux system that has a ```sysconf(_SC_OPEN_MAX)``` limit set. The test itself appears to be a common copypasta between gnu projects. Poking limits of available fd's is irrelevant to what findutils is designed to do, so I consider the test to be bogus.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
