### PR TITLE
circleci-cli: 0.1.0 -> 0.1.2307

### DIFF
--- a/pkgs/development/tools/misc/circleci-cli/default.nix
+++ b/pkgs/development/tools/misc/circleci-cli/default.nix
@@ -1,28 +1,24 @@
-{ stdenv, fetchFromGitHub, docker, makeWrapper }:
+{ stdenv, fetchFromGitHub, docker, makeWrapper, buildGoPackage }:
 
-stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+let
+  owner = "CircleCI-Public";
   pname = "circleci-cli";
-  version = "0.1.0";
+  version = "0.1.2307";
+in
+buildGoPackage rec {
+  name = "${pname}-${version}";
+  inherit version;
 
-  src = fetchFromGitHub {
-    owner = "circleci";
-    repo = "local-cli";
+  src =  fetchFromGitHub {
+    inherit owner;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1bv1ck5zvyl6pyvbfglizg8ybna4yg2nz441kiv5rmp4g27n6db2";
+    sha256 = "0z71jnq42idvhgpgn3mdpbajmgn4b41rpifv5qxn3h1pgi08f75s";
   };
 
+  goPackagePath = "github.com/${owner}/${pname}";
+
   nativeBuildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    mkdir -p "$out/bin/"
-    cp "$src/circleci.sh" "$out/bin/circleci"
-  '';
-
-  postFixup = ''
-    wrapProgram $out/bin/circleci \
-      --prefix "PATH" : "${docker}/bin"
-  '';
 
   meta = with stdenv.lib; {
     # Box blurb edited from the AUR package circleci-cli

--- a/pkgs/development/tools/misc/circleci-cli/default.nix
+++ b/pkgs/development/tools/misc/circleci-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, docker, makeWrapper, buildGoPackage }:
+{ stdenv, fetchFromGitHub, buildGoPackage }:
 
 let
   owner = "CircleCI-Public";
@@ -17,8 +17,6 @@ buildGoPackage rec {
   };
 
   goPackagePath = "github.com/${owner}/${pname}";
-
-  nativeBuildInputs = [ makeWrapper ];
 
   meta = with stdenv.lib; {
     # Box blurb edited from the AUR package circleci-cli


### PR DESCRIPTION
We are also building from source now, instead of using a pre-packaged
version. This means we need Go. Also did minor refactors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

