### PR TITLE
ultimate-oldschool-pc-font-pack: simplify using fetchzip

### DIFF
--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -1,24 +1,16 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, fetchzip }:
 
-stdenv.mkDerivation rec {
-  name = "ultimate-oldschool-pc-font-pack-${version}";
+let
   version = "1.0";
+in
+fetchzip rec {
+  name = "ultimate-oldschool-pc-font-pack-${version}";
+  url = "http://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
+  sha256 = "0hid4dgqfy2w26734vcw2rxmpacd9vd1r2qpdr9ww1n3kgc92k9y";
 
-  src = fetchurl {
-    url = "http://int10h.org/oldschool-pc-fonts/download/ultimate_oldschool_pc_font_pack_v${version}.zip";
-    sha256 = "7666cf23176e34ea03a218b5c1500f4ad729d97150ab7bdb7cf2adf4c99a9a7a";
-  };
-
-  buildInputs = [ unzip ];
-
-  dontBuild = true;
-
-  sourceRoot = ".";
-
-  installPhase = ''
+  postFetch= ''
     mkdir -p $out/share/fonts/truetype
-    cp 'Px437 (TrueType - DOS charset)'/*.ttf $out/share/fonts/truetype
-    cp 'PxPlus (TrueType - extended charset)'/*.ttf $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

@volth pointed out that  #45969 could be done much more simply using `fetchzip`, so I fixed it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

