### PR TITLE
inkscape, libreoffice-still: fixup to avoid needing to use old poppler

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     cd ${name}
   '';
 
-  patches = [ ./poppler-0.65.patch ];
+  patches = [ ./poppler-0.65.patch ./inkscape-0.92.3-poppler-0.64.patch ];
 
   postPatch = ''
     patchShebangs share/extensions

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation rec {
     cd ${name}
   '';
 
+  patches = [ ./poppler-0.65.patch ];
+
   postPatch = ''
     patchShebangs share/extensions
     patchShebangs fix-roff-punct

--- a/pkgs/applications/graphics/inkscape/inkscape-0.92.3-poppler-0.64.patch
+++ b/pkgs/applications/graphics/inkscape/inkscape-0.92.3-poppler-0.64.patch
@@ -1,0 +1,121 @@
+From f0697de012598ea84edafea9a326e5e101eccd2a Mon Sep 17 00:00:00 2001
+From: Eduard Braun <eduard.braun2@gmx.de>
+Date: Tue, 24 Apr 2018 19:18:26 +0200
+Subject: [PATCH] Fix compilation with poppler 0.64
+
+(cherry picked from commit a600c6438fef2f4c06f9a4a7d933d99fb054a973)
+---
+ src/extension/internal/pdfinput/pdf-parser.cpp  | 10 +++++-----
+ src/extension/internal/pdfinput/pdf-parser.h    |  2 +-
+ src/extension/internal/pdfinput/svg-builder.cpp |  4 ++--
+ src/extension/internal/pdfinput/svg-builder.h   |  3 +--
+ 4 files changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index 604b7f8079..721524e10a 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -2582,7 +2582,7 @@ void PdfParser::opShowSpaceText(Object args[], int /*numArgs*/)
+   }
+ }
+ 
+-void PdfParser::doShowText(GooString *s) {
++void PdfParser::doShowText(const GooString *s) {
+   GfxFont *font;
+   int wMode;
+   double riseX, riseY;
+@@ -2601,7 +2601,7 @@ void PdfParser::doShowText(GooString *s) {
+   font = state->getFont();
+   wMode = font->getWMode();
+ 
+-  builder->beginString(state, s);
++  builder->beginString(state);
+ 
+   // handle a Type 3 char
+   if (font->getType() == fontType3 && 0) {//out->interpretType3Chars()) {
+@@ -2631,7 +2631,7 @@ void PdfParser::doShowText(GooString *s) {
+     double lineX = state->getLineX();
+     double lineY = state->getLineY();
+     oldParser = parser;
+-    p = s->getCString();
++    p = g_strdup(s->getCString());
+     len = s->getLength();
+     while (len > 0) {
+       n = font->getNextChar(p, len, &code,
+@@ -2686,7 +2686,7 @@ void PdfParser::doShowText(GooString *s) {
+ 
+   } else {
+     state->textTransformDelta(0, state->getRise(), &riseX, &riseY);
+-    p = s->getCString();
++    p = g_strdup(s->getCString());
+     len = s->getLength();
+     while (len > 0) {
+       n = font->getNextChar(p, len, &code,
+@@ -2732,7 +2732,7 @@ void PdfParser::opXObject(Object args[], int /*numArgs*/)
+ {
+   Object obj1, obj2, obj3, refObj;
+ 
+-  char *name = args[0].getName();
++  char *name = g_strdup(args[0].getName());
+ #if defined(POPPLER_NEW_OBJECT_API)
+   if ((obj1 = res->lookupXObject(name)).isNull()) {
+ #else
+diff --git a/src/extension/internal/pdfinput/pdf-parser.h b/src/extension/internal/pdfinput/pdf-parser.h
+index e28fecc2e1..f985b15cad 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.h
++++ b/src/extension/internal/pdfinput/pdf-parser.h
+@@ -287,7 +287,7 @@ private:
+   void opMoveShowText(Object args[], int numArgs);
+   void opMoveSetShowText(Object args[], int numArgs);
+   void opShowSpaceText(Object args[], int numArgs);
+-  void doShowText(GooString *s);
++  void doShowText(const GooString *s);
+ 
+   // XObject operators
+   void opXObject(Object args[], int numArgs);
+diff --git a/src/extension/internal/pdfinput/svg-builder.cpp b/src/extension/internal/pdfinput/svg-builder.cpp
+index a448be6397..617861928d 100644
+--- a/src/extension/internal/pdfinput/svg-builder.cpp
++++ b/src/extension/internal/pdfinput/svg-builder.cpp
+@@ -1020,7 +1020,7 @@ void SvgBuilder::updateFont(GfxState *state) {
+     GfxFont *font = state->getFont();
+     // Store original name
+     if (font->getName()) {
+-        _font_specification = font->getName()->getCString();
++        _font_specification = g_strdup(font->getName()->getCString());
+     } else {
+         _font_specification = (char*) "Arial";
+     }
+@@ -1361,7 +1361,7 @@ void SvgBuilder::_flushText() {
+     _glyphs.clear();
+ }
+ 
+-void SvgBuilder::beginString(GfxState *state, GooString * /*s*/) {
++void SvgBuilder::beginString(GfxState *state) {
+     if (_need_font_update) {
+         updateFont(state);
+     }
+diff --git a/src/extension/internal/pdfinput/svg-builder.h b/src/extension/internal/pdfinput/svg-builder.h
+index ad15c9c06f..ed2a4d48e0 100644
+--- a/src/extension/internal/pdfinput/svg-builder.h
++++ b/src/extension/internal/pdfinput/svg-builder.h
+@@ -29,7 +29,6 @@ namespace Inkscape {
+ #include <glibmm/ustring.h>
+ 
+ #include "CharTypes.h"
+-class GooString;
+ class Function;
+ class GfxState;
+ struct GfxColor;
+@@ -136,7 +135,7 @@ public:
+     void clearSoftMask(GfxState *state);
+ 
+     // Text handling
+-    void beginString(GfxState *state, GooString *s);
++    void beginString(GfxState *state);
+     void endString(GfxState *state);
+     void addChar(GfxState *state, double x, double y,
+                  double dx, double dy,
+-- 
+2.17.0
+

--- a/pkgs/applications/graphics/inkscape/poppler-0.65.patch
+++ b/pkgs/applications/graphics/inkscape/poppler-0.65.patch
@@ -1,0 +1,29 @@
+From 332a80f4847715546be9a00756f693b4aa1316e2 Mon Sep 17 00:00:00 2001
+From: Jan Palus <atler@pld-linux.org>
+Date: Fri, 25 May 2018 00:30:17 +0200
+Subject: [PATCH] Fix compilation with poppler 0.65.0
+
+replace unused includes with one that is actually used
+
+Signed-off-by: Jan Palus <atler@pld-linux.org>
+---
+ src/extension/internal/pdfinput/pdf-parser.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index 6c498f9..caaeca1 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -37,8 +37,7 @@ extern "C" {
+ #include "util/units.h"
+ 
+ #include "goo/gmem.h"
+-#include "goo/GooTimer.h"
+-#include "goo/GooHash.h"
++#include "goo/GooString.h"
+ #include "GlobalParams.h"
+ #include "CharTypes.h"
+ #include "Object.h"
+-- 
+2.17.0
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17368,7 +17368,6 @@ with pkgs;
   });
   libreoffice-still-unwrapped = callPackage ../applications/office/libreoffice/still.nix
   (libreoffice-args // {
-      poppler = poppler_0_61;
   });
 
   libreoffice-fresh = lowPrio (callPackage ../applications/office/libreoffice/wrapper.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17122,7 +17122,6 @@ with pkgs;
 
   inkscape = callPackage ../applications/graphics/inkscape {
     lcms = lcms2;
-    poppler = poppler_0_61;
   };
 
   inspectrum = libsForQt5.callPackage ../applications/misc/inspectrum { };


### PR DESCRIPTION
libreoffice-still apparently no longer needs it (probably after big recent update)
and inkscape can use newer poppler with small patch apparently.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---