### PR TITLE
exim: enable LMTP support

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
       s:^\(CONFIGURE_FILE\)=.*:\1=/etc/exim.conf:
       s:^\(EXIM_USER\)=.*:\1=ref\:nobody:
       s:^\(SPOOL_DIRECTORY\)=.*:\1=/exim-homeless-shelter:
+      s:^# \(TRANSPORT_LMTP\)=.*:\1=yes:
       s:^# \(SUPPORT_MAILDIR\)=.*:\1=yes:
       s:^EXIM_MONITOR=.*$:# &:
       s:^\(FIXED_NEVER_USERS\)=root$:\1=0:


### PR DESCRIPTION
This enables support for the LMTP transport.
Since no additional dependency is required to activate this feature, I propose to enable it by default.

Builds and runs on NixOS.
It would be nice to back-port this to `release-18.09` too.

CC: @4z3 (Exim package maintainer)