### PR TITLE
bitcoin: don't build things not used, enable parallel building

### DIFF
--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -20,7 +20,11 @@ stdenv.mkDerivation rec{
                   ++ optionals stdenv.isLinux [ utillinux ]
                   ++ optionals withGui [ qtbase qttools qrencode ];
 
-  configureFlags = [ "--with-boost-libdir=${boost.out}/lib" ]
+  configureFlags = [ "--with-boost-libdir=${boost.out}/lib"
+                     "--disable-bench"
+                     "--disable-tests"
+                     "--disable-gui-tests"
+                   ]
                      ++ optionals withGui [ "--with-gui=qt5"
                                             "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
                                           ];

--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec{
 
   configureFlags = [ "--with-boost-libdir=${boost.out}/lib"
                      "--disable-bench"
+                   ] ++ optionals (!doCheck) [
                      "--disable-tests"
                      "--disable-gui-tests"
                    ]

--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec{
   # find or load the Qt platform plugin "minimal""
   doCheck = false;
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "Peer-to-peer electronic cash system";
     longDescription= ''


### PR DESCRIPTION
This was taking a very long time to build,
the parallel build was the big win probably but
doesn't help building things not used.

Probably not used, anyway?


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---