### PR TITLE
libsndfile: Add patch for CVE-2018-13139

### DIFF
--- a/pkgs/development/libraries/libsndfile/default.nix
+++ b/pkgs/development/libraries/libsndfile/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
       url = "https://github.com/erikd/libsndfile/commit/85c877d5072866aadbe8ed0c3e0590fbb5e16788.patch";
       sha256 = "0kc7vp22qsxidhvmlc6nfamw7k92n0hcfpmwhb3gaksjamwhb2df";
     })
+    (fetchurl {
+      name = "CVE-2018-13139.patch";
+      url = "https://github.com/erikd/libsndfile/commit/aaea680337267bfb6d2544da878890ee7f1c5077.patch";
+      sha256 = "01q3m7pa3xqkh05ijmfgv064v8flkg4p24bgy9wxnc6wfcdifggx";
+    })
   ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Add patch for CVE-2018-13139 (ref #47121) by applying the upstream patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

