### PR TITLE
gtk-doc: don't build with dblatex by default

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python, libxml2Python, libxslt, which
-, docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, dblatex, gettext, itstool
+, docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, gettext, itstool
+, withDblatex ? false, dblatex
 }:
 
 stdenv.mkDerivation rec {
@@ -20,8 +21,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs =
     [ pkgconfig perl python libxml2Python libxslt docbook_xml_dtd_43 docbook_xsl
-      gnome-doc-utils dblatex gettext which itstool
-    ];
+      gnome-doc-utils gettext which itstool
+    ] ++ stdenv.lib.optional withDblatex dblatex;
 
   configureFlags = [ "--disable-scrollkeeper" ];
 


### PR DESCRIPTION
###### Motivation for this change

Fix #46740 . Make it optional: (`withDblatex ? false`) to remove the dependency of `gtk-doc` on texlive.
Without `dblatex`, it cannot generate pdf docs, but most people wouldn't want those by default anyway.

Now changes to `texlive` don't trigger mass rebuilds any more. 
This may also help with https://github.com/NixOS/nixpkgs/pull/45950#issuecomment-421545698.

###### Things done

- [x] built in sandbox on NixOS 

---

cc @jtojnar 