### PR TITLE
win-virtio: 0.1.105-1 -> 0.1.141-1

### DIFF
--- a/pkgs/applications/virtualization/driver/win-virtio/default.nix
+++ b/pkgs/applications/virtualization/driver/win-virtio/default.nix
@@ -1,14 +1,13 @@
 { stdenv, fetchurl, p7zip }:
-
-stdenv.mkDerivation  {
-  name = "win-virtio-0.1.105-1";
-  version = "0.1.105-1";
+stdenv.mkDerivation rec {
+  name = "win-virtio-${version}";
+  version = "0.1.141-1";
 
   phases = [ "buildPhase" "installPhase" ];
 
   src = fetchurl {
-    url = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.105-1/virtio-win.iso";
-    sha256 = "065gz7s77y0q9kfqbr27451sr28rm9azpi88sqjkfph8c6r8q3wc";
+    url = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-${version}/virtio-win.iso";
+    sha256 = "0mn5gcgb9dk59nrw9scdza628yiji4vdkxmixikn9v02kgwnkja3";
   };
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Newer upstream stable version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

