### PR TITLE
allure: init at 2.7.0

### DIFF
--- a/pkgs/development/tools/allure/default.nix
+++ b/pkgs/development/tools/allure/default.nix
@@ -1,0 +1,42 @@
+
+#url = https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/2.7.0/allure-2.7.0.tgz;
+{ lib, stdenv, makeWrapper, fetchurl, jre }:
+
+stdenv.mkDerivation rec {
+  version = "2.7.0";
+  pname = "allure";
+  name = "${pname}-${version}";
+  share-app-dir = name;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ jre ];
+
+  src = fetchurl {
+    url = "https://dl.bintray.com/qameta/generic/io/qameta/allure/${pname}/${version}/${pname}-${version}.tgz";
+    sha256 = "181996wayplpmss5x4kiilpr4wg1mnbzbv88kr8kv3j22gwygx0g";
+  };
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p "$out/share"
+    cd "$out/share"
+    tar xvzf $src
+
+    mkdir -p "$out/bin"
+    makeWrapper $out/share/${share-app-dir}/bin/allure $out/bin/${pname} \
+      --prefix PATH : "${jre}/bin"
+  '';
+
+  meta = with lib; {
+    homepage = "https://docs.qameta.io/allure/";
+    description = ''
+        A flexible lightweight multi-language test report tool
+        with the possibility to add steps, attachments, parameters and so on.
+      '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jraygauthier ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7913,6 +7913,8 @@ with pkgs;
 
   alloy = callPackage ../development/tools/alloy { };
 
+  allure = callPackage ../development/tools/allure { };
+
   adtool = callPackage ../tools/admin/adtool { };
 
   augeas = callPackage ../tools/system/augeas { };


### PR DESCRIPTION
###### Motivation for this change

Missing package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

