### PR TITLE
[WIP] spotifyd: init at 0.2.2

### DIFF
--- a/nixos/modules/services/audio/spotifyd.nix
+++ b/nixos/modules/services/audio/spotifyd.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.spotifyd;
+
+  configFile = writeFile "spotifyd.cfg" cfg.config;
+
+in {
+  options = {
+
+    services.spotifyd = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable spotifyd.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.spotifyd;
+        defaultText = "pkgs.spotifyd";
+        description = "Spotifyd package to use.";
+      };
+
+      config = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Configuration of spotifyd. See https://github.com/Spotifyd/spotifyd#configuration";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.spotifyd = {
+      after = [ "network.target" ];
+      description = "Spotify daemon";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        User = "spotifyd";
+        Type = "forking";
+        ExecStart = "${cfg.package}/bin/spotifyd --config ${configFile}";
+      };
+    };
+
+    users = {
+      users.spotifyd = {
+        description = "spotifyd daemon user";
+        home = cfg.dataDir;
+        group = "spotifyd";
+      };
+      groups.spotifyd = {};
+    };
+  };
+
+}
+

--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, rustPlatform , fetchFromGitHub,
+openssl, alsaLib, pkgconfig,
+withPulseAudio ? false, libpulseaudio,
+withDbusMpris ? false, dbus }:
+rustPlatform.buildRustPackage rec {
+  name = "spotifyd-${version}";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Spotifyd";
+    repo = "spotifyd";
+    rev = "v${version}";
+    sha256 = "0xdv8c4nb427b81r57srcqn3gylblxfs8hbk1x3ckjsxzwn8vj9l";
+  };
+
+  buildInputs = [ openssl alsaLib pkgconfig ]
+  ++ (lib.optional withPulseAudio libpulseaudio)
+  ++ (lib.optional withDbusMpris dbus);
+
+  cargoSha256 = "1gbgirng21ak0kl3fiyr6lxwzrjd5v79gcrbzf941nb8y8rlvz7a";
+
+  cargoBuildFlags = [ "--features" "${lib.optionalString withPulseAudio "pulseaudio_backend"} ${lib.optionalString withDbusMpris "dbus_mpris"}" ];
+
+  meta = with stdenv.lib; {
+    description = "A spotify daemon";
+    homepage = https://github.com/Spotifyd/spotifyd;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.bobvanderlinden ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18720,6 +18720,10 @@ with pkgs;
     };
   };
 
+  spotifyd = callPackage ../applications/audio/spotifyd {
+    withPulseAudio = config.pulseaudio or true;
+  };
+
   libspotify = callPackage ../development/libraries/libspotify {
     apiKey = config.libspotify.apiKey or null;
   };


### PR DESCRIPTION
###### Motivation for this change

Spotifyd is a daemon for Spotify. It is especially useful for headless servers that need to be able to play songs from Spotify.

This PR includes a basic implementation for a spotifyd module.

This PR is WIP because the package was not able to build. This problem is related to https://github.com/NixOS/nixpkgs/issues/30742.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

