### PR TITLE
nvramtool: init at 4.8.1

### DIFF
--- a/pkgs/tools/misc/nvramtool/default.nix
+++ b/pkgs/tools/misc/nvramtool/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchgit, iasl, flex, bison }:
+
+stdenv.mkDerivation rec {
+  name = "nvramtool-${version}";
+  version = "4.8.1";
+
+  src = fetchgit {
+    url = "http://review.coreboot.org/p/coreboot";
+    rev = "refs/tags/${version}";
+    sha256 = "0nrf840jg4fn38zcnz1r10w2yfpvrk1nvsrnbbgdbgkmpjxz0zw9";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+  buildInputs = [ iasl ];
+
+  buildPhase = ''
+    export LEX=${flex}/bin/flex
+    make -C util/nvramtool
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp util/nvramtool/nvramtool $out/bin
+    '';
+
+  meta = with stdenv.lib; {
+    description = "utility for reading/writing coreboot parameters and displaying information from the coreboot table in CMOS/NVRAM";
+    homepage = https://www.coreboot.org/Nvramtool;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.cryptix ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13368,6 +13368,8 @@ with pkgs;
 
   cbfstool = callPackage ../applications/virtualization/cbfstool { };
 
+  nvramtool = callPackage ../tools/misc/nvramtool { };
+
   vmfs-tools = callPackage ../tools/filesystems/vmfs-tools { };
 
   pgbouncer = callPackage ../servers/sql/pgbouncer { };


### PR DESCRIPTION
###### Motivation for this change

https://www.coreboot.org/Nvramtool - useful for coreboot users to change settings like trackpad/wwan/bluetooth enabled.


###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

