### PR TITLE
OVMF: update homepage

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation (edk2.setup projectDscPath {
 
   meta = {
     description = "Sample UEFI firmware for QEMU and KVM";
-    homepage = https://sourceforge.net/apps/mediawiki/tianocore/index.php?title=OVMF;
+    homepage = https://github.com/tianocore/tianocore.github.io/wiki/OVMF;
     license = stdenv.lib.licenses.bsd2;
     platforms = ["x86_64-linux" "i686-linux" "aarch64-linux"];
   };


### PR DESCRIPTION
Tianocore was apparently moved from SourceForge to GitHub, so this updates the homepage of the OVMF package.

###### Motivation for this change

Repology reports old homepage as offline. https://www.tianocore.org/ovmf/ redirects to the updated one.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

