### PR TITLE
Add adwaita-qt & qgnomeplatform

### DIFF
--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, pkgconfig, gtk3, qtbase, qmake }:
+
+stdenv.mkDerivation rec {
+  name = "qgnomeplatform-${version}";
+  version = "0.4";
+
+  src = fetchFromGitHub {
+    owner = "FedoraQt";
+    repo = "QGnomePlatform";
+    rev = version;
+    sha256 = "1403300d435g7ngcxsgnllhryk63nrhl1ahx16b28wkxnh2vi9ly";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    qmake
+  ];
+
+  buildInputs = [
+    gtk3
+    qtbase
+  ];
+
+  postPatch = ''
+    # Fix plugin dir
+    substituteInPlace qgnomeplatform.pro \
+      --replace "\$\$[QT_INSTALL_PLUGINS]" "$out/$qtPluginPrefix"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "QPlatformTheme for a better Qt application inclusion in GNOME";
+    homepage = https://github.com/FedoraQt/QGnomePlatform;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/misc/themes/adwaita-qt/default.nix
+++ b/pkgs/misc/themes/adwaita-qt/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, ninja, qtbase }:
+
+stdenv.mkDerivation rec {
+  pname = "adwaita-qt";
+  version = "1.0";
+
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "FedoraQt";
+    repo = pname;
+    rev = version;
+    sha256 = "0xn8bianmdj15k11mnw52by9vxkmvpqr2s304kl3dbjj1l7v4cd7";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  postPatch = ''
+    # Fix plugin dir
+    substituteInPlace style/CMakeLists.txt \
+       --replace "DESTINATION \"\''${QT_PLUGINS_DIR}/styles" "DESTINATION \"$qtPluginPrefix/styles"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A style to bend Qt applications to look like they belong into GNOME Shell";
+    homepage = https://github.com/FedoraQt/adwaita-qt;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20578,6 +20578,8 @@ with pkgs;
 
   latte-dock = libsForQt5.callPackage ../applications/misc/latte-dock { };
 
+  adwaita-qt = libsForQt5.callPackage ../misc/themes/adwaita-qt { };
+
   orion = callPackage ../misc/themes/orion {};
 
   elementary-gtk-theme = callPackage ../misc/themes/elementary { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11953,6 +11953,8 @@ with pkgs;
 
   qrupdate = callPackage ../development/libraries/qrupdate { };
 
+  qgnomeplatform =  libsForQt5.callPackage ../development/libraries/qgnomeplatform { };
+
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };
 
   rhino = callPackage ../development/libraries/java/rhino {


### PR DESCRIPTION
###### Motivation for this change
elementary uses this to improve the look and feel of qt applications. 
(It's default in Fedora for Gnome too...)

###### Screenshots
Before:

![screenshot_2](https://user-images.githubusercontent.com/28888242/45986636-562b4280-c05c-11e8-9ddb-b00c3e6ffc24.png)


After:

![screenshot](https://user-images.githubusercontent.com/28888242/45986456-292a6000-c05b-11e8-9dee-57b426a0e2a2.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @jtojnar 
