### PR TITLE
nixos/tests/ferm: disable dhcpcd

### DIFF
--- a/nixos/tests/ferm.nix
+++ b/nixos/tests/ferm.nix
@@ -11,6 +11,7 @@ import ./make-test.nix ({ pkgs, ...} : {
         with pkgs.lib;
         {
           networking = {
+            dhcpcd.enable = false;
             interfaces.eth1.ipv6.addresses = mkOverride 0 [ { address = "fd00::2"; prefixLength = 64; } ];
             interfaces.eth1.ipv4.addresses = mkOverride 0 [ { address = "192.168.1.2"; prefixLength = 24; } ];
           };
@@ -20,6 +21,7 @@ import ./make-test.nix ({ pkgs, ...} : {
         with pkgs.lib;
         {
           networking = {
+            dhcpcd.enable = false;
             interfaces.eth1.ipv6.addresses = mkOverride 0 [ { address = "fd00::1"; prefixLength = 64; } ];
             interfaces.eth1.ipv4.addresses = mkOverride 0 [ { address = "192.168.1.1"; prefixLength = 24; } ];
           };
@@ -51,7 +53,7 @@ import ./make-test.nix ({ pkgs, ...} : {
     ''
       startAll;
 
-      $client->waitForUnit("network.target");
+      $client->waitForUnit("network-online.target");
       $server->waitForUnit("ferm.service");
       $server->waitForUnit("nginx.service");
       $server->waitUntilSucceeds("ss -ntl | grep -q 80");


### PR DESCRIPTION
###### Motivation for this change

The test failed in one [recent run on Hydra](https://hydra.nixos.org/build/81774547).

The only notable difference in the logs compared to successful runs is that dhcpcd changed ipv6 default routing on the client just when it tried to contact the server via ipv6. I could not reproduce the failure locally and it's hard to tell from the logs whether this really was the cause.

But since this test uses static IP addresses anyway, it doesn't need dhcpcd, so let's disable it and eliminate this potential cause of non-deterministic failure.

cc @Mic92 

###### Things done

- [x] NixOS test passes locally on x86_64-linux and i686-linux.

---

