### PR TITLE
stdenv: Improve ELF detection for isELF

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -211,7 +211,7 @@ isELF() {
     exec {fd}< "$fn"
     read -r -n 4 -u "$fd" magic
     exec {fd}<&-
-    if [[ "$magic" =~ ELF ]]; then return 0; else return 1; fi
+    if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
 }
 
 # Return success if the specified file is a script (i.e. starts with


### PR DESCRIPTION
The isELF function only checks whether ELF is contained within the first 4 bytes of the file, which is a bit fuzzy and will also return successful if it's a text file starting with ELF, for example:

```
ELF headers
-----------

Some text here about ELF headers...
```

So instead, we're now doing a precise match on `\x7fELF`.