### PR TITLE
treewide: mass rebuild noop cleanups

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -6,9 +6,10 @@
 # compiler and the linker just "work".
 
 { name ? ""
-, stdenvNoCC, nativeTools, propagateDoc ? !nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
-, bintools ? null, libc ? null
-, coreutils ? null, shell ? stdenvNoCC.shell, gnugrep ? null
+, stdenvNoCC
+, bintools ? null, libc ? null, coreutils ? null, shell ? stdenvNoCC.shell, gnugrep ? null
+, nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
+, propagateDoc ? bintools != null && bintools ? man
 , extraPackages ? [], extraBuildCommands ? ""
 , buildPackages ? {}
 , useMacosReexportHack ? false

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -6,8 +6,10 @@
 # compiler and the linker just "work".
 
 { name ? ""
-, stdenvNoCC, nativeTools, propagateDoc ? !nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
+, stdenvNoCC
 , cc ? null, libc ? null, bintools, coreutils ? null, shell ? stdenvNoCC.shell
+, nativeTools, noLibc ? false, nativeLibc, nativePrefix ? ""
+, propagateDoc ? cc != null && cc ? man
 , extraPackages ? [], extraBuildCommands ? ""
 , isGNU ? false, isClang ? cc.isClang or false, gnugrep ? null
 , buildPackages ? {}

--- a/pkgs/development/compilers/gcc/4.8/default.nix
+++ b/pkgs/development/compilers/gcc/4.8/default.nix
@@ -201,9 +201,7 @@ stdenv.mkDerivation ({
         ''
     else null;
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler langJava
+  inherit noSysDirs staticCompiler langJava crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/gcc/4.9/default.nix
+++ b/pkgs/development/compilers/gcc/4.9/default.nix
@@ -210,9 +210,7 @@ stdenv.mkDerivation ({
         ''
     else null;
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler langJava
+  inherit noSysDirs staticCompiler langJava crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/gcc/5/default.nix
+++ b/pkgs/development/compilers/gcc/5/default.nix
@@ -215,9 +215,7 @@ stdenv.mkDerivation ({
         )
     else null;
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler langJava
+  inherit noSysDirs staticCompiler langJava crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -216,9 +216,7 @@ stdenv.mkDerivation ({
         )
     else null;
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler langJava
+  inherit noSysDirs staticCompiler langJava crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -217,9 +217,7 @@ stdenv.mkDerivation ({
     ++ (optional hostPlatform.isDarwin targetPackages.stdenv.cc.bintools)
     ;
 
-  # TODO: Use optionalString with next rebuild.
-  ${if (stdenv.cc.isClang && langFortran) then "NIX_CFLAGS_COMPILE" else null} = "-Wno-unused-command-line-argument";
-
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument";
   NIX_LDFLAGS = stdenv.lib.optionalString  hostPlatform.isSunOS "-lm -ldl";
 
   preConfigure = stdenv.lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -189,9 +189,7 @@ stdenv.mkDerivation ({
         )
     else "");
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler
+  inherit noSysDirs staticCompiler crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/gcc/8/default.nix
+++ b/pkgs/development/compilers/gcc/8/default.nix
@@ -184,9 +184,7 @@ stdenv.mkDerivation ({
         )
     else "");
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler
+  inherit noSysDirs staticCompiler crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -131,7 +131,7 @@ if test "$noSysDirs" = "1"; then
         )
     fi
 
-    if test -n "${targetConfig-}" -a "$crossStageStatic" == 1; then
+    if test "$crossStageStatic" == 1; then
         # We don't want the gcc build to assume there will be a libc providing
         # limits.h in this stagae
         makeFlagsArray+=(

--- a/pkgs/development/compilers/gcc/snapshot/default.nix
+++ b/pkgs/development/compilers/gcc/snapshot/default.nix
@@ -154,9 +154,7 @@ stdenv.mkDerivation ({
         ''
     else null;
 
-  # TODO(@Ericson2314): Make passthru instead. Weird to avoid mass rebuild,
-  crossStageStatic = targetPlatform == hostPlatform || crossStageStatic;
-  inherit noSysDirs staticCompiler
+  inherit noSysDirs staticCompiler crossStageStatic
     libcCross crossMingw;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -10,11 +10,9 @@ stdenv.mkDerivation rec {
     export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
   '';
 
-  # on next rebuild, this can be replaced with optionals; for now set to null to avoid
-  # patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
-  patches = if stdenv.hostPlatform.isMusl then [
+  patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
     ../../libcxx-0001-musl-hacks.patch
-  ] else null;
+  ];
 
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -10,11 +10,9 @@ stdenv.mkDerivation rec {
     export LIBCXXABI_INCLUDE_DIR="$PWD/$(ls -d libcxxabi-${version}*)/include"
   '';
 
-  # on next rebuild, this can be replaced with optionals; for now set to null to avoid
-  # patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
-  patches = if stdenv.hostPlatform.isMusl then [
+  patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
     ../../libcxx-0001-musl-hacks.patch
-  ] else null;
+  ];
 
   prePatch = ''
     substituteInPlace lib/CMakeLists.txt --replace "/usr/lib/libc++" "\''${LIBCXX_LIBCXXABI_LIB_PATH}/libc++"

--- a/pkgs/development/libraries/libdaemon/default.nix
+++ b/pkgs/development/libraries/libdaemon/default.nix
@@ -1,12 +1,14 @@
 {stdenv, fetchurl}:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   name = "libdaemon-0.14";
 
   src = fetchurl {
     url = "${meta.homepage}/${name}.tar.gz";
     sha256 = "0d5qlq5ab95wh1xc87rqrh1vx6i8lddka1w3f1zcqvcqdxgyn8zx";
   };
+
+  patches = [ ./fix-includes.patch ];
 
   configureFlags = [ "--disable-lynx" ]
     ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform)
@@ -16,16 +18,8 @@ stdenv.mkDerivation (rec {
 
   meta = {
     description = "Lightweight C library that eases the writing of UNIX daemons";
-
     homepage = http://0pointer.de/lennart/projects/libdaemon/;
-
     license = stdenv.lib.licenses.lgpl2Plus;
-
     platforms = stdenv.lib.platforms.unix;
-    maintainers = [ ];
   };
-} // stdenv.lib.optionalAttrs stdenv.hostPlatform.isMusl {
-  # This patch should be applied unconditionally, but doing so will cause mass rebuild.
-  patches = ./fix-includes.patch;
-})
-
+}

--- a/pkgs/development/libraries/newt/default.nix
+++ b/pkgs/development/libraries/newt/default.nix
@@ -22,10 +22,9 @@ stdenv.mkDerivation rec {
     unset CPP
   '';
 
-  # Use `lib.optionalString` next mass rebuild.
-  makeFlags = if stdenv.buildPlatform == stdenv.hostPlatform
-              then null
-              else "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
+  makeFlags = stdenv.lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://fedorahosted.org/newt/;

--- a/pkgs/development/tools/misc/pkgconfig/default.nix
+++ b/pkgs/development/tools/misc/pkgconfig/default.nix
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
   patches = optional (!vanilla) ./requires-private.patch
     ++ optional stdenv.isCygwin ./2.36.3-not-win32.patch;
 
-  preConfigure = ""; # TODO(@Ericson2314): Remove next mass rebuild
   buildInputs = optional (stdenv.isCygwin || stdenv.isDarwin || stdenv.isSunOS) libiconv;
 
   configureFlags = [ "--with-internal-glib" ]

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -17,8 +17,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  # TODO: fix on mass rebuild
-  ${if interactive then "patches" else null} = optional (version == "6.5") ./perl.patch;
+  patches = optional (version == "6.5") ./perl.patch;
 
   # We need a native compiler to build perl XS extensions
   # when cross-compiling.

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  common = { version, sha256, patches ? null }: stdenvNoCC.mkDerivation {
+  common = { version, sha256, patches ? [] }: stdenvNoCC.mkDerivation {
     name = "linux-headers-${version}";
 
     src = fetchurl {
@@ -20,8 +20,6 @@ let
 
     extraIncludeDirs = lib.optional stdenvNoCC.hostPlatform.isPowerPC ["ppc"];
 
-    # "patches" array defaults to 'null' to avoid changing hash
-    # and causing mass rebuild
     inherit patches;
 
     buildPhase = ''

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -88,7 +88,6 @@ in rec {
         extraPackages = lib.optional (libcxx != null) libcxx;
 
         nativeTools  = false;
-        propagateDoc = false;
         nativeLibc   = false;
         inherit buildPackages coreutils gnugrep bintools;
         libc         = last.pkgs.darwin.Libsystem;

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -92,7 +92,6 @@ let
              else lib.makeOverridable (import ../../build-support/cc-wrapper) {
           name = "${name}-gcc-wrapper";
           nativeTools = false;
-          propagateDoc = false;
           nativeLibc = false;
           buildPackages = lib.optionalAttrs (prevStage ? stdenv) {
             inherit (prevStage) stdenv;


### PR DESCRIPTION
###### Motivation for this change

First patch is the first patch of #46115 (which should also close #43547 again, but without the "controversial" second patch of #46115), second patch is a fixed edited version of #46127, the rest are trivial noop changes that cause mass rebuilds.

###### Things done

- [X] Trivial.
- [X] All touched packages still build.
- [X] Running on top of this for a month without issues.

/cc @Ericson2314