### PR TITLE
adafruit-ampy: Init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/python-dotenv/default.nix
+++ b/pkgs/development/python-modules/python-dotenv/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage, pythonPackages }:
+
+buildPythonPackage rec {
+  pname = "python-dotenv";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "theskumar";
+    repo = "python-dotenv";
+    rev = "v${version}";
+    sha256 = "1jr0dd8996mx6g359fv4wbcafi2mpvsjjcxqkab5whfd54q9nfpf";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [ click ];
+
+  checkInputs = with pythonPackages; [
+    ipython
+    pytest
+    sh
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/theskumar/python-dotenv;
+    description = "Reads the key,value pair from .env file and adds them to environment variable";
+    platforms = platforms.all;
+    license = licenses.bsd3;
+    maintainers = [];
+  };
+}

--- a/pkgs/development/tools/adafruit-ampy/default.nix
+++ b/pkgs/development/tools/adafruit-ampy/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "adafruit-ampy";
+
+  src = fetchFromGitHub {
+    owner = "adafruit";
+    repo = "ampy";
+    rev  = "1.0.5";
+    sha256 = "1h71w8dx49bmdawnwvnywmc95nqbd5pxcl6kdia55lxalas3pzw6";
+  };
+
+  propagatedBuildInputs = with pythonPackages; [
+    pyserial
+    click
+    python-dotenv
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Utility to interact with a MicroPython board over a serial connection";
+    homepage = https://github.com/adafruit/ampy;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7824,6 +7824,8 @@ with pkgs;
 
   alloy = callPackage ../development/tools/alloy { };
 
+  adafruit-ampy = callPackage ../development/tools/adafruit-ampy { };
+
   adtool = callPackage ../tools/admin/adtool { };
 
   augeas = callPackage ../tools/system/augeas { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -583,6 +583,8 @@ in {
 
   asgiref = callPackage ../development/python-modules/asgiref { };
 
+  python-dotenv = callPackage ../development/python-modules/python-dotenv {};
+
   python-editor = callPackage ../development/python-modules/python-editor { };
 
   python-gnupg = callPackage ../development/python-modules/python-gnupg {};


### PR DESCRIPTION
###### Motivation for this change

Adafruit MicroPython Tool (ampy) - Utility to interact with a MicroPython board over a serial connection.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

