### PR TITLE
[18.03] php: 5.6.37 -> 5.6.38, 7.0.31 -> 7.0.32

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -338,8 +338,8 @@ let
 
 in {
   php56 = generic {
-    version = "5.6.37";
-    sha256 = "08wbg1qbbr80wcpv0l24vfyd9w8cxanils928gjs6knr0lyxcsl8";
+    version = "5.6.38";
+    sha256 = "00xw7rcq36dlrzgx9nr96jc64gnnrxjxkkpmkr1y8fynpldj6nyn";
   };
 
   php70 = generic {

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -343,8 +343,8 @@ in {
   };
 
   php70 = generic {
-    version = "7.0.31";
-    sha256 = "14bb230qip62cn7k6hvgr18kxj76zvl735fkg6hpkrnnrqzdg2vy";
+    version = "7.0.32";
+    sha256 = "1qcjch3293h3fwci767x9rih3nrvz02rhn33hvx8l5q8kk7xis2n";
   };
 
   php71 = generic {


### PR DESCRIPTION
###### Motivation for this change
These versions doesn't exist in unstable or 18.09 due to them both being EOL in december this year, but php tend to release bugfixes.

We would need someone to trigger the darwin build to see if the same bug as in #46694 exists in these versions. If so we shouldn't merge this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @xeji 