### PR TITLE
openspin: init at 2018-10-02

### DIFF
--- a/pkgs/development/compilers/openspin/default.nix
+++ b/pkgs/development/compilers/openspin/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "openspin-${version}";
+  version = "unstable-2018-10-02";
+
+  src = fetchFromGitHub {
+    owner = "parallaxinc";
+    repo = "OpenSpin";
+    rev = "f3a587ed3e4f6a50b3c8d2022bbec5676afecedb";
+    sha256 = "1knkbzdanb60cwp7mggymkhd0167lh2sb1c00d1vhw7s0s1rj96n";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv build/openspin $out/bin/openspin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Compiler for SPIN/PASM languages for Parallax Propeller MCU";
+    homepage = https://github.com/parallaxinc/OpenSpin;
+    license = licenses.mit;
+    maintainers = [ maintainers.redvers ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6869,6 +6869,8 @@ with pkgs;
 
   openshot-qt = libsForQt5.callPackage ../applications/video/openshot-qt { };
 
+  openspin = callPackage ../development/compilers/openspin { };
+
   oraclejdk = pkgs.jdkdistro true false;
 
   oraclejdk8 = pkgs.oraclejdk8distro true false;


### PR DESCRIPTION
###### Motivation for this change
OpenSpin is an open source compiler for the Parallax Propeller MCU.  Additional package for those propeller developers who run on NixOS.

###### Things done

- [✔] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ✔] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [✔] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [✔] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

