### PR TITLE
Revert "python: ldappool: 2.2.0 -> 2.3.0"

### DIFF
--- a/pkgs/development/python-modules/ldappool/default.nix
+++ b/pkgs/development/python-modules/ldappool/default.nix
@@ -3,12 +3,12 @@
 
 buildPythonPackage rec {
   name = "ldappool-${version}";
-  version = "2.3.0";
+  version = "2.2.0";
 
   src = fetchPypi {
     pname = "ldappool";
     inherit version;
-    sha256 = "899d38e891372981166350c813ff5ce2ad8ac383311edccda8102362c1d60952";
+    sha256 = "1akmzf51cjfvmd0nvvm562z1w9vq45zsx6fa72kraqgsgxhnrhqz";
   };
 
   nativeBuildInputs = [ pbr ];


### PR DESCRIPTION
###### Motivation for this change

This reverts commit 29acc8339fd5eb1f84ed99d9b71381269ec67a04.

This commit bumped `pythonPackages.ldappool` to 2.3.0, but missed the additional check input `stestr` which has several dependencies that aren't packaged in `nixpkgs` ATM, so the fastest way is to simply revert the patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

