### PR TITLE
python3Packages.py3exiv2: fix build

### DIFF
--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, isPy3k, fetchPypi, stdenv, exiv2, boost, libcxx }:
+{ buildPythonPackage, isPy3k, fetchPypi, stdenv, exiv2, boost, libcxx, substituteAll, python }:
 
 buildPythonPackage rec {
   pname = "py3exiv2";
@@ -16,7 +16,12 @@ buildPythonPackage rec {
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.isDarwin "-I${libcxx}/include/c++/v1";
 
   # fix broken libboost_python3 detection
-  patches = [ ./setup.patch ];
+  patches = [
+    (substituteAll {
+      src = ./setup.patch;
+      version = "3${stdenv.lib.versions.minor python.version}";
+    })
+  ];
 
   meta = {
     homepage = "https://launchpad.net/py3exiv2";

--- a/pkgs/development/python-modules/py3exiv2/setup.patch
+++ b/pkgs/development/python-modules/py3exiv2/setup.patch
@@ -5,7 +5,7 @@
                      return l.replace('libboost', 'boost')
  
 -libboost = get_libboost_name()
-+libboost = 'boost_python3'
++libboost = 'boost_python@version@'
  
  setup(
      name='py3exiv2',


### PR DESCRIPTION
###### Motivation for this change

Recent boost versions name their `python3` shared objects
`boost_python3x` rather than `boost_python3`.

See https://hydra.nixos.org/build/80712295
Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

