### PR TITLE
cctools: support LTO on Darwin

### DIFF
--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -119,12 +119,14 @@ in stdenv.mkDerivation (rec {
   + stdenv.lib.optionalString enableSharedLibraries ''
     moveToOutput "lib/libLLVM-*" "$lib"
     moveToOutput "lib/libLLVM${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
+    moveToOutput "lib/libLTO${stdenv.hostPlatform.extensions.sharedLibrary}" "$lib"
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
       --replace "\''${_IMPORT_PREFIX}/lib/libLLVM-" "$lib/lib/libLLVM-"
   ''
   + stdenv.lib.optionalString (stdenv.isDarwin && enableSharedLibraries) ''
     substituteInPlace "$out/lib/cmake/llvm/LLVMExports-${if debugVersion then "debug" else "release"}.cmake" \
-      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib"
+      --replace "\''${_IMPORT_PREFIX}/lib/libLLVM.dylib" "$lib/lib/libLLVM.dylib" \
+      --replace "\''${_IMPORT_PREFIX}/lib/libLTO.dylib" "$lib/lib/libLTO.dylib"
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${shortVersion}.dylib
     ln -s $lib/lib/libLLVM.dylib $lib/lib/libLLVM-${release_version}.dylib
   '';

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/default.nix
@@ -1,8 +1,6 @@
-{ cctools, appleDerivation }:
+{ appleDerivation }:
 
 appleDerivation {
-  nativeBuildInputs = [ cctools ];
-
   patches = [ ./clang-5.patch ];
 
   postPatch = ''

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -215,7 +215,7 @@ let
 
     # Splicing is currently broken in Nixpkgs
     # cctools need to be specified manually here to handle this
-    ICU             = applePackage "ICU"               "osx-10.10.5"     "1qihlp42n5g4dl0sn0f9pc0bkxy1452dxzf0vr6y5gqpshlzy03p" { inherit (buildPackages.darwin) cctools; };
+    ICU             = applePackage "ICU"               "osx-10.10.5"     "1qihlp42n5g4dl0sn0f9pc0bkxy1452dxzf0vr6y5gqpshlzy03p" {};
 
     IOKit           = applePackage "IOKit"             "osx-10.11.6"     "0kcbrlyxcyirvg5p95hjd9k8a01k161zg0bsfgfhkb90kh2s8x00" { inherit IOKitSrcs; };
     launchd         = applePackage "launchd"           "osx-10.9.5"      "0w30hvwqq8j5n90s3qyp0fccxflvrmmjnicjri4i1vd2g196jdgj" {};

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool_2, autoreconfHook
-, libcxxabi, libuuid
+, libcxxabi, libuuid, llvm
 , libobjc ? null, maloader ? null
 , enableDumpNormalizedLibArgs ? false
 }:
@@ -56,7 +56,7 @@ let
       autoreconfHook
     ];
     buildInputs = [ libuuid ] ++
-      stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ];
+      stdenv.lib.optionals stdenv.isDarwin [ llvm libcxxabi libobjc ];
 
     patches = [
       ./ld-rpath-nonfinal.patch ./ld-ignore-rpath-link.patch

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -201,6 +201,7 @@ in rec {
       python2 = self.python;
 
       ninja = super.ninja.override { buildDocs = false; };
+      darwin = super.darwin // { cctools = super.darwin.cctools.override { llvm = null; }; };
     };
   in with prevStage; stageFun 1 prevStage {
     extraPreHook = "export NIX_CFLAGS_COMPILE+=\" -F${bootstrapTools}/Library/Frameworks\"";


### PR DESCRIPTION
LTO is disabled during bootstrap to keep the bootstrap tools small and avoid unnecessary LLVM rebuilds, but is enabled in the final stdenv stage and should be usable by normal packages.

###### Motivation for this change

Enables better optimization if packages want it. Also, why not? 😄 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

