### PR TITLE
nixos/network-interfaces-scripted: fix a container networking bug

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -85,7 +85,8 @@ let
             after = [ "network-pre.target" "systemd-udevd.service" "systemd-sysctl.service" ];
             before = [ "network.target" "shutdown.target" ];
             wants = [ "network.target" ];
-            partOf = map (i: "network-addresses-${i.name}.service") interfaces;
+            # exclude bridges from the partOf relationship to fix container networking bug #47210
+            partOf = map (i: "network-addresses-${i.name}.service") (filter (i: !(hasAttr i.name cfg.bridges)) interfaces);
             conflicts = [ "shutdown.target" ];
             wantedBy = [ "multi-user.target" ] ++ optional hasDefaultGatewaySet "network-online.target";
 


### PR DESCRIPTION
###### Motivation for this change

Fixes #47210:  When a bridge interface was reconfigured, running containers using this bridge lost connectivity: restarting `network-addresses-brN.service` triggered a restart of `network-setup.service` via a `partOf` relationship introduced in 07e0c0e0a2f237639600f2a0d62f6eac748b1e6e. This in turn restarted `brN-netdev.service`.

The bridge was thus destroyed and recreated with the same name but a new interface id, causing attached `veth` interfaces to lose their connection.

This change removes the `partOf` relationship between `network-setup.service` and `network-addresses-brN.service` for all bridges so they can be reconfigured without being destroyed and recreated.

I don't see any negative side effects atm, but would kindly ask the the authors of of 07e0c0e0a2f237639600f2a0d62f6eac748b1e6e (which introduced the bug while fixing https://github.com/NixOS/nixops/issues/640) to have a look:  cc @nh2, @domenkozar, @fpletz, @aszlig, @basvandijk

There's also an (uglier) alternative solution without changing the `partOf` relationships: modify the start/stop scripts to skip deleting and recreating a bridge while there's still a veth interface attached.

###### Things done

NixOS tests:
- [x] `containers-restart_networking` now passes (which failed before due to the bug)
- [x] all other container tests still pass
- [x] all networking tests still pass

---

cc @srhb 


