### PR TITLE
nix-pin: 0.3.4 -> 0.4.0

### DIFF
--- a/pkgs/tools/package-management/nix-pin/default.nix
+++ b/pkgs/tools/package-management/nix-pin/default.nix
@@ -1,12 +1,12 @@
 { lib, pkgs, stdenv, fetchFromGitHub, mypy, python3, nix, git, makeWrapper }:
 let self = stdenv.mkDerivation rec {
   name = "nix-pin-${version}";
-  version = "0.3.4";
+  version = "0.4.0";
   src = fetchFromGitHub {
     owner = "timbertson";
     repo = "nix-pin";
-    rev = "version-0.3.4";
-    sha256 = "03wdxai3hpv2v9jp7r91x8y36ryz6v1cczmx3d26g1bf0ij5svb8";
+    rev = "version-${version}";
+    sha256 = "1pccvc0iqapms7kidrh09g5fdx44x622r5l9k7bkmssp3v4c68vy";
   };
   buildInputs = [ python3 mypy makeWrapper ];
   checkPhase = ''
@@ -36,6 +36,7 @@ let self = stdenv.mkDerivation rec {
           --set repo nix-pin \
           --set type fetchFromGitHub \
           --set rev 'version-{version}' \
+          --substitute rev 'version-''${{version}}' \
           --modify-nix default.nix
       '';
     };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

