### PR TITLE
devpi-client: 3.1.0 -> 4.1.0, fix tests

### DIFF
--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -9,28 +9,28 @@
 pythonPackages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "devpi-client";
-  version = "3.1.0";
+  version = "4.1.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "0w47x3lkafcg9ijlaxllmq4886nsc91w49ck1cd7vn2gafkwjkgr";
+    sha256 = "0f5jkvxx9fl8v5vwbwmplqhjsdfgiib7j3zvn0zxd8krvi2s38fq";
   };
 
   checkInputs = with pythonPackages; [
-                    pytest webtest mock
+                    pytest pytestflakes webtest mock
                     devpi-server tox
                     sphinx wheel git mercurial detox
                     setuptools
                     ];
   checkPhase = ''
     export PATH=$PATH:$out/bin
+    export HOME=$TMPDIR # fix tests failing in sandbox due to "/homeless-shelter"
 
     # setuptools do not get propagated into the tox call (cannot import setuptools)
     rm testing/test_test.py
 
     # test_pypi_index_attributes tries to connect to upstream pypi
-    # test_download_release_error is fixed in the next release
-    py.test -k 'not test_pypi_index_attributes and not test_download_release_error' testing
+    py.test -k 'not test_pypi_index_attributes' testing
   '';
 
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
###### Motivation for this change

Build failed on Hydra: https://hydra.nixos.org/job/nixpkgs/trunk/devpi-client.x86_64-linux/all
Update to latest version, fix failing tests, reenable a previously disabled test.

ZHF #45960, please backport to 18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @makefu @nlewo 

