### PR TITLE
pythonPackages.nixpkgs: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3978,6 +3978,11 @@
     github = "sztupi";
     name = "Attila Sztupak";
   };
+  t184256 = {
+    email = "monk@unboiled.info";
+    github = "t184256";
+    name = "Alexander Sosedkin";
+  };
   tadfisher = {
     email = "tadfisher@gmail.com";
     github = "tadfisher";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8247,6 +8247,24 @@ in {
     inherit (pkgs) which;
   };
 
+  nixpkgs = buildPythonPackage rec {
+    disabled = ! pythonAtLeast "3.5";
+    pname = "nixpkgs";
+    version = "0.2.2";
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "0gsrd99kkv99jsrh3hckz7ns1zwndi9vvh4465v4gnpz723dd6fj";
+    };
+    buildInputs = with self; [ pbr ];
+    propagatedBuildInputs = with self; [ pythonix ];
+    meta = {
+      description = "Allows to `from nixpkgs import` stuff in interactive Python sessions";
+      homepage = http://github.com/t184256/nixpkgs-python-importer;
+      license = licenses.mit;
+      maintainers = with maintainers; [ t184256 ];
+    };
+  };
+
   nodeenv = callPackage ../development/python-modules/nodeenv { };
 
   nose = buildPythonPackage rec {


### PR DESCRIPTION
Allows to `from nixpkgs import` stuff in interactive Python sessions

###### Motivation for this change

I am a researcher and I use python and xonsh interactively a lot. While I appreciate the purity of Nix, sometimes I really want to violate it and pull in some dependency into my shell right now, without tearing my session down, editing and rebuilding an environment, and then recreating my session from history.

[This module](https://github.com/t184256/nixpkgs-python-importer) allows me to bypass all the Nix purity goodness in a whim, `from nixpkgs import` something and go on with my analysis. Yes, this is an abuse, but it's too convenient to pass up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

