### PR TITLE
zita-njbridge: init at 0.4.4

### DIFF
--- a/pkgs/applications/audio/zita-njbridge/default.nix
+++ b/pkgs/applications/audio/zita-njbridge/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, libjack2, zita-resampler }:
+
+stdenv.mkDerivation rec {
+  version = "0.4.4";
+  name = "zita-njbridge-${version}";
+
+  src = fetchurl {
+    url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${name}.tar.bz2";
+    sha256 = "1l8rszdjhp0gq7mr54sdgfs6y6cmw11ssmqb1v9yrkrz5rmwzg8j";
+  };
+
+  buildInputs = [ libjack2 zita-resampler ];
+
+  preConfigure = ''
+    cd ./source/
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "MANDIR=$(out)"
+    "SUFFIX=''"
+  ];
+
+
+  meta = with stdenv.lib; {
+    description = "command line Jack clients to transmit full quality multichannel audio over a local IP network";
+    homepage = http://kokkinizita.linuxaudio.org/linuxaudio/index.html;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19731,6 +19731,8 @@ with pkgs;
 
   zim = callPackage ../applications/office/zim { };
 
+  zita-njbridge = callPackage ../applications/audio/zita-njbridge { };
+
   zoom-us = libsForQt59.callPackage ../applications/networking/instant-messengers/zoom-us { };
 
   zotero = callPackage ../applications/office/zotero { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

