### PR TITLE
Nethack cross

### DIFF
--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, coreutils, ncurses, gzip, flex, bison
 , less, makeWrapper
 , buildPackages
-, x11Mode ? false, qtMode ? false, libXaw, libXext, mkfontdir, pkgconfig, qt5
+, x11Mode ? false, qtMode ? false, libXaw, libXext, bdftopcf, mkfontdir, pkgconfig, qt5
 }:
 
 let
@@ -34,10 +34,11 @@ in stdenv.mkDerivation rec {
                 ++ lib.optionals qtMode [ gzip qt5.qtbase.bin qt5.qtmultimedia.bin ];
 
   nativeBuildInputs = [ flex bison ]
-                      ++ lib.optionals x11Mode [ mkfontdir ]
+                      ++ lib.optionals x11Mode [ mkfontdir bdftopcf ]
                       ++ lib.optionals qtMode [
                            pkgconfig mkfontdir qt5.qtbase.dev
                            qt5.qtmultimedia.dev makeWrapper
+                           bdftopcf
                          ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -64,12 +64,14 @@ in stdenv.mkDerivation rec {
       -e 's,^CFLAGS=-g,CFLAGS=,' \
       -i sys/unix/hints/macosx10.10
     sed -e '/define CHDIR/d' -i include/config.h
+    ${lib.optionalString qtMode ''
     sed \
       -e 's,^QTDIR *=.*,QTDIR=${qt5.qtbase.dev},' \
       -e 's,CFLAGS.*QtGui.*,CFLAGS += `pkg-config Qt5Gui --cflags`,' \
       -e 's,CFLAGS+=-DCOMPRESS.*,CFLAGS+=-DCOMPRESS=\\"${gzip}/bin/gzip\\" \\\
         -DCOMPRESS_EXTENSION=\\".gz\\",' \
       -i sys/unix/hints/linux-qt4
+    ''}
   '';
 
   configurePhase = ''

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -132,7 +132,8 @@ in stdenv.mkDerivation rec {
     chmod +x $out/bin/nethack
     ${lib.optionalString x11Mode "mv $out/bin/nethack $out/bin/nethack-x11"}
     ${lib.optionalString qtMode "mv $out/bin/nethack $out/bin/nethack-qt"}
-    install -Dm 555 util/{makedefs,dgn_comp,lev_comp,dlb} -t $out/libexec/nethack/
+    install -Dm 555 util/{makedefs,dgn_comp,lev_comp} -t $out/libexec/nethack/
+    ${lib.optionalString (!(x11Mode || qtMode)) "install -Dm 555 util/dlb -t $out/libexec/nethack/"}
   '';
 
   postFixup = lib.optionalString qtMode ''

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -73,7 +73,11 @@ in stdenv.mkDerivation rec {
         -DCOMPRESS_EXTENSION=\\".gz\\",' \
       -i sys/unix/hints/linux-qt4
     ''}
-    ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform)
+    # If we're cross-compiling, replace the paths to the data generation tools
+    # with the ones from the build platform's nethack package, since we can't
+    # run the ones we've built here.
+    ''
     ${buildPackages.perl}/bin/perl -p \
       -e 's,[a-z./]+/(makedefs|dgn_comp|lev_comp|dlb)(?!\.),${buildPackages.nethack}/libexec/nethack/\1,g' \
       -i sys/unix/Makefile.*


### PR DESCRIPTION
###### Motivation for this change
Allow cross-compiling nethack for a wider range of dungeon-crawling fun.

cc maintainer @abbradar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Tested by building `pkgsCross.aarch64-multiplatform.nethack` on an x86_64 machine, copying the result to the community box, and running it.