### PR TITLE
Doc: Minor fix for python virtualenv example in nix-shell

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -997,6 +997,7 @@ stdenv.mkDerivation {
   SOURCE_DATE_EPOCH=$(date +%s)
   virtualenv --no-setuptools venv
   export PATH=$PWD/venv/bin:$PATH
+  export PYTHONPATH=venv/lib/python2.7/site-packages/:$PYTHONPATH
   pip install -r requirements.txt
   '';
 }


### PR DESCRIPTION
Closes #43737

Based on suggestion mentioned in https://github.com/NixOS/nixpkgs/issues/39558#issuecomment-395429328

###### Motivation for this change
Took me some time to fix this, hope this helps someone else.


###### Things done
- Added single line to FAQ section in documentation

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

