### PR TITLE
nginx, postgresql: give corresponding groups permission to read

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -208,7 +208,7 @@ in
           ''
             # Create data directory.
             if ! test -e ${cfg.dataDir}/PG_VERSION; then
-              mkdir -m 0700 -p ${cfg.dataDir}
+              mkdir -m 0750 -p ${cfg.dataDir}
               rm -f ${cfg.dataDir}/*.conf
               chown -R postgres:postgres ${cfg.dataDir}
             fi

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -598,7 +598,7 @@ in
       preStart =
         ''
         mkdir -p ${cfg.stateDir}/logs
-        chmod 700 ${cfg.stateDir}
+        chmod 750 ${cfg.stateDir}
         chown -R ${cfg.user}:${cfg.group} ${cfg.stateDir}
         ${cfg.package}/bin/nginx -c ${configFile} -p ${cfg.stateDir} -t
         '';


### PR DESCRIPTION
The motivation here is that I'd like to add `datadog` user to `postgres` and `nginx` groups, which would allow datadog to read logs. I was actually the one that added exiting permissions to nginx back in 2013 and postgresql seems to date back to even svn in 2009.