### PR TITLE
NetworkManager VPN plugins are broken on master (and 18.09)

### DIFF
--- a/pkgs/tools/networking/network-manager/openvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/openvpn/default.nix
@@ -30,6 +30,10 @@ in stdenv.mkDerivation rec {
     "--localstatedir=/" # needed for the management socket under /run/NetworkManager
   ];
 
+  postInstall = ''
+    sed -i -e "s|plugin=|plugin=$out/lib/NetworkManager/|" $out/lib/NetworkManager/VPN/nm-openvpn-service.name
+  '';
+
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;


### PR DESCRIPTION
###### Motivation for this change

This PR includes only a fix for OpenVPN plugin, but we can consider it a hack since I'm not that familiar with networkmanager's build system and how to set `@PLUGINDIR@` correctly.

Any help / pointers from maintainers is greatly appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

