### PR TITLE
ISO/OVA closure size reductions

### DIFF
--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -7,7 +7,10 @@
   services.xserver = {
     enable = true;
     displayManager.sddm.enable = true;
-    desktopManager.plasma5.enable = true;
+    desktopManager.plasma5 = {
+      enable = true;
+      enableQt4Support = false;
+    };
     libinput.enable = true; # for touchpad support on many laptops
   };
 

--- a/pkgs/os-specific/linux/nfs-utils/default.nix
+++ b/pkgs/os-specific/linux/nfs-utils/default.nix
@@ -83,6 +83,8 @@ in stdenv.mkDerivation rec {
     "statdpath=$(TMPDIR)"
   ];
 
+  stripDebugList = [ "lib" "libexec" "bin" "etc/systemd/system-generators" ];
+
   postInstall =
     ''
       # Not used on NixOS


### PR DESCRIPTION
###### Motivation for this change

A few things to partially address #47292. Gets rid of GCC and Qt4 from the .ova build products (and GCC from the .iso)

- Properly strips nfs-utils binaries
- Disables Qt4 in the graphical profile (pretty soon we should make this the default everywhere)