### PR TITLE
nixos: make firefox the default browser

### DIFF
--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -11,5 +11,5 @@
     libinput.enable = true; # for touchpad support on many laptops
   };
 
-  environment.systemPackages = [ pkgs.glxinfo ];
+  environment.systemPackages = [ pkgs.glxinfo pkgs.firefox ];
 }


### PR DESCRIPTION
Without this, the graphical installer has no way to open the manual. You can fix it yourself by installing any HTML browser but this might be unfamiliar to users new to NixOS and without any other way to open the manual. The downside is that it increases sizes for the graphical installer and VirtualBox appliance.

Fixes #46537

