### PR TITLE
vlc: 3.0.3 -> 3.0.4

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -20,11 +20,11 @@ assert (withQt5 -> qtbase != null && qtsvg != null && qtx11extras != null);
 
 stdenv.mkDerivation rec {
   name = "vlc-${version}";
-  version = "3.0.3";
+  version = "3.0.4";
 
   src = fetchurl {
     url = "http://get.videolan.org/vlc/${version}/${name}.tar.xz";
-    sha256 = "0lavzly8l0ll1d9iris9cnirgcs77g48lxj14058dxqkvd5v1a4v";
+    sha256 = "17jsq0zqpqyxw4ckvjba0hf6zk8ywc4wf8sy3z03hh3ij0vxpwq1";
   };
 
   # VLC uses a *ton* of libraries for various pieces of functionality, many of
@@ -51,18 +51,6 @@ stdenv.mkDerivation rec {
   # vlc depends on a c11-gcc wrapper script which we don't have so we need to
   # set the path to the compiler
   BUILDCC = "${stdenv.cc}/bin/gcc";
-
-  patches = [
-    (fetchpatch {
-      name = "vlc-qt5.11.patch";
-      url = "https://git.archlinux.org/svntogit/packages.git/plain/trunk/vlc-qt5.11.patch?h=packages/vlc";
-      sha256 = "0yh65bhhaz876cazhagnafs1dr61184lpj3y0m3y7k37bswykj8p";
-    })
-    (fetchpatch {
-      url = "https://github.com/videolan/vlc/commit/26e2d3906658c30f2f88f4b1bc9630ec43bf5525.patch";
-      sha256 = "0sm73cbzxva8sww526bh5yin1k2pdkvj826wdlmqnj7xf0f3mki4";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace configure \


### PR DESCRIPTION
###### Motivation for this change

* vlc 3.0.3 does not compile due to missing vlc-qt5.11.patch
* update

Both patches appear unnecessary now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

