### PR TITLE
pythonPackages.flask_assets: fix tests

### DIFF
--- a/pkgs/development/python-modules/flask-assets/default.nix
+++ b/pkgs/development/python-modules/flask-assets/default.nix
@@ -9,6 +9,10 @@ buildPythonPackage rec {
     sha256 = "0ivqsihk994rxw58vdgzrx4d77d7lpzjm4qxb38hjdgvi5xm4cb0";
   };
 
+  patchPhase = ''
+    substituteInPlace tests/test_integration.py --replace 'static_path=' 'static_url_path='
+  '';
+
   propagatedBuildInputs = [ flask webassets flask_script nose ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
The package tests uses a `kwarg` that isn't present in Flask 1.0+.  Replace it with the correct one.

/cc ZHF #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

r? @abbradar 