### PR TITLE
gitlab: add missing meta.platforms

### DIFF
--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -109,5 +109,6 @@ stdenv.mkDerivation rec {
     description = "Web-based Git-repository manager";
     homepage = https://gitlab.com;
     license = licenses.mit;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

`meta.platforms` was missing. Fixes #46919. 
