### PR TITLE
octave: 4.2.2 -> 4.4.1

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -18,11 +18,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  version = "4.2.2";
+  version = "4.4.1";
   name = "octave-${version}";
   src = fetchurl {
     url = "mirror://gnu/octave/${name}.tar.gz";
-    sha256 = "0vkjfrpv7aikcn73bxqkph1qrhrdx7jqy193n8d8lwp7v2al7f3p";
+    sha256 = "15xfcx6dc7p204b92i7va2a7ygff637l370x7zjj3vzl2brd1yq9";
   };
 
   buildInputs = [ gfortran readline ncurses perl flex texinfo qhull
@@ -46,16 +46,14 @@ stdenv.mkDerivation rec {
     substituteInPlace libinterp/corefcn/help.cc \
       --replace 'Vmakeinfo_program = "makeinfo"' \
                 'Vmakeinfo_program = "${texinfo}/bin/makeinfo"'
-  ''
-  # REMOVE ON VERSION BUMP
-  # Needed for Octave-4.2.1 on darwin. See https://savannah.gnu.org/bugs/?50234
-  + stdenv.lib.optionalString stdenv.isDarwin ''
-    sed 's/inline file_stat::~file_stat () { }/file_stat::~file_stat () { }/' -i ./liboctave/system/file-stat.cc
   '';
 
   doCheck = !stdenv.isDarwin;
 
   enableParallelBuilding = true;
+
+  # See https://savannah.gnu.org/bugs/?50339
+  F77_INTEGER_8_FLAG = if openblas.blas64 then "-fdefault-integer-8" else "";
 
   configureFlags =
     [ "--enable-readline"
@@ -82,6 +80,7 @@ stdenv.mkDerivation rec {
     homepage = http://octave.org/;
     license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [raskin];
+    description = "Scientific Pragramming Language";
     platforms = if overridePlatforms == null then
       (with stdenv.lib.platforms; linux ++ darwin)
     else overridePlatforms;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

