### PR TITLE
sops: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/tools/security/sops/default.nix
+++ b/pkgs/tools/security/sops/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "sops-${version}";
-  version = "3.0.2";
+  version = "3.1.0";
 
   goPackagePath = "go.mozilla.org/sops";
 
@@ -10,12 +10,12 @@ buildGoPackage rec {
     rev = version;
     owner = "mozilla";
     repo = "sops";
-    sha256 = "0zszlb35cmw9j9dg1bpcbwxwh094wcfxhas4ns58jp5n79rqwv9i";
+    sha256 = "02s85affgs2991p4akff68myx4h7m3jcly6xihv9g2knml7ixrkj";
   };
 
   meta = with stdenv.lib; {
+    inherit (src.meta) homepage;
     description = "Mozilla sops (Secrets OPerationS) is an editor of encrypted files";
-    homepage = https://github.com/mozilla/sops;
     license = licenses.mpl20;
   };
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

