### PR TITLE
ipfs-migrator: 6 -> 7

### DIFF
--- a/pkgs/applications/networking/ipfs-migrator/default.nix
+++ b/pkgs/applications/networking/ipfs-migrator/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "ipfs-migrator-${version}";
-  version = "6";
+  version = "7";
 
   goPackagePath = "github.com/ipfs/fs-repo-migrations";
 
@@ -11,8 +11,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "fs-repo-migrations";
-    rev = "a89e9769b9cac25ad9ca31c7e9a4445c7966d35b";
-    sha256 = "0x4mbkx7wlqjmkg6852hljq947v9y9k3hjd5yfj7kka1hpvxd7bn";
+    rev = "4e8e0b41d7348646c719d572c678c3d0677e541a";
+    sha256 = "1i6izncgc3wgabppglnnrslffvwrv3cazbdhsk4vjfsd66hb4d37";
   };
 
   patches = [ ./lru-repo-path-fix.patch ];

--- a/pkgs/applications/networking/ipfs-migrator/deps.nix
+++ b/pkgs/applications/networking/ipfs-migrator/deps.nix
@@ -1,14 +1,5 @@
 [
   {
-    goPackagePath = "github.com/dustin/go-humanize";
-    fetch = {
-      type = "git";
-      url = https://github.com/dustin/go-humanize;
-      rev = "79e699ccd02f240a1f1fbbdcee7e64c1c12e41aa";
-      sha256 = "0awfqszgjw8qrdw31v74jnvj1jbp7czhd8aq59j57yyj4hy50fzj";
-    };
-  }
-  {
     goPackagePath = "github.com/jbenet/goprocess";
     fetch = {
       type = "git";
@@ -40,8 +31,8 @@
     fetch = {
       type = "git";
       url = https://github.com/hashicorp/golang-lru;
-      rev = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6";
-      sha256 = "1iq7lbpsz7ks052mpznmkf8s4k43p51z4dik2n9ivrxk666q2wxi";
+      rev = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768";
+      sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
     };
   }
   {
@@ -49,8 +40,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "71a035914f99bb58fe82eac0f1289f10963d876c";
-      sha256 = "06m16c9vkwc8m2mcxcxa7p8mb26ikc810lgzd5m8k1r6lp3hc8wm";
+      rev = "26e67e76b6c3f6ce91f7c52def5af501b4e0f3a2";
+      sha256 = "17bqkd64zksi1578lb10ls4qf5lbqs7shfjcc6bi97y1qz5k31c4";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

New version of the ipfs repo migration tools. This is required to migrate existing ipfs repos to repo v7.

Needs backport to 18.09 since existing ipfs repos from 18.03 will have to be migrated to v7 in 18.09.

###### Things done

- [x] built in a sandbox on NixOS

---