### PR TITLE
python.pkgs.asyncssh: 1.13.3 -> 1.14.0

### DIFF
--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -1,18 +1,19 @@
 { stdenv, buildPythonPackage, fetchPypi, pythonOlder
 , cryptography
-, bcrypt, gssapi, libnacl, libsodium, nettle, pyopenssl }:
+, bcrypt, gssapi, libnacl, libsodium, nettle, pyopenssl
+, openssl }:
 
 buildPythonPackage rec {
   pname = "asyncssh";
-  version = "1.13.3";
+  version = "1.14.0";
   disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "eb5b190badc5cd2a506a1b6ced3e92f948166974eef7d1abab61acc67aa379e6";
+    sha256 = "0f1i5a760a3jylkj00bxkshnylzyhyqz50v8mb8s9ygllpzja058";
   };
 
-  propagatedBuildInputs = [ 
+  propagatedBuildInputs = [
     bcrypt
     cryptography
     gssapi
@@ -22,6 +23,8 @@ buildPythonPackage rec {
     pyopenssl
   ];
 
+  checkInputs = [ openssl ];
+
   # Disables windows specific test (specifically the GSSAPI wrapper for Windows)
   postPatch = ''
     rm ./tests/sspi_stub.py
@@ -29,8 +32,8 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Provides an asynchronous client and server implementation of the SSHv2 protocol on top of the Python asyncio framework";
-    homepage = https://pypi.python.org/pypi/asyncssh;
-    license = licenses.epl10;
+    homepage    = https://pypi.python.org/pypi/asyncssh;
+    license     = licenses.epl20;
     maintainers = with maintainers; [ worldofpeace ];
   };
 }


### PR DESCRIPTION
[Change Log](https://github.com/ronf/asyncssh/blob/0c610d0f296593f4814ff1f2a3be18ee26a7b204/docs/changes.rst#change-log)

This includes changing the license from EPL 1.0 to EPL 2.0.

`openssl` was added to `checkInputs` because this [test](https://github.com/ronf/asyncssh/blob/0c610d0f296593f4814ff1f2a3be18ee26a7b204/tests/test_public_key.py) fails very early on without it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

