### PR TITLE
abi-compliance-checker: init at 2.3

### DIFF
--- a/pkgs/development/tools/misc/abi-compliance-checker/default.nix
+++ b/pkgs/development/tools/misc/abi-compliance-checker/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, ctags, perl, binutils, abi-dumper }:
+
+stdenv.mkDerivation rec {
+  name = "abi-compliance-checker-${version}";
+  version = "2.3";
+
+  src = fetchFromGitHub {
+    owner = "lvc";
+    repo = "abi-compliance-checker";
+    rev = version;
+    sha256 = "1f1f9j2nf9j83sfl2ljadch99v6ha8rq8xm7ax5akc05hjpyckij";
+  };
+
+  buildInputs = [ binutils ctags perl ];
+  propagatedBuildInputs = [ abi-dumper ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://lvc.github.io/abi-compliance-checker;
+    description = "A tool for checking backward API/ABI compatibility of a C/C++ library";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.bhipple ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/misc/abi-dumper/default.nix
+++ b/pkgs/development/tools/misc/abi-dumper/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, ctags, perl, elfutils, vtable-dumper }:
+
+stdenv.mkDerivation rec {
+  name = "abi-dumper-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "lvc";
+    repo = "abi-dumper";
+    rev = version;
+    sha256 = "1byhw132aj7a5a5zh5s3pnjlrhdk4cz6xd5irp1y08jl980qba5j";
+  };
+
+  patchPhase = ''
+    substituteInPlace abi-dumper.pl \
+      --replace eu-readelf ${elfutils}/bin/eu-readelf \
+      --replace vtable-dumper ${vtable-dumper}/bin/vtable-dumper \
+      --replace '"ctags"' '"${ctags}/bin/ctags"'
+  '';
+
+  buildInputs = [ elfutils ctags perl vtable-dumper ];
+
+  preBuild = "mkdir -p $out";
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/lvc/abi-dumper;
+    description = "Dump ABI of an ELF object containing DWARF debug info";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.bhipple ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/misc/vtable-dumper/default.nix
+++ b/pkgs/development/tools/misc/vtable-dumper/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, libelf }:
+
+stdenv.mkDerivation rec {
+  name = "vtable-dumper-${version}";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    owner = "lvc";
+    repo = "vtable-dumper";
+    rev = version;
+    sha256 = "0sl7lnjr2l4c2f7qaazvpwpzsp4gckkvccfam88wcq9f7j9xxbyp";
+  };
+
+  buildInputs = [ libelf ];
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/lvc/vtable-dumper;
+    description = "A tool to list content of virtual tables in a C++ shared library";
+    license = licenses.lgpl21;
+    maintainers = [ maintainers.bhipple ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7960,6 +7960,8 @@ with pkgs;
 
   ### DEVELOPMENT / TOOLS
 
+  abi-dumper = callPackage ../development/tools/misc/abi-dumper { };
+
   activator = throw ''
     Typesafe Activator was removed in 2017-05-08 as the actual package reaches end of life.
 
@@ -7968,12 +7970,12 @@ with pkgs;
     for more information.
   '';
 
+  adtool = callPackage ../tools/admin/adtool { };
+
   inherit (callPackage ../development/tools/alloy { })
     alloy4
     alloy5
     alloy;
-
-  adtool = callPackage ../tools/admin/adtool { };
 
   augeas = callPackage ../tools/system/augeas { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7960,6 +7960,8 @@ with pkgs;
 
   ### DEVELOPMENT / TOOLS
 
+  abi-compliance-checker = callPackage ../development/tools/misc/abi-compliance-checker { };
+
   abi-dumper = callPackage ../development/tools/misc/abi-dumper { };
 
   activator = throw ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8909,6 +8909,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  vtable-dumper = callPackage ../development/tools/misc/vtable-dumper { };
+
   watson-ruby = callPackage ../development/tools/misc/watson-ruby {};
 
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };


### PR DESCRIPTION
###### Motivation for this change
This adds `abi-compliance-checker` and its two dependencies, for dumping the API/ABI of C/C++ libraries.  It is the tool used to produce the reports on this webpage:
https://abi-laboratory.pro/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

