### PR TITLE
python3.pkgs.typeguard: fix builds by applying utf-8 locales

### DIFF
--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -4,6 +4,7 @@
 , stdenv
 , setuptools_scm
 , pytest
+, glibcLocales
 }:
 
 buildPythonPackage rec {
@@ -16,6 +17,9 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ glibcLocales ];
+
+  LC_ALL="en_US.utf-8";
 
   postPatch = ''
     substituteInPlace setup.cfg --replace " --cov" ""


### PR DESCRIPTION
ZHF #45960





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---