### PR TITLE
crystal: 0.26.1 and introduce 0.25.1

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -1,93 +1,142 @@
-{ stdenv, fetchurl, makeWrapper
+{ stdenv, lib, fetchFromGitHub, fetchurl, makeWrapper
+, gmp, openssl, readline, tzdata, libxml2, libyaml
 , boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which }:
 
-stdenv.mkDerivation rec {
-  name = "crystal-${version}";
-  version = "0.26.0";
+let
+  binaryVersion = "0.26.0";
+  releaseDate = "2018-08-29";
 
-  src = fetchurl {
-    url = "https://github.com/crystal-lang/crystal/archive/${version}.tar.gz";
-    sha256 = "18vv47xvnf3hl5js5sk58wj2khqq36kcs851i3lgr0ji7m0g3379";
-  };
-
-  prebuiltName = "crystal-0.26.0-1";
-  prebuiltSrc = let arch = {
-    "x86_64-linux" = "linux-x86_64";
-    "i686-linux" = "linux-i686";
+  arch = {
+    "x86_64-linux"  = "linux-x86_64";
+    "i686-linux"    = "linux-i686";
     "x86_64-darwin" = "darwin-x86_64";
-  }."${stdenv.hostPlatform.system}" or (throw "system ${stdenv.hostPlatform.system} not supported");
-  in fetchurl {
-    url = "https://github.com/crystal-lang/crystal/releases/download/0.26.0/${prebuiltName}-${arch}.tar.gz";
-    sha256 = {
-      "x86_64-linux" = "1xban102yiiwmlklxvn3xp3q546bp8hlxxpakayajkhhnpl6yv45";
-      "i686-linux" = "1igspf1lrv7wpmz0pfrkbx8m1ykvnv4zhic53cav4nicppm2v0ic";
-      "x86_64-darwin" = "0hzc65ccajr0yhmvi5vbdgbzbp1gbjy56da24ds3zwwkam1ddk0k";
-    }."${stdenv.hostPlatform.system}";
+  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+
+  checkInputs = [ gmp openssl readline libxml2 libyaml tzdata ];
+
+  # we could turn this into a function instead in case we cannot use the same
+  # binary to build multiple versions
+  binary = stdenv.mkDerivation rec {
+    name = "crystal-binary-${binaryVersion}";
+
+    src = fetchurl {
+      url = "https://github.com/crystal-lang/crystal/releases/download/${binaryVersion}/crystal-${binaryVersion}-1-${arch}.tar.gz";
+      sha256 = {
+        "x86_64-linux"  = "1xban102yiiwmlklxvn3xp3q546bp8hlxxpakayajkhhnpl6yv45";
+        "i686-linux"    = "1igspf1lrv7wpmz0pfrkbx8m1ykvnv4zhic53cav4nicppm2v0ic";
+        "x86_64-darwin" = "0hzc65ccajr0yhmvi5vbdgbzbp1gbjy56da24ds3zwwkam1ddk0k";
+      }."${stdenv.system}";
+    };
+
+    buildCommand = ''
+      mkdir -p $out
+      tar --strip-components=1 -C $out -xf ${src}
+    '';
   };
 
-  unpackPhase = ''
-    mkdir ${prebuiltName}
-    tar --strip-components=1 -C ${prebuiltName} -xf ${prebuiltSrc}
-    tar xf ${src}
-  '';
+  generic = { version, sha256, doCheck ? true }:
+  stdenv.mkDerivation rec {
+    inherit doCheck;
+    name = "crystal-${version}";
 
-  # crystal on Darwin needs libiconv to build
-  libs = [
-    boehmgc libatomic_ops pcre libevent
-  ] ++ stdenv.lib.optionals stdenv.isDarwin [
-    libiconv
-  ];
+    src = fetchFromGitHub {
+      owner  = "crystal-lang";
+      repo   = "crystal";
+      rev    = version;
+      inherit sha256;
+    };
 
-  nativeBuildInputs = [ which makeWrapper ];
+    # the first bit can go when https://github.com/crystal-lang/crystal/pull/6788 is merged
+    postPatch = ''
+      substituteInPlace src/compiler/crystal/config.cr \
+        --replace '{{ `date "+%Y-%m-%d"`.stringify.chomp }}' '"${releaseDate}"'
+      ln -s spec/compiler spec/std
+      substituteInPlace spec/std/process_spec.cr \
+        --replace /bin/ /run/current-system/sw/bin
+    '';
 
-  buildInputs = libs ++ [ llvm ];
+    buildInputs = [
+      boehmgc libatomic_ops pcre libevent
+      llvm
+    ] ++ stdenv.lib.optionals stdenv.isDarwin [
+      libiconv
+    ];
 
-  libPath = stdenv.lib.makeLibraryPath libs;
+    nativeBuildInputs = [ binary makeWrapper which ];
 
-  sourceRoot = "${name}";
 
-  preBuild = ''
-    patchShebangs bin/crystal
-    patchShebangs ../${prebuiltName}/bin/crystal
-    export PATH="$(pwd)/../${prebuiltName}/bin:$PATH"
-  '';
+    makeFlags = [
+      "CRYSTAL_CONFIG_BUILD_DATE=${releaseDate}"
+      "CRYSTAL_CONFIG_VERSION=${version}"
+    ];
 
-  makeFlags = [ "CRYSTAL_CONFIG_VERSION=${version}"
-                "FLAGS=--no-debug"
-                "release=1"
-                "all" "docs"
-              ];
+    buildFlags = [
+      "all" "docs"
+    ];
 
-  installPhase = ''
-    install -Dm755 .build/crystal $out/bin/crystal
-    wrapProgram $out/bin/crystal \
-        --suffix PATH : ${clang}/bin \
-        --suffix CRYSTAL_PATH : lib:$out/lib/crystal \
-        --suffix LIBRARY_PATH : $libPath
-    install -dm755 $out/lib/crystal
-    cp -r src/* $out/lib/crystal/
+    FLAGS = [
+      "--release"
+      "--single-module" # needed for deterministic builds
+    ];
 
-    install -dm755 $out/share/doc/crystal/api
-    cp -r docs/* $out/share/doc/crystal/api/
-    cp -r samples $out/share/doc/crystal/
+    # We *have* to add `which` to the PATH or crystal is unable to build stuff
+    # later if which is not available.
+    installPhase = ''
+      runHook preInstall
 
-    install -Dm644 etc/completion.bash $out/share/bash-completion/completions/crystal
-    install -Dm644 etc/completion.zsh $out/share/zsh/site-functions/_crystal
+      install -Dm755 .build/crystal $out/bin/crystal
+      wrapProgram $out/bin/crystal \
+          --suffix PATH : ${lib.makeBinPath [ clang which ]} \
+          --suffix CRYSTAL_PATH : lib:$out/lib/crystal \
+          --suffix LIBRARY_PATH : ${lib.makeLibraryPath buildInputs}
+      install -dm755 $out/lib/crystal
+      cp -r src/* $out/lib/crystal/
 
-    install -Dm644 man/crystal.1 $out/share/man/man1/crystal.1
+      install -dm755 $out/share/doc/crystal/api
+      cp -r docs/* $out/share/doc/crystal/api/
+      cp -r samples $out/share/doc/crystal/
 
-    install -Dm644 LICENSE $out/share/licenses/crystal/LICENSE
-  '';
+      install -Dm644 etc/completion.bash $out/share/bash-completion/completions/crystal
+      install -Dm644 etc/completion.zsh $out/share/zsh/site-functions/_crystal
 
-  dontStrip = true;
+      install -Dm644 man/crystal.1 $out/share/man/man1/crystal.1
 
-  enableParallelBuilding = false;
+      install -Dm644 -t $out/share/licenses/crystal LICENSE README.md
 
-  meta = {
-    description = "A compiled language with Ruby like syntax and type inference";
-    homepage = https://crystal-lang.org/;
-    license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ manveru david50407 ];
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+      runHook postInstall
+    '';
+
+    enableParallelBuilding = true;
+
+    dontStrip = true;
+
+    checkTarget = "spec";
+
+    preCheck = ''
+      export LIBRARY_PATH=${lib.makeLibraryPath checkInputs}:$LIBRARY_PATH
+    '';
+
+    meta = with lib; {
+      description = "A compiled language with Ruby like syntax and type inference";
+      homepage = https://crystal-lang.org/;
+      license = licenses.asl20;
+      maintainers = with maintainers; [ manveru david50407 peterhoeg ];
+      platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    };
   };
+
+in rec {
+  crystal_0_25 = generic {
+    version = "0.25.1";
+    sha256  = "15xmbkalsdk9qpc6wfpkly3sifgw6a4ai5jzlv78dh3jp7glmgyl";
+    doCheck = false;
+  };
+
+  crystal_0_26 = generic {
+    version = "0.26.1";
+    sha256  = "0jwxrqm99zcjj82gyl6bzvnfj79nwzqf8sa1q3f66q9p50v44f84";
+    doCheck = false; # about 20 tests out of more than 14000 are failing
+  };
+
+  crystal = crystal_0_26;
 }

--- a/pkgs/development/tools/build-managers/shards/default.nix
+++ b/pkgs/development/tools/build-managers/shards/default.nix
@@ -1,28 +1,32 @@
-{ stdenv, fetchurl, crystal, libyaml, which }:
+{ stdenv, fetchFromGitHub, crystal, pcre, libyaml, which }:
 
 stdenv.mkDerivation rec {
   name = "shards-${version}";
   version = "0.8.1";
 
-  src = fetchurl {
-    url = "https://github.com/crystal-lang/shards/archive/v${version}.tar.gz";
-    sha256 = "198768izbsqqp063847r2x9ddcf4qfxx7vx7c6gwbmgjmjv4mivm";
+  src = fetchFromGitHub {
+    owner  = "crystal-lang";
+    repo   = "shards";
+    rev    = "v${version}";
+    sha256 = "1cjn2lafr08yiqzlhyqx14jjjxf1y24i2kk046px07gljpnlgqwk";
   };
 
-  buildInputs = [ crystal libyaml which ];
+  buildInputs = [ crystal libyaml pcre which ];
 
   buildFlags = [ "CRFLAGS=--release" ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp bin/shards $out/bin/
+    runHook preInstall
+
+    install -Dm755 bin/shards $out/bin/shards
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://crystal-lang.org/;
-    license = licenses.asl20;
     description = "Dependency manager for the Crystal language";
-    maintainers = with maintainers; [ sifmelcara ];
-    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    license     = licenses.asl20;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit (crystal.meta) homepage platforms;
   };
 }

--- a/pkgs/development/tools/icr/default.nix
+++ b/pkgs/development/tools/icr/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, crystal, shards, which
+, openssl, readline }:
+
+stdenv.mkDerivation rec {
+  name = "icr";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner  = "crystal-community";
+    repo   = "icr";
+    rev    = "v${version}";
+    sha256 = "1vavdzgm06ssnxm6mylki6xma0mfsj63n5kivhk1v4pg4xj966w5";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace /usr/local $out
+  '';
+
+  buildInputs = [ openssl readline ];
+
+  nativeBuildInputs = [ crystal shards which ];
+
+  doCheck = true;
+
+  checkTarget = "test";
+
+  meta = with stdenv.lib; {
+    description = "Interactive console for the Crystal programming language";
+    homepage = https://github.com/crystal-community/icr;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/tools/scry/default.nix
+++ b/pkgs/development/tools/scry/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitHub, crystal, shards, which }:
+
+stdenv.mkDerivation rec {
+  name = "scry";
+  # 0.7.1 doesn't work with crystal > 0.25
+  version = "0.7.1.20180919";
+
+  src = fetchFromGitHub {
+    owner  = "crystal-lang-tools";
+    repo   = "scry";
+    rev    = "543c1c3f764298f9fff192ca884d10f72338607d";
+    sha256 = "1yq7jap3y5pr2yqc6fn6bxshzwv7dz3w97incq7wpcvi7ibb4lcn";
+  };
+
+  nativeBuildInputs = [ crystal shards which ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    shards build --release
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin bin/scry
+
+    runHook postInstall
+  '';
+
+  # https://github.com/crystal-lang-tools/scry/issues/138
+  doCheck = false;
+
+  checkPhase = ''
+    runHook preCheck
+
+    crystal spec
+
+    runHook postCheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Code analysis server for the Crystal programming language";
+    homepage = https://github.com/crystal-lang-tools/scry;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6418,6 +6418,8 @@ with pkgs;
 
   icr = callPackage ../development/tools/icr {};
 
+  scry = callPackage ../development/tools/scry {};
+
   devpi-client = callPackage ../development/tools/devpi-client {};
 
   devpi-server = callPackage ../development/tools/devpi-server {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6411,7 +6411,10 @@ with pkgs;
     '';
   });
 
-  crystal = callPackage ../development/compilers/crystal { };
+  inherit (callPackages ../development/compilers/crystal {})
+    crystal_0_25
+    crystal_0_26
+    crystal;
 
   devpi-client = callPackage ../development/tools/devpi-client {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6416,6 +6416,8 @@ with pkgs;
     crystal_0_26
     crystal;
 
+  icr = callPackage ../development/tools/icr {};
+
   devpi-client = callPackage ../development/tools/devpi-client {};
 
   devpi-server = callPackage ../development/tools/devpi-server {};


### PR DESCRIPTION
###### Motivation for this change

Crystal moves pretty quickly, so not all shards have caught up with the latest version. Here we introduce a generic builder that can be used to build other versions - for now just the latest 0.26.1 as well as 0.25.1

The bootstrap binary is also separated out so we don't have to pull it down every time.

Cc: @manveru @david50407 @sifmelcara 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

