### PR TITLE
nixos/tests/hibernate: prevent non-deterministic failure on i686

### DIFF
--- a/nixos/tests/hibernate.nix
+++ b/nixos/tests/hibernate.nix
@@ -35,8 +35,8 @@ import ./make-test.nix (pkgs: {
       $machine->waitForOpenPort(4444);
       $machine->succeed("systemctl hibernate &");
       $machine->waitForShutdown;
+      $probe->waitForUnit("multi-user.target");
       $machine->start;
-      $probe->waitForUnit("network.target");
       $probe->waitUntilSucceeds("echo test | nc machine 4444 -N");
     '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix non-deterministic failures, [mostly on i686](https://hydra.nixos.org/job/nixos/release-18.09/nixos.tests.hibernate.i686-linux).

Improve timing. With this, the failures are no longer reproducible on my machine. 

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

