### PR TITLE
pyo3-pack: init at 0.3.8

### DIFF
--- a/pkgs/development/tools/rust/pyo3-pack/default.nix
+++ b/pkgs/development/tools/rust/pyo3-pack/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, rustPlatform, dbus, gmp, openssl, pkgconfig
+, darwin }:
+
+let
+  inherit (darwin.apple_sdk.frameworks) Security;
+in rustPlatform.buildRustPackage rec {
+  name = "pyo3-pack-${version}";
+  version = "0.3.8";
+
+  src = fetchFromGitHub {
+    owner = "PyO3";
+    repo = "pyo3-pack";
+    rev = "v${version}";
+    sha256 = "14343209w7wphkqh7pnw08pah09spjbwhk6l548g9ivra057gwaz";
+  };
+
+  cargoSha256 = "0n7z9p3v92ijqc2ix60wi74as5rql61k5qbqi8b1b02b71xmsp7j";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ gmp openssl ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security
+    ++ stdenv.lib.optional stdenv.isLinux dbus;
+
+  # Requires network access, fails in sandbox.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Build and publish crates with pyo3 bindings as python packages";
+    homepage = https://github.com/PyO3/pyo3-pack;
+    license = licenses.mit;
+    maintainers = [ maintainers.danieldk ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7359,6 +7359,7 @@ with pkgs;
   cargo-asm = callPackage ../development/tools/rust/cargo-asm { };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
 
+  pyo3-pack = callPackage ../development/tools/rust/pyo3-pack { };
   rainicorn = callPackage ../development/tools/rust/rainicorn { };
   rustfmt = callPackage ../development/tools/rust/rustfmt { };
   rustracer = callPackage ../development/tools/rust/racer { };


### PR DESCRIPTION
###### Motivation for this change

pyo3-pack is a utility for building Python modules in Rust. It works with binding crates such as pyo3 and cpython.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

