### PR TITLE
python2Packages.plyplus: init at 0.7.5

### DIFF
--- a/pkgs/development/python-modules/plyplus/default.nix
+++ b/pkgs/development/python-modules/plyplus/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchPypi, buildPythonPackage, ply, isPy3k }:
+buildPythonPackage rec {
+  pname = "PlyPlus";
+  version = "0.7.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0g3flgfm3jpb2d8v9z0qmbwca5gxdqr10cs3zvlfhv5cs06ahpnp";
+  };
+
+  propagatedBuildInputs = [ ply ];
+
+  disabled = isPy3k;
+
+  meta = {
+    homepage = https://github.com/erezsh/plyplus;
+    description = "A general-purpose parser built on top of PLY";
+    maintainers = with lib.maintainers; [ twey ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3024,6 +3024,8 @@ in {
 
   ply = callPackage ../development/python-modules/ply { };
 
+  plyplus = callPackage ../development/python-modules/plyplus { };
+
   plyvel = callPackage ../development/python-modules/plyvel { };
 
   osc = callPackage ../development/python-modules/osc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

