### PR TITLE
gnuradio: PYTHONPATH and wrapper updates

### DIFF
--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -1,4 +1,4 @@
-{ callPackage, fetchurl }:
+{ pkgs, newScope, callPackage, fetchurl }:
 
 # To upgrade pick the hydra job of the nixops revision that you want to upgrade
 # to from: https://hydra.nixos.org/job/nixops/master/tarball
@@ -13,15 +13,15 @@ callPackage ./generic.nix (rec {
   # # Marking unstable as broken, instead of using the pinned version,
   # # like stable does You might be able to use the following code (as
   # # in stable), to run unstable against the pinned packages
-  # python2Packages = pkgs.python2Packages.override {
-  #   overrides = (self: super: let callPackage = newScope self; in {
-  #     azure-mgmt-compute = callPackage ./azure-mgmt-compute { };
-  #     azure-mgmt-network = callPackage ./azure-mgmt-network { };
-  #     azure-mgmt-nspkg = callPackage ./azure-mgmt-nspkg { };
-  #     azure-mgmt-resource = callPackage ./azure-mgmt-resource { };
-  #     azure-mgmt-storage = callPackage ./azure-mgmt-storage { };
-  #   });
-  # };
+   python2Packages = pkgs.python2Packages.override {
+     overrides = (self: super: let callPackage = newScope self; in {
+       azure-mgmt-compute = callPackage ./azure-mgmt-compute { };
+       azure-mgmt-network = callPackage ./azure-mgmt-network { };
+       azure-mgmt-nspkg = callPackage ./azure-mgmt-nspkg { };
+       azure-mgmt-resource = callPackage ./azure-mgmt-resource { };
+       azure-mgmt-storage = callPackage ./azure-mgmt-storage { };
+     });
+   };
   # # otherwise
   # # see https://github.com/NixOS/nixpkgs/pull/52550
   # # see https://github.com/NixOS/nixops/issues/1065


### PR DESCRIPTION
###### Motivation for this change
This change is in preparation for upcoming changes to gnuradio. The gnuradio python library must be present after other paths when there is a namespace conflict.

I will soon add a "master" or "unstable" version for the 3.8 tech-preview soon (https://github.com/gnuradio/gnuradio/releases/tag/3.8tech-preview).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

