### PR TITLE
ocamlPackages.odoc: init at 1.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/doc-ock-html/default.nix
+++ b/pkgs/development/ocaml-modules/doc-ock-html/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, dune, doc-ock, tyxml, xmlm }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-doc-ock-html-${version}";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-doc";
+    repo = "doc-ock-html";
+    rev = "v${version}";
+    sha256 = "1y620h48qrplmcm78g7c78zibpkai4j3icwmnx95zb3r8xq8554y";
+  };
+
+  buildInputs = [ ocaml findlib dune ];
+
+  propagatedBuildInputs = [ doc-ock tyxml xmlm ];
+
+  inherit (dune) installPhase;
+
+  meta = {
+    description = "From doc-ock to HTML";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/development/ocaml-modules/doc-ock-xml/default.nix
+++ b/pkgs/development/ocaml-modules/doc-ock-xml/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, dune, doc-ock, menhir, xmlm }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-doc-ock-xml-${version}";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-doc";
+    repo = "doc-ock-xml";
+    rev = "v${version}";
+    sha256 = "1s27ri7vj9ixi5p5ixg6g6invk96807bvxbqjrr1dm8sxgl1nd20";
+  };
+
+  buildInputs = [ ocaml findlib dune ];
+
+  propagatedBuildInputs = [ doc-ock menhir xmlm ];
+
+  inherit (dune) installPhase;
+
+  meta = {
+    description = "XML printer and parser for Doc-Ock";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/development/ocaml-modules/doc-ock/default.nix
+++ b/pkgs/development/ocaml-modules/doc-ock/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, dune, octavius, cppo }:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-doc-ock-${version}";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ocaml-doc";
+    repo = "doc-ock";
+    rev = "v${version}";
+    sha256 = "090vprm12jrl55yllk1hdzbsqyr107yjs2qnc49yahdhvnr4h5b7";
+  };
+
+  buildInputs = [ ocaml findlib dune cppo ];
+
+  propagatedBuildInputs = [ octavius ];
+
+  inherit (dune) installPhase;
+
+  meta = {
+    description = "Extract documentation from OCaml files";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, dune
+, bos, cmdliner, doc-ock-html, doc-ock-xml
+}:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-odoc-${version}";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "ocaml";
+    repo = "odoc";
+    rev = "v${version}";
+    sha256 = "0ixnhfpm1nw4bvjj8qhcyy283pdr5acqpg5wxwq3n1l4mad79cgh";
+  };
+
+  buildInputs = [ ocaml findlib dune cmdliner ];
+
+  propagatedBuildInputs = [ bos doc-ock-html doc-ock-xml ];
+
+  inherit (dune) installPhase;
+
+  meta = {
+    description = "A documentation generator for OCaml";
+    license = stdenv.lib.licenses.isc;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (ocaml.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -222,6 +222,8 @@ let
 
     doc-ock =  callPackage ../development/ocaml-modules/doc-ock { };
 
+    doc-ock-html =  callPackage ../development/ocaml-modules/doc-ock-html { };
+
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -220,6 +220,8 @@ let
 
     digestif =  callPackage ../development/ocaml-modules/digestif { };
 
+    doc-ock =  callPackage ../development/ocaml-modules/doc-ock { };
+
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -224,6 +224,8 @@ let
 
     doc-ock-html =  callPackage ../development/ocaml-modules/doc-ock-html { };
 
+    doc-ock-xml =  callPackage ../development/ocaml-modules/doc-ock-xml { };
+
     dolmen =  callPackage ../development/ocaml-modules/dolmen { };
 
     dolog = callPackage ../development/ocaml-modules/dolog { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -541,6 +541,8 @@ let
 
     octavius = callPackage ../development/ocaml-modules/octavius { };
 
+    odoc = callPackage ../development/ocaml-modules/odoc { };
+
     ojquery = callPackage ../development/ocaml-modules/ojquery { };
 
     omd = callPackage ../development/ocaml-modules/omd { };


### PR DESCRIPTION
###### Motivation for this change

odoc is a documentation generator for OCaml.

This PR also adds a few dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

