### PR TITLE
lightdm: ensure run-directory is /run/lightdm

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
   ] ++ optional withQt4 qt4
     ++ optional withQt5 qtbase;
 
+  patches = [ ./run-dir.patch ];
 
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 

--- a/pkgs/applications/display-managers/lightdm/run-dir.patch
+++ b/pkgs/applications/display-managers/lightdm/run-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/data/lightdm.conf b/data/lightdm.conf
+index 16b80f7..b3af435 100644
+--- a/data/lightdm.conf
++++ b/data/lightdm.conf
+@@ -28,7 +28,7 @@
+ #guest-account-script=guest-account
+ #logind-check-graphical=false
+ #log-directory=/var/log/lightdm
+-#run-directory=/var/run/lightdm
++run-directory=/run/lightdm
+ #cache-directory=/var/cache/lightdm
+ #sessions-directory=/usr/share/lightdm/sessions:/usr/share/xsessions:/usr/share/wayland-sessions
+ #remote-sessions-directory=/usr/share/lightdm/remote-sessions


### PR DESCRIPTION
###### Motivation for this change
We changed the tmpfiles here #46886 to squash an error so I think it wouldn't hurt to ensure this through a patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @xeji 
