### PR TITLE
prometheus-snmp-exporter: 0.11.0 -> 0.13.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/snmp-exporter.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "snmp_exporter-${version}";
-  version = "0.11.0";
+  version = "0.13.0";
 
   goPackagePath = "github.com/prometheus/snmp_exporter";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "prometheus";
     repo = "snmp_exporter";
     rev = "v${version}";
-    sha256 = "027p96jzhq9l7m3s5qxxg3rqp14pai7q66d3ppin19lg7al11c9x";
+    sha256 = "071v9qqhp2hcbgml94dm1l212qi18by88r9755npq9ycrsmawkll";
   };
 
   buildInputs = [ net_snmp ];


### PR DESCRIPTION
###### Motivation for this change
New features and a bugfix with the [two recent releases](https://github.com/prometheus/snmp_exporter/releases).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---