### PR TITLE
carp: init at unstable-2018-09-15

### DIFF
--- a/pkgs/development/compilers/carp/default.nix
+++ b/pkgs/development/compilers/carp/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, makeWrapper, clang, haskellPackages }:
+
+haskellPackages.mkDerivation rec {
+
+  pname = "carp";
+  version = "unstable-2018-09-15";
+
+  src = fetchFromGitHub {
+    owner = "carp-lang";
+    repo = "Carp";
+    rev = "cf9286c35cab1c170aa819f7b30b5871b9e812e6";
+    sha256 = "1k6kdxbbaclhi40b9p3fgbkc1x6pc4v0029xjm6gny6pcdci2cli";
+  };
+
+  buildDepends = [ makeWrapper ];
+
+  executableHaskellDepends = with haskellPackages; [
+    HUnit blaze-markup blaze-html split cmdargs
+  ];
+
+  isExecutable = true;
+
+  # The carp executable must know where to find its core libraries and other
+  # files. Set the environment variable CARP_DIR so that it points to the root
+  # of the Carp repo. See:
+  # https://github.com/carp-lang/Carp/blob/master/docs/Install.md#setting-the-carp_dir
+  #
+  # Also, clang must be available run-time because carp is compiled to C which
+  # is then compiled with clang.
+  postInstall = ''
+    wrapProgram $out/bin/carp                                  \
+      --set CARP_DIR $src                                      \
+      --prefix PATH : ${clang}/bin
+    wrapProgram $out/bin/carp-header-parse                     \
+      --set CARP_DIR $src                                      \
+      --prefix PATH : ${clang}/bin
+  '';
+
+  description = "A statically typed lisp, without a GC, for real-time applications";
+  homepage    = https://github.com/carp-lang/Carp;
+  license     = stdenv.lib.licenses.asl20;
+  maintainers = with stdenv.lib.maintainers; [ jluttine ];
+
+  # Windows not (yet) supported.
+  platforms   = with stdenv.lib.platforms; unix ++ darwin;
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2320,6 +2320,8 @@ with pkgs;
 
   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };
 
+  carp = callPackage ../development/compilers/carp { };
+
   emscriptenVersion = "1.37.36";
 
   emscripten = callPackage ../development/compilers/emscripten { };


### PR DESCRIPTION
###### Motivation for this change

Add Carp compiler. Carp is a statically typed lisp, without a GC, for real-time applications. See: https://github.com/carp-lang/Carp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

