### PR TITLE
openxpki: fix build, use current python3Packages

### DIFF
--- a/pkgs/servers/openxpki/default.nix
+++ b/pkgs/servers/openxpki/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPerlPackage, fetchgit, perl, openssl, perlPackages, gettext, python34Packages
+{ stdenv, buildPerlPackage, fetchgit, perl, openssl, perlPackages, gettext, python3Packages
 # TODO: Remove extra dependencies once it is clear that they are NOT needed somewhere.
 , extraDependencies1 ? false, extraDependencies2 ? false, extraDependencies3 ? false }:
 
@@ -11,7 +11,7 @@ buildPerlPackage {
     sha256 = "05bmhani2c7ays488xv3hx5xbxb612bnwq5rdjwmsj51xpaz454p";
   };
 
-  buildInputs = [ perl openssl gettext python34Packages.sphinx ];
+  buildInputs = [ perl openssl gettext python3Packages.sphinx ];
   propagatedBuildInputs = with perlPackages;
     [ # dependencies from Makefile.PL
       libintl_perl ConfigVersioned LWP ClassAccessorChained IOSocketSSL ClassStd


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960.

This package depended on obsolete `python34Packages`. Build failed because `python34Packages.pytest` didn't build anymore: https://hydra.nixos.org/build/81209561. Use `python3Packages` instead.

###### Things done

- [x] built in a sandbox on NixOS

---

