### PR TITLE
 firefox, firefox-bin:: 61.0.2 -> 62.0.2,  firefox-esr: 60.2.0esr -> 60.2.1esr [Moderate security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "62.0";
+  version = "62.0.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ach/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ach/firefox-62.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "68a0802cccd72ffd36bc9188fb96b819b6357b889630173294f92af4dcf719389d678232b986ff6aeb258d2cd149d670d70c2bc90309dc61fb359b1d3011cc6a";
+      sha512 = "30660e1377c125ec195006d84ba5ae356c8b53b21865675ac7649ffadd169e578ab91d0107f18f26530788ae66aacb7edeec1c507bccb456e1aa89bac95351dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/af/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/af/firefox-62.0.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "afdb463bc4bb5f0f3ba95a0af9430d5407a707b7cdd181c44ba0d343230d75e16a3078bc1f412dce8248991b8e752480be885355e394c1e4a4465c7c1929075e";
+      sha512 = "81e3d9b33af731c9a79bdac678c84d2f30de0b77b6d90d4adaa7da11383e360444f85bf7465add562048d13692cce88b3fb1bd63beac30a6d490f6b75eb9be26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/an/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/an/firefox-62.0.2.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "c54b5365a97c44559aeac1c50a5d22250eabb94180987e3745bc875e7f2d7a843fd1282946cf5f27e53f4e0e6958a00376e6f761333e9bd5fd9ae7f6c081e1a0";
+      sha512 = "42d3118c2bba77aed919a1675538f52230841ec6c8398e2b9964631100c22c70335fc80f8757a916aef7c0ebabccc5356ca323901061d1bd0e5ad4eb0a10b483";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ar/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ar/firefox-62.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "08d5c5aefa22408c15a44646ef1b82ec3100a8bd69beb68a1d34029d2b0b554e110092ea5ee905bd866393cf506cd658591bba2e6f670943b21187015d99a836";
+      sha512 = "c6a5a647e17b8b4fb4e20a32c2e492c6102cb899acf5af2d3af3af3cd122d989bfa452638d038b9b7c8c0bbade604f6caa11f42cbde5a3260fb13e44080cd720";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/as/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/as/firefox-62.0.2.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "c403ca739506adc934e3453bff0e282ed514580895dcab70d41ac92499feabaa0d811a821b4441b988a3c12320735794d891620e06c8f081f13882f3bb6a56e8";
+      sha512 = "c1664a83e3dbd7b3041449ab4f7b9b41b038425c126572d380bf9c5d1d7318264a8ba798d670156ba91625de0865ed0b6e4e38bbd2ea700a118b64bbeea95b25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ast/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ast/firefox-62.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "8d0e1c648c9eb8ddf8987360be83238eb6daf578f090687071ad5a63ff76028ebb4a988115a8ff9f7c40dc3522f06b4f79626f2ec8371040c76501457b93bcc6";
+      sha512 = "31c15cde2d9a0f93fa742c41032e8b6e06ad24a5e6126c953e70c0addc5d1a74c5b5d06088002b4c1516a1f75b2e3e82d9d04c0a624db781bde2d3e8182062f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/az/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/az/firefox-62.0.2.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "2cc58aa3833572ae3a97e0d2b70caf19f5429d360da8d3587399a3ef71b48bd1565b0a6eb560c032c45984930e74ad072ca6806686a18cbd7a0ee24805524a64";
+      sha512 = "8d3f949c325bd5efb9619e96f8d8688324d113ac7add21b1d3290c160bba1e2193f923a54d3ce295e75b2ea0a59ab9c718e117374a46963ef69c53f3ceaa1957";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/be/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/be/firefox-62.0.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "fa196010cf483c3f8a4bf63934cb54f543fd00bf8cee45d76aac29675a2b95757f687f8584e7f9122fa1e82b007aa13ef06f0c8fed7dcdea059223f3607db0ed";
+      sha512 = "7cb5fd02ba28c54acb1c73320f794165c0debf35a35c5e15602ccb7677b879ef41c910deb4668c0f160663b7a6afa43f30492fc23691406848e6adde7fcd0b02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/bg/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bg/firefox-62.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "e0f107ab8248ee3e1bdb30ed081e415f03dba9068599f9596706dc4fb907be7737a9f2378e347aeedd667f2526a5b5753c4f35b004da6db6dfc9ca1593e9c91e";
+      sha512 = "c6484b8b19941e135d2dd983085325d9f5bef118105879b0f830762ec1899096146a454397510286a902d175f9ad4eb3e849fdce38844535bc8a92bcaa478862";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/bn-BD/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bn-BD/firefox-62.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "794d93fa5bc61186b3cc1d7866a13d155420d6f829e9b20377c8bd8ed66418b92eac08e843170893a23249fefd7fb4c5a93df89fc9249b8de00ad803b9aad0ab";
+      sha512 = "4526b294ea939f88c92a3275ea17fe16932b410b0114af03d9f3db892cf6ed1a9d0ae0a6e0a651a0599aaee9bf53c69273b8d0286b94656635b3357ee2ab021a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/bn-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bn-IN/firefox-62.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "1ba17cf852e267f1adf9192d0081e03b7d96f4a23cb83ff1a67f31d7340b234037a6def0c821fb4a872fd011999b14b464a3041d308cf5135382c2164f9832c8";
+      sha512 = "3a17f78a48c7657d7ed834f4c05b523d661c5a692e27751e48ed8ea6f580cee21295b025a2474bca10fdc803ade0acef0ff0f0ce40de992a1fd072ca70a1062e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/br/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/br/firefox-62.0.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "7ff933244cabb95fbdad1a64ae900f6fd694dacf1d76621865b4a2066624c31f0686c4dff53add7523749d6f5befe6ec7bbf0160e426e1a02457f8d3d5e15016";
+      sha512 = "7932c59f390580c3a9f333fe40ddb9aace2c7d35703ec022468c503b4e58604fff777fb86e44cfcb84186845e8da26f55a7d0584d09982e88ee08e2b205f289e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/bs/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bs/firefox-62.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "dfd9a7b8f2f355f274dca7941349512339aeaa9da4412681a4e933cf0e1e9396d57d60887fca59c341e70496dd7073647794fbb4c8bcd1abd7b5062ee6809b53";
+      sha512 = "509b1d013a5ef5bf5f5a8167685a7232ee400202c1bfda37eab1ad8965cf0d7a6ae2988163be050b5d37741bb405df5b28aa937c82e086708cd6d943b5215ede";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ca/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ca/firefox-62.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "3785649ca22ab7882f751d0c2223589b7c8b5fa04bb0786ba5f64be405ba89a665244e7f4882d77a85569c46da9f6bc1d3fc95f0ff77e57f02cb8a7dc22f5b67";
+      sha512 = "75b918bb00c9039228b8881ac8fef4dbd36521b80651dc2d6b1ad1f6701ca39f3527b244c88d9e97ba1ac0a6e12ea7b6a3c40f9b95c0c2167e7c175b5d9ce37e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/cak/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/cak/firefox-62.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "e367d02bf8c743f7a5c42b6ca19521813ba31f6a6525f4fbd4ecf418c9927a083d218ded1ae8b11084d4cc5707f97312b327a40735d638e1d3ea07056dce7070";
+      sha512 = "8803b41c4651174e4999804071b27d7cbf47497a8a5b83488654d0586fd6245d5d517c03e64e8e75ccc0991b2be47cb0ee95143d08828027e627409fe6c55cd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/cs/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/cs/firefox-62.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "cfa21baf935d6e325b6ea13d19796ae7adb51bfa6923f7f13e5138628f8064154bbfc5a4a0131a147383b2bf723e1abc46a79b698b2682602faa9a8f80b5e6cc";
+      sha512 = "182cd25579ad04713852e0343e0d9604f42772a4c6ad06da512a8286314451f7b90c667c2f199afd1a1162c8ff6d1320abfc87207602182a3cb32196916189d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/cy/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/cy/firefox-62.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "0a9ad3a8ba02b863194fe4ba347be568fdb92bd72352251220f673349b77ebdb2b2c6e828e98c1c757fe3d4484783528e5f0129ae994a2f0226a17040a2f8c7a";
+      sha512 = "c65fff984a351cc67dba5574e7d2b3291de4e6c78f7659a6020d70f09cdb3bc951696ba88b778df4057633e9e06013799af58f5f2d0a052bdc22e7c98aaec278";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/da/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/da/firefox-62.0.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "21ce01d959f36084dacdcd52cd26440a67e724c79361ed1897371fe4b33a853c72fc4feec6fee446ef47c1ce29c4a88392266bfca08189f1d99127ca637b8be1";
+      sha512 = "e9fa596fb6c825fd3c2b1d5f42ad1c192db42ee046ad2f348733a979135d41bf2b0efbcd8ac2fb68e0337890ac3131a3454425425ef727225786ab0cb51f4d9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/de/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/de/firefox-62.0.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "cae69bd2193db9888ed3a415ed7147dc3002c05029a6cf3e7a010259919dfb0f209055b20e259459f008b99317a215cf6962ab173fac0f1e57c86341571d0eae";
+      sha512 = "7a4c786b18299378c4d8b797e99385e35ad501912f05c02bad311665be6d52a6435a3fa04c7a8ae8a562af654aa3cf17eb497fc9691fbd0b2cf46a67f5967353";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/dsb/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/dsb/firefox-62.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "4583f05b675973a2818b06baf771474b7bff9ec741c2e606cce13f6e4b153f92fadfb0c15d91c4a25d492a38fc3c48180cb6c7ea5e433aa774a9fffe26f4e593";
+      sha512 = "52ae2b79d9106fb304b4b3b945ac9960614efdc7780406e87bbe1dc15effc049e8cbb91c8f4f2dcd1966ed0085e3574e3e1a4234d933fa587e05901875234344";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/el/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/el/firefox-62.0.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "4419885f9b6510edbf2797a047a08c97008731ce4fad19cda1fde4ab70b8912c9aa96df533f9b138d843303e549baa30ff9338bd9531b3044bdcc521cff14678";
+      sha512 = "956d5d36ec255ec122c09edda12a2242bbbb03793385fa9c417fbb8037fb19506298a31bed94eb39e825e4fcb66184901b3580ced8812cbc44f8a4d8ba339d19";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/en-CA/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-CA/firefox-62.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "86cf4dda9c21faea5d5031f423c7badb1876b225ad618fa8c1dd49803d65aec1032bedfded3278dc19d84c1f88688cd4ba31a27ad6f706ad55e9b407e3151f9a";
+      sha512 = "6a93cedce6724a19ea663e70ef9d57d27c144c1250c438ff15cd8d36c3d92b8a95c9e3f81fb53862b550d0765a8f0b7bdc14d6d9929a41f18357e0d0cfae732e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/en-GB/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-GB/firefox-62.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "278d00ec48c2d88d3aa5bedbc9443e82f367a2c9f8261f624eef42fcbfb83d74a3f35d6ad450ef3974ca8a19f7e654c93c40c1941264a2372fafdbb803c08f40";
+      sha512 = "c3f825196d8f1d1284644ebf07f08a7626086c869408603d50ded5b0eeaa98bb9f874c7df38bbbf3083dbb4a1ae8afa8e4c90ed35a83fd99bec78cf3813dd92e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/en-US/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-US/firefox-62.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "f4dfc51d6c8f9ccac869691ea4efb0f5fd8257d661698dba4eb7cc9fb7d28314e00a09ec595d424186cc928c8a6f9f93af0efcb3651eaa4fa40f81cfda73770d";
+      sha512 = "f19a938af6bfe6499bb4e4337ece1cc0918fe56b361ced0f131f010652b2849d98e48a7cd06277580cc87843454c7bdfe816b65c99189e1ba749aaa64059a6ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/en-ZA/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-ZA/firefox-62.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "f6036fe984da3057e76d324c76a2cfb17903d73f3e6bc7884338bb0ef0f9f68ef69e94ee93331f81e17a8eacc40827263c74e5aeb9a70420c7cf0670a205c61c";
+      sha512 = "0214fbf75843617b0623eea8c8ea2ef46d23d739f63a74ff47fc87ff16817d9110862696f92ba614167386bc51c5e94a9627d0dcdd22c19c20bac4a24543c126";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/eo/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/eo/firefox-62.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "011a742e57cdc2134115ea294782716bdc49ac4d2d7b06bfed048f75d18a5780cb93a16cd0ec6b8017e6b8299a5b260015adfcb3f093883703ed9403768555f0";
+      sha512 = "7da531166d26dfa3cd1edc327eecd583e10c8a2c41d007daba41e6f28e42159e1c43be5759061891c74ab0157ca3d4ce58b8a6a7d879ad4ce4c50586341b460e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/es-AR/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-AR/firefox-62.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "f86be240d21d47eda8bb04ff6b502ccee3c94afd6763239c5a79e094532facb8e8beefdf024c089d35ecffbd687febde5a4f10f362fd3c4d71bdabdc3ef1ce04";
+      sha512 = "e5bc4003ec881a41a28b6847dc9d90c81dec5ba9d103111922fdcc718713c67027f5b04a9d608d4e8b20a656abd94e0c5c8d5819135e8884d84eeb952b855590";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/es-CL/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-CL/firefox-62.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "e6be4bff771e5c64d35fdce320fcd80283c964e16fa938824adfa6dff9c69c721ee9184a1f37de86ac42f730ebc7b4c8355d151306e761bc96308868d6d349a9";
+      sha512 = "c5360481d7a86bddb87805672dedab22735e484e3a048e5e57e9265034ac40d0e5586bedab617da1cb54a4b7c1d3b4e18bd5f0cc0c8b8d3563df54b7ad506b23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/es-ES/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-ES/firefox-62.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "32473438f9d39f53249faef39e467546db58b3dce905cc1f4c0250b5fcf5ff2eb671baef0ab179b27ea47bd85bc5684f9bd4846c785f2454076035711642a7d7";
+      sha512 = "8977a46f5946da99c4e3f30e3451110adf7993ad5a64f5dee09016932ee55a63ebca9126f7c3196191e658aa39465701db347068bdc6e6acc85d061873ccf226";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/es-MX/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-MX/firefox-62.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "e81563bd3cc51241b129f084d4d9f5e8b7f34c1f5517f041bbf6992b50e0ad4fdf33fb36f0d1cc22d2bf9eb0bcbd0515a1b21b5cbb8d084cadd0f5d9d80c7b3d";
+      sha512 = "2bb3eeb2bef0f7c72c9bd95093e4c80b69e6f56ec41d0d4b3c54d2f8d7496884394583fb77e9f5e985ff6dedeb94711d4732baaaf5947e26e1f7b13f3024470b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/et/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/et/firefox-62.0.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "5827c7dac8e12610e731e92128ed66f8f107c19de99937a730e7439b26dc404cf518145467cb702fb395d9cb3a0f4ad45c92484ffb053d88dc7ac858781f4ed0";
+      sha512 = "cad31e57d54d5e533f5c999b2009d29c22c9469b7b620499df7f433d0e86f14ba336665a9d9917a48f55d9a57e30be70dd461e8e2159092d5c2c1435e842603f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/eu/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/eu/firefox-62.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "c59ad7413f47ac19e9cd3a267150066099f561a455913714a18afd1b0e284202364f009cbe0361f5941b96d57b43c3d7d778235c9b9123133f864e75479556da";
+      sha512 = "6cfd46bc362a9dca327651ad9219979e321c8ec8ebef21fed64617e7c5540804ce0a16514848faff8e3a3018a454e8b90fac627054b92cb96f5fe8046326db50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/fa/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fa/firefox-62.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "fc3a1caac599a418ab0ce2208fa921dd40912e80ff075bf7d90ef64379057e83332483c1a7a44dece95a38be523d0ea2f92a57b45c300f032b174dde4812e5f8";
+      sha512 = "cfcd0562561478bf2d14ea6b2d87c081d86c5c6d30bd7c2c1eea673e2a82f875a2f954955fdac959ba96ce5fe8461c82137bd3c6313eefb3fb24bd4993692c29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ff/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ff/firefox-62.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "629c2b79571980bfdbf9bece6760d1553cc002f91f26fe46d58d4fa5040f437b6a8b9b6ff41cdcb3d615c479c66a17d87d878fca65025070a31073165098ed26";
+      sha512 = "ffda297f92bfa0a76d613e7c54a71d376c2264570ee8d9f2bbed9faacded01cc8ea9fb171ae14f4d349702d91896899299bfd6b2cb66e9ded933bc6e34e63033";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/fi/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fi/firefox-62.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "4393019f9dec44bc62985d84f95585de0a26736a923f873b92d87f7d46d11f8f3e8af53812696ed4d312fad51c3bdd34026cd7ef933fd047f771441245b30213";
+      sha512 = "be791b05d114f2d49c23714898f240aeaf9593aae6b7d06a85fb3e6dbe9116ee19d5089aff137e1c0fc56873c172a73937e15b19eb76db15122019649dd83a58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/fr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fr/firefox-62.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "9d9afd43288fe6719b8d4f76c4542a26dd4b36376abcc8a0d8111c701bf397345451ccec5bc5ed1f2c2927549c62a429d4d97470d850d0c83ef8362c40531f0b";
+      sha512 = "1f167a7df26ee83671a7c3dea3bcccaa7797da0253110eafa3de5a17b7e19d1710966ac3a82bb0e7bee3d7287a6b39f59b9152672618dbad5d782e297ea6587e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/fy-NL/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fy-NL/firefox-62.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "12050decaa38a27ead08d67130d43ba36666728d3920cf40ad2dc0eb18de6a204e81dfff72cc0a33022b0d96097ec83fb36c88b463707f04669e5c907b8cac15";
+      sha512 = "ed9ee111ba5b451b5fa730bc0f8e14046ad7613d542a7695f68e28d9fddb279770e3663d8b9964617d803f073c7f02dc036e4cc6ce3a17b69ba5fba782831da0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ga-IE/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ga-IE/firefox-62.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "fb028d4b55cb5758eddb89a506b68d322c758d2e8ce01151a30678dd01c4ce625c9a051650a2e115705dbe02967f0db5894a4476d6460ff08313d4767dad9b7a";
+      sha512 = "073b104cebd63452fecff3949195ebeb794dde2d4c2defb44f62f4493165f5dcac20320da8229bd7c3e5410b840bb51b4699d77fdc886974848745e066ccec16";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/gd/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gd/firefox-62.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "a1173104e4be1fdb6cf3a0c8c997075d40e5eb950dc2482107b5795adb2590575c1c79f50daca87227de6426f4ad9d756233f95a0ddd3aa6e949ab773d319db2";
+      sha512 = "307262bb8874fc6115051608bf4a79e51fb08910de7d3df44a6bb3bbde64d3a76aa88361f10b811a2af9a05518d7ba42b6f2e078d5db32f0118cd08f8a3ec7fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/gl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gl/firefox-62.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "b6b46ec64e4386c9196d1f5362674667e46b5006b756cdc164e6c1c42ebff417c57cacceee949d2e9a5f55c76b82471ed9cfa01cbddd8ab74d6669c6870864d9";
+      sha512 = "dbecb09308a701aaf13d278b208fb3b9e7631c8fc07b9b3fc99c27a4035ea7fd75da810063913449c2746933c63cf7a5175d4d5a17aa808f6bd8d19bf0692f0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/gn/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gn/firefox-62.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "3c35f52d34d57dfbfe43d8df6be4f04bc10c79b3b9e08949525a503952ebecb90e59d99565c44adf25addff6f713088bce3034513eea3108a37c02b0921e2f01";
+      sha512 = "f62e0a0cb6794f6fc36c85f98952ccd313676d4389b12a054461789e30effd3effb6fc729bbdfd83674c2691d03aa219ddccfcb6eb74426ff49bd4a458ff7ca9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/gu-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gu-IN/firefox-62.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "0bdaed369d5318c59b929193686960ea2ed2173027c2cdb0384936d724585a9f8db058cd00d5a9d4b5ff8182a59c65066a9daf70e1e0b0d6013b3753e6f36adf";
+      sha512 = "b0624b04a3a20a48358027aeac449c52198139a3e9dbf0bc035a06c22fae3bcb44f34a07ad88a14a44e87dc16a3393688ce8d45d5070264d1ce63b2c183aceb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/he/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/he/firefox-62.0.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "07074488f2b83055b66300b357e8fd4cd94dea52c359227cf33908a0abdfcf1bb969dbc8d00454c42e5b83f35651aadfd8492507deb5a229d3e70b329753a86d";
+      sha512 = "7b3f4478100b6122c22fc50a944dc86e46b3d2d73893209be748c001461968a21500562b2eb18a40669d13068618ca3093ada082470833085b78f4083064767f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/hi-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hi-IN/firefox-62.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "8e6b126bbd13b6ca9ecdf088a049e28328942c5153937198b851ddfdf1705211a03c6dbe71e95b3afd8f7d3889705d2c6a1bb0b135e34ba389830cff519dfbf3";
+      sha512 = "13d42b552bca18e0020b891f6b3a563b66dd86b3e5fb9b5badae88ecf5a37b5febd5b9c927807f7996b81ddfcd4ef076553fc82655eb05c8a04a920f2a64ca71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/hr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hr/firefox-62.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "d1c36d8cff63d070a827d24d3e95a823a1e302cd42a48ec50edd34ca3f76678f65897f060ff5365a677525e938baca6df512f27b0fa039eac6b78fcfd347b440";
+      sha512 = "5bf92b1abd156019935c8728435101fcee9973ea413cca05760322dce94b62fed9f7271699610e00e812f0c7d320cbc966bf03fd5250b9dbf9bb2ac2a5f96466";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/hsb/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hsb/firefox-62.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "384393359093655a50c6052cf25ba413fcc02000685fc6e97f15e3668cd93421dfd3fe95d266bd4ae5e687105ce7a4c364aef92faec9a5c01f6f5336c134fa21";
+      sha512 = "777ef75daae66a138f4013ff19fccaf7236700a8c2a46e6f0f811065326c7f4fb7dcb284ee9bac2dc3461b45cb8239015ff24731a691a85a199519398c03e53b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/hu/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hu/firefox-62.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "05c76472230f7ca011fd5f936568b50cfb646ce7efdde65d1640f0d4ccb31196873a8e5aa32ca6bc796e80400d52ea4c191e334270c04ed92354b6744ff4cb50";
+      sha512 = "800f1cecd46b4adfaf1ed20878d422191709801e148aef5e827c4cc3b9fbd46ecb475dd3c4b412a39ae2b05d4af2be8ec7d75515e2b98b1e07aef74fe49c4d70";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/hy-AM/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hy-AM/firefox-62.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "cd3f20095f0c31e20fb383089141f1aa22ba8f8e7734370fd377ba900cb71ba1f2e76e196bf30cf3e3a8139bd667575d139b03969ca3ceb3f2e1c231e70431bb";
+      sha512 = "910fe027a761480a4673207733fb5a78c0106249806f5c5347bb602de6853ba4299f2b13c896a088368eef036bef38962a487b4b3d6957f765f39eb06bedfebb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ia/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ia/firefox-62.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "834d2f397c3eefa2da5b184dcb4537ff28d26ade5ba985f916c4921473774d79a63cc97f3c72e49e19f37b4285a6efbc0bfd8ca78159b4a9e643027fbc4fc830";
+      sha512 = "4138b14e0cdb6f6760e5892bbdfea3c244460cf2c922e737a1af568b1df5aa0076cdebc836688cfd74d97ac859cb8fd71ba52752f5db1b28e8827ca59123756f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/id/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/id/firefox-62.0.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "25b18c83fa9899f54a6fea9c617582c06b6ace769deb95e2ee6d1f3f4d32ce1654041605072096fb434c483b2f47913a35b4cdf392989db108f48ac9376d62ae";
+      sha512 = "463f2d340b7c439ee64ee6429021062cf05b2fd4f32226723bff37a67c5f25566ba5d6815a5e604d82df97b426b677b3158b2f8a565762a340cfa7425ea097ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/is/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/is/firefox-62.0.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "596a5ae84a71ee3a5f1ba4896b794cd103d2bce08a505faa38ea6df9cdc5380d7b97b2c4b3c80cb525007bc2f08dfa2bccc2634a135e653c79b913c1624f56ea";
+      sha512 = "ec264aad9cfe095119f7f52f3391d376dc1864c24eb133bd51bde3349afc92c3cd1bcd0673b1fe95fa03ad36f869e0a6ee9835e97e922bd949228954779c075c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/it/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/it/firefox-62.0.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "46bb6c5d0e575acdd510b72375677fefc3feba3c7ca2d1ad4a84f82ebfb3e7d14a9b419964850f6b640adad0970b105b3ae45bdee4a8a47200c5ac7f290c204e";
+      sha512 = "c81ee4ff685fae9108b07235931b9d0347ca46e3063211764fd1762e2ef9b5e4e337001304a14309c97593543859800d7dab9fbeb21a18af1b84a2b2b6c6d5cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ja/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ja/firefox-62.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "031a4aebd4d676f724c95812dab0fa4ca289fe4144417ffb28c6c4579580666bfa690737f544a3b09f5e07c7661200c334c4a336ea45700b6e8fbf5bbe5cd81c";
+      sha512 = "2f0ac4bbf507d3c306dc30dbfb94cb3bf8d907431f9a5c6b863505012cc4b077e22144af3658dca60e056d287273129f4742c72cf78f800162347e64d2b887f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ka/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ka/firefox-62.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "14979e42ecff3c9005fd229a5516d36a72958ef810766a64963c2a6028c31e0717ca9079abe6103ece951c5ade140adbd35227dcb73c6101a145f1bc9e241721";
+      sha512 = "4a85a9f34e69abb29d63ef8cae372f225d246a5065a26d03d99a22d137085609e6ef5adc03df70fd7fe1057731472808f510fde2a40926418fb98cdf8dd452ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/kab/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/kab/firefox-62.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "16189c288a8807afc94b1d781a3afad833a52c16ad8a805787b7ba5603ed6988bffe34d9c9a98ea3db0eda25341ff24430ab68b59a1cf9724bd16246a52c1847";
+      sha512 = "7b03433b9c79203feb40705469c6788b8df08505ec2e92c704570e0cc5b8066d2b305a68a4c7a61f81e07cb6ea7ea12c059b00e8c11870bc44be54406e8a224b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/kk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/kk/firefox-62.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "c4a35a83e41df1149c1ab38d8f243753865a50d6d896b89499bee42db45c8237b9b8d6599fb3c932717977c5e460ce7adc6c93d561fa69a4704e1931fc11d21f";
+      sha512 = "51c141c62e3251101a5b110573c26547533fb2a8bb2019cee63734ffe4ef2c4d1b4b6e5e540d88e0237721ec7d0d88c26bf5c179630f685c037e3f9eaa0a6f02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/km/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/km/firefox-62.0.2.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "dadea116c3bce18f18f2bfb3652ee1d26b3cd11442b8e941565772d202d2a8a2e7d6277a1737f39c63947b2972ed8a84680b4c7dc351563c5ff11abeebd6205f";
+      sha512 = "113303e05d1ea54c38ddcb0476873214696f38b17aeae64381a7bc00bd59d3ec551540125190c0a48e9e85abc4de9ab232bda0a6dacd1bf7584b7d09c9be67ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/kn/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/kn/firefox-62.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "dd6109e92bdc9a7b3c8e08d9e104691a1ee449f9f915b5a4090ca471089ea000da34dda44883f10f72f4a5ca21078263663444a413ab1f1e7599f85f01f3700a";
+      sha512 = "3dc579341533e0d9b82919aea3dddae1ad247f9a994d52d26699bd371c8910ae5b417e76be04002af53eb3caf5a6c2323261e48dccb8b4ffa63b27fe80272681";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ko/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ko/firefox-62.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "1dc4383f48dc1aedb80c373398a5539649397f1660664181c97ecfaa17eac2c503a976ae15b1e7607a83ed90e3b4f6c3b15d1bd60e13e22b8f071d91d373fab6";
+      sha512 = "4269f0f945c360e8385dd83d3a62450825a9e74c349dd74a9f8f18e683a83526113ed315e5e363dfe00706b59bad92739e6b08c004e27608addcbf599b7da21e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/lij/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/lij/firefox-62.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "a26d5e50807efe3d4e3e01d10b0131ecbde0ef141f13310db4b01adcbac63d003db073ee24620745ab551ecba92965a5055e553b31fcfbd2df9af0a8913c7823";
+      sha512 = "ee26793ff03184b9221f7cfc88bb351f27ce01a04fbf74681f355e2a0c6b4330eded098a4ecabc3215e3c6b78fd2d09090275a4793c845b3c6debab962e2999c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/lt/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/lt/firefox-62.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "dd99282b5eea3a1e4518644acdd9bebdcb1532cde148f8c60fc83177fd39757e98e7fe3cc54c681305c699a085788a14cd44e93e5f10e11a6812afae10b2db8c";
+      sha512 = "2f7b98d182b4aea92f8e370107d56f647e16a11a1966c2e2e47b8b4ce2b45d9b9742d09c19478c200cd7fe42889ec4c2498304626fefa7531e987ad134e3c05b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/lv/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/lv/firefox-62.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "4be6a61d0ccf424ced36aad978f6419d00afb3db93751c1cd9f6d1ec0c2db8530e77099efbdd8883b333fc2dcb315143088423c359debdc7da5808853aa99268";
+      sha512 = "7c31be85ff6b3295636f50b9c7491fa467b2cba1e5ffe9c7ef997c3674d8cd801e14ab8fc9bc2d1ab75d2a379aa590109530c1ac81599f26b747a43cb557cfa9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/mai/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/mai/firefox-62.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "71aa1872d28a5f741df79e4f1490b110fd9bc13e9f6c4f2aea8d5028b434d02f0bff859613dcac258e0af7e8840b5a5b37fe80eb6d94d4712e83b96d971a46bf";
+      sha512 = "e365c3e4a9d2ccb80871c1530ae1e372d4ac1a809cb2c72f82c682161dab6d7707591194a72481a312760a7819fba0e5dc9ae3f80308b7a9c45af66d97e47230";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/mk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/mk/firefox-62.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "5b9e7e8f865675c0488fb9f7e965dc37b35ff53f0ab84c3cc0d37f9baab0084bf5981e4a1dc65557a02f83de7a92302c5cc72c7c25c20baa484fc6abc552c279";
+      sha512 = "e28b9564ce368a8e68c27436e967cd5ad5adbff1b78b50bad64f7646cee32a28f2dfbeaf0bd049d7057ffef59ce709765cedc85ea139b84cb6b02d95c743cb81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ml/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ml/firefox-62.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "d3ea17e668e021f9f002d775df1117c51e7b5bd92780b014bbdd869f93e50400e290a35e4f056c4ce8a235fc2851b630d24ddb3b8e6ccce7c21b65a94fe9816b";
+      sha512 = "50ce7dc0445a37d125fddfb51951d455b91bec19f807df262bcba0734a7cf855d455e965144e1d8da4692c4013861f62cb683e364e33e85f4962c99097b74838";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/mr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/mr/firefox-62.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "9022898d857eae94054ed357cc5d06bae72ea38fe2f1efb6d09baa6b18d55cb8a75a5c0f2b312458366e2146b36d12407373e8862278ef348e588a893c068a17";
+      sha512 = "defcaaf5c589d0a11104f06890f986ea3cb627db499c2bcd1fc39162402b09f8c1be3fd05ca33571dadae9e8d127d1d67dc5f08804f670e8f8db45b33ead6234";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ms/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ms/firefox-62.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "c81f40e528ec7f141de902432f1f367023a39889794a46de8b271e9c4bebcfbb4b6124dc8e0b86c560214c493d650389829a04c3f4a4d121b3243ae66092a100";
+      sha512 = "2f36fd10942b2a700b6901efafe2fc14e8a7cd97d41241a070f87edf4d1ebed63bcb1d202b1c557426bdd8fd96639ac263ffcf0c96ecad9196916cc69c9e3e90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/my/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/my/firefox-62.0.2.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "ba942bcab35045de32a2d7914bf7f953dd1f683ff0d142246035df830d4528b47f195b8a6b96c95b62e2d03e89215c938072ae23b19af41bbbbc40bed3d0212e";
+      sha512 = "71001dd61027cd3acbb12f555a19ac3534c547b2d9b2c964a6bdb656524429ccb25b6c601422ec7f8af9e7d6319319e4bdf0db15df3f3833611d72d3d9eba410";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/nb-NO/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/nb-NO/firefox-62.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "dc86c87a0e51105bd89ee579711aea9e61904f17afae27236ad12bf754831dd592f9ef938ab35d037b2da884aa301044eb71462a6c4ad26af97e9911e6356bd7";
+      sha512 = "2bbb7a4cd756757c0559294a487c972ab0c6bc6df005c948a24978a35f51c369b66269dcf6fa96795525758ae66e24670fe8ef7fa0f5b05b7d81bff79f2cb762";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ne-NP/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ne-NP/firefox-62.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "9bb1e18c015696ee9b17853a942537bf462101e687107771d34c4f62d3cb3f7d9debbbba9efdcf7acafd8a9f8c4f8c197b2df15c80b9c5a562ca1ee765867b3a";
+      sha512 = "4bd51046dd55004e6a08dd0fc646344f91d7d830249fa8a33284f4c66bd5f11b1913920119593e45d9488db1b9d7aad1a74b296226633d94a02c0c705f527a60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/nl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/nl/firefox-62.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "2fa2082a1a9cd71f0ae7019507055e6109292bdacc9ad4c860aa5ca9ea6896c37609a083981df309d2c53811674261147053ee6247908ec1ce7a2e030d320443";
+      sha512 = "408bf232f3c1e592a929ff2364b52af899aba1a7542e6199366a7bb0369ec14bf3c44964851a6dfb37ece8e9ffb342ce7448c11013c3013bb0d4e1d67a43e2ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/nn-NO/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/nn-NO/firefox-62.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "4665302f9850b93c4cf178c3e2397e299716ccf92e4fbec9762892b17960f275c1167396de4073b899d4bdbd73bf06f87f10c36be7eda22934faaaa78925e8dc";
+      sha512 = "450239e4d62d03151b0ff093e04e4cd5cffafeaa91da7374390d31c5944366bdfd0361e6e59b162352418436f7bdb1ebdfbe959107efd14f0015de0e873cd5e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/oc/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/oc/firefox-62.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "d0b9a462b7157a1452a54e2fd3d9d0c38ab478eb6c6391350c8c7c9c581e425262f42d33fdd0ac9e50eb8cf77f0d8b71372cf15b079254c2294f5bb613337bd2";
+      sha512 = "a7c00d91430494659a4a2285ae9505329e18a10985757a50f9543d46b6ddcb740cbc440e31a1718ba4b830661bed56a0054c5309b04bbd8029abc691b59f0c08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/or/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/or/firefox-62.0.2.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "555135a96975771bc9bef17601f1e2a2e308e07ba3681164512f2939da1892ac592a8f69264a365dfad36a473306d6d33712fc6868bc809ad5d5a3ef16eaf5e2";
+      sha512 = "e0ed4fc73fcffd0c59f87b6ed8d1ba4ebf8526acc79ab5a2fdbd689c1329d185bf9717cd34f0921d9ae2028a18bb12d485a0cfdd20dffb3e2a9b33969df943b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/pa-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pa-IN/firefox-62.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "a1d01ebf734b6357ecdddb3601b9062216c040966d633e282d61a28ecb830b5edb5152dff4c46a3cc273034fdc7110cc56858cbf31c6e90ada6efeb4130c510a";
+      sha512 = "8106baacbc84b053eed0527ef78f9ba4bdc94f0679c0d887d72bf19ef5c6a7950b6d8e9a35d493b51de031ef2e4720d03abb9677355a65b2a539c9e73a4ab633";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/pl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pl/firefox-62.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "701b496e7d20e8eff7484db6bf5e15f1bac769fc97f69de028a0dcbfe0f681d0a9031242b30367833f8cf1f8fbb1acd6d469a225152bf5b220a38b369c740381";
+      sha512 = "9295362613e98387d10160af9f779a03c8318797e98daf39a514d70618eeffa53066113198257c6cbf1373fbcde33cef525c917c85fc3e838df5f918868e10b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/pt-BR/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pt-BR/firefox-62.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "c4b3be3a9483ed76f7b8334998d75b293db031329852ec59ce8ae13e1184a541f2f35b5d1bce413ecf525d482277d27d7470444e477f297e361751d07cf64920";
+      sha512 = "d5bb188822c7b8e5ecba035585621685cd1b334950b8480d73b1841f871325236f9a13a3a4f0098d11588c0085c20fac7525a57cf83687a29d15f05cf9d9cbd2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/pt-PT/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pt-PT/firefox-62.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "389ffbbd4dfeb1c7149a02cdbcb70479be32ac8e91683570093f99e38b4c541f145ec27fc3cbe54f70ec3ebc21e5c0ded3b18124307976befd8f2ae1839c5dc2";
+      sha512 = "ee2f8aa32c2e20bb69ee291f3bd4ea931d5b2ab863f6f650bce92d35b331234491b93296803f5ede49ce49027b805241db44989bf48ee6d68722d262625b1fe1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/rm/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/rm/firefox-62.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "cf9b89f1828bec694147528a0db8a8ec4530fb60e8a1957b77c8202e95459217c95bea2f104ec303922074c3528321f775fd955080b5e012b8941bb7f6575bdb";
+      sha512 = "60605882860f1e1b805f8cb74539c421e45438aff07e79d6b3b1db3546d38950059665ca443d84617ddc9a4a3c104940d885f294932390170b3bc6c2eedd0529";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ro/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ro/firefox-62.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "44e3ac3e35af41616c1dfab41edb172b4dd92bc622aa53b8626375d782235ce3e9540e72e14b1d25dc19f4e44db5717fede7429b1fb245b644c20f2e13c0d7e3";
+      sha512 = "850063575dd69270903a031748e665cb8363105057f1e170e43f264b3a9b228976fc901f7e3749cee22e3d9489b3357240198dc3f22e20de5b9581729e8c601c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ru/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ru/firefox-62.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "7b38581a552ae9df2222ef9bd8f2c272cd98458d4a11c55a8f942870411d08c72da0c1dc5c4354b8e2e17d0a97794e4f2d59446a394e3c95376f5e7ee296d57b";
+      sha512 = "8491c625171c0bf7c88c3f3a053e5f49a7c56b9dfc7c0ea7c381bfcb7505ffdce6a1079d15c73ce6a4edc5f89125e849e8b5fe8d464a4440d4413dcf6666a0e8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/si/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/si/firefox-62.0.2.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "dbb7cc9c9efd5c1305cb7c770db67ace1b10c2afa55d2dc9b8de896629e4e69e79bdc5d06cf3d7900635d03420c32e0dcb1b0b8ead25ab8fb3cd12a154eaf0c7";
+      sha512 = "bde4eaf6879cb40967ebc872738f5ac6b931f6a1a633886e35985fda76de4ea4c0a4ebc7e68585dab34f7f453cd54977bc84fbcca636d53d6c5eddfad6d13bde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/sk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sk/firefox-62.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "04f9b7c1977aff8144ad53a2bb7bc5aaaa11054cb8bd00b1747ab7ec34e3664d1fb3adf65b49b5d5acbbde2e1ab45ee642033e3ab57e99d5973ec853a1a6194c";
+      sha512 = "776ea025a2e087a7d8717c3b63e8a203f13ae7e44812e0bcbef8075aad1166f80cb6977970d88f68720772668cca982662c2172f1bfca02732a79daf45974112";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/sl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sl/firefox-62.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "3202a009f73fab2326611c65ee97a8249f5ccf047365874db92da588c5cb8693ad1a7b7852511bbab10a9146d0beb7cefdc79d3269c3b7404205d616a7394dfa";
+      sha512 = "1bc1a53815d287acef056c981bf306b1ae7cc36d4c8acd3bf556f3a2f44e6af2c05bede49f04bf7fd591cc5f0be40dba10b38c5b64379c673705b57ac0853d79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/son/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/son/firefox-62.0.2.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "a4f718670b73af088e87910197a78dace22d9e04bf268e4653709eebfa499ffa4a97b4048e4ac80c6a847afa598b0e19bdff07c6a7d6e164dfbf3d09f1070593";
+      sha512 = "ba3f5377ad15c8586c7e826ffe8c614ba71f49c9867caeb1fbddf9ffa86d513f299fcf39d750c7e91db88ba17533097d38def63c8614aca743946d2a3b0b0484";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/sq/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sq/firefox-62.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "8b67dfcd41328b677bb33a640c1045b3643368b8c0004cb55027d36ac2f3fb9cc99c272d132c355567ab0505a50d34fab80f6fdb8598cef09ea9806e19d6107e";
+      sha512 = "c3f35991e3ff9410c4829491acc4a7f7cdd61f9104778c168adf3e1d359d5d0c8cb57ef552aeed669f80098c546a72f7adaa09cac4f486dacf78bd381f5fad76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/sr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sr/firefox-62.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "51834193c037ca0e23f2c73800a351debd8327908f7c6b378a89424ea86b01a272bed893df59b1102760303592604812794c7ac70effcd50c20fbd676f4b5640";
+      sha512 = "df6bdface285322457f676d74703084cb677c6c429992a87dfb933bb3da25eff374dd2894f13c37616268266e3934a55cd61f3f6239a487595282ada58bf69ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/sv-SE/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sv-SE/firefox-62.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "8763a55b6a3f7ffb75afe854aaa54bd7bd5a5ee8dbd741f4348fd29ce015603f81cd98bed3547c628dafe98dfa800a97b64e281606223fbb400c03a0af332018";
+      sha512 = "a48a11e4b1e1bea955ddd73c77e7f5e1a7d03435b29659f7b610a089b604cdfed57893420d0c1827198efea6365a52ed236a8296646a980fabb6007b865a78e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ta/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ta/firefox-62.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "82d687d98f2e75b637e76416ed1b749d1af18c7ac140eab32f8fdf99238fec76f3f926caaf212fb42f054d51d8c807536da8cb0ac5354ad123a3030fdf46690d";
+      sha512 = "e01845b225c5516ecfc25afde98e9691b9afedf27405207cb91e655a9b48edb416786a2cb99ad73df37da41cb22c58958165836e5e6b1018c6c9f788f2b9337f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/te/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/te/firefox-62.0.2.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "2a690bbaf6f8ba90f98c2761d6ac6030fe17d384478a3bf7c07875bc6e3e6285f154e3e21db4b639602f205cc03360fb36bcfe26473ec48cb1749a65b781875d";
+      sha512 = "95b795fd6f995527d85fa83b122bfd9a2c091c792c879f7f4611dde63b4ddaf0502d3ae0ee33002363da359d1931d008c01e40611eea61f1ff66aafac2844f52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/th/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/th/firefox-62.0.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "ebc344d1439fc4fdb71d772b047466e5bc19a04a83de09e64e9c820d19bc057f3deeff5d0ec9bd9cb11ed2079f4bff459f3727b0ba92fb7426e2e186bd0cb4f6";
+      sha512 = "9ad3d99c9479155e20559ee1c8ef276a69b591be2cb96700075ca19352f033d9063d9f9b57ea9fbcab5db9bf46e1cb03c9b001e6254b6b0bee5547f8c91fb59c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/tr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/tr/firefox-62.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "9096da5a647463a3643e3e5f21dc51ee9be87d857004285de7dab164255103bca4ceb9d8474fce587ae497397c753803b8157c40d05dd8d3310d59e97965ca0c";
+      sha512 = "90fca950893500868edc6ae1c0aee417cbbee7b7a0f48e0f10421b3d7ba495a56e090543ffd097949c9bebe69784cb8fb03b559156863f9dee940aa867421135";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/uk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/uk/firefox-62.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "f9f609eb7f3050e95bff33de4b88d8e17949c4c167d3bbd7a9901cb0d19926a37f72e40a6bdde1f6c7610a3ffc67d7fbcfaf298659e519aca16592714c70bb4d";
+      sha512 = "18942b931cf09b03973a10e390ac15c6e5bfd1f730953b782b7929943838be19bf4a61f157b33979f1a8e13042f1f4facb08ab205b7825d285b9e96c0ac897b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/ur/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ur/firefox-62.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "35a755f1c1d93d9d8e4bd813c83a332a1cee74989d993921f987e023da90a851863f83b56a41c58878f5aed07b4e08e0ca9d3f4d4ccc8610544516bf903855c0";
+      sha512 = "7f16c4810467469385a88346f5ee3fac4d3d95342c6a6d37e0df7880f0b08896d0e39e77091eb0262a66ed7fa15c3151f244eb47ce4ea774ad21797b5da502ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/uz/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/uz/firefox-62.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "d957def873388aa5f5051ed3ab5cf51196f8b5fc83e2fc4b56476f63357ff26ef38e6f3d469cf4f117b094c3e31a0f561b1f5c0a90c85e827436ecfe0d61e98d";
+      sha512 = "8266d638c74a78fa26c939c1ba7a6abd05ede85a9e349135f1934a6e3df27e3f6172026486738cea28e50689b84c29c0dbc63cc8779faa11a6ae55b4f367c23d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/vi/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/vi/firefox-62.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "e7f10deacc80f55928f3f6ea4dff80142e790cf9dc814c38f173cd03ea59de45438fda5cce1073b0c9e1b528870c7d979d16254b038bd351834def51944193f8";
+      sha512 = "787e570afae27cb668d6f4b9b6e8b3097f02148c2e2974efd1c58e406354724def031f04fc69c0ed10a04ce5833cbf7bb2ae8fd77ef068f8f17bf2118d1305c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/xh/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/xh/firefox-62.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "0e64c9a9c1ebada345f02d6dd40d2ab1ae157ee238b8716b011aeddfb18775c1594ae0f7706c4ddda97ca01c44304391570f526524f4f19d3eb5580a1839c19a";
+      sha512 = "805df0dcc24a7d77afca47335b31cbdfd0d0df51145c9cedfdaba4d865aae71697eee14e446351e6fd8db950e3264ed788f66d683356d4fbbab17ea9d7c2c452";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/zh-CN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/zh-CN/firefox-62.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "cf1381aeb00f19fa6f8665ffbda8a9c6c19939a29e16fb49a2cf9097dbb2674eaf4e32b658dfb126645540582c52ad86e87a9679c1dabe03757d57032e0d3d4a";
+      sha512 = "cb251f942c31cc0c30c46bab04f658567b16f379068e7bc946970ed512e2de08c6e3511990b722541756e95261dcdf96b03cb247072f0b230f66ba7afdb038f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-x86_64/zh-TW/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/zh-TW/firefox-62.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "9d28b0b773227d7efc611e300250d518b303b9e03396092420e8195872c6e8c78aed6f9985e491bb01f75c541299bb7f0cf78abdf25d3a8587b085e3f6489e0e";
+      sha512 = "afa5847337657cee3ec28896a089bfc0fc2b25750d6dc271bb83740ea5170e2f926fdf3158b0b136eabe0d2d6b4b81db1ecfabcd8c2049164af54cd796e9a7c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ach/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ach/firefox-62.0.2.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "6de54e5cde101eff5c1edd43b7f3286f10cd631398f646608e0d6f22c9dc6d8dc2a3346c8d5fa9caf6ab1a82af8708ba3ee17fcf605d0404e2beb5d10b623ca9";
+      sha512 = "99781074276e530b9ceaf2cdb8f902673ceeba3df515a6c2c2ece3fb3dfa84e6f3d494a3a69346a3f9fef20d11f7bac0361eb80968ec7b9e76b603f8b001749b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/af/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/af/firefox-62.0.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "29c5898b88cda4a1f365b8792789c854b954b4d6533ed7a556f7d0e3dde3f7705adf5a6c3bf14444268648ad3b3002eef49dac200d5eb89cbda5ee33e1cb4d4d";
+      sha512 = "bd9c6fe306a8802b22860cad8cb452b6591c0227e12ffc4a33db1a88b811d06725348e5f128d624240b9666393cef35b30f5bc7d12e41a046bb318dd346f63f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/an/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/an/firefox-62.0.2.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "484a8277cca9e437d8372f750403c71c5e4923b28b776b5809f58debb8d0d3ceb5d523df05691f326d06efba5970e27bb06abffcefc500748b04e99ee41664bf";
+      sha512 = "289c00b7bf464fb6d86cdbf24274514dca98dc47e78389125287792e8f77708090c120aeb5ebaf4688e16857c5fc6b78fc1eb6f0a7efd7afb62c22fee325e78d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ar/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ar/firefox-62.0.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "7e3deb89acab69012c5f1aa99219ec0ff0cb380ae5f1dd71eea078bee4434855c612c808a574bcf46512d2eb77b3e8f9c26ea524ece97b02699b2434d8cacf45";
+      sha512 = "412cdcb82e2d60e2f37658001638bbe50cdd3a7db1e9bb4cb0e2fab49b878fe64b62ef019e499c3a960bca3510266a0afb3fb4c57cc5a8b6bff22aca772e643f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/as/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/as/firefox-62.0.2.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "0836d6d22d13096db35f5ee3da13cd4a8504a55de73ce24897a8e4903eca5b7d56f244321d2b6b623a357b1741d419957f67ee65e71d1c71606db24bbbd95631";
+      sha512 = "8068c78be22e42f9174cd6f9e1e7dedff527a00865f722c6dd9062c6f5cce2b83693d0938ae5f56197f72f5af71bbb485b0970b632ca5dfec9190214558fea2a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ast/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ast/firefox-62.0.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "247817ddfd24b97b991ac916311e01871a831197c92025d3a2ea97937fe993869c7a12e118b32baa3aaca49ae469dfaa8e892150731b6dfdca1c4e0929c2ba08";
+      sha512 = "37ab6ad2899b3b115bd2b59f6be121e2d340c27eb745f698fd2942ab6424c0840273ddb4afeaf1083d9f458408b939270d971676e9b08e1f0fa409bca69f3e84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/az/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/az/firefox-62.0.2.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "4f0977cc5ce9e01c311d256d239a3e89dcc1db5b78b4c08f08999d7c52731fd58fce08c9f77a80fde1176a0a5289b5c59f06eb790cedd3625d96928dbdec46da";
+      sha512 = "5724ae7680d7e88061a4cc45706590d519a5bd769b204d06ee0e8e6e86f706b312b665354d22314853af0a73b073acf68be8b7c3ae9dadb87984e1222722b4a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/be/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/be/firefox-62.0.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "294adf3029076f9dceb32a54330d63b10ba9219d9f688e3c7246e04fdff2ff10bdc24b577f48b18935c35b8d9acb2437a7d6cc3533fd6441b9027ca67e7cacc8";
+      sha512 = "6249b41382a1d2cdac2d9c9d235697a70bac76d0dfb341d3db41c0f329cce868ef66df6d2f249b4e22a1daf737d5ea3b7f2cad36a2d30b1dcd649fc1476218a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/bg/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bg/firefox-62.0.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "41b78104367cd25e67a38b71d3db6054995caa28fd0c4dfa0ebb494d2293c92c20a347fd763f88b65d31a514987c607102206390b2dc41335d00aabd9d5d589d";
+      sha512 = "a769ead4a10d4168d64ac9c2391c0cfcc5e0dc33f4521d6df73c5b53087e3aa073096af09adc49c901489e60af9839ac888483d63f7e9bcb1de2588236cba75a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/bn-BD/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bn-BD/firefox-62.0.2.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "79241d9dc44b5ad35ed76f7b33bc8be8bf7f5da09855df9e34354994554aff2ddd2dfe8a2a3410916887568fc92a70927b8cae4747f20d0dacb067206eec3d7a";
+      sha512 = "0761e32fd88fdea9c87686411ed87affa8875f2047ff9b1b1ec11376583001c9c9b421b2b27cedfe883cc5cd233d4d3a932aba74e50cbd74aea63a6aaeb64c8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/bn-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bn-IN/firefox-62.0.2.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "5194de3d21783d335a11c824cd46b0e01ea512f900a7e3fb45ed2567501acd27d5f5bf8dd68f146ff550f6ae4c70089d539f56823cf7280f02b67d5111715760";
+      sha512 = "1868b2d7d6f32936c6072998afd1ebfc232158940e5270bf483c6c29a8a30682f0ba729161e9b0aeef7d839c9e9209739380a20b8b118c49112bd71caba03ec9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/br/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/br/firefox-62.0.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "59dfe19ea10c4698067a8ca70143b160ed5a73c38e0f6ed3a14d9a60209378acfaa1f8b09647a1a96d519e6fd6a34cb7e2a8bc3cc276653842c2bb3a6ee3cbe3";
+      sha512 = "43d1691d6b1d9aafaee55be50bf8c4934b75c0501c811314d12e1156c2b68cd58914362e167ed50fdf5267a0d7a2db9730c68bf318d492bacb8c33eee7bdd12e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/bs/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bs/firefox-62.0.2.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "7e6069ecc137c1b0b479159fc8eb323a8c417c81edd8c7d54498c47cea4f1a2fd4a1cc52bed17b899ca72df8b0fbaf88e1794b17f86086d249011ccb592ce5d1";
+      sha512 = "aeac8dc018ed59e2aeb68b63c1a1d6281e543975844e3ce5b7f22991968bf0e05f40cdf1ad3bf434cf9de774363b0ffa6f96d1c0b457f0372d4d1d943c0a40bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ca/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ca/firefox-62.0.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "932ce6517bd55ddbd927eb28935bc99ff5576ee924d239dc490fa79b3d90dd77f579a7b16c0b4fe4ddf8fedb4e825664aee7fe246145ebbe19c8f8841d098464";
+      sha512 = "10b6c40701b7cb8f2543e97a61335f426b210273d46d542034bcefd7d23c95124cada1d1df85c3b5e33d25e8680678b18815ed0c8ed58936061f670b0abf1d87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/cak/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/cak/firefox-62.0.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "38c4ed4be2e79145056bfbc5a476e3a03c4f1f6aed1ccb834a7ddb2576f99fc52305b93939145ee1e7ae9144b656e857bfcc6b084ea4b501c3a574e10d7438a8";
+      sha512 = "029cfee850c3ba5ac408b6db45d66dd9849db392097dcedc64d637756ffba893770a93915eaded6302f6e667f072949fe6decfdd918be292abb9ab8d1300c2fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/cs/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/cs/firefox-62.0.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "1d569ba50f84ada02f0962e0418ee7f26e79fe19cc09f50dee4350a59262ddc87440dabbf10129d73172e512eff5904062f60561f4bd2d4eda395bc67af90dd1";
+      sha512 = "ce919ca42a629f171df4faacabc18fc3db0faf2d38f04912720ba697612215e0c26f650781a535b5e956dca912fd47d1d9b9528910b8e9b7a18841c411e25623";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/cy/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/cy/firefox-62.0.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "9294f39bf32de7eb2a1bc2480cf7f7e51dcdd124d3281f9e45c4729b6926002f8ac99c30403ea53a5c6857077633ec08e0c35f5160ea8e08a7f5f881e8a90748";
+      sha512 = "727827fa6b47cdec5048f40005872f021cc506d7c72a7f1a6bef9f736612341fe3cc6127b3bf005f63620f17b180a00c3fa0f799f63e685111119f9661d9ca7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/da/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/da/firefox-62.0.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "77bde4fc9cacdec311b513045f3f026c44d7c199cfe0520cde20ed711c1cdb40d6b64483944f4da47b8fb280764899ff5931a8e5639bd0a8a4e03425835d8f2e";
+      sha512 = "e795a7aaa38c28733a8864928229d91d752d6f0fe108bc5a3350b34e783155c3be14a5c0261eea26642097db2a583a34553d746d6040704f34de82953952f21a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/de/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/de/firefox-62.0.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "b2bf1a5fc4536c3c0822d84c7f0138f04f6bf4597804eff101502d3d782f2b22fc54dff966c2f32821471622cb1602050de1c51aaf9f64c63314f8ba002ea201";
+      sha512 = "56185cb92f9a246140b58119cbbb6a128905c8e244a7ed8917613a65fe8f87a542b103afe69f1fa542e47efca18c8666e669c266e9c107661b800c5e3b4ebb75";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/dsb/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/dsb/firefox-62.0.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "812842664c8b0088f33acc42ae1581a33cb2527d3aaea0ed102fdc27a088c06008b96a3a052f95a900694d869591311dd986bea2e828a02238aaff854a77aaf6";
+      sha512 = "ff30865cf3135f466d67143487ad34a50b73c11000419b2caec1c232d4efc805cee5cbd282bd1e0b9ccaf03ccc95e08ac4d1baed93abde27b45b0f2af5d71fbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/el/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/el/firefox-62.0.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "f1116c938bed2333309d32c13ef69f806418c14fb8a2fc10f63c932d8d8ae169aa76a8e3835eb6bb2d61cde7c8d8dfec56240b8280695f1c2273899bb7c8aa4e";
+      sha512 = "e22d89c822843db26e05834c088e5d687c6d315a870ef2457f13126bd740135016ebacf83b9fae131128b4fcf62b474a68fcb1fa12098aec22f199a5871e63b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/en-CA/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-CA/firefox-62.0.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "ba07c206a4b4ee0bf27ff82e8ea14e3ddff262fec11e088a114253ef4a4a81951cd5c85cf6eb9f6e1ba06f97be0bf5787f5e26c65b7f2aadfedf27f968146efe";
+      sha512 = "0f462a6900bf92513c40f28a9fd2ecb0fb3a69678b2b0091e6495b89b9a2fbe6c805e48b2e55fe274996ff7a15c32294d02a3e025b97505f920069cd71b23341";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/en-GB/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-GB/firefox-62.0.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "558c10ec35144d696e1458a4b70de954ed3c8d3f05d5d1ae492374ee3b90752a93d55e6e41de30a64a3ee3b9e68bab88aa479066b849971d78121961ce2aaab9";
+      sha512 = "dd7a7fc0b05877f1e1f297b123075695c97247e2641311ff646b953e002278e2e16187682226eb46034cf3959880b2d17d74314ff7dcc654b1963beca6785410";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/en-US/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-US/firefox-62.0.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "51d606c5d9fdc2d6b611b1fea06c54ee4a6ac7666b4dce0a26dbaec99d110a2e304f88108d307b011f27312f8b935fcbf473f87b52056a465b667f8ecff9a48f";
+      sha512 = "bdb45cca1c207502ae5f76fe10e4b73d3f7e6079913bc9a6216e9325b8c70fac37d14e32b4e5ef6acadd73c301c3ca1aa2d72a5d44acc0b6cb0c22b481de2e46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/en-ZA/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-ZA/firefox-62.0.2.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "b88ea68f4eabf086ff2f3fa6752cc42bd19391029d4c0565342bf24d90817717e5f07f774e164df234eeb735e426491adf35784dd9096475635365912e57ba62";
+      sha512 = "351ab5114b25daf11ff2ce1aa377e6c16a7adf9807a7609c97e04f30911f8680da727c6dd1d3067e028978d3f6f793351d99f500374372dc22b11ca760e4d36a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/eo/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/eo/firefox-62.0.2.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "b97c269786efad57ff954d27ec69a4983e18a7ee4e0ffdc6925268830104103a99a31247359eba915be0710455f0626379b801d5fbcf501f30e3cc0b9736eb32";
+      sha512 = "1ec40261c42db667f1680361e4e7f12db271f5fbe6d213d44d0722e692a93421bb92d73193f87f42e43df40700cfddc7913454d6a64f5e15fb78f08d7a5a3c0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/es-AR/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-AR/firefox-62.0.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "a5fd087a8852f39e1208b388a2507981af3d989a8b86b1b0e2e83adcc9f6a494116050ff811e8b2225fd113ef1e689bace73a617c0e569df627df7e9c655a14e";
+      sha512 = "00cc8c232fb4b7b2c56aeed098719d60deb26abacb38f8a7ffd9117c8d8875c838fc702413a6d8584f862b35843262e2bd31074bfbbc7cefa6f62247d8a16abe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/es-CL/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-CL/firefox-62.0.2.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "bdf7aeb5fbb80711d7b8dd7ac30e544847e00f015f7bb8835315f5ee3023458bf781a368f0dcf11c57737fb1d0f077352c0eab28d32e801861bba36bce5e52cc";
+      sha512 = "70da97fd43b84b5475e707780c215f73b05a423577f6ccb67a31e01370842319d40c6d691c99da138db881d6c5de8f73c1bea8287fb9ba1cd3647bc74ff8125b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/es-ES/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-ES/firefox-62.0.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "47bf0dbb55435016312a6f6650033f28710471e7aaf14e0dc83488f1ff87e559de552fd95d5a58864420032392f84de06d8a1916efb8128423826c7e4577ab44";
+      sha512 = "76b717e852c1aa2f3801a5460a8f0d51256486d5bb688b30cb85abaa30eb8a441cb28391988ef8ac4fdd1a430e0c09a2c298c8738f7a76e6a18742bc2a4f3998";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/es-MX/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-MX/firefox-62.0.2.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "79e42f01744b05df6c1c7928743914ac28f3dd696a6918a08000a531b050fda95ca621ce0484c216f2eadf728db867707c1ec45188c70bb91ee611eaff7ac565";
+      sha512 = "e4e7f734ba533a0daf56d9c99881c0c1c758ba6e492e8e62b67944fc3a6c42c82df7e4d01a27fe797077708d49c810a51bb05d3fa4f2cf91fb63548f82e25322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/et/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/et/firefox-62.0.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "8489f6dcc733debebe1acbaa86cd093e5dcbdb4c8d60480414ec1e27710bf57590fef3a29fb208e9eeaa5d8858e5807d7cf0be5130d57bfe308b7653de431db4";
+      sha512 = "6b832c2b71b0e42db5a2292d90f1545ab545845f30b09baf277bd48597975e426cb98442fc16b7053d5c573d50d42e37e89cc49d7f325835aa5582262333fc4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/eu/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/eu/firefox-62.0.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "92f49ebaf7777962eb2d1b13043a10e82cebcad1a0f43a3527d7e7a5a31e720b812febda86051125e64d5f0355225dcb6cb496df5ace1ed10c2c6a4cfbe16cf8";
+      sha512 = "5bc67a8afec07f48c99ad331257236cb2fdde7fa23afadeb3de8c270d78e93bf855702bf82781c9c90eb5a4a0b9966d83bcc6d8f357ff5ef2bc265378200d674";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/fa/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fa/firefox-62.0.2.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "1bf258264b77fc9cece834363a12c34be719121afd55378e23fb2af9cf20da2a7ef4ffdb2d39c34c9970ea5d259a47c894b6f9d703ecf75834a2239844d783e1";
+      sha512 = "43d16efdabc3eb39e3aa924387040f6e92c80333087369b754065c34403d202f0881c993bf667322f8ddf303a8e066c4203b2a4daebaf68ce5b95a8c1cf80844";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ff/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ff/firefox-62.0.2.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "0b60ade68d6f4b9f1fda4a3ce36fe54e69583efa5ecb41443f0f92d394257449c2d5ca7124d1e194fc7394ba0daeb67f828de4aaf13f78c89aff8dc273213ea5";
+      sha512 = "86837496c81d9f1209719d46aa396d17eca17a13f111ad0ac3b94f1d3f9bc60ddf8d8b10018e41100e091996d820975db897abb470fc85e0d87a0ff742a67b34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/fi/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fi/firefox-62.0.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "f5cd4ed69914705a01765cce884e3f3fd66cea53e85d33da378087ac7ccbc9afcb1b2ebaa78bb4ffbdca2fc34b2ce4aebad6d55fdff44b8740a815265026d2dd";
+      sha512 = "baae77ef1bfc59c87eb72c3ad6f8524dbdf5fda9502abccf297c3b3f6e1033002d9b4e5b341c9fe101bbdbc93dbac768bd962ac9378088c9c567ec5d71ff00d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/fr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fr/firefox-62.0.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "3dc1eda7eba9e0112b246a370a296c6f5e11f318e514d08fc800d198afa5fc692f13ba66fa7b2ec891929c53572ade6caed21f967b880262cb36718fd76e18c1";
+      sha512 = "60fc885a6b5703a88dbbb60bed41296e2a1bf73405eba33a82e5f916ac0b22972377aec321c2b13d7007dbd94fdfcd24d43fc8f0acee37fcc9e23543c5a65f67";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/fy-NL/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fy-NL/firefox-62.0.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "576b0645bb3c2367138e3f385282f77c72040b0a4c75ac5f39163a7f1e23a34e7702305857ae2250c96adcebd587c1cb83b1e7d129667307089b38842bc4e175";
+      sha512 = "945c2b7241e0faa83e1dfa1f36a3dc86cefb03d3c48191f2ae6b3dfe8384ae848440731d69363197f724da3c32988e20c0bbfa3adbc52e7eb99018b7ef8c4510";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ga-IE/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ga-IE/firefox-62.0.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "416cad5b5859bf1565f7e68fd3a53ca8b180609a488e2201f70d42eda3186fb1e22c647016c67fd3068d67b50af678bc6dcd96194001511844afff43e31611bb";
+      sha512 = "6b3ffd73216ce3879b26211a3dd26db393eba8f0ec3f35b6626bea3847a614d6624f1fd6fcedd5ac00e5bb08c9465b8ae63fd4105a79acf86bc357dd331d44c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/gd/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gd/firefox-62.0.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "167ac1a9411d1cc3ab052d3b206de6a119e8b56854b7e9588ed68815e7c9b9e1722210951a8b731e944aeb8b2890095cdfa7d73b03b473a5ac99a90095de6917";
+      sha512 = "cdea3ed1ffd14d02d6489983832cf11f87b1f17bc73539e4b27f7a76f267b491ddd3163a80ef9a953e3c79fe184631a32be842474427d9792b2d525df8006ffd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/gl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gl/firefox-62.0.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "efefb9e9d53be16fda773e8f40073c357c4b46cedecedcfd311e890a45810b7fbfb368ea3e93b07efd0f9111b9fa7a67808298c0ce98be2c8bc7eff354f7efb8";
+      sha512 = "b098ab10e0fda3fe67a04bf3040112e08ae1e94e30d65a076fa0e1f4d4e30e1be99e9578e06650f2fcddc6cc6b57309afbbda71008af67ad97caf9eacc7dd550";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/gn/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gn/firefox-62.0.2.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "044c8e610d639ac8830b00ba2e4e2ff8e1bf827c3f91101edd45a6d478b5b8b99c1100c9fb2273a6fd378826f0bcbaf8817cdf1e3303bdb1b9b0e0c01cf095ec";
+      sha512 = "a83c0134556894a375ba91137d9513322a876299edd0347eead0869aebb4b04003dca12594cb276e3a521452d4b6ebbabc6be8f79040514f26f6827f55c15d3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/gu-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gu-IN/firefox-62.0.2.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "433bc4b580bb3d164ad78a21ef8894e053b4c6d972d5e4aa46a9b8ac27cdf38e395164eb46e24815cc645d8048c237371a3abbd1bb639e69b65efbeff00a30b5";
+      sha512 = "d313657b11f3fecbb0ef26a0c5a2d4b9ead411f2a3c55bbb4bca3ea3a6d861ee54ed1950e9bd5b14b24b9fa569c7c67b73807353331af60e3cd942b570430a76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/he/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/he/firefox-62.0.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "d6acd3b06216d4b0f0856cb6576c36381dd9f48bfbd3543e410eb0e0e5aa11977cf3d68b38b0be7b6700831c1561e2a8dc75eb5193637bbd2484673d83bd3a1b";
+      sha512 = "a05a94f0634f1a857eab463825c97ebf2fa1b5315c44082095d6fb674884b77375968ebd39df05fe6f0f3892b87d9f1313532ea022012cb411eb32a43e1d01f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/hi-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hi-IN/firefox-62.0.2.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "49856be15be3ab0ca687f8d6616c481d61bc0380133b043d394cdcd21d1f7cd8816b2bca5538f2e601a32ffa8c51745e89f537f62bfa853da42759db70186ee1";
+      sha512 = "e4cc460637c6aefab1b323ac5a13674f9f95eaf5cf0bfc2020869a196fd13f1708814b33c938981017fc27cdaaf57e75591ce2917cc66e5f97b3c8f22d3d44ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/hr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hr/firefox-62.0.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "0040ba7333a13820e4c0a85fb24c30131d4b477da3da9e4e04296088d1c0e938fd495777aedbe3bec22533a6c4766be902adbd8b470a81380fe4dd23f831d0f2";
+      sha512 = "74c11421c3815b5772cd9a5f74e1c48d914d335babcffbca984187b72dc7a5db0609e7b31915f58d358a12c52a0db204ff191c78af28609c1e68d002a32f313a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/hsb/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hsb/firefox-62.0.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "715d14b52fb82f255300dbc828ab05fd578f61325cdf4d4cf86f1a47e22fc1856b57bb459941a4bfa8d325b7168fb0e39c075122b56de3455933fa89927f025f";
+      sha512 = "8b399983719f73f65d2db17af40065faaab4793ab32ab1596e79b6f844d43fe4bf3386343b50a244480bb9f724defc795a6479703cfdce305dba0321e4b5fc09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/hu/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hu/firefox-62.0.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "deac0b43865960d665f13a2f0a77cd9413ba9b3172fd2660695464b5f72944f4013f6d9a47801e528db63c3e05496aa7df890624a39ddc6651ff5e8d0d02883e";
+      sha512 = "a5443cc52bcc5881a7297f2f200418e2a9791835f705d472bb657caceb0bb59f8dc1a7c424b196c2a66bf1f0c042d092a55c5b0d04a085dea702e11e433ed98e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/hy-AM/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hy-AM/firefox-62.0.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "22e134785777ea4e4fd72cdc7f17765d5bf8e943be33a0991baada71fb254f60f9ce9b68b4ba5640dc807a6db0e4ac3c81784a7a33e5096cda1833b22336f9de";
+      sha512 = "ea3e471c41d3e17c99c5b819ab8c3de8759a275d1ee1af66f133f835ebb6be9c7aeb52ae8b6f79d849e489e0c8f79f69d557d101efe681b27ff38b4e8b306b54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ia/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ia/firefox-62.0.2.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "91112a783ed4402cec7ce357e68806609b202bd1553c649271ccf4cb90a724ec612951b3acfe0eb64646957870726cb40f66b4a233cc0b73fdeed51083d6894a";
+      sha512 = "8bd09d0a8bfefc1a73b3a256a2e5be976b88998055299485c6270afc7ee7805a90e6ea9de144bd5ee8d3e40c079adac1dc29e9beb6d7ca376514fbac902f8de2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/id/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/id/firefox-62.0.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "8b87e2f13550334a96bde04fb7d61ac963548e35de2717b8738fd14fafb015944403a1bf175e2c13ceb7d4f482f5a6d56b57b44cf015b6dabfac3fed77d86f81";
+      sha512 = "c19859ab8b24aa239b0fc91930d8fb581850e631a9aa9033a98aea0287055d2a02ca6ae154ea23e37fd407a00999af1b5f7ce0854865b4b19a8462ccc3838cf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/is/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/is/firefox-62.0.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "8ea8972b5dc06bd12844fbafff92f6f493f604ebe03139043435fb5f761098cee81c0ccd42b67bcf3c7d1b370f3382858c08d4c14eb24a75fb851e78c51c296c";
+      sha512 = "68fc21b8b3aefe39bc6e87e8d90fb2652f2125af45520e7f91eef12615aff81d0c6237f3fbacce99259761f0f45c7b49aecb59894f161faa8760184271b2fbbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/it/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/it/firefox-62.0.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "b50a422dcd94d6ea69ab22426d6f79b3997313bf4e0e17f2af31d8b64ee85d603cde1768a730b279a10ff87639ba2af26185bdb81ea4bcb7b61947b1836ab700";
+      sha512 = "8c8866bff0ea8c2e70a82798253334feca4d96d2e79d37d479f8bf2b5580912565ce08bc47777ff9340ceb4e5677d01eda6cb1d28f25274bab400086493e4610";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ja/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ja/firefox-62.0.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "f52d31f997b291e2a0c9cedaafbcb5bc3ffd2148b52700eb5c140846f2809613c9061f339728b1810bc5f899fd208a3eedad06ace984dad41fac0a057c101ec1";
+      sha512 = "56e1bd61de818e9271d483bdbeac7c8a95e00a1a2acee2ad7d7e5779b0bba452170d8e0fa6463b0f978ee3c3df720bf338367b8b1f041e5000054268cf267af6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ka/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ka/firefox-62.0.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "e155d5c70de47d6f96f3f0e34ee317e90ac1aaeee4be68ed265d4bec46d52e6d67d7a140f3fb135dd086d9d6cfb5e8f80063a85f07e8b2197b23233a122efbb6";
+      sha512 = "de329fbe61b7563aaa2e62b1dad827445809df6f675518d7d19d9483acd6e23fc502f6abeabc13ed7c5eb2cc5b26a6ad0f0dd431c733f25a68a0ae7e2ee9923b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/kab/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/kab/firefox-62.0.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "153ed4ce1692e6691222779860a066b27dc9a5e747d79f4e1bd3273541d849d4b093062b3ff8d702786542fe99caefcde13f63cada7d0f67f461531aa32603a1";
+      sha512 = "f739aa9432ce0bd8bea4917f590b076c0d88643aa595be951dfec27872d534fa3926a7ed8d82527e95a70689d365c1219d164cda79e06b7418b90652bd2b7cc7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/kk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/kk/firefox-62.0.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "dd88ca465251b9489e766c268755a66babdcaa5962d40ddb4ebdc3f100a31f34b9b962bcf5fb5a0e46b2871e7ebb8d4169982a3a7174bbdaf5e6716274321ae3";
+      sha512 = "131b3ab83b953130cda7c9c388bf096edf90c424f86d1b6f4221b3601829a2ae0b7cc073a9336d7e4af588e497fb5df7731cca80a8413edf40a2f605927ba410";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/km/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/km/firefox-62.0.2.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "ccb473d36522f34c889ae3d211a1cd4ebf4e60da341c51c34cf05d9d8d75615b91eb4b00e327409c6fe406aaeaa07f8eec53c364bec50ae87c48c37ac1602e69";
+      sha512 = "6b0f4a83a746630b87b5a6c933f9aa65d6dbdb2e686af870562800aaa683371a23fbe79f31dcb0ef6ed397f556df83e1e30f83cb493921631e6ac1c8cbcd37f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/kn/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/kn/firefox-62.0.2.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "e1c718690141b6e89f4df017d5804efe07a1dfa838f1c23ca14b90438458278bfe90e178abb5ad6c52d43a993b6a65664c0e801a9f58ac57f9300a9bb6f9679a";
+      sha512 = "e4042bb8884ecf46396e9e45a70b57c22b0ef76dd6d452ee0609382e87669e6163c1d86845aa904e13894e750eb2f35d1c9a2b7987aa6e7d3fcd5eaad38d8199";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ko/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ko/firefox-62.0.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "e916fddce4044fd924f7aded0b0c082f82bb50fe0f7587d7aed4782d545be8b0dad67ed4d2c41bc75360f6ed7c236bd7c40cb3503b472792f1b27c8f0742f597";
+      sha512 = "02d30f4b2cc7285506239adfea681c780d0e16c1719c6cb68c908c54388e565bf98f1a3a3d98449b0e55b2cdda00627ad6c6f3e63fc9ad10f8c96b2df6138620";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/lij/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/lij/firefox-62.0.2.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "ab86bf8a92b05bc5defee073afa19ab00be704ce49a2d26f032edcbb60d9e5ef4e7a6196d31bec8d6e090c586a88d6e9b69f576ed5e587ca09dcfb60a0661b3d";
+      sha512 = "3cf57550bc091d756c5a2bb707aabf78cfab1660e1486c9276de5ad37cbae91be24f2170f5b20560ecf7f53d21217bd738b4e4277504d6f8934d3fe1ca5fcb1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/lt/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/lt/firefox-62.0.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "d716f7fc2c4015f97962d07ba7ffd6903675a6c36416765f2e81da43f9e4aba759b3ff31bd82bb7cf64c7d8b99f9d7454716f4ce6daa022f9fa31f4a49d9efee";
+      sha512 = "606f27cc78c5ee0ea3a61f6110611ecc10c35af63cb9e7c5fa1d3d0ca7a74ac8cd81fec30c1ffe5573c27e0a7f5f04ed82105b8cf26b7c22d648ea217cb57e83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/lv/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/lv/firefox-62.0.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "453e0bbf9eb2e9678ed029ecb797b701b4b39e030f9555bcca7eb6d56676bb44366e2d1ccc613b12a09f95d99ed08f9d3f34cfc9dd16cf38c9ab8e162dbae3e0";
+      sha512 = "ab028d6f31a966ffee99cbcd5263b18cae94c6e0a6e3e055d2c86354849b68120d870a142678184a32f816c7e5803d221f3230b895c6ec71dda20a6540101c50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/mai/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/mai/firefox-62.0.2.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "75e863c56d68cf2304f0c6c2f1861ce025d934d033341c23d3b95a70e73bfe66334c3beb77d9fd597f7b4091baf70729419ce452131009ccf03d2d33d16621c0";
+      sha512 = "faebf74c8a194f3dfe33addea35965b11f3f9e0c2b4bac4f9e4056c2248df24c26bc9e5a5696fe3f8c2e30e2172dae03fddcffef09bf7837fb6dd9fb6a1b3075";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/mk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/mk/firefox-62.0.2.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "bb87f94a4de4984544477837cde4186a55309eec70b85f0cffaf0cfe747b7c761d9a6553adfa1ab1fba72d732be855e2bb46e4c7f22a0f25529207b42b6da396";
+      sha512 = "dddef2e42aef03d11327ae2bc186c0dfd25e81b11845b319848e7c7253c101d32b2801548f6444f4ca01a91c365cb2bc6067e765490f3b876d149899a9edbf3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ml/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ml/firefox-62.0.2.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "5754b4a0a3c6c67191f4ef3dda7bc208766ed8171de772d4250033039b2b39dddc3bee800a28fffe41c68cfca82a5c9c6005625fc6bb5bf232b256d7bd58de71";
+      sha512 = "0157abf3d8dbd54f50f6a17d796fba6c66e0270649b8dea1674a696a036d2a59f5841bda55d8b326d90266a198ec0dea3a65753b09fffa583b104c976ab75cd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/mr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/mr/firefox-62.0.2.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "04e40c1d060b848cf957af34079f6d1cdd12589b0f31932f15b5ebf837e37d84d332fe3ee4a54c501ac47050233f891ec6617802d03472ae9d7e45baca809adc";
+      sha512 = "9c6aa7a0a943b8f62f6888effeb65c6c3f36aac3353ff54011eeba06ff2bb0b66ead6b75d1107ffc358184df927cb2dc7cd3bca183fc54879427baf74cb8e570";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ms/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ms/firefox-62.0.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "1b84fd0960c4952ff42bc50595683da47545fec9ab10d7b3fee3e3541b2a47aee084526766fb2bbf17dad413f4dd2dc458cb0c3e8153b7ef897a9573292abe2a";
+      sha512 = "b7a723f79a18db5b3d886c39e76a65975c2f6229022c62cab7d7e38c840206d9004c81da1783f4bf0cc373438518f1367f4a34e3764ea9919568ed4c8725c94a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/my/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/my/firefox-62.0.2.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "95fd60b8c2e9b0add3163c67a5b46e794f0105621293017838fdce48cf90a0b0bd62bcefec2693fa16b0616260b39587bf3c619b506d56b072f0c715398307ae";
+      sha512 = "5538fa15d3ff02409bf9145d384e1c8e28a182239a682aa5beba671c09a0b813b56af6482476d57084af6a5895ad21af1f6ead71ecf23ea817780aedbd33661b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/nb-NO/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/nb-NO/firefox-62.0.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "05c83c17e5470f009ab369d0c8a1c64cb8ecc008161fe1ced3ca85e9065f36f7ee4e220f8ed7a0320305ac31b35a035b5c8f7525b3b04c6b96e95e4044418f33";
+      sha512 = "8349c51a6b01301de6b0e0e37b665f44bd83abe9f771bc086c3f369534b6d4efc692441a46576b2335afda93cd8dbeff60ce17936e205e3c7212a2ef1b2844ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ne-NP/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ne-NP/firefox-62.0.2.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "2ad4756b8800554c54aa1f47effe512de332a61fcd7571e27ae83bd5e0100cd8b60fd5d8381764f9bc2b1d925ec4b53fc3c6c6a88840cb12f57e9acba892dc5d";
+      sha512 = "f16911685a7d233a8957780c5526be9e94c07f73b259dad09855b8c21bdba1756ca70ee71dd7b732ac56555135d749584986bf4501adb056373ded74f96e265d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/nl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/nl/firefox-62.0.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "a3ba32bb48a6bc386d49e4ec703f51cda3bf917673e23965d7f5e7977dc8ae0696b375535aa04d1a416b6b5655cb3302cb9738a238d9cc8a6bcb78dda52afae6";
+      sha512 = "07e271170d05cb87cee9361efe8fee2007ca032b462ce68c562406fde581f4baab96c2ccea66cf92b8e72aba4647e7bb8271ec50e3adcfff6b787699b687a23c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/nn-NO/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/nn-NO/firefox-62.0.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "35bac6119415eaca5c8d9fd2d57e0a550abcd7d069454202a02ce6418f9e47ae59563224763008f23d49604cde09ad251dc8785d2205d4e9623c138a97b69533";
+      sha512 = "eaace3b808dbc919d05a9701e7af2bdb241d57cb0356e4eb60b4706def37372a16b7767540947efaa91d5a3f338785187f83caf8bfa5bffe5f4f92aa3bec13d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/oc/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/oc/firefox-62.0.2.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "40d3e74b204da461cdd79163cc838e538a5dbb8c4e693a59d801202363cfba4bf48e01bcc87d247dce6b1fdad0a24f2bdd15272399e407b26293156698f7bf7c";
+      sha512 = "aeaab0fc9ba77aae2c0ddd92d7096c167a99335b3d795f232a24e685d49b53678bed59b6e873ce1c7667f76d1527bf685b910bb51b8defc539999500eac14d5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/or/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/or/firefox-62.0.2.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "2220ecdcb26b459ebb0fb3380bb8b9430c1a09aa899418b18a765a4ba76c8d35480f59b71edaf6047e0eae04146ec6dd6bf25ccb619f559a260ff6f2828a0db0";
+      sha512 = "92b82c7bca322a9bfb6e6df61c9f2b6d82cf39c67848f2905dd372a627eb0379d235982e5634577825ad72794fd1d49b2e591ad5347977dac9a745d1167f7467";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/pa-IN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pa-IN/firefox-62.0.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "91425dba14c27a3bbb744cf5added1545c071f466c6cfb77d7b2ff0b0b5ab289ffcb56821023e50d12deb4ff29cc5ae490c028420384da84811c661d277017f3";
+      sha512 = "2aec320ba120dd3632fa95599a9934ce133544e7b0d15a74236fb20435ab0a9ad44d6515f82897e7badeeeae19eb80d6b68fec4d000d63772d4e5ccd1f11d1eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/pl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pl/firefox-62.0.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "a5581c2e2d7de1187967af10802c4a6577a5bbf9a0ab56448b0695ca3fdee845117fa364ea53149b81a5aeb3ddab22c58ff65863fc981445bd34858766fb438c";
+      sha512 = "b62565b94eaae3ee225f2bbc8981f493594f48d40e8e8d83564a6d4ac6a4194c952663f9db52d7694993f08f714463b7607d659790236a727cbf803b084eb73e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/pt-BR/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pt-BR/firefox-62.0.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "70a9cc592980afbaa3efa37b57e190f6bd6c76fe975ee16b3a3b2e3498c65e792a83870f569836fe79fabc289c201b7f6764d4d512f9d561058eb496d1bc1cf8";
+      sha512 = "2b218b66feb456a86919b395d1cdc40aa73de6ebbca3bc4135c54d5dc1ac993bfaf169bc7b0d2d770aa6f4565e71ead1fa2aaab02dc7362a9f4e5a896dae2c2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/pt-PT/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pt-PT/firefox-62.0.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "8e1d94b4b3e01e684387b4e3c9439ee1df9712cef607f370d63ff0072876c2ad9e22a978fcaba14c03802c8fd5b559c6dc412fdadaa6a01425bb491852c4ce02";
+      sha512 = "d89122b993083bee798279c72a2d6296a5b966f7ac30269edcfe17a2036db648cd3e1e77eaf5f2479afc3c6831657267b22f2507176d62ee08dfaf4c100e074c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/rm/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/rm/firefox-62.0.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "77500b96558c055ea90750d99aeb096d789a920fac4fd368b95a032cfa565ea0ee1259503ef0d198c4802bbeeb847a3ca22f06ae79b6e554c54d336a99f61687";
+      sha512 = "4ecba1d3bc6b3bbbc3ca974afa86e9b6e7664a0dd23605ea34349bbf822fc2098e7dd394f132b43e2e4127eeec36ec820710391671405b14c414d966540b63e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ro/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ro/firefox-62.0.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "e3cfec0059f0372d2b3764a4c3809b7a8c9ee6e795bb1d8eccf663feb1d054be58c15569b8dcad55b5ad37a1332d950f5286ad88ca5db55441c1cb3dd879bb8d";
+      sha512 = "97e8ebd7bc491bd320106765408bdd88542bd932c3c1b43a373aa5679f20e2a0aa12b48182454ec36812dbf4044364850cfe3e6878bec670ee46e8971e9293cc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ru/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ru/firefox-62.0.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "91077e66da0403828807fe1a3ee274ac162898efafd651b3c243c315c9f0f1cfb88925e738b9bf25fa7fc0c7b747f2a9f2a5a1c77b87cb83d3aa620475239822";
+      sha512 = "f8f433e0d2970d028a01f1039951f1e725cae8e263bed9f0dff64387913ae269558f037d672a65d32614408cdd3267ddd65677dbcf212188c531d04960266535";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/si/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/si/firefox-62.0.2.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "f770321771e965776b55d7681783e3782b7ce4df3c3d7cce581a3de1db0f8fc8c3ded3d606fc7f7f61e62b33986e8e05ff64e49427a8cb85b68b7b6fe43f6c3b";
+      sha512 = "11620e27c01dd91114d5e2080b430876282316ce6d527100305806314b4e7fccc38f2e93165f3e544cd3ef63b03aeaf738d6079201a0f7ae3f867b2e0b28239f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/sk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sk/firefox-62.0.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "150792fbeebcd0969fdbef0827b617f83383bcaaf3eed9dac0790aa0ffb893d4498dae29eb480fda05a2feaca0428cf600bfb3398dfbcc921e92cf2ca01c7a1c";
+      sha512 = "0a43e8fdc1c3f2bc63b6bacc15f9e3f3527302d0d7f0f0e0cc9498bab7728cca944fddf886c33ab67c60bcd9bafa051db97c8e8a77e781d6869a4bdb8096f4b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/sl/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sl/firefox-62.0.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "d423c10683ba690a8d8eec50e4e966b7233d565e2c35b5fdd70aa917908daab5d01f847c32f7e24c604aa19ab941ca70c6e6613b39271d01f1370dbd974800fa";
+      sha512 = "343a22feab53142ff585985fbaa8a037dbe9c3d3c2c073361f8d4af3b74272a47e5df2053ea91b333bf0da15334b9512c0513726ae80176838774020a7c7c639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/son/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/son/firefox-62.0.2.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "7f1d638cbd729b51d959b0b1ee0e4ec5473f5478bf315c890fd9df20e3065861a5c8447399e973cac78bd078d2a1f0e1bad829f6b462ec6ffc55e7748760677a";
+      sha512 = "bb9c9c4bc82550b6d83c3b9995a1ca3afadc9fb5b27a5de4503682d29428ed7751895d1225a3b5ba8472d539c9efca957522187e4119e4e134f46b37da2f43e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/sq/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sq/firefox-62.0.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "823b4b5043e3fd8fcf0bcb345d00dbfa38e6e03fdf172a30c272f51eee7f9057ec99423c7117ab8d21e9037bcc1e19a7082401a0b25514e2258542aef4c4af80";
+      sha512 = "97b2c394f71e9bda6fa679353c579a01f40a4fb5b588bc177329d6fbfcff0d126e2db072c868eafd6078c26f9190f1a2d4c65f887754af4d25eb9c128d807030";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/sr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sr/firefox-62.0.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "a08ef0de87e4f01c11b20301e45e98d3bf10bbd4d2699de56f66470d7f4298aec3744f44888ba46ec1293fb713487f6df20bb9f5682a57827993f0ddd28cdde3";
+      sha512 = "84024816cfd48076ef5ddbe0af392ab5ae0bcb8a02cc0ee1f6d0dafdf5673d9dfee377e83f0a9508c11593d8f4db682ad400c336a1c37591c25864c9299939f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/sv-SE/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sv-SE/firefox-62.0.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "e3e65e32e5e11547e220bb34d0009257f3c4f18aec0fe961f310ef4b76311d8d885a01d6bc4420c2b97687b886c3d00c09d43af0c6c7eaca8e6a804d78d4bfe7";
+      sha512 = "b630b627b038b16ae1b97f669e79afccba95e66a93dc3b7358e26960ae836f1f3663a49394b7a9be9906871a2301824c6b1f78f1f38943b54e4631f9beb90407";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ta/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ta/firefox-62.0.2.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "47753ccbe4471ab3d3de3ea11992cd332251868ae3a7772e860531d013c657f5ff559d34592fedf7b52ecf3a54476dc2e0fc68119170afb9c482fccd04a36776";
+      sha512 = "1306d444c620f558894ea81512944e1d07dfe706306206d1638c2e86ae5a2dba4e02b5927e4c9250df3cbc607d15da15bf2cb1c9e1ff74332354ae883c6bcc42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/te/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/te/firefox-62.0.2.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "90327dd95f3a597692cf5ea54258c31ed813261f102a7f668f5bc5062499a6bfe64d2d241dc33ffdc5cd152802e7d462c7ffdbe4498825ad88be48d21031919b";
+      sha512 = "3b0e1d6fea01ac99e315419365afdee54c107dd33ad577b19fcd9a59de1a176f34497e607fc7466217ddef5a6c442a62f1dd41cdb137651c0274274cb9357171";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/th/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/th/firefox-62.0.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "652a7bf7f2a7c6fa27edbd5e78cfecd2df661e1a7a01cc532b1caaed53bd40025aaee2126dd1116e77ef9e050777e78e96537ed2decfe493caa1d03c7bbb0646";
+      sha512 = "7bcb0d7e17d397a7b114172234f3306f9faa28e7d9f8bb2db1399b58c28bd36ce4e478686c3ec98c76793cc75bbb974a316599b3a7c38fb034e852100ffa13e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/tr/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/tr/firefox-62.0.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "f98d45b831f51a0caa47fcaaaf1ed37f267035e1f1ab95ae0cfbafa06f03b89f99b7a7accb9812644f862b819c2bb294f5a3454ece80f775359ac77734a99d44";
+      sha512 = "5c543b8bf79fdcb605b6d763688ca5bcd1e61b0e2088441e1d6d6dd4f0823f9f3d2075f39776d582bb468dc41ef39f7d562c7ebb6d5e4f084c3c1aaf1e61de8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/uk/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/uk/firefox-62.0.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "6c67554c87c7941fec8193bfcdd9d5d0af906d13ab237e0ddd97733816d2df27fee5e11eb450e85f9143f71049219e8ef9c6cd4d327faf3e335247130cdd26f6";
+      sha512 = "2fe636a02d0adc75d00f67620fcfaba902d16b5d828c2c9770560300c33cd0a8a8bd7208f146943cd62ac0aa8e3be784ff8549de78eb4f247783e1cfc823dd1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/ur/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ur/firefox-62.0.2.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "0c90e5575d057d9f32c18a102d2db7848f8821d71edb3cb9ae4f2565a1cc2851da7fb1bd493e81dca003a50a9f26454af8cf0ef7f947ea42aa22baf20abc06d8";
+      sha512 = "c84e1bf737b3a4b93f77098a087bd7ae598364d6a15110d3032bab4ee8aab6d1a64ce3ec4ef17b197b920e334f1e57a7a093581b8ac3b1ecab85d9cbb2da2c50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/uz/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/uz/firefox-62.0.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "fc35bb30011063bda8c256b6c405bffae55ae7d67ce5809367aaadaddb1094acfe0186f2cd84b2dceb55a76358ee46e29ec013058e035123a7797b5ac49b6e4d";
+      sha512 = "cee9849825181c517a82c6f6cb07920767ff2c02d54b87c8e509e60bef3adff260f282882b9495b6034fa61b11e2cf831e3adc3ed3928ff32792a62084cf115b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/vi/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/vi/firefox-62.0.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "0c6a94f811ba509dc468b31f9448eba7f1004e6652a418db8ef84d03d79ff850237bd7555b8f73d515f8a0c546df371a18bc51ccd3dad069bc481f58f9a4c989";
+      sha512 = "a0eddaf392addf41017108ded0d32418175ab5ff7cddf74e3224929da93bc84cf07312671f16aa5652ecdc315707a4301c69b856be709f4298861298541a065f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/xh/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/xh/firefox-62.0.2.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "b113f1f4a81a7cac63a8604a8152bf651ebee3ad48eaabef84d09d3576b37b529f56c04fc9fd1b3326364aeaefad77cc123a97b662c85665c7f239384f5c6d7c";
+      sha512 = "50741d2ff1b7f1d9cf503af66ec61a2d19600ad7240db837392440b2943c6d96a7b8d5538ca24f0d528cbe9fbaede7964c9f8404474f95a1c022e193fa91f81e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/zh-CN/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/zh-CN/firefox-62.0.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "7c3da83ebdfbcaf8a67ac8cf953d648dd3eb54d1c9f6e74680b00ef94e01a0384a53d27c4a78312e25e284209f3e4c53661958347e3250eb820a20873e66c3fd";
+      sha512 = "103be3f37fa7a92c00d6465f93bedffc31527939bd85df0c742c04ac75f9ddec4018a368a2ff29730f5a055459b018c64afa344df255638ec3c26bb295e1a31a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0/linux-i686/zh-TW/firefox-62.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/zh-TW/firefox-62.0.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "659ea2bbd51d99a0c3573043a55ee580839e5f0323c57bb7b086ebc41a19f493baadecf67b64443b5abcf5db69e7e82e0c965a40b151d141557cda04b3ce6d52";
+      sha512 = "0ac22e595f2d87f75b586eabab07470f9eec16026a45902fb40c19fd2cbf93f2f88241900a13703edb89290953127c689bacbc0eccd560822e43bc07a97e3ddf";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -20,10 +20,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "62.0";
+    version = "62.0.2";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "0byxslbgr37sm1ra3wywl5c2a39qbkjwc227yp4j2l930m5j86m5g7rmv8zm944vv5vnyzmwhym972si229fm2lwq74p4xam5rfv948";
+      sha512 = "0j5q1aa7jhq4pydaywp8ymibc319wv3gw2q15qp14i069qk3fpn33zb5z86lhb6z864f88ikx3zxv6phqs96qvzj25yqbh7nxmzwhvv";
     };
 
     patches = nixpkgsPatches ++ [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -70,10 +70,10 @@ rec {
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    version = "60.2.0esr";
+    version = "60.2.1esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "1nf7nsycvzafvy4jjli5xh59d2mac17gfx91a1jh86f41w6qcsi3lvkfa8xhxsq8wfdsmqk1f4hmqzyx63h4m691qji7838g2nk49k7";
+      sha512 = "2mklws09haki91w3js2i5pv8g3z5ck4blnzxvdbk5qllqlv465hn7rvns78hbcbids55mqx50fsn0161la73v25zs04bf8xdhbkcpsm";
     };
 
     patches = nixpkgsPatches ++ [


### PR DESCRIPTION
###### Motivation for this change

- Moderate security fixes
- Other fixes

https://www.mozilla.org/en-US/firefox/62.0.2/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2018-22/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

