### PR TITLE
dvtm: refactor (fix on darwin)

### DIFF
--- a/pkgs/tools/misc/dvtm/default.nix
+++ b/pkgs/tools/misc/dvtm/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     homepage = http://www.brain-dump.org/projects/dvtm;
     license = licenses.mit;
     maintainers = [ maintainers.vrthra ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/dvtm/default.nix
+++ b/pkgs/tools/misc/dvtm/default.nix
@@ -9,6 +9,17 @@ stdenv.mkDerivation rec {
     sha256 = "0475w514b7i3gxk6khy8pfj2gx9l7lv2pwacmq92zn1abv01a84g";
   };
 
+  patches = [
+    # https://github.com/martanne/dvtm/pull/69
+    # Use self-pipe instead of signal blocking fixes issues on darwin.
+    (fetchurl {
+      url = "https://github.com/martanne/dvtm/commit/1f1ed664d64603f3f1ce1388571227dc723901b2.patch";
+      sha256 = "1cby8x3ckvhzqa8yxlfrwzgm8wk7yz84kr9psdjr7xwpnca1cqrd";
+    })
+  ];
+
+  CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
+
   postPatch = stdenv.lib.optionalString (customConfig != null) ''
     cp ${builtins.toFile "config.h" customConfig} ./config.h
   '';
@@ -28,7 +39,6 @@ stdenv.mkDerivation rec {
     description = "Dynamic virtual terminal manager";
     homepage = http://www.brain-dump.org/projects/dvtm;
     license = licenses.mit;
-    platforms = platforms.linux;
     maintainers = [ maintainers.vrthra ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

This PR adds the required CFLAGS to get dvtm to build in darwin. It also applies a patch which has been sitting idle upstream for a while. This patch is required for dvtm to work on newer versions of macOS.

See https://github.com/martanne/dvtm/pull/69

The patch works fine on Linux as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

