### PR TITLE
go: skip flaky os/exec TestExtraFiles

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -125,6 +125,7 @@ stdenv.mkDerivation rec {
     ./remove-fhs-test-references.patch
     ./skip-external-network-tests.patch
     ./skip-nohup-tests.patch
+    ./skip-test-extra-files-on-386.patch
   ];
 
   postPatch = optionalString stdenv.isDarwin ''

--- a/pkgs/development/compilers/go/skip-test-extra-files-on-386.patch
+++ b/pkgs/development/compilers/go/skip-test-extra-files-on-386.patch
@@ -1,0 +1,15 @@
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index 558345ff63..22129bf022 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -593,6 +593,10 @@ func TestExtraFiles(t *testing.T) {
+ 		t.Skipf("skipping test on %q", runtime.GOOS)
+ 	}
+ 
++	if runtime.GOOS == "linux" && runtime.GOARCH  == "386" {
++		t.Skipf("skipping test on %q %q", runtime.GOARCH, runtime.GOOS)
++	}
++
+ 	// Ensure that file descriptors have not already been leaked into
+ 	// our environment.
+ 	if !testedAlreadyLeaked {


### PR DESCRIPTION
###### Motivation for this change

Currently the builds regarding go 1.11 on i686-linux are failing. This hits a number of NixOS tests.

The test only fails on i686 and not just on NixOS. It also happens on
Debian. For more information:

https://github.com/golang/go/issues/25628

This probably needs to be backported to 18.09 (#45960)

Closes #46705

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

