### PR TITLE
rhash: 2018-02-05 -> 1.3.6

### DIFF
--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, which }:
 
 stdenv.mkDerivation rec {
-  version = "2018-02-05";
+  version = "1.3.6";
   name = "rhash-${version}";
 
   src = fetchFromGitHub {
     owner = "rhash";
     repo = "RHash";
-    rev = "cc26d54ff5df0f692907a5e3132a5eeca559ed61";
-    sha256 = "1ldagp931lmxxpyvsb9rrar4iqwmv94m6lfjzkbkshpmk3p5ng7h";
+    rev = "v${version}";
+    sha256 = "1c8gngjj34ylx1f56hjbvml22bif0bx1b88dx2cyxbix8praxqh7";
   };
 
   nativeBuildInputs = [ which ];


### PR DESCRIPTION
Move to official release now that one exists
beyond the pinned git revision.



Staging because this was previously the source of a mass-rebuild.

Motivation is to 'undo' the non-release "temporary" change
I made previously, hopefully this gives us no problems :).



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---