### PR TITLE
ejson: init at 1.2.0

### DIFF
--- a/pkgs/development/tools/ejson/Gemfile
+++ b/pkgs/development/tools/ejson/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'fpm'
+gem 'ronn'

--- a/pkgs/development/tools/ejson/Gemfile.lock
+++ b/pkgs/development/tools/ejson/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arr-pm (0.0.10)
+      cabin (> 0)
+    backports (3.8.0)
+    cabin (0.9.0)
+    childprocess (0.7.1)
+      ffi (~> 1.0, >= 1.0.11)
+    clamp (1.0.1)
+    dotenv (2.2.1)
+    ffi (1.9.18)
+    fpm (1.9.2)
+      arr-pm (~> 0.0.10)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      childprocess
+      clamp (~> 1.0.0)
+      ffi
+      json (>= 1.7.7, < 2.0)
+      pleaserun (~> 0.0.29)
+      ruby-xz
+      stud
+    hpricot (0.8.6)
+    insist (1.0.0)
+    io-like (0.3.0)
+    json (1.8.6)
+    mustache (0.99.8)
+    pleaserun (0.0.30)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    rdiscount (2.2.0.1)
+    ronn (0.7.3)
+      hpricot (>= 0.8.2)
+      mustache (>= 0.7.0)
+      rdiscount (>= 1.5.8)
+    ruby-xz (0.2.3)
+      ffi (~> 1.9)
+      io-like (~> 0.3)
+    stud (0.0.23)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fpm
+  ronn
+
+BUNDLED WITH
+   1.16.0

--- a/pkgs/development/tools/ejson/default.nix
+++ b/pkgs/development/tools/ejson/default.nix
@@ -1,0 +1,46 @@
+{ lib, bundlerEnv, ruby, buildGoPackage, fetchFromGitHub }:
+let
+  # needed for manpage generation
+  gems = bundlerEnv {
+    name = "ejson-gems";
+    gemdir = ./.;
+    inherit ruby;
+  };
+in buildGoPackage rec {
+  name = "ejson-${version}";
+  version = "1.2.0";
+  rev = "v${version}";
+
+  nativeBuildInputs = [ gems ];
+
+  goPackagePath = "github.com/Shopify/ejson";
+  subPackages = [ "cmd/ejson" ];
+
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    owner = "Shopify";
+    repo = "ejson";
+    inherit rev;
+    sha256 = "07ig24fryb9n0mfyqb0sgpj7di9y7wbvh2ppwfs2jqfpvpncd7yh";
+  };
+
+  # set HOME, otherwise bundler will insert stuff in the manpages
+  postBuild = ''
+    cd go/src/$goPackagePath
+    HOME=$PWD make man
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp -r build/man $out/share
+  '';
+
+  meta = with lib; {
+    description = "A small library to manage encrypted secrets using asymmetric encryption.";
+    license = licenses.mit;
+    homepage = https://github.com/Shopify/ejson;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.manveru ];
+  };
+}

--- a/pkgs/development/tools/ejson/deps.nix
+++ b/pkgs/development/tools/ejson/deps.nix
@@ -1,0 +1,48 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/codegangsta/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/codegangsta/cli";
+      rev =  "9908e96513e5a94de37004098a3974a567f18111";
+      sha256 = "0g6sihdb53nlf770dp3jc0qqxnlir5n2yjbp5p5vf7kcj3p54p34";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dustin/gojson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/gojson";
+      rev =  "057ac0edc14e44d03df3bb03449e666ff50884c1";
+      sha256 = "1kzzbi5yshcg1v99gab5ymd3psild3p0rbq9jf7mssjvh11yza6f";
+    };
+  }
+  {
+    goPackagePath  = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev =  "90f2eae17a8bdcbe3f6f654fc76af7f39e97d7b9";
+      sha256 = "0s984ksmc8npf642nwwd1a81c2sfi613v7yia9jff710i5472fah";
+    };
+  }
+  {
+    goPackagePath  = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev =  "cfb38830724cc34fedffe9a2a29fb54fa9169cd1";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "ca7e7f10cb9fd9c1a6ff7f60436c086d73714180";
+      sha256 = "02wmfdq40fjszrd9l2w4c1g34zxnxyydwr4sqvp2blmw2s6ww4bx";
+    };
+  }
+]

