### PR TITLE
nix: move perl-bindings inside common function

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -13,153 +13,154 @@ let
 
   sh = busybox-sandbox-shell;
 
-  common = { name, suffix ? "", src, fromGit ? false }: stdenv.mkDerivation rec {
-    inherit name src;
-    version = lib.getVersion name;
+  common = { name, suffix ? "", src, fromGit ? false }:
+    let nix = stdenv.mkDerivation rec {
+      inherit name src;
+      version = lib.getVersion name;
 
-    is20 = lib.versionAtLeast version "2.0pre";
+      is20 = lib.versionAtLeast version "2.0pre";
 
-    VERSION_SUFFIX = lib.optionalString fromGit suffix;
+      VERSION_SUFFIX = lib.optionalString fromGit suffix;
 
-    outputs = [ "out" "dev" "man" "doc" ];
+      outputs = [ "out" "dev" "man" "doc" ];
 
-    nativeBuildInputs =
-      [ pkgconfig ]
-      ++ lib.optionals (!is20) [ curl perl ]
-      ++ lib.optionals fromGit [ autoreconfHook autoconf-archive bison flex libxml2 libxslt docbook5 docbook_xsl_ns ];
+      nativeBuildInputs =
+        [ pkgconfig ]
+        ++ lib.optionals (!is20) [ curl perl ]
+        ++ lib.optionals fromGit [ autoreconfHook autoconf-archive bison flex libxml2 libxslt docbook5 docbook_xsl_ns ];
 
-    buildInputs = [ curl openssl sqlite xz bzip2 ]
-      ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
-      ++ lib.optionals is20 [ brotli boost editline ]
-      ++ lib.optional withLibseccomp libseccomp
-      ++ lib.optional (withAWS && is20)
-          ((aws-sdk-cpp.override {
-            apis = ["s3" "transfer"];
-            customMemoryManagement = false;
-          }).overrideDerivation (args: {
-            patches = args.patches or [] ++ [(fetchpatch {
-              url = https://github.com/edolstra/aws-sdk-cpp/commit/7d58e303159b2fb343af9a1ec4512238efa147c7.patch;
-              sha256 = "103phn6kyvs1yc7fibyin3lgxz699qakhw671kl207484im55id1";
-            })];
-          }));
+      buildInputs = [ curl openssl sqlite xz bzip2 ]
+        ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
+        ++ lib.optionals is20 [ brotli boost editline ]
+        ++ lib.optional withLibseccomp libseccomp
+        ++ lib.optional (withAWS && is20)
+            ((aws-sdk-cpp.override {
+              apis = ["s3" "transfer"];
+              customMemoryManagement = false;
+            }).overrideDerivation (args: {
+              patches = args.patches or [] ++ [(fetchpatch {
+                url = https://github.com/edolstra/aws-sdk-cpp/commit/7d58e303159b2fb343af9a1ec4512238efa147c7.patch;
+                sha256 = "103phn6kyvs1yc7fibyin3lgxz699qakhw671kl207484im55id1";
+              })];
+            }));
 
-    propagatedBuildInputs = [ boehmgc ];
+      propagatedBuildInputs = [ boehmgc ];
 
-    # Seems to be required when using std::atomic with 64-bit types
-    NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.system == "armv6l-linux") "-latomic";
+      # Seems to be required when using std::atomic with 64-bit types
+      NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.system == "armv6l-linux") "-latomic";
 
