### PR TITLE
nixos lircd: fix deletion of lircd socket

### DIFF
--- a/nixos/modules/services/hardware/lirc.nix
+++ b/nixos/modules/services/hardware/lirc.nix
@@ -65,6 +65,10 @@ in {
 
       serviceConfig = {
         RuntimeDirectory = "lirc";
+
+        # socket lives in runtime directory; we have to keep is available
+        RuntimeDirectoryPreserve = true;
+
         ExecStart = ''
           ${pkgs.lirc}/bin/lircd --nodaemon \
             ${escapeShellArgs cfg.extraArguments} \


### PR DESCRIPTION
###### Motivation for this change
socket gets delete during stop/restart. This PR fixes that issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

