### PR TITLE
scrcpy: 1.2 -> 1.3

### DIFF
--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -9,10 +9,10 @@
 }:
 
 let
-  version = "1.2";
+  version = "1.3";
   prebuilt_server = fetchurl {
     url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}.jar";
-    sha256 = "0q0zyqw7y33r9ybjp8ay6yac7ifca1lq14pjvw6x78zxs976affb";
+    sha256 = "1ha04wfmghblwr9ajfl96cswacfgrk0b7klq2ixfvw1kgwhmm6hg";
   };
 in
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "Genymobile";
     repo = "scrcpy";
     rev = "v${version}";
-    sha256 = "01zw6h6mz2cwqfh9lwypm8pbfx9m9df91l1fq1i0f1d8v49x8wqc";
+    sha256 = "02szi8w3w0lacyz42hlayxififi863qpm63yg9qir3jcl2vs7vdk";
   };
 
   nativeBuildInputs = [ makeWrapper meson ninja pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Update to newest version: Running 1.2 I ran into issues when changing my Pixel 2's resolution, 1.3 seems to have fixed those.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also tested with updated android-platform-tools from PR #46720.