### PR TITLE
nixos: fix fallout from #46193

### DIFF
--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -22,7 +22,7 @@ with lib;
   config = {
 
     # Enable in installer, even if the minimal profile disables it.
-    documentation.nixos.enable = mkForce true;
+    documentation.enable = mkForce true;
 
     # Show the manual.
     services.nixosManual.showManual = true;

--- a/nixos/modules/profiles/minimal.nix
+++ b/nixos/modules/profiles/minimal.nix
@@ -12,7 +12,6 @@ with lib;
   i18n.supportedLocales = [ (config.i18n.defaultLocale + "/UTF-8") ];
 
   documentation.enable = mkDefault false;
-  documentation.nixos.enable = mkDefault false;
 
   sound.enable = mkDefault false;
 }

--- a/nixos/modules/services/misc/nixos-manual.nix
+++ b/nixos/modules/services/misc/nixos-manual.nix
@@ -6,7 +6,10 @@
 
 with lib;
 
-let cfg = config.services.nixosManual; in
+let
+  cfg = config.services.nixosManual;
+  cfgd = config.documentation;
+in
 
 {
 
@@ -44,7 +47,7 @@ let cfg = config.services.nixosManual; in
   config = mkIf cfg.showManual {
 
     assertions = [{
-      assertion = config.documentation.nixos.enable;
+      assertion = cfgd.enable && cfgd.nixos.enable;
       message   = "Can't enable `service.nixosManual.showManual` without `documentation.nixos.enable`";
     }];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes an issue reported in https://github.com/NixOS/nixpkgs/pull/46193#issuecomment-424106727.

Enabling `minimal` and `installation-device` profiles at the same time (like `netboot` profile does) started failing after #46193.

###### Things done

- [X] Installers in `./nixos/release.nix` evaluate.