### PR TITLE
matcha: init at 2018-09-14

### DIFF
--- a/pkgs/misc/themes/matcha/default.nix
+++ b/pkgs/misc/themes/matcha/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, gdk_pixbuf, librsvg, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "matcha-${version}";
+  version = "2018-09-14";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "matcha";
+    rev = "fe35259742b5ae007ab17d46d21acad5754477b9";
+    sha256 = "1qwb8l1xfx9ca2y9gcsckxikijz1ij28dirvpqvhbbyn1m8i9hwd";
+  };
+
+  buildInputs = [ gdk_pixbuf librsvg ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    patchShebangs .
+    substituteInPlace Install --replace '$HOME/.themes' "$out/share/themes"
+    ./Install
+    install -D -t $out/share/gtksourceview-3.0/styles src/extra/gedit/matcha.xml
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A stylish Design theme for GTK based desktop environments";
+    homepage = https://vinceliuice.github.io/theme-matcha;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21680,6 +21680,8 @@ with pkgs;
 
   martyr = callPackage ../development/libraries/martyr { };
 
+  matcha = callPackage ../misc/themes/matcha { };
+
   # previously known as flat-plat
   materia-theme = callPackage ../misc/themes/materia-theme { };
 


### PR DESCRIPTION
###### Motivation for this change

Add [matcha](https://vinceliuice.github.io/theme-matcha), a flat Design theme for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Unity, Budgie, Pantheon, XFCE, Mate, etc.

[See also](https://www.opendesktop.org/p/1187179).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).