### PR TITLE
nixos/tests/atd: wait for atd to start

### DIFF
--- a/nixos/tests/atd.nix
+++ b/nixos/tests/atd.nix
@@ -16,6 +16,7 @@ import ./make-test.nix ({ pkgs, ... }:
   testScript = ''
     startAll;
 
+    $machine->waitForUnit('atd.service'); # wait for atd to start
     $machine->fail("test -f ~root/at-1");
     $machine->fail("test -f ~alice/at-1");
 


### PR DESCRIPTION
###### Motivation for this change

The test [failed non-deterministically on Hydra](https://hydra.nixos.org/build/81774753) when an `at` command was issued before the `atd` daemon was running.

ZHF #45960, please backport.

###### Things done

- [x] NixOS test passes locally for x86_64-linux and i686-linux

---

