### PR TITLE
nixos/tests/networking.virtual: prevent non-deterministic failure

### DIFF
--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -467,7 +467,7 @@ let
 
         # Wait for networking to come up
         $machine->start;
-        $machine->waitForUnit("network.target");
+        $machine->waitForUnit("network-online.target");
 
         # Test interfaces set up
         my $list = $machine->succeed("ip tuntap list | sort");
@@ -479,7 +479,9 @@ let
 
         # Test interfaces clean up
         $machine->succeed("systemctl stop network-addresses-tap0");
+        $machine->sleep(10);
         $machine->succeed("systemctl stop network-addresses-tun0");
+        $machine->sleep(10);
         my $residue = $machine->succeed("ip tuntap list");
         $residue eq "" or die(
           "Some virtual interface has not been properly cleaned:\n",


### PR DESCRIPTION
###### Motivation for this change

The test [failed non-deterministically on Hydra](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.networking.networkd.virtual.x86_64-linux/all) because interfaces sometimes weren't yet fully cleaned up when the result was checked, probably due to high load. Should be fixed by waiting a little.

Please backport to 18.09 #45960. 

###### Things done

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

---

