### PR TITLE
fetchzip: Use unzip from buildPackages

### DIFF
--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -14,7 +14,7 @@
 , name ? "source"
 , ... } @ args:
 
-lib.overrideDerivation (fetchurl ({
+(fetchurl ({
   inherit name;
 
   recursiveHash = true;
@@ -23,8 +23,6 @@ lib.overrideDerivation (fetchurl ({
 
   postFetch =
     ''
-      export PATH=${unzip}/bin:$PATH
-
       unpackDir="$TMPDIR/unpack"
       mkdir "$unpackDir"
       cd "$unpackDir"
@@ -48,6 +46,7 @@ lib.overrideDerivation (fetchurl ({
       mv "$unpackDir" "$out"
     '') #*/
     + extraPostFetch;
-} // removeAttrs args [ "stripRoot" "extraPostFetch" ]))
-# Hackety-hack: we actually need unzip hooks, too
-(x: {nativeBuildInputs = x.nativeBuildInputs++ [unzip];})
+} // removeAttrs args [ "stripRoot" "extraPostFetch" ])).overrideAttrs (x: {
+  # Hackety-hack: we actually need unzip hooks, too
+  nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];
+})


### PR DESCRIPTION
###### Motivation for this change

Backport of #47145.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

