### PR TITLE
roundcube: init at 1.3.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4421,6 +4421,11 @@
     github = "vrthra";
     name = "Rahul Gopinath";
   };
+  vskilet = {
+    email = "victor@sene.ovh";
+    github = "vskilet";
+    name = "Victor SENE";
+  };
   vyp = {
     email = "elisp.vim@gmail.com";
     github = "vyp";

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name= "roundcube-${version}";
+  version = "1.3.7";
+
+  src = fetchurl {
+    url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz"; 
+    sha256 = "31bd37d0f89dc634064f170c6ed8981c258754b6f81eccb59a2634b29d0bb01c";
+  };
+
+  installPhase = ''
+    mkdir -p $out/
+    cp -R . $out/
+    ln -sf /etc/roundcube/config.inc.php $out/config/config.inc.php
+    rm -rf $out/installer
+  '';
+
+  meta = {
+    description = "Open Source Webmail Software";
+    maintainers = with stdenv.lib.maintainers; [ vskilet ];
+    license = stdenv.lib.licenses.gpl3;
+    platforms = stdenv.lib.platforms.all;
+  };
+}
+

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -1,17 +1,14 @@
-{ lib, stdenv, fetchurl }:
-
-stdenv.mkDerivation rec {
-  name= "roundcube-${version}";
+{ lib, stdenv, fetchzip }:
+let
   version = "1.3.7";
+in
+fetchzip rec {
+  name= "roundcube-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz"; 
-    sha256 = "31bd37d0f89dc634064f170c6ed8981c258754b6f81eccb59a2634b29d0bb01c";
-  };
-
-  installPhase = ''
-    mkdir -p $out/
-    cp -R . $out/
+  url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz"; 
+  sha256 = "0xwqy0adynx7066a0cvz9vyg85waax1i4p70kcdkz7q5jnw4jzhf";
+ 
+  extraPostFetch = ''
     ln -sf /etc/roundcube/config.inc.php $out/config/config.inc.php
     rm -rf $out/installer
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1532,6 +1532,8 @@ with pkgs;
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
     conf = config.riot-web.conf or null;
   };
+  
+  roundcube = callPackage ../servers/roundcube { };
 
   rsbep = callPackage ../tools/backup/rsbep { };
 


### PR DESCRIPTION
###### Motivation for this change
Add a package for roundcube
I usage roundcube here : https://roundcube.sene.ovh
This is my first package pull request so I might have forgotten some things. Feedbacks are welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

