### PR TITLE
git-appraise: init unstable at 2018-02-26

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -31,6 +31,8 @@ let
 
   git = appendToName "minimal" gitBase;
 
+  git-appraise = callPackage ./git-appraise {};
+
   git-fame = callPackage ./git-fame {};
 
   # The full-featured Git.

--- a/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-appraise/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "git-appraise-unstable-${version}";
+  version = "2018-02-26";
+  rev = "2414523905939525559e4b2498c5597f86193b61";
+
+  goPackagePath = "github.com/google/git-appraise";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "google";
+    repo = "git-appraise";
+    sha256 = "04xkp1jpas1dfms6i9j09bgkydih0q10nhwn75w9ds8hi2qaa3sa";
+  };
+
+  meta = {
+    description = "Distributed code review system for Git repos";
+    homepage = https://github.com/google/git-appraise;
+    license = stdenv.lib.licenses.asl20;
+    platforms = stdenv.lib.platforms.all;
+    maintainers = [ stdenv.lib.maintainers.vdemeester ];
+  };
+}


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Package up a recent version of https://github.com/google/git-appraise… That's why it's starting from `master` (a.k.a. unstable-2018-02-26)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

