### PR TITLE
clightning: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/applications/altcoins/clightning.nix
+++ b/pkgs/applications/altcoins/clightning.nix
@@ -4,14 +4,14 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "clightning-${version}";
-  version = "0.6";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     fetchSubmodules = true;
     owner = "ElementsProject";
     repo = "lightning";
     rev = "v${version}";
-    sha256 = "1xbi8c7kn21wj255fxnb9s0sqnzbn3wsz4p96z084k8mw1nc71vn";
+    sha256 = "0qx30i1c97ic4ii8bm0sk9dh76nfg4ihl9381gxjj14i4jr1q8y4";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Update to the latest release.

Highlights for c-lightning users
--------------------------------

  - Less stuck payments: Liveness ping test before locking up funds with peers.
  - Better routing: now considers size of channels.
  - Fewer spurious closes: fee estimate improvements, and new feerates command
  - Several annoying bugs fixed.

Highlights for the network
--------------------------

  - Gossipd now less spammy with channel_update.
  - option_data_loss_protect to protect peers against being out-of-date.
  - Payment errors now refer to the correct channel.

Internal Improvements
---------------------

  - Simplified client flow; after init message exchange by connectd, each is
    isolated in its own daemon.
  - JSON parameter handling vastly simplfied.
  - Python testing framework now uses proper fixtures, and split into separate
    files.
  - Many other cleanups and clarifications.
  - We keepachangelog.com!

Signed-off-by: William Casarin <jb55@jb55.com>

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @roconnor 

