### PR TITLE
czmq: 4.0.2 -> 4.1.1

### DIFF
--- a/pkgs/development/libraries/czmq/4.x.nix
+++ b/pkgs/development/libraries/czmq/4.x.nix
@@ -1,20 +1,13 @@
 { stdenv, fetchurl, fetchpatch, zeromq }:
 
 stdenv.mkDerivation rec {
-  version = "4.0.2";
+  version = "4.1.1";
   name = "czmq-${version}";
 
   src = fetchurl {
     url = "https://github.com/zeromq/czmq/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "12gbh57xnz2v82x1g80gv4bwapmyzl00lbin5ix3swyac8i7m340";
+    sha256 = "1h5hrcsc30fcwb032vy5gxkq4j4vv1y4dj460rfs1hhxi0cz83zh";
   };
-
-  patches = [
-    (fetchpatch {
-      url = https://patch-diff.githubusercontent.com/raw/zeromq/czmq/pull/1618.patch;
-      sha256 = "1dssy7k0fni6djail8rz0lk8p777158jvrqhgn500i636gkxaxhp";
-    })
-  ];
 
   # Needs to be propagated for the .pc file to work
   propagatedBuildInputs = [ zeromq ];


### PR DESCRIPTION
###### Motivation for this change

This update fixes the build of `intecture-auth`,  `intecture-agent` and `intecture-cli` which failed on Hydra due to an instance of this bug: https://github.com/zeromq/libzmq/issues/2991. 

ZHF #45960, please backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-review`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

