### PR TITLE
hdf4: fix build on aarch64-linux

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, fetchpatch
 , fetchurl
 , cmake
 , libjpeg
@@ -13,6 +14,22 @@ stdenv.mkDerivation rec {
     url = "https://support.hdfgroup.org/ftp/HDF/releases/HDF${version}/src/hdf-${version}.tar.bz2";
     sha256 = "0n29klrrbwan9307np0d9hr128dlpc4nnlf57a140080ll3jmp8l";
   };
+
+  patches = let
+    # The Debian patch revision to fetch from; this may differ from our package
+    # version, but older patches should still apply.
+    patchRev = "4.2.13-4";
+    getPatch = name: sha256: fetchpatch {
+      inherit sha256;
+      url = "https://salsa.debian.org/debian-gis-team/hdf4/raw/debian/${patchRev}/debian/patches/${name}";
+    };
+
+  in [
+    (getPatch "64bit"                     "1xqk9zpch4m6ipa0f3x2cm8rwaz4p0ppp1vqglvz18j6q91p8b5y")
+    (getPatch "hdfi.h"                    "01fr9csylnvk9jd9jn9y23bvxy192s07p32pr76mm3gwhgs9h7r4")
+    (getPatch "hdf-4.2.10-aarch64.patch"  "1hl0xw5pd9xhpq49xpwgg7c4z6vv5p19x6qayixw0myvgwj1r4zn")
+    (getPatch "reproducible-builds.patch" "02j639w26xkxpxx3pdhbi18ywz8w3qmjpqjb83n47gq29y4g13hc")
+  ];
 
   buildInputs = [
     cmake


### PR DESCRIPTION
###### Motivation for this change
Pull in the Debian patches for AArch64 support, and a bonus patch for reproducible builds while we're at it.

I don't have an AArch64 host to test on, so I'd appreciate someone poking @GrahamcOfBorg for me :smiley:  I _think_ this should work, though, according to the [failures in the build log](https://hydra.nixos.org/build/80736872/nixlog/1).

/cc ZHF #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @knedlsepp 