### PR TITLE
lib: Deprecate `overrideScope` in lieu of `overrideScope'` taking arguments in the conventional order for 18.09

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -643,15 +643,15 @@ cp ${myEmacsConfig} $out/share/emacs/site-lisp/default.el
     required dependencies manually - but it's tedious and there is always a
     possibility that an unwanted dependency will sneak in through some other
     package. To completely override such a package you can use
-    <varname>overrideScope</varname>.
+    <varname>overrideScope'</varname>.
    </para>
 
 <screen>
-overrides = super: self: rec {
+overrides = self: super: rec {
   haskell-mode = self.melpaPackages.haskell-mode;
   ...
 };
-((emacsPackagesNgGen emacs).overrideScope overrides).emacsWithPackages (p: with p; [
+((emacsPackagesNgGen emacs).overrideScope' overrides).emacsWithPackages (p: with p; [
   # here both these package will use haskell-mode of our own choice
   ghc-mod
   dante

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -185,7 +185,7 @@ rec {
   /* Make a set of packages with a common scope. All packages called
      with the provided `callPackage' will be evaluated with the same
      arguments. Any package in the set may depend on any other. The
-     `overrideScope' function allows subsequent modification of the package
+     `overrideScope'` function allows subsequent modification of the package
      set in a consistent way, i.e. all packages in the set will be
      called with the overridden packages. The package sets may be
      hierarchical: the packages in the set are called with the scope
@@ -195,10 +195,10 @@ rec {
     let self = f self // {
           newScope = scope: newScope (self // scope);
           callPackage = self.newScope {};
-          # TODO(@Ericson2314): Haromonize argument order of `g` with everything else
-          overrideScope = g:
-            makeScope newScope
-            (lib.fixedPoints.extends (lib.flip g) f);
+          overrideScope = g: lib.warn
+            "`overrideScope` (from `lib.makeScope`) is deprecated. Do `overrideScope' (self: self: { … })` instead of `overrideScope (super: self: { … })`. All other overrides have the parameters in that order, including other definitions of `overrideScope`. This was the only definition violating the pattern."
+            (makeScope newScope (lib.fixedPoints.extends (lib.flip g) f));
+          overrideScope' = g: makeScope newScope (lib.fixedPoints.extends g f);
           packages = f;
         };
     in self;

--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -21,7 +21,7 @@ set which contains `emacsWithPackages`. For example, to override
 `emacsPackagesNg.emacsWithPackages`,
 ```
 let customEmacsPackages =
-      emacsPackagesNg.overrideScope (super: self: {
+      emacsPackagesNg.overrideScope' (self: super: {
         # use a custom version of emacs
         emacs = ...;
         # use the unstable MELPA version of magit


### PR DESCRIPTION
###### Motivation for this change

Backport of #47238. Unfortunately I cannot reopen #47239 for this purpose.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

