### PR TITLE
sublimeMerge: init at 1058

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2015,6 +2015,11 @@
     github = "joncojonathan";
     name = "Jonathan Haddock";
   };
+  jonoabroad = {
+    email = "github@jonoabroad.com";
+    github = "jonoabroad";
+    name = "Jonathan Ferguson";
+  };
   jpdoyle = {
     email = "joethedoyle@gmail.com";
     github = "jpdoyle";

--- a/pkgs/development/tools/sublime-merge/common.nix
+++ b/pkgs/development/tools/sublime-merge/common.nix
@@ -34,9 +34,6 @@ in let
           --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
           $i
       done
-
-      # Rewrite pkexec|gksudo argument. Note that we can't delete bytes in binary.
-      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' sublime_merge
     '';
 
     installPhase = ''
@@ -67,14 +64,14 @@ in stdenv.mkDerivation (rec {
   installPhase = ''
     mkdir -p $out/bin
 
-    cat > $out/bin/sublM <<-EOF
+    cat > $out/bin/smerge <<-EOF
     #!/bin/sh
     exec $sublimeMerge/sublime_merge "\$@"
     EOF
-    chmod +x $out/bin/sublM
+    chmod +x $out/bin/smerge
 
-    ln $out/bin/sublM $out/bin/sublime_merge
-    ln $out/bin/sublM $out/bin/sublimeMerge
+    ln $out/bin/smerge $out/bin/sublime_merge
+    ln $out/bin/smerge $out/bin/sublimeMerge
     mkdir -p $out/share/applications
     ln -s $sublimeMerge/sublime_merge.desktop $out/share/applications/sublime_merge.desktop
     ln -s $sublimeMerge/Icon/256x256/ $out/share/icons
@@ -85,6 +82,6 @@ in stdenv.mkDerivation (rec {
     homepage = https://www.sublimemerge.com/;
     maintainers = with maintainers; [ jonoabroad ];
     license = licenses.unfree;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/development/tools/sublime-merge/common.nix
+++ b/pkgs/development/tools/sublime-merge/common.nix
@@ -1,0 +1,90 @@
+{buildVersion, x64sha256}:
+
+{ fetchurl, stdenv, glib, xorg, cairo, gtk2, pango, makeWrapper, openssl, bzip2,
+  pkexecPath ? "/run/wrappers/bin/pkexec", libredirect,
+  gksuSupport ? false, gksu, unzip, zip, bash}:
+
+assert gksuSupport -> gksu != null;
+
+let
+
+  libPath = stdenv.lib.makeLibraryPath [glib xorg.libX11 gtk2 cairo pango];
+  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
+    ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
+in let
+
+  # package with just the binaries
+  sublimeMerge = stdenv.mkDerivation {
+    name = "sublimeMerge-${buildVersion}-bin";
+    src =
+      fetchurl {
+        name = "sublime_merge_${buildVersion}_x64.tar.xz";
+        url = "https://download.sublimetext.com/sublime_merge_build_${buildVersion}_x64.tar.xz";
+        sha256 = x64sha256;
+      };
+
+    dontStrip = true;
+    dontPatchELF = true;
+    buildInputs = [ makeWrapper zip unzip ];
+
+    buildPhase = ''
+      for i in crash_reporter git-credential-sublime ssh-askpass-sublime  sublime_merge; do
+        patchelf \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"} \
+          $i
+      done
+
+      # Rewrite pkexec|gksudo argument. Note that we can't delete bytes in binary.
+      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' sublime_merge
+    '';
+
+    installPhase = ''
+      # Correct sublime_merge.desktop to exec `sublime' instead of /opt/sublime_merge
+      sed -e "s,/opt/sublime_merge/sublime_merge,$out/sublime_merge," -i sublime_merge.desktop
+
+      mkdir -p $out
+      cp -prvd * $out/
+
+      # We can't just call /usr/bin/env bash because a relocation error occurs
+      # when trying to run a build from within Sublime Merge
+      ln -s ${bash}/bin/bash $out/sublime_bash
+      wrapProgram $out/sublime_bash \
+        --set LD_PRELOAD "${stdenv.cc.cc.lib}/lib${stdenv.lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1"
+
+      wrapProgram $out/sublime_merge \
+        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+        --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects}
+    '';
+  };
+in stdenv.mkDerivation (rec {
+  name = "sublimemerge-${buildVersion}";
+
+  phases = [ "installPhase" ];
+
+  inherit sublimeMerge;
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cat > $out/bin/sublM <<-EOF
+    #!/bin/sh
+    exec $sublimeMerge/sublime_merge "\$@"
+    EOF
+    chmod +x $out/bin/sublM
+
+    ln $out/bin/sublM $out/bin/sublime_merge
+    ln $out/bin/sublM $out/bin/sublimeMerge
+    mkdir -p $out/share/applications
+    ln -s $sublimeMerge/sublime_merge.desktop $out/share/applications/sublime_merge.desktop
+    ln -s $sublimeMerge/Icon/256x256/ $out/share/icons
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Meet a new Git client, from the makers of Sublime Text";
+    homepage = https://www.sublimemerge.com/;
+    maintainers = with maintainers; [ jonoabroad ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+})

--- a/pkgs/development/tools/sublime-merge/packages.nix
+++ b/pkgs/development/tools/sublime-merge/packages.nix
@@ -8,4 +8,8 @@ in
       buildVersion = "1058";
       x64sha256 = "1yj3cg3z9421h36mgjprr94p4m0i4hl4ndi215bfp1i1b02rrva8";
     } {};
+    sublimeMerge-dev = common {
+      buildVersion = "1060";
+      x64sha256 = "e3b362d9e544157fa6e1811dc4e8892387a0609858a2503f45aeb62f19aefa2a";
+    } {};
   }

--- a/pkgs/development/tools/sublime-merge/packages.nix
+++ b/pkgs/development/tools/sublime-merge/packages.nix
@@ -1,0 +1,11 @@
+{ callPackage }:
+
+let
+  common = opts: callPackage (import ./common.nix opts);
+in
+  rec {
+    sublimeMerge = common {
+      buildVersion = "1058";
+      x64sha256 = "1yj3cg3z9421h36mgjprr94p4m0i4hl4ndi215bfp1i1b02rrva8";
+    } {};
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18786,6 +18786,13 @@ with pkgs;
 
   sublime3-dev = sublime3Packages.sublime3-dev;
 
+  sublimeMergePackages = recurseIntoAttrs (callPackage ../development/tools/sublime-merge/packages.nix { });
+
+  sublimeMerge = sublimeMergePackages.sublimeMerge;
+
+  sublimeMerge-dev = sublimeMergePackages.sublimeMerge-dev;  
+
+
   inherit (callPackages ../applications/version-management/subversion {
       bdbSupport = true;
       httpServer = false;
@@ -18805,10 +18812,6 @@ with pkgs;
     perlBindings = true;
     pythonBindings = true;
   });
-
-  sublimeMergePackages = recurseIntoAttrs (callPackage ../development/tools/sublime-merge/packages.nix { });
-
-  sublimeMerge = sublimeMergePackages.sublimeMerge;
 
   subunit = callPackage ../development/libraries/subunit { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18806,6 +18806,10 @@ with pkgs;
     pythonBindings = true;
   });
 
+  sublimeMergePackages = recurseIntoAttrs (callPackage ../development/tools/sublime-merge/packages.nix { });
+
+  sublimeMerge = sublimeMergePackages.sublimeMerge;
+
   subunit = callPackage ../development/libraries/subunit { };
 
   surf = callPackage ../applications/networking/browsers/surf { gtk = gtk2; };


### PR DESCRIPTION
###### Motivation for this change
Provide git client Sublime Merge  addressing https://github.com/NixOS/nixpkgs/issues/47377
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

