### PR TITLE
emby: 3.4.1.0 -> 3.5.2.0

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -1,22 +1,31 @@
-{ stdenv, fetchurl, pkgs, unzip, sqlite, makeWrapper, mono54, ffmpeg, ... }:
+{ stdenv, fetchurl, unzip, sqlite, makeWrapper, mono54, ffmpeg }:
 
 stdenv.mkDerivation rec {
   name = "emby-${version}";
-  version = "3.4.1.0";
+  version = "3.5.2.0";
 
+  # We are fetching a binary here, however, a source build is possible.
+  # See -> https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=emby-server-git#n43
+  # Though in my attempt it failed with this error repeatedly
+  # The type 'Attribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'.
+  # This may also need msbuild (instead of xbuild) which isn't in nixpkgs
+  # See -> https://github.com/NixOS/nixpkgs/issues/29817
   src = fetchurl {
-    url = "https://github.com/MediaBrowser/Emby/releases/download/${version}/Emby.Mono.zip";
-    sha256 = "08jr6v8xhmiwbby0lfvpjrlma280inwh5qp6v4p93lzd07fjynh5";
+    url = "https://github.com/MediaBrowser/Emby.Releases/releases/download/${version}/embyserver-mono_${version}.zip";
+    sha256 = "12f9skvnr9qxnrvr3q014yggfwvkpjk0ynbgf0fwk56h4kal7fx8";
   };
 
-  buildInputs = with pkgs; [
+  buildInputs = [
     unzip
     makeWrapper
   ];
-  propagatedBuildInputs = with pkgs; [
+
+  propagatedBuildInputs = [
     mono54
     sqlite
   ];
+
+  preferLocalBuild = true;
 
   # Need to set sourceRoot as unpacker will complain about multiple directory output
   sourceRoot = ".";
@@ -27,18 +36,18 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -r * $out/bin
+    mkdir -p "$out/bin"
+    cp -r * "$out/bin"
 
     makeWrapper "${mono54}/bin/mono" $out/bin/MediaBrowser.Server.Mono \
       --add-flags "$out/bin/MediaBrowser.Server.Mono.exe -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
-  meta = {
+  meta =  with stdenv.lib; {
     description = "MediaBrowser - Bring together your videos, music, photos, and live television";
     homepage = https://emby.media/;
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.fadenb ];
-    platforms = stdenv.lib.platforms.all;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ fadenb ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
An update and #44884 had conflicts.

@numinit noticed this
```
System.UnauthorizedAccessException: Access to the path "/nix/store/nfmvvn6jv5b29q8a1m8pz2mmx4y3fjfn-emby-3.5.2.0/bin/plugins/Emby.Server.CinemaMode.dll" or "/var/lib/emby/ProgramData-Server/plugins/Emby.Server.CinemaMode.dll" is denied.
  at System.IO.File.Copy (System.String sourceFileName, System.String destFileName, System.Boolean overwrite) [0x00192] in <2bf5cbaa96234d758393ee9c32a4b268>:0
  at Emby.Server.Implementations.ApplicationHost.CopyPlugins (System.String source, System.String target) [0x0008f] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetPluginAssemblies () [0x00023] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetComposablePartAssemblies () [0x00000] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.DiscoverTypes () [0x00015] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.Init () [0x0009b] in <ea7199aea78e429a84e168a1e154646a>:0
  at MediaBrowser.Server.Mono.MainClass.RunApplication (Emby.Server.Implementations.ServerApplicationPaths appPaths, MediaBrowser.Model.Logging.ILogManager logManager, Emby.Server.Implementations.StartupOptions options) [0x000c2] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
  at MediaBrowser.Server.Mono.MainClass.Main (System.String[] args) [0x0009c] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
System.UnauthorizedAccessException
  at System.IO.File.Copy (System.String sourceFileName, System.String destFileName, System.Boolean overwrite) [0x00192] in <2bf5cbaa96234d758393ee9c32a4b268>:0
  at Emby.Server.Implementations.ApplicationHost.CopyPlugins (System.String source, System.String target) [0x0008f] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetPluginAssemblies () [0x00023] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetComposablePartAssemblies () [0x00000] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.DiscoverTypes () [0x00015] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.Init () [0x0009b] in <ea7199aea78e429a84e168a1e154646a>:0
  at MediaBrowser.Server.Mono.MainClass.RunApplication (Emby.Server.Implementations.ServerApplicationPaths appPaths, MediaBrowser.Model.Logging.ILogManager logManager, Emby.Server.Implementations.StartupOptions options) [0x000c2] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
  at MediaBrowser.Server.Mono.MainClass.Main (System.String[] args) [0x0009c] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
```

This is going on here [Emby.Server.Implementations.ApplicationHost.CopyPlugins](https://github.com/MediaBrowser/Emby/blob/f1998b6aa926269761071990e829ae4f5b351745/Emby.Server.Implementations/ApplicationHost.cs#L1814)
Any ideas?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

