### PR TITLE
xfitter: init at 2.0.0

### DIFF
--- a/pkgs/applications/science/misc/root/5.nix
+++ b/pkgs/applications/science/misc/root/5.nix
@@ -1,0 +1,77 @@
+{ stdenv, fetchurl, cmake, pcre, pkgconfig, python2
+, libX11, libXpm, libXft, libXext, libGLU_combined, zlib, libxml2, lzma, gsl_1
+, Cocoa, OpenGL, noSplash ? false }:
+
+stdenv.mkDerivation rec {
+  name = "root-${version}";
+  version = "5.34.36";
+
+  src = fetchurl {
+    url = "https://root.cern.ch/download/root_v${version}.source.tar.gz";
+    sha256 = "1kbx1jxc0i5xfghpybk8927a0wamxyayij9c74zlqm0595gqx1pw";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ cmake pcre python2 zlib libxml2 lzma gsl_1 ]
+    ++ stdenv.lib.optionals (!stdenv.isDarwin) [ libX11 libXpm libXft libXext libGLU_combined ]
+    ++ stdenv.lib.optionals (stdenv.isDarwin) [ Cocoa OpenGL ]
+    ;
+
+  patches = [
+    ./sw_vers_root5.patch
+  ];
+
+  preConfigure = ''
+    patchShebangs build/unix/
+    ln -s ${stdenv.lib.getDev stdenv.cc.libc}/include/AvailabilityMacros.h cint/cint/include/
+  '' + stdenv.lib.optionalString noSplash ''
+    substituteInPlace rootx/src/rootx.cxx --replace "gNoLogo = false" "gNoLogo = true"
+  '';
+
+  cmakeFlags = [
+    "-Drpath=ON"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-Dalien=OFF"
+    "-Dbonjour=OFF"
+    "-Dcastor=OFF"
+    "-Dchirp=OFF"
+    "-Ddavix=OFF"
+    "-Ddcache=OFF"
+    "-Dfftw3=OFF"
+    "-Dfitsio=OFF"
+    "-Dfortran=OFF"
+    "-Dgfal=OFF"
+    "-Dgsl_shared=ON"
+    "-Dgviz=OFF"
+    "-Dhdfs=OFF"
+    "-Dkrb5=OFF"
+    "-Dldap=OFF"
+    "-Dmathmore=ON"
+    "-Dmonalisa=OFF"
+    "-Dmysql=OFF"
+    "-Dodbc=OFF"
+    "-Dopengl=ON"
+    "-Doracle=OFF"
+    "-Dpgsql=OFF"
+    "-Dpythia6=OFF"
+    "-Dpythia8=OFF"
+    "-Drfio=OFF"
+    "-Dsqlite=OFF"
+    "-Dssl=OFF"
+    "-Dxml=ON"
+    "-Dxrootd=OFF"
+  ]
+  ++ stdenv.lib.optional stdenv.isDarwin "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks";
+
+  enableParallelBuilding = true;
+
+  setupHook = ./setup-hook.sh;
+
+  meta = with stdenv.lib; {
+    homepage = https://root.cern.ch/;
+    description = "A data analysis framework";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/applications/science/misc/root/sw_vers_root5.patch
+++ b/pkgs/applications/science/misc/root/sw_vers_root5.patch
@@ -1,0 +1,104 @@
+diff --git a/build/unix/compiledata.sh b/build/unix/compiledata.sh
+--- a/build/unix/compiledata.sh
++++ b/build/unix/compiledata.sh
+@@ -49,7 +49,7 @@ fi
+ 
+ if [ "$ARCH" = "macosx" ] || [ "$ARCH" = "macosx64" ] || \
+    [ "$ARCH" = "macosxicc" ]; then
+-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
++   macosx_minor=7
+    SOEXT="so"
+    if [ $macosx_minor -ge 5 ]; then
+       if [ "x`echo $SOFLAGS | grep -- '-install_name'`" != "x" ]; then
+diff --git a/cmake/modules/SetUpMacOS.cmake b/cmake/modules/SetUpMacOS.cmake
+--- a/cmake/modules/SetUpMacOS.cmake
++++ b/cmake/modules/SetUpMacOS.cmake
+@@ -12,25 +12,11 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} /usr/X11R6)
+ #---------------------------------------------------------------------------------------------------------
+ 
+ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+-  EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
+-                  COMMAND cut -d . -f 1-2
+-                  OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+-  MESSAGE(STATUS "Found a Mac OS X System ${MACOSX_VERSION}")
+-  EXECUTE_PROCESS(COMMAND sw_vers "-productVersion"
+-                  COMMAND cut -d . -f 2
+-                  OUTPUT_VARIABLE MACOSX_MINOR OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
+-  if(MACOSX_VERSION VERSION_GREATER 10.7 AND ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
+     set(libcxx ON CACHE BOOL "Build using libc++" FORCE)
+-  endif()
+ 
+-  if(${MACOSX_MINOR} GREATER 4)
+     #TODO: check haveconfig and rpath -> set rpath true
+     #TODO: check Thread, define link command
+     #TODO: more stuff check configure script
+-    execute_process(COMMAND /usr/sbin/sysctl machdep.cpu.extfeatures OUTPUT_VARIABLE SYSCTL_OUTPUT)
+-    if(${SYSCTL_OUTPUT} MATCHES 64)
+-       MESSAGE(STATUS "Found a 64bit system")
+        set(ROOT_ARCHITECTURE macosx64)
+        SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+        SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -m64")
+@@ -38,28 +24,6 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64")
+        SET(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} -m64")
+-    else(${SYSCTL_OUTPUT} MATCHES 64)
+-       MESSAGE(STATUS "Found a 32bit system")
+-       SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+-       SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
+-       SET(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} -m32")
+-    endif(${SYSCTL_OUTPUT} MATCHES 64)
+-  endif()
+-
+-  if(MACOSX_VERSION VERSION_GREATER 10.6)
+-    set(MACOSX_SSL_DEPRECATED ON)
+-  endif()
+-  if(MACOSX_VERSION VERSION_GREATER 10.7)
+-    set(MACOSX_ODBC_DEPRECATED ON)
+-  endif()
+-  if(MACOSX_VERSION VERSION_GREATER 10.8)
+-    set(MACOSX_GLU_DEPRECATED ON)
+-    set(MACOSX_KRB5_DEPRECATED ON)
+-    set(MACOSX_TMPNAM_DEPRECATED ON)
+-  endif()
+-  if(MACOSX_VERSION VERSION_GREATER 10.9)
+-    set(MACOSX_LDAP_DEPRECATED ON)
+-  endif()
+ 
+   if (CMAKE_COMPILER_IS_GNUCXX)
+      message(STATUS "Found GNU compiler collection")
+@@ -132,7 +96,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
+   endif()
+ 
+   #---Set Linker flags----------------------------------------------------------------------
+-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  -mmacosx-version-min=${MACOSX_VERSION} -Wl,-rpath,@loader_path/../lib")
++  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,@loader_path/../lib")
+ 
+ 
+ else (CMAKE_SYSTEM_NAME MATCHES Darwin)
+diff --git a/config/root-config.in b/config/root-config.in
+--- a/config/root-config.in
++++ b/config/root-config.in
+@@ -391,7 +391,7 @@ macosxicc)
+    ;;
+ macosx64)
+    # MacOS X with gcc (GNU cc v4.x) in 64 bit mode
+-   macosx_minor=`sw_vers | sed -n 's/ProductVersion://p' | cut -d . -f 2`
++   macosx_minor=7
+    # cannot find the one linked to libGraf if relocated after built
+    if [ $macosx_minor -le 4 ]; then
+       rootlibs="$rootlibs -lfreetype"
+diff --git a/cint/ROOT/CMakeLists.txt b/cint/ROOT/CMakeLists.txt
+--- a/cint/ROOT/CMakeLists.txt
++++ b/cint/ROOT/CMakeLists.txt
+@@ -232,9 +232,7 @@ foreach(_name ${CINTINCDLLNAMES})
+                        DEPENDS ${HEADER_OUTPUT_PATH}/systypes.h
+                       )
+
+-    if(MACOSX_MINOR GREATER 4)
+       set(_ExtraFlag "-D__DARWIN_UNIX03")
+-    endif()
+
+     add_custom_command(OUTPUT ${OutFileName}
+                        COMMAND cint_tmp -K -w1 -z${_name} -n${OutFileName} -D__MAKECINT__ -DG__MAKECINT ${_ExtraFlag} -c-2 -Z0 ${InFileName} ${AdditionalHeaderFiles} ${CMAKE_BINARY_DIR}/cint/cint/include/sys/types.h ${CMAKE_SOURCE_DIR}/cint/cint/lib/posix/posix.h

--- a/pkgs/applications/science/physics/xfitter/calling_convention.patch
+++ b/pkgs/applications/science/physics/xfitter/calling_convention.patch
@@ -1,0 +1,355 @@
+diff --git a/DY/src/finterface.cc b/DY/src/finterface.cc
+index 0405786..eb171d0 100644
+--- a/DY/src/finterface.cc
++++ b/DY/src/finterface.cc
+@@ -14,17 +14,17 @@
+ using namespace std;
+ 
+ extern "C" {
+-  int dy_create_calc_(const int *ds_id, const int *chg_prod, 
++  void dy_create_calc_(const int *ds_id, const int *chg_prod, 
+       const double *beam_en, const char *boz,
+       const double *ranges, const char *var_name, 
+       const int *n_bins, const double *bin_edges);
+ 
+-  int dy_do_calc_();
++  void dy_do_calc_();
+ 
+-  int dy_get_res_(const int *ds_id, double *calc_res);
++  void dy_get_res_(const int *ds_id, double *calc_res);
+ 
+   int dy_release_();
+-  int dy_set_ewpars_();
++  void dy_set_ewpars_();
+ }
+ 
+ typedef map <int, DYcalc* > DCmap;
+@@ -34,7 +34,7 @@ vector<BinMatrix*> gBinMatrices;
+ 
+ // initializes Drell-Yan LO calculations with info on
+ // beam, process, kinematic cuts, and bins.
+-int dy_create_calc_(const int *ds_id, const int *chg_prod, 
++void dy_create_calc_(const int *ds_id, const int *chg_prod, 
+     const double *beam_en, const char *boz,
+     const double *ranges, const char *var_name, 
+     const int *n_bins, const double *bin_edges)
+@@ -99,13 +99,11 @@ int dy_create_calc_(const int *ds_id, const int *chg_prod,
+   // create calculator and put to map
+   DYcalc * dc = new DYcalc(bm, pc, int_steps);
+   gCalcs.insert( pair<int,DYcalc*>( *ds_id,dc ) );
+-
+-  return 1;
+ }
+ 
+ 
+ // calculate Drell-Yan LO cross sections for all data sets
+-int dy_do_calc_()
++void dy_do_calc_()
+ {
+   // evolve convolutions
+   vector<PDFconv*>::iterator ipc = gPDFconvs.begin();
+@@ -118,24 +116,20 @@ int dy_do_calc_()
+     if ( true != idc->second->Integrate() ) {
+       cout << "Something is wrong with DY integration for " 
+            << idc->first << " data set." << endl;
+-      return 0;
++      return;
+     }
+   }
+-
+-  return 1;
+ }
+ 
+ 
+ // return DY calculations for data set ds_name
+-int dy_get_res_(const int *ds_id, double *calc_res)
++void dy_get_res_(const int *ds_id, double *calc_res)
+ {
+   DYcalc * dc = gCalcs.find(*ds_id)->second;
+   dc->getCalcRes(calc_res);
+-
+-  return 1;
+ }
+ 
+-int dy_set_ewpars_(){
++void dy_set_ewpars_(){
+   PhysPar::setPhysPar();
+ }
+ 
+@@ -155,6 +149,4 @@ int dy_release_()
+   for (; idc != gCalcs.end() ; idc++){
+     delete (idc->second);
+   }
+-
+-  return 1;
+ }
+diff --git a/FastNLO/src/FastNLOInterface.cc b/FastNLO/src/FastNLOInterface.cc
+index 20f8a75..a6dac79 100644
+--- a/FastNLO/src/FastNLOInterface.cc
++++ b/FastNLO/src/FastNLOInterface.cc
+@@ -39,14 +39,14 @@ void gauleg(double x1,double x2,double *x,double *w, int n);
+ 
+ 
+ extern "C" {
+-  int fastnloinit_(const char *s, const int *idataset, const char *thfile, int *I_FIT_ORDER, bool *PublicationUnits , double* murdef, double* murscale, double *mufdef, double* mufscale);
+-  int fastnlocalc_(const int *idataset, double *xsec);
+-  int fastnlocalctop_(const int *idataset, double *xsec, double *thbin, double *tot, int *Npt);
+-  int fastnlopointskip_(const int *idataset, int *point, int *npoints);
+-  int hf_errlog_(const int* ID, const char* TEXT, long length);
+-  int hf_stop_();
++  void fastnloinit_(const char *s, const int *idataset, const char *thfile, int *I_FIT_ORDER, bool *PublicationUnits , double* murdef, double* murscale, double *mufdef, double* mufscale);
++  void fastnlocalc_(const int *idataset, double *xsec);
++  void fastnlocalctop_(const int *idataset, double *xsec, double *thbin, double *tot, int *Npt);
++  void fastnlopointskip_(const int *idataset, int *point, int *npoints);
++  void hf_errlog_(const int* ID, const char* TEXT, long length);
++  void hf_stop_();
+   double interp_(double *A, double *xx1, double *x, int *NGrid1, double *res);
+-  int setfastnlotoppar_(const int *idataset);
++  void setfastnlotoppar_(const int *idataset);
+ }
+ 
+ 
+@@ -58,7 +58,7 @@ map<int, FastNLOxFitter*> gFastNLO_array;
+ map<int, BoolArray*>     gUsedPoints_array;
+ int CreateUsedPointsArray(int idataset, int npoints);
+ 
+-int fastnloinit_(const char *s, const int *idataset, const char *thfile, int *I_FIT_ORDER, bool *PublicationUnits , double* murdef, double* murscale, double *mufdef, double* mufscale) {
++void fastnloinit_(const char *s, const int *idataset, const char *thfile, int *I_FIT_ORDER, bool *PublicationUnits , double* murdef, double* murscale, double *mufdef, double* mufscale) {
+ 
+   
+    map<int, FastNLOxFitter*>::const_iterator FastNLOIterator = gFastNLO_array.find(*idataset);
+@@ -67,7 +67,7 @@ int fastnloinit_(const char *s, const int *idataset, const char *thfile, int *I_
+      const char* text = "I: Double initialization of the same fastnlo data set!";
+      hf_errlog_(&id, text, (long)strlen(text));
+      //hf_stop_();
+-     return 1;
++     return;
+    }
+    
+    FastNLOxFitter* fnloreader = new FastNLOxFitter( thfile );  
+@@ -112,10 +112,9 @@ int fastnloinit_(const char *s, const int *idataset, const char *thfile, int *I_
+    }
+    
+    gFastNLO_array.insert(pair<int, FastNLOxFitter*>(*idataset, fnloreader) );
+-   return 0;
+ }
+ 
+-int setfastnlotoppar_(const int *idataset) {
++void setfastnlotoppar_(const int *idataset) {
+    //!< Dedicated settings for difftop
+    map<int, FastNLOxFitter*>::const_iterator FastNLOIterator = gFastNLO_array.find(*idataset);
+    map<int, BoolArray*>::const_iterator UsedPointsIterator = gUsedPoints_array.find(*idataset);
+@@ -130,11 +129,9 @@ int setfastnlotoppar_(const int *idataset) {
+    fnloreader->SetExternalFuncForMuF( &Function_Mu );
+    fnloreader->SetExternalFuncForMuR( &Function_Mu);
+    //fnloreader->SetScaleFactorsMuRMuF(1.0,1.0); //Be reminded that muR and muF scales are hard coded (that's not true!)
+-
+-   return 0;
+ }
+ 
+-int fastnlocalc_(const int *idataset, double *xsec) {
++void fastnlocalc_(const int *idataset, double *xsec) {
+   
+    map<int, FastNLOxFitter*>::const_iterator FastNLOIterator = gFastNLO_array.find(*idataset);
+    map<int, BoolArray*>::const_iterator UsedPointsIterator = gUsedPoints_array.find(*idataset);
+@@ -176,13 +173,10 @@ int fastnlocalc_(const int *idataset, double *xsec) {
+        outputidx++;
+      }
+    }
+- 
+-
+-   return 0;
+ }
+ 
+ //MK14 New function for Difftop calculation: it is called in trunk/src/difftop_fastnlo.f
+-int fastnlocalctop_(const int *idataset, double *xsec, double *thbin, double *tot, int *Npt){
++void fastnlocalctop_(const int *idataset, double *xsec, double *thbin, double *tot, int *Npt){
+   
+    map<int, FastNLOxFitter*>::const_iterator FastNLOIterator = gFastNLO_array.find(*idataset);
+    map<int, BoolArray*>::const_iterator UsedPointsIterator = gUsedPoints_array.find(*idataset);
+@@ -262,10 +256,6 @@ int fastnlocalctop_(const int *idataset, double *xsec, double *thbin, double *to
+      Total += interpC(xsec,xg[k],thbin,Nthpoints)*wg[k];
+ 
+    *tot = Total;
+-
+-
+-
+-   return 0;
+ }
+ 
+ 
+@@ -277,7 +267,7 @@ int fastnlocalctop_(const int *idataset, double *xsec, double *thbin, double *to
+ 
+ 
+ 
+-int fastnlopointskip_(const int *idataset, int *point, int *npoints) {
++void fastnlopointskip_(const int *idataset, int *point, int *npoints) {
+   map<int, BoolArray*>::const_iterator UsedPointsIterator = gUsedPoints_array.find(*idataset);
+   if(UsedPointsIterator == gUsedPoints_array.end( )) 
+     CreateUsedPointsArray(*idataset, *npoints);
+@@ -292,8 +282,6 @@ int fastnlopointskip_(const int *idataset, int *point, int *npoints) {
+   
+   BoolArray*     usedpoints = UsedPointsIterator->second;
+   usedpoints->at(*point-1) = false;
+-
+-  return 0;
+ }
+ 
+ int CreateUsedPointsArray(int idataset, int npoints) {
+diff --git a/Hathor/src/HathorInterface.cc b/Hathor/src/HathorInterface.cc
+index 7da88b1..96576a3 100644
+--- a/Hathor/src/HathorInterface.cc
++++ b/Hathor/src/HathorInterface.cc
+@@ -6,9 +6,9 @@
+ #include "../interface/xFitterPdf.h"
+ 
+ extern "C" {
+-  int hathorinit_(const int* idataset, const double& sqrtS, const bool& ppbar, const double& mt,
++  void hathorinit_(const int* idataset, const double& sqrtS, const bool& ppbar, const double& mt,
+ 		  const unsigned int& pertubOrder, const unsigned int& precisionLevel);
+-  int hathorcalc_(const int *idataset, double *xsec);
++  void hathorcalc_(const int *idataset, double *xsec);
+ }
+ 
+ extern "C" {
+@@ -19,7 +19,7 @@ extern "C" {
+ }
+ 
+ extern "C" {
+-  int hf_errlog_(const int* ID, const char* TEXT, long length);
++  void hf_errlog_(const int* ID, const char* TEXT, long length);
+ }
+ 
+ // FIXME: delete pointers at the end! (in some hathordestroy_ or so)
+@@ -28,7 +28,7 @@ xFitterPdf* pdf;
+ int* rndStore;
+ double mtop;
+ 
+-int hathorinit_(const int* idataset, const double& sqrtS, const bool& ppbar, const double& mt,
++void hathorinit_(const int* idataset, const double& sqrtS, const bool& ppbar, const double& mt,
+ 		const unsigned int& pertubOrder, const unsigned int& precisionLevel) {
+ 
+   if(hathor_array.size()==0) {
+@@ -69,7 +69,7 @@ int hathorinit_(const int* idataset, const double& sqrtS, const bool& ppbar, con
+   return 0;
+ }
+ 
+-int hathorcalc_(const int *idataset, double *xsec) {
++void hathorcalc_(const int *idataset, double *xsec) {
+   rlxd_reset(rndStore);
+ 
+   std::map<int, Hathor*>::const_iterator hathorIter = hathor_array.find(*idataset);
+diff --git a/src/ftheor_eval.cc b/src/ftheor_eval.cc
+index 1dd4e8b..8bc7991 100644
+--- a/src/ftheor_eval.cc
++++ b/src/ftheor_eval.cc
+@@ -19,15 +19,15 @@
+ using namespace std;
+ 
+ extern "C" {
+-  int set_theor_eval_(int *dsId);//, int *nTerms, char **TermName, char **TermType, 
++  void set_theor_eval_(int *dsId);//, int *nTerms, char **TermName, char **TermType, 
+ //    char **TermSource, char *TermExpr);
+-  int set_theor_bins_(int *dsId, int *nBinDimension, int *nPoints, int *binFlags, 
++  void set_theor_bins_(int *dsId, int *nBinDimension, int *nPoints, int *binFlags, 
+     double *allBins);
+ //  int set_theor_units_(int *dsId, double *units);
+-  int init_theor_eval_(int *dsId);
+-  int update_theor_ckm_();
+-  int get_theor_eval_(int *dsId, int* np, int* idx);
+-  int close_theor_eval_();
++  void init_theor_eval_(int *dsId);
++  void update_theor_ckm_();
++  void get_theor_eval_(int *dsId, int* np, int* idx);
++  void close_theor_eval_();
+ }
+ 
+ /// global dataset to theory evaluation pointer map
+@@ -59,7 +59,7 @@ extern struct ord_scales {
+  dataset ID.
+  write details on argumets
+  */
+-int set_theor_eval_(int *dsId)//, int *nTerms, char **TermName, char **TermType, 
++void set_theor_eval_(int *dsId)//, int *nTerms, char **TermName, char **TermType, 
+ //  char **TermSource, char *TermExpr)
+ {
+   // convert fortran strings to c++
+@@ -90,15 +90,13 @@ int set_theor_eval_(int *dsId)//, int *nTerms, char **TermName, char **TermType,
+     << " already exists." << endl;
+     exit(1); // make proper exit later
+   }
+-
+-  return 1;
+ }
+ 
+ /*!
+  Sets datasets bins in theory evaluations.
+  write details on argumets
+  */
+-int set_theor_bins_(int *dsId, int *nBinDimension, int *nPoints, int *binFlags, 
++void set_theor_bins_(int *dsId, int *nBinDimension, int *nPoints, int *binFlags, 
+   double *allBins)
+ {
+   tTEmap::iterator it = gTEmap.find(*dsId);
+@@ -110,7 +108,6 @@ int set_theor_bins_(int *dsId, int *nBinDimension, int *nPoints, int *binFlags,
+   
+   TheorEval *te = gTEmap.at(*dsId);
+   te->setBins(*nBinDimension, *nPoints, binFlags, allBins);
+-  return 1;
+ }
+ 
+ /*
+@@ -132,7 +129,7 @@ int set_theor_units_(int *dsId, double *units)
+ /*!
+  Initializes theory for requested dataset.
+  */
+-int init_theor_eval_(int *dsId)
++void init_theor_eval_(int *dsId)
+ {
+   tTEmap::iterator it = gTEmap.find(*dsId);
+   if (it == gTEmap.end() ) { 
+@@ -148,7 +145,7 @@ int init_theor_eval_(int *dsId)
+ /*!
+  Updates the CKM matrix to all the initialized appl grids
+  */
+-int update_theor_ckm_()
++void update_theor_ckm_()
+ {
+   double a_ckm[] = { ckm_matrix_.Vud, ckm_matrix_.Vus, ckm_matrix_.Vub,
+                                   ckm_matrix_.Vcd, ckm_matrix_.Vcs, ckm_matrix_.Vcb,
+@@ -164,7 +161,7 @@ int update_theor_ckm_()
+ /*!
+  Evaluates theory for requested dataset and writes it to the global THEO array.
+  */
+-int get_theor_eval_(int *dsId, int *np, int*idx)
++void get_theor_eval_(int *dsId, int *np, int*idx)
+ {
+ 
+   tTEmap::iterator it = gTEmap.find(*dsId);
+@@ -194,11 +191,11 @@ int get_theor_eval_(int *dsId, int *np, int*idx)
+   // write the predictions to THEO array
+   if( ip != *np ){
+     cout << "ERROR in get_theor_eval_: number of points mismatch" << endl;
+-    return -1;
++    return;
+   }
+ }
+ 
+-int close_theor_eval_()
++void close_theor_eval_()
+ {
+   tTEmap::iterator it = gTEmap.begin();
+   for (; it!= gTEmap.end(); it++){
+diff --git a/src/lhapdf6_output.c b/src/lhapdf6_output.c
+index 4b20b68..549c521 100644
+--- a/src/lhapdf6_output.c
++++ b/src/lhapdf6_output.c
+@@ -64,7 +64,7 @@ extern double bvalij_(int *,int *,int *,int *,int *);
+ extern double bvalxq_(int *,int *,double *,double *,int *);
+ extern double hf_get_alphas_(double *);
+ extern int getord_(int *);
+-extern int grpars_(int *, double *, double *, int *, double *, double *, int *);
++extern void grpars_(int *, double *, double *, int *, double *, double *, int *);
+ extern int getcbt_(int *, double *, double *, double *);
+ extern void getpdfunctype_heraf_(int *mc, int *asymh, int *symh, char *name, size_t size);
+ extern void hf_errlog_(int *, char *, size_t);

--- a/pkgs/applications/science/physics/xfitter/default.nix
+++ b/pkgs/applications/science/physics/xfitter/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, apfel, apfelgrid, applgrid, blas, gfortran, lhapdf, liblapackWithoutAtlas, libyaml, lynx, mela, root5, qcdnum, which }:
+
+stdenv.mkDerivation rec {
+  name = "xfitter-${version}";
+  version = "2.0.0";
+
+  src = fetchurl {
+    name = "${name}.tgz";
+    url = "https://www.xfitter.org/xFitter/xFitter/DownloadPage?action=AttachFile&do=get&target=${name}.tgz";
+    sha256 = "0j47s8laq3aqjlgp769yicvgyzqjb738a3rqss51d9fjrihi2515";
+  };
+
+  patches = [
+    ./calling_convention.patch
+  ];
+
+  preConfigure =
+  # Fix F77LD to workaround for a following build error:
+  #
+  #   gfortran: error: unrecognized command line option '-stdlib=libc++'
+  #
+    stdenv.lib.optionalString stdenv.isDarwin ''
+      substituteInPlace src/Makefile.in \
+        --replace "F77LD = \$(F77)" "F77LD = \$(CXXLD)" \
+    '';
+
+  configureFlags = [
+    "--enable-apfel"
+    "--enable-apfelgrid"
+    "--enable-applgrid"
+    "--enable-mela"
+    "--enable-lhapdf"
+  ];
+
+  nativeBuildInputs = [ gfortran which ];
+  buildInputs =
+    [ apfel apfelgrid applgrid blas lhapdf liblapackWithoutAtlas mela root5 qcdnum ]
+    # pdf2yaml requires fmemopen and open_memstream which are not readily available on Darwin
+    ++ stdenv.lib.optional (!stdenv.isDarwin) libyaml
+    ;
+  propagatedBuildInputs = [ lynx ];
+
+  enableParallelBuilding = true;
+
+  hardeningDisable = [ "format" ];
+
+  meta = with stdenv.lib; {
+    description = "The xFitter project is an open source QCD fit framework ready to extract PDFs and assess the impact of new data";
+    license     = licenses.gpl3;
+    homepage    = https://www.xfitter.org/xFitter;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/physics/apfel/default.nix
+++ b/pkgs/development/libraries/physics/apfel/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, gfortran, lhapdf, python2 }:
+
+stdenv.mkDerivation rec {
+  name = "apfel-${version}";
+  version = "3.0.3";
+
+  src = fetchFromGitHub {
+    owner = "scarrazza";
+    repo = "apfel";
+    rev = version;
+    sha256 = "13dvcc5ba6djflrcy5zf5ikaw8s78zd8ac6ickc0hxhbmx1gjb4j";
+  };
+
+  buildInputs = [ gfortran lhapdf python2 ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A PDF Evolution Library";
+    license     = licenses.gpl3;
+    homepage    = http://apfel.mi.infn.it/;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/physics/apfelgrid/default.nix
+++ b/pkgs/development/libraries/physics/apfelgrid/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, apfel, applgrid, lhapdf, root }:
+
+stdenv.mkDerivation rec {
+  name = "apfelgrid-${version}";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "nhartland";
+    repo = "APFELgrid";
+    rev = "v${version}";
+    sha256 = "0l0cyxd00kmb5aggzwsxg83ah0qiwav0shbxkxwrz3dvw78n89jk";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ apfel applgrid lhapdf root ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Ultra-fast theory predictions for collider observables";
+    license     = licenses.mit;
+    homepage    = http://nhartland.github.io/APFELgrid/;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/physics/applgrid/bad_code.patch
+++ b/pkgs/development/libraries/physics/applgrid/bad_code.patch
@@ -1,0 +1,39 @@
+diff --git a/appl_grid/appl_grid.h b/appl_grid/appl_grid.h
+index 5059622..a0651c9 100644
+--- a/appl_grid/appl_grid.h
++++ b/appl_grid/appl_grid.h
+@@ -56,7 +56,7 @@ public:
+   class exception : public std::exception { 
+   public:
+     exception(const std::string& s) { std::cerr << what() << " " << s << std::endl; }; 
+-    exception(std::ostream& s)      { std::cerr << what() << " " << s << std::endl; }; 
++    exception(std::ostream& s)      { s << what() << " " << std::endl; }; 
+     virtual const char* what() const throw() { return "appl::grid::exception"; }
+   };
+ 
+diff --git a/appl_grid/appl_pdf.h b/appl_grid/appl_pdf.h
+index c71fd84..2525527 100644
+--- a/appl_grid/appl_pdf.h
++++ b/appl_grid/appl_pdf.h
+@@ -51,7 +51,7 @@ public:
+   class exception : public std::exception { 
+   public: 
+     exception(const std::string& s="") { std::cerr << what() << " " << s << std::endl; }; 
+-    exception(std::ostream& s)         { std::cerr << what() << " " << s << std::endl; }; 
++    exception(std::ostream& s)         { s << " " << std::endl; }; 
+     const char* what() const throw() { return "appl::appl_pdf::exception "; }
+   };
+   
+diff --git a/src/appl_igrid.h b/src/appl_igrid.h
+index d25288e..be354df 100644
+--- a/src/appl_igrid.h
++++ b/src/appl_igrid.h
+@@ -52,7 +52,7 @@ private:
+   class exception { 
+   public:
+     exception(const std::string& s) { std::cerr << s << std::endl; }; 
+-    exception(std::ostream& s)      { std::cerr << s << std::endl; }; 
++    exception(std::ostream& s)      { s << std::endl; }; 
+   };
+ 
+   typedef double (igrid::*transform_t)(double) const;

--- a/pkgs/development/libraries/physics/applgrid/default.nix
+++ b/pkgs/development/libraries/physics/applgrid/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, gfortran, hoppet, lhapdf, root5 }:
+
+stdenv.mkDerivation rec {
+  name = "applgrid-${version}";
+  version = "1.4.70";
+
+  src = fetchurl {
+    url = "https://www.hepforge.org/archive/applgrid/${name}.tgz";
+    sha256 = "1yw9wrk3vjv84kd3j4s1scfhinirknwk6xq0hvj7x2srx3h93q9p";
+  };
+
+  buildInputs = [ gfortran hoppet lhapdf root5 ];
+
+  patches = [
+    ./bad_code.patch
+  ];
+
+  preConfigure = ''
+    substituteInPlace src/Makefile.in \
+      --replace "-L\$(subst /libgfortran.a, ,\$(FRTLIB) )" "-L${gfortran.cc.lib}/lib"
+  '' + (if stdenv.isDarwin then ''
+    substituteInPlace src/Makefile.in \
+      --replace "gfortran -print-file-name=libgfortran.a" "gfortran -print-file-name=libgfortran.dylib"
+  '' else "");
+
+  enableParallelBuilding = false; # broken
+
+  # Install private headers required by APFELgrid
+  postInstall = ''
+    for header in src/*.h; do
+      install -Dm644 "$header" "$out"/include/appl_grid/"`basename $header`"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The APPLgrid project provides a fast and flexible way to reproduce the results of full NLO calculations with any input parton distribution set in only a few milliseconds rather than the weeks normally required to gain adequate statistics";
+    license     = licenses.gpl3;
+    homepage    = http://applgrid.hepforge.org;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/physics/hoppet/default.nix
+++ b/pkgs/development/libraries/physics/hoppet/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, gfortran }:
+
+stdenv.mkDerivation rec {
+  name = "hoppet-${version}";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://hoppet.hepforge.org/downloads/${name}.tgz";
+    sha256 = "0j7437rh4xxbfzmkjr22ry34xm266gijzj6mvrq193fcsfzipzdz";
+  };
+
+  buildInputs = [ gfortran ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Higher Order Perturbative Parton Evolution Toolkit";
+    license     = licenses.gpl2;
+    homepage    = https://hoppet.hepforge.org;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/physics/mela/default.nix
+++ b/pkgs/development/libraries/physics/mela/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, gfortran }:
+
+stdenv.mkDerivation rec {
+  name = "mela-${version}";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "vbertone";
+    repo = "MELA";
+    rev = version;
+    sha256 = "01sgd4mwx4n58x95brphp4dskqkkx8434bvsr38r5drg9na5nc9y";
+  };
+
+  buildInputs = [ gfortran ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "a Mellin Evolution LibrAry";
+    license     = licenses.gpl3;
+    homepage    = https://github.com/vbertone/MELA;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/development/libraries/physics/qcdnum/default.nix
+++ b/pkgs/development/libraries/physics/qcdnum/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, gfortran }:
+
+stdenv.mkDerivation rec {
+  name = "QCDNUM-${version}";
+  version = "17-01-14";
+
+  src = fetchurl {
+    url = "http://www.nikhef.nl/user/h24/qcdnum-files/download/qcdnum${builtins.replaceStrings ["-"] [""] version}.tar.gz";
+    sha256 = "199s6kgmszxgjzd9214mpx3kyplq2q6987sii67s5xkg10ynyv31";
+  };
+
+  nativeBuildInputs = [ gfortran ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "QCDNUM is a very fast QCD evolution program written in FORTRAN77";
+    license     = stdenv.lib.licenses.gpl3;
+    homepage    = https://www.nikhef.nl/~h24/qcdnum/index.html;
+    platforms   = stdenv.lib.platforms.unix;
+    maintainers = with stdenv.lib.maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21405,6 +21405,8 @@ with pkgs;
 
   ### SCIENCE / PHYSICS
 
+  applgrid = callPackage ../development/libraries/physics/applgrid { };
+
   hoppet = callPackage ../development/libraries/physics/hoppet { };
 
   fastjet = callPackage ../development/libraries/physics/fastjet { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21405,6 +21405,8 @@ with pkgs;
 
   ### SCIENCE / PHYSICS
 
+  apfelgrid = callPackage ../development/libraries/physics/apfelgrid { };
+
   apfel = callPackage ../development/libraries/physics/apfel { };
 
   applgrid = callPackage ../development/libraries/physics/applgrid { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21438,6 +21438,8 @@ with pkgs;
     withRootSupport = true;
   });
 
+  qcdnum = callPackage ../development/libraries/physics/qcdnum { };
+
   ### SCIENCE/ROBOTICS
 
   apmplanner2 = libsForQt5.callPackage ../applications/science/robotics/apmplanner2 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21405,6 +21405,8 @@ with pkgs;
 
   ### SCIENCE / PHYSICS
 
+  apfel = callPackage ../development/libraries/physics/apfel { };
+
   applgrid = callPackage ../development/libraries/physics/applgrid { };
 
   hoppet = callPackage ../development/libraries/physics/hoppet { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21401,6 +21401,8 @@ with pkgs;
 
   ### SCIENCE / PHYSICS
 
+  hoppet = callPackage ../development/libraries/physics/hoppet { };
+
   fastjet = callPackage ../development/libraries/physics/fastjet { };
 
   fastnlo = callPackage ../development/libraries/physics/fastnlo { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21421,6 +21421,8 @@ with pkgs;
 
   mcgrid = callPackage ../development/libraries/physics/mcgrid { };
 
+  mela = callPackage ../development/libraries/physics/mela { };
+
   nlojet = callPackage ../development/libraries/physics/nlojet { };
 
   pythia = callPackage ../development/libraries/physics/pythia { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20988,6 +20988,8 @@ with pkgs;
 
   sherpa = callPackage ../applications/science/physics/sherpa {};
 
+  xfitter = callPackage ../applications/science/physics/xfitter {};
+
   ### SCIENCE/PROGRAMMING
 
   dafny = dotnetPackages.Dafny;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21380,6 +21380,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
+  root5 = lowPrio (callPackage ../applications/science/misc/root/5.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
+  });
+
   simgrid = callPackage ../applications/science/misc/simgrid { };
 
   spyder = callPackage ../applications/science/spyder { };


### PR DESCRIPTION
###### Motivation for this change

Add xfitter package into nixpkgs.

Older root5 is a dependency of older APPLgrid 1.4.70, which I chose to use because it is advertised as compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

