### PR TITLE
python3Packages.mypy: 0.620 -> 0.630

### DIFF
--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchPypi, buildPythonPackage, lxml, typed-ast, psutil, isPy3k
-,mypy_extensions }:
+{ stdenv, fetchPypi, buildPythonPackage, typing, isPy3k }:
 
 buildPythonPackage rec {
-  pname = "mypy";
-  version = "0.630";
+  pname = "mypy_extensions";
+  version = "0.4.1";
 
   # Tests not included in pip package.
   doCheck = false;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p8rnap4ngczfm2q4035mcmn5nsprbljnhksx2jxzxrb9immh137";
+    sha256 = "04h8brrbbx151dfa2cvvlnxgmb5wa00mhd2z7nd20s8kyibfkq1p";
   };
 
   disabled = !isPy3k;
 
-  propagatedBuildInputs = [ lxml typed-ast psutil mypy_extensions ];
+  propagatedBuildInputs = [ typing ];
 
   meta = with stdenv.lib; {
-    description = "Optional static typing for Python";
+    description = "Experimental type system extensions for programs checked with the mypy typechecker";
     homepage    = "http://www.mypy-lang.org";
     license     = licenses.mit;
     maintainers = with maintainers; [ martingms lnl7 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7786,6 +7786,8 @@ in {
 
   mypy = callPackage ../development/python-modules/mypy { };
 
+  mypy_extensions = callPackage ../development/python-modules/mypy/extensions.nix { };
+
   mypy-protobuf = callPackage ../development/python-modules/mypy-protobuf { };
 
   mwclient = buildPythonPackage rec {


### PR DESCRIPTION
Now requires mypy_extensions so added it as well.

###### Motivation for this change
I've had mypy problems when running with python language server. I updated mypy, sadly it doesn''t fix my problem but let's share the update eitherway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

