### PR TITLE
gsconnect: init at 20

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -179,7 +179,10 @@ in {
                               networkmanager-iodine networkmanager-l2tp; };
 
     # Needed for themes and backgrounds
-    environment.pathsToLink = [ "/share" ];
+    environment.pathsToLink = [
+      "/share"
+      "/share/nautilus-python/extensions"
+    ];
 
   };
 

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -338,6 +338,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   metacity = callPackage ./misc/metacity { };
 
+  nautilus-python = callPackage ./misc/nautilus-python { };
+
   pidgin-im-gnome-shell-extension = callPackage ./misc/pidgin { };
 
   gtkhtml = callPackage ./misc/gtkhtml { };

--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -1,0 +1,91 @@
+{ stdenv, fetchFromGitHub, substituteAll, python3, openssl
+, meson, ninja, libxml2, pkgconfig, gobject-introspection, wrapGAppsHook
+, glib, gtk3, at-spi2-core, upower, openssh, gnome3 }:
+
+stdenv.mkDerivation rec {
+  name = "gnome-shell-gsconnect-${version}";
+  version = "20";
+
+  src = fetchFromGitHub {
+    owner = "andyholmes";
+    repo = "gnome-shell-extension-gsconnect";
+    rev = "v${version}";
+    sha256 = "1x5lrb4hdw482hr5dh4ki0p1651w1s0ijs96vs65vrh15cd60h02";
+  };
+
+  patches = [
+    # Make typelibs available in the extension
+    (substituteAll {
+      src = ./fix-paths.patch;
+      gapplication = "${glib.bin}/bin/gapplication";
+      mutter_gsettings_path = "${gnome3.mutter}/share/gsettings-schemas/${gnome3.mutter.name}/glib-2.0/schemas";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig
+    gobject-introspection # for locating typelibs
+    wrapGAppsHook # for wrapping daemons
+    libxml2 # xmllint
+  ];
+
+  buildInputs = [
+    (python3.withPackages (pkgs: [ python3.pkgs.pygobject3 ])) # for folks.py
+    glib # libgobject
+    gtk3
+    at-spi2-core # atspi
+    gnome3.folks # libfolks
+    gnome3.nautilus # TODO: this contaminates the package with nautilus and gnome-autoar typelibs but it is only needed for the extension
+    gnome3.nautilus-python
+    gnome3.gsound
+    upower
+    gnome3.caribou
+    gnome3.gjs # for running daemon
+    gnome3.evolution-data-server # folks.py requires org.gnome.Evolution.DefaultSources gsettings; TODO: hardcode the schema path to the library (similarly to https://github.com/NixOS/nixpkgs/issues/47226)
+  ];
+
+  mesonFlags = [
+    "-Dgnome_shell_libdir=${gnome3.gnome-shell}/lib"
+    "-Dgsettings_schemadir=${placeholder "out"}/share/gsettings-schemas/${name}/glib-2.0/schemas"
+    "-Dchrome_nmhdir=${placeholder "out"}/etc/opt/chrome/native-messaging-hosts"
+    "-Dchromium_nmhdir=${placeholder "out"}/etc/chromium/native-messaging-hosts"
+    "-Dopenssl_path=${openssl}/bin/openssl"
+    "-Dsshadd_path=${openssh}/bin/ssh-add"
+    "-Dsshkeygen_path=${openssh}/bin/ssh-keygen"
+    "-Dpost_install=true"
+  ];
+
+  postPatch = ''
+    patchShebangs meson/nmh.sh
+    patchShebangs meson/post-install.sh
+
+    # TODO: do not include every typelib everywhere
+    # for example, we definitely do not need nautilus
+    for file in src/extension.js src/prefs.js; do
+      substituteInPlace "$file" \
+        --subst-var-by typelibPath "$GI_TYPELIB_PATH"
+    done
+  '';
+
+  preFixup = ''
+    # TODO: figure out why folks GIR does not contain shared-library attribute
+    # https://github.com/NixOS/nixpkgs/issues/47226
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ gnome3.folks ]}")
+  '';
+
+  postFixup = ''
+    # Let’s wrap the daemons
+    for file in $out/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/{{daemon,nativeMessagingHost}.js,components/folks.py}; do
+      echo "Wrapping program ''${file}"
+      wrapProgram "''${file}" "''${gappsWrapperArgs[@]}"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "KDE Connect implementation for Gnome Shell";
+    homepage = https://github.com/andyholmes/gnome-shell-extension-gsconnect/wiki;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/fix-paths.patch
@@ -1,0 +1,44 @@
+--- a/data/org.gnome.Shell.Extensions.GSConnect.desktop
++++ b/data/org.gnome.Shell.Extensions.GSConnect.desktop
+@@ -1,7 +1,7 @@
+ [Desktop Entry]
+ Type=Application
+ Name=GSConnect
+-Exec=gapplication launch org.gnome.Shell.Extensions.GSConnect %U
++Exec=@gapplication@ launch org.gnome.Shell.Extensions.GSConnect %U
+ Terminal=false
+ NoDisplay=true
+ Icon=org.gnome.Shell.Extensions.GSConnect
+--- a/src/extension.js
++++ b/src/extension.js
+@@ -1,5 +1,7 @@
+ 'use strict';
+ 
++'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
++
+ const Gio = imports.gi.Gio;
+ const GLib = imports.gi.GLib;
+ const Gtk = imports.gi.Gtk;
+--- a/src/prefs.js
++++ b/src/prefs.js
+@@ -1,5 +1,7 @@
+ 'use strict';
+ 
++'@typelibPath@'.split(':').forEach(path => imports.gi.GIRepository.Repository.prepend_search_path(path));
++
+ const Gio = imports.gi.Gio;
+ const GLib = imports.gi.GLib;
+ const Gtk = imports.gi.Gtk;
+--- a/src/service/__init__.js
++++ b/src/service/__init__.js
+@@ -600,7 +600,9 @@
+ /**
+  * Convenience functions for saving/restoring window geometry
+  */
+-const _mutter = new Gio.Settings({schema_id: 'org.gnome.mutter'});
++const _schema_source = Gio.SettingsSchemaSource.new_from_directory('@mutter_gsettings_path@', Gio.SettingsSchemaSource.get_default(), true);
++const _schema = _schema_source.lookup('org.gnome.mutter', false);
++const _mutter = new Gio.Settings({settings_schema: _schema});
+ 
+ Gtk.Window.prototype.restore_geometry = function() {
+     let [width, height] = this.settings.get_value('window-size').deep_unpack();

--- a/pkgs/desktops/gnome-3/misc/nautilus-python/default.nix
+++ b/pkgs/desktops/gnome-3/misc/nautilus-python/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, which
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_412
+, python3
+, ncurses
+, nautilus
+, gtk3
+, gnome3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nautilus-python";
+  version = "1.2.2";
+
+  outputs = [ "out" "dev" "doc" ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "04pib6fan6cq8x0fhf5gll2f5d2dh5pxrhj79qhi5l1yc7ys7kch";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    which
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+  ];
+
+  buildInputs = [
+    python3
+    ncurses # required by python3
+    python3.pkgs.pygobject3
+    nautilus
+    gtk3 # required by libnautilus-extension
+  ];
+
+  makeFlags = [
+    "PYTHON_LIB_LOC=${python3}/lib"
+  ];
+
+  PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Python bindings for the Nautilus Extension API";
+    homepage = https://wiki.gnome.org/Projects/NautilusPython;
+    license = licenses.gpl2Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21245,6 +21245,7 @@ in
     clipboard-indicator = callPackage ../desktops/gnome-3/extensions/clipboard-indicator { };
     dash-to-dock = callPackage ../desktops/gnome-3/extensions/dash-to-dock { };
     dash-to-panel = callPackage ../desktops/gnome-3/extensions/dash-to-panel { };
+    gsconnect = callPackage ../desktops/gnome-3/extensions/gsconnect { };
     icon-hider = callPackage ../desktops/gnome-3/extensions/icon-hider { };
     impatience = callPackage ../desktops/gnome-3/extensions/impatience.nix { };
     mediaplayer = callPackage ../desktops/gnome-3/extensions/mediaplayer { };


### PR DESCRIPTION
###### Motivation for this change
It seems like a nice gnome extension that we all want :wink:

I think this may be the 3rd or 4th known try to package this up for NixOS. And after submitting a ticket and waiting a bit they have refactored a lot of their extension to be more friendly for packaging as documented here: https://github.com/andyholmes/gnome-shell-extension-gsconnect/issues/91#issuecomment-423036690

~~Note, this is *far* from complete. The install phase is still missing and isn't working yet.~~ I just wanted to publish my WIP to reduce overlapping efforts.

cc @jtojnar 

Things to do

- [x] Package nautilus-python
- [ ] Test the nautilus integration
- [x] Figure out what to do about the missing Chromium icon in the settings
- [x] Move hard-coding the program paths upstream
- [ ] Test bluetooth connection
- [x] Open tracking issues for the TODO comments
- [ ] Write some docs (something like [this](https://github.com/NixOS/nixpkgs/pull/46779/files#diff-dd4c714984d1e6e681ffa3f64117bb6b)
    - Needs to be installed using `environment.systemPackage`
    - Firewall settings
    - Native messaging hosts setup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

