### PR TITLE
luaPackages.luadbi: 0.5 -> 0.6

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -380,35 +380,36 @@ let
 
   luadbi = buildLuaPackage rec {
     name = "luadbi-${version}";
-    version = "0.5";
-    src = fetchurl {
-      url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/luadbi/luadbi.${version}.tar.gz";
-      sha256 = "07ikxgxgfpimnwf7zrqwcwma83ss3wm2nzjxpwv2a1c0vmc684a9";
+    version = "0.6";
+
+    src = fetchFromGitHub {
+      owner = "mwild1";
+      repo = "luadbi";
+      rev = "v${version}";
+      sha256 = "1cpl84pl75wqd9zph3w4srd5lxij359p8xmmf7xpdbxz67695vah";
     };
-    sourceRoot = ".";
 
-    buildInputs = [ mysql.connector-c postgresql sqlite ];
+    MYSQL_INC="-I${mysql.connector-c}/include/mysql";
 
-    preConfigure = ''
-      substituteInPlace Makefile --replace CC=gcc CC=cc
-    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    buildInputs = [ mysql postgresql sqlite ];
+
+    preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
       substituteInPlace Makefile \
         --replace '-shared' '-bundle -undefined dynamic_lookup -all_load'
     '';
 
-    NIX_CFLAGS_COMPILE = [
-      "-I${mysql.connector-c}/include/mysql"
-      "-L${mysql.connector-c}/lib/mysql"
-      "-I${postgresql}/include/server"
+    installFlags = [
+      "LUA_CDIR=$(out)/lib/lua/${lua.luaversion}"
+      "LUA_LDIR=$(out)/share/lua/${lua.luaversion}"
     ];
 
-    installPhase = ''
-      mkdir -p $out/lib/lua/${lua.luaversion}
-      install -p DBI.lua *.so $out/lib/lua/${lua.luaversion}
-    '';
+    installTargets = [
+      "install_lua" "install_mysql" "install_psql" "install_sqlite3"
+    ];
 
     meta = with stdenv.lib; {
-      homepage = "https://code.google.com/archive/p/luadbi/";
+      homepage = https://github.com/mwild1/luadbi;
+      license = licenses.mit;
       platforms = stdenv.lib.platforms.unix;
     };
   };


### PR DESCRIPTION
Switch to maintained fork that is compatible with lua5.2/lua5.3.
This package was tested with prosody (the only user in nixpkgs itself).
Since it was not actually compatible with lua5.2 before I would recommend to backport it,
otherwise prosody will not work.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

