### PR TITLE
pythonPackages.elasticsearch-dsl: 0.0.9 -> 6.2.1

### DIFF
--- a/pkgs/development/python-modules/elasticsearch-dsl/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-dsl/default.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, elasticsearch
+, ipaddress
+, python-dateutil
+, pytz
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "elasticsearch-dsl";
+  version = "6.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0f0w23kzyym0fkzisdkcl4xpnm8fsi97v1kskyvfrhj3mxy179fh";
+  };
+
+  propagatedBuildInputs = [ elasticsearch python-dateutil six ]
+                          ++ stdenv.lib.optional (!isPy3k) ipaddress;
+
+  # ImportError: No module named test_elasticsearch_dsl
+  # Tests require a local instance of elasticsearch
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "High level Python client for Elasticsearch";
+    longDescription = ''
+      Elasticsearch DSL is a high-level library whose aim is to help with
+      writing and running queries against Elasticsearch. It is built on top of
+      the official low-level client (elasticsearch-py).
+    '';
+    homepage = https://github.com/elasticsearch/elasticsearch-dsl-py;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ desiderius ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2197,27 +2197,9 @@ in {
 
   elasticsearch = callPackage ../development/python-modules/elasticsearch { };
 
-  elasticsearchdsl = buildPythonPackage (rec {
-    name = "elasticsearch-dsl-0.0.9";
-
-    src = pkgs.fetchurl {
-      url = "mirror://pypi/e/elasticsearch-dsl/${name}.tar.gz";
-      sha256 = "1gdcdshk881vy18p0czcmbb3i4s5hl8llnfg6961b6x7jkvhihbj";
-    };
-
-    buildInputs = with self; [ covCore dateutil elasticsearch mock pytest pytestcov unittest2 urllib3 pytz ];
-
-    # ImportError: No module named test_elasticsearch_dsl
-    # Tests require a local instance of elasticsearch
-    doCheck = false;
-
-    meta = {
-      description = "Python client for Elasticsearch";
-      homepage = https://github.com/elasticsearch/elasticsearch-dsl-py;
-      license = licenses.asl20;
-      maintainers = with maintainers; [ desiderius ];
-    };
-  });
+  elasticsearch-dsl = callPackage ../development/python-modules/elasticsearch-dsl { };
+  # alias
+  elasticsearchdsl = self.elasticsearch-dsl;
 
   elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator { };
 


### PR DESCRIPTION
###### Motivation for this change
This bumps the `elasticsearchdsl` package to the current version 6.2.1, moves the file outside `python-packages.nix`, matches it's name with upstream, and adds an alias as fallback.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

