### PR TITLE
installer: autorun xserver in graphical media

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -28,6 +28,14 @@
      Postgresql for NixOS service now defaults to v11.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The graphical installer image starts the graphical session automatically.
+     Before you'd be greeted by a tty and asked to enter <command>systemctl start display-manager</command>.
+     It is now possible to disable the display-manager from running by selecting the <literal>Disable display-manager</literal>
+     quirk in the boot menu.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -25,9 +25,6 @@ with lib;
   services.xserver = {
     enable = true;
 
-    # Don't start the X server by default.
-    autorun = mkForce false;
-
     # Automatically login as nixos.
     displayManager.slim = {
       enable = true;

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -284,6 +284,14 @@ let
         ${buildMenuAdditionalParamsGrub2 config "video=1920x1080@60"}
       }
 
+      # If we boot into a graphical environment where X is autoran
+      # and always crashes, it makes the media unusable. Allow the user
+      # to disable this.
+      submenu "Disable display-manager" --class quirk-disable-displaymanager {
+        ${grubMenuCfg}
+        ${buildMenuAdditionalParamsGrub2 config "systemd.mask=display-manager.service"}
+      }
+
       # Some laptop and convertibles have the panel installed in an
       # inconvenient way, rotated away from the keyboard.
       # Those entries makes it easier to use the installer.


### PR DESCRIPTION
###### Motivation for this change
When I first used the NixOS iso I found it confusing and strange to have to do `systemctl start display-manager`. I assumed that I would have went straight to the graphical environment.

If anyone has a reason as to why it shouldn't do this please share.

###### Notes
In #42610 @adisbladis suggested:
> I think we should add another boot entry so you can still choose not to start the graphical environment, at the same time we make the one that autostarts the graphical environment the default.

Wouldn't this need https://github.com/NixOS/nixpkgs/pull/45345 to include that configuration as a child config in the grub menu?

Though I feel that might be to complex.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @samueldr @xeji @grahamc 
