### PR TITLE
xf86-input-libinput: 0.26.0 -> 0.28.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1760,11 +1760,11 @@ let
   }) // {inherit inputproto xorgserver xproto ;};
 
   xf86inputlibinput = (mkDerivation "xf86inputlibinput" {
-    name = "xf86-input-libinput-0.26.0";
+    name = "xf86-input-libinput-0.28.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/driver/xf86-input-libinput-0.26.0.tar.bz2;
-      sha256 = "0yrqs88b7yn9nljwlxzn76jfmvf0sh939kzij5b2jvr2qa7mbjmb";
+      url = mirror://xorg/individual/driver/xf86-input-libinput-0.28.0.tar.bz2;
+      sha256 = "189h8vl0005yizwrs4d0sng6j8lwkd3xi1zwqg8qavn2bw34v691";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ inputproto xorgserver xproto ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -335,10 +335,10 @@ in
   };
 
   xf86inputlibinput = attrs: attrs // rec {
-    name = "xf86-input-libinput-0.26.0";
+    name = "xf86-input-libinput-0.28.0";
     src = args.fetchurl {
       url = "mirror://xorg/individual/driver/${name}.tar.bz2";
-      sha256 = "0yrqs88b7yn9nljwlxzn76jfmvf0sh939kzij5b2jvr2qa7mbjmb";
+      sha256 = "189h8vl0005yizwrs4d0sng6j8lwkd3xi1zwqg8qavn2bw34v691";
     };
     outputs = [ "out" "dev" ];
     buildInputs = attrs.buildInputs ++ [ args.libinput ];

--- a/pkgs/servers/x11/xorg/tarballs-7.7.list
+++ b/pkgs/servers/x11/xorg/tarballs-7.7.list
@@ -123,7 +123,7 @@ mirror://xorg/X11R7.7/src/everything/xf86driproto-2.1.1.tar.bz2
 mirror://xorg/individual/driver/xf86-input-evdev-2.10.5.tar.bz2
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.3.tar.bz2
 mirror://xorg/individual/driver/xf86-input-keyboard-1.9.0.tar.bz2
-mirror://xorg/individual/driver/xf86-input-libinput-0.26.0.tar.bz2
+mirror://xorg/individual/driver/xf86-input-libinput-0.28.0.tar.bz2
 mirror://xorg/individual/driver/xf86-input-mouse-1.9.2.tar.bz2
 mirror://xorg/individual/driver/xf86-input-synaptics-1.9.0.tar.bz2
 mirror://xorg/individual/driver/xf86-input-vmmouse-13.1.0.tar.bz2


### PR DESCRIPTION
https://cgit.freedesktop.org/xorg/driver/xf86-input-libinput/log/



Fixes features update goodness.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Testing in conjunction with libinput 1.12 update, but that's not a
requirement for this.