### PR TITLE
nixos/tt_rss: Give a proper UID

### DIFF
--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -624,7 +624,11 @@ let
     };
 
     users = optionalAttrs (cfg.user == "tt_rss") {
-      users.tt_rss.group = "tt_rss";
+      users.tt_rss = {
+        description = "tt-rss service user";
+        isSystemUser = true;
+        group = "tt_rss";
+      };
       groups.tt_rss = {};
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Currently, a UID from the user area is allocated.
This might break current setups as the UID of the user (which owns files) changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

