### PR TITLE
linuxPackages.jool: 3.5.7 -> unstable-20180706

### DIFF
--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, kernel }:
 
-assert stdenv.lib.versionOlder kernel.version "4.17";
+assert stdenv.lib.versionOlder kernel.version "4.18";
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };

--- a/pkgs/os-specific/linux/jool/source.nix
+++ b/pkgs/os-specific/linux/jool/source.nix
@@ -1,11 +1,11 @@
 { fetchFromGitHub }:
 
 rec {
-  version = "3.5.7";
+  version = "unstable-20180706";
   src = fetchFromGitHub {
     owner = "NICMx";
     repo = "Jool";
-    rev = "v${version}";
-    sha256 = "1qxhrchhm4lbyxkp6wm47a85aa4d9wlyy3kdijl8rarngvh8j1yx";
+    rev = "de791931d94e972c36bb3c102a9cadab5230c285";
+    sha256 = "09mr7lc9k17znpslsfmndx4vgl240llcgblxm92fizmwz23y1d6c";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

3.5.7 [doesn't build with kernel 4.14.71](https://hydra.nixos.org/job/nixpkgs/trunk/linuxPackages.jool.x86_64-linux).
Needs most recent upstream revision to build, which supports kernels up to 4.17.

Relevant for ZHF #45960 

###### Things done

- [x] built in a sandbox on NixOS

---
cc @fpletz 
