### PR TITLE
retroshare: mark as broken

### DIFF
--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.domenkozar ];
+    broken = true; # broken by libupnp: 1.6.21 -> 1.8.3 (#41684)
   };
 }


### PR DESCRIPTION
###### Motivation for this change

It was broken by libupnp: 1.6.21 -> 1.8.3 (#41684).

Even after patching libupnp with https://github.com/mrjimenez/pupnp/commit/9220f76b17816b476f7662bae959d9f403046a37 to fix an include bug in libupnp, and updating retroshare to the latest release 0.6.4, it fails to compile with errors like:
```
error: invalid static_cast from type 'int (*)(Upnp_EventType, void*, void*) {aka int (*)(Upnp_EventType_e, void*, void*)}' to type 'Upnp_FunPtr {aka int (*)(Upnp_EventType_e, const void*, void*)}'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).