### PR TITLE
protobuf3_6: init at 3.6.1

### DIFF
--- a/pkgs/development/libraries/protobuf/3.6.nix
+++ b/pkgs/development/libraries/protobuf/3.6.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... }:
+
+callPackage ./generic-v3.nix {
+  version = "3.6.1";
+  sha256 = "1bg40miylzpy2wgbd7l7zjgmk43l12q38fq0zkn0vzy1lsj457sq";
+}

--- a/pkgs/development/libraries/protobuf/generic-v3.nix
+++ b/pkgs/development/libraries/protobuf/generic-v3.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   # make sure you test also -A pythonPackages.protobuf
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "protocolbuffers";
     repo = "protobuf";
     rev = "v${version}";
     inherit sha256;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11644,6 +11644,7 @@ with pkgs;
 
   protobuf = protobuf3_4;
 
+  protobuf3_6 = callPackage ../development/libraries/protobuf/3.6.nix { };
   protobuf3_5 = callPackage ../development/libraries/protobuf/3.5.nix { };
   protobuf3_4 = callPackage ../development/libraries/protobuf/3.4.nix { };
   protobuf3_1 = callPackage ../development/libraries/protobuf/3.1.nix { };


### PR DESCRIPTION
###### Motivation for this change

`protobuf` was moved from `google` to `protocolbuffers` on GitHub: https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.0

This update is common to #45709 and #47184, except that I did not add `NIX_CFLAGS_COMPILE = "-Wno-error";` because it is not necessary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
