### PR TITLE
pyjet: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/pyjet/default.nix
+++ b/pkgs/development/python-modules/pyjet/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildPythonPackage, fetchPypi, nose, numpy }:
+
+buildPythonPackage rec {
+  pname = "pyjet";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1glcwv9ni8i40smfw6m456xjadlkackim5nk33xmas1fa96lpagg";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+  checkInputs = [ nose ];
+
+  meta = with lib; {
+    homepage = "https://github.com/scikit-hep/pyjet";
+    description = "The interface between FastJet and NumPy";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1789,6 +1789,8 @@ in {
 
   pyjade = callPackage ../development/python-modules/pyjade {};
 
+  pyjet = callPackage ../development/python-modules/pyjet {};
+
   PyLD = callPackage ../development/python-modules/PyLD { };
 
   python-jose = callPackage ../development/python-modules/python-jose {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

