### PR TITLE
xloadimage: init at 4.1

### DIFF
--- a/pkgs/tools/X11/xloadimage/default.nix
+++ b/pkgs/tools/X11/xloadimage/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, fetchurl
+, libX11
+, libXt
+
+, libjpeg ? null
+, libpng ? null
+, libtiff ? null
+
+, withJpegSupport ? true
+, withPngSupport ? true
+, withTiffSupport ? true
+}:
+
+assert withJpegSupport -> libjpeg != null;
+assert withPngSupport -> libpng != null;
+assert withTiffSupport -> libtiff != null;
+
+let
+  deb_patch = "25";
+in
+stdenv.mkDerivation rec {
+  version = "4.1";
+  name = "xloadimage-${version}";
+
+  src = fetchurl {
+    url = "mirror://debian/pool/main/x/xloadimage/xloadimage_${version}.orig.tar.gz";
+    sha256 = "1i7miyvk5ydhi6yi8593vapavhwxcwciir8wg9d2dcyg9pccf2s0";
+  };
+
+  patches = fetchurl {
+    url = "mirror://debian/pool/main/x/xloadimage/xloadimage_${version}-${deb_patch}.debian.tar.xz";
+    sha256 = "17k518vrdrya5c9dqhpmm4g0h2vlkq1iy87sg2ngzygypbli1xvn";
+  };
+
+  buildInputs = [
+    libX11 libXt
+  ] ++ stdenv.lib.optionals withJpegSupport [
+    libjpeg
+  ] ++ stdenv.lib.optionals withPngSupport [
+    libpng
+  ] ++ stdenv.lib.optionals withTiffSupport [
+    libtiff
+  ];
+
+  # NOTE: we patch the build-info script so that it never detects the utilities
+  # it's trying to find; one of the Debian patches adds support for
+  # $SOURCE_DATE_EPOCH, but we want to make sure we don't even call these.
+  preConfigure = ''
+    substituteInPlace build-info \
+      --replace '[ -x /bin/date ]' 'false' \
+      --replace '[ -x /bin/id ]' 'false' \
+      --replace '[ -x /bin/uname ]' 'false' \
+      --replace '[ -x /usr/bin/id ]' 'false'
+
+    chmod +x build-info configure
+  '';
+
+  enableParallelBuilding = true;
+
+  # NOTE: we're not installing the `uufilter` binary; if needed, the standard
+  # `uudecode` tool should work just fine.
+  installPhase = ''
+    install -Dm755 xloadimage $out/bin/xloadimage
+    ln -sv $out/bin/{xloadimage,xsetbg}
+
+    install -D -m644 xloadimagerc $out/etc/xloadimagerc.example
+    install -D -m644 xloadimage.man $out/share/man/man1/xloadimage.1x
+    ln -sv $out/share/man/man1/{xloadimage,xsetbg}.1x
+  '';
+
+  meta = {
+    description = "Graphics file viewer under X11";
+
+    longDescription = ''
+      Can view png, jpeg, gif, tiff, niff, sunraster, fbm, cmuraster, pbm,
+      faces, rle, xwd, vff, mcidas, vicar, pcx, gem, macpaint, xpm and xbm
+      files. Can view images, put them on the root window, or dump them. Does a
+      variety of processing, including: clipping, dithering, depth reduction,
+      zoom, brightening/darkening and merging.
+    '';
+
+    license = stdenv.lib.licenses.gpl2Plus;
+
+    maintainers = with stdenv.lib.maintainers; [ andrew-d ];
+    platforms = stdenv.lib.platforms.linux;  # arbitrary choice
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19605,6 +19605,8 @@ with pkgs;
 
   xss-lock = callPackage ../misc/screensavers/xss-lock { };
 
+  xloadimage = callPackage ../tools/X11/xloadimage { };
+
   xssproxy = callPackage ../misc/screensavers/xssproxy { };
 
   xsynth_dssi = callPackage ../applications/audio/xsynth-dssi { };


### PR DESCRIPTION
###### Motivation for this change
This add `xloadimage`, a program that can be used to view images or write them to another window.

I'm adding this in order to be able to display a background image with `xsecurelock`; you can display a background image by using `xloadimage` to write an image to the given window, by creating an `xsecurelock` screensaver module:

```
xloadimage -fullscreen -windowid $XSCREENSAVER_WINDOW $XSECURELOCK_IMAGE_FILE
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

