### PR TITLE
php: set mysql socket path if mysql[i] or pdo_mysql support is enabled

### DIFF
--- a/pkgs/development/interpreters/php/default.nix
+++ b/pkgs/development/interpreters/php/default.nix
@@ -115,12 +115,14 @@ let
         };
 
         mysql = {
-          configureFlags = ["--with-mysql${if mysqlndSupport then "=mysqlnd" else ""}"];
+          configureFlags = ["--with-mysql${if mysqlndSupport then "=mysqlnd" else ""}"
+                            "--with-mysql-sock=/run/mysqld/mysqld.sock"];
           buildInputs = mysqlBuildInputs;
         };
 
         mysqli = {
-          configureFlags = ["--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${mysql.connector-c}/bin/mysql_config"}"];
+          configureFlags = ["--with-mysqli=${if mysqlndSupport then "mysqlnd" else "${mysql.connector-c}/bin/mysql_config"}"
+                            "--with-mysql-sock=/run/mysqld/mysqld.sock"];
           buildInputs = mysqlBuildInputs;
         };
 
@@ -131,7 +133,8 @@ let
         };
 
         pdo_mysql = {
-          configureFlags = ["--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else mysql.connector-c}"];
+          configureFlags = ["--with-pdo-mysql=${if mysqlndSupport then "mysqlnd" else mysql.connector-c}"
+                            "--with-mysql-sock=/run/mysqld/mysqld.sock"];
           buildInputs = mysqlBuildInputs;
         };
 


### PR DESCRIPTION
Manual backport of #47220 for 18.03.

As the php expression still uses `composableDerivation`, we can't easily query what's enabled while defining `configureFlags`, so simply add the `with-mysql-sock` on each enabled feature.
PHPs configure phase is happy with that being defined multiple times - not elegant, but I didn't want to resort to bash hackery for that backport :-)

---

PHP tries to discover the mysql default socket path during configure
phase by probing the file system:
https://github.com/php/php-src/blob/cf3b852109a88a11370d0207cd3b72a53b6a64c3/ext/mysqli/config.m4#L4

This obviously fails to discover /run/mysqld/mysqld.sock, which is being
used (hardcoded) across all MySQL flavours.

This leads to PHP having no mysql socket path set for the mysql[i]
extensions, and `/tmp/mysql.sock` set for pdo_mysql,
meaning one currently has to manually configure and set it in php.ini.

Luckily, PHP supports setting that path via
`--with-mysql-sock=/run/mysqld/mysqld.sock` during configure phase,
so let's do this as soon as one of the three modules is enabled.

(cherry picked from commit baa04e4204b80225c5086611f305a0c412dc9967)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

