### PR TITLE
gtkspellmm: 3.0.4 -> 3.0.5

### DIFF
--- a/pkgs/development/libraries/gtkspellmm/default.nix
+++ b/pkgs/development/libraries/gtkspellmm/default.nix
@@ -3,18 +3,14 @@
 , gtk3, glib, glibmm, gtkmm3, gtkspell3
 }:
 
-let
-  version = "3.0.4";
-
-in
-
 stdenv.mkDerivation rec {
   name = "gtkspellmm-${version}";
+  version = "3.0.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/gtkspell/gtkspellmm/" +
-          "${name}.tar.gz";
-    sha256 = "0x6zx928dl62f0c0x6b2s32i06lvn18wx7crrgs1j9yjgkim4k4k";
+          "${name}.tar.xz";
+    sha256 = "0i8mxwyfv5mskachafa4qlh315q0cfph7s66s1s34nffadbmm1sv";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Archive extension changed from tar.gz to tar.xz so be careful !

###### Motivation for this change
gImageReader requires a version >= 3.0.5

###### Things done
Added `file` dependency to make a configure warning go away.
Also moved version field inside the attrset so that it can be overriden.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

