### PR TITLE
circleci-cli: 0.1.2307 -> 0.1.2569

### DIFF
--- a/pkgs/development/tools/misc/circleci-cli/default.nix
+++ b/pkgs/development/tools/misc/circleci-cli/default.nix
@@ -3,7 +3,7 @@
 let
   owner = "CircleCI-Public";
   pname = "circleci-cli";
-  version = "0.1.2307";
+  version = "0.1.2569";
 in
 buildGoPackage rec {
   name = "${pname}-${version}";
@@ -13,7 +13,7 @@ buildGoPackage rec {
     inherit owner;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0z71jnq42idvhgpgn3mdpbajmgn4b41rpifv5qxn3h1pgi08f75s";
+    sha256 = "0ixiqx8rmia02r44zbhw149p5x9r9cv1fsnlhl8p2x5zd2bdr18x";
   };
 
   goPackagePath = "github.com/${owner}/${pname}";


### PR DESCRIPTION
###### Motivation for this change

New version? These guys have several releases per day, because they release whenever their CI succeeds (not too strange for a CI comany, but _I'm_ not gonna keep up with them). Any suggestions on how to handle this? Can @r-ryantm (@ryantm) handle this package already?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

