### PR TITLE
kde: add kdoctools to default environment

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -81,6 +81,7 @@ in
           kconfig
           kconfigwidgets
           kcoreaddons
+          kdoctools
           kdbusaddons
           kdeclarative
           kded


### PR DESCRIPTION
khelpcenter needs meinproc5 to work properly. Hopefully doesn’t effect
closure sizes too much - kdoctools is rather small.

Fixes #46539