### PR TITLE
pythonPackages.jupyter-repo2docker: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/jupyter-repo2docker/default.nix
+++ b/pkgs/development/python-modules/jupyter-repo2docker/default.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pkgs-docker
+, docker
+, traitlets
+, python-json-logger
+, escapism
+, jinja2
+, ruamel_yaml
+, pyyaml
+, pytest
+, wheel
+, pytestcov
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  version = "0.6.0";
+  pname = "jupyter-repo2docker";
+  disabled = !(pythonAtLeast "3.4");
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "32c6dc6fd2402d6f5a955f8ab59299097bb5f4972c7dcc6fe2a8fe4c96dcab27";
+  };
+
+  checkInputs = [ pytest pyyaml wheel pytestcov ];
+  propagatedBuildInputs = [ pkgs-docker docker traitlets python-json-logger escapism jinja2 ruamel_yaml ];
+
+  # tests not packaged with pypi release
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = https://repo2docker.readthedocs.io/en/latest/;
+    description = "Repo2docker: Turn code repositories into Jupyter enabled Docker Images";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/python-json-logger/default.nix
+++ b/pkgs/development/python-modules/python-json-logger/default.nix
@@ -1,0 +1,25 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, nose
+}:
+
+buildPythonPackage rec {
+  version = "0.1.9";
+  pname = "python-json-logger";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e3636824d35ba6a15fc39f573588cba63cf46322a5dc86fb2f280229077e9fbe";
+  };
+
+  checkInputs = [ nose ];
+
+  meta = with stdenv.lib; {
+    homepage = http://github.com/madzak/python-json-logger;
+    description = "A python library adding a json log formatter";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.costrouc ];
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6320,6 +6320,10 @@ in {
 
   jupyter_core = callPackage ../development/python-modules/jupyter_core { };
 
+  jupyter-repo2docker = callPackage ../development/python-modules/jupyter-repo2docker {
+    pkgs-docker = pkgs.docker;
+  };
+
   jupyterhub = callPackage ../development/python-modules/jupyterhub { };
 
   jupyterhub-ldapauthenticator = callPackage ../development/python-modules/jupyterhub-ldapauthenticator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1659,6 +1659,8 @@ in {
 
   python-jose = callPackage ../development/python-modules/python-jose {};
 
+  python-json-logger = callPackage ../development/python-modules/python-json-logger { };
+
   python-ly = callPackage ../development/python-modules/python-ly {};
 
   pyhepmc = buildPythonPackage rec {


### PR DESCRIPTION
###### Motivation for this change

Considering developing a nix environment for repo2docker so wanted to get it building first and add to package repository.

###### Things done

pythonPackages.jupyter-repo2docker: init at 0.6.0 
pythonPackages.python-json-logger: init at 0.1.9 
pythonPackages.escapism: 0.0.1 -> 1.0.0 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

