### PR TITLE
sierra-gtk-theme: init at 2018-09-14

### DIFF
--- a/pkgs/misc/themes/sierra/default.nix
+++ b/pkgs/misc/themes/sierra/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, libxml2, gdk_pixbuf, librsvg, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "sierra-gtk-theme-${version}";
+  version = "2018-09-14";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "sierra-gtk-theme";
+    rev = "4c07f9e4978ab2d87ce0f8d4a5d60da21784172c";
+    sha256 = "0mp5v462wbjq157hfnqzd8sw374mc611kpk92is2c3qhvj5qb6qd";
+  };
+
+  nativeBuildInputs = [ libxml2 ];
+
+  buildInputs = [ gdk_pixbuf librsvg ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    patchShebangs .
+    mkdir -p $out/share/themes
+    name= ./install.sh --dest $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Mac OSX like theme for GTK based desktop environments";
+    homepage = https://github.com/vinceliuice/Sierra-gtk-theme;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22007,6 +22007,8 @@ with pkgs;
     libsemanage = libsemanage.override { python = python3; };
   };
 
+  sierra-gtk-theme = callPackage ../misc/themes/sierra { };
+
   slock = callPackage ../misc/screensavers/slock {
     conf = config.slock.conf or null;
   };


### PR DESCRIPTION
###### Motivation for this change

Add [sierra-gtk-theme](https://github.com/vinceliuice/Sierra-gtk-theme). Sierra is a Mac OSX like theme for GTK 3, GTK 2 and Gnome-Shell which supports GTK 3 and GTK 2 based desktop environments like Gnome, Pantheon, XFCE, Mate, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).