### PR TITLE
pahole: (??) -> v1.12, cleanup

### DIFF
--- a/pkgs/development/tools/misc/pahole/default.nix
+++ b/pkgs/development/tools/misc/pahole/default.nix
@@ -1,20 +1,19 @@
 { stdenv, fetchgit, cmake, elfutils, zlib }:
 
-stdenv.mkDerivation {
-  name = "pahole-head";
+stdenv.mkDerivation rec {
+  name = "pahole-${version}";
+  version = "1.12";
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/devel/pahole/pahole.git;
-    sha256 = "05f8a14ea6c200c20e9c6738593b38e4ced73a9cef86499ccd7af910eb9b74b3";
-    rev = "1decb1bc4a412a0902b7b25190d755a875022d03";
+    sha256 = "1a8xfwqdc2j3ydh9bk2pkvsaf3lrkbxj66vj991c7knc31ix8kpw";
+    rev = "v${version}";
   };
-  buildInputs = [ cmake elfutils zlib ];
 
-  postInstall = ''
-    for p in $out/bin/*; do
-      rpath=`patchelf --print-rpath $p || true`:$out
-      patchelf --set-rpath "$rpath" $p || true
-    done
-  '';
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ elfutils zlib ];
+
+  # Put libraries in "lib" subdirectory, not top level of $out
+  cmakeFlags = [ "-D__LIB=lib" ];
 
   meta = with stdenv.lib; {
     homepage = https://git.kernel.org/cgit/devel/pahole/pahole.git/;


### PR DESCRIPTION
(roughly 2015-09-15 -> 2018-08-16)



Much newer, reasonable library location.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---