### PR TITLE
fetchgit with leaveDotGit: increase determinism, fix hashes

### DIFF
--- a/pkgs/applications/altcoins/stellar-core.nix
+++ b/pkgs/applications/altcoins/stellar-core.nix
@@ -11,7 +11,7 @@ in stdenv.mkDerivation {
   src = fetchgit {
     url = "https://github.com/stellar/stellar-core.git";
     rev = "refs/tags/v${version}";
-    sha256 = "0ldw3qr0sajgam38z2w2iym0214ial6iahbzx3b965cw92n8n88z";
+    sha256 = "0c4jg4bz0sq2q70n6fdgyh3zsq4mplg5q3mzghxgvzv1vkzn8mmp";
     fetchSubmodules = true;
     leaveDotGit = true;
   };

--- a/pkgs/applications/science/logic/vampire/default.nix
+++ b/pkgs/applications/science/logic/vampire/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "vprover";
     repo = "vampire";
     rev = version;
-    sha256 = "1n0kf0g15yjw3v7z60l51h7fdn880mmvqsbb2szh48vzy20l92il";
+    sha256 = "0dsiz9ry946d9p1m3hkj77b6ybrraya43szhv6gpwnzm4y9yf208";
     fetchSubmodules = true;
     leaveDotGit = true;
   };

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -260,8 +260,7 @@ make_deterministic_repo(){
     done
 
     # Do a full repack. Must run single-threaded, or else we lose determinism.
-    git config pack.threads 1
-    git repack -A -d -f
+    git repack -A -d -F --threads=1
     rm -f .git/config
 
     # Garbage collect unreferenced objects.


### PR DESCRIPTION
###### Motivation for this change

Increase determinism of ```fetchgit``` output when ```leaveDotGit``` is used.

It is not the final solution, as @Mic92 pointed out, the hashes may change if a newer git changes its internal format, but if should prevent the mess like we had with ```gn``` recently (https://github.com/NixOS/nixpkgs/pull/46328 https://github.com/NixOS/nixpkgs/pull/46721 https://github.com/NixOS/nixpkgs/pull/46718)

Also, fixed the hashes which are already incorrect.

