### PR TITLE
WIP: Factoring out unfree non-redistributable vs. unfree redistributale licenses

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -387,6 +387,14 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     fullName = "ISC License";
   };
 
+  # Proprietary binaries; free to redistribute without modification.
+  issl = {
+    fullName = "Intel Simplified Software License";
+    url = https://software.intel.com/en-us/license/intel-simplified-software-license;
+    free = false;
+    redistributable = true;
+  };
+
   lgpl2 = spdx {
     spdxId = "LGPL-2.0";
     fullName = "GNU Library General Public License v2 only";
@@ -605,12 +613,19 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
   unfreeRedistributable = {
     fullName = "Unfree redistributable";
     free = false;
+    # TODO: Go through the NixPkgs tree, replacing unfreeRedistributable
+    # licenses with the correct license that has
+    # { free = false; redistributable = true; }
+    redistributable = true;
   };
 
   unfreeRedistributableFirmware = {
     fullName = "Unfree redistributable firmware";
     # Note: we currently consider these "free" for inclusion in the
     # channel and NixOS images.
+    # TODO: Set to false now that we have redistributable?
+    free = true;
+    redistributable = true;
   };
 
   unlicense = spdx {

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -15,8 +15,14 @@
 , limitedSupportedSystems ? [ "i686-linux" ]
   # Strip most of attributes when evaluating to spare memory usage
 ,  scrubJobs ? true
-  # Attributes passed to nixpkgs. Don't build packages marked as unfree.
-,  nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+  # Attributes passed to nixpkgs. Don't build packages marked as unfree, unless
+  # they are also marked as redistributable.
+  # TODO: Consider adding this predicate to stdenv's check-meta for generic re-use?
+,  nixpkgsArgs ? { config = {
+     allowUnfree = false;
+     allowUnfreePredicate = (p: p.meta.license.redistributable or false);
+     inHydra = true;
+   }; }
 }:
 
 with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };


### PR DESCRIPTION
Currently, we have a catch-all `unfreeRedistributable` license that is intended
to allow Hydra to build these packages; however, there are two issues:

1. It's not currently working (check any unfreeRedistributable package and you
will not see it on Hydra's jobset). For example, a search for aliza [1] on hydra [2]
comes up empty.

2. It obscures the actual license in question for a package.

[1] https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/science/medicine/aliza/default.nix
[2] https://hydra.nixos.org/jobset/nixpkgs/trunk#tabs-jobs


