### PR TITLE
shades-of-gray-theme: init at 1.1.1

### DIFF
--- a/pkgs/misc/themes/shades-of-gray/default.nix
+++ b/pkgs/misc/themes/shades-of-gray/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, gtk_engines, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "shades-of-gray-theme-${version}";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "WernerFP";
+    repo = "Shades-of-gray-theme";
+    rev = version;
+    sha256 = "1m75m6aq4hh39m8qrmbkaw31j4gzkh63ial4xnhw2habf31av682";
+  };
+
+  buildInputs = [ gtk_engines ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -a Shades-of-gray* README.md preview_01.png $out/share/themes/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A flat dark GTK-theme with ergonomic contrasts";
+    homepage = https://github.com/WernerFP/Shades-of-gray-theme;
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22030,6 +22030,8 @@ with pkgs;
     libsemanage = libsemanage.override { python = python3; };
   };
 
+  shades-of-gray-theme = callPackage ../misc/themes/shades-of-gray { };
+
   sierra-gtk-theme = callPackage ../misc/themes/sierra { };
 
   slock = callPackage ../misc/screensavers/slock {


### PR DESCRIPTION
###### Motivation for this change

Add [Shades-of-gray](https://github.com/WernerFP/Shades-of-gray-theme) theme.

See also https://www.opendesktop.org/p/1244058/.

It is a flat dark GTK-theme with ergonomic contrasts. It supports Gnome, Cinnamon, Xfce4, Mate and Openbox. Theme customizations for Firefox, Thunderbird and Inkscape are additionally included. Shades-of-gray is available in seven color variants:
- Gray
- Arch
- Cerulean
- Firebrick
- Harvest
- Orient
- Patina

![preview_01](https://user-images.githubusercontent.com/1217934/45964083-29930e80-bffb-11e8-9016-5aded474641e.png)

![251b3d4ed61bc234d76fc3a168ddf79939fb](https://user-images.githubusercontent.com/1217934/45964026-01a3ab00-bffb-11e8-8978-c7f453b1a4ba.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).