### PR TITLE
heroku: 5.6.32 -> 7.16.0

### DIFF
--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -1,70 +1,29 @@
-{ stdenv, lib, fetchurl, makeWrapper, buildGoPackage, fetchFromGitHub
-, nodejs-6_x, postgresql, ruby }:
+{ stdenv, lib, fetchurl, makeWrapper, nodejs }:
 
-with stdenv.lib;
+stdenv.mkDerivation rec {
+  name = "heroku-${version}";
+  version = "7.16.0";
 
-let
-  cli = buildGoPackage rec {
-    name = "cli-${version}";
-    version = "5.6.32";
-
-    goPackagePath = "github.com/heroku/cli";
-
-    src = fetchFromGitHub {
-      owner  = "heroku";
-      repo   = "cli";
-      rev    = "v${version}";
-      sha256 = "062aa79mv2njjb0ix7isbz6646wxmsldv27bsz5v2pbv597km0vz";
-    };
-
-    buildFlagsArray = ''
-      -ldflags=
-        -X=main.Version=${version}
-        -X=main.Channel=stable
-        -X=main.Autoupdate=no
-    '';
-
-    preCheck = ''
-      export HOME=/tmp
-    '';
-
-    doCheck = true;
+  src = fetchurl {
+    url = "https://cli-assets.heroku.com/heroku-v${version}/heroku-v${version}.tar.xz";
+    sha256 = "434573b4773ce7ccbb21b43b19529475d941fa7dd219b01b75968b42e6b62abe";
   };
 
-in stdenv.mkDerivation rec {
-  name = "heroku-${version}";
-  version = "3.43.16";
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/share/heroku $out/bin
+    cp -pr * $out/share/heroku
+    substituteInPlace $out/share/heroku/bin/run \
+      --replace "/usr/bin/env node" "${nodejs}/bin/node"
+    makeWrapper $out/share/heroku/bin/run $out/bin/heroku
+  '';
 
   meta = {
     homepage = https://toolbelt.heroku.com;
     description = "Everything you need to get started using Heroku";
-    maintainers = with maintainers; [ aflatter mirdhyn peterhoeg ];
-    license = licenses.mit;
-    platforms = with platforms; unix;
-    broken = true; # Outdated function, not supported upstream. https://github.com/NixOS/nixpkgs/issues/27447
+    maintainers = with lib.maintainers; [ aflatter mirdhyn peterhoeg ];
+    license = lib.licenses.mit;
+    platforms = with lib.platforms; unix;
   };
-
-  binPath = lib.makeBinPath [ postgresql ruby ];
-
-  buildInputs = [ makeWrapper ];
-
-  doUnpack = false;
-
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-${version}.tgz";
-    sha256 = "08pai3cjaj7wshhyjcmkvyr1qxv5ab980whcm406798ng8f91hn7";
-  };
-
-  installPhase = ''
-    mkdir -p $out
-
-    tar xzf $src -C $out --strip-components=1
-    install -Dm755 ${cli}/bin/cli $out/share/heroku/cli/bin/heroku
-
-    wrapProgram $out/bin/heroku \
-      --set HEROKU_NODE_PATH ${nodejs-6_x}/bin/node \
-      --set XDG_DATA_HOME    $out/share \
-      --set XDG_DATA_DIRS    $out/share \
-      --prefix PATH : ${binPath}
-  '';
 }

--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
     cp -pr * $out/share/heroku
     substituteInPlace $out/share/heroku/bin/run \
       --replace "/usr/bin/env node" "${nodejs}/bin/node"
-    makeWrapper $out/share/heroku/bin/run $out/bin/heroku
+    makeWrapper $out/share/heroku/bin/run $out/bin/heroku \
+      --set HEROKU_DISABLE_AUTOUPDATE 1
   '';
 
   meta = {

--- a/pkgs/development/tools/heroku/default.nix
+++ b/pkgs/development/tools/heroku/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ makeWrapper ];
 
+  dontBuild = true;
+
   installPhase = ''
     mkdir -p $out/share/heroku $out/bin
     cp -pr * $out/share/heroku

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8386,7 +8386,9 @@ with pkgs;
     inherit (perlPackages) LocaleGettext;
   };
 
-  heroku = callPackage ../development/tools/heroku { };
+  heroku = callPackage ../development/tools/heroku {
+    nodejs = nodejs-10_x;
+  };
 
   htmlunit-driver = callPackage ../development/tools/selenium/htmlunit-driver { };
 


### PR DESCRIPTION
###### Motivation for this change

This is an alternative implementation of heroku 7.16.0 from #42869. This was inspired by @jdxcode's suggestion to use the same method as brew: using the tarball of heroku that contains all required nodejs files, except for the nodejs executable itself.

See the suggestion here: https://github.com/NixOS/nixpkgs/pull/42869#issuecomment-421935008

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

