### PR TITLE
bluez-alsa: init at 1.3.1

### DIFF
--- a/pkgs/tools/bluetooth/bluez-alsa/default.nix
+++ b/pkgs/tools/bluetooth/bluez-alsa/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
+, alsaLib, bluez, glib, sbc
+
+# optional, but useful utils
+, readline, libbsd, ncurses
+
+# optional codecs
+, aacSupport ? true, fdk_aac
+# TODO: aptxSupport
+}:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "bluez-alsa-${version}";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Arkq";
+    repo = "bluez-alsa";
+    rev = "v${version}";
+    sha256 = "1rzcl65gipszsmlcg24gh1xkjkyk4929xhakn6y2smrgwv1zjqdh";
+  };
+
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+
+  buildInputs = [
+    alsaLib bluez glib sbc
+    readline libbsd ncurses
+  ]
+  ++ optional aacSupport fdk_aac;
+
+  configureFlags = [
+    "--with-alsaplugindir=\$out/lib/alsa-lib"
+    "--enable-rfcomm"
+    "--enable-hcitop"
+  ]
+  ++ optional aacSupport "--enable-aac";
+
+  doCheck = false; # fails 1 of 3 tests, needs access to ALSA
+
+  meta = {
+    description = "Bluez 5 Bluetooth Audio ALSA Backend";
+    longDescription = ''
+      Bluez-ALSA (BlueALSA) is an ALSA backend for Bluez 5 audio interface.
+      Bluez-ALSA registers all Bluetooth devices with audio profiles in Bluez
+      under a virtual ALSA PCM device called `bluealsa` that supports both
+      playback and capture.
+
+      Some backstory: Bluez 5 removed built-in support for ALSA in favor of a
+      generic interface for 3rd party appliations. Thereafter, PulseAudio
+      implemented a backend for that interface and became the only way to get
+      Bluetooth audio with Bluez 5. Users prefering ALSA stayed on Bluez 4.
+      However, Bluez 4 eventually became deprecated.
+
+      This package is a rebirth of a direct interface between ALSA and Bluez 5,
+      that, unlike PulseAudio, provides KISS near-metal-like experience. It is
+      not possible to run BluezALSA and PulseAudio Bluetooth at the same time
+      due to limitations in Bluez, but it is possible to run PulseAudio over
+      BluezALSA if you disable `bluetooth-discover` and `bluez5-discover`
+      modules in PA and configure it to play/capture sound over `bluealsa` PCM.
+    '';
+    homepage = src.meta.homepage;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.oxij ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -930,6 +930,8 @@ with pkgs;
     libgit2 = libgit2_0_27;
   };
 
+  bluez-alsa = callPackage ../tools/bluetooth/bluez-alsa { };
+
   bluez-tools = callPackage ../tools/bluetooth/bluez-tools { };
 
   bmon = callPackage ../tools/misc/bmon { };


### PR DESCRIPTION
###### Motivation for this change

A package for doing ALSA stuff over Bluetooth with Bluez-5.

###### Things done

- [X] It works, assuming you can configure your ALSA.

NixOS-side support that will properly configure your ALSA for you is in the queue for a later PR.