### PR TITLE
musl: apply upstream fix for locking race, minor cleanup

### DIFF
--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -61,7 +61,8 @@ stdenv.mkDerivation rec {
     configureFlagsArray+=("--syslibdir=$out/lib")
   '';
 
-  CFLAGS="-fstack-protector-strong" + lib.optionalString stdenv.hostPlatform.isPower " -mlong-double-64";
+  CFLAGS = [ "-fstack-protector-strong" ]
+    ++ lib.optional stdenv.hostPlatform.isPower "-mlong-double-64";
 
   configureFlags = [
     "--enable-shared"

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation rec {
       url = https://raw.githubusercontent.com/openwrt/openwrt/87606e25afac6776d1bbc67ed284434ec5a832b4/toolchain/musl/patches/300-relative.patch;
       sha256 = "0hfadrycb60sm6hb6by4ycgaqc9sgrhh42k39v8xpmcvdzxrsq2n";
     })
+    # Upstream bugfix, see: https://git.musl-libc.org/cgit/musl/commit/?id=0db393d3a77bb9f300a356c6a5484fc2dddb161d
+    # Explicitly flagged for inclusion by distributions using musl
+    ./fix-file-locking-race.patch
   ];
   preConfigure = ''
     configureFlagsArray+=("--syslibdir=$out/lib")

--- a/pkgs/os-specific/linux/musl/fix-file-locking-race.patch
+++ b/pkgs/os-specific/linux/musl/fix-file-locking-race.patch
@@ -1,0 +1,54 @@
+From 0db393d3a77bb9f300a356c6a5484fc2dddb161d Mon Sep 17 00:00:00 2001
+From: Kaarle Ritvanen <kaarle.ritvanen@datakunkku.fi>
+Date: Tue, 18 Sep 2018 10:03:27 +0300
+Subject: fix race condition in file locking
+
+The condition occurs when
+- thread #1 is holding the lock
+- thread #2 is waiting for it on __futexwait
+- thread #1 is about to release the lock and performs a_swap
+- thread #3 enters the __lockfile function and manages to grab the lock
+  before thread #1 calls __wake, resetting the MAYBE_WAITERS flag
+- thread #1 calls __wake
+- thread #2 wakes up but goes again to __futexwait as the lock is
+  held by thread #3
+- thread #3 releases the lock but does not call __wake as the
+  MAYBE_WAITERS flag is not set
+
+This condition results in thread #2 not being woken up. This patch fixes
+the problem by making the woken up thread ensure that the flag is
+properly set before going to sleep again.
+
+Mainainer's note: This fixes a regression introduced in commit
+c21f750727515602a9e84f2a190ee8a0a2aeb2a1.
+---
+ src/stdio/__lockfile.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/stdio/__lockfile.c b/src/stdio/__lockfile.c
+index 2ff75d8a..0dcb2a42 100644
+--- a/src/stdio/__lockfile.c
++++ b/src/stdio/__lockfile.c
+@@ -8,13 +8,13 @@ int __lockfile(FILE *f)
+ 	int owner = f->lock, tid = __pthread_self()->tid;
+ 	if ((owner & ~MAYBE_WAITERS) == tid)
+ 		return 0;
+-	for (;;) {
+-		owner = a_cas(&f->lock, 0, tid);
+-		if (!owner) return 1;
+-		if (a_cas(&f->lock, owner, owner|MAYBE_WAITERS)==owner) break;
++	owner = a_cas(&f->lock, 0, tid);
++	if (!owner) return 1;
++	while ((owner = a_cas(&f->lock, 0, tid|MAYBE_WAITERS))) {
++		if ((owner & MAYBE_WAITERS) ||
++		    a_cas(&f->lock, owner, owner|MAYBE_WAITERS)==owner)
++			__futexwait(&f->lock, owner|MAYBE_WAITERS, 1);
+ 	}
+-	while ((owner = a_cas(&f->lock, 0, tid|MAYBE_WAITERS)))
+-		__futexwait(&f->lock, owner, 1);
+ 	return 1;
+ }
+ 
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
Apply important upstream fix.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---