### PR TITLE
tint2: 16.4 -> 16.6.1

### DIFF
--- a/pkgs/applications/misc/tint2/default.nix
+++ b/pkgs/applications/misc/tint2/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "tint2-${version}";
-  version = "16.4";
+  version = "16.6.1";
 
   src = fetchFromGitLab {
     owner = "o9000";
     repo = "tint2";
     rev = version;
-    sha256 = "1h9l45zimai2hqfcf2y98g4i03imhmvm3mlsld9x99i650kxr5jm";
+    sha256 = "1h5bn4vi7gffwi4mpwpn0s6vxvl44rn3m9b23w8q9zyz9v24flz7";
   };
 
   enableParallelBuilding = true;
@@ -24,20 +24,18 @@ stdenv.mkDerivation rec {
     libXdmcp libstartup_notification hicolor-icon-theme ];
 
   postPatch = ''
-    substituteInPlace CMakeLists.txt --replace /etc $out/etc
     for f in ./src/launcher/apps-common.c \
-             ./src/launcher/icon-theme-common.c \
-             ./themes/*tint2rc
+             ./src/launcher/icon-theme-common.c
     do
       substituteInPlace $f --replace /usr/share/ /run/current-system/sw/share/
     done
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://gitlab.com/o9000/tint2;
     description = "Simple panel/taskbar unintrusive and light (memory, cpu, aestetic)";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.romildo ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to version [16.6.1](https://gitlab.com/o9000/tint2/blob/16.6.1/ChangeLog)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).