### PR TITLE
utmps: init at 0.0.1.3

### DIFF
--- a/pkgs/development/libraries/utmps/default.nix
+++ b/pkgs/development/libraries/utmps/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, skawarePackages }:
+
+with skawarePackages;
+
+buildPackage {
+  pname = "utmps";
+  version = "0.0.1.3";
+  sha256 = "0dwskdclac4afmh7f7zn6jdiydgaf59a65q43r6b813mghczjvvd";
+
+  description = "A secure utmpx and wtmp implementation";
+
+  configureFlags = [
+    "--libdir=\${lib}/lib"
+    "--dynlibdir=\${lib}/lib"
+    "--bindir=\${bin}/bin"
+    "--includedir=\${dev}/include"
+    "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
+    "--with-include=${skalibs.dev}/include"
+    "--with-lib=${skalibs.lib}/lib"
+    "--with-dynlib=${skalibs.lib}/lib"
+  ];
+
+  postInstall = ''
+    # remove all execline executables from build directory
+    rm $(find -type f -mindepth 1 -maxdepth 1 -executable)
+    rm libutmps.*
+
+    mv doc $doc/share/doc/utmps/html
+    mv examples $doc/share/doc/utmps/examples
+  '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12365,6 +12365,8 @@ with pkgs;
 
   uthash = callPackage ../development/libraries/uthash { };
 
+  utmps = skawarePackages.utmps;
+
   ucommon = ucommon_openssl;
 
   ucommon_openssl = callPackage ../development/libraries/ucommon {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12075,6 +12075,7 @@ with pkgs;
     s6-rc = callPackage ../tools/system/s6-rc { };
 
     nsss = callPackage ../development/libraries/nsss { };
+    utmps = callPackage ../development/libraries/utmps { };
 
   };
 


### PR DESCRIPTION
Haven't tried using it, but packging it is first step! :)





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---