### PR TITLE
mkspiffs: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1610,6 +1610,11 @@
     github = "hamhut1066";
     name = "Hamish Hutchings";
   };
+  haslersn = {
+    email = "haslersn@fius.informatik.uni-stuttgart.de";
+    github = "haslersn";
+    name = "Sebastian Hasler";
+  };
   havvy = {
     email = "ryan.havvy@gmail.com";
     github = "havvy";

--- a/pkgs/tools/filesystems/mkspiffs/default.nix
+++ b/pkgs/tools/filesystems/mkspiffs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, git }:
 
-# We can build mkspiffs with custom CPPFLAGS by passing them in extraBuidFlags.
-# The upstream has several named presets for CPPFLAGS whose names will be passed in buildConfigName.
+# Changing the variables CPPFLAGS and BUILD_CONFIG_NAME can be done by
+# overriding the same-named attributes. See ./presets.nix for examples.
 
 stdenv.mkDerivation rec {
   name = "mkspiffs-${version}";

--- a/pkgs/tools/filesystems/mkspiffs/default.nix
+++ b/pkgs/tools/filesystems/mkspiffs/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, fetchgit, git
-, extraBuildFlags ? ""
-, buildConfigName ? "generic" }:
+{ stdenv, fetchFromGitHub, git }:
 
 # We can build mkspiffs with custom CPPFLAGS by passing them in extraBuidFlags.
 # The upstream has several named presets for CPPFLAGS whose names will be passed in buildConfigName.
@@ -9,17 +7,17 @@ stdenv.mkDerivation rec {
   name = "mkspiffs-${version}";
   version = "0.2.3";
 
-  src = fetchgit {
-    url = "https://github.com/igrr/mkspiffs";
+  src = fetchFromGitHub {
+    owner = "igrr";
+    repo = "mkspiffs";
     rev = version;
-    deepClone = true;
-    sha256 = "0lgw8iyz57qc2l9nvn054cpsl3piik4n63gw7bp7rpci03xazi9j";
+    fetchSubmodules = true;
+    sha256 = "1fgw1jqdlp83gv56mgnxpakky0q6i6f922niis4awvxjind8pbm1";
   };
 
   nativeBuildInputs = [ git ];
+  buildFlags = [ "dist" ];
   installPhase = ''
-    make clean
-    make dist CPPFLAGS="${extraBuildFlags}" BUILD_CONFIG_NAME="-${buildConfigName}"
     mkdir -p $out/bin
     cp mkspiffs $out/bin
   '';

--- a/pkgs/tools/filesystems/mkspiffs/default.nix
+++ b/pkgs/tools/filesystems/mkspiffs/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit, git
+, extraBuildFlags ? ""
+, buildConfigName ? "generic" }:
+
+# We can build mkspiffs with custom CPPFLAGS by passing them in extraBuidFlags.
+# The upstream has several named presets for CPPFLAGS whose names will be passed in buildConfigName.
+
+stdenv.mkDerivation rec {
+  name = "mkspiffs-${version}";
+  version = "0.2.3";
+
+  src = fetchgit {
+    url = "https://github.com/igrr/mkspiffs";
+    rev = version;
+    deepClone = true;
+    sha256 = "0lgw8iyz57qc2l9nvn054cpsl3piik4n63gw7bp7rpci03xazi9j";
+  };
+
+  nativeBuildInputs = [ git ];
+  installPhase = ''
+    make clean
+    make dist CPPFLAGS="${extraBuildFlags}" BUILD_CONFIG_NAME="-${buildConfigName}"
+    mkdir -p $out/bin
+    cp mkspiffs $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool to build and unpack SPIFFS images";
+    license = licenses.mit;
+    homepage = https://github.com/igrr/mkspiffs;
+    maintainers = with maintainers; [ haslersn ];
+  };
+}

