### PR TITLE
influxdb: 1.4.1 -> 1.6.3

### DIFF
--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "influxdb-${version}";
-  version = "1.4.1";
+  version = "1.6.3";
 
   src = fetchFromGitHub {
     owner = "influxdata";
     repo = "influxdb";
     rev = "v${version}";
-    sha256 = "048ap70hdfkxhy0y8q1jsb0lql1i99jnf3cqaqar6qs2ynzsw9hd";
+    sha256 = "0xf16liapllk8qnw0vsy1ja4if1xlazwwaa4p0r5j7bny5lxm7zy";
   };
 
   buildFlagsArray = [ ''-ldflags=
@@ -19,7 +19,7 @@ buildGoPackage rec {
 
   excludedPackages = "test";
 
-  # Generated with the nix2go
+  # Generated with dep2nix (for 1.6.3) / nix2go (for 1.4.1).
   goDeps = ./. + "/deps-${version}.nix";
 
   meta = with lib; {

--- a/pkgs/servers/nosql/influxdb/deps-1.6.3.nix
+++ b/pkgs/servers/nosql/influxdb/deps-1.6.3.nix
@@ -1,0 +1,444 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "collectd.org";
+    fetch = {
+      type = "git";
+      url = "https://github.com/collectd/go-collectd";
+      rev =  "2ce144541b8903101fb8f1483cc0497a68798122";
+      sha256 = "0rr9rnc777jk27a7yxhdb7vgkj493158a8k6q44x51s30dkp78x3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev =  "a368813c5e648fee92e5f6c30e3944ff9d5e8895";
+      sha256 = "1sjxs2lwc8jpln80s4rlzp7nprbcljhy5mz4rf9995gq93wqnym5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/RoaringBitmap/roaring";
+    fetch = {
+      type = "git";
+      url = "https://github.com/RoaringBitmap/roaring";
+      rev =  "d6540aab65a17321470b1661bfc52da1823871e9";
+      sha256 = "1lsrz7j55blalpp95vgz214b35sjf8nfmrw3fxybdl4xipk2ssdj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev =  "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9";
+      sha256 = "1hrybsql68xw57brzj805xx2mghydpdiysv3gbhr7f5wlxj2514y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bmizerany/pat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bmizerany/pat";
+      rev =  "6226ea591a40176dd3ff9cd8eff81ed6ca721a00";
+      sha256 = "0qjkm7169y6pybwh0s02fjjk251isa2b367xqfzrwvl6cy4yzfxp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/boltdb/bolt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/boltdb/bolt";
+      rev =  "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8";
+      sha256 = "0z7j06lijfi4y30ggf2znak2zf2srv2m6c68ar712wd2ys44qb3r";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cespare/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cespare/xxhash";
+      rev =  "5c37fe3735342a2e0d01c87a907579987c8936cc";
+      sha256 = "02aii7z46sasagw816zz3v0gzax1z5d1hkjslz7ng25386p0gzk1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgryski/go-bitstream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgryski/go-bitstream";
+      rev =  "9f22ccc24718d9643ac427c8c897ae1a01575783";
+      sha256 = "0x3hbsrn7qafhhjz6lgyc1pd1p5kgkrkbccvsr6yygkl785h5lhn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/glycerine/go-unsnap-stream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/glycerine/go-unsnap-stream";
+      rev =  "62a9a9eb44fd8932157b1a8ace2149eff5971af6";
+      sha256 = "1ray7p4q3vv5zn9w5xs7m9kjh68b2ck98nh25mxhfiwl9jxkabrc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "1adfc126b41513cc696b209667c8656ea7aac67c";
+      sha256 = "1j7azzlnihcvnd1apw5zr0bz30h7n0gyimqqkgc76vzb1n5dpi7m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "925541529c1fa6821df4e44ce2723319eb2be768";
+      sha256 = "1d3zjvhl115l23xakj0014qpjchivlg098h10v5nfirkk1i9f9sa";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev =  "d9eb7a3d35ec988b8585d4a0068e462c27d28380";
+      sha256 = "0wynarlr1y8sm9y9l29pm9dgflxriiialpwn01066snzjxnpmbyn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev =  "3af367b6b30c263d47e8895973edcca9a49cf029";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath  = "github.com/influxdata/influxql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/influxdata/influxql";
+      rev =  "a7267bff5327e316e54c54342b0bc9598753e3d5";
+      sha256 = "0mqc9xki5l9yfbb0dqjb417cmv3pca1bj71m90dkshladr2wlcg3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/influxdata/usage-client";
+    fetch = {
+      type = "git";
+      url = "https://github.com/influxdata/usage-client";
+      rev =  "6d3895376368aa52a3a81d2a16e90f0f52371967";
+      sha256 = "0a5adnid42f9vpckgcpkj7v60fh147j7zlg1rhxcpq5vkw698ifl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/influxdata/yamux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/influxdata/yamux";
+      rev =  "1f58ded512de5feabbe30b60c7d33a7a896c5f16";
+      sha256 = "08y1lgcyyaa8zrg24ck64b5dfassgb2pp1fb9x5lw9q16fb170bx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/influxdata/yarpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/influxdata/yarpc";
+      rev =  "f0da2db138cad2fb425541938fc28dd5a5bc6918";
+      sha256 = "1g71flc8s8xas7vmaiwv0425paii1akc7jsdqsgxkhyfxx2gvib0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jsternberg/zap-logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jsternberg/zap-logfmt";
+      rev =  "ac4bd917e18a4548ce6e0e765b29a4e7f397b0b6";
+      sha256 = "0pqp2nsqvsq8kqc7l14340lrvl03715s12bag63kdbi25s8fcdkx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jwilder/encoding";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jwilder/encoding";
+      rev =  "b4e1701a28efcc637d9afcca7d38e495fe909a09";
+      sha256 = "195js5njz86k096p3ggglgpc7rw3801mpqzdfwfr3miflhnp7nwg";
+    };
+  }
+  {
+    goPackagePath  = "github.com/klauspost/compress";
+    fetch = {
+      type = "git";
+      url = "https://github.com/klauspost/compress";
+      rev =  "6c8db69c4b49dd4df1fff66996cf556176d0b9bf";
+      sha256 = "00h2lpqcyc3pg2xk3q4a9cgyv0vkn15bx0hb725j5zbkr9vah23x";
+    };
+  }
+  {
+    goPackagePath  = "github.com/klauspost/cpuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/klauspost/cpuid";
+      rev =  "ae7887de9fa5d2db4eaa8174a7eff2c1ac00f2da";
+      sha256 = "178apw89g8nsd7w6mbdylxn956h3iig6rbw3bkivp6lplhb5dvq4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/klauspost/crc32";
+    fetch = {
+      type = "git";
+      url = "https://github.com/klauspost/crc32";
+      rev =  "cb6bfca970f6908083f26f39a79009d608efd5cd";
+      sha256 = "0q4yr4isgmph1yf1vq527lpmid7vqv56q7vxh3gkp5679fb90q6n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/klauspost/pgzip";
+    fetch = {
+      type = "git";
+      url = "https://github.com/klauspost/pgzip";
+      rev =  "0bf5dcad4ada2814c3c00f996a982270bb81a506";
+      sha256 = "0dgp2iljvhibzxia1g3lsfg4bjmfh4kf0bfrmfi7sd49hwhrvk7s";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev =  "3247c84500bff8d9fb6d579d800f20b3e091582c";
+      sha256 = "12hcych25wf725zxdkpnyx4wa0gyxl8v4m8xmhdmmaki9bbmqd0d";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mschoch/smat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mschoch/smat";
+      rev =  "90eadee771aeab36e8bf796039b8c261bebebe4f";
+      sha256 = "141saq6d4z3c7v3jw45zy4gn6wwjlyralqygjff1fzvz1gkvimk3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/opentracing/opentracing-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opentracing/opentracing-go";
+      rev =  "328fceb7548c744337cd010914152b74eaf4c4ab";
+      sha256 = "1w6s42n9glqwif6awyiapr7sh1wjvkxan41qhc1yi555byyw200k";
+    };
+  }
+  {
+    goPackagePath  = "github.com/paulbellamy/ratecounter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/paulbellamy/ratecounter";
+      rev =  "524851a93235ac051e3540563ed7909357fe24ab";
+      sha256 = "0z4c61ac6v8mpnr9z37d91h1cf8v9psja5jfdxmsf69r1b7qr4f9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/peterh/liner";
+    fetch = {
+      type = "git";
+      url = "https://github.com/peterh/liner";
+      rev =  "6106ee4fe3e8435f18cd10e34557e5e50f0e792a";
+      sha256 = "178s1amw5r60lywgmh24pd2ljim0b05fdfsm4c8px22fkycmn1qr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/philhofer/fwd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/philhofer/fwd";
+      rev =  "bb6d471dc95d4fe11e432687f8b70ff496cf3136";
+      sha256 = "1pg84khadh79v42y8sjsdgfb54vw2kzv7hpapxkifgj0yvcp30g2";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev =  "661e31bf844dfca9aeba15f27ea8aa0d485ad212";
+      sha256 = "0r9sr3m57ks7rc5bbghl0gy9wxlznzmz331xdp42zlgk6g774xcn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev =  "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c";
+      sha256 = "19y4ywsivhpxj7ikf2j0gm9k3cmyw37qcbfi78n526jxcc7kw998";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev =  "e4aa40a9169a88835b849a6efb71e05dc04b88f0";
+      sha256 = "0m1n616d694jca0qjwjn5ci7scfgm2jpi94dhi356arm9lhda4jc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev =  "54d17b57dd7d4a3aa092476596b3f8a933bde349";
+      sha256 = "1b5218hi6k9i637k6xc7ynpll577zbnrhjm9jr2iczy3j0rr4rvr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/retailnext/hllpp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/retailnext/hllpp";
+      rev =  "101a6d2f8b52abfc409ac188958e7e7be0116331";
+      sha256 = "1dyyjyrscd3d22jhh2pbn67c6nzva0v069215sjjmj313k1xzmj3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/tinylib/msgp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tinylib/msgp";
+      rev =  "b2b6a672cf1e5b90748f79b8b81fc8c5cf0571a1";
+      sha256 = "0pypfknghg1hcjjrqz3f1riaylk6hcxn9h0qyzynb74rp0qmlxjc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/willf/bitset";
+    fetch = {
+      type = "git";
+      url = "https://github.com/willf/bitset";
+      rev =  "d860f346b89450988a379d7d705e83c58d1ea227";
+      sha256 = "18419ip5mnblnyx2rjixad90dhjb1x2kaiidr7zk9b3qci799rh0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/xlab/treeprint";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xlab/treeprint";
+      rev =  "f3a15cfd24bf976c724324cb6846a8b54b88b639";
+      sha256 = "0fgbdyk2mfj5vh8902sga33w5gw7q0f1if4nqx631ca33fd6pfbn";
+    };
+  }
+  {
+    goPackagePath  = "go.uber.org/atomic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/atomic";
+      rev =  "8474b86a5a6f79c443ce4b2992817ff32cf208b8";
+      sha256 = "166shnjw8rvjvksymi2gqw1ygsbxlq15xb10j2dx5rwy4y4asq8x";
+    };
+  }
+  {
+    goPackagePath  = "go.uber.org/multierr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/multierr";
+      rev =  "3c4937480c32f4c13a875a1829af76c98ca3d40a";
+      sha256 = "1slfc6syvw8cvr6rbrjsy6ja5w8gsx0f8aq8qm16rp2x5c2pj07w";
+    };
+  }
+  {
+    goPackagePath  = "go.uber.org/zap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/zap";
+      rev =  "35aad584952c3e7020db7b839f6b102de6271f89";
+      sha256 = "0n79ir7jcr7s51j85swji7an0jgy1w5dxg1g68j722rmpbvsagwv";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "c3a3ad6d03f7a915c0f7e194b7152974bb73d287";
+      sha256 = "0x18275g5xlaw55bpx8hdna66d2hpbcw6hs0pxf1kmvfds6gzn6n";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "92b859f39abd2d91a854c9f9c4621b2f5054a92d";
+      sha256 = "1nzbay48k53pxa1sh102v571k6pa57540p0bzcil4qgan47yxba6";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev =  "1d60e4601c6fd243af51cc01ddf169918a5407ca";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "d8e400bc7db4870d786864138af681469693d18c";
+      sha256 = "08d23f9gjarp63dw0wj54nlqh3x2lqnchzkw8n5d7ik3wy7qy4yf";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev =  "26559e0f760e39c24d730d3224364aef164ee23f";
+      sha256 = "00fx6m59cjbi7y0ri4a57q1zs6r310xbg5yqns5kfm2cax0dkmnf";
+    };
+  }
+]


### PR DESCRIPTION
###### Motivation for this change

Wanted to use InfluxDB but saw that the version in Nixpkgs was almost a year old (2017-11).

I'm not sure if InfluxDB can be bumped just like this, or if both versions 1.4.1 and 1.6.3 should be made available and a switch is made (in the NixOS InfluxDB service) based on `stateVersion`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

