### PR TITLE
nodejs-10_x: 10.9.0 -> 10.11.0

### DIFF
--- a/pkgs/development/web/nodejs/v10.nix
+++ b/pkgs/development/web/nodejs/v10.nix
@@ -5,6 +5,6 @@ let
 in
   buildNodejs {
     inherit enableNpm;
-    version = "10.9.0";
-    sha256 = "00hdachbmcf9pyd1iksprsi5mddwp6z59mb3lr81z8ynfbmzhzni";
+    version = "10.11.0";
+    sha256 = "16wfgwnb2yd6y608svj2fizdq3sid44m0wqn4swkvclxb71444mr";
   }


### PR DESCRIPTION
###### Motivation for this change
Nodejs released a new version on the 10.x branch. This updates us to use that latest release.

We closed a previous attempt for this change (#47107) pending the upgrade of `libuv`. This is the same PR rebased on current master. I couldn't reopen the previous PR because of the rebase, so I created this new one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

