### PR TITLE
nixos/release.nix: disable tests.ec2-config

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -285,7 +285,8 @@ in rec {
   tests.ecryptfs = callTest tests/ecryptfs.nix {};
   tests.etcd = callTestOnMatchingSystems ["x86_64-linux"] tests/etcd.nix {};
   tests.ec2-nixops = (callSubTestsOnMatchingSystems ["x86_64-linux"] tests/ec2.nix {}).boot-ec2-nixops or {};
-  tests.ec2-config = (callSubTestsOnMatchingSystems ["x86_64-linux"] tests/ec2.nix {}).boot-ec2-config or {};
+  # ec2-config doesn't work in a sandbox as the simulated ec2 instance needs network access
+  #tests.ec2-config = (callSubTestsOnMatchingSystems ["x86_64-linux"] tests/ec2.nix {}).boot-ec2-config or {};
   tests.elk = callSubTestsOnMatchingSystems ["x86_64-linux"] tests/elk.nix {};
   tests.env = callTest tests/env.nix {};
   tests.ferm = callTest tests/ferm.nix {};


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960 , please backport.

This test doesn't work in a sandbox and [never succeeded in available Hydra history](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.ec2-config.x86_64-linux/all).
It simulates an EC2 instance reconfiguring itself at runtime with userdata, which apparently needs network access. I tried to fix it by adding missing `system.extraDependencies` but was unable to get it to work entirely without  accessing the network.

This disables the test on Hydra.
It can still be run manually and succeeds with sandboxing turned off.

---
cc @copumpkin who originally wrote the test
