### PR TITLE
xsecurelock: 1.0 -> 1.1

### DIFF
--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -1,21 +1,21 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, libX11, libXcomposite, libXft, pam, apacheHttpd, imagemagick
+, libX11, libXcomposite, libXft, libXmu, pam, apacheHttpd, imagemagick
 , pamtester, xscreensaver }:
 
 stdenv.mkDerivation rec {
   name = "xsecurelock-${version}";
-  version = "1.0";
+  version = "1.1";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "xsecurelock";
     rev = "v${version}";
-    sha256 = "0k135hnfnn1j82wvc03b8jkq06wws1xk325x5m25ps6xwsn725sw";
+    sha256 = "0yqp5xhkl9jpjyrmrxbyp7azwxmqc3lxv5lxrjqjaapl3q3096g5";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [
-    libX11 libXcomposite libXft pam
+    libX11 libXcomposite libXft libXmu pam
     apacheHttpd imagemagick pamtester
   ];
 


### PR DESCRIPTION
###### Motivation for this change
Upgrade to the latest released version which fixes a couple bugs with compositors and allows switching keyboard layouts.

I'd like to get this into 18.09, if possible!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @fpletz 