### PR TITLE
net_snmp: build with default perl

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13377,11 +13377,7 @@ with pkgs;
 
   check-esxi-hardware = callPackage ../servers/monitoring/plugins/esxi.nix {};
 
-  net_snmp = callPackage ../servers/monitoring/net-snmp {
-    # https://sourceforge.net/p/net-snmp/bugs/2712/
-    # remove after net-snmp > 5.7.3
-    perl = perl522;
-  };
+  net_snmp = callPackage ../servers/monitoring/net-snmp { };
 
   newrelic-sysmond = callPackage ../servers/monitoring/newrelic-sysmond { };
 


### PR DESCRIPTION
###### Motivation for this change

I cannot reproduce the bug https://sourceforge.net/p/net-snmp/bugs/2712/ and able to build net_snmp with default perl (which is 5.28)

Let's see what ofborg says. If it fails, there is either an option to upgrade ```net_snmp``` to 5.8 or a  [patch](https://github.com/FreeSNMP/net-snmp/commit/4e793461e96a2b4fd81142ab312d074d5c8841fa.patch) to fix the bug in ```net_snmp``` 5.7.3 LTS

The goal is to deprecate perl-5.22 and perl-5.24, it is the last reference
