### PR TITLE
sbsigntool: 0.5 -> 0.9.1

### DIFF
--- a/pkgs/tools/security/sbsigntool/autoconf.patch
+++ b/pkgs/tools/security/sbsigntool/autoconf.patch
@@ -1,17 +1,27 @@
-diff -uNr sbsigntool/configure.ac sbsigntool-new/configure.ac
---- sbsigntool/configure.ac	2015-07-05 12:18:18.932717136 +0200
-+++ sbsigntool-new/configure.ac	2015-07-05 14:51:39.659284938 +0200
-@@ -65,7 +65,7 @@
+--- sbsigntools/configure.ac	2018-09-25 10:30:00.878766256 -0500
++++ configure.ac.new	2018-09-25 10:34:56.231277375 -0500
+@@ -71,15 +71,16 @@
+ # no consistent view of where gnu-efi should dump the efi stuff, so find it
+ ##
+ for path in /lib /lib64 /usr/lib /usr/lib64 /usr/lib32 /lib/efi /lib64/efi /usr/lib/efi /usr/lib64/efi; do
+-    if test -e $path/crt0-efi-$EFI_ARCH.o; then
+-       CRTPATH=$path
++    if test -e @@NIX_GNUEFI@@/$path/crt0-efi-$EFI_ARCH.o; then
++       CRTPATH=@@NIX_GNUEFI@@/$path
++       break
+     fi
+ done
+ if test -z "$CRTPATH"; then
+    AC_MSG_ERROR([cannot find the gnu-efi crt path])
+ fi
  
- dnl gnu-efi headers require extra include dirs
- EFI_ARCH=$(uname -m)
 -EFI_CPPFLAGS="-I/usr/include/efi -I/usr/include/efi/$EFI_ARCH \
 +EFI_CPPFLAGS="-I@@NIX_GNUEFI@@/include/efi -I@@NIX_GNUEFI@@/include/efi/$EFI_ARCH \
   -DEFI_FUNCTION_WRAPPER"
  CPPFLAGS_save="$CPPFLAGS"
  CPPFLAGS="$CPPFLAGS $EFI_CPPFLAGS"
-@@ -74,5 +74,5 @@
- AC_SUBST(EFI_CPPFLAGS, $EFI_CPPFLAGS)
+@@ -90,5 +91,5 @@
+ AC_SUBST(CRTPATH, $CRTPATH)
  
  AC_CONFIG_FILES([Makefile src/Makefile lib/ccan/Makefile]
 -		[docs/Makefile tests/Makefile])

--- a/pkgs/tools/security/sbsigntool/default.nix
+++ b/pkgs/tools/security/sbsigntool/default.nix
@@ -5,12 +5,12 @@
 
 stdenv.mkDerivation rec {
   name = "sbsigntool-${version}";
-  version = "0.5";
+  version = "0.9.1";
 
   src = fetchgit {
-    url = "git://kernel.ubuntu.com/jk/sbsigntool";
-    rev = "951ee95a301674c046f55330cd7460e1314deff2";
-    sha256 = "1skqrfhvsaay01l94m57sxxqp909rvn07xwmzc6vzzfcnsh6f2yk";
+    url = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git";
+    rev = "v0.9.1";
+    sha256 = "098gxmhjn8acxjw5bq59wq4xhgkpx1xn8kjvxwdzpqkwq9ivrsbp";
   };
 
   patches = [ ./autoconf.patch ];
@@ -18,12 +18,12 @@ stdenv.mkDerivation rec {
   prePatch = "patchShebangs .";
 
   nativeBuildInputs = [ autoconf automake pkgconfig help2man ];
-  buildInputs = [ utillinux openssl libuuid gnu-efi libbfd ];
+  buildInputs = [ openssl libuuid libbfd gnu-efi ];
 
   configurePhase = ''
     substituteInPlace configure.ac --replace "@@NIX_GNUEFI@@" "${gnu-efi}"
 
-    lib/ccan.git/tools/create-ccan-tree --build-type=automake lib/ccan "talloc read_write_all build_assert array_size"
+    lib/ccan.git/tools/create-ccan-tree --build-type=automake lib/ccan "talloc read_write_all build_assert array_size endian"
     touch AUTHORS
     touch ChangeLog
 


### PR DESCRIPTION
###### Motivation for this change

0.9.0 adds support for OpenSSL 1.1; 0.9.1 adds engine support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS (not supported)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`) (*functionality* not tested across all tools, but *invocation* checked everywhere)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

