### PR TITLE
ocamlPackages.elpi: init at 1.0.5

### DIFF
--- a/pkgs/development/ocaml-modules/elpi/default.nix
+++ b/pkgs/development/ocaml-modules/elpi/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, camlp5_strict
+, ppx_tools_versioned, ppx_deriving, re
+}:
+
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-elpi-${version}";
+  version = "1.0.5";
+  src = fetchFromGitHub {
+    owner = "LPCIC";
+    repo = "elpi";
+    rev = "v${version}";
+    sha256 = "1n1m183l4ms949m2l24w0887m1rmvc9b3j8alnbw8ckn6wwnhpmk";
+  };
+
+  buildInputs = [ ocaml findlib ppx_tools_versioned ];
+
+  propagatedBuildInputs = [ camlp5_strict ppx_deriving re ];
+
+  createFindlibDestdir = true;
+
+  preInstall = "make byte";
+
+  postInstall = ''
+    mkdir -p $out/bin
+    make install-bin BIN=$out/bin
+    make install-bin BYTE=1 BIN=$out/bin
+  '';
+
+  meta = {
+    description = "Embeddable λProlog Interpreter";
+    license = stdenv.lib.licenses.lgpl21Plus;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -234,6 +234,8 @@ let
 
     eliom = callPackage ../development/ocaml-modules/eliom { };
 
+    elpi = callPackage ../development/ocaml-modules/elpi { };
+
     enumerate = callPackage ../development/ocaml-modules/enumerate { };
 
     erm_xml = callPackage ../development/ocaml-modules/erm_xml { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

