### PR TITLE
eiskaltdcpp: mark linux only

### DIFF
--- a/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
+++ b/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, qt4, boost, bzip2, libX11
-, fetchpatch, pcre-cpp, libidn, lua5, miniupnpc, aspell, gettext }:
+, fetchpatch, libiconv, pcre-cpp, libidn, lua5, miniupnpc, aspell, gettext }:
 
 stdenv.mkDerivation rec {
   name = "eiskaltdcpp-${version}";
@@ -12,8 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "1mqz0g69njmlghcra3izarjxbxi1jrhiwn4ww94b8jv8xb9cv682";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake qt4 boost bzip2 libX11 pcre-cpp libidn lua5 miniupnpc aspell gettext ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ qt4 boost bzip2 libX11 pcre-cpp libidn lua5 miniupnpc aspell gettext ]
+    ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
   patches = [
     (fetchpatch {
@@ -59,6 +60,6 @@ stdenv.mkDerivation rec {
     description = "A cross-platform program that uses the Direct Connect and ADC protocols";
     homepage = https://github.com/eiskaltdcpp/eiskaltdcpp;
     license = licenses.gpl3Plus;
-    platforms = platforms.all;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
The darwin build fails and other platforms will probably run into
similar issues.

    Determining if the Q_WS_QWS exist failed with the following output:
    Change Dir: /tmp/nix-build-eiskaltdcpp-2.2.10.drv-0/source/build/CMakeFiles/CMakeTmp

    Run Build Command:"/nix/store/qfag24z6xsr6jkyi8gb4cv62rp945rbk-gnumake-4.2.1/bin/make" "cmTC_14e67/fast"
    /nix/store/qfag24z6xsr6jkyi8gb4cv62rp945rbk-gnumake-4.2.1/bin/make -f CMakeFiles/cmTC_14e67.dir/build.make CMakeFiles/cmTC_14e67.dir/build
    make[1]: Entering directory '/private/tmp/nix-build-eiskaltdcpp-2.2.10.drv-0/source/build/CMakeFiles/CMakeTmp'
    Building CXX object CMakeFiles/cmTC_14e67.dir/CheckSymbolExists.cxx.o
    /nix/store/2gdwhdzhy4iwkp7fh8v6gy6nxj1zi9pv-clang-wrapper-5.0.2/bin/clang++   -I/nix/store/8dzqilmdr0p3qmmrxh51xk7wli6grm0i-qt-4.8.7/include -F/nix/store/8dzqilmdr0p3qmmrxh51xk7wli6grm0i-qt-4.8.7/lib  -std=c++0x -pipe -Wformat -Werror=format-security  -arch x86_64   -o CMakeFiles/cmTC_14e67.dir/CheckSymbolExists.cxx.o -c /tmp/nix-build-eiskaltdcpp-2.2.10.drv-0/source/build/CMakeFiles/CMakeTmp/CheckSymbolExists.cxx
    /tmp/nix-build-eiskaltdcpp-2.2.10.drv-0/source/build/CMakeFiles/CMakeTmp/CheckSymbolExists.cxx:8:19: error: use of undeclared identifier 'Q_WS_QWS'
      return ((int*)(&Q_WS_QWS))[argc];
                  ^

/cc ZHF #45961

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

