### PR TITLE
mkl: init at 2019.0.117

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -387,6 +387,14 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "ISC License";
   };
 
+  # Proprietary binaries; free to redistribute without modification.
+  issl = {
+    fullName = "Intel Simplified Software License";
+    url = https://software.intel.com/en-us/license/intel-simplified-software-license;
+    free = false;
+  };
+
+
   lgpl2 = spdx {
     spdxId = "LGPL-2.0";
     fullName = "GNU Library General Public License v2 only";

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -1,0 +1,55 @@
+{ stdenvNoCC, writeText, fetchurl, rpm, cpio, openmp }:
+
+stdenvNoCC.mkDerivation rec {
+  name = "mkl-${version}";
+  version = "${date}.${rel}";
+  date = "2019.0";
+  rel = "117";
+
+  src = fetchurl {
+    url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/13575/l_mkl_${version}.tgz";
+    sha256 = "1bf7i54iqlf7x7fn8kqwmi06g30sxr6nq3ac0r871i6g0p3y47sf";
+  };
+
+  buildInputs = [ rpm cpio ];
+  propagatedBuildInputs = [ openmp ];
+
+  buildPhase = ''
+    rpm2cpio rpm/intel-mkl-common-c-${date}-${rel}-${date}-${rel}.noarch.rpm | cpio -idmv
+    rpm2cpio rpm/intel-mkl-core-rt-${date}-${rel}-${date}-${rel}.x86_64.rpm | cpio -idmv
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/include $out/
+    cp -r opt/intel/compilers_and_libraries_${version}/linux/mkl/lib/intel64_lin/* $out/lib/
+    cp license.txt $out/lib/
+  '';
+
+  # Per license agreement, do not modify the binary
+  dontStrip = true;
+  dontPatchELF = true;
+
+  # Some mkl calls require openmp, but Intel does not add these to SO_NEEDED and
+  # instructs users to put openmp on their LD_LIBRARY_PATH.
+  setupHook = writeText "setup-hook.sh" ''
+    addOpenmp() {
+        addToSearchPath LD_LIBRARY_PATH ${openmp}/lib
+    }
+    addEnvHooks "$targetOffset" addOpenmp
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    description = "Intel Math Kernel Library";
+    longDescription = ''
+      Intel Math Kernel Library (Intel MKL) optimizes code with minimal effort
+      for future generations of Intel processors. It is compatible with your
+      choice of compilers, languages, operating systems, and linking and
+      threading models.
+    '';
+    homepage = https://software.intel.com/en-us/mkl;
+    license = licenses.issl;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.bhipple ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20858,6 +20858,10 @@ with pkgs;
 
   m4rie = callPackage ../development/libraries/science/math/m4rie { };
 
+  mkl = callPackage ../development/libraries/science/math/mkl {
+    inherit (llvmPackages) openmp;
+  };
+
   nasc = callPackage ../applications/science/math/nasc { };
 
   openblas = callPackage ../development/libraries/science/math/openblas { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20858,9 +20858,7 @@ with pkgs;
 
   m4rie = callPackage ../development/libraries/science/math/m4rie { };
 
-  mkl = callPackage ../development/libraries/science/math/mkl {
-    inherit (llvmPackages) openmp;
-  };
+  mkl = callPackage ../development/libraries/science/math/mkl { };
 
   nasc = callPackage ../applications/science/math/nasc { };
 


### PR DESCRIPTION
This packags the Intel Math Kernel library on x86-64 platforms, which is a
dependency for many data science and machine learning packages.

Upstream, Intel provides proprietary binary RPMs with a permissive
redistribution license. These have been repackaged in both Debian and Anaconda,
so we are not the first distribution to redistribute.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

