### PR TITLE
phraseapp: 1.6.0 -> 1.11.0

### DIFF
--- a/pkgs/tools/misc/phraseapp-client/default.nix
+++ b/pkgs/tools/misc/phraseapp-client/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "phraseapp-client-${version}";
-  version = "1.6.0";
+  version = "1.11.0";
 
   goPackagePath = "github.com/phrase/phraseapp-client";
   subPackages = [ "." ];
@@ -11,8 +11,12 @@ buildGoPackage rec {
     owner = "phrase";
     repo = "phraseapp-client";
     rev = version;
-    sha256 = "0rgwl0rgkci045hg36s0q8jwkni1hzapqpi0mc0gk3rl7nagw622";
+    sha256 = "0lfx0wv95hgczi74qnkw2cripwgvl53z2gi5i6nyflisy4r7vvkr";
   };
+
+  postInstall = ''
+    ln -s $bin/bin/phraseapp-client $bin/bin/phraseapp
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://docs.phraseapp.com;


### PR DESCRIPTION
###### Motivation for this change

simple version bump, but also add `phraseapp` executable for compatiblity with normal phraseapp installs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

