### PR TITLE
link-grammar: init at 5.5.0

### DIFF
--- a/pkgs/tools/text/link-grammar/default.nix
+++ b/pkgs/tools/text/link-grammar/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, pkgconfig, python3, sqlite, libedit, zlib }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  version = "5.5.1";
+  pname = "link-grammar";
+
+  outputs = [ "bin" "out" "dev" "man" ];
+
+  src = fetchurl {
+    url = "http://www.abisource.com/downloads/${pname}/${version}/${name}.tar.gz";
+    sha256 = "1x8kj1yr3b7b6qrvc5b8mm90ff3m4qdbdqplvzii2xlkpvik92ff";
+  };
+
+  nativeBuildInputs = [ pkgconfig python3 ];
+  buildInputs = [ sqlite libedit zlib ];
+
+  configureFlags = [
+    "--disable-java-bindings"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A Grammar Checking library";
+    homepage = https://www.abisource.com/projects/link-grammar/;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1421,6 +1421,8 @@ with pkgs;
 
   libxnd = callPackage ../development/libraries/libxnd { };
 
+  link-grammar = callPackage ../tools/text/link-grammar { };
+
   loadwatch = callPackage ../tools/system/loadwatch { };
 
   loccount = callPackage ../development/tools/misc/loccount { };


### PR DESCRIPTION
###### Motivation for this change

Hasn't been packaged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@jtojnar gave me this nix file and said he'd be okay with maintaining it, but didn't want to submit a PR himself, so here it is.