### PR TITLE
Replace overridePythonAttrs with overrideArgs, add for Rust and Go as well

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -616,7 +616,7 @@ All parameters from `stdenv.mkDerivation` function are still supported. The foll
 
 ##### Overriding Python packages
 
-The `buildPythonPackage` function has a `overridePythonAttrs` method that
+The `buildPythonPackage` function has a `overrideArgs` method that
 can be used to override the package. In the following example we create an
 environment where we have the `blaze` package using an older version of `pandas`.
 We override first the Python interpreter and pass
@@ -628,7 +628,7 @@ with import <nixpkgs> {};
 (let
   python = let
     packageOverrides = self: super: {
-      pandas = super.pandas.overridePythonAttrs(old: rec {
+      pandas = super.pandas.overrideArgs(old: rec {
         version = "0.19.1";
         src =  super.fetchPypi {
           pname = "pandas";
@@ -894,7 +894,7 @@ with import <nixpkgs> {};
 (let
   python = let
     packageOverrides = self: super: {
-      pandas = super.pandas.overridePythonAttrs(old: {name="foo";});
+      pandas = super.pandas.overrideArgs(old: {name="foo";});
     };
   in pkgs.python35.override {inherit packageOverrides;};
 

--- a/nixos/tests/common/letsencrypt/common.nix
+++ b/nixos/tests/common/letsencrypt/common.nix
@@ -15,7 +15,7 @@
     # Need to override the attribute used by simp_le, which is python3Packages
     python3Packages = (super.python3.override {
       packageOverrides = lib.const (pysuper: {
-        certifi = pysuper.certifi.overridePythonAttrs (attrs: {
+        certifi = pysuper.certifi.overrideArgs (attrs: {
           postPatch = (attrs.postPatch or "") + ''
             cat "${self.cacert}/etc/ssl/certs/ca-bundle.crt" \
               > certifi/cacert.pem

--- a/pkgs/applications/editors/jupyter/default.nix
+++ b/pkgs/applications/editors/jupyter/default.nix
@@ -12,7 +12,7 @@ let
 in
 
 with python3.pkgs; toPythonModule (
-  notebook.overridePythonAttrs(oldAttrs: {
+  notebook.overrideArgs(oldAttrs: {
     makeWrapperArgs = ["--set JUPYTER_PATH ${jupyterPath}"];
   })
 )

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -5,7 +5,7 @@ let
     packageOverrides = self: super: {
 
       # https://github.com/pimutils/khal/issues/780
-      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
+      python-dateutil = super.python-dateutil.overrideArgs (oldAttrs: rec {
         version = "2.6.1";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -5,7 +5,7 @@ let
     packageOverrides = self: super: {
 
       # https://github.com/pimutils/khal/issues/780
-      python-dateutil = super.python-dateutil.overridePythonAttrs (oldAttrs: rec {
+      python-dateutil = super.python-dateutil.overrideArgs (oldAttrs: rec {
         version = "2.6.1";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -4,7 +4,7 @@ let
 
   pythonPackages = python2.pkgs.override {
     overrides = self: super: with self; {
-      backports_ssl_match_hostname = super.backports_ssl_match_hostname.overridePythonAttrs (oldAttrs: rec {
+      backports_ssl_match_hostname = super.backports_ssl_match_hostname.overrideArgs (oldAttrs: rec {
         version = "3.4.0.2";
         src = oldAttrs.src.override {
           inherit version;
@@ -12,7 +12,7 @@ let
         };
       });
 
-      flask = super.flask.overridePythonAttrs (oldAttrs: rec {
+      flask = super.flask.overrideArgs (oldAttrs: rec {
         version = "0.12.4";
         src = oldAttrs.src.override {
           inherit version;
@@ -63,7 +63,7 @@ let
         doCheck = false;
       };
 
-      pylru = super.pylru.overridePythonAttrs (oldAttrs: rec {
+      pylru = super.pylru.overrideArgs (oldAttrs: rec {
         version = "1.0.9";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -13,7 +13,7 @@ let
   python' = python.override { inherit packageOverrides; };
 
   packageOverrides = self: super: {
-    sqlalchemy = super.sqlalchemy.overridePythonAttrs (old: rec {
+    sqlalchemy = super.sqlalchemy.overrideArgs (old: rec {
       version = "1.1.10";
       src = old.src.override {
         inherit version;
@@ -21,7 +21,7 @@ let
       };
     });
 
-    guessit = super.guessit.overridePythonAttrs (old: rec {
+    guessit = super.guessit.overrideArgs (old: rec {
       version = "2.1.4";
       src = old.src.override {
         inherit version;

--- a/pkgs/development/arduino/platformio/chrootenv.nix
+++ b/pkgs/development/arduino/platformio/chrootenv.nix
@@ -7,7 +7,7 @@ let
         packageOverrides = self: super: {
 
           # https://github.com/platformio/platformio-core/issues/349
-          click = super.click.overridePythonAttrs (oldAttrs: rec {
+          click = super.click.overrideArgs (oldAttrs: rec {
             version = "5.1";
             src = oldAttrs.src.override {
               inherit version;

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -1,230 +1,236 @@
 { go, govers, parallel, lib, fetchgit, fetchhg, fetchbzr, rsync
 , removeReferencesTo, fetchFromGitHub }:
 
-{ name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}, preFixup ? ""
-, shellHook ? ""
-
-# We want parallel builds by default
-, enableParallelBuilding ? true
-
-# Disabled flag
-, disabled ? false
-
-# Go import path of the package
-, goPackagePath
-
-# Go package aliases
-, goPackageAliases ? [ ]
-
-# Extra sources to include in the gopath
-, extraSrcs ? [ ]
-
-# Extra gopaths containing src subfolder
-# with sources to include in the gopath
-, extraSrcPaths ? [ ]
-
-# go2nix dependency file
-, goDeps ? null
-
-, dontRenameImports ? false
-
-# Do not enable this without good reason
-# IE: programs coupled with the compiler
-, allowGoReference ? false
-
-, meta ? {}, ... } @ args':
-
-if disabled then throw "${name} not supported for go ${go.meta.branch}" else
-
-with builtins;
-
 let
-  args = lib.filterAttrs (name: _: name != "extraSrcs") args';
+  buildGoPackage =
+    { name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}, preFixup ? ""
+    , shellHook ? ""
 
-  removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
+    # We want parallel builds by default
+    , enableParallelBuilding ? true
 
-  removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
+    # Disabled flag
+    , disabled ? false
 
-  dep2src = goDep:
-    {
-      inherit (goDep) goPackagePath;
-      src = if goDep.fetch.type == "git" then
-        fetchgit {
-          inherit (goDep.fetch) url rev sha256;
+    # Go import path of the package
+    , goPackagePath
+
+    # Go package aliases
+    , goPackageAliases ? [ ]
+
+    # Extra sources to include in the gopath
+    , extraSrcs ? [ ]
+
+    # Extra gopaths containing src subfolder
+    # with sources to include in the gopath
+    , extraSrcPaths ? [ ]
+
+    # go2nix dependency file
+    , goDeps ? null
+
+    , dontRenameImports ? false
+
+    # Do not enable this without good reason
+    # IE: programs coupled with the compiler
+    , allowGoReference ? false
+
+    , meta ? {}, ... } @ args':
+
+    if disabled then throw "${name} not supported for go ${go.meta.branch}" else
+
+    with builtins;
+
+    let
+      args = lib.filterAttrs (name: _: name != "extraSrcs") args';
+
+      removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
+
+      removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
+
+      dep2src = goDep:
+        {
+          inherit (goDep) goPackagePath;
+          src = if goDep.fetch.type == "git" then
+            fetchgit {
+              inherit (goDep.fetch) url rev sha256;
+            }
+          else if goDep.fetch.type == "hg" then
+            fetchhg {
+              inherit (goDep.fetch) url rev sha256;
+            }
+          else if goDep.fetch.type == "bzr" then
+            fetchbzr {
+              inherit (goDep.fetch) url rev sha256;
+            }
+          else if goDep.fetch.type == "FromGitHub" then
+            fetchFromGitHub {
+              inherit (goDep.fetch) owner repo rev sha256;
+            }
+          else abort "Unrecognized package fetch type: ${goDep.fetch.type}";
+        };
+
+      importGodeps = { depsFile }:
+        map dep2src (import depsFile);
+
+      goPath = if goDeps != null then importGodeps { depsFile = goDeps; } ++ extraSrcs
+                                 else extraSrcs;
+    in
+
+    go.stdenv.mkDerivation (
+      (builtins.removeAttrs args [ "goPackageAliases" "disabled" ]) // {
+
+      inherit name;
+      nativeBuildInputs = [ removeReferencesTo go parallel ]
+        ++ (lib.optional (!dontRenameImports) govers) ++ nativeBuildInputs;
+      buildInputs = [ go ] ++ buildInputs;
+
+      configurePhase = args.configurePhase or ''
+        runHook preConfigure
+
+        # Extract the source
+        cd "$NIX_BUILD_TOP"
+        mkdir -p "go/src/$(dirname "$goPackagePath")"
+        mv "$sourceRoot" "go/src/$goPackagePath"
+
+      '' + lib.flip lib.concatMapStrings goPath ({ src, goPackagePath }: ''
+        mkdir goPath
+        (cd goPath; unpackFile "${src}")
+        mkdir -p "go/src/$(dirname "${goPackagePath}")"
+        chmod -R u+w goPath/*
+        mv goPath/* "go/src/${goPackagePath}"
+        rmdir goPath
+
+      '') + (lib.optionalString (extraSrcPaths != []) ''
+        ${rsync}/bin/rsync -a ${lib.concatMapStringsSep " " (p: "${p}/src") extraSrcPaths} go
+
+      '') + ''
+        export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
+
+        runHook postConfigure
+      '';
+
+      renameImports = args.renameImports or (
+        let
+          inputsWithAliases = lib.filter (x: x ? goPackageAliases)
+            (buildInputs ++ (args.propagatedBuildInputs or [ ]));
+          rename = to: from: "echo Renaming '${from}' to '${to}'; govers -d -m ${from} ${to}";
+          renames = p: lib.concatMapStringsSep "\n" (rename p.goPackagePath) p.goPackageAliases;
+        in lib.concatMapStringsSep "\n" renames inputsWithAliases);
+
+      buildPhase = args.buildPhase or ''
+        runHook preBuild
+
+        runHook renameImports
+
+        buildGoDir() {
+          local d; local cmd;
+          cmd="$1"
+          d="$2"
+          . $TMPDIR/buildFlagsArray
+          echo "$d" | grep -q "\(/_\|examples\|Godeps\)" && return 0
+          [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
+          local OUT
+          if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" -v $d 2>&1)"; then
+            if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
+              echo "$OUT" >&2
+              return 1
+            fi
+          fi
+          if [ -n "$OUT" ]; then
+            echo "$OUT" >&2
+          fi
+          return 0
         }
-      else if goDep.fetch.type == "hg" then
-        fetchhg {
-          inherit (goDep.fetch) url rev sha256;
+
+        getGoDirs() {
+          local type;
+          type="$1"
+          if [ -n "$subPackages" ]; then
+            echo "$subPackages" | sed "s,\(^\| \),\1$goPackagePath/,g"
+          else
+            pushd "$NIX_BUILD_TOP/go/src" >/dev/null
+            find "$goPackagePath" -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort | uniq
+            popd >/dev/null
+          fi
         }
-      else if goDep.fetch.type == "bzr" then
-        fetchbzr {
-          inherit (goDep.fetch) url rev sha256;
-        }
-      else if goDep.fetch.type == "FromGitHub" then
-        fetchFromGitHub {
-          inherit (goDep.fetch) owner repo rev sha256;
-        }
-      else abort "Unrecognized package fetch type: ${goDep.fetch.type}";
+
+        if (( "''${NIX_DEBUG:-0}" >= 1 )); then
+          buildFlagsArray+=(-x)
+        fi
+
+        if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
+          declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
+        else
+          touch $TMPDIR/buildFlagsArray
+        fi
+        export -f buildGoDir # parallel needs to see the function
+        if [ -z "$enableParallelBuilding" ]; then
+            export NIX_BUILD_CORES=1
+        fi
+        getGoDirs "" | parallel -j $NIX_BUILD_CORES buildGoDir install
+
+        runHook postBuild
+      '';
+
+      doCheck = args.doCheck or false;
+      checkPhase = args.checkPhase or ''
+        runHook preCheck
+
+        getGoDirs test | parallel -j $NIX_BUILD_CORES buildGoDir test
+
+        runHook postCheck
+      '';
+
+      installPhase = args.installPhase or ''
+        runHook preInstall
+
+        mkdir -p $bin
+        dir="$NIX_BUILD_TOP/go/bin"
+        [ -e "$dir" ] && cp -r $dir $bin
+
+        runHook postInstall
+      '';
+
+      preFixup = preFixup + ''
+        find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
+      '';
+
+      # Disable go cache, which is not reused in nix anyway
+      GOCACHE = "off";
+
+      shellHook = ''
+        d=$(mktemp -d "--suffix=-$name")
+      '' + toString (map (dep: ''
+         mkdir -p "$d/src/$(dirname "${dep.goPackagePath}")"
+         ln -s "${dep.src}" "$d/src/${dep.goPackagePath}"
+      ''
+      ) goPath) + ''
+        export GOPATH=${lib.concatStringsSep ":" ( ["$d"] ++ ["$GOPATH"] ++ ["$PWD"] ++ extraSrcPaths)}
+      '' + shellHook;
+
+      disallowedReferences = lib.optional (!allowGoReference) go
+        ++ lib.optional (!dontRenameImports) govers;
+
+      passthru = passthru //
+        { inherit go; } //
+        lib.optionalAttrs (goPackageAliases != []) { inherit goPackageAliases; };
+
+      enableParallelBuilding = enableParallelBuilding;
+
+      # I prefer to call this dev but propagatedBuildInputs expects $out to exist
+      outputs = args.outputs or [ "bin" "out" ];
+
+      meta = {
+        # Add default meta information
+        homepage = "https://${goPackagePath}";
+        platforms = go.meta.platforms or lib.platforms.all;
+      } // meta // {
+        # add an extra maintainer to every package
+        maintainers = (meta.maintainers or []) ++
+                      [ lib.maintainers.ehmry lib.maintainers.lethalman ];
+      };
+    }) // {
+      overrideArgs = f: (args // (f args));
     };
 
-  importGodeps = { depsFile }:
-    map dep2src (import depsFile);
-
-  goPath = if goDeps != null then importGodeps { depsFile = goDeps; } ++ extraSrcs
-                             else extraSrcs;
-in
-
-go.stdenv.mkDerivation (
-  (builtins.removeAttrs args [ "goPackageAliases" "disabled" ]) // {
-
-  inherit name;
-  nativeBuildInputs = [ removeReferencesTo go parallel ]
-    ++ (lib.optional (!dontRenameImports) govers) ++ nativeBuildInputs;
-  buildInputs = [ go ] ++ buildInputs;
-
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-
-    # Extract the source
-    cd "$NIX_BUILD_TOP"
-    mkdir -p "go/src/$(dirname "$goPackagePath")"
-    mv "$sourceRoot" "go/src/$goPackagePath"
-
-  '' + lib.flip lib.concatMapStrings goPath ({ src, goPackagePath }: ''
-    mkdir goPath
-    (cd goPath; unpackFile "${src}")
-    mkdir -p "go/src/$(dirname "${goPackagePath}")"
-    chmod -R u+w goPath/*
-    mv goPath/* "go/src/${goPackagePath}"
-    rmdir goPath
-
-  '') + (lib.optionalString (extraSrcPaths != []) ''
-    ${rsync}/bin/rsync -a ${lib.concatMapStringsSep " " (p: "${p}/src") extraSrcPaths} go
-
-  '') + ''
-    export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
-
-    runHook postConfigure
-  '';
-
-  renameImports = args.renameImports or (
-    let
-      inputsWithAliases = lib.filter (x: x ? goPackageAliases)
-        (buildInputs ++ (args.propagatedBuildInputs or [ ]));
-      rename = to: from: "echo Renaming '${from}' to '${to}'; govers -d -m ${from} ${to}";
-      renames = p: lib.concatMapStringsSep "\n" (rename p.goPackagePath) p.goPackageAliases;
-    in lib.concatMapStringsSep "\n" renames inputsWithAliases);
-
-  buildPhase = args.buildPhase or ''
-    runHook preBuild
-
-    runHook renameImports
-
-    buildGoDir() {
-      local d; local cmd;
-      cmd="$1"
-      d="$2"
-      . $TMPDIR/buildFlagsArray
-      echo "$d" | grep -q "\(/_\|examples\|Godeps\)" && return 0
-      [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
-      local OUT
-      if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" -v $d 2>&1)"; then
-        if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
-          echo "$OUT" >&2
-          return 1
-        fi
-      fi
-      if [ -n "$OUT" ]; then
-        echo "$OUT" >&2
-      fi
-      return 0
-    }
-
-    getGoDirs() {
-      local type;
-      type="$1"
-      if [ -n "$subPackages" ]; then
-        echo "$subPackages" | sed "s,\(^\| \),\1$goPackagePath/,g"
-      else
-        pushd "$NIX_BUILD_TOP/go/src" >/dev/null
-        find "$goPackagePath" -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort | uniq
-        popd >/dev/null
-      fi
-    }
-
-    if (( "''${NIX_DEBUG:-0}" >= 1 )); then
-      buildFlagsArray+=(-x)
-    fi
-
-    if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
-      declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
-    else
-      touch $TMPDIR/buildFlagsArray
-    fi
-    export -f buildGoDir # parallel needs to see the function
-    if [ -z "$enableParallelBuilding" ]; then
-        export NIX_BUILD_CORES=1
-    fi
-    getGoDirs "" | parallel -j $NIX_BUILD_CORES buildGoDir install
-
-    runHook postBuild
-  '';
-
-  doCheck = args.doCheck or false;
-  checkPhase = args.checkPhase or ''
-    runHook preCheck
-
-    getGoDirs test | parallel -j $NIX_BUILD_CORES buildGoDir test
-
-    runHook postCheck
-  '';
-
-  installPhase = args.installPhase or ''
-    runHook preInstall
-
-    mkdir -p $bin
-    dir="$NIX_BUILD_TOP/go/bin"
-    [ -e "$dir" ] && cp -r $dir $bin
-
-    runHook postInstall
-  '';
-
-  preFixup = preFixup + ''
-    find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
-  '';
-
-  # Disable go cache, which is not reused in nix anyway
-  GOCACHE = "off";
-
-  shellHook = ''
-    d=$(mktemp -d "--suffix=-$name")
-  '' + toString (map (dep: ''
-     mkdir -p "$d/src/$(dirname "${dep.goPackagePath}")"
-     ln -s "${dep.src}" "$d/src/${dep.goPackagePath}"
-  ''
-  ) goPath) + ''
-    export GOPATH=${lib.concatStringsSep ":" ( ["$d"] ++ ["$GOPATH"] ++ ["$PWD"] ++ extraSrcPaths)}
-  '' + shellHook;
-
-  disallowedReferences = lib.optional (!allowGoReference) go
-    ++ lib.optional (!dontRenameImports) govers;
-
-  passthru = passthru //
-    { inherit go; } //
-    lib.optionalAttrs (goPackageAliases != []) { inherit goPackageAliases; };
-
-  enableParallelBuilding = enableParallelBuilding;
-
-  # I prefer to call this dev but propagatedBuildInputs expects $out to exist
-  outputs = args.outputs or [ "bin" "out" ];
-
-  meta = {
-    # Add default meta information
-    homepage = "https://${goPackagePath}";
-    platforms = go.meta.platforms or lib.platforms.all;
-  } // meta // {
-    # add an extra maintainer to every package
-    maintainers = (meta.maintainers or []) ++
-                  [ lib.maintainers.ehmry lib.maintainers.lethalman ];
-  };
-})
+in buildGoPackage

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -5,7 +5,7 @@
 let
 
   # Needed for celery
-  pytest_32 = pytest.overridePythonAttrs( oldAttrs: rec {
+  pytest_32 = pytest.overrideArgs( oldAttrs: rec {
     version = "3.2.5";
     src = oldAttrs.src.override {
       inherit version;

--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -2,28 +2,28 @@
 
 let newPython = python3.override {
   packageOverrides = self: super: {
-    distro = super.distro.overridePythonAttrs (oldAttrs: rec {
+    distro = super.distro.overrideArgs (oldAttrs: rec {
       version = "1.1.0";
       src = oldAttrs.src.override {
         inherit version;
         sha256 = "1vn1db2akw98ybnpns92qi11v94hydwp130s8753k6ikby95883j";
       };
     });
-    node-semver = super.node-semver.overridePythonAttrs (oldAttrs: rec {
+    node-semver = super.node-semver.overrideArgs (oldAttrs: rec {
       version = "0.2.0";
       src = oldAttrs.src.override {
         inherit version;
         sha256 = "1080pdxrvnkr8i7b7bk0dfx6cwrkkzzfaranl7207q6rdybzqay3";
       };
     });
-    astroid = super.astroid.overridePythonAttrs (oldAttrs: rec {
+    astroid = super.astroid.overrideArgs (oldAttrs: rec {
       version = "1.6.5";
       src = oldAttrs.src.override {
         inherit version;
         sha256 = "fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a";
       };
     });
-    pylint = super.pylint.overridePythonAttrs (oldAttrs: rec {
+    pylint = super.pylint.overrideArgs (oldAttrs: rec {
       version = "1.8.4";
       src = oldAttrs.src.override {
         inherit version;

--- a/pkgs/servers/home-assistant/appdaemon.nix
+++ b/pkgs/servers/home-assistant/appdaemon.nix
@@ -4,7 +4,7 @@ let
   python = python3.override {
     packageOverrides = self: super: {
 
-      aiohttp = super.aiohttp.overridePythonAttrs (oldAttrs: rec {
+      aiohttp = super.aiohttp.overrideArgs (oldAttrs: rec {
         version = "2.3.10";
         src = oldAttrs.src.override {
           inherit version;
@@ -12,7 +12,7 @@ let
         };
       });
 
-      yarl = super.yarl.overridePythonAttrs (oldAttrs: rec {
+      yarl = super.yarl.overrideArgs (oldAttrs: rec {
         version = "1.1.0";
         src = oldAttrs.src.override {
           inherit version;
@@ -20,7 +20,7 @@ let
         };
       });
 
-      aiohttp-jinja2 = super.aiohttp-jinja2.overridePythonAttrs (oldAttrs: rec {
+      aiohttp-jinja2 = super.aiohttp-jinja2.overrideArgs (oldAttrs: rec {
         version = "0.15.0";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -7,7 +7,7 @@
 , extraPackages ? ps: []
 
 # Override Python packages using
-# self: super: { pkg = super.pkg.overridePythonAttrs (oldAttrs: { ... }); }
+# self: super: { pkg = super.pkg.overrideArgs (oldAttrs: { ... }); }
 # Applied after defaultOverrides
 , packageOverrides ? self: super: { }
 
@@ -52,7 +52,7 @@ let
 
   mkOverride = attrname: version: sha256:
     self: super: {
-      ${attrname} = super.${attrname}.overridePythonAttrs (oldAttrs: {
+      ${attrname} = super.${attrname}.overrideArgs (oldAttrs: {
         inherit version;
         src = oldAttrs.src.override {
           inherit version sha256;

--- a/pkgs/servers/isso/default.nix
+++ b/pkgs/servers/isso/default.nix
@@ -2,7 +2,7 @@
 
 let python = python2.override {
   packageOverrides = self: super: {
-    misaka = super.misaka.overridePythonAttrs (old: rec {
+    misaka = super.misaka.overrideArgs (old: rec {
       version = "1.0.2";
       src = old.src.override {
         inherit version;
@@ -10,7 +10,7 @@ let python = python2.override {
       };
       propagatedBuildInputs = [ ];
     });
-    html5lib = super.html5lib.overridePythonAttrs (old: rec {
+    html5lib = super.html5lib.overrideArgs (old: rec {
       version = "0.9999999";
       src = old.src.override {
         inherit version;

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -7,7 +7,7 @@
 let
   py = python.override {
     packageOverrides = self: super: {
-      colorama = super.colorama.overridePythonAttrs (oldAttrs: rec {
+      colorama = super.colorama.overrideArgs (oldAttrs: rec {
         version = "0.3.7";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/tools/misc/pubs/default.nix
+++ b/pkgs/tools/misc/pubs/default.nix
@@ -4,7 +4,7 @@ let
   python3Packages = (python3.override {
     packageOverrides = self: super: {
       # https://github.com/pubs/pubs/issues/131
-      pyfakefs = super.pyfakefs.overridePythonAttrs (oldAttrs: rec {
+      pyfakefs = super.pyfakefs.overrideArgs (oldAttrs: rec {
         version = "3.3";
         src = self.fetchPypi {
           pname = "pyfakefs";

--- a/pkgs/tools/networking/linkchecker/default.nix
+++ b/pkgs/tools/networking/linkchecker/default.nix
@@ -4,7 +4,7 @@ let
   # see: https://github.com/linkcheck/linkchecker/issues/76
   python2Packages = (python2.override {
     packageOverrides = self: super: {   
-      requests = super.requests.overridePythonAttrs(oldAttrs: rec {
+      requests = super.requests.overrideArgs(oldAttrs: rec {
         version = "2.14.2";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/tools/virtualization/awsebcli/default.nix
+++ b/pkgs/tools/virtualization/awsebcli/default.nix
@@ -3,7 +3,7 @@ let
 
   localPython = python3.override {
     packageOverrides = self: super: {
-      cement = super.cement.overridePythonAttrs (oldAttrs: rec {
+      cement = super.cement.overrideArgs (oldAttrs: rec {
         version = "2.8.2";
         src = oldAttrs.src.override {
           inherit version;
@@ -11,7 +11,7 @@ let
         };
       });
 
-      colorama = super.colorama.overridePythonAttrs (oldAttrs: rec {
+      colorama = super.colorama.overrideArgs (oldAttrs: rec {
         version = "0.3.7";
         src = oldAttrs.src.override {
           inherit version;
@@ -19,7 +19,7 @@ let
         };
       });
 
-      pathspec = super.pathspec.overridePythonAttrs (oldAttrs: rec {
+      pathspec = super.pathspec.overrideArgs (oldAttrs: rec {
         version = "0.5.5";
         src = oldAttrs.src.override {
           inherit version;
@@ -27,7 +27,7 @@ let
         };
       });
 
-      requests = super.requests.overridePythonAttrs (oldAttrs: rec {
+      requests = super.requests.overrideArgs (oldAttrs: rec {
         version = "2.9.1";
         src = oldAttrs.src.override {
           inherit version;
@@ -35,7 +35,7 @@ let
         };
       });
 
-      semantic-version = super.semantic-version.overridePythonAttrs (oldAttrs: rec {
+      semantic-version = super.semantic-version.overrideArgs (oldAttrs: rec {
         version = "2.5.0";
         src = oldAttrs.src.override {
           inherit version;
@@ -43,7 +43,7 @@ let
         };
       });
 
-      tabulate = super.tabulate.overridePythonAttrs (oldAttrs: rec {
+      tabulate = super.tabulate.overrideArgs (oldAttrs: rec {
         version = "0.7.5";
         src = oldAttrs.src.override {
           inherit version;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -36,17 +36,17 @@ let
   bootstrapped-pip = callPackage ../development/python-modules/bootstrapped-pip { };
 
   # Derivations built with `buildPythonPackage` can already be overriden with `override`, `overrideAttrs`, and `overrideDerivation`.
-  # This function introduces `overridePythonAttrs` and it overrides the call to `buildPythonPackage`.
+  # This function introduces `overrideArgs` and it overrides the call to `buildPythonPackage`.
   makeOverridablePythonPackage = f: origArgs:
     let
       ff = f origArgs;
       overrideWith = newArgs: origArgs // (if pkgs.lib.isFunction newArgs then newArgs origArgs else newArgs);
     in
       if builtins.isAttrs ff then (ff // {
-        overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
+        overrideArgs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
       })
       else if builtins.isFunction ff then {
-        overridePythonAttrs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
+        overrideArgs = newArgs: makeOverridablePythonPackage f (overrideWith newArgs);
         __functor = self: ff;
       }
       else ff;
@@ -1138,7 +1138,7 @@ in {
 
   CommonMark = callPackage ../development/python-modules/commonmark { };
 
-  CommonMark_54 = self.CommonMark.overridePythonAttrs (oldAttrs: rec {
+  CommonMark_54 = self.CommonMark.overrideArgs (oldAttrs: rec {
     version = "0.5.4";
     src = oldAttrs.src.override {
       inherit version;
@@ -1582,7 +1582,7 @@ in {
 
   fudge = callPackage ../development/python-modules/fudge { };
 
-  fudge_9 = self.fudge.overridePythonAttrs (old: rec {
+  fudge_9 = self.fudge.overrideArgs (old: rec {
      version = "0.9.6";
 
      src = fetchPypi {
@@ -2326,7 +2326,7 @@ in {
   fusepy = callPackage ../development/python-modules/fusepy { };
 
   future = callPackage ../development/python-modules/future { };
-  future15 = self.future.overridePythonAttrs (old: rec {
+  future15 = self.future.overrideArgs (old: rec {
     name = "future-${version}";
     version = "0.15.2";
     src = fetchPypi {
@@ -2805,7 +2805,7 @@ in {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy {};
 
-  msgpack-python = self.msgpack.overridePythonAttrs {
+  msgpack-python = self.msgpack.overrideArgs {
     pname = "msgpack-python";
     postPatch = ''
       substituteInPlace setup.py --replace "TRANSITIONAL = False" "TRANSITIONAL = True"
@@ -6850,7 +6850,7 @@ in {
 
   sphinx = callPackage ../development/python-modules/sphinx { };
 
-  sphinx_1_2 = self.sphinx.overridePythonAttrs rec {
+  sphinx_1_2 = self.sphinx.overrideArgs rec {
     name = "sphinx-1.2.3";
     src = pkgs.fetchurl {
       url = "mirror://pypi/s/sphinx/sphinx-1.2.3.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

This allows, eg, specifying a custom `src` to use a different version of a package, like `overrideAttrs` does for normal packages, or `overridePythonAttrs` for Python packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

