### PR TITLE
zsh: 5.6.1 -> 5.6.2

### DIFF
--- a/pkgs/shells/zsh/default.nix
+++ b/pkgs/shells/zsh/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ncurses, pcre }:
 
 let
-  version = "5.6.1";
+  version = "5.6.2";
 
   documentation = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}-doc.tar.xz";
-    sha256 = "15j8w1ddfparfnqymx67rycgfdl50xcrnd6p1d6q9n3n0462jjmn";
+    sha256 = "05014rg6hkwiv1p56iij8wn2rghmwjxs5qsj3d3xigbwaikk55wq";
   };
 
 in
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://sourceforge/zsh/zsh-${version}.tar.xz";
-    sha256 = "1s5kzfbfvixibb1sbzmmlrrx898zqwi5cfmnnq4bhcbx64zparlm";
+    sha256 = "17iffliqcj4hv91g0bd2sxsyfcz51mfyh97sp2iyrs2p0mndc2x5";
   };
 
   buildInputs = [ ncurses pcre ];


### PR DESCRIPTION
From upstream's NEWS:

> Changes from 5.6.1 to 5.6.2
> ---------------------------
>
> Fix another SIGTTOU case.
>
> Fix SIGWINCH being ignored when zsh is not in the foreground.
>
> The release tarballs are now compressed using xz(1), whereas previously
> both xz(1) and gzip(1) versions were available.  If this gets in your way,
> give us a shout.
>


This fixed an issue that was driving me crazy trying to isolate,
but may not happen to everyone.

FWIW, it's basically exactly what you expect from the description above
(so I was very excited when saw the commits leading to this release!)
but I'll explain briefly in case anyone else encountered it:

1. Terminal running vim
2. Resize terminal
3. Exit vim
4. WTF my shell's RPROMPT is aligned wrong and various things
(completion, etc.) are borked.  What gives?!

Anyway, hope this helps! :)




<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---