### PR TITLE
lc0: init at 0.18.0-rc1

### DIFF
--- a/pkgs/games/lc0/default.nix
+++ b/pkgs/games/lc0/default.nix
@@ -1,0 +1,78 @@
+{
+  stdenv, fetchFromGitHub,
+  meson, ninja, pkgconfig,
+  zlib, ispc,
+  protobuf, protobufc, gtest,
+  buildBackends ? true,
+  useCUDA ? false, cudatoolkit ? null, cudnn ? null,
+  useOpenCL ? false, opencl-headers ? null, ocl-icd ? null,
+  useOpenBLAS ? false, openblas ? null
+}:
+let
+  pname = "lc0";
+  version = "0.18.0-rc1";
+  optionals = stdenv.lib.optionals;
+in
+
+assert buildBackends -> useCUDA || useOpenBLAS || useOpenCL;
+assert useCUDA -> cudatoolkit != null && cudnn != null;
+assert (useOpenBLAS || useOpenCL) -> openblas != null;
+assert useOpenCL -> opencl-headers != null && ocl-icd != null;
+
+stdenv.mkDerivation {
+  inherit pname version;
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner = "LeelaChessZero";
+    repo = pname;
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "18m5hmhc770b0m1p2ni8pl4dy9q81120cjxz9sag25inwn5vybc0";
+  };
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig
+    zlib
+    protobuf protobufc ispc gtest
+    cudnn cudatoolkit
+    openblas
+    ocl-icd opencl-headers
+  ];
+
+  mesonFlags = [
+    "-Dbuild_backends=${if buildBackends then "true" else "false"}"
+  ] ++ optionals useCUDA [
+    # Cuda needs cudalibdirs set to a merger of the two cuda packages. Broken for now.
+    "-Dcuda=true"
+    "-Dcudnn_libdirs=${cudatoolkit}/lib"
+  ] ++ optionals useOpenBLAS [
+    "-Dblas=true"
+  ] ++ optionals (useOpenCL || useOpenBLAS) [
+    "-Dopenblas_libdirs=${openblas}/lib"
+  ] ++ optionals useOpenCL [
+    "-Dopencl=true"
+    "-Dopencl_libdirs=${ocl-icd}/lib"
+    "-Dopencl_include=${opencl-headers}/include"
+  ];
+
+  doCheck = gtest != null;
+  checkPhase = ''
+    for test in /build/source/build/*_test
+    do
+      $test
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+      Lc0 is a UCI-compliant chess engine designed to play chess via neural
+      network, specifically those of the LeelaChessZero project.
+    '';
+    homepage = https://lczero.org/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ synthetica ];
+    platforms = platforms.linux;
+    broken = useCUDA;
+  };
+}

--- a/pkgs/games/lc0/default.nix
+++ b/pkgs/games/lc0/default.nix
@@ -3,7 +3,7 @@
   meson, ninja, pkgconfig,
   zlib, ispc,
   protobuf, protobufc, gtest,
-  useCUDA ? false, cudatoolkit ? null, cudnn ? null, symlinkJoin,
+  useCUDA ? false, cudnn ? null, symlinkJoin,
   useOpenCL ? false, opencl-headers ? null, ocl-icd ? null,
   useOpenBLAS ? false, openblas ? null
 }:
@@ -12,6 +12,7 @@ let
   version = "0.18.1";
   optionals = stdenv.lib.optionals;
   buildBackends = useCUDA || useOpenBLAS || useOpenCL;
+  cudatoolkit = cudnn.cudotoolkit or null;
 
   cuda-combined = symlinkJoin {
     name = "cuda-combined";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20350,25 +20350,25 @@ with pkgs;
 
   kobodeluxe = callPackage ../games/kobodeluxe { };
 
-  lc0-cuda = callPackage ../games/lc0 {
+  lc0 = callPackage ../games/lc0 { };
+
+  lc0-cuda = lc0.override {
     useCUDA = true;
     cudatoolkit = cudatoolkit;
     cudnn = cudnn;
   };
 
-  lc0-openblas = callPackage ../games/lc0 {
+  lc0-openblas = lc0.override {
     useOpenBLAS = true;
     inherit openblas;
   };
 
-  lc0-opencl = callPackage ../games/lc0 {
+  lc0-opencl = lc0.override {
     useOpenCL = true;
     inherit opencl-headers ocl-icd;
   };
 
-  lc0-random = callPackage ../games/lc0 {
-    buildBackends = false;
-  };
+  lc0-random = lc0;
 
 
   lgogdownloader = callPackage ../games/lgogdownloader { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20354,7 +20354,6 @@ with pkgs;
 
   lc0-cuda = lc0.override {
     useCUDA = true;
-    cudatoolkit = cudatoolkit;
     cudnn = cudnn;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20350,6 +20350,27 @@ with pkgs;
 
   kobodeluxe = callPackage ../games/kobodeluxe { };
 
+  lc0-cuda = callPackage ../games/lc0 {
+    useCUDA = true;
+    cudatoolkit = cudatoolkit;
+    cudnn = cudnn;
+  };
+
+  lc0-openblas = callPackage ../games/lc0 {
+    useOpenBLAS = true;
+    inherit openblas;
+  };
+
+  lc0-opencl = callPackage ../games/lc0 {
+    useOpenCL = true;
+    inherit opencl-headers ocl-icd;
+  };
+
+  lc0-random = callPackage ../games/lc0 {
+    buildBackends = false;
+  };
+
+
   lgogdownloader = callPackage ../games/lgogdownloader { };
 
   liberal-crime-squad = callPackage ../games/liberal-crime-squad { };


### PR DESCRIPTION
The CUDA backend is broken for now, since the way NixOS packages CUDA seems to be incompatible with the way this package sets up it's build. The OpenCL and OpenBLAS versions work. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

