### PR TITLE
nixos/tests/codimd: fix non-deterministic failure

### DIFF
--- a/nixos/tests/codimd.nix
+++ b/nixos/tests/codimd.nix
@@ -40,7 +40,7 @@ import ./make-test.nix ({ pkgs, lib, ... }:
     subtest "CodiMD sqlite", sub {
       $codimdSqlite->waitForUnit("codimd.service");
       $codimdSqlite->waitForOpenPort(3000);
-      $codimdPostgres->succeed("sleep 2"); # avoid 503 during startup
+      $codimdSqlite->sleep(10); # avoid 503 during startup
       $codimdSqlite->succeed("curl -sSf http://localhost:3000/new");
     };
 
@@ -49,7 +49,7 @@ import ./make-test.nix ({ pkgs, lib, ... }:
       $codimdPostgres->waitForUnit("codimd.service");
       $codimdPostgres->waitForOpenPort(5432);
       $codimdPostgres->waitForOpenPort(3000);
-      $codimdPostgres->succeed("sleep 2"); # avoid 503 during startup
+      $codimdPostgres->sleep(10); # avoid 503 during startup
       $codimdPostgres->succeed("curl -sSf http://localhost:3000/new");
     };
   '';


### PR DESCRIPTION
###### Motivation for this change

Test [failed non-deterministically](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.codimd.x86_64-linux) due to an obvious copy/paste error.
Fix it and increase wait time to 10s (2s may not be enough on Hydra).

###### Things done

- [x] NixOS test passes (with sandboxing enabled)

---
cc @WilliButz 
