### PR TITLE
numix-cursor-theme: 20160110 -> 1.1

### DIFF
--- a/pkgs/data/icons/numix-cursor-theme/default.nix
+++ b/pkgs/data/icons/numix-cursor-theme/default.nix
@@ -1,24 +1,27 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, inkscape, xcursorgen }:
 
 stdenv.mkDerivation rec {
-  version = "20160110";
-
+  version = "1.1";
   package-name = "numix-cursor-theme";
-
   name = "${package-name}-${version}";
 
   src = fetchFromGitHub {
     owner = "numixproject";
     repo = package-name;
-    rev = "e92186d9df47c04d4e0a778eb6941ef58590b179";
-    sha256 = "1sr4pisgrn3632phsiny2fyr2ib6l51fnjdsanmh9ampagl4ly7g";
+    rev = "v${version}";
+    sha256 = "0p8h48wsy3z5dz9vdnp01fpn6q8ky0h74l5qgixlip557bsa1spi";
   };
 
-  dontBuild = true;
+  nativeBuildInputs = [ inkscape xcursorgen ];
+
+  buildPhase = ''
+    patchShebangs .
+    HOME=$TMP ./build.sh
+  '';
 
   installPhase = ''
     install -dm 755 $out/share/icons
-    cp -dr --no-preserve='ownership' Numix{,-Light} $out/share/icons/
+    cp -dr --no-preserve='ownership' Numix-Cursor{,-Light} $out/share/icons/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.1](https://github.com/numixproject/numix-cursor-theme/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).