### PR TITLE
nixos-manual: Include all modules in documentation generation

### DIFF
--- a/nixos/modules/services/misc/nixos-manual.nix
+++ b/nixos/modules/services/misc/nixos-manual.nix
@@ -3,12 +3,13 @@
 # of the virtual consoles.  The latter is useful for the installation
 # CD.
 
-{ config, lib, pkgs, baseModules, ... }:
+{ config, lib, pkgs, modules, baseModules, ... }:
 
 with lib;
 
 let
 
+  allModules = modules;
   cfg = config.services.nixosManual;
 
   /* For the purpose of generating docs, evaluate options with each derivation
@@ -23,7 +24,7 @@ let
     options =
       let
         scrubbedEval = evalModules {
-          modules = [ { nixpkgs.localSystem = config.nixpkgs.localSystem; } ] ++ baseModules;
+          modules = [ { nixpkgs.localSystem = config.nixpkgs.localSystem; } ] ++ baseModules ++ allModules;
           args = (config._module.args) // { modules = [ ]; };
           specialArgs = { pkgs = scrubDerivations "pkgs" pkgs; };
         };


### PR DESCRIPTION
Previously,  `man 5 configuration.nix` would only show
options of modules in the `baseModules` set, which
consists only of the list of modules in `nixos/modules/module-list.nix`

however, with this change, any extra module that is included
in your `configuration.nix` file by the means of

```
  imports = [ ./rootfs.nix ]
```

will also be included the generated documentation.

Example output:

```
OPTIONS
       You can use the following options in configuration.nix.

       arian.rootfs.device
           The device that contains the btrfs volume

           Type: string

           Declared by:
               /home/arian/Projects/nixos-stuff/computers/t430s/rootfs.nix

       boot.enableContainers
           Whether to enable support for nixos containers.

           Type: boolean

           Default: true

           Declared by:
               <nixpkgs/nixos/modules/virtualisation/containers.nix>
```

###### Motivation for this change

I found it useful for my machine to be self-documenting.  It also means
that if you import modules like `gce.nix` or `azure.nix` which aren't in
`module-list.nix`,  documentation is still generated for these modules

cc:  https://github.com/NixOS/nixpkgs/issues/11499

###### Things to do

- [ ] I have no idea if this patch impacts the way the documentation for https://nixos.org/nixos
is generated. It might.  We should check this.


---

