### PR TITLE
greybird: remove license cc-by-nc-sa-30

### DIFF
--- a/pkgs/misc/themes/greybird/default.nix
+++ b/pkgs/misc/themes/greybird/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Grey and blue theme from the Shimmer Project for GTK+-based environments";
     homepage = https://github.com/shimmerproject/Greybird;
-    license = with licenses; [ gpl2Plus cc-by-nc-sa-30 ];
+    license = with licenses; [ gpl2Plus ]; # or alternatively: cc-by-nc-sa-30
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];
   };


### PR DESCRIPTION
###### Motivation for this change

Greybird is dual-licensed as GPLv2 or later (free) and
CC-BY-SA 3.0 or later (unfree). Remove the unfree one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).