### PR TITLE
abduco: refactor (compile on darwin)

### DIFF
--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -10,8 +10,9 @@ stdenv.mkDerivation rec {
         license = licenses.isc;
         description = "Allows programs to be run independently from its controlling terminal";
         maintainers = with maintainers; [ pSub ];
-        platforms = platforms.linux;
     };
+
+    CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
 
     src = fetchurl {
         url = "http://www.brain-dump.org/projects/abduco/${name}.tar.gz";

--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation rec {
         license = licenses.isc;
         description = "Allows programs to be run independently from its controlling terminal";
         maintainers = with maintainers; [ pSub ];
+        platforms = platforms.unix;
     };
 
     CFLAGS = stdenv.lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

