### PR TITLE
uftrace: init at 0.9

### DIFF
--- a/pkgs/development/tools/uftrace/default.nix
+++ b/pkgs/development/tools/uftrace/default.nix
@@ -1,0 +1,22 @@
+{stdenv, fetchFromGitHub, libelf, libdwarf, ncurses }:
+
+stdenv.mkDerivation rec {
+  name = "uftrace-${version}";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "namhyung";
+    repo = "uftrace";
+    rev = "f0fed0b24a9727ffed04673b62f66baad21a1f99";
+    sha256 = "0rn2xwd87qy5ihn5zq9pwq8cs1vfmcqqz0wl70wskkgp2ccsd9x8";
+  };
+
+  meta = {
+    description = "Function (graph) tracer for user-space";
+    homepage = https://github.com/namhyung/uftrace;
+    license = stdenv.lib.licenses.gpl2;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = [stdenv.lib.maintainers.nthorne];
+  };
+}
+

--- a/pkgs/development/tools/uftrace/default.nix
+++ b/pkgs/development/tools/uftrace/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, libelf, libdwarf, ncurses }:
+{stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "uftrace-${version}";

--- a/pkgs/development/tools/uftrace/default.nix
+++ b/pkgs/development/tools/uftrace/default.nix
@@ -11,6 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0rn2xwd87qy5ihn5zq9pwq8cs1vfmcqqz0wl70wskkgp2ccsd9x8";
   };
 
+  postUnpack = ''
+        patchShebangs .
+  '';
+
   meta = {
     description = "Function (graph) tracer for user-space";
     homepage = https://github.com/namhyung/uftrace;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5710,6 +5710,8 @@ with pkgs;
     stdenv = overrideCC stdenv gcc6; # doesn't build with gcc7
   };
 
+  uftrace = callPackage ../development/tools/uftrace { };
+
   uget = callPackage ../tools/networking/uget { };
 
   uget-integrator = callPackage ../tools/networking/uget-integrator { };


### PR DESCRIPTION
###### Motivation for this change

To introduce the uftrace tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

