### PR TITLE
iputils: upstream fixes for musl

### DIFF
--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -30,6 +30,16 @@ in stdenv.mkDerivation {
       url = "https://github.com/iputils/iputils/commit/d0ff83e87ea9064d9215a18e93076b85f0f9e828.patch";
       sha256 = "05wrwf0bfmax69bsgzh3b40n7rvyzw097j8z5ix0xsg0kciygjvx";
     })
+    (fetchpatch {
+      name = "add-missing-idn-declarations.patch";
+      url = "https://github.com/iputils/iputils/commit/5007d7067918fb3d950d34c01d059e5222db679a.patch";
+      sha256 = "0dhgxdhjcbb2q6snm3mjp38l066knykmrx4k8rn167cizn7akpdx";
+    })
+    (fetchpatch {
+      name = "fix-ping-idn.patch";
+      url = "https://github.com/iputils/iputils/commit/25899e849aa3abc1ad29ebf0b830262a859eaed5.patch";
+      sha256 = "1bqjcdjjnc2j6indcli7s7gbbhkcaligvh94asixfrmjzkbn533n";
+    })
   ];
 
   prePatch = ''


### PR DESCRIPTION
Applied regardless of platform since they're from upstream
and will be included in next version.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---