### PR TITLE
firefox: disable auto updates using distribution policies.

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -42,6 +42,7 @@
 , channel
 , generated
 , writeScript
+, writeText
 , xidel
 , coreutils
 , gnused
@@ -68,6 +69,12 @@ let
       (isPrefixOf source.locale locale) && source.arch == arch;
 
   systemLocale = config.i18n.defaultLocale or "en-US";
+
+  policies = {
+    DisableAppUpdate = true;
+  };
+
+  policiesJson = writeText "no-update-firefox-policy.json" (builtins.toJSON { inherit policies; });
 
   defaultSource = stdenv.lib.findFirst (sourceMatches "en-US") {} sources;
 
@@ -172,6 +179,10 @@ stdenv.mkDerivation {
       ln -s "$out/usr/lib" "$out/lib"
 
       gappsWrapperArgs+=(--argv0 "$out/bin/.firefox-wrapped")
+
+      # See: https://github.com/mozilla/policy-templates/blob/master/README.md
+      mkdir -p "$out/lib/firefox-bin-${version}/distribution";
+      ln -s ${policiesJson} "$out/lib/firefox-bin-${version}/distribution/policies.json";
     '';
 
   passthru.execdir = "/bin";


### PR DESCRIPTION
Resolves #33884 

###### Motivation for this change

#33884

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary fil#33884es (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

