### PR TITLE
compactor: 0.11.0 -> 0.11.1

### DIFF
--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "compactor-${version}";
-  version = "0.11.0";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "dns-stats";
     repo = "compactor";
     rev = "${version}";
-    sha256 = "1zn6w99xqq5igaz0n89429i78a5pj4nnfn1mm5yv1yfbn1lm0y3l";
+    sha256 = "0bd82956nkpdmfj8f05z37hy7f33cd2nfdxr7s9fgz1xi5flnzjc";
   };
 
   # cbor-diag, cddl and wireshark-cli are only used for tests.


### PR DESCRIPTION
###### Motivation for this change
Update compactor, adding compatibility with libtins 4.0 (required for #38208)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

