### PR TITLE
ibus-typing-booster: init at 2.1.1

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -814,4 +814,64 @@ citrix_receiver.override {
    </para>
   </section>
  </section>
+ <section xml:id="sec-ibus-typing-booster">
+  <title>ibus-engines.typing-booster</title>
+
+  <para>This package is an ibus-based completion method to speed up typing.</para>
+
+  <section xml:id="sec-ibus-typing-booster-activate">
+   <title>Activating the engine</title>
+
+   <para>
+    IBus needs to be configured accordingly to activate <literal>typing-booster</literal>. The configuration
+    depends on the desktop manager in use. For detailed instructions, please refer to the
+    <link xlink:href="https://mike-fabian.github.io/ibus-typing-booster/documentation.html">upstream docs</link>.
+   </para>
+   <para>
+    On NixOS you need to explicitly enable <literal>ibus</literal> with given engines
+    before customizing your desktop to use <literal>typing-booster</literal>. This can be achieved
+    using the <literal>ibus</literal> module:
+<programlisting>{ pkgs, ... }: {
+  i18n.inputMethod = {
+    enabled = "ibus";
+    ibus.engines = with pkgs.ibus-engines; [ typing-booster ];
+  };
+}</programlisting>
+   </para>
+  </section>
+
+  <section xml:id="sec-ibus-typing-booster-customize-hunspell">
+   <title>Using custom hunspell dictionaries</title>
+
+   <para>
+    The IBus engine is based on <literal>hunspell</literal> to support completion in many languages.
+    By default the dictionaries <literal>de-de</literal>, <literal>en-us</literal>, <literal>es-es</literal>,
+    <literal>it-it</literal>, <literal>sv-se</literal> and <literal>sv-fi</literal>
+    are in use. To add another dictionary, the package can be overridden like this:
+<programlisting>ibus-engines.typing-booster.override {
+  langs = [ "de-at" "en-gb" ];
+}</programlisting>
+   </para>
+   <para>
+     <emphasis>Note: each language passed to <literal>langs</literal> must be an attribute name in
+     <literal>pkgs.hunspellDicts</literal>.</emphasis>
+   </para>
+  </section>
+
+  <section xml:id="sec-ibus-typing-booster-emoji-picker">
+   <title>Built-in emoji picker</title>
+
+   <para>
+    The <literal>ibus-engines.typing-booster</literal> package contains a program
+    named <literal>emoji-picker</literal>. To display all emojis correctly,
+    a special font such as <literal>noto-fonts-emoji</literal> is needed:
+   </para>
+   <para>
+    On NixOS it can be installed using the following expression:
+<programlisting>{ pkgs, ... }: {
+  fonts.fonts = with pkgs; [ noto-fonts-emoji ];
+}</programlisting>
+   </para>
+  </section>
+ </section>
 </chapter>

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, python3, ibus, pkgconfig, gtk3, m17n_lib
+, wrapGAppsHook, gobjectIntrospection
+}:
+
+let
+
+  python = python3.withPackages (ps: with ps; [
+    pygobject3
+    dbus-python
+  ]);
+
+in
+
+stdenv.mkDerivation rec {
+  name = "ibus-typing-booster-${version}";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "mike-fabian";
+    repo = "ibus-typing-booster";
+    rev = version;
+    sha256 = "01kpxplk9nh56f32fkq3nnsqykbzpi7pcxbfp38dq0prgrhw9a6b";
+  };
+
+  patches = [ ./hunspell-dirs.patch ];
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig wrapGAppsHook gobjectIntrospection ];
+  buildInputs = [ python ibus gtk3 m17n_lib ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${m17n_lib}/lib")
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://mike-fabian.github.io/ibus-typing-booster/;
+    license = licenses.gpl3Plus;
+    description = "A typing booster engine for the IBus platform";
+    maintainers = with maintainers; [ ma27 ];
+    isIbusEngine = true;
+  };
+}

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/hunspell-dirs.patch
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/hunspell-dirs.patch
@@ -1,0 +1,31 @@
+diff --git a/engine/itb_util.py b/engine/itb_util.py
+index ded236a..633525a 100755
+--- a/engine/itb_util.py
++++ b/engine/itb_util.py
+@@ -1876,14 +1876,18 @@ def find_hunspell_dictionary(language):
+             If no dictionary can be found for the requested language,
+             the return value is ('', '').
+     '''
+-    dirnames = [
+-        '/usr/share/hunspell',
+-        '/usr/share/myspell',
+-        '/usr/share/myspell/dicts',
+-        '/usr/local/share/hunspell', # On FreeBSD the dictionaries are here
+-        '/usr/local/share/myspell',
+-        '/usr/local/share/myspell/dicts',
+-    ]
++
++    if "NIX_HUNSPELL_DIRS" in os.environ:
++        dirnames = os.environ["NIX_HUNSPELL_DIRS"].split(":")
++    else:       # fallback to the original behavior
++        dirnames = [
++            '/usr/share/hunspell',
++            '/usr/share/myspell',
++            '/usr/share/myspell/dicts',
++            '/usr/local/share/hunspell', # On FreeBSD the dictionaries are here
++            '/usr/local/share/myspell',
++            '/usr/local/share/myspell/dicts',
++        ]
+     dic_path = ''
+     aff_path = ''
+     for language in expand_languages([language]):

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
@@ -1,0 +1,30 @@
+{ typing-booster, symlinkJoin, hunspellDicts, lib, makeWrapper
+, langs ? [ "de-de" "en-us" "es-es" "it-it" "sv-se" "sv-fi" ]
+}:
+
+let
+
+  hunspellDirs = with lib; makeSearchPath ":" (flatten (flip map langs (lang: [
+    "${hunspellDicts.${lang}}/share/hunspell"
+    "${hunspellDicts.${lang}}/share/myspell"
+    "${hunspellDicts.${lang}}/share/myspell/dicts"
+  ])));
+
+in
+
+symlinkJoin {
+  name = "${typing-booster.name}-with-hunspell";
+  paths = [ typing-booster ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    for i in bin/emoji-picker libexec/ibus-{setup,engine}-typing-booster; do
+      wrapProgram "$out/$i" \
+        --prefix NIX_HUNSPELL_DIRS : ${hunspellDirs}
+    done
+
+    sed -i -e "s,${typing-booster},$out," $out/share/ibus/component/typing-booster.xml
+  '';
+
+  inherit (typing-booster) meta;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1906,6 +1906,12 @@ with pkgs;
     };
 
     uniemoji = callPackage ../tools/inputmethods/ibus-engines/ibus-uniemoji { };
+
+    typing-booster-unwrapped = callPackage ../tools/inputmethods/ibus-engines/ibus-typing-booster { };
+
+    typing-booster = callPackage ../tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix {
+      typing-booster = ibus-engines.typing-booster-unwrapped;
+    };
   };
 
   ibus-with-plugins = callPackage ../tools/inputmethods/ibus/wrapper.nix {


### PR DESCRIPTION
###### Motivation for this change

This package providesa completion input method for faster typing.
See https://mike-fabian.github.io/ibus-typing-booster

Detailed instructions how to activate this IBus engine on your desktop
can be found in the upstream docs: https://mike-fabian.github.io/ibus-typing-booster/documentation.html

A simple VM with the Gnome3 desktop and activated `ibus' looks like
this:

```nix
{
  emojipicker = { pkgs, ... }: {
    services.xserver = {
      enable = true;
      desktopManager.gnome3.enable = true;
      desktopManager.xterm.enable = false;
    };
    users.extraUsers.vm = {
      password = "vm";
      isNormalUser = true;
    };
    i18n.inputMethod.ibus.engines = [
      pkgs.ibus-engines.typing-booster
    ];
    i18n.inputMethod.enabled = "ibus";
    virtualisation.memorySize = 2048;
  };
}
```

Fixes #38721

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

