### PR TITLE
broken darwin packages (d)

### DIFF
--- a/pkgs/applications/virtualization/docker/proxy.nix
+++ b/pkgs/applications/virtualization/docker/proxy.nix
@@ -24,6 +24,6 @@ buildGoPackage rec {
     license = licenses.asl20;
     homepage = https://github.com/docker/libnetwork;
     maintainers = with maintainers; [vdemeester];
-    platforms = docker.meta.platforms;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/misc/emulators/dolphin-emu/master.nix
+++ b/pkgs/misc/emulators/dolphin-emu/master.nix
@@ -78,6 +78,7 @@ in stdenv.mkDerivation rec {
     branch = "master";
     # x86_32 is an unsupported platform.
     # Enable generic build if you really want a JIT-less binary.
+    broken = stdenv.isDarwin;
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     homepage    = http://www.gnu.org/software/dico/;
     license     = licenses.gpl3Plus;
     maintainers = with maintainers; [ lovek323 ];
-    platforms   = platforms.unix;
+    platforms   = platforms.linux;
 
     longDescription = ''
       GNU Dico is a flexible modular implementation of DICT server


### PR DESCRIPTION
###### Motivation for this change

Disable various broken packages on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

