### PR TITLE
mr: 1.20170129 -> 1.20180726

### DIFF
--- a/pkgs/applications/version-management/mr/default.nix
+++ b/pkgs/applications/version-management/mr/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchgit, perl }:
 
 stdenv.mkDerivation rec {
-  version = "1.20170129";
+  version = "1.20180726";
   name = "mr-${version}";
 
   src = fetchgit {


### PR DESCRIPTION
###### Motivation for this change
Upgrade myrepos from 1.20170129 to 1.20180726

###### Things done
Bumped version to 1.20170129

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

