### PR TITLE
mpack: Invoke /run/wrappers/bin/sendmail via execvp

### DIFF
--- a/pkgs/tools/networking/mpack/default.nix
+++ b/pkgs/tools/networking/mpack/default.nix
@@ -8,16 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "0k590z96509k96zxmhv72gkwhrlf55jkmyqlzi72m61r7axhhh97";
   };
 
-  patches = [ ./build-fix.patch ];
+  patches = [ ./build-fix.patch ./sendmail-via-execvp.diff ];
 
   postPatch = ''
     for f in *.{c,man,pl,unix} ; do
       substituteInPlace $f --replace /usr/tmp /tmp
-    done
-
-    for f in unixpk.c ; do
-      substituteInPlace $f \
-        --replace /usr/sbin /run/current-system/sw/bin
     done
 
     # this just shuts up some warnings

--- a/pkgs/tools/networking/mpack/sendmail-via-execvp.diff
+++ b/pkgs/tools/networking/mpack/sendmail-via-execvp.diff
@@ -1,0 +1,12 @@
+--- mpack-1.6/unixpk.c	2003-07-21 22:50:41.000000000 +0200
++++ mpack-1.6/unixpk.c	2018-09-16 12:57:14.104026964 +0200
+@@ -254,8 +254,9 @@
+ #ifdef SCO
+     execv("/usr/lib/mail/execmail", addr+start);
+ #else
++    execvp("sendmail", addr+start);
+     execv("/usr/lib/sendmail", addr+start);
+     execv("/usr/sbin/sendmail", addr+start);
+ #endif
+     perror("execv");
+     _exit(1);


### PR DESCRIPTION
Calling /run/current-sw/bin/sendmail fails under postfix because
setgid bits are not set. Switching the hardcoded path to an invocation
via execvp should cover both cases, when the sendmail binary is
setgid-wrapped and when it is not.

###### Motivation for this change
mpack can't send mails under a postfix installation, as the setgid bits are missing in postdrop.
```
$ strace -etrace=execve -f mpack -s ethereum-cc.pdf tmp.pdf clemens@endorphin.org                                                          execve("/home/clemens/.nix-profile/bin/mpack", ["mpack", "-s", "ethereum-cc.pdf", "tmp.pdf", "clemens@endorphin.org"], 0x7ffeb53e6220 /* 82 vars */) = 0
strace: Process 36692 attached
[pid 36692] execve("/usr/lib/sendmail", ["sendmail", "-oi", "clemens@endorphin.org"], 0x7ffe0fc75808 /* 82 vars */) = -1 ENOENT (No such file or directory)
[pid 36692] execve("/run/current-system/sw/bin/sendmail", ["sendmail", "-oi", "clemens@endorphin.org"], 0x7ffe0fc75808 /* 82 vars */) = 0
strace: Process 36693 attached
[pid 36693] execve("/nix/store/a9ck93r3rw8frqph73fhgr0mfvs6dzv8-postfix-3.3.1/bin/postdrop", ["/nix/store/a9ck93r3rw8frqph73fhg"..., "-r"], 0x563f5b430220 /* 2 vars */) = 0
postdrop: warning: mail_queue_enter: create file maildrop/528081.36693: Permission denied
postdrop: warning: mail_queue_enter: create file maildrop/528270.36693: Permission denied
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

