### PR TITLE
U-Boot: Add Orange Pi Zero Plus2 (H5) build

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -158,6 +158,13 @@ in rec {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootOrangePiZeroPlus2H5 = buildUBoot rec {
+    defconfig = "orangepi_zero_plus2_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
   ubootPcduino3Nano = buildUBoot rec {
     defconfig = "Linksprite_pcDuino3_Nano_defconfig";
     extraMeta.platforms = ["armv7l-linux"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14738,6 +14738,7 @@ with pkgs;
     ubootNovena
     ubootOdroidXU3
     ubootOrangePiPc
+    ubootOrangePiZeroPlus2H5
     ubootPcduino3Nano
     ubootPine64
     ubootQemuAarch64


### PR DESCRIPTION
###### Motivation for this change

Adds support for that board.

 * http://www.orangepi.org/OrangePiZeroPlus2/
 * http://linux-sunxi.org/Xunlong_Orange_Pi_Zero_Plus_2

The board is supported by mainline U-Boot, and uses the mainline build. It works right; HDMI starts, can boot the NixOS ARM mainline AArch64 img.

While unrelated to this PR, note that the mainline kernel *currently* has issues starting the HDMI output, so anyone using 4.18.6 mainline kernel on a NixOS image, use a serial device to confirm whether it works or not.

The instructions to flash are as expected from AArch64 allwinner. After using `dd` on the SD card:

```
dd if=u-boot-sunxi-with-spl.bin of=/dev/sdX bs=1024 seek=8
```

And while still directly unrelated to this PR; useful to know that booting from the 8GB internal eMMC works; boot from an SD system, and `dd` the NixOS AArch64 image, and then `dd` the `u-boot` binary using the same command, but substituting for the right `/dev/mmcblk` device.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
   - 🆖 macOS
   - ⬜ other Linux distributions
- ⬜ Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ✔️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ⬜ Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
