### PR TITLE
lib: Make `overrideScope` take arguments in the conventional order for 18.09

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -195,10 +195,9 @@ rec {
     let self = f self // {
           newScope = scope: newScope (self // scope);
           callPackage = self.newScope {};
-          # TODO(@Ericson2314): Haromonize argument order of `g` with everything else
           overrideScope = g:
             makeScope newScope
-            (lib.fixedPoints.extends (lib.flip g) f);
+            (lib.fixedPoints.extends g f);
           packages = f;
         };
     in self;

--- a/nixos/doc/manual/release-notes/rl-1809.xml
+++ b/nixos/doc/manual/release-notes/rl-1809.xml
@@ -247,6 +247,28 @@ $ nix-instantiate -E '(import &lt;nixpkgsunstable&gt; {}).gitFull'
       They should be using that anyways for clarity.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <literal>lib.customization.makeScope</literal> binds a
+     <varname>callPackage</varname> which in turn binds an
+     <varname>overrideScipe</varname>. That <varname>overrideScope</varname>
+     now takes a function with parameters in the opposite order: <literal>self:
+     super: { … }</literal> now whereas it was <literal>super: self: { …
+     }</literal> before. This brings makes it consistent with everything else
+     related to <literal>super: self: { … }</literal> overrides, including
+     even the other more common implementations of
+     <varname>overrideScope</varname> used in the Haskell infrastructure and
+     other language-specific infrastructures. The most prominant uses of
+     <varname>makeScope</varname> today include
+     <varname>emacsPackagesNg</varname>, <varname>q5*</varname>, and most
+     desktop enironments' package sets such as <varname>gnome3</varname>, KDE
+     and <varname>plasma5</varname>, <varname>xfce4-13</varname>, and
+     <varname>deepin</varname>. If you use any of these package sets and
+     experience problems, please check your local configuration for any
+     overrides / overlays and make sure they are now in the conventional
+     <literal>self: super: { … }</literal> form.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -21,7 +21,7 @@ set which contains `emacsWithPackages`. For example, to override
 `emacsPackagesNg.emacsWithPackages`,
 ```
 let customEmacsPackages =
-      emacsPackagesNg.overrideScope (super: self: {
+      emacsPackagesNg.overrideScope (self: super: {
         # use a custom version of emacs
         emacs = ...;
         # use the unstable MELPA version of magit


### PR DESCRIPTION
###### Motivation for this change

Backport of #47238.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

