### PR TITLE
twa: init at 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -376,6 +376,11 @@
     github = "auntie";
     name = "Jonathan Glines";
   };
+  avaq = {
+    email = "avaq+nixos@xs4all.nl";
+    github = "avaq";
+    name = "Aldwin Vlasblom";
+  };
   avery = {
     email = "averyl+nixos@protonmail.com";
     github = "AveryLychee";

--- a/pkgs/tools/networking/twa/default.nix
+++ b/pkgs/tools/networking/twa/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, makeWrapper, bash, gawk, curl, netcat, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "twa-${version}";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "trailofbits";
+    repo = "twa";
+    rev = version;
+    sha256 = "16x9nzsrf10waqmjm423vx44820c6mls7gxc8azrdqnz18vdy1h4";
+  };
+
+  dontBuild = true;
+
+  buildInputs = [ makeWrapper bash gawk curl netcat ];
+
+  installPhase = ''
+    install -Dm 0755 twa "$out/bin/twa"
+    install -Dm 0755 tscore "$out/bin/tscore"
+    install -Dm 0644 twa.1 "$out/share/man/man1/twa.1"
+    install -Dm 0644 README.md "$out/share/doc/twa/README.md"
+
+    wrapProgram "$out/bin/twa" \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ curl netcat ncurses ]}
+  '';
+
+  meta = {
+    description = "A tiny web auditor with strong opinions";
+    homepage = https://github.com/trailofbits/twa;
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ avaq ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14733,6 +14733,8 @@ with pkgs;
 
   tunctl = callPackage ../os-specific/linux/tunctl { };
 
+  twa = callPackage ../tools/networking/twa { };
+
   # Upstream U-Boots:
   inherit (callPackage ../misc/uboot {})
     buildUBoot


### PR DESCRIPTION
###### Motivation for this change

More and more of my colleagues are making the switch to NixOS, and it would be convenient for them, and myself, if we could install `twa` (a tool we use) directly from nixpkgs.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).