### PR TITLE
neap: init at 0.7.2

### DIFF
--- a/pkgs/applications/misc/neap/default.nix
+++ b/pkgs/applications/misc/neap/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, python2Packages }:
+
+stdenv.mkDerivation rec {
+  name = "neap-${version}";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "vzxwco";
+    repo = "neap";
+    rev = "v${version}";
+    sha256 = "04da8rq23rl1qcvrdm5m3l90xbwyli7x601sckv7hmkip2q3g1kz";
+  };
+
+  nativeBuildInputs = [
+    python2Packages.wrapPython
+  ];
+
+  buildInputs = [
+    python2Packages.python
+  ];
+
+  pythonPath = [
+    python2Packages.xlib
+    python2Packages.pygtk
+  ];
+
+  installPhase = ''
+    install -D -t $out/bin neap
+    install -D -t $out/share/man/man1 neap.1
+    install -D -t $out/share/applications neap.desktop
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Systray workspace pager";
+    homepage = https://github.com/vzxwco/neap;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17793,6 +17793,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  neap = callPackage ../applications/misc/neap { };
+
   neomutt = callPackage ../applications/networking/mailreaders/neomutt { };
 
   natron = callPackage ../applications/video/natron { };


### PR DESCRIPTION
###### Motivation for this change

Add [neap](https://github.com/vzxwco/neap).

neap is a neat X11 workspace pager unintrusive and light that runs in the notification area (i.e. systray) of your panel. neap follows freedesktop specifications.

![screenshot](https://user-images.githubusercontent.com/1217934/46090894-05b10380-c188-11e8-97c1-984baa21edb7.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).