### PR TITLE
ocaml ≤ 4.05: mark as broken on Aarch64

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (args // rec {
       '';
 
     platforms = with platforms; linux ++ darwin;
-    broken = stdenv.isAarch64 && !stdenv.lib.versionAtLeast major_version "4.06";
+    broken = stdenv.isAarch64 && !stdenv.lib.versionAtLeast version "4.06";
   };
 
 })


### PR DESCRIPTION
###### Motivation for this change

#46726 marked **all** versions of OCaml as broken on Aarch64, which is a bit too much. I hope this one is better.

cc/ @Mic92.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

