### PR TITLE
pythonPackages.circus: fix build, add meta

### DIFF
--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi
 , iowait, psutil, pyzmq, tornado, mock }:
 
 buildPythonPackage rec {
@@ -10,7 +10,22 @@ buildPythonPackage rec {
     sha256 = "d1603cf4c4f620ce6593d3d2a67fad25bf0242183ea24110d8bb1c8079c55d1b";
   };
 
+  postPatch = ''
+    # relax version restrictions to fix build
+    substituteInPlace setup.py \
+      --replace "pyzmq>=13.1.0,<17.0" "pyzmq>13.1.0" \
+      --replace "tornado>=3.0,<5.0" "tornado>=3.0"
+  '';
+
+  checkInputs = [ mock ];
+
   doCheck = false; # weird error
 
-  propagatedBuildInputs = [ iowait psutil pyzmq tornado mock ];
+  propagatedBuildInputs = [ iowait psutil pyzmq tornado ];
+
+  meta = with stdenv.lib; {
+    description = "A process and socket manager";
+    homepage = "https://github.circus.com/circus-tent/circus";
+    license = licenses.asl20;
+  };
 }


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960. Build failed due to version restrictions, relax them. Also add missing `meta`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
