### PR TITLE
pokerth: 1.1.1 -> 1.1.2, refactor, Qt 5

### DIFF
--- a/pkgs/games/pokerth/default.nix
+++ b/pkgs/games/pokerth/default.nix
@@ -1,47 +1,74 @@
-{ stdenv, fetchFromGitHub, qmake4Hook, qt4, protobuf, boost155, tinyxml2, libgcrypt, sqlite, gsasl, curl, SDL, SDL_mixer, libircclient }:
+{ stdenv, fetchFromGitHub, runCommand, fetchpatch, patchutils, qmake, qtbase
+, SDL, SDL_mixer, boost, curl, gsasl, libgcrypt, libircclient, protobuf, sqlite
+, tinyxml2, target ? "client" }:
 
-let boost = boost155;
-in stdenv.mkDerivation rec {
-  name            = "${pname}-${version}";
-  pname           = "pokerth";
-  version         = "1.1.2";
+with stdenv.lib;
 
-  src = fetchFromGitHub {
-    owner  = pname;
-    repo   = pname;
-    rev    = "v${version}";
-    sha256 = "0m74jyd9h3yaly3avy65zw7r2iv5b62c2dqizbxsagjsr9a3g0cg";
+let
+  hiDPI = fetchpatch {
+    url = https://github.com/pokerth/pokerth/commit/ad8c9cabfb85d8293720d0f14840278d38b5feeb.patch;
+    sha256 = "192x3lqvd1fanasb95shdygn997qfrpk1k62k1f4j3s5chkwvjig";
   };
 
-  buildInputs = [ qmake4Hook qt4 protobuf boost tinyxml2 libgcrypt sqlite gsasl curl SDL SDL_mixer libircclient ];
+  revertPatch = patch: runCommand "revert-${patch.name}" {} ''
+    ${patchutils}/bin/interdiff ${patch} /dev/null > $out
+  '';
+in
 
-  outputs = [ "out" "server" ];
+stdenv.mkDerivation rec {
+  name = "pokerth-${target}-${version}";
+  version = "1.1.2";
 
-  qmakeFlags = [ "pokerth.pro" "DEFINES+=_WEBSOCKETPP_NOEXCEPT_TOKEN_=noexcept" ];
+  src = fetchFromGitHub {
+    owner = "pokerth";
+    repo = "pokerth";
+    rev = "f5688e01b0efb37035e3b0e3a432200185b9a0c5";
+    sha256 = "0la8d036pbscjnbxf8lkrqjfq8a4ywsfwxil452fhlays6mr19h0";
+  };
+
+  patches = [
+    (revertPatch hiDPI)
+  ];
+
+  postPatch = ''
+    for f in *.pro; do
+      substituteInPlace $f \
+        --replace '$$'{PREFIX}/include/libircclient ${libircclient.dev}/include/libircclient \
+        --replace 'LIB_DIRS =' 'LIB_DIRS = ${boost.out}/lib' \
+        --replace /opt/gsasl ${gsasl}
+    done
+  '';
+
+  nativeBuildInputs = [ qmake ];
+
+  buildInputs = [
+    SDL
+    SDL_mixer
+    boost
+    curl
+    gsasl
+    libgcrypt
+    libircclient
+    protobuf
+    qtbase
+    sqlite
+    tinyxml2
+  ];
+
+  qmakeFlags = [
+    "CONFIG+=${target}"
+    "pokerth.pro"
+  ];
 
   NIX_CFLAGS_COMPILE = [ "-I${SDL.dev}/include/SDL" ];
 
-  postPatch = ''
-    for f in connectivity.pro load.pro pokerth_game.pro pokerth_server.pro
-    do
-      substituteInPlace $f \
-        --replace 'LIB_DIRS =' 'LIB_DIRS = ${boost.out}/lib' \
-        --replace '/opt/gsasl/' '${gsasl}/'
-    done
-    substituteInPlace pokerth_server.pro --replace '$$'{PREFIX}/include/libircclient '${libircclient.dev}/include/libircclient'
-  '';
-
   enableParallelBuilding = true;
 
-  postInstall = ''
-    install -D -m755 bin/pokerth_server $server/bin/pokerth_server
-  '';
-
-  meta = with stdenv.lib; {
-    homepage    = https://www.pokerth.net;
-    description = "Open Source Poker client and server";
-    license     = licenses.gpl3;
-    maintainers = with maintainers; [ obadz ];
-    platforms   = platforms.all;
+  meta = {
+    homepage = https://www.pokerth.net;
+    description = "Poker game ${target}";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ obadz yegortimoshenko ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/games/pokerth/default.nix
+++ b/pkgs/games/pokerth/default.nix
@@ -4,13 +4,13 @@ let boost = boost155;
 in stdenv.mkDerivation rec {
   name            = "${pname}-${version}";
   pname           = "pokerth";
-  version         = "1.1.1";
+  version         = "1.1.2";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
-    rev    = "7f3c8a860848c16c8c2f78e3929a65a54ef4c04c";
-    sha256 = "1md3sl7pdpn3n42k75pxqbkkl19cz4699g1vdi04qpp0jxx09a2k";
+    rev    = "v${version}";
+    sha256 = "0m74jyd9h3yaly3avy65zw7r2iv5b62c2dqizbxsagjsr9a3g0cg";
   };
 
   buildInputs = [ qmake4Hook qt4 protobuf boost tinyxml2 libgcrypt sqlite gsasl curl SDL SDL_mixer libircclient ];
@@ -25,8 +25,10 @@ in stdenv.mkDerivation rec {
     for f in connectivity.pro load.pro pokerth_game.pro pokerth_server.pro
     do
       substituteInPlace $f \
-        --replace 'LIB_DIRS =' 'LIB_DIRS = ${boost.out}/lib'
+        --replace 'LIB_DIRS =' 'LIB_DIRS = ${boost.out}/lib' \
+        --replace '/opt/gsasl/' '${gsasl}/'
     done
+    substituteInPlace pokerth_server.pro --replace '$$'{PREFIX}/include/libircclient '${libircclient.dev}/include/libircclient'
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20305,9 +20305,9 @@ with pkgs;
 
   pong3d = callPackage ../games/pong3d { };
 
-  pokerth = callPackage ../games/pokerth { };
+  pokerth = libsForQt5.callPackage ../games/pokerth { };
 
-  pokerth-server = pokerth.server;
+  pokerth-server = libsForQt5.callPackage ../games/pokerth { target = "server"; };
 
   prboom = callPackage ../games/prboom { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20305,9 +20305,7 @@ with pkgs;
 
   pong3d = callPackage ../games/pong3d { };
 
-  pokerth = callPackage ../games/pokerth {
-    protobuf = protobuf3_4;
-  };
+  pokerth = callPackage ../games/pokerth { };
 
   pokerth-server = pokerth.server;
 


### PR DESCRIPTION
###### Motivation for this change
Disclaimer: I'm not a user of pokerth, so ping @obadz. I've just picked up a random item from #33248, and updated from Qt4 to Qt5 version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