--- a/pkgs/development/tools/ejson/gemset.nix
+++ b/pkgs/development/tools/ejson/gemset.nix
@@ -1,0 +1,188 @@
+{
+  arr-pm = {
+    dependencies = ["cabin"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07yx1g1nh4zdy38i2id1xyp42fvj4vl6i196jn7szvjfm0jx98hg";
+      type = "gem";
+    };
+    version = "0.0.10";
+  };
+  backports = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17pcz0z6jms5jydr1r95kf1bpk3ms618hgr26c62h34icy9i1dpm";
+      type = "gem";
+    };
+    version = "3.8.0";
+  };
+  cabin = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0b3b8j3iqnagjfn1261b9ncaac9g44zrx1kcg81yg4z9i513kici";
+      type = "gem";
+    };
+    version = "0.9.0";
+  };
+  childprocess = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04cypmwyy4aj5p9b5dmpwiz5p1gzdpz6jaxb42fpckdbmkpvn6j1";
+      type = "gem";
+    };
+    version = "0.7.1";
+  };
+  clamp = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jb6l4scp69xifhicb5sffdixqkw8wgkk9k2q57kh2y36x1px9az";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  dotenv = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pgzlvs0sswnqlgfm9gkz2hlhkc0zd3vnlp2vglb1wbgnx37pjjv";
+      type = "gem";
+    };
+    version = "2.2.1";
+  };
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "034f52xf7zcqgbvwbl20jwdyjwznvqnwpbaps9nk18v9lgb1dpx0";
+      type = "gem";
+    };
+    version = "1.9.18";
+  };
+  fpm = {
+    dependencies = ["arr-pm" "backports" "cabin" "childprocess" "clamp" "ffi" "json" "pleaserun" "ruby-xz" "stud"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09vzjsiwa2dlhph6fc519x5l0bfn2qfhayfld48cdl2561x5c7fb";
+      type = "gem";
+    };
+    version = "1.9.2";
+  };
+  hpricot = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jn8x9ch79gqmnzgyz78kppavjh5lqx0y0r6frykga2b86rz9s6z";
+      type = "gem";
+    };
+    version = "0.8.6";
+  };
+  insist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bw3bdwns14mapbgb8cbjmr0amvwz8y72gyclq04xp43wpp5jrvg";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  io-like = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04nn0s2wmgxij3k760h3r8m1dgih5dmd9h4v1nn085yi824i5z6k";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qmj7fypgb9vag723w1a49qihxrcf5shzars106ynw2zk352gbv5";
+      type = "gem";
+    };
+    version = "1.8.6";
+  };
+  mustache = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g5hplm0k06vwxwqzwn1mq5bd02yp0h3rym4zwzw26aqi7drcsl2";
+      type = "gem";
+    };
+    version = "0.99.8";
+  };
+  pleaserun = {
+    dependencies = ["cabin" "clamp" "dotenv" "insist" "mustache" "stud"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hgnrl67zkqaxmfkwbyscawj4wqjm7h8khpbj58s6iw54wp3408p";
+      type = "gem";
+    };
+    version = "0.0.30";
+  };
+  rdiscount = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1arvk3k06prxasq1djbj065ixar4zl171340g7wr1ww4gj9makx3";
+      type = "gem";
+    };
+    version = "2.2.0.1";
+  };
+  ronn = {
+    dependencies = ["hpricot" "mustache" "rdiscount"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07plsxxfx5bxdk72ii9za6km0ziqlq8jh3bicr4774dalga6zpw2";
+      type = "gem";
+    };
+    version = "0.7.3";
+  };
+  ruby-xz = {
+    dependencies = ["ffi" "io-like"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11bgpvvk0098ghvlxr4i713jmi2izychalgikwvdwmpb452r3ndw";
+      type = "gem";
+    };
+    version = "0.2.3";
+  };
+  stud = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qpb57cbpm9rwgsygqxifca0zma87drnlacv49cqs2n5iyi6z8kb";
+      type = "gem";
+    };
+    version = "0.0.23";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1292,6 +1292,8 @@ with pkgs;
 
   et = callPackage ../applications/misc/et {};
 
+  ejson = callPackage ../development/tools/ejson {};
+
   eternal-terminal = callPackage ../tools/networking/eternal-terminal {};
 
   f3 = callPackage ../tools/filesystems/f3 { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

