### PR TITLE
hunspellDict.fr-any: Link `fr-moderne.dic` to `fr_FR.dic`

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -494,7 +494,7 @@ stdenv.mkDerivation {
    <para>
     The IBus engine is based on <literal>hunspell</literal> to support
     completion in many languages. By default the dictionaries
-    <literal>de-de</literal>, <literal>en-us</literal>,
+    <literal>de-de</literal>, <literal>en-us</literal>, <literal>fr-moderne</literal>
     <literal>es-es</literal>, <literal>it-it</literal>,
     <literal>sv-se</literal> and <literal>sv-fi</literal> are in use. To add
     another dictionary, the package can be overridden like this:

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -156,6 +156,12 @@
      </listitem>
     </itemizedlist>
    </listitem>
+   <listitem>
+    <para>
+      The <literal>hunspellDicts.fr-any</literal> dictionary now ships with <literal>fr_FR.{aff,dic}</literal>
+      which is linked to <literal>fr-toutesvariantes.{aff,dic}</literal>.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/development/libraries/hunspell/dictionaries.nix
+++ b/pkgs/development/libraries/hunspell/dictionaries.nix
@@ -20,6 +20,7 @@ let
       # docs
       install -dm755 "$out/share/doc"
       install -m644 ${readmeFile} $out/share/doc/${name}.txt
+      runHook postInstall
     '';
   } // args);
 
@@ -107,7 +108,7 @@ let
     };
 
   mkDictFromDicollecte =
-    { shortName, shortDescription, longDescription, dictFileName }:
+    { shortName, shortDescription, longDescription, dictFileName, isDefault ? false }:
     mkDict rec {
       inherit dictFileName;
       version = "5.3";
@@ -130,6 +131,12 @@ let
       sourceRoot = ".";
       unpackCmd = ''
         unzip $src ${dictFileName}.dic ${dictFileName}.aff ${readmeFile}
+      '';
+      postInstall = stdenv.lib.optionalString isDefault ''
+        for ext in aff dic; do
+          ln -sv $out/share/hunspell/${dictFileName}.$ext $out/share/hunspell/fr_FR.$ext
+          ln -sv $out/share/myspell/dicts/${dictFileName}.$ext $out/share/myspell/dicts/fr_FR.$ext
+        done
       '';
     };
 
@@ -483,6 +490,7 @@ in {
       réformées, suivant la lente évolution de l’orthographe actuelle. Ce
       dictionnaire contient les graphies les moins polémiques de la réforme.
     '';
+    isDefault = true;
   };
 
   fr-reforme1990 = mkDictFromDicollecte {

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-typing-booster/wrapper.nix
@@ -1,5 +1,5 @@
 { typing-booster, symlinkJoin, hunspellDicts, lib, makeWrapper
-, langs ? [ "de-de" "en-us" "es-es" "it-it" "sv-se" "sv-fi" ]
+, langs ? [ "de-de" "en-us" "es-es" "fr-moderne" "it-it" "sv-se" "sv-fi" ]
 }:
 
 let


### PR DESCRIPTION
###### Motivation for this change

See #46940 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

