### PR TITLE
google-compute-engine: 20180510 -> 20180905

### DIFF
--- a/nixos/modules/virtualisation/google-compute-image.nix
+++ b/nixos/modules/virtualisation/google-compute-image.nix
@@ -97,8 +97,8 @@ in
       "google-instance-setup.service"
       "google-network-setup.service"
     ];
-    wantedBy = [ "multi-user.target" ];
     requires = ["network.target"];
+    wantedBy = ["multi-user.target"];
     path = with pkgs; [ shadow ];
     serviceConfig = {
       Type = "simple";
@@ -113,8 +113,8 @@ in
       "google-instance-setup.service"
       "google-network-setup.service"
     ];
-    requires = [ "network.target" ];
-    wantedBy = [ "multi-user.target" ];
+    requires = ["network.target"];
+    wantedBy = ["multi-user.target"];
     serviceConfig = {
       Type = "simple";
       ExecStart = "${gce}/bin/google_clock_skew_daemon --debug";
@@ -123,7 +123,7 @@ in
 
   systemd.services.google-instance-setup = {
     description = "Google Compute Engine Instance Setup";
-    after = ["fs.target" "network-online.target" "network.target" "rsyslog.service"];
+    after = ["local-fs.target" "network-online.target" "network.target" "rsyslog.service"];
     before = ["sshd.service"];
     wants = ["local-fs.target" "network-online.target" "network.target"];
     wantedBy = [ "sshd.service" "multi-user.target" ];
@@ -134,15 +134,17 @@ in
     };
   };
 
-  systemd.services.google-ip-forwarding-daemon = {
-    description = "Google Compute Engine IP Forwarding Daemon";
-    after = ["network.target" "google-instance-setup.service" "google-network-setup.service"];
+  systemd.services.google-network-daemon = {
+    description = "Google Compute Engine Network Daemon";
+    after = ["local-fs.target" "network-online.target" "network.target" "rsyslog.service" "google-instance-setup.service"];
+    wants = ["local-fs.target" "network-online.target" "network.target"];
     requires = ["network.target"];
+    partOf = ["network.target"];
     wantedBy = [ "multi-user.target" ];
     path = with pkgs; [ iproute ];
     serviceConfig = {
-      Type = "simple";
-      ExecStart = "${gce}/bin/google_ip_forwarding_daemon --debug";
+      ExecStart = "${gce}/bin/google_network_daemon --debug";
+      Type = "oneshot";
     };
   };
 
@@ -153,8 +155,9 @@ in
       "network-online.target"
       "network.target"
       "rsyslog.service"
+      "systemd-resolved.service"
       "google-instance-setup.service"
-      "google-network-setup.service"
+      "google-network-daemon.service"
     ];
     wants = [ "local-fs.target" "network-online.target" "network.target"];
     wantedBy = [ "multi-user.target" ];
@@ -167,23 +170,6 @@ in
     };
   };
 
-  systemd.services.google-network-setup = {
-    description = "Google Compute Engine Network Setup";
-    after = [
-      "local-fs.target"
-      "network-online.target"
-      "network.target"
-      "rsyslog.service"
-    ];
-    wants = [ "local-fs.target" "network-online.target" "network.target"];
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      ExecStart = "${gce}/bin/google_network_setup --debug";
-      KillMode = "process";
-      Type = "oneshot";
-    };
-  };
-
   systemd.services.google-startup-scripts = {
     description = "Google Compute Engine Startup Scripts";
     after = [
@@ -192,9 +178,9 @@ in
       "network.target"
       "rsyslog.service"
       "google-instance-setup.service"
-      "google-network-setup.service"
+      "google-network-daemon.service"
     ];
-    wants = [ "local-fs.target" "network-online.target" "network.target"];
+    wants = ["local-fs.target" "network-online.target" "network.target"];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
       ExecStart = "${gce}/bin/google_metadata_script_runner --debug --script-type startup";

--- a/pkgs/tools/virtualization/google-compute-engine/default.nix
+++ b/pkgs/tools/virtualization/google-compute-engine/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonApplication rec {
   name = "google-compute-engine-${version}";
-  version = "20180510";
+  version = "20180905";
   namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "compute-image-packages";
     rev = version;
-    sha256 = "13hmg29s1pljcvf40lrv5yickg8x51rcnv68wxhs6zkkg75k448p";
+    sha256 = "0095f000kgk2lc5p1y4080sbc0r7ly60a7i9id8hydfnkhqqz75n";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Fix the GCE daemons. There are still issues but it's better than before.

The google-ip-forwarding-daemon and google-network-setup have been merged to google-network-daemon.

Known issues:
* The startup service is not executed during startup for some reason which prevents to execute the metadata script
* SSH keys are not propagating
* OSLogin isn't installed, this is a new way to authenticate

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

