### PR TITLE
Newtonsoft.Json: 6.0.8 -> 11.0.2

### DIFF
--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -871,40 +871,11 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     };
   };
 
-  NewtonsoftJson = buildDotnetPackage rec {
+  NewtonsoftJson = fetchNuGet {
     baseName = "Newtonsoft.Json";
-    version = "6.0.8";
-
-    src = fetchurl {
-      name = "${baseName}-${version}.tar.gz";
-      url = "https://github.com/JamesNK/Newtonsoft.Json/archive/${version}.tar.gz";
-      sha256 = "14znf5mycka578bxjnlnz6a3f9nfkc682hgmgg42gdzksnarvhlm";
-    };
-
-    buildInputs = [
-      fsharp
-      dotnetPackages.NUnit
-      dotnetPackages.SystemCollectionsImmutable
-      dotnetPackages.Autofac
-    ];
-
-    patches = [ ../development/dotnet-modules/patches/newtonsoft-json.references.patch ];
-
-    postConfigure = ''
-       # Just to make sure there's no attempt to call these executables
-       rm -rvf Tools
-    '';
-
-    xBuildFiles = [ "Src/Newtonsoft.Json.sln" ];
-    outputFiles = [ "Src/Newtonsoft.Json/bin/Release/Net45/*" ];
-
-    meta = {
-      description = "Popular high-performance JSON framework for .NET";
-      homepage = "https://www.newtonsoft.com/json";
-      license = stdenv.lib.licenses.mit;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
-    };
+    version = "11.0.2";
+    sha256 = "07na27n4mlw77f3hg5jpayzxll7f4gyna6x7k9cybmxpbs6l77k7";
+    outputFiles = [ "*" ];
   };
 
   Nuget = buildDotnetPackage {


### PR DESCRIPTION
###### Motivation for this change

This upgrades Newtonsoft.Json and fixes a few failing packages, among which `openra`.

I cherry-picked c632384 as @matthewbauer suggested.

This is based on https://github.com/NixOS/nixpkgs/pull/44478.
This replaces https://github.com/NixOS/nixpkgs/pull/46425
This is part of https://github.com/NixOS/nixpkgs/issues/45960

Ping @samueldr @nek0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

