### PR TITLE
zathura: disable synctexSupport by default

### DIFF
--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, useMupdf ? true, synctexSupport ? true }:
+{ pkgs, useMupdf ? true, synctexSupport ? false }:
 
 let
   callPackage = pkgs.newScope self;


### PR DESCRIPTION
If enabled, zathura currently fails to build on 18.09

###### Motivation for this change
This is currently broken on: https://github.com/NixOS/nixpkgs-channels/tree/nixos-18.09

Failing with:
```
[29/38] Compiling C object 'zathura@sta/zathura_shortcuts.c.o'.
[30/38] Compiling C object 'zathura@sta/zathura_synctex.c.o'.
FAILED: zathura@sta/zathura_synctex.c.o
/nix/store/iw94llkj05wgaz268mlzvgx8jkbi1ss0-gcc-wrapper-7.3.0/bin/cc -Izathura@sta -I. -I.. -I../ -Idata -I/nix/store/xv568b9mz2vdszss8qm76ck0q05g9ww5-gtk+3-3.22.30-dev/include/gtk-3.0 -I/nix/store/7w6fz25rxw43xihfhyzj2j9c4jlnsdp0-glib-2.56.0-dev/include/glib-2.0 -I/nix/store/wgki8qb0h5q963pm890i0i3kpf15mmd8-glib-2.56.0/lib/glib-2.0/include -I/nix/store/27jaxgs7azws5gpb2w5pddc1qg9nr6m3-cairo-1.15.12-dev/include/cairo -I/nix/store/zavrkx3070qvv5zv8840grl8jrzp3wsk-freetype-2.9-dev/include/freetype2 -I/nix/store/zavrkx3070qvv5zv8840grl8jrzp3wsk-freetype-2.9-dev/include -I/nix/store/qr3k68h122nclxvgfwl9rh25ij36140j-pango-1.42.1-dev/include/pango-1.0 -I/nix/store/w3whis019b8fqsnpgyh3460r84rx4ms7-fribidi-1.0.5/include/fribidi -I/nix/store/ip6incsc37i9lhhyrasl669zi4yy392b-gdk-pixbuf-2.36.12-dev/include/gdk-pixbuf-2.0 -I/nix/store/pkq35lfwa1img2d4jb74nid73g9mbxwl-atk-2.28.1-dev/include/atk-1.0 -I/nix/store/mcf1dlzaglp66rp9ajxal7g4lz8kp38x-girara-0.3.0/include -I/nix/store/7w6fz25rxw43xihfhyzj2j9c4jlnsdp0-glib-2.56.0-dev/include/gio-unix-2.0/ -I/nix/store/1f78125jdwigxk7m72p7rxplvhy30abf-sqlite-3.24.0-dev/include -I/nix/store/lqziwnwams56sil06vddravn6iiaswb6-texlive-bin-2018/include/synctex -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -O3 -fPIC -pthread '-DGETTEXT_PACKAGE="zathura"' '-DLOCALEDIR="/nix/store/plbnhjkw1la7aihmcdn8l6x34v3g3sha-zathura-core-0.4.0/share/locale"' '-DZATHURA_PLUGINDIR="/nix/store/plbnhjkw1la7aihmcdn8l6x34v3g3sha-zathura-core-0.4.0/lib/zathura"' -D_DEFAULT_SOURCE -DWITH_SQLITE -DWITH_SYNCTEX -DWITH_SYNCTEX1 -DWITH_MAGIC -Wall -Wextra -pedantic -Werror=implicit-function-declaration -Werror=vla -fvisibility=hidden  -MD -MQ 'zathura@sta/zathura_synctex.c.o' -MF 'zathura@sta/zathura_synctex.c.o.d' -o 'zathura@sta/zathura_synctex.c.o' -c ../zathura/synctex.c
In file included from ../zathura/synctex.c:8:0:
/nix/store/lqziwnwams56sil06vddravn6iiaswb6-texlive-bin-2018/include/synctex/synctex_parser.h:53:10: fatal error: synctex_version.h: No such file or directory
 #include "synctex_version.h"
          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
builder for '/nix/store/5nnjbn8cdq0mxz9cq34gaz9v697k81xs-zathura-core-0.4.0.drv' failed with exit code 1
cannot build derivation '/nix/store/bz90skc33pp4g5gvxviaqdlx9dryqqxk-zathura-with-plugins-0.4.0.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/qrxlymp46pnm4rjrhg279xvy02bngn1y-system-path.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/0p4laz83y06a28sm8zzan81xkhgkhpzi-nixos-system-nebula-18.09.git.643f31a.drv': 1 dependencies couldn't be built
error: build of '/nix/store/0p4laz83y06a28sm8zzan81xkhgkhpzi-nixos-system-nebula-18.09.git.643f31a.drv' failed
```

Disabling it makes zathura build successfully.


#### I'd also like to request a backport of this change to 18.09 in order to avoid having the package broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

