### PR TITLE
doc/stdenv: libaries -> libraries

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2129,7 +2129,7 @@ someVar=$(stripHash $name)
    The most typical use of the setup hook is actually to add other hooks which
    are then run (i.e. after all the setup hooks) on each dependency. For
    example, the C compiler wrapper's setup hook feeds itself flags for each
-   dependency that contains relevant libaries and headers. This is done by
+   dependency that contains relevant libraries and headers. This is done by
    defining a bash function, and appending its name to one of
    <envar>envBuildBuildHooks</envar>`, <envar>envBuildHostHooks</envar>`,
    <envar>envBuildTargetHooks</envar>`, <envar>envHostHostHooks</envar>`,


### PR DESCRIPTION
This commit corrects a minor typo in the stdenv portion of the
documentation for the nix language.

###### Motivation for this change
Found a small typo while reading documentation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

