### PR TITLE
ltc-tools: init at 0.6.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4263,6 +4263,11 @@
     github = "tex";
     name = "Milan Svoboda";
   };
+  tg-x = {
+    email = "*@tg-x.net";
+    github = "tg-x";
+    name = "TG ⊗ Θ";
+  };
   thall = {
     email = "niclas.thall@gmail.com";
     github = "thall";

--- a/pkgs/applications/audio/ltc-tools/default.nix
+++ b/pkgs/applications/audio/ltc-tools/default.nix
@@ -1,0 +1,25 @@
+{stdenv, fetchFromGitHub, pkgconfig, libltc, libsndfile, jack2}:
+
+stdenv.mkDerivation rec {
+  name = "ltc-tools-${version}";
+  version = "0.6.4";
+
+  src = fetchFromGitHub {
+    owner = "x42";
+    repo = "ltc-tools";
+    rev = "v${version}";
+    sha256 = "1a7r99mwc7p5j5y453mrgph67wlznd674v4k2pfmlvc91s6lh44y";
+  };
+
+  buildInputs = [ pkgconfig libltc libsndfile jack2 ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/x42/ltc-tools";
+    description = "Tools to deal with linear-timecode (LTC)";
+    license = licenses.gpl2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tg-x ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17807,6 +17807,8 @@ with pkgs;
 
   looking-glass-client = callPackage ../applications/virtualization/looking-glass-client { };
 
+  ltc-tools = callPackage ../applications/audio/ltc-tools { };
+
   lumail = callPackage ../applications/networking/mailreaders/lumail {
     lua = lua5_1;
   };


### PR DESCRIPTION
###### Motivation for this change

add ltc-tools package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

