### PR TITLE
xsecurelock: add extra derivation parameter and NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -752,6 +752,7 @@
   ./services/x11/xautolock.nix
   ./services/x11/xbanish.nix
   ./services/x11/xfs.nix
+  ./services/x11/xsecurelock.nix
   ./services/x11/xserver.nix
   ./system/activation/activation-script.nix
   ./system/activation/top-level.nix

--- a/nixos/modules/services/x11/xsecurelock.nix
+++ b/nixos/modules/services/x11/xsecurelock.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.xserver.xsecurelock;
+
+  # Script for the image screensaver.
+  imageSaver = pkgs.writeScriptBin "saver_image" ''
+    #!${pkgs.bash}/bin/sh
+    
+    # Fall back to blanking the screen with the built-in module if we don't
+    # have an image file.
+    if [[ -z "$XSECURELOCK_IMAGE_FILE" ]]; then
+      exec ./saver_blank
+    fi
+    
+    # Otherwise, we draw the image onto the specified window.
+    exec ${pkgs.xloadimage}/bin/xloadimage \
+      -fullscreen \
+      -windowid "$XSCREENSAVER_WINDOW" \
+      "$XSECURELOCK_IMAGE_FILE"
+  '';
+
+in {
+
+  options = {
+    services.xserver.xsecurelock = {
+      enable = mkEnableOption "xsecurelock";
+
+      imageSaver = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          If enabled, create a screen saver module for xsecurelock that will
+          display an image file.
+        '';
+      };
+
+      extraModules = mkOption  {
+        type = with types; listOf path;
+        default = [];
+
+        description = ''
+          Extra modules to make available to xautolock. Module files must start
+          with "auth_" or "saver_" in order for xautolock to run them, though
+          files with other names may be referenced.
+        '';
+
+        example = literalExample ''
+          services.xserver.xsecurelock.extraModules =
+            let
+              pkg = lib.writeScriptBin "saver_example" '''
+                echo "Do something here; falling back to built-in..."
+                exec ./saver_blank 
+              ''';
+            in
+              [ "''${pkg}/bin/saver_example" ];
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.xsecurelock;
+
+        description = ''
+          The xsecurelock package to use.
+
+          This may be helpful if you wish to customize the package in ways
+          other than adding additional modules.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [
+      (cfg.package.override {
+        extraModules = cfg.extraModules
+          ++ optional cfg.imageSaver "${imageSaver}/bin/saver_image";
+      })
+    ];
+
+  };
+}

--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -1,6 +1,25 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, libX11, libXcomposite, libXft, libXmu, pam, apacheHttpd, imagemagick
-, pamtester, xscreensaver }:
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, autoreconfHook
+, pkgconfig
+
+, libX11
+, libXcomposite
+, libXft
+, libXmu
+, pam
+, apacheHttpd
+, imagemagick
+, pamtester
+, xscreensaver
+
+# Extra modules to be copied into the derivation's helper directory;
+# xsecurelock will only run modules from this directory, so they must be part
+# of the derivation.
+, extraModules ? []
+}:
 
 stdenv.mkDerivation rec {
   name = "xsecurelock-${version}";
@@ -18,6 +37,13 @@ stdenv.mkDerivation rec {
     libX11 libXcomposite libXft libXmu pam
     apacheHttpd imagemagick pamtester
   ];
+
+  # Allow adding extra modules to the helper directory
+  postInstall =
+    let
+      copyHelper = path: "cp -v ${path} $out/libexec/xsecurelock/";
+    in
+      builtins.concatStringsSep "\n" (map copyHelper extraModules);
 
   configureFlags = [
     "--with-pam-service-name=login"


### PR DESCRIPTION
###### Motivation for this change
I'd like to use `xsecurelock` in NixOS, but adding a new screensaver or auth module requires that you build the changes into the derivation.  I've added a NixOS module that allows easier configuration of such modules.

I would appreciate any input; I think this is the first NixOS module I've ever written from scratch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc? @fpletz (maintainer of `xsecurelock`)