### PR TITLE
Cython 0.28.5, hypothesis 3.69.2

### DIFF
--- a/pkgs/development/python-modules/Cython/default.nix
+++ b/pkgs/development/python-modules/Cython/default.nix
@@ -25,11 +25,11 @@ let
 
 in buildPythonPackage rec {
   pname = "Cython";
-  version = "0.28.3";
+  version = "0.28.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1aae6d6e9858888144cea147eb5e677830f45faaff3d305d77378c3cba55f526";
+    sha256 = "b64575241f64f6ec005a4d4137339fb0ba5e156e826db2fdb5f458060d9979e0";
   };
 
   nativeBuildInputs = [
@@ -51,11 +51,10 @@ in buildPythonPackage rec {
   doCheck = !stdenv.isDarwin;
 
   patches = [
-    # The following is in GitHub in 0.28.3 but not in the `sdist`.
-    # https://github.com/cython/cython/issues/2319
     (fetchpatch {
-      url = https://github.com/cython/cython/commit/c485b1b77264c3c75d090a3c526de24966830d42.patch;
-      sha256 = "1p6jj9rb097kqvhs5j5127sj5zy18l7x9v0p478cjyzh41khh9r0";
+      name = "Cython-fix-test-py3.7.patch";
+      url = https://github.com/cython/cython/commit/eae37760bfbe19e7469aa41269480b84ce12b6cd.patch;
+      sha256 = "0irk53psrs05kzzlvbfv7s3q02x5lsnk5qrv0zd1ra3mw2sfyym6";
     })
   ];
 

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -2,14 +2,15 @@
 , isPy3k, attrs, coverage, enum34
 , doCheck ? true, pytest, pytest_xdist, flaky, mock
 }:
-buildPythonPackage rec {
+
+buildPythonPackage (rec {
   # http://hypothesis.readthedocs.org/en/latest/packaging.html
 
   # Hypothesis has optional dependencies on the following libraries
   # pytz fake_factory django numpy pytest
   # If you need these, you can just add them to your environment.
 
-  version = "3.66.2";
+  version = "3.69.2";
   pname = "hypothesis";
 
   # Use github tarballs that includes tests
@@ -17,7 +18,7 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis-python";
     rev = "hypothesis-python-${version}";
-    sha256 = "17ywbwa76z7f0pgash0003fvm25fsj7hxdrdiprdbv99y3i8bm88";
+    sha256 = "08pg05s7866sd32d48n9m4rkl5h758dv2qjjkz1yjhn6djqpisnl";
   };
 
   postUnpack = "sourceRoot=$sourceRoot/hypothesis-python";
@@ -27,14 +28,17 @@ buildPythonPackage rec {
   checkInputs = [ pytest pytest_xdist flaky mock ];
   inherit doCheck;
 
-  checkPhase = ''
-    rm tox.ini # This file changes how py.test runs and breaks it
-    py.test tests/cover
-  '';
-
   meta = with lib; {
     description = "A Python library for property based testing";
     homepage = https://github.com/HypothesisWorks/hypothesis;
     license = licenses.mpl20;
   };
 }
+//
+# We use this trick to avoid rebuilding py.test, if only checkPhase was changed.
+(if doCheck then {
+  checkPhase = ''
+    rm tox.ini # This file changes how py.test runs and breaks it
+    py.test tests/cover
+  '';
+} else {}))


### PR DESCRIPTION
###### Motivation for this change
Update 2 packages to their latest versions, fix cython build with python 3.7.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS: python 2.7, 3.6, 3.7
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

