### PR TITLE
nixos/tests/gdk-pixbuf: fix test on i686

### DIFF
--- a/nixos/tests/gdk-pixbuf.nix
+++ b/nixos/tests/gdk-pixbuf.nix
@@ -10,10 +10,12 @@ import ./make-test.nix ({ pkgs, ... }: {
     environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
     environment.variables.XDG_DATA_DIRS = [ "${pkgs.gdk_pixbuf.installedTests}/share" ];
 
-    virtualisation.memorySize = 4096; # Tests allocate a lot of memory trying to exploit a CVE
+    # Tests allocate a lot of memory trying to exploit a CVE
+    # but qemu-system-i386 has a 2047M memory limit
+    virtualisation.memorySize = if pkgs.stdenv.isi686 then 2047 else 4096;
   };
 
   testScript = ''
-    $machine->succeed("gnome-desktop-testing-runner");
+    $machine->succeed("gnome-desktop-testing-runner -t 1800"); # increase timeout to 1800s
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

Test VM [didn't start up on i686](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.gdk-pixbuf.i686-linux) because it tried to create a VM with 4096M RAM but `qemu-system-i386` has a hard 2047M memory limit.

- reduce memory to 2047M on i686.
- increase timeout 300s -> 1800s because the tests are much slower
  on i686 and timed out.

This fixes the test on my machine (but no guarantees for Hydra :smile:).

ZHF #45960 , please backport

###### Things done

- [x] test succeeds on my local machine for i686 and x86_64-linux

---

cc @jtojnar 
