### PR TITLE
Firefox bin patch channels

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation {
 
   src = fetchurl { inherit (source) url sha512; };
 
-  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+  phases = [ "unpackPhase" "patchPhase" "installPhase" "fixupPhase" ];
 
   libPath = stdenv.lib.makeLibraryPath
     [ stdenv.cc.cc
@@ -142,8 +142,8 @@ stdenv.mkDerivation {
   dontPatchELF = true;
 
   patchPhase = ''
-    sed -i -e '/^pref("app.update.channel",/d' defaults/pref/channel-prefs.js
-    echo 'pref("app.update.channel", "non-existing-channel")' >> defaults/pref/channel-prefs.js
+    # Don't download updates from Mozilla directly
+    echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
   '';
 
   installPhase =


### PR DESCRIPTION
###### Motivation for this change

Avoid Firefox auto-update checks

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

