### PR TITLE
mesa: 18.1.8 -> 18.2.1

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -144,7 +144,7 @@ let self = stdenv.mkDerivation {
   buildInputs = with xorg; [
     expat llvmPackages.llvm libglvnd
     glproto dri2proto dri3proto presentproto
-    libX11 libXext libxcb libXt libXfixes libxshmfence
+    libX11 libXext libxcb libXt libXfixes libxshmfence libXrandr
     libffi libvdpau libelf libXvMC
     libpthreadstubs openssl/*or another sha1 provider*/
     valgrind-light python2 python2.pkgs.Mako

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -67,7 +67,7 @@ let
 in
 
 let
-  version = "18.1.8";
+  version = "18.2.1";
   branch  = head (splitString "." version);
 in
 
@@ -81,7 +81,7 @@ let self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
       "https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
     ];
-    sha256 = "bd1be67fe9c73b517765264ac28911c84144682d28dbff140e1c2deb2f44c21b";
+    sha256 = "0mhhr1id11s1fbdxbvr4a81xjh1nsznpra9dl36bv2hq7mpxqdln";
   };
 
   prePatch = "patchShebangs .";

--- a/pkgs/development/libraries/mesa/missing-includes.patch
+++ b/pkgs/development/libraries/mesa/missing-includes.patch
@@ -32,16 +32,6 @@
  #include <unistd.h>
  #include <fcntl.h>
  #else
---- ./src/mesa/drivers/dri/i965/brw_bufmgr.h
-+++ ./src/mesa/drivers/dri/i965/brw_bufmgr.h
-@@ -37,6 +37,7 @@
- #include <stdbool.h>
- #include <stdint.h>
- #include <stdio.h>
-+#include <time.h>
- #include "util/u_atomic.h"
- #include "util/list.h"
-
 --- ./src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
 +++ ./src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
 @@ -28,6 +28,8 @@

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1136,11 +1136,11 @@ let
   }) // {inherit ;};
 
   libxcb = (mkDerivation "libxcb" {
-    name = "libxcb-1.12";
+    name = "libxcb-1.13";
     builder = ./builder.sh;
     src = fetchurl {
-      url = http://xcb.freedesktop.org/dist/libxcb-1.12.tar.bz2;
-      sha256 = "0nvv0la91cf8p5qqlb3r5xnmg1jn2wphn4fb5jfbr6byqsvv3psa";
+      url = http://xcb.freedesktop.org/dist/libxcb-1.13.tar.bz2;
+      sha256 = "1ahxhmdqp4bhb90zmc275rmf5wixqra4bnw9pqnzyl1w3598g30q";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ libxslt libpthreadstubs python libXau xcbproto libXdmcp ];
@@ -1448,11 +1448,11 @@ let
   }) // {inherit ;};
 
   xcbproto = (mkDerivation "xcbproto" {
-    name = "xcb-proto-1.12";
+    name = "xcb-proto-1.13";
     builder = ./builder.sh;
     src = fetchurl {
-      url = http://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.bz2;
-      sha256 = "01j91946q8f34l1mbvmmgvyc393sm28ym4lxlacpiav4qsjan8jr";
+      url = http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2;
+      sha256 = "1qdxw9syhbvswiqj5dvj278lrmfhs81apzmvx6205s4vcqg7563v";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ python ];

--- a/pkgs/servers/x11/xorg/extra.list
+++ b/pkgs/servers/x11/xorg/extra.list
@@ -1,6 +1,6 @@
 http://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.bz2
-http://xcb.freedesktop.org/dist/libxcb-1.12.tar.bz2
-http://xcb.freedesktop.org/dist/xcb-proto-1.12.tar.bz2
+http://xcb.freedesktop.org/dist/libxcb-1.13.tar.bz2
+http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.3.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-image-0.4.0.tar.bz2


### PR DESCRIPTION
Bump libxcb as well, since new version is required.





<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---