### PR TITLE
autoPatchelfHook: do not patch statically linked files

### DIFF
--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -155,8 +155,10 @@ autoPatchelf() {
     # outside of this function.
     while IFS= read -r -d $'\0' file; do
       isELF "$file" || continue
-      # dynamically linked?
-      readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+      if isExecutable "$file"; then
+          # Skip if the executable is statically linked.
+          readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+      fi
       autoPatchelfFile "$file"
     done < <(find "$prefix" -type f -print0)
 }

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -7,7 +7,7 @@ gatherLibraries() {
 addEnvHooks "$targetOffset" gatherLibraries
 
 isExecutable() {
-    readelf -h "$1" | grep -q '^ *Type: *EXEC\>'
+    readelf -h "$1" 2> /dev/null | grep -q '^ *Type: *EXEC\>'
 }
 
 # We cache dependencies so that we don't need to search through all of them on

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -7,21 +7,7 @@ gatherLibraries() {
 addEnvHooks "$targetOffset" gatherLibraries
 
 isExecutable() {
-    [ "$(file -b -N --mime-type "$1")" = application/x-executable ]
-}
-
-findElfs() {
-    find "$1" -type f -exec "$SHELL" -c '
-        while [ -n "$1" ]; do
-            mimeType="$(file -b -N --mime-type "$1")"
-            if [ "$mimeType" = application/x-executable \
-              -o "$mimeType" = application/x-pie-executable \
-              -o "$mimeType" = application/x-sharedlib ]; then
-                echo "$1"
-            fi
-            shift
-        done
-    ' -- {} +
+    readelf -h "$1" | grep -q '^ *Type: *EXEC\>'
 }
 
 # We cache dependencies so that we don't need to search through all of them on
@@ -167,9 +153,12 @@ autoPatchelf() {
     # findDependency outside of this, the dependency cache needs to be rebuilt
     # from scratch, so keep this in mind if you want to run findDependency
     # outside of this function.
-    findElfs "$prefix" | while read -r elffile; do
-        autoPatchelfFile "$elffile"
-    done
+    while IFS= read -r -d $'\0' file; do
+      isELF "$file" || continue
+      # dynamically linked?
+      readelf -l "$file" | grep -q "^ *INTERP\\>" || continue
+      autoPatchelfFile "$file"
+    done < <(find "$prefix" -type f -print0)
 }
 
 # XXX: This should ultimately use fixupOutputHooks but we currently don't have

--- a/pkgs/servers/search/elasticsearch/default.nix
+++ b/pkgs/servers/search/elasticsearch/default.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation (rec {
     sed -i "s|ES_CLASSPATH=\"\$ES_HOME/lib/\*\"|ES_CLASSPATH=\"$out/lib/*\"|" ./bin/elasticsearch-env
   '';
 
-  buildInputs = [ makeWrapper jre_headless utillinux ];
+  buildInputs = [ makeWrapper jre_headless utillinux ]
+             ++ optional enableUnfree zlib;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -81,8 +81,7 @@ with pkgs;
     { deps = [ autoconf264 automake111x gettext libtool ]; }
     ../build-support/setup-hooks/autoreconf.sh;
 
-  autoPatchelfHook = makeSetupHook
-    { name = "auto-patchelf-hook"; deps = [ file ]; }
+  autoPatchelfHook = makeSetupHook { name = "auto-patchelf-hook"; }
     ../build-support/setup-hooks/auto-patchelf.sh;
 
   ensureNewerSourcesHook = { year }: makeSetupHook {}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