-    preConfigure =
-      # Copy libboost_context so we don't get all of Boost in our closure.
-      # https://github.com/NixOS/nixpkgs/issues/45462
-      if is20 then ''
-        mkdir -p $out/lib
-        cp ${boost}/lib/libboost_context* $out/lib
-      '' else ''
-        configureFlagsArray+=(BDW_GC_LIBS="-lgc -lgccpp")
+      preConfigure =
+        # Copy libboost_context so we don't get all of Boost in our closure.
+        # https://github.com/NixOS/nixpkgs/issues/45462
+        if is20 then ''
+          mkdir -p $out/lib
+          cp ${boost}/lib/libboost_context* $out/lib
+        '' else ''
+          configureFlagsArray+=(BDW_GC_LIBS="-lgc -lgccpp")
+        '';
+
+      configureFlags =
+        [ "--with-store-dir=${storeDir}"
+          "--localstatedir=${stateDir}"
+          "--sysconfdir=${confDir}"
+          "--disable-init-state"
+          "--enable-gc"
+        ]
+        ++ lib.optionals (!is20) [
+          "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
+          "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
+          "--with-www-curl=${perlPackages.WWWCurl}/${perl.libPrefix}"
+        ] ++ lib.optionals (is20 && stdenv.isLinux) [
+          "--with-sandbox-shell=${sh}/bin/busybox"
+        ]
+        ++ lib.optional (
+            stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform ? nix && stdenv.hostPlatform.nix ? system
+        ) ''--with-system=${stdenv.hostPlatform.nix.system}''
+           # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
+        ++ lib.optional (!withLibseccomp) "--disable-seccomp-sandboxing";
+
+      makeFlags = "profiledir=$(out)/etc/profile.d";
+
+      installFlags = "sysconfdir=$(out)/etc";
+
+      doInstallCheck = true; # not cross
+
+      # socket path becomes too long otherwise
+      preInstallCheck = lib.optional stdenv.isDarwin ''
+        export TMPDIR=$NIX_BUILD_TOP
       '';
 
-    configureFlags =
-      [ "--with-store-dir=${storeDir}"
-        "--localstatedir=${stateDir}"
-        "--sysconfdir=${confDir}"
-        "--disable-init-state"
-        "--enable-gc"
-      ]
-      ++ lib.optionals (!is20) [
-        "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
-        "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
-        "--with-www-curl=${perlPackages.WWWCurl}/${perl.libPrefix}"
-      ] ++ lib.optionals (is20 && stdenv.isLinux) [
-        "--with-sandbox-shell=${sh}/bin/busybox"
-      ]
-      ++ lib.optional (
-          stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform ? nix && stdenv.hostPlatform.nix ? system
-      ) ''--with-system=${stdenv.hostPlatform.nix.system}''
-         # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
-      ++ lib.optional (!withLibseccomp) "--disable-seccomp-sandboxing";
+      separateDebugInfo = stdenv.isLinux;
 
-    makeFlags = "profiledir=$(out)/etc/profile.d";
+      enableParallelBuilding = true;
 
-    installFlags = "sysconfdir=$(out)/etc";
+      meta = {
+        description = "Powerful package manager that makes package management reliable and reproducible";
+        longDescription = ''
+          Nix is a powerful package manager for Linux and other Unix systems that
+          makes package management reliable and reproducible. It provides atomic
+          upgrades and rollbacks, side-by-side installation of multiple versions of
+          a package, multi-user package management and easy setup of build
+          environments.
+        '';
+        homepage = https://nixos.org/;
+        license = stdenv.lib.licenses.lgpl2Plus;
+        maintainers = [ stdenv.lib.maintainers.eelco ];
+        platforms = stdenv.lib.platforms.all;
+        outputsToInstall = [ "out" "man" ];
+      };
 
