### PR TITLE
broken darwin packages (f)

### DIFF
--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, fltk13, ghostscript}:
+{ stdenv, fetchurl, fltk13, ghostscript, xlibs }:
 
 stdenv.mkDerivation rec {
   name = "flpsed-${version}";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     description = "WYSIWYG PostScript annotator";
     homepage = http://flpsed.org/flpsed.html;
     license = licenses.gpl3;
-    platforms = platforms.mesaPlatforms;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ fuuzetsu ];
   };
 }

--- a/pkgs/development/libraries/fox/default.nix
+++ b/pkgs/development/libraries/fox/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     homepage = http://fox-toolkit.org;
     license = licenses.lgpl3;
     maintainers = [];
+    broken = stdenv.isDarwin;
     platforms = platforms.all;
   };
 }

--- a/pkgs/games/freedroidrpg/default.nix
+++ b/pkgs/games/freedroidrpg/default.nix
@@ -58,5 +58,6 @@ in stdenv.mkDerivation rec {
 
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;
+    hydraPlatforms = platforms.linux; # sdl-config times out on darwin
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Mark various packages linux only or broken on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

