### PR TITLE
llvm7: update sanitizer patch to fix w/musl

### DIFF
--- a/pkgs/development/compilers/llvm/7/sanitizers-nongnu.patch
+++ b/pkgs/development/compilers/llvm/7/sanitizers-nongnu.patch
@@ -1,7 +1,7 @@
-From 7b4b3333a2718628b1d510ec1d8438ad67308299 Mon Sep 17 00:00:00 2001
+From f7a253f8f85d0f49df6b73996737a3e84ac64236 Mon Sep 17 00:00:00 2001
 From: Will Dietz <w@wdtz.org>
-Date: Fri, 29 Jun 2018 09:48:59 -0500
-Subject: [PATCH] Ported to 6.0, taken from gentoo-musl project.
+Date: Mon, 24 Sep 2018 11:17:25 -0500
+Subject: [PATCH] Ported to 7.0, taken from gentoo-musl project.
 
 ------
 Ported to compiler-rt-sanitizers-5.0.0. Taken from
@@ -13,7 +13,7 @@ Taken from gentoo-musl project, with a few additional minor fixes.
 ---
  lib/asan/asan_linux.cc                        |  4 +-
  lib/interception/interception_linux.cc        |  2 +-
- lib/interception/interception_linux.h         |  3 +-
+ lib/interception/interception_linux.h         |  2 +-
  lib/msan/msan_linux.cc                        |  2 +-
  lib/sanitizer_common/sanitizer_allocator.cc   |  2 +-
  .../sanitizer_common_interceptors_ioctl.inc   |  4 +-
@@ -24,7 +24,7 @@ Taken from gentoo-musl project, with a few additional minor fixes.
  .../sanitizer_platform_interceptors.h         |  4 +-
  .../sanitizer_platform_limits_posix.cc        | 37 +++++++++++--------
  lib/tsan/rtl/tsan_platform_linux.cc           |  2 +-
- 13 files changed, 51 insertions(+), 35 deletions(-)
+ 13 files changed, 51 insertions(+), 34 deletions(-)
 
 diff --git a/lib/asan/asan_linux.cc b/lib/asan/asan_linux.cc
 index 625f32d40..73cf77aca 100644
@@ -49,34 +49,33 @@ index 625f32d40..73cf77aca 100644
  void AsanCheckDynamicRTPrereqs() {}
  void AsanCheckIncompatibleRT() {}
 diff --git a/lib/interception/interception_linux.cc b/lib/interception/interception_linux.cc
-index c991550a4..2b706418b 100644
+index 26bfcd8f6..529b234f7 100644
 --- a/lib/interception/interception_linux.cc
 +++ b/lib/interception/interception_linux.cc
 @@ -43,7 +43,7 @@ bool GetRealFunctionAddress(const char *func_name, uptr *func_addr,
  }
  
  // Android and Solaris do not have dlvsym
--#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS
-+#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+-#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD
++#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
  void *GetFuncAddrVer(const char *func_name, const char *ver) {
    return dlvsym(RTLD_NEXT, func_name, ver);
  }
 diff --git a/lib/interception/interception_linux.h b/lib/interception/interception_linux.h
-index 98fe51b85..c13302b98 100644
+index 942c25609..24a4d5080 100644
 --- a/lib/interception/interception_linux.h
 +++ b/lib/interception/interception_linux.h
-@@ -35,8 +35,7 @@ void *GetFuncAddrVer(const char *func_name, const char *ver);
-       (::__interception::uptr) & (func),                                   \
+@@ -36,7 +36,7 @@ void *GetFuncAddrVer(const char *func_name, const char *ver);
        (::__interception::uptr) & WRAP(func))
  
