### PR TITLE
oraclejdk: deprecate oraclejdk 10

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk10-linux.nix
@@ -150,6 +150,7 @@ let result = stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ]; # some inherit jre.meta.platforms
+    knownVulnerabilities = [ "Support ended in September 2018.  Use OpenJDK or JDK 8." ];
   };
 
 }; in result


### PR DESCRIPTION
###### Motivation for this change

Oracle JDK 10 is no longer supported in favor of JDK 11. Oracle JDK 11 is not free of charge, and free users are guided to use OpenJDK 11.
Should we just remove the `oraclejdk10` package rather than warning existing users?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

