### PR TITLE
pythonPackages.python-binance: init at 0.7.0

### DIFF
--- a/pkgs/development/python-modules/python-binance/default.nix
+++ b/pkgs/development/python-modules/python-binance/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, fetchPypi
+, pytest, requests-mock, tox
+, autobahn, certifi, chardet, cryptography, dateparser, pyopenssl, requests, service-identity, twisted }:
+
+buildPythonPackage rec {
+  version = "0.7.0";
+  pname = "python-binance";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h8kd88j53w6yfc60fr8a45zi30p09l98vm8yzqym4lcgx76nvps";
+  };
+
+  doCheck = false;  # Tries to test multiple interpreters with tox
+  checkInputs = [ pytest requests-mock tox ];
+
+  propagatedBuildInputs = [ autobahn certifi chardet cryptography dateparser pyopenssl requests service-identity twisted ];
+
+  meta = {
+    description = "Binance Exchange API python implementation for automated trading";
+    homepage = https://github.com/sammchardy/python-binance;
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -511,6 +511,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  python-binance = callPackage ../development/python-modules/python-binance { };
+
   python-hosts = callPackage ../development/python-modules/python-hosts { };
 
   python-lz4 = callPackage ../development/python-modules/python-lz4 { };


### PR DESCRIPTION
Library for communicating with the Binance REST API.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

