### PR TITLE
texlive/combine.nix: drop nix1 support

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -12,11 +12,9 @@ let
       (bin.core.doc // { pname = "core"; tlType = "doc"; })
     ];
   };
-  partition = builtins.partition or (pred: l:
-    { right = builtins.filter pred l; wrong = builtins.filter (e: !(pred e)) l; });
   pkgList = rec {
     all = lib.filter pkgFilter (combinePkgs pkgSet);
-    splitBin = partition (p: p.tlType == "bin") all;
+    splitBin = builtins.partition (p: p.tlType == "bin") all;
     bin = mkUniquePkgs splitBin.right
       ++ lib.optional
           (lib.any (p: p.tlType == "run" && p.pname == "pdfcrop") splitBin.wrong)


### PR DESCRIPTION
Since 7d1968c0e38 ('Nix minimal version: 1.11 -> 2.0') nixpkgs now require nix 2.0+

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

