### PR TITLE
dotnet-sdk: Reduce closure: Unpack to a subdirectory to prevent copying build files

### DIFF
--- a/pkgs/development/compilers/dotnet/sdk/default.nix
+++ b/pkgs/development/compilers/dotnet/sdk/default.nix
@@ -22,9 +22,9 @@ in
     };
 
     unpackPhase = ''
-    mkdir src
-    cd src
-    tar xvzf $src
+      mkdir src
+      cd src
+      tar xvzf $src
     '';
 
     buildPhase = ''

--- a/pkgs/development/compilers/dotnet/sdk/default.nix
+++ b/pkgs/development/compilers/dotnet/sdk/default.nix
@@ -21,7 +21,11 @@ in
       sha512 = "639f9f68f225246d9cce798d72d011f65c7eda0d775914d1394df050bddf93e2886555f5eed85a75d6c72e9063a54d8aa053c64c326c683b94e9e0a0570e5654";
     };
 
-    unpackPhase = "tar xvzf $src";
+    unpackPhase = ''
+    mkdir src
+    cd src
+    tar xvzf $src
+    '';
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
###### Motivation for this change

`env-vars` of the setup script is accidentally copied to `$out` directory, resulting in all inputs being added as runtime dependencies.
```
% nix why-depends /nix/store/pj4vifg24dhag3jqckljmahwabkwcz88-dotnet-sdk-2.1.401/ /nix/store/i2sfx353yg2njfs1vjqily0rkcl1jy2i-dotnet-sdk-2.1.401-linux-x64.tar.gz
/nix/store/pj4vifg24dhag3jqckljmahwabkwcz88-dotnet-sdk-2.1.401
╚═══env-vars: …ash".declare -x src="/nix/store/i2sfx353yg2njfs1vjqily0rkcl1jy2i-dotnet-sdk-2.1.401-linux-x64.ta…
    => /nix/store/i2sfx353yg2njfs1vjqily0rkcl1jy2i-dotnet-sdk-2.1.401-linux-x64.tar.gz
```

**before**
```
% nix path-info -rS /nix/store/pj4vifg24dhag3jqckljmahwabkwcz88-dotnet-sdk-2.1.401/ | sort -nk2|numfmt --field 2 --to=iec
/nix/store/z82dl6ialp166drqihzkz67nkl6w3l16-move-sbin.sh                                664
/nix/store/mjjy30kxz775bhhi6j9phw81qh6dsbrf-move-docs.sh                                760
/nix/store/a92kz10cwkpa91k5239inl3fd61zp5dh-move-lib64.sh                               896
/nix/store/81ikflgpwzgjk8b5vmvg9gaw9mbkc86k-compress-man-pages.sh                      1.1K
/nix/store/15kgcm8hnd99p7plqzx7p4lcr2jni4df-set-source-date-epoch-to-latest.sh         1.5K
/nix/store/mqbgca1svm5ncd3i3ih6w62v2hknmhvq-audit-tmpdir.sh                            1.5K
/nix/store/jw961avfhaq38h828wnawqsqniasqfwz-strip.sh                                   1.8K
/nix/store/gpy3r9ss5ngfkib8ylx7jzgahq7m0x5b-patch-shebangs.sh                          2.9K
/nix/store/9ny6szla9dg61jv8q22qbnqsz37465n0-multiple-outputs.sh                        7.4K
/nix/store/x4n2gl488ir336hd5nq992fldx7yikfg-linux-headers-4.15                         4.5M
/nix/store/fg4yq8i8wd08xg3fy58l6q73cjy8hjr2-glibc-2.27                                  24M
/nix/store/ynb9h0q59ykdpmsn5m2qrkmnq1p683wr-expand-response-params                      24M
/nix/store/63j8mi5vjyxfc89rhjknwxaxqg3a2sx2-paxctl-0.9                                  24M
/nix/store/1kk3vawy29wy3xlh8rp0nlhsrjc4gp51-keyutils-1.5.10-lib                         24M
/nix/store/wwhp4klykgvd7xwl94izc8xxb9idf4wy-bzip2-1.0.6.0.1                             24M
/nix/store/gzxckycv7v43aa1pf0manyva5p58nd4m-attr-2.4.47                                 24M
/nix/store/bv6znzsv2qkbcwwa251dx7n5dshz3nr3-zlib-1.2.11                                 24M
/nix/store/kspghzdcy9wfdikc81mm8lm2gg3zn2w4-ed-1.14.2                                   24M
/nix/store/1iih7pgc7krhis13zaq8ajdcb2hd10d9-bzip2-1.0.6.0.1-bin                         24M
/nix/store/ix13jm9a1jfkcg1fs3skagyz4s1w77r6-gzip-1.9                                    24M
/nix/store/xbnwfn8dslrmq9w39k3a52bdvigwqx23-acl-2.2.52                                  25M
/nix/store/zsglbnyb42fg0gyxrg6sm96phfj7ig4k-nghttp2-1.32.0-lib                          25M
/nix/store/6v0w8pn91zqdm2ri7wgrlg3y16gqsbij-xz-5.2.4                                    25M
/nix/store/61m8xswm9xxwb3ddw1za2cxvcikgk656-patch-2.7.6                                 25M
/nix/store/26lgqf0ja6rx8dnz972a3f56vfxmmmv5-xz-5.2.4-bin                                25M
/nix/store/3jg1sj3va3rmm4fhw5xkybq9q3v8wnyi-pcre-8.42                                   25M
/nix/store/rx397w2d3h760g8mjkbyv8qx4a4lmfqp-libunwind-1.2.1                             25M
/nix/store/ny5p32137wfyzdm485xfdck21w1gyl3g-gnused-4.5                                  25M
/nix/store/czx8vkrb9jdgjyz8qfksh10vrnqa723l-bash-4.4-p23                                25M
/nix/store/ql3azyviwyc6w73h6prk1j2945skfapf-gnumake-4.2.1                               25M
/nix/store/9f89z51na7w931aja8lqlmhqny9h16cj-gnugrep-3.1                                 26M
/nix/store/8gd9mslrhrmim2zf23s6jxhh9bsbxp4f-util-linux-2.32.1                           26M
/nix/store/zdadpaj5z8k9ifkgsc16yvfjn4wdv0r2-gawk-4.2.1                                  26M
/nix/store/5hir9w0mnrw86yv7sf4qghsard0ccwl1-glibc-2.27-bin                              27M
/nix/store/lxbaya2mzjc3xzbcsykrcbvcf5vxvfia-gnutar-1.30                                 27M
/nix/store/574xmi6n0ys0qdxk9q2lh7fk5ipjsg85-libkrb5-1.15.2                              28M
/nix/store/9kr8r78bwk12050ppywfbhg1vrsd6dp8-openssl-1.0.2p                              28M
/nix/store/k97dv1k3fpsxcrrdqx79n1d72py1qssc-libssh2-1.8.0                               28M
/nix/store/zk5zj2307zxaq7dx585yia3dn5k4qlsl-gcc-7.3.0-lib                               30M
/nix/store/bqp3d4yhpx6h60fv8jww5id0nkm44034-patchelf-0.9                                30M
/nix/store/9c9vryq51hlw0jr8ddk2yk1qvkaq0vl2-curl-7.61.0                                 32M
/nix/store/akak0rxhbi4n87z3nx78ipv76frvj841-glibc-2.27-dev                              34M
/nix/store/wm8va53fh5158ipi0ic9gir64hrvqv1z-coreutils-8.29                              35M
/nix/store/2wdj4rznh37jd44lxz9nn6ymnbqs9axp-diffutils-3.6                               36M
/nix/store/g5dlpwd44kd75i71nwzii8w4bp4inxwk-findutils-4.6.0                             36M
/nix/store/4xgzbmqhkvh8141c496by0d9kvma54zy-icu4c-59.1                                  61M
/nix/store/i2sfx353yg2njfs1vjqily0rkcl1jy2i-dotnet-sdk-2.1.401-linux-x64.tar.gz        157M
/nix/store/vv4r320p5yd1k01kld62q1lppjxcswhb-gcc-7.3.0                                  166M
/nix/store/h0lbngpv6ln56hjj59i6l77vxq25flbz-binutils-2.30                              242M
/nix/store/6yz7851vibc1xjxpiyfzqqi2ksbv6qah-binutils-wrapper-2.30                      263M
/nix/store/iw94llkj05wgaz268mlzvgx8jkbi1ss0-gcc-wrapper-7.3.0                          396M
/nix/store/i6vl5lwlz5jbkg4r6p340dwmj6fha3xq-stdenv-linux                               406M
/nix/store/pj4vifg24dhag3jqckljmahwabkwcz88-dotnet-sdk-2.1.401                         927M
```