-    doInstallCheck = true; # not cross
+      passthru = {
+        inherit fromGit;
 
-    # socket path becomes too long otherwise
-    preInstallCheck = lib.optional stdenv.isDarwin ''
-      export TMPDIR=$NIX_BUILD_TOP
-    '';
+        perl-bindings = stdenv.mkDerivation {
+          name = "nix-perl-${version}";
 
-    separateDebugInfo = stdenv.isLinux;
+          inherit src;
 
-    enableParallelBuilding = true;
+          postUnpack = "sourceRoot=$sourceRoot/perl";
 
-    meta = {
-      description = "Powerful package manager that makes package management reliable and reproducible";
-      longDescription = ''
-        Nix is a powerful package manager for Linux and other Unix systems that
-        makes package management reliable and reproducible. It provides atomic
-        upgrades and rollbacks, side-by-side installation of multiple versions of
-        a package, multi-user package management and easy setup of build
-        environments.
-      '';
-      homepage = https://nixos.org/;
-      license = stdenv.lib.licenses.lgpl2Plus;
-      maintainers = [ stdenv.lib.maintainers.eelco ];
-      platforms = stdenv.lib.platforms.all;
-      outputsToInstall = [ "out" "man" ];
+          # This is not cross-compile safe, don't have time to fix right now
+          # but noting for future travellers.
+          nativeBuildInputs =
+            [ perl pkgconfig curl nix libsodium ]
+            ++ lib.optionals fromGit [ autoreconfHook autoconf-archive ]
+            ++ lib.optional is20 boost;
+
+          configureFlags =
+            [ "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
+              "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
+            ];
+
+          preConfigure = "export NIX_STATE_DIR=$TMPDIR";
+
+          preBuild = "unset NIX_INDENT_MAKE";
+        };
+      };
     };
-
-    passthru = { inherit fromGit; };
-  };
-
-  perl-bindings = { nix, needsBoost ? false }: stdenv.mkDerivation {
-    name = "nix-perl-" + nix.version;
-
-    inherit (nix) src;
-
-    postUnpack = "sourceRoot=$sourceRoot/perl";
-
-    # This is not cross-compile safe, don't have time to fix right now
-    # but noting for future travellers.
-    nativeBuildInputs =
-      [ perl pkgconfig curl nix libsodium ]
-      ++ lib.optionals nix.fromGit [ autoreconfHook autoconf-archive ]
-      ++ lib.optional needsBoost boost;
-
-    configureFlags =
-      [ "--with-dbi=${perlPackages.DBI}/${perl.libPrefix}"
-        "--with-dbd-sqlite=${perlPackages.DBDSQLite}/${perl.libPrefix}"
-      ];
-
-    preConfigure = "export NIX_STATE_DIR=$TMPDIR";
-
-    preBuild = "unset NIX_INDENT_MAKE";
-  };
+  in nix;
 
 in rec {
 
   nix = nixStable;
 
-  nix1 = (common rec {
+  nix1 = common rec {
     name = "nix-1.11.16";
     src = fetchurl {
       url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
       sha256 = "0ca5782fc37d62238d13a620a7b4bff6a200bab1bd63003709249a776162357c";
     };
-  }) // { perl-bindings = nix1; };
+  };
 
-  nixStable = (common rec {
+  nixStable = common rec {
     name = "nix-2.2";
     src = fetchurl {
       url = "http://nixos.org/releases/nix/${name}/${name}.tar.xz";
       sha256 = "63238d00d290b8a93925891fc9164439d3941e2ccc569bf7f7ca32f53c3ec0c7";
     };
-  }) // { perl-bindings = perl-bindings {
-    nix = nixStable;
-    needsBoost = true;
-  }; };
+  };
 
-  nixUnstable = (lib.lowPrio (common rec {
+  nixUnstable = lib.lowPrio (common rec {
     name = "nix-2.2${suffix}";
     suffix = "pre6600_85488a93";
     src = fetchFromGitHub {
@@ -169,9 +170,6 @@ in rec {
       sha256 = "1n5dp7p2lzpnj7f834d25k020v16gnnsm56jz46y87v2x7b69ccm";
     };
     fromGit = true;
-  })) // { perl-bindings = perl-bindings {
-    nix = nixUnstable;
-    needsBoost = true;
-  }; };
+  });
 
 }


### PR DESCRIPTION
###### Motivation for this change

It looks like originally not all Nix packages had perl bindings, but now that they do, it seems pretty redundant to add them seperately for each package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).