### PR TITLE
libinput: 1.11.3 -> 1.12.0

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -16,11 +16,11 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "libinput-${version}";
-  version = "1.11.3";
+  version = "1.12.0";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/libinput/${name}.tar.xz";
-    sha256 = "01nb1shnl871d939wgfd7nc9svclcnfjfhlq64b4yns2dvcr24gk";
+    sha256 = "1901wxh9k8kz3krfmvacf8xa8r4idfyisw8d80a2ql0bxiw2pb0m";
   };
 
   outputs = [ "bin" "out" "dev" ];

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -46,12 +46,6 @@ stdenv.mkDerivation rec {
 
   patches = [ ./udev-absolute-path.patch ];
 
-   preBuild = ''
-    # meson setup-hook changes the directory so the files are located one level up
-    patchShebangs ../udev/parse_hwdb.py
-    patchShebangs ../test/symbols-leak-test.in
-  '';
-
   doCheck = testsSupport;
 
   meta = {

--- a/pkgs/development/libraries/libinput/udev-absolute-path.patch
+++ b/pkgs/development/libraries/libinput/udev-absolute-path.patch
@@ -5,7 +5,7 @@
  
  udev_rules_config = configuration_data()
 -udev_rules_config.set('UDEV_TEST_PATH', '')
-+udev_rules_config.set('UDEV_TEST_PATH', udev_dir + '/')
++udev_rules_config.set('UDEV_TEST_PATH', dir_udev + '/')
  configure_file(input : 'udev/80-libinput-device-groups.rules.in',
  	       output : '80-libinput-device-groups.rules',
  	       install : true,


### PR DESCRIPTION
Still rebuilding to test in "action", FWIW.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---