### PR TITLE
epoxy: 1.5.1 -> 1.5.2

### DIFF
--- a/pkgs/development/libraries/epoxy/default.nix
+++ b/pkgs/development/libraries/epoxy/default.nix
@@ -6,13 +6,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "epoxy-${version}";
-  version = "1.5.1";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "anholt";
     repo = "libepoxy";
     rev = "${version}";
-    sha256 = "1811agxr7g9wd832np8sw152j468kg3qydmfkc564v54ncfcgaci";
+    sha256 = "0frs42s7d3ff2wlw0jns6vb3myx2bhz9m5nkzbnfyn436s2qqls3";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/epoxy/libgl-path.patch
+++ b/pkgs/development/libraries/epoxy/libgl-path.patch
@@ -1,20 +1,11 @@
-From 4046e0ac8ed93354c01de5f3b5cae790cce70404 Mon Sep 17 00:00:00 2001
-From: Will Dietz <w@wdtz.org>
-Date: Thu, 29 Mar 2018 07:21:02 -0500
-Subject: [PATCH] Explicitly search LIBGL_PATH as fallback, if defined.
-
----
- src/dispatch_common.c | 12 ++++++++++++
- 1 file changed, 12 insertions(+)
-
 diff --git a/src/dispatch_common.c b/src/dispatch_common.c
-index bc2fb94..776237b 100644
+index b3e4f5f..303e8f5 100644
 --- a/src/dispatch_common.c
 +++ b/src/dispatch_common.c
-@@ -306,6 +306,18 @@ get_dlopen_handle(void **handle, const char *lib_name, bool exit_on_fail)
-     pthread_mutex_lock(&api.mutex);
-     if (!*handle) {
-         *handle = dlopen(lib_name, RTLD_LAZY | RTLD_LOCAL);
+@@ -310,6 +310,19 @@ get_dlopen_handle(void **handle, const char *lib_name, bool exit_on_fail, bool l
+             flags |= RTLD_NOLOAD;
+ 
+         *handle = dlopen(lib_name, flags);
 +#ifdef LIBGL_PATH
 +        if (!*handle) {
 +          char pathbuf[sizeof(LIBGL_PATH) + 1 + 1024 + 1];
@@ -24,12 +15,10 @@ index bc2fb94..776237b 100644
 +            fprintf(stderr, "Error prefixing library pathname\n");
 +            exit(1);
 +          }
-+          *handle = dlopen(pathbuf, RTLD_LAZY | RTLD_LOCAL);
++          *handle = dlopen(pathbuf, flags);
 +        }
 +#endif
++
          if (!*handle) {
              if (exit_on_fail) {
                  fprintf(stderr, "Couldn't open %s: %s\n", lib_name, dlerror());
--- 
-2.16.3
-


### PR DESCRIPTION
libgl-path.patch was updated (it applied with little fuzz, because I am
a bit lazy, and rebase it on master of epoxy, not 1.5.2)

###### Motivation for this change

Doing it as part of work on #46423, which looks unrelated to epoxy, but also l found that it worth to update to latest minor release as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

