### PR TITLE
pythonPackages.ovito: init at 3.0.0

### DIFF
--- a/pkgs/development/python-modules/ovito/default.nix
+++ b/pkgs/development/python-modules/ovito/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit
+, cmake
+, qtbase, libav, netcdf, qscintilla, zlib, boost, git, fftw, hdf5, libssh
+, pythonPackages
+}:
+
+stdenv.mkDerivation rec {
+  # compilation error in 2.9.0 https://gitlab.com/stuko/ovito/issues/40
+  # This is not the "released" 3.0.0 just a commit
+  version = "3.0.0";
+  name = "ovito-${version}";
+
+  src = fetchgit {
+    url = "https://gitlab.com/stuko/ovito";
+    rev = "a28c28182a879d2a1b511ec56f9845306dd8a4db";
+    sha256 = "1vqzv3gzwf8r0g05a7fj8hdyvnzq2h3wdfck7j6n1av6rvp7hi5r";
+  };
+
+  buildInputs = [ cmake libav netcdf qscintilla zlib boost zlib git fftw hdf5 libssh ];
+  propagatedBuildInputs = with pythonPackages; [ sphinx numpy sip pyqt5 matplotlib ase ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Scientific visualization and analysis software for atomistic simulation data";
+    homepage = https://www.ovito.org;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.costrouc ];
+    # ensures not built on hydra
+    # https://github.com/NixOS/nixpkgs/pull/46846#issuecomment-436388048
+    hydraPlatforms = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -422,6 +422,10 @@ in {
 
   outcome = callPackage ../development/python-modules/outcome {};
 
+  ovito = toPythonModule (pkgs.libsForQt5.callPackage ../development/python-modules/ovito {
+      pythonPackages = self;
+    });
+
   palettable = callPackage ../development/python-modules/palettable { };
 
   pathlib = callPackage ../development/python-modules/pathlib { };
@@ -559,7 +563,7 @@ in {
     slurm = pkgs.slurm;
   };
 
-  pystache = callPackage ../development/python-modules/pystache { }; 
+  pystache = callPackage ../development/python-modules/pystache { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 


### PR DESCRIPTION
###### Motivation for this change

ovito is a visualization package for visualizing molecules and doing quick analysis.

###### Things done

pythonPackages.ovito: init at 3.0.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

