### PR TITLE
boost: limit concurrent jobs to the maximum supported number

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -47,10 +47,24 @@ let
   # To avoid library name collisions
   layout = if taggedLayout then "tagged" else "system";
 
+  # Versions of b2 before 1.65 have job limits; specifically:
+  #   - Versions before 1.58 support up to 64 jobs[0]
+  #   - Versions before 1.65 support up to 256 jobs[1]
+  #
+  # [0]: https://github.com/boostorg/build/commit/0ef40cb86728f1cd804830fef89a6d39153ff632
+  # [1]: https://github.com/boostorg/build/commit/316e26ca718afc65d6170029284521392524e4f8
+  jobs =
+    if versionOlder version "1.58" then
+      "$(($NIX_BUILD_CORES<=64 ? $NIX_BUILD_CORES : 64))"
+    else if versionOlder version "1.65" then
+      "$(($NIX_BUILD_CORES<=256 ? $NIX_BUILD_CORES : 256))"
+    else
+      "$NIX_BUILD_CORES";
+
   b2Args = concatStringsSep " " ([
     "--includedir=$dev/include"
     "--libdir=$out/lib"
-    "-j$NIX_BUILD_CORES"
+    "-j${jobs}"
     "--layout=${layout}"
     "variant=${variant}"
     "threading=${threading}"


### PR DESCRIPTION
###### Motivation for this change
Versions of b2 before 1.65 have job limits; specifically:
  - Versions before 1.58 support [up to 64 jobs][0]
  - Versions before 1.65 support [up to 256 jobs][1]

You can see from [the build failures](https://hydra.nixos.org/build/81007373/nixlog/1) that we appear to be running into this error

[0]: https://github.com/boostorg/build/commit/0ef40cb86728f1cd804830fef89a6d39153ff632
[1]: https://github.com/boostorg/build/commit/316e26ca718afc65d6170029284521392524e4f8 

/cc ZHF #45960

~(sent to staging under the assumption that this will be a huge rebuild...)~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peti @wkennington 