### PR TITLE
nixos/emby: ensure plugins are writeable

### DIFF
--- a/nixos/modules/services/misc/emby.nix
+++ b/nixos/modules/services/misc/emby.nix
@@ -36,11 +36,18 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
-        test -d ${cfg.dataDir} || {
-          echo "Creating initial Emby data directory in ${cfg.dataDir}"
-          mkdir -p ${cfg.dataDir}
-          chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
-          }
+        if [ -d ${cfg.dataDir} ]
+        then
+            for plugin in ${cfg.dataDir}/plugins/*
+            do
+                echo "Correcting permissions of plugin: $plugin"
+                chmod u+w $plugin
+            done
+        else
+            echo "Creating initial Emby data directory in ${cfg.dataDir}"
+            mkdir -p ${cfg.dataDir}
+            chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
+        fi
       '';
 
       serviceConfig = {


### PR DESCRIPTION
Emby manages plugins at `/var/lib/emby/${dataDir}/plugins` like [this](https://github.com/MediaBrowser/Emby/blob/f1998b6aa926269761071990e829ae4f5b351745/Emby.Server.Implementations/ApplicationHost.cs#L1814).
When an upgrade occurs the plugins are already there and it just overwrites them.
However it can't because they aren't writeable. This causes an exception during runtime.

A very simple solution for now is to just make them writeable after we know the `dataDir` exists.
(definitely after an upgrade)

I've testing in a vm a couple times by simulating an upgrade and I no longer see the exception @numinit reported.

###### Motivation for this change
```
System.UnauthorizedAccessException: Access to the path "/nix/store/nfmvvn6jv5b29q8a1m8pz2mmx4y3fjfn-emby-3.5.2.0/bin/plugins/Emby.Server.CinemaMode.dll" or "/var/lib/emby/ProgramData-Server/plugins/Emby.Server.CinemaMode.dll" is denied.
  at System.IO.File.Copy (System.String sourceFileName, System.String destFileName, System.Boolean overwrite) [0x00192] in <2bf5cbaa96234d758393ee9c32a4b268>:0
  at Emby.Server.Implementations.ApplicationHost.CopyPlugins (System.String source, System.String target) [0x0008f] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetPluginAssemblies () [0x00023] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetComposablePartAssemblies () [0x00000] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.DiscoverTypes () [0x00015] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.Init () [0x0009b] in <ea7199aea78e429a84e168a1e154646a>:0
  at MediaBrowser.Server.Mono.MainClass.RunApplication (Emby.Server.Implementations.ServerApplicationPaths appPaths, MediaBrowser.Model.Logging.ILogManager logManager, Emby.Server.Implementations.StartupOptions options) [0x000c2] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
  at MediaBrowser.Server.Mono.MainClass.Main (System.String[] args) [0x0009c] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
System.UnauthorizedAccessException
  at System.IO.File.Copy (System.String sourceFileName, System.String destFileName, System.Boolean overwrite) [0x00192] in <2bf5cbaa96234d758393ee9c32a4b268>:0
  at Emby.Server.Implementations.ApplicationHost.CopyPlugins (System.String source, System.String target) [0x0008f] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetPluginAssemblies () [0x00023] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.GetComposablePartAssemblies () [0x00000] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.DiscoverTypes () [0x00015] in <ea7199aea78e429a84e168a1e154646a>:0
  at Emby.Server.Implementations.ApplicationHost.Init () [0x0009b] in <ea7199aea78e429a84e168a1e154646a>:0
  at MediaBrowser.Server.Mono.MainClass.RunApplication (Emby.Server.Implementations.ServerApplicationPaths appPaths, MediaBrowser.Model.Logging.ILogManager logManager, Emby.Server.Implementations.StartupOptions options) [0x000c2] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
  at MediaBrowser.Server.Mono.MainClass.Main (System.String[] args) [0x0009c] in <674f05e6c9e14fbaa7955ba5ed6025ed>:0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

