### PR TITLE
compton{,-git}: bump to v2, set COMPTON_VERSION so '--version' has sane output

### DIFF
--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -42,9 +42,11 @@ let
     };
   });
 
-  stableSource = {
+  stableSource = rec {
     pname = "compton";
     version = "0.1_beta2.5";
+
+    COMPTON_VERSION = version;
 
     src = fetchFromGitHub {
       owner = "chjj";
@@ -58,15 +60,17 @@ let
     };
   };
 
-  gitSource = {
+  gitSource = rec {
     pname = "compton-git";
-    version = "2018-08-14";
+    version = "2";
+
+    COMPTON_VERSION = "v${version}";
 
     src = fetchFromGitHub {
       owner  = "yshui";
       repo   = "compton";
-      rev    = "cac8094ce12cd40706fb48f9ab35354d9ee7c48f";
-      sha256 = "0qif3nx8vszlr06bixasna13pzfaikp86xax9miwnba50517y7v5";
+      rev    = COMPTON_VERSION;
+      sha256 = "1b6jgkkjbmgm7d7qjs94h722kgbqjagcxznkh2r84hcmcl8pibjq";
     };
 
     meta = {


### PR DESCRIPTION
Previously they both would claim to be 'git--' :).





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---