### PR TITLE
pythonPackages.osmnx: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/osmnx/default.nix
+++ b/pkgs/development/python-modules/osmnx/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub, geopandas, descartes, matplotlib, networkx, numpy
+, pandas, requests, Rtree, shapely, pytest, coverage, coveralls, folium, scikitlearn, scipy}:
+
+buildPythonPackage rec {
+  pname = "osmnx";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner  = "gboeing";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1pn2v3dhbmb0yhqif9padg7x3sdx27pgfr95i3kxj4v0yrviaf9k";
+  };
+
+  propagatedBuildInputs = [ geopandas descartes matplotlib networkx numpy pandas requests Rtree shapely folium scikitlearn scipy ];
+
+  checkInputs = [ coverage pytest coveralls ];
+  #Fails when using sandboxing as it requires internet connection, works fine without it
+  doCheck = false;
+
+  #Check phase for the record
+  #checkPhase = ''
+  #  coverage run --source osmnx -m pytest --verbose
+  #'';
+
+  meta = with stdenv.lib; {
+    description = "A package to easily download, construct, project, visualize, and analyze complex street networks from OpenStreetMap with NetworkX.";
+    homepage = https://github.com/gboeing/osmnx;
+    license = licenses.mit;
+    maintainers = with maintainers; [ psyanticy ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -368,6 +368,8 @@ in {
 
   ordered-set = callPackage ../development/python-modules/ordered-set { };
 
+  osmnx = callPackage ../development/python-modules/osmnx { };
+
   outcome = callPackage ../development/python-modules/outcome {};
 
   palettable = callPackage ../development/python-modules/palettable { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

