### PR TITLE
ephoto: add dependency on mesa_noglu.dev

### DIFF
--- a/pkgs/desktops/enlightenment/ephoto.nix
+++ b/pkgs/desktops/enlightenment/ephoto.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, efl, pcre, makeWrapper }:
+{ stdenv, fetchurl, pkgconfig, efl, pcre, mesa_noglu, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "ephoto-${version}";
@@ -9,9 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "09kraa5zz45728h2dw1ssh23b87j01bkfzf977m48y1r507sy3vb";
   };
 
-  nativeBuildInputs = [ (pkgconfig.override { vanilla = true; }) makeWrapper ];
+  nativeBuildInputs = [
+    (pkgconfig.override { vanilla = true; })
+    mesa_noglu.dev # otherwise pkg-config does not find gbm
+    makeWrapper
+  ];
 
-  buildInputs = [ efl pcre ];
+  buildInputs = [
+    efl
+    pcre
+  ];
 
   meta = {
     description = "Image viewer and editor written using the Enlightenment Foundation Libraries";


### PR DESCRIPTION
###### Motivation for this change

Building ephoto fails because the file `gbm.pc` is not being found. Adding the `mesa_noglu.dev` dependency fixes this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).