--- a/pkgs/tools/filesystems/mkspiffs/default.nix
+++ b/pkgs/tools/filesystems/mkspiffs/default.nix
@@ -27,5 +27,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = https://github.com/igrr/mkspiffs;
     maintainers = with maintainers; [ haslersn ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/filesystems/mkspiffs/presets.nix
+++ b/pkgs/tools/filesystems/mkspiffs/presets.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchgit, git }:
+
+let
+  buildMkspiffs = overrides : import ./default.nix (
+    { inherit stdenv fetchgit git; } // overrides
+  );
+in
+
+rec {
+  arduino-esp32 = buildMkspiffs {
+    extraBuildFlags = "-DSPIFFS_OBJ_META_LEN=4";
+    buildConfigName = "arduino-esp32";
+  };
+
+  esp-idf = buildMkspiffs {
+    extraBuildFlags = "-DSPIFFS_OBJ_META_LEN=4";
+    buildConfigName = "esp-idf";
+  };
+
+  arduino-esp8266 = buildMkspiffs {
+    extraBuildFlags = "-DSPIFFS_USE_MAGIC_LENGTH=0 -DSPIFFS_ALIGNED_OBJECT_INDEX_TABLES=1";
+    buildConfigName = "arduino-esp8266";
+  };
+}

--- a/pkgs/tools/filesystems/mkspiffs/presets.nix
+++ b/pkgs/tools/filesystems/mkspiffs/presets.nix
@@ -1,5 +1,7 @@
 { lib, mkspiffs }:
 
+# We provide the same presets as the upstream
+
 lib.mapAttrs (
   name: { CPPFLAGS }:
   mkspiffs.overrideAttrs (drv: {

--- a/pkgs/tools/filesystems/mkspiffs/presets.nix
+++ b/pkgs/tools/filesystems/mkspiffs/presets.nix
@@ -1,24 +1,18 @@
-{ stdenv, fetchgit, git }:
+{ lib, mkspiffs }:
 
-let
-  buildMkspiffs = overrides : import ./default.nix (
-    { inherit stdenv fetchgit git; } // overrides
-  );
-in
+lib.mapAttrs (
+  name: { CPPFLAGS }:
+  mkspiffs.overrideAttrs (drv: {
+    inherit CPPFLAGS;
+    BUILD_CONFIG_NAME = "-${name}";
+  })
+) {
+  arduino-esp8266.CPPFLAGS = [
+    "-DSPIFFS_USE_MAGIC_LENGTH=0"
+    "-DSPIFFS_ALIGNED_OBJECT_INDEX_TABLES=1"
+  ];
 
-rec {
-  arduino-esp32 = buildMkspiffs {
-    extraBuildFlags = "-DSPIFFS_OBJ_META_LEN=4";
-    buildConfigName = "arduino-esp32";
-  };
+  arduino-esp32.CPPFLAGS = [ "-DSPIFFS_OBJ_META_LEN=4" ];
 
-  esp-idf = buildMkspiffs {
-    extraBuildFlags = "-DSPIFFS_OBJ_META_LEN=4";
-    buildConfigName = "esp-idf";
-  };
-
-  arduino-esp8266 = buildMkspiffs {
-    extraBuildFlags = "-DSPIFFS_USE_MAGIC_LENGTH=0 -DSPIFFS_ALIGNED_OBJECT_INDEX_TABLES=1";
-    buildConfigName = "arduino-esp8266";
-  };
+  esp-idf.CPPFLAGS = [ "-DSPIFFS_OBJ_META_LEN=4" ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1447,6 +1447,10 @@ with pkgs;
 
   metabase = callPackage ../servers/metabase { };
 
+  mkspiffs = callPackage ../tools/filesystems/mkspiffs { };
+
+  mkspiffs-presets = recurseIntoAttrs (callPackages ../tools/filesystems/mkspiffs/presets.nix { });
+
   monetdb = callPackage ../servers/sql/monetdb { };
 
   mp3blaster = callPackage ../applications/audio/mp3blaster { };


### PR DESCRIPTION
###### Motivation for this change

There wasn't a derivation for mkspiffs yet, so I made one.

Supersedes #46623 as it does, besides the generic version, also contain the versions for arduino-esp32, arduino-esp8266 and esp-idf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

