### PR TITLE
gImageReader: init at 3.2.99 [rdy]

### DIFF
--- a/pkgs/applications/misc/gImageReader/default.nix
+++ b/pkgs/applications/misc/gImageReader/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libuuid
+, sane-backends, podofo, libjpeg, djvulibre, libxmlxx3, libzip, tesseract
+, enchant, intltool, poppler, json-glib
+, ninja
+, python3
+
+# Gtk deps
+# upstream gImagereader supports Qt too
+, gtk3, gobjectIntrospection, wrapGAppsHook
+, gnome3, gtkspell3, gtkspellmm, cairomm
+}:
+
+let
+  variant = "gtk";
+  pythonEnv = python3.withPackages( ps: with ps;[ pygobject3 ] );
+in
+stdenv.mkDerivation rec {
+  name = "gImageReader-${version}";
+  version = "3.2.99";
+
+  src = fetchFromGitHub {
+    owner= "manisandro";
+    repo = "gImageReader";
+    rev = "v${version}";
+    sha256 = "19dbxq83j77lbvi10a8x0xxgw5hbsqyc852c196zzvmwk3km6pnc";
+  };
+
+  nativeBuildInputs = [
+    cmake ninja
+    intltool
+    pkgconfig
+    pythonEnv
+
+    # Gtk specific
+    wrapGAppsHook
+    gobjectIntrospection
+  ];
+
+  buildInputs = [
+    enchant
+    libxmlxx3
+    libzip
+    libuuid
+    sane-backends
+    podofo
+    libjpeg
+    djvulibre
+    tesseract
+    poppler
+
+    # Gtk specific
+    gnome3.gtkmm
+    gtkspell3
+    gtkspellmm
+    gnome3.gtksourceview
+    gnome3.gtksourceviewmm
+    cairomm
+    json-glib
+  ];
+
+  # interface type can be where <type> is either gtk, qt5, qt4
+  cmakeFlags = [ "-DINTERFACE_TYPE=${variant}" ];
+
+  meta = with stdenv.lib; {
+    description = "A simple Gtk/Qt front-end to tesseract-ocr";
+    homepage = https://github.com/manisandro/gImageReader;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [teto];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7984,6 +7984,8 @@ with pkgs;
 
   jython = callPackage ../development/interpreters/jython {};
 
+  gImageReader = callPackage ../applications/misc/gImageReader { };
+
   guile-cairo = callPackage ../development/guile-modules/guile-cairo { };
 
   guile-fibers = callPackage ../development/guile-modules/guile-fibers { };


### PR DESCRIPTION
GImageReader is a GUI for tesseract, an optical character recognition engine.

###### Motivation for this change
Tired of CLI.

###### Things done

While the program supports multiple GUI (qt4/5/gtk), I just implemented gtk. I believe a Qt one might miss some dependencies so I leave it for someone else :)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

