### PR TITLE
salt: fix darwin build by specifying dependency on tornado 4

### DIFF
--- a/pkgs/development/python-modules/tornado/default.nix
+++ b/pkgs/development/python-modules/tornado/default.nix
@@ -8,12 +8,25 @@
 , singledispatch
 , pythonOlder
 , futures
+, version ? "5.1"
 }:
+
+let
+  versionMap = {
+    "4.5.3" = {
+      sha256 = "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d";
+    };
+    "5.1" = {
+      sha256 = "4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582";
+    };
+  };
+in
+
+with versionMap.${version};
 
 buildPythonPackage rec {
   pname = "tornado";
-  version = "5.1";
-
+  inherit version;
 
   propagatedBuildInputs = [ backports_abc  certifi singledispatch ]
     ++ lib.optional (pythonOlder "3.5") backports_ssl_match_hostname
@@ -26,8 +39,7 @@ buildPythonPackage rec {
   '';
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582";
+    inherit pname sha256 version;
   };
 
   meta = {

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -23,7 +23,7 @@ pythonPackages.buildPythonApplication rec {
     pyyaml
     pyzmq
     requests
-    tornado
+    tornado_4
   ] ++ stdenv.lib.optional (!pythonPackages.isPy3k) [
     futures
   ] ++ extraInputs;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14901,6 +14901,7 @@ EOF
   };
 
   tornado = callPackage ../development/python-modules/tornado { };
+  tornado_4 = callPackage ../development/python-modules/tornado { version = "4.5.3"; };
 
   tokenlib = buildPythonPackage rec {
     name = "tokenlib-${version}";


### PR DESCRIPTION
/cc ZHF #45961

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

