### PR TITLE
spl/zfs: 0.7.10 -> 0.7.11

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -10,13 +10,13 @@ assert kernel != null;
 
 stdenv.mkDerivation rec {
   name = "spl-${version}-${kernel.version}";
-  version = "0.7.10";
+  version = "0.7.11";
 
   src = fetchFromGitHub {
     owner = "zfsonlinux";
     repo = "spl";
     rev = "spl-${version}";
-    sha256 = "1jkv6sdrd6yvaqx0jg86fjwnsqyxqb2061k7yrka7iyivgjzpi26";
+    sha256 = "15h02g5k3i20y2cycc72vr6hdn8n70jmzqii8dmx9za6bl9nk2rm";
   };
 
   patches = [ ./install_prefix.patch ];

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -161,9 +161,9 @@ in {
     # incompatibleKernelVersion = null;
 
     # this package should point to the latest release.
-    version = "0.7.10";
+    version = "0.7.11";
 
-    sha256 = "1kq35ij29fag77dxq21jf9ghbl4nkyjgc2bxzyry9rawznq542v1";
+    sha256 = "0m9wkq6wf4cg8w38s3avd0bvybnv0avqwxk3gwz9rgb9rn0m98jg";
 
     extraPatches = [
       (fetchpatch {


### PR DESCRIPTION
(cherry picked from commit 81082c6c60bfcfe2ffc20fb3cab406c621a8f7fe)

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/46675

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
 - nix-build -A stable nixos/tests/zfs.nix
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

