### PR TITLE
php: 7.2.8 -> 7.2.10, 7.1.21 -> 7.1.22

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -223,8 +223,8 @@ let
 
 in {
   php71 = generic {
-    version = "7.1.21";
-    sha256 = "104mn4kppklb21hgz1a50kgmc0ak5y996sx990xpc8yy9dbrqh62";
+    version = "7.1.22";
+    sha256 = "0qz74qdlk19cw478f42ckyw5r074y0fg73r2bzlhm0dar0cizsf8";
   };
 
   php72 = generic {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -37,7 +37,10 @@ let
   , opensslSupport ? config.php.openssl or true
   , mbstringSupport ? config.php.mbstring or true
   , gdSupport ? config.php.gd or true
-  , intlSupport ? config.php.intl or true
+  # Because of an upstream bug: https://bugs.php.net/bug.php?id=76826
+  # We need to disable the intl support on darwin. Whenever the upstream bug is
+  # fixed we should revert this to just just "config.php.intl or true".
+  , intlSupport ? (config.php.intl or true) && (!stdenv.isDarwin)
   , exifSupport ? config.php.exif or true
   , xslSupport ? config.php.xsl or false
   , mcryptSupport ? config.php.mcrypt or true
@@ -225,7 +228,7 @@ in {
   };
 
   php72 = generic {
-    version = "7.2.8";
-    sha256 = "1rky321gcvjm0npbfd4bznh36an0y14viqcvn4yzy3x643sni00z";
+    version = "7.2.10";
+    sha256 = "17fsvdi6ihjghjsz9kk2li2rwrknm2ccb6ys0xmn789116d15dh1";
   };
 }


### PR DESCRIPTION
###### Motivation for this change
This should *not* be backported due to flag changes due to upstream bugs.

Changelog 7.2.9: http://php.net/ChangeLog-7.php#7.2.9
Changelog 7.2.10: http://php.net/ChangeLog-7.php#7.2.10
Changelog 7.1.22: http://php.net/ChangeLog-7.php#7.1.22

If someone could trigger a borg build for darwin as well it would be great since 7.2.9 seemed to fail on darwin in the 7.2.9 PR that never got merged due to darwin failure #45159.

This fixes #45159.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @xeji @globin 