### PR TITLE
mattermost: 5.1.0 -> 5.3.0

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, buildGoPackage, buildEnv }:
 
 let
-  version = "5.1.0";
+  version = "5.3.0";
 
   mattermost-server = buildGoPackage rec {
     name = "mattermost-server-${version}";
@@ -10,7 +10,7 @@ let
       owner = "mattermost";
       repo = "mattermost-server";
       rev = "v${version}";
-      sha256 = "069ihmfr6np991mbgg001y0kyafghn57nsv3kpyyvfmhv07p0qbc";
+      sha256 = "0hll62ad12drlqarr7y7zvjj0b12snqm8j5k923lj0064nlpc47z";
     };
 
     goPackagePath = "github.com/mattermost/mattermost-server";
@@ -27,7 +27,7 @@ let
 
     src = fetchurl {
       url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-      sha256 = "1bm5nqnhk2w3sy8mvm81k7d65j6bgpvakgphgwqgnlm864i4253z";
+      sha256 = "1yzhy37frbhik6iq5z8bglpfcjlwnbgcf5iy1davkh7iqpcbxb0s";
     };
 
     installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
New version

###### Things done
- Built on NixOS
- Tested on a ~60 person deployment on NixOS