### PR TITLE
nixos/iso-image: fix 32bit UEFI boot

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -233,7 +233,7 @@ let
             "
     # Make our own efi program, we can't rely on "grub-install" since it seems to
     # probe for devices, even with --skip-fs-probe.
-    ${pkgs.grub2_efi}/bin/grub-mkimage -o $out/EFI/boot/${if targetArch == "x64" then "bootx64" else "bootx32"}.efi -p /EFI/boot -O ${if targetArch == "x64" then "x86_64" else "i386"}-efi \
+    ${pkgs.grub2_efi}/bin/grub-mkimage -o $out/EFI/boot/${if targetArch == "x64" then "bootx64" else "bootia32"}.efi -p /EFI/boot -O ${if targetArch == "x64" then "x86_64" else "i386"}-efi \
       $MODULES
     cp ${pkgs.grub2_efi}/share/grub/unicode.pf2 $out/EFI/boot/
 


### PR DESCRIPTION
###### Motivation for this change

The UEFI iso image for i686 didn't boot. Because the default boot file was incorrectly named `bootx32.efi`, the firmware didn't find it and dropped down to the UEFI shell.

This caused two tests to fail: [`tests.boot.uefiUsb.i686-linux`](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.boot.uefiUsb.i686-linux)  and  [`tests.boot.uefiCdrom.i686-linux`](https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.boot.uefiCdrom.i686-linux) 

The correct name for 32bit is `bootia32.efi` (which is a little inconsistent with `bootx64.efi` for 64bit.)

ZHF #45960, please backport.

###### Things done

- [x] the two tests pass now

---

