### PR TITLE
nixos: set nixos in nixPath

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -347,6 +347,7 @@ in
           [
             "$HOME/.nix-defexpr/channels"
             "nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos"
+            "nixos=/nix/var/nix/profiles/per-user/root/channels/nixos"
             "nixos-config=/etc/nixos/configuration.nix"
             "/nix/var/nix/profiles/per-user/root/channels"
           ];


### PR DESCRIPTION
This makes using the nixos channel work out of the box with the new
Nix commands. For example:

$ nix run nixos.firefox -c firefox

Fixes #46536