### PR TITLE
lmdbxx: change repo location

### DIFF
--- a/pkgs/development/libraries/lmdbxx/default.nix
+++ b/pkgs/development/libraries/lmdbxx/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   version = "0.9.14.0";
 
   src = fetchFromGitHub {
-    owner = "bendiken";
+    owner = "drycpp";
     repo = "lmdbxx";
     rev = "${version}";
     sha256 = "1jmb9wg2iqag6ps3z71bh72ymbcjrb6clwlkgrqf1sy80qwvlsn6";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/bendiken/lmdbxx#readme";
+    homepage = "https://github.com/drycpp/lmdbxx#readme";
     description = "C++11 wrapper for the LMDB embedded B+ tree database library";
     license = stdenv.lib.licenses.unlicense;
     maintainers = with stdenv.lib.maintainers; [ fgaz ];


### PR DESCRIPTION
###### Motivation for this change


Owner changed from bendiken to drycpp




###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

