### PR TITLE
gnuradio-limesdr: init at 1.0.0-RC

### DIFF
--- a/pkgs/applications/misc/gnuradio/limesdr.nix
+++ b/pkgs/applications/misc/gnuradio/limesdr.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, cmake, boost, gnuradio
+, pythonSupport ? true, python, swig, limesuite
+} :
+
+assert pythonSupport -> python != null && swig != null;
+
+let
+  version = "1.0.0-RC";
+
+in stdenv.mkDerivation rec {
+  name = "gnuradio-limesdr-${version}";
+
+  src = fetchFromGitHub {
+    owner = "myriadrf";
+    repo = "gr-limesdr";
+    rev = "v${version}";
+    sha256 = "0b34mg9nfar2gcir98004ixrxmxi8p3p2hrvvi1razd869x2a0lf";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ stdenv.lib.optionals pythonSupport [ swig ];
+
+  buildInputs = [
+    boost gnuradio limesuite
+  ] ++ stdenv.lib.optionals pythonSupport [ python ];
+
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Gnuradio source and sink blocks for LimeSDR";
+    homepage = https://wiki.myriadrf.org/Gr-limesdr_Plugin_for_GNURadio;
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16413,7 +16413,7 @@ with pkgs;
 
   gnuradio-with-packages = callPackage ../applications/misc/gnuradio/wrapper.nix {
     inherit (python2Packages) python;
-    extraPackages = [ gnuradio-nacl gnuradio-osmosdr gnuradio-gsm gnuradio-ais gnuradio-rds ];
+    extraPackages = [ gnuradio-nacl gnuradio-osmosdr gnuradio-gsm gnuradio-ais gnuradio-rds gnuradio-limesdr ];
   };
 
   gnuradio-nacl = callPackage ../applications/misc/gnuradio/nacl.nix { };
@@ -16421,6 +16421,8 @@ with pkgs;
   gnuradio-gsm = callPackage ../applications/misc/gnuradio/gsm.nix { };
 
   gnuradio-ais = callPackage ../applications/misc/gnuradio/ais.nix { };
+
+  gnuradio-limesdr = callPackage ../applications/misc/gnuradio/limesdr.nix { };
 
   gnuradio-rds = callPackage ../applications/misc/gnuradio/rds.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
This gnuradio module adds source and sink blocks for LimeSDR devices.

###### Things done
Tested with a LimeSDR-mini

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

