### PR TITLE
nixos/tests/prosody: use sqlite database

### DIFF
--- a/nixos/tests/prosody.nix
+++ b/nixos/tests/prosody.nix
@@ -6,6 +6,9 @@ import ./make-test.nix {
       enable = true;
       # TODO: use a self-signed certificate
       c2sRequireEncryption = false;
+      extraConfig = ''
+        storage = "sql"
+      '';
     };
     environment.systemPackages = let
       sendMessage = pkgs.writeScriptBin "send-message" ''


### PR DESCRIPTION
###### Motivation for this change

The test didn't catch an issue with `luadbi` (see #47156) because it used internal storage only. Enable sql (which uses sqlite3 by default) to also test sql access.

Please backport to 18.09 (QA).

###### Things done

- [x] test succeeds in a sandbox (after #47156 is merged)

---

cc @Mic92
