### PR TITLE
iwd: 0.7 -> 0.8

### DIFF
--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -22,6 +22,8 @@ in {
 
     systemd.packages = [ pkgs.iwd ];
 
+    systemd.services.iwd.wantedBy = [ "multi-user.target" ];
+
     systemd.tmpfiles.rules = [
       "d /var/lib/iwd 0700 root root -"
     ];

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -3,17 +3,17 @@
 let
   ell = fetchgit {
      url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
-     rev = "0.9";
-     sha256 = "1kg7cx7ir8bvz33n624ncrq9r4fh7rg9z22fly894a3mk1imq22p";
+     rev = "0.10";
+     sha256 = "1yzbx4l3a6hbdmirgbvnrjfiwflyzd38mbxnp23gn9hg3ni3br34";
   };
 in stdenv.mkDerivation rec {
   name = "iwd-${version}";
-  version = "0.7";
+  version = "0.8";
 
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
     rev = version;
-    sha256 = "0q76fh6fcl7nxyjl8z2n4plp2qaxc1fqx575by6xqf1rnv4nk0ab";
+    sha256 = "0bx31f77mz3rbl3xja48lb5zgwgialg7hvax889kpkz92wg26mgv";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Mic92 