### PR TITLE
nixos/tests/containers-imperative: fix on i686

### DIFF
--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -13,6 +13,7 @@ import ./make-test.nix ({ pkgs, ...} : {
       # XXX: Sandbox setup fails while trying to hardlink files from the host's
       #      store file system into the prepared chroot directory.
       nix.useSandbox = false;
+      nix.binaryCaches = []; # don't try to access cache.nixos.org
 
       virtualisation.writableStore = true;
       virtualisation.memorySize = 1024;
@@ -27,9 +28,10 @@ import ./make-test.nix ({ pkgs, ...} : {
             };
           };
         };
-      in [
-        pkgs.stdenv pkgs.stdenvNoCC emptyContainer.config.containers.foo.path
-        pkgs.libxslt
+      in with pkgs; [
+        stdenv stdenvNoCC emptyContainer.config.containers.foo.path
+        libxslt desktop-file-utils texinfo docbook5 libxml2
+        docbook_xsl_ns xorg.lndir documentation-highlighter
       ];
     };
 


### PR DESCRIPTION
###### Motivation for this change

Test [failed on i686](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.containers-imperative.i686-linux/all) in a sandbox because some packages required in the test vm to build the nixos manual for the container were missing. Add them.

ZHF #45960, please backport.

###### Things done

- [x] NixOS test passes in a sandbox for x86_64-linux and i686-linux
---

