### PR TITLE
go-2fa: Init at 1.1.0

### DIFF
--- a/pkgs/tools/security/2fa/default.nix
+++ b/pkgs/tools/security/2fa/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  version = "1.1.0";
+  name = "2fa-${version}";
+
+  goPackagePath = "rsc.io/2fa";
+
+  src = fetchFromGitHub {
+    owner = "rsc";
+    repo = "2fa";
+    rev = "v${version}";
+    sha256 = "0827vl2bxd6m2rbj00x7857cs7cic3mlg5nlhqzd0n73dm5vk2za";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://rsc.io/2fa;
+    description = "Two-factor authentication on the command line";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ rvolosatovs ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1338,6 +1338,8 @@ with pkgs;
 
   gdrive = callPackage ../applications/networking/gdrive { };
 
+  go-2fa = callPackage ../tools/security/2fa {};
+
   go-dependency-manager = callPackage ../development/tools/gdm { };
 
   geckodriver = callPackage ../development/tools/geckodriver { };


### PR DESCRIPTION
###### Motivation for this change
Added https://github.com/rsc/2fa

AFAIK Nix does not support attribute names starting with numerals, hence I named the attribute `go-2fa`, however the name of the "package" is `2fa`.
Output of `nix search`:
```
Attribute name: nixpkgs.go-2fa
Package name: 2fa
Version: 1.1.0
Description: Two-factor authentication on the command line
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

