### PR TITLE
vagrant: Clean up Gemfile

### DIFF
--- a/pkgs/development/tools/vagrant/Gemfile
+++ b/pkgs/development/tools/vagrant/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem 'vagrant', git: "https://github.com/hashicorp/vagrant.git", tag: "v2.0.4"
+gem 'vagrant'


### PR DESCRIPTION
###### Motivation for this change

@alyssais [pointed out](https://github.com/NixOS/nixpkgs/pull/43620#discussion_r219435538) that @Mic92 [changed this](https://github.com/NixOS/nixpkgs/pull/39597/files#diff-08bce830733efa94b2e31e9c3dd7b3b0) from [the original](https://github.com/NixOS/nixpkgs/pull/30952/files#diff-08bce830733efa94b2e31e9c3dd7b3b0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).