### PR TITLE
haskellPackages.hasktags: remove dontCheck

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1103,9 +1103,6 @@ self: super: {
   # Can be removed once yi-language >= 0.18 is in the LTS
   yi-core = super.yi-core.overrideScope (self: super: { yi-language = self.yi-language_0_18_0; });
 
-  # https://github.com/MarcWeber/hasktags/issues/52
-  hasktags = dontCheck super.hasktags;
-
   # https://github.com/haskell/hoopl/issues/50
   hoopl = dontCheck super.hoopl;
 


### PR DESCRIPTION
https://github.com/MarcWeber/hasktags/issues/52 has been closed and a new version (0.71.1) has been released. Will need to wait for the Hackage update before this can be merged, but then it should be AOK.

###### Motivation for this change

Cleaning up exceptions in `configuration-common.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

