### PR TITLE
gitAndTools.pass-git-helper: init at 0.4

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -113,6 +113,8 @@ let
 
   pre-commit = callPackage ./pre-commit { };
 
+  pass-git-helper = python3Packages.callPackage ./pass-git-helper { };
+
   qgit = qt5.callPackage ./qgit { };
 
   stgit = callPackage ./stgit {

--- a/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
@@ -1,10 +1,8 @@
-{ stdenv, buildPythonApplication, isPy3k, fetchFromGitHub, pyxdg }:
+{ stdenv, buildPythonApplication, fetchFromGitHub, pyxdg }:
 
 buildPythonApplication rec {
   pname   = "pass-git-helper";
   version = "0.4";
-
-  disabled = !isPy3k;
 
   src = fetchFromGitHub {
     owner  = "languitar";

--- a/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pass-git-helper/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonApplication, isPy3k, fetchFromGitHub, pyxdg }:
+
+buildPythonApplication rec {
+  pname   = "pass-git-helper";
+  version = "0.4";
+
+  disabled = !isPy3k;
+
+  src = fetchFromGitHub {
+    owner  = "languitar";
+    repo   = "pass-git-helper";
+    rev    = "${version}";
+    sha256 = "1zccbmq5l6asl9qm1f90vg9467y3spmv3ayrw07qizrj43yfd9ap";
+  };
+
+  propagatedBuildInputs = [ pyxdg ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/languitar/pass-git-helper";
+    description = "A git credential helper interfacing with pass, the standard unix password manager";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ vanzef ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Adding pass integration for git credentials.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

