### PR TITLE
nixos/tests/hound: fix non-deterministic failure

### DIFF
--- a/nixos/tests/hound.nix
+++ b/nixos/tests/hound.nix
@@ -52,7 +52,7 @@ import ./make-test.nix ({ pkgs, ... } : {
        $machine->waitForUnit("network.target");
        $machine->waitForUnit("hound.service");
        $machine->waitForOpenPort(6080);
-       $machine->succeed('curl http://127.0.0.1:6080/api/v1/search\?stats\=fosho\&repos\=\*\&rng=%3A20\&q\=hi\&files\=\&i=nope | grep "Filename" | grep "hello"');
+       $machine->waitUntilSucceeds('curl http://127.0.0.1:6080/api/v1/search\?stats\=fosho\&repos\=\*\&rng=%3A20\&q\=hi\&files\=\&i=nope | grep "Filename" | grep "hello"');
 
     '';
 })


### PR DESCRIPTION
###### Motivation for this change

The test failed on Hydra [in one recent run](https://hydra.nixos.org/build/81782734) because a request to the server was sent before indexing was finished (or even started?).  Retry the request until it succeeds (or times out).

Relevant for ZHF #45960, please backport.

###### Things done

- [x] test passes in a sandbox on NixOS

---
cc @grahamc