### PR TITLE
erlangR19: 19.3.6.6 -> 19.3.6.11

### DIFF
--- a/pkgs/development/interpreters/erlang/R19.nix
+++ b/pkgs/development/interpreters/erlang/R19.nix
@@ -1,8 +1,8 @@
 { mkDerivation, fetchpatch }:
 
 mkDerivation rec {
-  version = "19.3.6.6";
-  sha256 = "05l81gig0hmr951pjvwknc9x2qvpm95ph9z072hn4jqg13rzbgvg";
+  version = "19.3.6.11";
+  sha256 = "0b02iv8dly1vkc2xnqqi030sdj34h4gji2h4qgilllajr1f868vm";
 
   patches = [
     # macOS 10.13 crypto fix from OTP-20.1.2


### PR DESCRIPTION
###### Motivation for this change

A new version is available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

