### PR TITLE
podofo: fix library linkage on Darwin

### DIFF
--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -4,7 +4,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "podofo-0.9.6";
+  version = "0.9.6";
+  name = "podofo-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/podofo/${name}.tar.gz";
@@ -29,6 +30,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ lua5 ] ++ stdenv.lib.optional stdenv.isLinux stdenv.cc.libc;
 
   cmakeFlags = "-DPODOFO_BUILD_SHARED=ON -DPODOFO_BUILD_STATIC=OFF";
+
+  postFixup = if stdenv.isDarwin then ''
+    for i in $out/bin/* ; do
+      install_name_tool -change libpodofo.${version}.dylib $out/lib/libpodofo.${version}.dylib "$i"
+    done
+  '' else null;
 
   meta = {
     homepage = http://podofo.sourceforge.net;

--- a/pkgs/development/libraries/podofo/default.nix
+++ b/pkgs/development/libraries/podofo/default.nix
@@ -31,11 +31,11 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = "-DPODOFO_BUILD_SHARED=ON -DPODOFO_BUILD_STATIC=OFF";
 
-  postFixup = if stdenv.isDarwin then ''
+  postFixup = stdenv.lib.optionalString stdenv.isDarwin ''
     for i in $out/bin/* ; do
       install_name_tool -change libpodofo.${version}.dylib $out/lib/libpodofo.${version}.dylib "$i"
     done
-  '' else null;
+  '';
 
   meta = {
     homepage = http://podofo.sourceforge.net;


### PR DESCRIPTION
The podofo package is currently broken on Darwin: the podofo tools do not find libpodofo.0.9.6.dylib at runtime, because the library path the binary is linked against is incomplete.

The reason is that podofo builds both the library and the tools using this library in the same `cmake` run. And since the library is not yet installed when the tools are build, it does not contain the final store path as its install name. Linking the tools therefore picks up this incorrect install name.

I fixed this with a fixupPost script. I am not sure this is the correct way, since I am rather new to Nix, but the package works on Darwin now and this should have no effect for Linux.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).