### PR TITLE
richgo: Init at 0.2.8

### DIFF
--- a/pkgs/development/tools/richgo/default.nix
+++ b/pkgs/development/tools/richgo/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "richgo-${version}";
+  version = "0.2.8";
+  goPackagePath = "github.com/kyoh86/richgo";
+
+  src = fetchFromGitHub {
+    owner = "kyoh86";
+    repo = "richgo";
+    rev = "v${version}";
+    sha256 = "0kbwl3a2gima23zmahk0jxp7wga91bs927a1rp5xl889ikng1n4j";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Enrich `go test` outputs with text decorations.";
+    homepage = https://github.com/kyoh86/richgo;
+    license = licenses.unlicense; # NOTE: The project switched to MIT in https://git.io/fA1ik
+    maintainers = with maintainers; [ rvolosatovs ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4917,6 +4917,8 @@ with pkgs;
 
   redsocks = callPackage ../tools/networking/redsocks { };
 
+  richgo = callPackage ../development/tools/richgo {  };
+
   rst2html5 = callPackage ../tools/text/rst2html5 { };
 
   rt = callPackage ../servers/rt { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

