### PR TITLE
arcanist: fix mtime impurity

### DIFF
--- a/pkgs/development/tools/misc/arcanist/default.nix
+++ b/pkgs/development/tools/misc/arcanist/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ php makeWrapper flex ];
 
   unpackPhase = ''
-    cp -R ${libphutil} libphutil
-    cp -R ${arcanist} arcanist
+    cp -aR ${libphutil} libphutil
+    cp -aR ${arcanist} arcanist
     chmod +w -R libphutil arcanist
   '';
 


### PR DESCRIPTION
This package would sometimes require bison, depending on file enumeration order. Adding -a flag to cp to preserve mtimes fixes this.

###### Motivation for this change

Arcanist build was failing, bisecting nixpkgs turned up the first commit to cause a rebuild of it. It worked on some systems but not others. With this commit, it works on all systems again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

