### PR TITLE
android-platform-tools: 26.0.2 -> 28.0.1

### DIFF
--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     ${stdenv.lib.optionalString (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
       ''
-        for i in adb dmtracedump fastboot hprof-conv sqlite3
+        for i in adb dmtracedump e2fsdroid fastboot hprof-conv make_f2fs mke2fs sload_f2fs sqlite3
         do
             patchelf --set-interpreter ${stdenv.cc.libc.out}/lib/ld-linux-x86-64.so.2 $i
             patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:`pwd`/lib64 $i

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -6,16 +6,16 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "26.0.2";
+  version = "28.0.1";
   name = "android-platform-tools-r${version}";
   src = if (stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux")
     then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-linux.zip";
-      sha256 = "0695npvxljbbh8xwfm65k34fcpyfkzvfkssgnp46wkmnq8w5mcb3";
+      sha256 = "14kkr9xib5drjjd0bclm0jn3f5xlmlg652mbv4xd83cv7a53a49y";
     }
     else if stdenv.hostPlatform.system == "x86_64-darwin" then fetchurl {
       url = "https://dl.google.com/android/repository/platform-tools_r${version}-darwin.zip";
-      sha256 = "0gy7apw9pmnnm41z6ywglw5va4ghmny4j57778may4q7ar751l56";
+      sha256 = "117syrddq1haicwyjzd1p4pfphj0wldjs7w10fpk3n2b7yp37j1v";
     }
     else throw "System ${stdenv.hostPlatform.system} not supported!";
 


### PR DESCRIPTION
###### Motivation for this change

Updating to latest platform tools for supporting newer devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Successfully tested by flashing my Pixel 2 and perfroming remote operations via adb.

I do not have a MacOS device around for testing, but made sure the SHA256 hash for x86_64-darwin matches:

```
nix-prefetch-url "https://dl.google.com/android/repository/platform-tools_r28.0.1-darwin.zip"
path is '/nix/store/5ii60jmd4fd4r4g2f2y7f8b5i27r73g3-platform-tools_r28.0.1-darwin.zip'
117syrddq1haicwyjzd1p4pfphj0wldjs7w10fpk3n2b7yp37j1v
```