### PR TITLE
Backport the noti package to 18.09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3893,6 +3893,11 @@
     github = "StillerHarpo";
     name = "Florian Engel";
   };
+  stites = {
+    email = "sam@stites.io";
+    github = "stites";
+    name = "Sam Stites";
+  };
   stumoss = {
     email = "samoss@gmail.com";
     github = "stumoss";

--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "noti-${version}";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "variadico";
+    repo = "noti";
+    rev = "${version}";
+    sha256 = "1chsqfqk0pnhx5k2nr4c16cpb8m6zv69l1jvv4v4903zgfzcm823";
+  };
+
+  goPackagePath = "github.com/variadico/noti";
+
+  preBuild = ''
+    buildFlagsArray+=("-ldflags" "-X ${goPackagePath}/internal/command.Version=${version}")
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/man/man{1,5}/
+    cp $src/docs/man/noti.1      $out/share/man/man1/
+    cp $src/docs/man/noti.yaml.5 $out/share/man/man5/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Monitor a process and trigger a notification.";
+    longDescription = ''
+      Monitor a process and trigger a notification.
+
+      Never sit and wait for some long-running process to finish. Noti can alert you when it's done. You can receive messages on your computer or phone.
+    '';
+    homepage = https://github.com/variadico/noti;
+    license = licenses.mit;
+    maintainers = [ maintainers.stites ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/misc/noti/default.nix
+++ b/pkgs/tools/misc/noti/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, Cocoa }:
 
 buildGoPackage rec {
   name = "noti-${version}";
@@ -10,6 +10,10 @@ buildGoPackage rec {
     rev = "${version}";
     sha256 = "1chsqfqk0pnhx5k2nr4c16cpb8m6zv69l1jvv4v4903zgfzcm823";
   };
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Cocoa ];
+  # TODO: Remove this when we update apple_sdk
+  NIX_CFLAGS_COMPILE = stdenv.lib.optionals stdenv.isDarwin [ "-fno-objc-arc" ];
 
   goPackagePath = "github.com/variadico/noti";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1462,6 +1462,8 @@ with pkgs;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };
 
+  noti = callPackage ../tools/misc/noti { };
+
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
   nwipe = callPackage ../tools/security/nwipe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1462,7 +1462,9 @@ with pkgs;
 
   noteshrink = callPackage ../tools/misc/noteshrink { };
 
-  noti = callPackage ../tools/misc/noti { };
+  noti = callPackage ../tools/misc/noti {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 


### PR DESCRIPTION
This cherry-picks the package `noti` from master to 18.09. I'm doing this because Home Manager is having a [`noti` module](https://github.com/rycee/home-manager/blob/master/modules/programs/noti.nix) in its master branch and I would like to keep the HM master branch compatible with Nixpkgs 18.09 as long as possible to reduce the amount of maintenance I have to do.