### PR TITLE
erlangR18: apply upstream patches to fix nondeterministic build failures

### DIFF
--- a/pkgs/development/interpreters/erlang/R18.nix
+++ b/pkgs/development/interpreters/erlang/R18.nix
@@ -11,6 +11,16 @@ let
      sha256 = "00fx5wc88ki3z71z5q4xzi9h3whhjw1zblpn09w995ygn07m9qhm";
   };
 
+  makeOrderingPatch = fetchpatch {
+     url = "https://github.com/erlang/otp/commit/2f1a37f1011ff9d129bc35a6efa0ab937a2aa0e9.patch";
+     sha256 = "0xfa6hzxh9d7qllkyidcgh57xrrx11w65y7s1hyg52alm06l6b9n";
+  };
+
+  makeParallelInstallPatch = fetchpatch {
+     url ="https://github.com/erlang/otp/commit/de8fe86f67591dd992bae33f7451523dab36e5bd.patch";
+     sha256 = "1cj9fjhdng6yllajjm3gkk04ag9bwyb3n70hrb5nk6c292v8a45c";
+  };
+
 in mkDerivation rec {
   version = "18.3.4.8";
   sha256 = "16c0h25hh5yvkv436ks5jbd7qmxzb6ndvk64mr404347a20iib0g";
@@ -18,5 +28,7 @@ in mkDerivation rec {
   patches = [
     rmAndPwdPatch
     envAndCpPatch
+    makeOrderingPatch
+    makeParallelInstallPatch
   ];
 }


### PR DESCRIPTION
###### Motivation for this change

As per the following bug report, sometimes erts/start_scripts will fail to compile because of a Makefile ordering issue. Apply the upstream patches to fix this.
  https://bugs.erlang.org/browse/ERL-241

This also fixes, at the very least, `yaws`.

/cc ZHF #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @the-kenny @sjmackenzie @couchemar @gleber 