**after**

```
% nix path-info -rS /nix/store/ys2idcfikc0yl10ba27433ksp52x0v7x-dotnet-sdk-2.1.401 | sort -nk2|numfmt --field 2 --to=iec
/nix/store/fg4yq8i8wd08xg3fy58l6q73cjy8hjr2-glibc-2.27                  24M
/nix/store/ckch7vy96c34q6mlxwvczlwpdv2as7xq-keyutils-1.5.10-lib         24M
/nix/store/bv6znzsv2qkbcwwa251dx7n5dshz3nr3-zlib-1.2.11                 24M
/nix/store/3krnixx4qr2xagba18chz0j9g64w5cxh-nghttp2-1.32.0-lib          25M
/nix/store/6v0w8pn91zqdm2ri7wgrlg3y16gqsbij-xz-5.2.4                    25M
/nix/store/gs75d1gaalcqcxm01v4jl34cmzqpjrfd-libunwind-1.2.1             25M
/nix/store/czx8vkrb9jdgjyz8qfksh10vrnqa723l-bash-4.4-p23                25M
/nix/store/vj3cqbz3ca9bl25s76x760a636mnfjqj-util-linux-2.32.1           26M
/nix/store/810wimadvyxffr9rpgrplnv7fg1sp95c-libkrb5-1.15.2              28M
/nix/store/gsgdj34vv5hh3iyyfm7yh69j6dq0br9q-openssl-1.0.2p              28M
/nix/store/n6i3f9q2r1ikbdhy6j51c30fslrhqvww-libssh2-1.8.0               28M
/nix/store/zk5zj2307zxaq7dx585yia3dn5k4qlsl-gcc-7.3.0-lib               30M
/nix/store/j1wn33xcznwhdjnf7kdngqhzvs4f2r70-curl-7.61.0                 32M
/nix/store/3jlpc2zyymn3davrz3ccgx4a9z53gzls-icu4c-59.1                  61M
/nix/store/ys2idcfikc0yl10ba27433ksp52x0v7x-dotnet-sdk-2.1.401         396M

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

