### PR TITLE
paperwork: 1.2.2 -> 1.2.4

### DIFF
--- a/pkgs/applications/office/paperwork/backend.nix
+++ b/pkgs/applications/office/paperwork/backend.nix
@@ -1,23 +1,19 @@
-{ buildPythonPackage, lib, fetchFromGitHub
+{ buildPythonPackage, lib
 
 , isPy3k, isPyPy
 
 , pyenchant, simplebayes, pillow, pycountry, whoosh, termcolor
 , python-Levenshtein, pyinsane2, pygobject3, pyocr, natsort
 
-, pkgs
+, pkgs, callPackage
 }:
-
-buildPythonPackage rec {
+let
+  source = (callPackage ./source.nix {});
+in buildPythonPackage rec {
   pname = "paperwork-backend";
-  version = "1.2.2";
+  inherit (source) version;
 
-  src = fetchFromGitHub {
-    owner = "openpaperwork";
-    repo = "paperwork-backend";
-    rev = version;
-    sha256 = "1rvf06vphm32601ja1bfkfkfpgjxiv0lh4yxjy31jll0bfnsf7pf";
-  };
+  src = source.backend;
 
   # Python 2.x is not supported.
   disabled = !isPy3k && !isPyPy;

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -1,20 +1,16 @@
-{ lib, python3Packages, fetchFromGitHub, gtk3, cairo
+{ lib, python3Packages, gtk3, cairo
 , aspellDicts, buildEnv
 , gnome3, hicolor-icon-theme, librsvg
 , xvfb_run, dbus, libnotify
+, callPackage
 }:
-
-python3Packages.buildPythonApplication rec {
+let
+  source = (callPackage ./source.nix {});
+in python3Packages.buildPythonApplication rec {
   name = "paperwork-${version}";
-  # Don't forget to also update paperwork-backend when updating this!
-  version = "1.2.2";
+  inherit (source) version;
 
-  src = fetchFromGitHub {
-    repo = "paperwork";
-    owner = "openpaperwork";
-    rev = version;
-    sha256 = "1nb5sna2s952xb7c89qccg9qp693pyqj8g7xz16ll16ydfqnzsdk";
-  };
+  src = source.frontend;
 
   # Patch out a few paths that assume that we're using the FHS:
   postPatch = ''

--- a/pkgs/applications/office/paperwork/source.nix
+++ b/pkgs/applications/office/paperwork/source.nix
@@ -1,0 +1,16 @@
+{ python3Packages }:
+let
+  version = "1.2.4";
+in {
+  inherit version;
+  frontend = python3Packages.fetchPypi {
+    pname = "paperwork";
+    inherit version;
+    sha256 = "0kdbwdm3d7r7dna7gw5jj2lvalzzdyj4r6dvcadj3z3d0ybx4ich";
+  };
+  backend = python3Packages.fetchPypi {
+    pname = "paperwork-backend";
+    inherit version;
+    sha256 = "1fy0349dqc7aqdg1igkk5j5vw0ybhks7ykxfqnndgf0zkrrlzmfg";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Update to latest stable version of paperwork. In the meantime (since the last bump) the source tree layout has changed and I switched to fetching the releases from PyPi instead. The source repository is lacking a few files (namely the version descriptions) on the release tags thus using those PyPi source releases seems to be a sane approach.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

