### PR TITLE
elementary-xfce-icon-theme: 0.12 -> 0.13

### DIFF
--- a/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
@@ -1,27 +1,24 @@
-{ stdenv, fetchFromGitHub, gtk3, hicolor-icon-theme }:
+{ stdenv, fetchFromGitHub, pkgconfig, gdk_pixbuf, optipng, librsvg, gtk3, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "elementary-xfce-icon-theme-${version}";
-  version = "0.12";
+  version = "0.13";
 
   src = fetchFromGitHub {
     owner = "shimmerproject";
     repo = "elementary-xfce";
-    rev = "elementary-xfce-${version}";
-    sha256 = "036676443sj4lxm7z211b0br87zdnbrb9z41czfq65r1wwwdf3rq";
+    rev = "v${version}";
+    sha256 = "01hlpw4vh4kgyghki01jp0snbn0g79mys28fb1m993mivnlzmn75";
   };
 
-  nativeBuildInputs = [ gtk3 hicolor-icon-theme ];
+  nativeBuildInputs = [ pkgconfig gdk_pixbuf librsvg optipng gtk3 hicolor-icon-theme ];
 
-  installPhase = ''
-    mkdir -p $out/share/icons
-    mv elementary-xfce* $out/share/icons
+  postPatch = ''
+    substituteInPlace svgtopng/Makefile --replace "-O0" "-O"
   '';
 
-  postFixup = ''
-    for theme in $out/share/icons/*; do
-      gtk-update-icon-cache $theme
-    done
+  postInstall = ''
+    make icon-caches
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
+++ b/pkgs/data/icons/elementary-xfce-icon-theme/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
     description = "Elementary icons for Xfce and other GTK+ desktops like GNOME";
     homepage = https://github.com/shimmerproject/elementary-xfce;
     license = licenses.gpl2;
-    platforms = platforms.unix;
+    # darwin cannot deal with file names differing only in case
+    platforms = platforms.linux;
     maintainers = with maintainers; [ davidak ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version [0.13](https://github.com/shimmerproject/elementary-xfce/releases/tag/v0.13)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).