### PR TITLE
zuki-themes: 3.28-1 -> 3.28-3

### DIFF
--- a/pkgs/misc/themes/zuki/default.nix
+++ b/pkgs/misc/themes/zuki/default.nix
@@ -1,32 +1,30 @@
-{ stdenv, fetchFromGitHub, gdk_pixbuf, gtk_engines, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, gdk_pixbuf, librsvg, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   name = "zuki-themes-${version}";
-  version = "3.28-1";
+  version = "3.28-3";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "zuki-themes";
     rev = "v${version}";
-    sha256 = "1if39k8vgk4cpshl625vdf8lz6jgicgybd5nilycj66sf1k5jgb9";
+    sha256 = "0sgp41fpd8lyyb0v82y41v3hmb0ayv3zqqrv0m3ln0dzkr7ym9g7";
   };
 
-  buildInputs = [ gdk_pixbuf gtk_engines ];
+  buildInputs = [ gdk_pixbuf librsvg ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
-
-  dontBuild = true;
 
   installPhase = ''
     install -dm 755 $out/share/themes
     cp -a Zuki* $out/share/themes/
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Themes for GTK3, gnome-shell and more";
     homepage = https://github.com/lassekongo83/zuki-themes;
-    license = stdenv.lib.licenses.gpl3;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version [3.28-3](https://github.com/lassekongo83/zuki-themes/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).