### PR TITLE
Deedle: 1.2.0 -> 1.2.5

### DIFF
--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -402,50 +402,11 @@ let self = dotnetPackages // overrides; dotnetPackages = with self; {
     };
   };
 
-  Deedle = buildDotnetPackage rec {
+  Deedle = fetchNuGet rec {
     baseName = "Deedle";
-    version = "1.2.0";
-
-    src = fetchFromGitHub {
-      owner = "BlueMountainCapital";
-      repo = baseName;
-      rev = "v${version}";
-      sha256 = "115zzh3q57w8wr02cl2v8wijnj1rg01j1mk9zbzixbb4aird72n5";
-    };
-
-    # Enough files from this repo are needed that it will be quicker to just get the entire repo
-    fsharpDataSrc = fetchFromGitHub {
-      owner = "fsharp";
-      repo = "FSharp.Data";
-      rev = "2.2.3";
-      sha256 = "1h3v9rc8k0khp61cv5n01larqbxd3xcx3q52sw5zf9l0661vw7qr";
-    };
-
-    buildInputs = [
-      fsharp
-      dotnetPackages.FsCheck
-      dotnetPackages.FSharpCompilerService
-      dotnetPackages.FSharpData
-      dotnetPackages.FSharpFormatting
-      dotnetPackages.MathNetNumerics
-      dotnetPackages.NUnit
-    ];
-
-    preConfigure = ''
-      mkdir -vp paket-files/fsharp
-      ln -sv ${fsharpDataSrc} paket-files/fsharp/FSharp.Data
-    '';
-
-    xBuildFiles = [ "Deedle.Core.sln" ];  # Come back later to get RProvider as well
-    outputFiles = [ "bin/*" "LICENSE.md" ];
-
-    meta = {
-      description = "Deedle is an easy to use library for data and time series manipulation and for scientific programming";
-      homepage = "http://bluemountaincapital.github.io/Deedle/";
-      license = stdenv.lib.licenses.free;
-      maintainers = with stdenv.lib.maintainers; [ obadz ];
-      platforms = with stdenv.lib.platforms; linux;
-    };
+    version = "1.2.5";
+    sha256 = "0g19ll6bp97ixprcnpwwvshr1n9jxxf9xjhkxp0r63mg46z48jnw";
+    outputFiles = [ "*" ];
   };
 
   ExcelDna = buildDotnetPackage rec {


### PR DESCRIPTION
Deedle was outdated and the build was failing.

This probably needs backporting to 18.09 (#45960)


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---