### PR TITLE
plano-theme: 3.28-2 -> 3.28-3

### DIFF
--- a/pkgs/misc/themes/plano/default.nix
+++ b/pkgs/misc/themes/plano/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "plano-theme-${version}";
-  version = "3.28-2";
+  version = "3.28-3";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "plano-theme";
     rev = "v${version}";
-    sha256 = "1xd8xpd8pxxsx6nqrxv2scm9fy6vig8qyxdydgkzhpscrjg9iq9f";
+    sha256 = "0k9jgnifc2s8vsw9fanknx1mg8vlh6qa1cbb910nm4vgrxsbrc74";
   };
 
   buildInputs = [ gdk_pixbuf gtk_engines ];
@@ -23,11 +23,11 @@ stdenv.mkDerivation rec {
     rm $out/share/themes/Plano/LICENSE
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Flat theme for GNOME & Xfce4";
     homepage = https://github.com/lassekongo83/plano-theme;
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.unix;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version 3.28-3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).