### PR TITLE
lammps: update, hoomd-blue, dl_poly: init

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/dl-poly-classic/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/dl-poly-classic/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl
+, gfortran, mpi
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.10";
+  name = "DL_POLY_Classic-${version}";
+
+  src = fetchurl {
+    url = "https://ccpforge.cse.rl.ac.uk/gf/download/frsrelease/574/8924/dl_class_1.10.tar.gz";
+    sha256 = "1r76zvln3bwycxlmqday0sqzv5j260y7mdh66as2aqny6jzd5ld7";
+  };
+
+  buildInputs = [ mpi gfortran ];
+
+  configurePhase = ''
+    cd source
+    cp -v ../build/MakePAR Makefile
+  '';
+
+  buildPhase = ''
+    make dlpoly
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -v ../execute/DLPOLY.X $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.ccp5.ac.uk/DL_POLY_C;
+    description = "DL_POLY Classic is a general purpose molecular dynamics simulation package";
+    license = licenses.bsdOriginal;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/hoomd-blue/default.nix
+++ b/pkgs/development/python-modules/hoomd-blue/default.nix
@@ -1,0 +1,67 @@
+{ stdenv, buildPythonPackage, fetchgit
+, cmake, pkgconfig
+, python
+, mpi ? null
+}:
+
+let components = {
+     cgcmm = true;
+     depreciated = true;
+     hpmc = true;
+     md = true;
+     metal = true;
+     testing = false;
+   };
+   onOffBool = b: if b then "ON" else "OFF";
+   withMPI = (mpi != null);
+in
+stdenv.mkDerivation rec {
+  version = "2.3.4";
+  name = "hoomd-blue-${version}";
+
+  src = fetchgit {
+    url = "https://bitbucket.org/glotzer/hoomd-blue";
+    rev = "v${version}";
+    sha256 = "0in49f1dvah33nl5n2qqbssfynb31pw1ds07j8ziryk9w252j1al";
+  };
+
+  passthru = {
+    inherit components mpi;
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = stdenv.lib.optionals withMPI [ mpi ];
+  propagatedBuildInputs = [ python.pkgs.numpy ]
+   ++ stdenv.lib.optionals withMPI [ python.pkgs.mpi4py ];
+
+  enableParallelBuilding = true;
+
+  dontAddPrefix = true;
+  cmakeFlags = [
+       "-DENABLE_MPI=${onOffBool withMPI}"
+       "-DBUILD_CGCMM=${onOffBool components.cgcmm}"
+       "-DBUILD_DEPRECIATED=${onOffBool components.depreciated}"
+       "-DBUILD_HPMC=${onOffBool components.hpmc}"
+       "-DBUILD_MD=${onOffBool components.md}"
+       "-DBUILD_METAL=${onOffBool components.metal}"
+       "-DBUILD_TESTING=${onOffBool components.testing}"
+  ];
+
+  preConfigure = ''
+    # Since we can't expand $out in `cmakeFlags`
+    cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_PREFIX=$out/${python.sitePackages}"
+  '';
+
+  # tests fail but have tested that package runs properly
+  doCheck = false;
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    homepage = http://glotzerlab.engin.umich.edu/hoomd-blue/;
+    description = "HOOMD-blue is a general-purpose particle simulation toolkit";
+    license = licenses.bsdOriginal;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.costrouc ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21138,6 +21138,10 @@ with pkgs;
 
   ### SCIENCE/MOLECULAR-DYNAMICS
 
+  dl-poly-classic-mpi = callPackage ../applications/science/molecular-dynamics/dl-poly-classic {
+    mpi = openmpi;
+  };
+
   lammps = callPackage ../applications/science/molecular-dynamics/lammps {
     fftw = fftw;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21146,8 +21146,7 @@ with pkgs;
     fftw = fftw;
   };
 
-  lammps-mpi = appendToName "mpi" (lammps.override {
-    mpiSupport = true;
+  lammps-mpi = lowPrio (lammps.override {
     mpi = openmpi;
   });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -366,6 +366,10 @@ in {
 
   hdmedians = callPackage ../development/python-modules/hdmedians { };
 
+  hoomd-blue = toPythonModule (callPackage ../development/python-modules/hoomd-blue {
+    inherit python;
+  });
+
   httpsig = callPackage ../development/python-modules/httpsig { };
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };


### PR DESCRIPTION
###### Motivation for this change

Adding molecular dynamics codes that our group uses at UTK. Hoomd-blue is the most interesting addition. While I have not added GPU support it is mpi enabled and a fun code to work with. I do not have enough experience packaging with GPUs yet (maybe will be packaged at a future date). Scales to 10K GPUs according to benchmarks.

Would like to request @markuskowa for review.

###### Things done

lammps: patch_2Aug2018 -> stable_22Aug2018
dl-poly-classic: init 1.10
hoomd-blue: init at 2.3.4 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

