### PR TITLE
rsyslogd: fix broken module

### DIFF
--- a/nixos/modules/services/logging/rsyslogd.nix
+++ b/nixos/modules/services/logging/rsyslogd.nix
@@ -85,6 +85,8 @@ in
 
     environment.systemPackages = [ pkgs.rsyslog ];
 
+    services.journald.extraConfig = "ForwardToSyslog=yes";
+
     systemd.services.syslog =
       { description = "Syslog Daemon";
 


### PR DESCRIPTION
###### Motivation for this change
I've tested rsyslogd on NixOS 18.09 and no output is generated from rsyslogd at all. The module appears to be broken because of systemd changes.

According to https://wiki.archlinux.org/index.php/rsyslog "ForwardToSyslog=yes" needs to be added to journald.conf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

