### PR TITLE
znc: require network-online.target to start

### DIFF
--- a/nixos/modules/services/networking/znc.nix
+++ b/nixos/modules/services/networking/znc.nix
@@ -375,7 +375,8 @@ in
     systemd.services.znc = {
       description = "ZNC Server";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.service" ];
+      after = [ "network-online.target" ];
+      requires = [ "network-online.target" ];
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;


### PR DESCRIPTION
###### Motivation for this change

ZNC fails to connect to a remote IRC server just after boot due to
name resolution failure. For some reason, it keeps the failure in a
local cache and isn't able to recover without a restart.

This happens with znc 1.6.5 in 18.03. This is also reported in various
places, like: https://bugzilla.redhat.com/show_bug.cgi?id=1381580.
This may be fixed in more recent versions of znc. However, it doesn't
hurt to put a hard dependency on network-online.target since znc is of
little use without a proper network connection.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

