### PR TITLE
pythonPackages.mahotas: skip `test_moments.test_normalize` testcase

### DIFF
--- a/pkgs/development/python-modules/mahotas/disable-impure-tests.patch
+++ b/pkgs/development/python-modules/mahotas/disable-impure-tests.patch
@@ -32,3 +32,45 @@ index 462f467..2381793 100644
  def test_ellipse_axes():
      Y,X = np.mgrid[:1024,:1024]
      Y = Y/1024.
+diff --git a/mahotas/tests/test_moments.py b/mahotas/tests/test_moments.py
+index 686c7c3..ba3487b 100644
+--- a/mahotas/tests/test_moments.py
++++ b/mahotas/tests/test_moments.py
+@@ -1,6 +1,7 @@
+ import numpy as np
+ import mahotas as mh
+ from mahotas.features.moments import moments
++from nose.tools import nottest
+ 
+ def _slow(A, p0, p1, cm):
+     c0,c1 = cm
+@@ -28,7 +29,7 @@ def test_against_slow():
+     yield perform, 1, 2, (0, 0), A
+     yield perform, 1, 0, (0, 0), A
+ 
+-
++@nottest
+ def test_normalize():
+     A,B = np.meshgrid(np.arange(128),np.arange(128))
+     for p0,p1 in [(1,1), (1,2), (2,1), (2,2)]:
+diff --git a/mahotas/tests/test_texture.py b/mahotas/tests/test_texture.py
+index 7e101ba..af1305d 100644
+--- a/mahotas/tests/test_texture.py
++++ b/mahotas/tests/test_texture.py
+@@ -2,7 +2,7 @@ import numpy as np
+ from mahotas.features import texture
+ import mahotas as mh
+ import mahotas.features._texture
+-from nose.tools import raises
++from nose.tools import raises, nottest
+ 
+ def test__cooccurence():
+     cooccurence = mahotas.features._texture.cooccurence
+@@ -149,6 +149,7 @@ def test_float_haralick():
+     A[2,2]=12
+     texture.haralick(A)
+ 
++@nottest
+ def test_haralick3d():
+     np.random.seed(22)
+     img = mahotas.stretch(255*np.random.rand(20,20,4))


### PR DESCRIPTION
###### Motivation for this change

As stated in #46368, this package seems to have issues with impure tests
(reported in https://github.com/luispedro/mahotas/issues/97).

Unfortunately the `release-18.09` job on Hydra fails at the attempt to
build this package since `test_moments.test_normalize1` breaks. Until
the root cause is identified, we skip the disabled tests to ensure that
the resulting package is not entirely broken (which can't be confirmed
with `doCheck = false`).

See https://hydra.nixos.org/job/nixos/release-18.09/nixpkgs.python27Packages.mahotas.x86_64-linux
See https://hydra.nixos.org/job/nixos/release-18.09/nixpkgs.python36Packages.mahotas.x86_64-linux

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

