### PR TITLE
tig: fix zsh completion

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/tig/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/tig/default.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
   installPhase = ''
     make install
     make install-doc
+
+    substituteInPlace contrib/tig-completion.zsh \
+      --replace 'e=$(dirname ''${funcsourcetrace[1]%:*})/tig-completion.bash' "e=$out/etc/bash_completion.d/tig-completion.bash"
+
     install -D contrib/tig-completion.bash $out/etc/bash_completion.d/tig-completion.bash
     install -D contrib/tig-completion.zsh $out/share/zsh/site-functions/_tig
     cp contrib/vim.tigrc $out/etc/


### PR DESCRIPTION
###### Motivation for this change

The ZSH completion script of `tig` basically imports the bash completion
script and uses it as completion approach. Unfortunately the script
takes several assumptions about the directory structure using
`$funcsourcetrace`[1] that don't apply on NixOS.

The easiest workaround is t opatch the completion script and import the
bash completion script from `$out`.

[1] http://zsh.sourceforge.net/Doc/Release/Zsh-Modules.html#index-funcsourcetrace

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

