### PR TITLE
pythonPackages.gmpy2: update homepage

### DIFF
--- a/pkgs/development/python-modules/gmpy2/default.nix
+++ b/pkgs/development/python-modules/gmpy2/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage {
 
   meta = with stdenv.lib; {
     description = "GMP/MPIR, MPFR, and MPC interface to Python 2.6+ and 3.x";
-    homepage = http://code.google.com/p/gmpy/;
+    homepage = https://github.com/aleaxit/gmpy/;
     license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Project moved to GitHub

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

