### PR TITLE
php: Refactor so we can upgrade PHP per platform

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -37,10 +37,7 @@ let
   , opensslSupport ? config.php.openssl or true
   , mbstringSupport ? config.php.mbstring or true
   , gdSupport ? config.php.gd or true
-  # Because of an upstream bug: https://bugs.php.net/bug.php?id=76826
-  # We need to disable the intl support on darwin. Whenever the upstream bug is
-  # fixed we should revert this to just just "config.php.intl or true".
-  , intlSupport ? (config.php.intl or true) && (!stdenv.isDarwin)
+  , intlSupport ? config.php.intl or true
   , exifSupport ? config.php.exif or true
   , xslSupport ? config.php.xsl or false
   , mcryptSupport ? config.php.mcrypt or true
@@ -225,13 +222,35 @@ let
     };
 
 in {
-  php71 = generic {
-    version = "7.1.22";
-    sha256 = "0qz74qdlk19cw478f42ckyw5r074y0fg73r2bzlhm0dar0cizsf8";
-  };
+  # Because of an upstream bug: https://bugs.php.net/bug.php?id=76826
+  # We can't update the darwin versions because they simply don't compile at
+  # all due to a bug in the intl extensions.
+  #
+  # The bug so far is present in 7.1.21, 7.2.9, 7.2.10.
 
-  php72 = generic {
-    version = "7.2.10";
-    sha256 = "17fsvdi6ihjghjsz9kk2li2rwrknm2ccb6ys0xmn789116d15dh1";
-  };
+  php71 = generic (
+    if stdenv.isDarwin then
+      {
+        version = "7.1.21";
+        sha256 = "104mn4kppklb21hgz1a50kgmc0ak5y996sx990xpc8yy9dbrqh62";
+      }
+    else
+      {
+        version = "7.1.22";
+        sha256 = "0qz74qdlk19cw478f42ckyw5r074y0fg73r2bzlhm0dar0cizsf8";
+      }
+  );
+
+  php72 = generic (
+    if stdenv.isDarwin then
+      {
+        version = "7.2.8";
+        sha256 = "1rky321gcvjm0npbfd4bznh36an0y14viqcvn4yzy3x643sni00z";
+      }
+    else
+      {
+        version = "7.2.10";
+        sha256 = "17fsvdi6ihjghjsz9kk2li2rwrknm2ccb6ys0xmn789116d15dh1";
+      }
+  );
 }

--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -226,13 +226,13 @@ in {
   # We can't update the darwin versions because they simply don't compile at
   # all due to a bug in the intl extensions.
   #
-  # The bug so far is present in 7.1.21, 7.2.9, 7.2.10.
+  # The bug so far is present in 7.1.21, 7.1.22, 7.2.9, 7.2.10.
 
   php71 = generic (
     if stdenv.isDarwin then
       {
-        version = "7.1.21";
-        sha256 = "104mn4kppklb21hgz1a50kgmc0ak5y996sx990xpc8yy9dbrqh62";
+        version = "7.1.20";
+        sha256 = "0i8xd6p4zdg8fl6f0j430raanlshsshr3s3jlm72b0gvi1n4f6rs";
       }
     else
       {


### PR DESCRIPTION
###### Motivation for this change
This way we don't need to disable flags etc by platform and can still
backport new versions to stable for linux even if there's a bug or
something in the darwin build.

We would need to trigger a build on darwin as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @xeji 