### PR TITLE
click: 0.3.1 -> 0.3.2

### DIFF
--- a/pkgs/applications/networking/cluster/click/default.nix
+++ b/pkgs/applications/networking/cluster/click/default.nix
@@ -4,17 +4,18 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "click-${version}";
-  version = "0.3.1";
-  rev = "b5dfb4a8f8344330a098cb61523695dfe0fd296a";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
+    rev = "v${version}";
     owner = "databricks";
     repo = "click";
-    sha256 = "0a2hq4hcxkkx7gs5dv7sr3j5jy2dby4r6y090z7zl2xy5wydr7bi";
-    inherit rev;
+    sha256 = "0sbj41kypn637z1w115w2h5v6bxz3y6w5ikgpx3ihsh89lkc19d2";
   };
 
-  cargoSha256 = "03vgbkv9xsnx44vivbbhjgxv9drp0yjnimgy6hwm32x74r00k3hj";
+  cargoSha256 = "05asqp5312a1g26pvf5hgqhc4kj3iw2hdvml2ycvga33sxb7zm7r";
+
+  patches = [ ./fix_cargo_lock_version.patch ];
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 

--- a/pkgs/applications/networking/cluster/click/fix_cargo_lock_version.patch
+++ b/pkgs/applications/networking/cluster/click/fix_cargo_lock_version.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index ff80350..c86c6fe 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -111,7 +111,7 @@ dependencies = [
+
+ [[package]]
+ name = "click"
+-version = "0.3.1"
++version = "0.3.2"
+ dependencies = [
+  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
patch necessary to fix "error: the lock file needs to be updated but --frozen was passed to prevent this"

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

