### PR TITLE
musl: apply other selected upstream fixes while rebuilding

### DIFF
--- a/pkgs/os-specific/linux/musl/0001-in-pthread_mutex_trylock-EBUSY-out-more-directly-whe.patch
+++ b/pkgs/os-specific/linux/musl/0001-in-pthread_mutex_trylock-EBUSY-out-more-directly-whe.patch
@@ -1,0 +1,37 @@
+From 4e4a162d9af283cf71f7310c497672e0c2b8ca3b Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Tue, 4 Sep 2018 21:28:38 -0400
+Subject: [PATCH 1/3] in pthread_mutex_trylock, EBUSY out more directly when
+ possible
+
+avoid gratuitously setting up and tearing down the robust list pending
+slot.
+---
+ src/thread/pthread_mutex_trylock.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/thread/pthread_mutex_trylock.c b/src/thread/pthread_mutex_trylock.c
+index 54876a61..783ca0c4 100644
+--- a/src/thread/pthread_mutex_trylock.c
++++ b/src/thread/pthread_mutex_trylock.c
+@@ -15,6 +15,7 @@ int __pthread_mutex_trylock_owner(pthread_mutex_t *m)
+ 		return 0;
+ 	}
+ 	if (own == 0x7fffffff) return ENOTRECOVERABLE;
++	if (own && (!(own & 0x40000000) || !(type & 4))) return EBUSY;
+ 
+ 	if (m->_m_type & 128) {
+ 		if (!self->robust_list.off) {
+@@ -25,8 +26,7 @@ int __pthread_mutex_trylock_owner(pthread_mutex_t *m)
+ 		self->robust_list.pending = &m->_m_next;
+ 	}
+ 
+-	if ((own && (!(own & 0x40000000) || !(type & 4)))
+-	    || a_cas(&m->_m_lock, old, tid) != old) {
++	if (a_cas(&m->_m_lock, old, tid) != old) {
+ 		self->robust_list.pending = 0;
+ 		return EBUSY;
+ 	}
+-- 
+2.19.0
+

--- a/pkgs/os-specific/linux/musl/0002-in-pthread_mutex_timedlock-avoid-repeatedly-reading-.patch
+++ b/pkgs/os-specific/linux/musl/0002-in-pthread_mutex_timedlock-avoid-repeatedly-reading-.patch
@@ -1,0 +1,41 @@
+From d1fa28860634af4f0efd70d533a756b51a45f83e Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Tue, 4 Sep 2018 21:31:47 -0400
+Subject: [PATCH 2/3] in pthread_mutex_timedlock, avoid repeatedly reading
+ mutex type field
+
+compiler cannot cache immutable fields of the mutex object across
+external calls it can't see, much less across atomics.
+---
+ src/thread/pthread_mutex_timedlock.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/thread/pthread_mutex_timedlock.c b/src/thread/pthread_mutex_timedlock.c
+index 0a240e79..f91f4a61 100644
+--- a/src/thread/pthread_mutex_timedlock.c
++++ b/src/thread/pthread_mutex_timedlock.c
+@@ -6,7 +6,8 @@ int __pthread_mutex_timedlock(pthread_mutex_t *restrict m, const struct timespec
+ 	    && !a_cas(&m->_m_lock, 0, EBUSY))
+ 		return 0;
+ 
+-	int r, t, priv = (m->_m_type & 128) ^ 128;
++	int type = m->_m_type;
++	int r, t, priv = (type & 128) ^ 128;
+ 
+ 	r = pthread_mutex_trylock(m);
+ 	if (r != EBUSY) return r;
+@@ -15,9 +16,9 @@ int __pthread_mutex_timedlock(pthread_mutex_t *restrict m, const struct timespec
+ 	while (spins-- && m->_m_lock && !m->_m_waiters) a_spin();
+ 
+ 	while ((r=pthread_mutex_trylock(m)) == EBUSY) {
+-		if (!(r=m->_m_lock) || ((r&0x40000000) && (m->_m_type&4)))
++		if (!(r=m->_m_lock) || ((r&0x40000000) && (type&4)))
+ 			continue;
+-		if ((m->_m_type&3) == PTHREAD_MUTEX_ERRORCHECK
++		if ((type&3) == PTHREAD_MUTEX_ERRORCHECK
+ 		 && (r&0x7fffffff) == __pthread_self()->tid)
+ 			return EDEADLK;
+ 
+-- 
+2.19.0
+

--- a/pkgs/os-specific/linux/musl/0003-fix-namespace-violation-for-c11-mutex-functions.patch
+++ b/pkgs/os-specific/linux/musl/0003-fix-namespace-violation-for-c11-mutex-functions.patch
@@ -1,0 +1,35 @@
+From 2de29bc994029b903a366b8a4a9f8c3c3ee2be90 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Tue, 4 Sep 2018 22:56:57 -0400
+Subject: [PATCH 3/3] fix namespace violation for c11 mutex functions
+
+__pthread_mutex_timedlock is used to implement c11 mutex functions,
+and therefore cannot call pthread_mutex_trylock by name.
+---
+ src/thread/pthread_mutex_timedlock.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/thread/pthread_mutex_timedlock.c b/src/thread/pthread_mutex_timedlock.c
+index f91f4a61..d2bd1960 100644
+--- a/src/thread/pthread_mutex_timedlock.c
++++ b/src/thread/pthread_mutex_timedlock.c
+@@ -1,5 +1,7 @@
+ #include "pthread_impl.h"
+ 
++int __pthread_mutex_trylock(pthread_mutex_t *);
++
+ int __pthread_mutex_timedlock(pthread_mutex_t *restrict m, const struct timespec *restrict at)
+ {
+ 	if ((m->_m_type&15) == PTHREAD_MUTEX_NORMAL
+@@ -15,7 +17,7 @@ int __pthread_mutex_timedlock(pthread_mutex_t *restrict m, const struct timespec
+ 	int spins = 100;
+ 	while (spins-- && m->_m_lock && !m->_m_waiters) a_spin();
+ 
+-	while ((r=pthread_mutex_trylock(m)) == EBUSY) {
++	while ((r=__pthread_mutex_trylock(m)) == EBUSY) {
+ 		if (!(r=m->_m_lock) || ((r&0x40000000) && (type&4)))
+ 			continue;
+ 		if ((type&3) == PTHREAD_MUTEX_ERRORCHECK
+-- 
+2.19.0
+

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -61,7 +61,8 @@ stdenv.mkDerivation rec {
     configureFlagsArray+=("--syslibdir=$out/lib")
   '';
 
-  CFLAGS="-fstack-protector-strong" + lib.optionalString stdenv.hostPlatform.isPower " -mlong-double-64";
+  CFLAGS = [ "-fstack-protector-strong" ]
+    ++ lib.optional stdenv.hostPlatform.isPower "-mlong-double-64";
 
   configureFlags = [
     "--enable-shared"

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation rec {
       url = https://raw.githubusercontent.com/openwrt/openwrt/87606e25afac6776d1bbc67ed284434ec5a832b4/toolchain/musl/patches/300-relative.patch;
       sha256 = "0hfadrycb60sm6hb6by4ycgaqc9sgrhh42k39v8xpmcvdzxrsq2n";
     })
+    # Upstream bugfix, see: https://git.musl-libc.org/cgit/musl/commit/?id=0db393d3a77bb9f300a356c6a5484fc2dddb161d
+    # Explicitly flagged for inclusion by distributions using musl
+    ./fix-file-locking-race.patch
   ];
   preConfigure = ''
     configureFlagsArray+=("--syslibdir=$out/lib")

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -59,6 +59,14 @@ stdenv.mkDerivation rec {
     # Upstream bugfix, see: https://git.musl-libc.org/cgit/musl/commit/?id=0db393d3a77bb9f300a356c6a5484fc2dddb161d
     # Explicitly flagged for inclusion by distributions using musl
     ./fix-file-locking-race.patch
+    # More specific error reporting
+    ./tty-more-precise-errors.patch
+    # Use execveat to impl fexecve when avail (useful for containers)
+    ./fexecve-execveat.patch
+    # improve behavior in few cases
+		./0001-in-pthread_mutex_trylock-EBUSY-out-more-directly-whe.patch
+		./0002-in-pthread_mutex_timedlock-avoid-repeatedly-reading-.patch
+		./0003-fix-namespace-violation-for-c11-mutex-functions.patch
   ];
   preConfigure = ''
     configureFlagsArray+=("--syslibdir=$out/lib")

--- a/pkgs/os-specific/linux/musl/fexecve-execveat.patch
+++ b/pkgs/os-specific/linux/musl/fexecve-execveat.patch
@@ -1,0 +1,33 @@
+From e36f80cba6d5eefcc1ee664f16c2c72054b83134 Mon Sep 17 00:00:00 2001
+From: "Joseph C. Sible" <josephcsible@gmail.com>
+Date: Sun, 2 Sep 2018 13:42:26 -0400
+Subject: implement fexecve in terms of execveat when it exists
+
+This lets fexecve work even when /proc isn't mounted.
+---
+ src/process/fexecve.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/process/fexecve.c b/src/process/fexecve.c
+index 6507b429..8be3f760 100644
+--- a/src/process/fexecve.c
++++ b/src/process/fexecve.c
+@@ -1,10 +1,15 @@
++#define _GNU_SOURCE
+ #include <unistd.h>
+ #include <errno.h>
++#include <fcntl.h>
++#include "syscall.h"
+ 
+ void __procfdname(char *, unsigned);
+ 
+ int fexecve(int fd, char *const argv[], char *const envp[])
+ {
++	int r = __syscall(SYS_execveat, fd, "", argv, envp, AT_EMPTY_PATH);
++	if (r != -ENOSYS) return __syscall_ret(r);
+ 	char buf[15 + 3*sizeof(int)];
+ 	__procfdname(buf, fd);
+ 	execve(buf, argv, envp);
+-- 
+cgit v1.2.1
+

--- a/pkgs/os-specific/linux/musl/fix-file-locking-race.patch
+++ b/pkgs/os-specific/linux/musl/fix-file-locking-race.patch
@@ -1,0 +1,54 @@
+From 0db393d3a77bb9f300a356c6a5484fc2dddb161d Mon Sep 17 00:00:00 2001
+From: Kaarle Ritvanen <kaarle.ritvanen@datakunkku.fi>
+Date: Tue, 18 Sep 2018 10:03:27 +0300
+Subject: fix race condition in file locking
+
+The condition occurs when
+- thread #1 is holding the lock
+- thread #2 is waiting for it on __futexwait
+- thread #1 is about to release the lock and performs a_swap
+- thread #3 enters the __lockfile function and manages to grab the lock
+  before thread #1 calls __wake, resetting the MAYBE_WAITERS flag
+- thread #1 calls __wake
+- thread #2 wakes up but goes again to __futexwait as the lock is
+  held by thread #3
+- thread #3 releases the lock but does not call __wake as the
+  MAYBE_WAITERS flag is not set
+
+This condition results in thread #2 not being woken up. This patch fixes
+the problem by making the woken up thread ensure that the flag is
+properly set before going to sleep again.
+
+Mainainer's note: This fixes a regression introduced in commit
+c21f750727515602a9e84f2a190ee8a0a2aeb2a1.
+---
+ src/stdio/__lockfile.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/stdio/__lockfile.c b/src/stdio/__lockfile.c
+index 2ff75d8a..0dcb2a42 100644
+--- a/src/stdio/__lockfile.c
++++ b/src/stdio/__lockfile.c
+@@ -8,13 +8,13 @@ int __lockfile(FILE *f)
+ 	int owner = f->lock, tid = __pthread_self()->tid;
+ 	if ((owner & ~MAYBE_WAITERS) == tid)
+ 		return 0;
+-	for (;;) {
+-		owner = a_cas(&f->lock, 0, tid);
+-		if (!owner) return 1;
+-		if (a_cas(&f->lock, owner, owner|MAYBE_WAITERS)==owner) break;
++	owner = a_cas(&f->lock, 0, tid);
++	if (!owner) return 1;
++	while ((owner = a_cas(&f->lock, 0, tid|MAYBE_WAITERS))) {
++		if ((owner & MAYBE_WAITERS) ||
++		    a_cas(&f->lock, owner, owner|MAYBE_WAITERS)==owner)
++			__futexwait(&f->lock, owner|MAYBE_WAITERS, 1);
+ 	}
+-	while ((owner = a_cas(&f->lock, 0, tid|MAYBE_WAITERS)))
+-		__futexwait(&f->lock, owner, 1);
+ 	return 1;
+ }
+ 
+-- 
+cgit v1.2.1
+

--- a/pkgs/os-specific/linux/musl/tty-more-precise-errors.patch
+++ b/pkgs/os-specific/linux/musl/tty-more-precise-errors.patch
@@ -1,0 +1,51 @@
+From c84971995b3a6d5118f9357c040572f4c78bcd55 Mon Sep 17 00:00:00 2001
+From: Benjamin Peterson <benjamin@python.org>
+Date: Thu, 13 Sep 2018 14:23:42 -0700
+Subject: improve error handling of ttyname_r and isatty
+
+POSIX allows ttyname(_r) and isatty to return EBADF if passed file
+descriptor is invalid.
+
+maintainer's note: these are optional ("may fail") errors, but it's
+non-conforming for ttyname_r to return ENOTTY when it failed for a
+different reason.
+---
+ src/unistd/isatty.c    | 6 +++++-
+ src/unistd/ttyname_r.c | 2 +-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/unistd/isatty.c b/src/unistd/isatty.c
+index c8badaf5..75a9c186 100644
+--- a/src/unistd/isatty.c
++++ b/src/unistd/isatty.c
+@@ -1,9 +1,13 @@
+ #include <unistd.h>
++#include <errno.h>
+ #include <sys/ioctl.h>
+ #include "syscall.h"
+ 
+ int isatty(int fd)
+ {
+ 	struct winsize wsz;
+-	return !__syscall(SYS_ioctl, fd, TIOCGWINSZ, &wsz);
++	unsigned long r = syscall(SYS_ioctl, fd, TIOCGWINSZ, &wsz);
++	if (r == 0) return 1;
++	if (errno != EBADF) errno = ENOTTY;
++	return 0;
+ }
+diff --git a/src/unistd/ttyname_r.c b/src/unistd/ttyname_r.c
+index cb364c29..82acb75e 100644
+--- a/src/unistd/ttyname_r.c
++++ b/src/unistd/ttyname_r.c
+@@ -9,7 +9,7 @@ int ttyname_r(int fd, char *name, size_t size)
+ 	char procname[sizeof "/proc/self/fd/" + 3*sizeof(int) + 2];
+ 	ssize_t l;
+ 
+-	if (!isatty(fd)) return ENOTTY;
++	if (!isatty(fd)) return errno;
+ 
+ 	__procfdname(procname, fd);
+ 	l = readlink(procname, name, size);
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
Builds on top of #46870 .

I've been using most of these for some time,
namely the pthread and fexecve commits.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---