### PR TITLE
gnuradio-[rds,nacl]: 2016-08-27 -> 1.0.0, 2015-11-05 -> 2017-04-10

### DIFF
--- a/pkgs/applications/misc/gnuradio/nacl.nix
+++ b/pkgs/applications/misc/gnuradio/nacl.nix
@@ -7,13 +7,13 @@ assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
   name = "gnuradio-nacl-${version}";
-  version = "2015-11-05";
+  version = "2017-04-10";
 
   src = fetchFromGitHub {
     owner = "stwunsch";
     repo = "gr-nacl";
-    rev = "d6dd3c02dcda3f601979908b61b1595476f6bf95";
-    sha256 = "0q28lgkndcw9921hm6cw5ilxd83n65hjajwl78j50mh6yc3bim35";
+    rev = "15276bb0fcabf5fe4de4e58df3d579b5be0e9765";
+    sha256 = "018np0qlk61l7mlv3xxx5cj1rax8f1vqrsrch3higsl25yydbv7v";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/applications/misc/gnuradio/rds.nix
+++ b/pkgs/applications/misc/gnuradio/rds.nix
@@ -6,12 +6,12 @@ assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
   name = "gnuradio-rds-${version}";
-  version = "2016-08-27";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "bastibl";
     repo = "gr-rds";
-    rev = "5246b75180808d47f321cb26f6c16d7c7a7af4fc";
+    rev = "$v{version}";
     sha256 = "008284ya464q4h4fd0zvcn6g7bym231p8fl3kdxncz9ks4zsbsxs";
   };
 


### PR DESCRIPTION
###### Motivation for this change
Update the gnuradio modules for RDS and encryption (nacl)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

