### PR TITLE
slimserver: Relax audio scan dependency

### DIFF
--- a/pkgs/servers/slimserver/default.nix
+++ b/pkgs/servers/slimserver/default.nix
@@ -10,11 +10,6 @@ buildPerlPackage rec {
     sha256 = "0szp5zkmx2b5lncsijf97asjnl73fyijkbgbwkl1i7p8qnqrb4mp";
   };
 
-  patches = [ (fetchpatch {
-    url = "https://github.com/Logitech/slimserver/pull/204.patch";
-    sha256 = "0n1c8nsbvqkmwj5ivkcxh1wkqqm1lwymmfz9i47ih6ifj06hkpxk";
-  } ) ];
-
   buildInputs = [
     makeWrapper
     perl
@@ -72,6 +67,10 @@ buildPerlPackage rec {
     rm -rf CPAN
     rm -rf Bin
     touch Makefile.PL
+
+    # relax audio scan version constraints
+    substituteInPlace lib/Audio/Scan.pm --replace "0.93" "1.01"
+    substituteInPlace modules.conf --replace "Audio::Scan 0.93 0.95" "Audio::Scan 0.93"
     '';
 
   preConfigurePhase = "";


### PR DESCRIPTION
###### Motivation for this change

Fix broken dependency constraint #46813 , fixes slimserver service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

