### PR TITLE
undervolt: 2.8 -> 2.9

### DIFF
--- a/pkgs/os-specific/linux/undervolt/default.nix
+++ b/pkgs/os-specific/linux/undervolt/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python3Packages }:
 
 python3Packages.buildPythonApplication rec {
-  version = "0.2.8";
+  version = "0.2.9";
   pname = "undervolt";
 
   src = fetchFromGitHub {
     owner = "georgewhewell";
     repo = "undervolt";
     rev = "${version}";
-    sha256 = "0crkqc5zq0gpyg031hfwdxymfc2gc1h8b6m0axzlh7gvnxlf5hra";
+    sha256 = "1d934lp8yczrfslmwff6fxzd4arja2vg00s5kwdr949bxpa6w59c";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Looking to try this, noticed update :).

Looks fine but probably should be tested by someone.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---