### PR TITLE
exim: add optional support for PAM

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -2,6 +2,7 @@
 , enableLDAP ? false, openldap
 , enableMySQL ? false, mysql, zlib
 , enableAuthDovecot ? false, dovecot
+, enablePAM ? false, pam
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ coreutils db openssl perl pcre ]
     ++ stdenv.lib.optional enableLDAP openldap
     ++ stdenv.lib.optionals enableMySQL [ mysql zlib ]
-    ++ stdenv.lib.optional enableAuthDovecot dovecot;
+    ++ stdenv.lib.optional enableAuthDovecot dovecot
+    ++ stdenv.lib.optional enablePAM pam;
 
   preBuild = ''
     ${stdenv.lib.optionalString enableMySQL "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${mysql}/share/mysql/pkgconfig/"}
@@ -56,6 +58,11 @@ stdenv.mkDerivation rec {
       ''}
       ${stdenv.lib.optionalString enableAuthDovecot ''
         s:^# \(AUTH_DOVECOT\)=.*:\1=yes:
+      ''}
+      ${stdenv.lib.optionalString enablePAM ''
+        s:^# \(SUPPORT_PAM\)=.*:\1=yes:
+        s:^\(EXTRALIBS_EXIM\)=\(.*\):\1=\2 -lpam:
+        s:^# \(EXTRALIBS_EXIM\)=.*:\1=-lpam:
       ''}
       #/^\s*#.*/d
       #/^\s*$/d


### PR DESCRIPTION
CC: @4z3 (Exim package maintainer)

It would be nice if this could be back-ported to `release-18.09` too if it's not too late.