### PR TITLE
eztrace: 1.0.6 -> 1.1-7, fix build

### DIFF
--- a/pkgs/development/tools/profiling/EZTrace/default.nix
+++ b/pkgs/development/tools/profiling/EZTrace/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.6";
+  version = "1.1-7";
   name = "EZTrace-${version}";
 
   src = fetchurl {
-    url = "https://gforge.inria.fr/frs/download.php/file/34082/eztrace-${version}.tar.gz";
-    sha256 = "06q5y9qmdn1h0wjmy28z6gwswskmph49j7simfqcqwv05gvd9svr";
+    url = "https://gforge.inria.fr/frs/download.php/file/37155/eztrace-${version}.tar.gz";
+    sha256 = "0cr2d4fdv4ljvag55dsz3rpha1jan2gc3jhr06ycyk43450pl58p";
   };
 
   # Goes past the rpl_malloc linking failure; fixes silent file breakage


### PR DESCRIPTION
###### Motivation for this change

See https://hydra.nixos.org/build/80721509
Addresses #45960

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

