### PR TITLE
pythonPackages.pyodbc: fix build

### DIFF
--- a/pkgs/development/python-modules/pyodbc/default.nix
+++ b/pkgs/development/python-modules/pyodbc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPyPy, libiodbc }:
+{ stdenv, buildPythonPackage, fetchPypi, isPyPy, unixODBC }:
 
 buildPythonPackage rec {
   pname = "pyodbc";
@@ -10,7 +10,9 @@ buildPythonPackage rec {
     sha256 = "4326abb737dec36156998d52324921673d30f575e1e0998f0c5edd7de20e61d4";
   };
 
-  buildInputs = [ libiodbc ];
+  buildInputs = [ unixODBC ];
+
+  doCheck = false; # tests require a database server
 
   meta = with stdenv.lib; {
     description = "Python ODBC module to connect to almost any database";


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960.
Build failed with libiodbc after pyodbc 4.0.23->4.0.24 update: https://hydra.nixos.org/build/80724929.

To fix, build with unixODBC instead of libiodbc, see discussion in https://github.com/mkleehammer/pyodbc/issues/444

###### Things done

- [x] Built in a sandbox on NixOS

---

