### PR TITLE
darwin.apple_sdk: update to 10.13

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -3,25 +3,24 @@
 let
   # TODO: make this available to other packages and generalize the unpacking a bit
   # from https://gist.github.com/pudquick/ff412bcb29c9c1fa4b8d
-  # This isn't needed until we get to SDK 10.11, but that presents other challenges
-  # unpbzx = fetchurl {
-  #   url    = "https://gist.githubusercontent.com/pudquick/ff412bcb29c9c1fa4b8d/raw/24b25538ea8df8d0634a2a6189aa581ccc6a5b4b/parse_pbzx2.py";
-  #   sha256 = "0jgp6qbfl36i0jlz7as5zk2w20z4ca8wlrhdw49lwsld6wi3rfhc";
-  # };
+  unpbzx = fetchurl {
+    url    = "https://gist.githubusercontent.com/pudquick/ff412bcb29c9c1fa4b8d/raw/24b25538ea8df8d0634a2a6189aa581ccc6a5b4b/parse_pbzx2.py";
+    sha256 = "0jgp6qbfl36i0jlz7as5zk2w20z4ca8wlrhdw49lwsld6wi3rfhc";
+  };
 
   # sadly needs to be exported because security_tool needs it
   sdk = stdenv.mkDerivation rec {
-    version = "10.10";
+    version = "10.13";
     name    = "MacOS_SDK-${version}";
 
-    # This URL comes from https://swscan.apple.com/content/catalogs/others/index-10.10.merged-1.sucatalog, which we found by:
+    # This URL comes from https://swscan.apple.com/content/catalogs/others/index-10.13.merged-1.sucatalog, which we found by:
     #  1. Google: site:swscan.apple.com and look for a name that seems appropriate for your version
-    #  2. In the resulting file, search for a file called DevSDK ending in .pkg
+    #  2. In the resulting file, search for a file called DevSDK ending in .pkg, prefer the latest one based on `PostDate`
     #  3. ???
     #  4. Profit
     src = fetchurl {
-      url    = "http://swcdn.apple.com/content/downloads/22/52/031-45139/hcjjv7cm4n6yqk56ict73qqw15ikm5iaql/DevSDK_OSX1010.pkg";
-      sha256 = "08bxa93zw7r4vzs28j9giq2qyk3b68ky6jx1bb9850gflr3nvgq1";
+      url    = "http://swcdn.apple.com/content/downloads/17/04/091-87532/na7u7461yf0watevifclf88mz06kspm896/DevSDK_macOS1013_Public.pkg";
+      sha256 = "12z2wac3fhh8rzjri6il9fq83fr3a6clk5lsz4gyh71c4jingzfq";
     };
 
     buildInputs = [ xar xz cpio python ];
@@ -31,13 +30,14 @@ let
 
     unpackPhase = ''
       xar -x -f $src
+      python ${unpbzx} Payload
     '';
 
     installPhase = ''
       start="$(pwd)"
       mkdir -p $out
       cd $out
-      cat $start/Payload | gzip -d | cpio -idm
+      cat $start/Payload.*.xz | xz -d | cpio -idm
 
       mv usr/* .
       rmdir usr
@@ -155,6 +155,30 @@ let
   };
 in rec {
   libs = {
+    availability = stdenv.mkDerivation {
+      name   = "apple-lib-availability";
+      phases = [ "installPhase" "fixupPhase" ];
+
+      installPhase = ''
+        mkdir -p $out/include/os
+        cp "${lib.getDev sdk}/include/AvailabilityInternal.h" $out/include/AvailabilityInternal.h
+        cp "${lib.getDev sdk}/include/os/availability.h" $out/include/os/availability.h
+      '';
+    };
+
+    utmp = stdenv.mkDerivation {
+      name   = "apple-lib-utmp";
+      phases = [ "installPhase" "fixupPhase" ];
+
+      installPhase = ''
+        mkdir -p $out/include
+        pushd $out/include >/dev/null
+        ln -s "${lib.getDev sdk}/include/utmp.h"
+        ln -s "${lib.getDev sdk}/include/utmpx.h"
+        popd >/dev/null
+      '';
+    };
+
     xpc = stdenv.mkDerivation {
       name   = "apple-lib-xpc";
       phases = [ "installPhase" "fixupPhase" ];
@@ -183,19 +207,6 @@ in rec {
         mkdir -p $out/include $out/lib
         ln -s "${lib.getDev sdk}/include/Xplugin.h" $out/include/Xplugin.h
         ln -s "/usr/lib/libXplugin.1.dylib" $out/lib/libXplugin.dylib
-      '';
-    };
-
-    utmp = stdenv.mkDerivation {
-      name   = "apple-lib-utmp";
-      phases = [ "installPhase" "fixupPhase" ];
-
-      installPhase = ''
-        mkdir -p $out/include
-        pushd $out/include >/dev/null
-        ln -s "${lib.getDev sdk}/include/utmp.h"
-        ln -s "${lib.getDev sdk}/include/utmpx.h"
-        popd >/dev/null
       '';
     };
   };

--- a/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/frameworks.nix
@@ -22,9 +22,10 @@ with frameworks; with libs; {
   CalendarStore           = [];
   Cocoa                   = [ AppKit ];
   Collaboration           = [];
+  ColorSync               = [];
   # Impure version of CoreFoundation, this should not be used unless another
   # framework includes headers that are not available in the pure version.
-  CoreFoundation          = [];
+  CoreFoundation          = [ availability ];
   CoreAudio               = [ CF IOKit ];
   CoreAudioKit            = [ AudioUnit ];
   CoreData                = [];
@@ -107,7 +108,7 @@ with frameworks; with libs; {
 
   # Umbrellas
   Accelerate          = [ CoreWLAN IOBluetooth ];
-  ApplicationServices = [ CF CoreServices CoreText ImageIO ];
+  ApplicationServices = [ CF CoreServices CoreText ImageIO ColorSync ];
   Carbon              = [ ApplicationServices CF CoreServices Foundation IOKit Security QuartzCore ];
   CoreBluetooth       = [];
   CoreServices        = [ CFNetwork CoreAudio CoreData CF DiskArbitration Security NetFS OpenDirectory ServiceManagement ];

--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/default.nix
@@ -33,6 +33,7 @@ appleDerivation rec {
     #define TARGET_OS_WIN32         0
     #define TARGET_OS_UNIX          0
     #define TARGET_OS_EMBEDDED      0
+    #define TARGET_OS_OSX           1
     #define TARGET_OS_IPHONE        0
     #define TARGET_IPHONE_SIMULATOR 0
     #define TARGET_OS_LINUX         0


### PR DESCRIPTION
###### Motivation for this change

10.10 SDKs don't support type arguments in Foundation classes, leading to "type arguments cannot be applied to non-parameterized class" errors.

Based on 377cef8d16c47df74d2653432d9bba968236c8a0.

## WARNING:

This will cause mass rebuilds on Darwin, and should be merged into staging I think, rather than master, please advise whether I should submit the PR against staging instead (it has merge conflicts between master and staging so if I submit it against staging it won't apply cleanly on master and vice versa).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---