### PR TITLE
pev: init at unstable-2018-07-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1847,6 +1847,11 @@
     github = "jerith666";
     name = "Matt McHenry";
   };
+  jeschli = {
+    email = "jeschli@gmail.com";
+    github = "jeschli";
+    name = "Markus Hihn";
+  };
   jethro = {
     email = "jethrokuan95@gmail.com";
     github = "jethrokuan";

--- a/pkgs/development/tools/analysis/pev/default.nix
+++ b/pkgs/development/tools/analysis/pev/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, openssl, fetchFromGitHub }:
+stdenv.mkDerivation {
+  name = "pev-unstable-2018-07-22";
+  buildInputs = [ openssl ];
+  src = fetchFromGitHub {
+    owner = "merces";
+    repo = "pev";
+    rev = "aa4ef7f"; 
+    sha256 = "00a3g486343lhqcsf4vrdy5xif6v3cgcf2y8yp5b96x15c0wid36"; 
+    fetchSubmodules = true;
+  };
+
+  makeFlags = [ "prefix=$(out)" ];
+  installFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "pev is a full-featured, open source, multiplatform command line toolkit to work with PE (Portable Executables) binaries.";
+    homepage = "http://pev.sourceforge.net/";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.jeschli ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1487,6 +1487,8 @@ with pkgs;
 
   pbzx = callPackage ../tools/compression/pbzx { };
 
+  pev = callPackage ../development/tools/analysis/pev { };
+
   photon = callPackage ../tools/networking/photon { };
 
   playerctl = callPackage ../tools/audio/playerctl { };


### PR DESCRIPTION
###### Motivation for this change
adding pev to NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

