### PR TITLE
rage: add dependency on mesa_noglu.dev

### DIFF
--- a/pkgs/desktops/enlightenment/rage.nix
+++ b/pkgs/desktops/enlightenment/rage.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, efl, gst_all_1, pcre, wrapGAppsHook }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig, efl, gst_all_1, pcre, mesa_noglu, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "rage-${version}";
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
     meson
     ninja
     (pkgconfig.override { vanilla = true; })
+    mesa_noglu.dev
     wrapGAppsHook
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Building rage fails because the file `gbm.pc` is not being found. Adding the `mesa_noglu.dev` dependency fixes this.

Fixes build failure reported on #47108.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).