### PR TITLE
cryus-sasl: cleanup, fix w/musl (although not at all musl-specific)

### DIFF
--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -36,15 +36,15 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-openssl=${openssl.dev}"
+    "--with-plugindir=${placeholder "out"}/lib/sasl2"
+    "--with-saslauthd=/run/saslauthd"
+    "--enable-login"
+    "--enable-shared"
   ] ++ lib.optional enableLdap "--with-ldap=${openldap.dev}";
 
-  # Set this variable at build-time to make sure $out can be evaluated.
-  preConfigure = ''
-    configureFlagsArray=( --with-plugindir=$out/lib/sasl2
-                          --with-saslauthd=/run/saslauthd
-                          --enable-login
-                        )
-  '';
+  # Avoid triggering regenerating using broken autoconf/libtool bits.
+  # (many distributions carry patches to remove/replace, but this works for now)
+  dontUpdateAutotoolsGnuConfigScripts = true;
 
   installFlags = lib.optional stdenv.isDarwin [ "framedir=$(out)/Library/Frameworks/SASL2.framework" ];
 
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://cyrusimap.web.cmu.edu/;
+    homepage = https://www.cyrusimap.org/sasl;
     description = "Library for adding authentication support to connection-based protocols";
     platforms = platforms.unix;
   };

--- a/pkgs/development/libraries/cyrus-sasl/default.nix
+++ b/pkgs/development/libraries/cyrus-sasl/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   # Avoid triggering regenerating using broken autoconf/libtool bits.
   # (many distributions carry patches to remove/replace, but this works for now)
-  dontUpdateAutotoolsGnuConfigScripts = true;
+  dontUpdateAutotoolsGnuConfigScripts = if stdenv.hostPlatform.isMusl then true else null;
 
   installFlags = lib.optional stdenv.isDarwin [ "framedir=$(out)/Library/Frameworks/SASL2.framework" ];
 


### PR DESCRIPTION
musl is fixed by disabling update of config.{guess,sub}.


Let's check how this fares on Aarch64, since that platform (I think?)
also automatically updates these files by default.

Fixes #47105.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---