### PR TITLE
jabref: 3.8.1 -> 4.3.1

### DIFF
--- a/pkgs/applications/office/jabref/default.nix
+++ b/pkgs/applications/office/jabref/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, makeWrapper, makeDesktopItem, jdk, jre, wrapGAppsHook, gtk3, gsettings-desktop-schemas }:
 
 stdenv.mkDerivation rec {
-  version = "3.8.1";
+  version = "4.3.1";
   name = "jabref-${version}";
 
   src = fetchurl {
     url = "https://github.com/JabRef/jabref/releases/download/v${version}/JabRef-${version}.jar";
-    sha256 = "11asfym74zdq46i217z5n6vc79gylcx8xn7nvwacfqmym0bz79cg";
+    sha256 = "15f3risav4vlr3jvmrn93qfw54filfxl99h6j3cmj2j3kh3ywljv";
   };
 
   desktopItem = makeDesktopItem {
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
 
     cp -r ${desktopItem}/share/applications $out/share/
 
-    jar xf $src images/icons/JabRef-icon-mac.svg
-    cp images/icons/JabRef-icon-mac.svg $out/share/icons/jabref.svg
+    jar xf $src images/external/JabRef-icon-128.png
+    cp images/external/JabRef-icon-128.png $out/share/icons/jabref.png
 
     ln -s $src $out/share/java/jabref-${version}.jar
     makeWrapper ${jre}/bin/java $out/bin/jabref \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17141,7 +17141,10 @@ with pkgs;
 
   j4-dmenu-desktop = callPackage ../applications/misc/j4-dmenu-desktop { };
 
-  jabref = callPackage ../applications/office/jabref { };
+  # JabRef needs JavaFX, only available in oracle jre.
+  jabref = callPackage ../applications/office/jabref {
+    jre = oraclejre;
+  };
 
   jack_capture = callPackage ../applications/audio/jack-capture { };
 


### PR DESCRIPTION
Previous version is one year old.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
- [X] Tested execution of all binary files (usually in `./result/bin/`)

---

/cc @gebner