### PR TITLE
rabbitmq module: Update documentation

### DIFF
--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -87,9 +87,19 @@ in {
           }
         '';
         description = ''
-          New style config options.
+          Configuration options in RabbitMQ's new config file format,
+          which is a simple key-value format that can not express nested
+          data structures. This is known as the <literal>rabbitmq.conf</literal> file,
+          although outside NixOS that filename may have Erlang syntax, particularly
+          prior to RabbitMQ 3.7.0.
 
-          See http://www.rabbitmq.com/configure.html
+          If you do need to express nested data structures, you can use
+          <literal>config</literal> option. Configuration from <literal>config</literal>
+          will be merged into the these options by RabbitMQ at runtime to
+          form the final configuration.
+
+          See http://www.rabbitmq.com/configure.html#config-items
+          For the distinct formats, see http://www.rabbitmq.com/configure.html#config-file-formats
         '';
       };
 
@@ -97,10 +107,17 @@ in {
         default = "";
         type = types.str;
         description = ''
-          Verbatim advanced configuration file contents.
-          Prefered way is to use configItems.
+          Verbatim advanced configuration file contents using the Erlang syntax.
+          This is also known as the <literal>advanced.config</literal> file or the old config format.
 
-          See http://www.rabbitmq.com/configure.html
+          Where possible, the use <literal>configItems</literal> is preferred. However, nested
+          data structures can only be expressed properly using the <literal>config</literal> option.
+
+          The contents of this option will be merged into the <literal>configItems</literal>
+          by RabbitMQ at runtime to form the final configuration.
+
+          See the second table on http://www.rabbitmq.com/configure.html#config-items
+          For the distinct formats, see http://www.rabbitmq.com/configure.html#config-file-formats
         '';
       };
 

--- a/nixos/modules/services/amqp/rabbitmq.nix
+++ b/nixos/modules/services/amqp/rabbitmq.nix
@@ -95,7 +95,7 @@ in {
 
           If you do need to express nested data structures, you can use
           <literal>config</literal> option. Configuration from <literal>config</literal>
-          will be merged into the these options by RabbitMQ at runtime to
+          will be merged into these options by RabbitMQ at runtime to
           form the final configuration.
 
           See http://www.rabbitmq.com/configure.html#config-items
@@ -110,7 +110,7 @@ in {
           Verbatim advanced configuration file contents using the Erlang syntax.
           This is also known as the <literal>advanced.config</literal> file or the old config format.
 
-          Where possible, the use <literal>configItems</literal> is preferred. However, nested
+          <literal>configItems</literal> is preferred whenever possible. However, nested
           data structures can only be expressed properly using the <literal>config</literal> option.
 
           The contents of this option will be merged into the <literal>configItems</literal>


### PR DESCRIPTION
Elaborate on the two config file formats.

###### Motivation for this change

The module was changed to support both formats, but the documentation was quite minimal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

