### PR TITLE
perl: add devel version at 5.29.3

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -77,7 +77,7 @@ let
         "-Dlocincpth=${libcInc}/include"
         "-Dloclibpth=${libcLib}/lib"
       ]
-      ++ optionals ((builtins.match "5\.[0-9]*[13579]\..+" version) != null) [ "-Dusedevel" "-Uversiononly" ]
+      ++ optionals ((builtins.match ''5\.[0-9]*[13579]\..+'' version) != null) [ "-Dusedevel" "-Uversiononly" ]
       ++ optional stdenv.isSunOS "-Dcc=gcc"
       ++ optional enableThreading "-Dusethreads";
 

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -77,6 +77,7 @@ let
         "-Dlocincpth=${libcInc}/include"
         "-Dloclibpth=${libcLib}/lib"
       ]
+      ++ optionals ((builtins.match "5\.[0-9]*[13579]\..+" version) != null) [ "-Dusedevel" "-Uversiononly" ]
       ++ optional stdenv.isSunOS "-Dcc=gcc"
       ++ optional enableThreading "-Dusethreads";
 
@@ -186,8 +187,15 @@ in rec {
     sha256 = "03gpnxx1g6hvlh0v4aqx00580h787sfywp1vlvw64q2xcbm9qbsp";
   };
 
+  # the latest Maint version
   perl528 = common {
     version = "5.28.0";
     sha256 = "1a3f822lcl8dr8v0hk80yyhpzqlljg49z9flb48rs3nbsij9z4ky";
+  };
+
+  # the latest Devel version
+  perldevel = common {
+    version = "5.29.3";
+    sha256 = "054xi629408p2hv9475jghv6zd1bj69qqpiby8cy9qw5vismgi17";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7605,7 +7605,7 @@ with pkgs;
 
   ocropus = callPackage ../applications/misc/ocropus { };
 
-  inherit (callPackages ../development/interpreters/perl {}) perl522 perl524 perl526 perl528;
+  inherit (callPackages ../development/interpreters/perl {}) perl522 perl524 perl526 perl528 perldevel;
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 
@@ -12841,6 +12841,7 @@ with pkgs;
 
   ### DEVELOPMENT / PERL MODULES
 
+  # old versions
   perl522Packages = recurseIntoAttrs (callPackage ./perl-packages.nix {
     perl = perl522;
     overrides = (config.perlPackageOverrides or (p: {})) pkgs;
@@ -12853,8 +12854,14 @@ with pkgs;
     perl = perl526;
     overrides = (config.perlPackageOverrides or (p: {})) pkgs;
   });
+  # the latest Maint version
   perl528Packages = recurseIntoAttrs (callPackage ./perl-packages.nix {
     perl = perl528;
+    overrides = (config.perlPackageOverrides or (p: {})) pkgs;
+  });
+  # the latest Devel version
+  perldevelPackages = recurseIntoAttrs (callPackage ./perl-packages.nix {
+    perl = perldevel;
     overrides = (config.perlPackageOverrides or (p: {})) pkgs;
   });
 


### PR DESCRIPTION
###### Motivation for this change

The idea is to build ```perlPackages``` also against the bleeding edge ```perl``` and to see failures and to fix them before the next ```perl``` release.

It should not cause any rebuild