### PR TITLE
rsyslogd & syslog-nd: fix broken module

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -588,7 +588,8 @@ in
     };
 
     services.journald.forwardToSyslog = mkOption {
-      default = (if config.services.rsyslogd.enable || config.services.syslog-ng.enable then true else false);
+      default = config.services.rsyslogd.enable || config.services.syslog-ng.enable;
+      defaultText = "config.services.rsyslogd.enable || config.services.syslog-ng.enable";
       type = types.bool;
       description = ''
         Whether to forward log messages to syslog.

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -587,6 +587,14 @@ in
       '';
     };
 
+    services.journald.forwardToSyslog = mkOption {
+      default = (if config.services.rsyslog.enable || config.services.syslog-ng.enable then true else false);
+      type = types.bool;
+      description = ''
+        Whether to forward log messages to syslog.
+      '';
+    };
+
     services.logind.extraConfig = mkOption {
       default = "";
       type = types.lines;
@@ -752,6 +760,9 @@ in
         ${optionalString (config.services.journald.console != "") ''
           ForwardToConsole=yes
           TTYPath=${config.services.journald.console}
+        ''}
+        ${optionalString (config.services.journald.forwardToSyslog) ''
+          ForwardToSyslog=yes
         ''}
         ${config.services.journald.extraConfig}
       '';

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -588,7 +588,7 @@ in
     };
 
     services.journald.forwardToSyslog = mkOption {
-      default = (if config.services.rsyslog.enable || config.services.syslog-ng.enable then true else false);
+      default = (if config.services.rsyslogd.enable || config.services.syslog-ng.enable then true else false);
       type = types.bool;
       description = ''
         Whether to forward log messages to syslog.

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -392,6 +392,7 @@ in rec {
   tests.rabbitmq = callTest tests/rabbitmq.nix {};
   tests.radicale = callTest tests/radicale.nix {};
   tests.rspamd = callSubTests tests/rspamd.nix {};
+  tests.rsyslogd = callSubTests tests/rsyslogd.nix {};
   tests.runInMachine = callTest tests/run-in-machine.nix {};
   tests.rxe = callTest tests/rxe.nix {};
   tests.samba = callTest tests/samba.nix {};

--- a/nixos/tests/rsyslogd.nix
+++ b/nixos/tests/rsyslogd.nix
@@ -1,0 +1,27 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+{
+  name = "rsyslogd";
+  meta.maintainers = [ lib.maintainers.aanderse ];
+
+  nodes = {
+    machine1 =
+      { config, pkgs, ... }:
+      { services.rsyslogd.enable = true;
+        services.journald.forwardToSyslog = false;
+      };
+
+    machine2 =
+      { config, pkgs, ... }:
+      { services.rsyslogd.enable = true;
+      };
+  };
+
+  # ensure rsyslogd is receiving messages from journald if and only if setup to do so
+  testScript = ''
+    $machine1->waitForUnit("default.target");
+    $machine1->fail("test -f /var/log/messages");
+
+    $machine2->waitForUnit("default.target");
+    $machine2->succeed("test -f /var/log/messages");
+  '';
+})

--- a/nixos/tests/rsyslogd.nix
+++ b/nixos/tests/rsyslogd.nix
@@ -1,27 +1,37 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
-{
-  name = "rsyslogd";
-  meta.maintainers = [ lib.maintainers.aanderse ];
+{ system ? builtins.currentSystem }:
 
-  nodes = {
-    machine1 =
+with import ../lib/testing.nix { inherit system; };
+{
+  test1 = makeTest {
+    name = "rsyslogd-test1";
+    meta.maintainers = [ lib.maintainers.aanderse ];
+
+    machine =
       { config, pkgs, ... }:
       { services.rsyslogd.enable = true;
         services.journald.forwardToSyslog = false;
       };
 
-    machine2 =
+    # ensure rsyslogd isn't receiving messages from journald if explicitly disabled
+    testScript = ''
+      $machine->waitForUnit("default.target");
+      $machine->fail("test -f /var/log/messages");
+    '';
+  };
+
+  test2 = makeTest {
+    name = "rsyslogd-test2";
+    meta.maintainers = [ lib.maintainers.aanderse ];
+
+    machine =
       { config, pkgs, ... }:
       { services.rsyslogd.enable = true;
       };
+
+    # ensure rsyslogd is receiving messages from journald
+    testScript = ''
+      $machine->waitForUnit("default.target");
+      $machine->succeed("test -f /var/log/messages");
+    '';
   };
-
-  # ensure rsyslogd is receiving messages from journald if and only if setup to do so
-  testScript = ''
-    $machine1->waitForUnit("default.target");
-    $machine1->fail("test -f /var/log/messages");
-
-    $machine2->waitForUnit("default.target");
-    $machine2->succeed("test -f /var/log/messages");
-  '';
-})
+}


### PR DESCRIPTION
###### Motivation for this change
I've tested rsyslogd on NixOS 18.09 and no output is generated from rsyslogd at all. The module appears to be broken because of systemd changes.

According to https://wiki.archlinux.org/index.php/rsyslog "ForwardToSyslog=yes" needs to be added to journald.conf.

NOTE: This PR is to replace #47134

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

