### PR TITLE
gitAndTools.pre-commit: 1.11.0 -> 1.11.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/pre-commit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/pre-commit/default.nix
@@ -1,11 +1,11 @@
 { stdenv, python3Packages }:
 with python3Packages; buildPythonApplication rec {
   pname = "pre_commit";
-  version = "1.11.0";
+  version = "1.11.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "03nxkma8qp5j2bg6ailclnyqfhakp8r8d1mn6zcnjw0ac5r9imc8";
+    sha256 = "1kjrq8z78b6aqhyyw07dlwf6cqls88kik6f5l07hs71fj5ddvs9w";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update pre-commit to latest version

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

