### PR TITLE
exempi: fix i686 build

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2396,7 +2396,9 @@ with pkgs;
 
   exa = callPackage ../tools/misc/exa { };
 
-  exempi = callPackage ../development/libraries/exempi { };
+  exempi = callPackage ../development/libraries/exempi {
+    stdenv = if stdenv.isi686 then overrideCC stdenv gcc6 else stdenv;
+  };
 
   execline = skawarePackages.execline;
 


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960.
Build failed on i686 with `unknown symbol __divmoddi4`. Standard fix is to use gcc6.

###### Things done

- [x] built in sandbox on NixOS
- [x] change doesn't affect other platforms

---

