### PR TITLE
pythonPackages.pyftgl: fix build

### DIFF
--- a/pkgs/development/python-modules/pyftgl/default.nix
+++ b/pkgs/development/python-modules/pyftgl/default.nix
@@ -1,5 +1,13 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, isPy3k
-, boost, freetype, ftgl, libGLU_combined }:
+{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+, boost, freetype, ftgl, libGLU_combined
+, python
+}:
+
+let
+
+  pythonVersion = with lib.versions; "${major python.version}${minor python.version}";
+
+in
 
 buildPythonPackage rec {
   pname = "pyftgl";
@@ -13,13 +21,13 @@ buildPythonPackage rec {
     sha256 = "12zcjv4cwwjihiaf74kslrdmmk4bs47h7006gyqfwdfchfjdgg4r";
   };
 
-  postPatch = stdenv.lib.optional isPy3k ''
-    sed -i "s,'boost_python','boost_python3',g" setup.py
+  postPatch = ''
+    sed -i "s,'boost_python','boost_python${pythonVersion}',g" setup.py
   '';
 
   buildInputs = [ boost freetype ftgl libGLU_combined ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Python bindings for FTGL (FreeType for OpenGL)";
     license = licenses.gpl2Plus;
   };


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80705583

Recent `boost` versions with `python` enabled have changed their naming
scheme for `boost_python` shared objects which causes issues with the
proper linking when building `pyftgl`.

Previously the library was named `boost_python3`, no it's named
`boost_python36` for current python (3.6.x).

Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

