### PR TITLE
ios-depoy: Add missing rsync dep

### DIFF
--- a/pkgs/development/node-packages/default-v8.nix
+++ b/pkgs/development/node-packages/default-v8.nix
@@ -27,14 +27,15 @@ nodePackages // {
     '';
   };
 
-  ios-deploy = nodePackages.ios-deploy.override {
+  ios-deploy = nodePackages.ios-deploy.override (drv: {
+    nativeBuildInputs = drv.nativeBuildInputs or [] ++ [ pkgs.buildPackages.rsync ];
     preRebuild = ''
       LD=$CC
       tmp=$(mktemp -d)
       ln -s /usr/bin/xcodebuild $tmp
       export PATH="$PATH:$tmp"
     '';
-  };
+  });
 
   fast-cli = nodePackages."fast-cli-1.x".override {
     preRebuild = ''


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @luigy
