### PR TITLE
spectral: init at 2018-09-24; nheko: 0.5.0 -> 0.6.0 and bump dep mtxclient

### DIFF
--- a/pkgs/applications/networking/instant-messengers/nheko/default.nix
+++ b/pkgs/applications/networking/instant-messengers/nheko/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchurl
-, cmake, lmdb, qt5, qtmacextras, mtxclient
+, cmake, cmark, lmdb, qt5, qtmacextras, mtxclient
 , boost, spdlog, olm, pkgconfig
 }:
 
@@ -20,13 +20,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "nheko-${version}";
-  version = "0.5.5";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "mujx";
     repo = "nheko";
     rev = "v${version}";
-    sha256 = "0k5gmfwmisfavliyz0nfsmwy317ps8a4r3l1d831giqp9pvqvi0i";
+    sha256 = "1qd2c5684722jlpgqyxq6pbb1rdk1zc3sk88mkjyqypj1k0pj3dc";
   };
 
   # If, on Darwin, you encounter the error
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    mtxclient olm boost lmdb spdlog
+    mtxclient olm boost lmdb spdlog cmark
     qt5.qtbase qt5.qtmultimedia qt5.qttools
   ] ++ lib.optional stdenv.isDarwin qtmacextras;
 

--- a/pkgs/applications/networking/instant-messengers/spectral/default.nix
+++ b/pkgs/applications/networking/instant-messengers/spectral/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchgit
+, pkgconfig
+, qmake, qtbase, qtquickcontrols2, qtmultimedia
+, libpulseaudio
+# Not mentioned but seems needed
+, qtgraphicaleffects
+# Unsure but needed by similar
+, qtdeclarative, qtsvg
+}:
+
+stdenv.mkDerivation rec {
+  name = "spectral-${version}";
+  version = "2018-09-24";
+
+  src = fetchgit {
+    url = "https://gitlab.com/b0/spectral.git";
+    rev = "c9d1d6887722860a52b597a0f74d0ce39c8622e1";
+    sha256 = "1ym8jlqls4lcq5rd81vxw1dni79fc6ph00ip8nsydl6i16fngl4c";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ pkgconfig qmake ];
+  buildInputs = [ qtbase qtquickcontrols2 qtmultimedia qtgraphicaleffects qtdeclarative qtsvg ]
+    ++ stdenv.lib.optional stdenv.hostPlatform.isLinux libpulseaudio;
+
+  meta = with stdenv.lib; {
+    description = "A glossy client for Matrix, written in QtQuick Controls 2 and C++";
+    homepage = https://gitlab.com/b0/spectral;
+    license = licenses.gpl3;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "mtxclient-${version}";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "mujx";
     repo = "mtxclient";
     rev = "v${version}";
-    sha256 = "0i58y45diysayjzy5ick15356972z67dfxm0w41ay88nm42x1imp";
+    sha256 = "19v1qa6mzvc65m7wy7x0g4i24bcg9xk31y1grwvd3zr0l4v6xcgs";
   };
 
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16989,6 +16989,8 @@ with pkgs;
 
   spectrwm = callPackage ../applications/window-managers/spectrwm { };
 
+  spectral = qt5.callPackage ../applications/networking/instant-messengers/spectral { };
+
   super-productivity = callPackage ../applications/networking/super-productivity { };
 
   wlc = callPackage ../development/libraries/wlc { };


### PR DESCRIPTION
I would love a semi-usable linux client for matrix! :)

These are looking pretty good...

See notes on spectral commit.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---