### PR TITLE
particl-qt: init at 0.18.1.4

### DIFF
--- a/pkgs/applications/blockchains/particl/particl-qt.nix
+++ b/pkgs/applications/blockchains/particl/particl-qt.nix
@@ -1,0 +1,87 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, boost, db48, libevent, miniupnpc
+, openssl, pkgconfig, zeromq, zlib, unixtools, python3, makeWrapper, qtbase
+, qttools, qrencode, protobuf, libusb1, hidapi, wrapQtAppsHook, rapidcheck }:
+
+let
+  # Following "borrowed" from yubikey-manager-qt
+  qmlPath = qmlLib: "${qmlLib}/${qtbase.qtQmlPrefix}";
+
+  qml2ImportPath =
+    stdenv.lib.concatMapStringsSep ":" qmlPath [ qtbase.bin qrencode ];
+
+in with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "particl-qt";
+
+  version = "0.18.1.4";
+
+  src = fetchFromGitHub {
+    owner = "particl";
+    repo = "particl-core";
+    rev = "v${version}";
+    sha256 = "1vih5z0zr83g662am52xyk043x2ix2lvvj1a1szc5q2wapl7r0k9";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook wrapQtAppsHook ];
+
+  buildInputs = [
+    openssl
+    db48
+    boost
+    zlib
+    miniupnpc
+    libevent
+    zeromq
+    unixtools.hexdump
+    makeWrapper
+    qtbase
+    qttools
+    qrencode
+    protobuf
+    libusb1
+    hidapi
+  ];
+
+  configureFlags = [
+    "--disable-bench"
+    "--with-boost-libdir=${boost.out}/lib"
+    "--with-gui=qt5"
+    "--enable-usbdevice=yes"
+    "--with-qt-bindir=${qtbase}/bin:${qttools}/bin:${qtbase.dev}/bin:${qttools.dev}/bin"
+  ] ++ optionals (!doCheck) [ "--disable-tests" "--disable-gui-tests" ];
+
+  checkInputs = [ rapidcheck python3 ];
+
+  # Always check during Hydra builds
+  doCheck = true;
+
+  # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Bitcoin's GUI.
+  # See also https://github.com/NixOS/nixpkgs/issues/24256
+  checkFlags = [
+    "LC_ALL=C.UTF-8"
+    "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/particl-qt \
+      --set QML2_IMPORT_PATH "${qml2ImportPath}" \
+      --set QT_PLUGIN_PATH "${qtbase.bin}/${qtbase.qtPluginPrefix}"
+  '';
+
+  preCheck = "patchShebangs test";
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description =
+      "Privacy-Focused Marketplace & Decentralized Application Platform";
+    longDescription = ''
+      An open source, decentralized privacy platform built for global person to person eCommerce.
+    '';
+    homepage = "https://particl.io/";
+    maintainers = with maintainers; [ demyanrogozhin ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21767,6 +21767,7 @@ in
   polkadot = callPackage ../applications/blockchains/polkadot { };
 
   particl-core = callPackage ../applications/blockchains/particl/particl-core.nix { miniupnpc = miniupnpc_2; };
+  particl-qt = libsForQt5.callPackage ../applications/blockchains/particl/particl-qt.nix { miniupnpc = miniupnpc_2; };
 
   ### GAMES
 


### PR DESCRIPTION
###### Motivation for this change

Particl QT wallet that can be used to activate cold staking with Ladger hardware wallet.
Works Linux only so far.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

