### PR TITLE
krakenx: 0.0.1 -> 0.0.3

### DIFF
--- a/pkgs/tools/system/krakenx/default.nix
+++ b/pkgs/tools/system/krakenx/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "krakenx";
-  version = "0.0.1";
+  version = "0.0.3";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1vxyindph81srya0pfmb3n64n8h7ghp38ak86vc2zc5nyirf5zq8";
+    sha256 = "1khw1rxra5hn7hwp16i6kgj89znq8vjsyly3r2dxx2z2bddil000";
   };
 
   propagatedBuildInputs = lib.singleton python3Packages.pyusb;
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   doCheck = false; # there are no tests
 
   meta = with lib; {
-    description = "Python script to control NZXT cooler Kraken X52/X62";
+    description = "Python script to control NZXT cooler Kraken X52/X62/X72";
     homepage = https://github.com/KsenijaS/krakenx;
     license = licenses.gpl2;
     maintainers = [ maintainers.willibutz ];


### PR DESCRIPTION
It now also supports Kraken X72.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---