### PR TITLE
udisks: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "2.8.0";
+  version = "2.8.1";
 in stdenv.mkDerivation rec {
   name = "udisks-${version}";
 
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
     owner = "storaged-project";
     repo = "udisks";
     rev = name;
-    sha256 = "110g3vyai3p6vjzy01yd0bbvxk7n7dl5glxf54f3jvqf0zmaqipx";
+    sha256 = "073iqa0pwa7ab0qw33h3ic89508a78incmg6rq914d6br7s030zy";
   };
 
   outputs = [ "out" "man" "dev" "devdoc" ];


### PR DESCRIPTION
https://github.com/storaged-project/udisks/blob/udisks-2.8.1/NEWS


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---