### PR TITLE
 golden-cheetah: add desktop item and icon

### DIFF
--- a/pkgs/applications/misc/golden-cheetah/default.nix
+++ b/pkgs/applications/misc/golden-cheetah/default.nix
@@ -1,8 +1,19 @@
 { stdenv, fetchurl
 , qtbase, qtsvg, qtserialport, qtwebkit, qtmultimedia, qttools, qtconnectivity
-, yacc, flex, zlib, qmake, makeWrapper
+, yacc, flex, zlib, qmake, makeDesktopItem, makeWrapper
 }:
-stdenv.mkDerivation rec {
+
+let
+  desktopItem = makeDesktopItem {
+    name = "goldencheetah";
+    exec = "GoldenCheetah";
+    icon = "goldencheetah";
+    desktopName = "GoldenCheetah";
+    genericName = "GoldenCheetah";
+    comment = "Performance software for cyclists, runners and triathletes";
+    categories = "Application;Utility;";
+  };
+in stdenv.mkDerivation rec {
   name = "golden-cheetah-${version}";
   version = "3.4";
   src = fetchurl {
@@ -27,6 +38,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp src/GoldenCheetah $out/bin
     wrapProgram $out/bin/GoldenCheetah --set LD_LIBRARY_PATH "${zlib.out}/lib"
+    install -Dm644 "${desktopItem}/share/applications/"* -t $out/share/applications/
+    install -Dm644 src/Resources/images/gc.png $out/share/pixmaps/goldencheetah.png
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change
This adds the currently missing `.desktop` file and its icon to GoldenCheetah.

Shouldn't hurt to add this to 18.09 as well :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

