### PR TITLE
Add developer accessible backdoor to VM tests infrastructure.

### DIFF
--- a/nixos/doc/manual/development/debugging-nixos-tests.xml
+++ b/nixos/doc/manual/development/debugging-nixos-tests.xml
@@ -1,0 +1,36 @@
+<section xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:xi="http://www.w3.org/2001/XInclude"
+        version="5.0"
+        xml:id="sec-debugging-nixos-tests">
+ <title>Debugging NixOS tests</title>
+
+ <para>
+  Tests may fail and infrastructure offers access to inspect machine state.
+ </para>
+
+ <para>
+  To prevent test from stopping and cleaning up, insert a sleep command:
+ </para>
+
+<programlisting>
+$machine->succeed("sleep 84000");
+</programlisting>
+
+ <para>
+  As soon as machine starts run as root:
+ </para>
+
+<programlisting>
+nix-shell -p socat --run "socat STDIO,raw,echo=0,escape=0x11 UNIX:/tmp/nix-build-vm-test-run-*.drv-0/vm-state-machine/backdoor"
+</programlisting>
+
+ <para>
+  You may need to find the correct path, replacing <literal>/tmp</literal>, <literal>*</literal> or <literal>machine</literal>.
+ </para>
+
+ <para>
+  Press "enter" to open up console and login as "root". After you're done, press "ctrl-q" to exit the console.
+ </para>
+ 
+</section>

--- a/nixos/doc/manual/development/nixos-tests.xml
+++ b/nixos/doc/manual/development/nixos-tests.xml
@@ -16,4 +16,5 @@ xlink:href="https://github.com/NixOS/nixpkgs/tree/master/nixos/tests">nixos/test
  <xi:include href="writing-nixos-tests.xml" />
  <xi:include href="running-nixos-tests.xml" />
  <xi:include href="running-nixos-tests-interactively.xml" />
+ <xi:include href="debugging-nixos-tests.xml" />
 </chapter>

--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -155,8 +155,10 @@ sub start {
         $ENV{USE_TMPDIR} = 1;
         $ENV{QEMU_OPTS} =
             ($self->{allowReboot} ? "" : "-no-reboot ") .
-            "-monitor unix:./monitor -chardev socket,id=shell,path=./shell " .
-            "-device virtio-serial -device virtconsole,chardev=shell " .
+            "-monitor unix:./monitor " .
+            "-chardev socket,id=shell,path=./shell -device virtio-serial -device virtconsole,chardev=shell " .
+            # socket backdoor, see "Debugging NixOS tests" section in NixOS manual
+            "-chardev socket,id=backdoor,path=./backdoor,server,nowait -device virtio-serial -device virtconsole,chardev=backdoor " .
             "-device virtio-rng-pci " .
             ($showGraphics ? "-serial stdio" : "-nographic") . " " . ($ENV{QEMU_OPTS} || "");
         chdir $self->{stateDir} or die;

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -55,7 +55,8 @@ with import ../../lib/qemu-flags.nix { inherit pkgs; };
     systemd.services."serial-getty@hvc0".enable = false;
 
     # Only use a serial console, no TTY.
-    virtualisation.qemu.consoles = [ qemuSerialDevice ];
+    # hvc1: socket backdoor, see "Debugging NixOS tests" section in NixOS manual
+    virtualisation.qemu.consoles = [ "hvc1" qemuSerialDevice ];
 
     boot.initrd.preDeviceCommands =
       ''


### PR DESCRIPTION
Thanks to @dezgeg for prototype implementation, I've
cleaned it up and added documentation.

I admit it's not clear to me if console access via $TMPDIR is considered a security issue, on a builder running multiple tests, I'd expect this could be considered an adversary.