### PR TITLE
deepin.go-x11-client: init at 0.0.4.1

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -25,6 +25,7 @@ let
     go-dbus-generator = callPackage ./go-dbus-generator { };
     go-gir-generator = callPackage ./go-gir-generator { };
     go-lib = callPackage ./go-lib { };
+    go-x11-client = callPackage ./go-x11-client { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
     qt5integration = callPackage ./qt5integration { };
 

--- a/pkgs/desktops/deepin/go-x11-client/default.nix
+++ b/pkgs/desktops/deepin/go-x11-client/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "go-x11-client";
+  version = "0.0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "11n2m3ipyxb5v0bh098lrc24jjdmfavjbas8r8n3jkzb9953883q";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "A X11 client Go bindings for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/go-x11-client;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Add [go-x11-client](https://github.com/linuxdeepin/go-x11-client), a X11 protocol go language binding.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).