### PR TITLE
qboot: 20150603 -> 20170330, fix build

### DIFF
--- a/pkgs/applications/virtualization/qboot/default.nix
+++ b/pkgs/applications/virtualization/qboot/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
-  name = "qboot-pre-release";
+  name = "qboot-20170330";
 
-  src = fetchgit {
-    url = "https://github.com/yangchengwork/qboot";
-    rev = "b2bdaf4c878ef34f309c8c79613fabd1b9c4bf75";
-    sha256 = "00f24125733d24713880e430f409d6ded416286d209c9fabb45541311b01cf8d";
+  src = fetchFromGitHub {
+    owner = "bonzini";
+    repo = "qboot";
+    rev = "ac9488f26528394856b94bda0797f5bd9c69a26a";
+    sha256 = "0l83nbjndin1cbcimkqkiqr5df8d76cnhyk26rd3aygb2bf7cspy";
   };
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13394,7 +13394,7 @@ with pkgs;
   softether_4_25 = callPackage ../servers/softether/4.25.nix { };
   softether = softether_4_25;
 
-  qboot = callPackage ../applications/virtualization/qboot { stdenv = stdenv_32bit; };
+  qboot = pkgsi686Linux.callPackage ../applications/virtualization/qboot { };
 
   OVMF = callPackage ../applications/virtualization/OVMF { seabios = null; openssl = null; };
   OVMF-CSM = OVMF.override { openssl = null; };


### PR DESCRIPTION
###### Motivation for this change

ZHF #45960. Didn't build.
Switch back to original upstream repo which is more recent than the fork we used. Bump and fix build.

###### Things done

- [x] built in a sandbox on NixOS
- [x] firmware boots a kernel in qemu

---
(listed maintainer: tstrobel, no github account given)
