### PR TITLE
lollypop-portal: add python3

### DIFF
--- a/pkgs/misc/lollypop-portal/default.nix
+++ b/pkgs/misc/lollypop-portal/default.nix
@@ -1,10 +1,13 @@
 { stdenv, fetchFromGitLab, meson, ninja, pkgconfig
-, python36Packages, gnome3, gst_all_1, gtk3, libnotify
+, python3, gnome3, gst_all_1, gtk3, libnotify
 , kid3, easytag, gobjectIntrospection, wrapGAppsHook }:
 
-stdenv.mkDerivation rec {
+python3.pkgs.buildPythonApplication rec {
   name = "lollypop-portal-${version}";
   version = "0.9.7";
+
+  format = "other";
+  doCheck = false;
 
   src = fetchFromGitLab {
      domain = "gitlab.gnome.org";
@@ -19,33 +22,31 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkgconfig
-    python36Packages.wrapPython
     wrapGAppsHook
   ];
 
   buildInputs = [
-    gnome3.totem-pl-parser
-    gnome3.libsecret
     gnome3.gnome-settings-daemon
-
-    gst_all_1.gstreamer
+    gnome3.libsecret
+    gnome3.totem-pl-parser
     gst_all_1.gst-plugins-base
-
+    gst_all_1.gstreamer
     gtk3
     libnotify
+    python3
   ];
 
-  pythonPath = with python36Packages; [
-    pygobject3
-    pydbus
+  pythonPath = with python3.pkgs; [
     pycairo
+    pydbus
+    pygobject3
   ];
 
   preFixup = ''
     buildPythonPath "$out/libexec/lollypop-portal $pythonPath"
+    patchPythonScript "$out/libexec/lollypop-portal"
 
     gappsWrapperArgs+=(
-      --prefix PYTHONPATH : "$program_PYTHONPATH"
       --prefix PATH : "${stdenv.lib.makeBinPath [ easytag kid3 ]}"
     )
   '';


### PR DESCRIPTION
###### Motivation for this change
This [build failure](https://hydra.nixos.org/build/81614206) against https://github.com/NixOS/nixpkgs/pull/45950

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jtojnar 