--// Android and Solaris do not have dlvsym
--#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS
-+#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+ // Android,  Solaris and OpenBSD do not have dlvsym
+-#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD
++#if !SANITIZER_ANDROID && !SANITIZER_SOLARIS && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
  #define INTERCEPT_FUNCTION_VER_LINUX_OR_FREEBSD(func, symver) \
    (::__interception::real_##func = (func##_f)(                \
         unsigned long)::__interception::GetFuncAddrVer(#func, symver))
 diff --git a/lib/msan/msan_linux.cc b/lib/msan/msan_linux.cc
-index 4e6321fcb..4d50feb82 100644
+index 385a650c4..6e30a8ce9 100644
 --- a/lib/msan/msan_linux.cc
 +++ b/lib/msan/msan_linux.cc
 @@ -13,7 +13,7 @@
@@ -87,12 +86,12 @@ index 4e6321fcb..4d50feb82 100644
 +#if SANITIZER_FREEBSD || (SANITIZER_LINUX && !SANITIZER_NONGNU) || SANITIZER_NETBSD
  
  #include "msan.h"
- #include "msan_thread.h"
+ #include "msan_report.h"
 diff --git a/lib/sanitizer_common/sanitizer_allocator.cc b/lib/sanitizer_common/sanitizer_allocator.cc
-index fc4f7a75a..76cf4f769 100644
+index 6bfd5e5ee..048f6154f 100644
 --- a/lib/sanitizer_common/sanitizer_allocator.cc
 +++ b/lib/sanitizer_common/sanitizer_allocator.cc
-@@ -23,7 +23,7 @@ namespace __sanitizer {
+@@ -27,7 +27,7 @@ const char *SecondaryAllocatorName = "LargeMmapAllocator";
  
  // ThreadSanitizer for Go uses libc malloc/free.
  #if SANITIZER_GO || defined(SANITIZER_USE_MALLOC)
@@ -102,10 +101,10 @@ index fc4f7a75a..76cf4f769 100644
  #  if !SANITIZER_GO
  extern "C" void *__libc_memalign(uptr alignment, uptr size);
 diff --git a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
-index 24e7548a5..20259b1d6 100644
+index 2d633c173..b6eb23116 100644
 --- a/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
 +++ b/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
-@@ -102,7 +102,7 @@ static void ioctl_table_fill() {
+@@ -104,7 +104,7 @@ static void ioctl_table_fill() {
    _(SIOCGETVIFCNT, WRITE, struct_sioc_vif_req_sz);
  #endif
  
@@ -114,7 +113,7 @@ index 24e7548a5..20259b1d6 100644
    // Conflicting request ids.
    // _(CDROMAUDIOBUFSIZ, NONE, 0);
    // _(SNDCTL_TMR_CONTINUE, NONE, 0);
-@@ -363,7 +363,7 @@ static void ioctl_table_fill() {
+@@ -365,7 +365,7 @@ static void ioctl_table_fill() {
    _(VT_WAITACTIVE, NONE, 0);
  #endif
  
@@ -137,59 +136,59 @@ index 469c8eb7e..24f87867d 100644
                         void *old_rlim) {
    if (new_rlim) PRE_READ(new_rlim, struct_rlimit64_sz);
 diff --git a/lib/sanitizer_common/sanitizer_linux.cc b/lib/sanitizer_common/sanitizer_linux.cc
-index 6c83e8db4..542c4fe64 100644
+index 96d6c1eff..9e2b7fb9d 100644
 --- a/lib/sanitizer_common/sanitizer_linux.cc
 +++ b/lib/sanitizer_common/sanitizer_linux.cc
-@@ -522,13 +522,13 @@ const char *GetEnv(const char *name) {
+@@ -541,13 +541,13 @@ const char *GetEnv(const char *name) {
  #endif
  }
  
--#if !SANITIZER_FREEBSD && !SANITIZER_NETBSD
-+#if !SANITIZER_FREEBSD && !SANITIZER_NETBSD && !SANITIZER_NONGNU
+-#if !SANITIZER_FREEBSD && !SANITIZER_NETBSD && !SANITIZER_OPENBSD
++#if !SANITIZER_FREEBSD && !SANITIZER_NETBSD && !SANITIZER_OPENBSD && !SANITIZER_NONGNU
  extern "C" {
-   SANITIZER_WEAK_ATTRIBUTE extern void *__libc_stack_end;
+ SANITIZER_WEAK_ATTRIBUTE extern void *__libc_stack_end;
  }
  #endif
  
--#if !SANITIZER_GO && !SANITIZER_FREEBSD && !SANITIZER_NETBSD
-+#if (!SANITIZER_GO || SANITIZER_NONGNU) && !SANITIZER_FREEBSD && !SANITIZER_NETBSD
+-#if !SANITIZER_GO && !SANITIZER_FREEBSD && !SANITIZER_NETBSD &&                \
++#if (!SANITIZER_GO || SANITIZER_NONGNU) && !SANITIZER_FREEBSD && !SANITIZER_NETBSD &&                \
+     !SANITIZER_OPENBSD
  static void ReadNullSepFileToArray(const char *path, char ***arr,
                                     int arr_size) {
-   char *buff;
-@@ -569,6 +569,10 @@ static void GetArgsAndEnv(char ***argv, char ***envp) {
+@@ -590,6 +590,10 @@ static void GetArgsAndEnv(char ***argv, char ***envp) {
  #elif SANITIZER_NETBSD
    *argv = __ps_strings->ps_argvstr;
-   *argv = __ps_strings->ps_envstr;
+   *envp = __ps_strings->ps_envstr;
 +#elif SANITIZER_NONGNU
 +    static const int kMaxArgv = 2000, kMaxEnvp = 2000;
 +    ReadNullSepFileToArray("/proc/self/cmdline", argv, kMaxArgv);
 +    ReadNullSepFileToArray("/proc/self/environ", envp, kMaxEnvp);
- #else
+ #else // SANITIZER_FREEBSD
  #if !SANITIZER_GO
    if (&__libc_stack_end) {
 diff --git a/lib/sanitizer_common/sanitizer_linux_libcdep.cc b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
-index 56fdfc870..a932d5db1 100644
+index 4962ff832..438f94dbe 100644
 --- a/lib/sanitizer_common/sanitizer_linux_libcdep.cc
 +++ b/lib/sanitizer_common/sanitizer_linux_libcdep.cc
-@@ -174,7 +174,7 @@ bool SanitizerGetThreadName(char *name, int max_len) {
+@@ -179,7 +179,7 @@ __attribute__((unused)) static bool GetLibcVersion(int *major, int *minor,
  }
  
- #if !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO && \
--    !SANITIZER_NETBSD && !SANITIZER_SOLARIS
-+    !SANITIZER_NETBSD && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
+ #if !SANITIZER_FREEBSD && !SANITIZER_ANDROID && !SANITIZER_GO &&               \
+-    !SANITIZER_NETBSD && !SANITIZER_OPENBSD && !SANITIZER_SOLARIS
++    !SANITIZER_NETBSD && !SANITIZER_OPENBSD && !SANITIZER_SOLARIS && !SANITIZER_NONGNU
  static uptr g_tls_size;
  
  #ifdef __i386__
-@@ -207,7 +207,7 @@ void InitTlsSize() { }
- 
- #if (defined(__x86_64__) || defined(__i386__) || defined(__mips__) \
-     || defined(__aarch64__) || defined(__powerpc64__) || defined(__s390__) \
--    || defined(__arm__)) && SANITIZER_LINUX && !SANITIZER_ANDROID
-+    || defined(__arm__)) && SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
+@@ -261,7 +261,7 @@ void InitTlsSize() { }
+ #if (defined(__x86_64__) || defined(__i386__) || defined(__mips__) ||          \
+      defined(__aarch64__) || defined(__powerpc64__) || defined(__s390__) ||    \
+      defined(__arm__)) &&                                                      \
+-    SANITIZER_LINUX && !SANITIZER_ANDROID
++    SANITIZER_LINUX && !SANITIZER_ANDROID && !SANITIZER_NONGNU
  // sizeof(struct pthread) from glibc.
- static atomic_uintptr_t kThreadDescriptorSize;
+ static atomic_uintptr_t thread_descriptor_size;
  
-@@ -391,7 +391,7 @@ int GetSizeFromHdr(struct dl_phdr_info *info, size_t size, void *data) {
+@@ -426,7 +426,7 @@ int GetSizeFromHdr(struct dl_phdr_info *info, size_t size, void *data) {
  
  #if !SANITIZER_GO
  static void GetTls(uptr *addr, uptr *size) {
@@ -198,29 +197,29 @@ index 56fdfc870..a932d5db1 100644
  # if defined(__x86_64__) || defined(__i386__) || defined(__s390__)
    *addr = ThreadSelf();
    *size = GetTlsSize();
-@@ -432,7 +432,7 @@ static void GetTls(uptr *addr, uptr *size) {
-       *addr = (uptr)tcb->tcb_dtv[1];
-     }
-   }
+@@ -470,7 +470,7 @@ static void GetTls(uptr *addr, uptr *size) {
+ #elif SANITIZER_OPENBSD
+   *addr = 0;
+   *size = 0;
 -#elif SANITIZER_ANDROID
 +#elif SANITIZER_ANDROID || SANITIZER_NONGNU
    *addr = 0;
    *size = 0;
  #elif SANITIZER_SOLARIS
-@@ -448,7 +448,7 @@ static void GetTls(uptr *addr, uptr *size) {
+@@ -486,7 +486,7 @@ static void GetTls(uptr *addr, uptr *size) {
  #if !SANITIZER_GO
  uptr GetTlsSize() {
- #if SANITIZER_FREEBSD || SANITIZER_ANDROID || SANITIZER_NETBSD || \
--    SANITIZER_SOLARIS
-+    SANITIZER_SOLARIS || SANITIZER_NONGNU
+ #if SANITIZER_FREEBSD || SANITIZER_ANDROID || SANITIZER_NETBSD ||              \
+-    SANITIZER_OPENBSD || SANITIZER_SOLARIS
++    SANITIZER_OPENBSD || SANITIZER_SOLARIS || SANITIZER_NONGNU
    uptr addr, size;
    GetTls(&addr, &size);
    return size;
 diff --git a/lib/sanitizer_common/sanitizer_platform.h b/lib/sanitizer_common/sanitizer_platform.h
-index 334903c26..fc2afac2c 100644
+index d81e25580..e10680ac8 100644
 --- a/lib/sanitizer_common/sanitizer_platform.h
 +++ b/lib/sanitizer_common/sanitizer_platform.h
-@@ -195,6 +195,12 @@
+@@ -208,6 +208,12 @@
  # define SANITIZER_SOLARIS32 0
  #endif
  
@@ -230,14 +229,14 @@ index 334903c26..fc2afac2c 100644
 +# define SANITIZER_NONGNU 0
 +#endif
 +
- // By default we allow to use SizeClassAllocator64 on 64-bit platform.
- // But in some cases (e.g. AArch64's 39-bit address space) SizeClassAllocator64
- // does not work well and we need to fallback to SizeClassAllocator32.
+ #if defined(__myriad2__)
+ # define SANITIZER_MYRIAD2 1
+ #else
 diff --git a/lib/sanitizer_common/sanitizer_platform_interceptors.h b/lib/sanitizer_common/sanitizer_platform_interceptors.h
-index b99ac4480..628d226a1 100644
+index f95539a73..6c53b3415 100644
 --- a/lib/sanitizer_common/sanitizer_platform_interceptors.h
 +++ b/lib/sanitizer_common/sanitizer_platform_interceptors.h
-@@ -38,7 +38,7 @@
+@@ -39,7 +39,7 @@
  # include "sanitizer_platform_limits_solaris.h"
  #endif
  
@@ -246,17 +245,17 @@ index b99ac4480..628d226a1 100644
  # define SI_LINUX_NOT_ANDROID 1
  #else
  # define SI_LINUX_NOT_ANDROID 0
-@@ -291,7 +291,7 @@
-   (SI_FREEBSD || SI_MAC || SI_LINUX_NOT_ANDROID)
+@@ -322,7 +322,7 @@
  #define SANITIZER_INTERCEPT_ETHER_R (SI_FREEBSD || SI_LINUX_NOT_ANDROID)
- #define SANITIZER_INTERCEPT_SHMCTL                       \
--  (SI_NETBSD || SI_SOLARIS || ((SI_FREEBSD || SI_LINUX_NOT_ANDROID) && \
-+  (SI_NETBSD || SI_SOLARIS || ((SI_FREEBSD || SI_LINUX_NOT_ANDROID || SANITIZER_NONGNU) && \
-                  SANITIZER_WORDSIZE == 64))  // NOLINT
+ #define SANITIZER_INTERCEPT_SHMCTL          \
+   (SI_NETBSD || SI_OPENBSD || SI_SOLARIS || \
+-  ((SI_FREEBSD || SI_LINUX_NOT_ANDROID) && \
++  ((SI_FREEBSD || SI_LINUX_NOT_ANDROID || SANITIZER_NONGNU) && \
+     SANITIZER_WORDSIZE == 64))  // NOLINT
  #define SANITIZER_INTERCEPT_RANDOM_R SI_LINUX_NOT_ANDROID
  #define SANITIZER_INTERCEPT_PTHREAD_ATTR_GET SI_POSIX
 diff --git a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
-index feb7bad6f..4e89ab2a6 100644
+index 54da635d7..2f6ff69c3 100644
 --- a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
 +++ b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
 @@ -14,6 +14,9 @@
@@ -357,9 +356,9 @@ index feb7bad6f..4e89ab2a6 100644
  CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_type);
 +#endif
  
- COMPILER_CHECK(sizeof(__sanitizer_dirent) <= sizeof(dirent));
- CHECK_SIZE_AND_OFFSET(dirent, d_ino);
-@@ -1138,7 +1145,7 @@ CHECK_SIZE_AND_OFFSET(mntent, mnt_passno);
+ #ifndef __GLIBC_PREREQ
+ #define __GLIBC_PREREQ(x, y) 0
+@@ -1145,7 +1152,7 @@ CHECK_SIZE_AND_OFFSET(mntent, mnt_passno);
  
  CHECK_TYPE_SIZE(ether_addr);
  
@@ -368,7 +367,7 @@ index feb7bad6f..4e89ab2a6 100644
  CHECK_TYPE_SIZE(ipc_perm);
  # if SANITIZER_FREEBSD
  CHECK_SIZE_AND_OFFSET(ipc_perm, key);
-@@ -1199,7 +1206,7 @@ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_dstaddr);
+@@ -1206,7 +1213,7 @@ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_dstaddr);
  CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_data);
  #endif
  
@@ -377,7 +376,7 @@ index feb7bad6f..4e89ab2a6 100644
  COMPILER_CHECK(sizeof(__sanitizer_mallinfo) == sizeof(struct mallinfo));
  #endif
  
-@@ -1249,7 +1256,7 @@ COMPILER_CHECK(__sanitizer_XDR_DECODE == XDR_DECODE);
+@@ -1256,7 +1263,7 @@ COMPILER_CHECK(__sanitizer_XDR_DECODE == XDR_DECODE);
  COMPILER_CHECK(__sanitizer_XDR_FREE == XDR_FREE);
  #endif
  
@@ -386,7 +385,7 @@ index feb7bad6f..4e89ab2a6 100644
  COMPILER_CHECK(sizeof(__sanitizer_FILE) <= sizeof(FILE));
  CHECK_SIZE_AND_OFFSET(FILE, _flags);
  CHECK_SIZE_AND_OFFSET(FILE, _IO_read_ptr);
-@@ -1268,7 +1275,7 @@ CHECK_SIZE_AND_OFFSET(FILE, _chain);
+@@ -1275,7 +1282,7 @@ CHECK_SIZE_AND_OFFSET(FILE, _chain);
  CHECK_SIZE_AND_OFFSET(FILE, _fileno);
  #endif
  
@@ -396,10 +395,10 @@ index feb7bad6f..4e89ab2a6 100644
  CHECK_SIZE_AND_OFFSET(_obstack_chunk, limit);
  CHECK_SIZE_AND_OFFSET(_obstack_chunk, prev);
 diff --git a/lib/tsan/rtl/tsan_platform_linux.cc b/lib/tsan/rtl/tsan_platform_linux.cc
-index e14d5f575..389a3bc88 100644
+index de989b780..51a97b554 100644
 --- a/lib/tsan/rtl/tsan_platform_linux.cc
 +++ b/lib/tsan/rtl/tsan_platform_linux.cc
-@@ -285,7 +285,7 @@ void InitializePlatform() {
+@@ -294,7 +294,7 @@ void InitializePlatform() {
  // This is required to properly "close" the fds, because we do not see internal
  // closes within glibc. The code is a pure hack.
  int ExtractResolvFDs(void *state, int *fds, int nfd) {
@@ -409,5 +408,5 @@ index e14d5f575..389a3bc88 100644
    struct __res_state *statp = (struct __res_state*)state;
    for (int i = 0; i < MAXNS && cnt < nfd; i++) {
 -- 
-2.18.0
+2.19.0
 

--- a/pkgs/development/libraries/libpfm/default.nix
+++ b/pkgs/development/libraries/libpfm/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
 
   installFlags = "DESTDIR=\${out} PREFIX= LDCONFIG=true";
 
+  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
   meta = with stdenv.lib; {
     description = "Helper library to program the performance monitoring events";
     longDescription = ''


### PR DESCRIPTION
On the way, fix libpfm to not die on warnings.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---