### PR TITLE
buildGoPackage: add overrideGoAttrs

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -1,229 +1,240 @@
 { go, govers, parallel, lib, fetchgit, fetchhg, fetchbzr, rsync
 , removeReferencesTo, fetchFromGitHub }:
 
-{ name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}, preFixup ? ""
-, shellHook ? ""
-
-# We want parallel builds by default
-, enableParallelBuilding ? true
-
-# Disabled flag
-, disabled ? false
-
-# Go import path of the package
-, goPackagePath
-
-# Go package aliases
-, goPackageAliases ? [ ]
-
-# Extra sources to include in the gopath
-, extraSrcs ? [ ]
-
-# Extra gopaths containing src subfolder
-# with sources to include in the gopath
-, extraSrcPaths ? [ ]
-
-# go2nix dependency file
-, goDeps ? null
-
-, dontRenameImports ? false
-
-# Do not enable this without good reason
-# IE: programs coupled with the compiler
-, allowGoReference ? false
-
-, meta ? {}, ... } @ args':
-
-if disabled then throw "${name} not supported for go ${go.meta.branch}" else
-
 with builtins;
 
 let
-  args = lib.filterAttrs (name: _: name != "extraSrcs") args';
+  buildGoPackage =
+    { name, buildInputs ? [], nativeBuildInputs ? [], passthru ? {}
+    , preFixup ? "", shellHook ? ""
 
-  removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
+    # We want parallel builds by default
+    , enableParallelBuilding ? true
 
-  removeExpr = refs: ''remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}'';
+    # Disabled flag
+    , disabled ? false
 
-  dep2src = goDep:
-    {
-      inherit (goDep) goPackagePath;
-      src = if goDep.fetch.type == "git" then
-        fetchgit {
-          inherit (goDep.fetch) url rev sha256;
+    # Go import path of the package
+    , goPackagePath
+
+    # Go package aliases
+    , goPackageAliases ? [ ]
+
+    # Extra sources to include in the gopath
+    , extraSrcs ? [ ]
+
+    # Extra gopaths containing src subfolder
+    # with sources to include in the gopath
+    , extraSrcPaths ? [ ]
+
+    # go2nix dependency file
+    , goDeps ? null
+
+    , dontRenameImports ? false
+
+    # Do not enable this without good reason
+    # IE: programs coupled with the compiler
+    , allowGoReference ? false
+
+    , meta ? {}, ... } @ args':
+
+    if disabled then throw "${name} not supported for go ${go.meta.branch}" else
+
+    with builtins;
+
+    let
+      args = lib.filterAttrs (name: _: name != "extraSrcs") args';
+
+      removeReferences = [ ] ++ lib.optional (!allowGoReference) go;
+
+      removeExpr = refs:
+        "remove-references-to ${lib.concatMapStrings (ref: " -t ${ref}") refs}";
+
+      dep2src = goDep:
+        {
+          inherit (goDep) goPackagePath;
+          src = if goDep.fetch.type == "git" then
+            fetchgit {
+              inherit (goDep.fetch) url rev sha256;
+            }
+          else if goDep.fetch.type == "hg" then
+            fetchhg {
+              inherit (goDep.fetch) url rev sha256;
+            }
+          else if goDep.fetch.type == "bzr" then
+            fetchbzr {
+              inherit (goDep.fetch) url rev sha256;
+            }
+          else if goDep.fetch.type == "FromGitHub" then
+            fetchFromGitHub {
+              inherit (goDep.fetch) owner repo rev sha256;
+            }
+          else abort "Unrecognized package fetch type: ${goDep.fetch.type}";
+        };
+
+      importGodeps = { depsFile }:
+        map dep2src (import depsFile);
+
+      goPath = if goDeps != null
+               then importGodeps { depsFile = goDeps; } ++ extraSrcs
+               else extraSrcs;
+    in
+
+    go.stdenv.mkDerivation (
+      (builtins.removeAttrs args [ "goPackageAliases" "disabled" ]) // {
+
+      inherit name;
+      nativeBuildInputs = [ removeReferencesTo go parallel ]
+        ++ (lib.optional (!dontRenameImports) govers) ++ nativeBuildInputs;
+      buildInputs = [ go ] ++ buildInputs;
+
+      configurePhase = args.configurePhase or ''
+        runHook preConfigure
+
+        # Extract the source
+        cd "$NIX_BUILD_TOP"
+        mkdir -p "go/src/$(dirname "$goPackagePath")"
+        mv "$sourceRoot" "go/src/$goPackagePath"
+
+      '' + lib.flip lib.concatMapStrings goPath ({ src, goPackagePath }: ''
+        mkdir goPath
+        (cd goPath; unpackFile "${src}")
+        mkdir -p "go/src/$(dirname "${goPackagePath}")"
+        chmod -R u+w goPath/*
+        mv goPath/* "go/src/${goPackagePath}"
+        rmdir goPath
+
+      '') + (lib.optionalString (extraSrcPaths != []) ''
+        ${rsync}/bin/rsync -a ${lib.concatMapStringsSep " " (p: "${p}/src") extraSrcPaths} go
+
+      '') + ''
+        export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
+
+        runHook postConfigure
+      '';
+
+      renameImports = args.renameImports or (
+        let
+          inputsWithAliases = lib.filter (x: x ? goPackageAliases)
+            (buildInputs ++ (args.propagatedBuildInputs or [ ]));
+          rename = to: from: "echo Renaming '${from}' to '${to}'; govers -d -m ${from} ${to}";
+          renames = p: lib.concatMapStringsSep "\n" (rename p.goPackagePath) p.goPackageAliases;
+        in lib.concatMapStringsSep "\n" renames inputsWithAliases);
+
+      buildPhase = args.buildPhase or ''
+        runHook preBuild
+
+        runHook renameImports
+
+        buildGoDir() {
+          local d; local cmd;
+          cmd="$1"
+          d="$2"
+          . $TMPDIR/buildFlagsArray
+          echo "$d" | grep -q "\(/_\|examples\|Godeps\)" && return 0
+          [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
+          local OUT
+          if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" -v $d 2>&1)"; then
+            if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
+              echo "$OUT" >&2
+              return 1
+            fi
+          fi
+          if [ -n "$OUT" ]; then
+            echo "$OUT" >&2
+          fi
+          return 0
         }
-      else if goDep.fetch.type == "hg" then
-        fetchhg {
-          inherit (goDep.fetch) url rev sha256;
+
+        getGoDirs() {
+          local type;
+          type="$1"
+          if [ -n "$subPackages" ]; then
+            echo "$subPackages" | sed "s,\(^\| \),\1$goPackagePath/,g"
+          else
+            pushd "$NIX_BUILD_TOP/go/src" >/dev/null
+            find "$goPackagePath" -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort | uniq
+            popd >/dev/null
+          fi
         }
-      else if goDep.fetch.type == "bzr" then
-        fetchbzr {
-          inherit (goDep.fetch) url rev sha256;
-        }
-      else if goDep.fetch.type == "FromGitHub" then
-        fetchFromGitHub {
-          inherit (goDep.fetch) owner repo rev sha256;
-        }
-      else abort "Unrecognized package fetch type: ${goDep.fetch.type}";
+
+        if (( "''${NIX_DEBUG:-0}" >= 1 )); then
+          buildFlagsArray+=(-x)
+        fi
+
+        if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
+          declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
+        else
+          touch $TMPDIR/buildFlagsArray
+        fi
+        export -f buildGoDir # parallel needs to see the function
+        if [ -z "$enableParallelBuilding" ]; then
+            export NIX_BUILD_CORES=1
+        fi
+        getGoDirs "" | parallel -j $NIX_BUILD_CORES buildGoDir install
+
+        runHook postBuild
+      '';
+
+      checkPhase = args.checkPhase or ''
+        runHook preCheck
+
+        getGoDirs test | parallel -j $NIX_BUILD_CORES buildGoDir test
+
+        runHook postCheck
+      '';
+
+      installPhase = args.installPhase or ''
+        runHook preInstall
+
+        mkdir -p $bin
+        dir="$NIX_BUILD_TOP/go/bin"
+        [ -e "$dir" ] && cp -r $dir $bin
+
+        runHook postInstall
+      '';
+
+      preFixup = preFixup + ''
+        find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
+      '';
+
+      # Disable go cache, which is not reused in nix anyway
+      GOCACHE = "off";
+
+      shellHook = ''
+        d=$(mktemp -d "--suffix=-$name")
+      '' + toString (map (dep: ''
+         mkdir -p "$d/src/$(dirname "${dep.goPackagePath}")"
+         ln -s "${dep.src}" "$d/src/${dep.goPackagePath}"
+      ''
+      ) goPath) + ''
+        export GOPATH=${lib.concatStringsSep ":" ( ["$d"] ++ ["$GOPATH"] ++ ["$PWD"] ++ extraSrcPaths)}
+      '' + shellHook;
+
+      disallowedReferences = lib.optional (!allowGoReference) go
+        ++ lib.optional (!dontRenameImports) govers;
+
+      passthru = passthru //
+        { inherit go; } //
+        lib.optionalAttrs (goPackageAliases != []) { inherit goPackageAliases; };
+
+      enableParallelBuilding = enableParallelBuilding;
+
+      # I prefer to call this dev but propagatedBuildInputs expects $out to
+      # exist
+      outputs = args.outputs or [ "bin" "out" ];
+
+      meta = {
+        # Add default meta information
+        homepage = "https://${goPackagePath}";
+        platforms = go.meta.platforms or lib.platforms.all;
+      } // meta // {
+        # add an extra maintainer to every package
+        maintainers = (meta.maintainers or []) ++
+                      [ lib.maintainers.ehmry lib.maintainers.lethalman ];
+      };
+    }) // {
+      overrideGoAttrs = f: buildGoPackage (args // (f args));
     };
 
-  importGodeps = { depsFile }:
-    map dep2src (import depsFile);
-
-  goPath = if goDeps != null then importGodeps { depsFile = goDeps; } ++ extraSrcs
-                             else extraSrcs;
-in
-
-go.stdenv.mkDerivation (
-  (builtins.removeAttrs args [ "goPackageAliases" "disabled" ]) // {
-
-  inherit name;
-  nativeBuildInputs = [ removeReferencesTo go parallel ]
-    ++ (lib.optional (!dontRenameImports) govers) ++ nativeBuildInputs;
-  buildInputs = [ go ] ++ buildInputs;
-
-  configurePhase = args.configurePhase or ''
-    runHook preConfigure
-
-    # Extract the source
-    cd "$NIX_BUILD_TOP"
-    mkdir -p "go/src/$(dirname "$goPackagePath")"
-    mv "$sourceRoot" "go/src/$goPackagePath"
-
-  '' + lib.flip lib.concatMapStrings goPath ({ src, goPackagePath }: ''
-    mkdir goPath
-    (cd goPath; unpackFile "${src}")
-    mkdir -p "go/src/$(dirname "${goPackagePath}")"
-    chmod -R u+w goPath/*
-    mv goPath/* "go/src/${goPackagePath}"
-    rmdir goPath
-
-  '') + (lib.optionalString (extraSrcPaths != []) ''
-    ${rsync}/bin/rsync -a ${lib.concatMapStringsSep " " (p: "${p}/src") extraSrcPaths} go
-
-  '') + ''
-    export GOPATH=$NIX_BUILD_TOP/go:$GOPATH
-
-    runHook postConfigure
-  '';
-
-  renameImports = args.renameImports or (
-    let
-      inputsWithAliases = lib.filter (x: x ? goPackageAliases)
-        (buildInputs ++ (args.propagatedBuildInputs or [ ]));
-      rename = to: from: "echo Renaming '${from}' to '${to}'; govers -d -m ${from} ${to}";
-      renames = p: lib.concatMapStringsSep "\n" (rename p.goPackagePath) p.goPackageAliases;
-    in lib.concatMapStringsSep "\n" renames inputsWithAliases);
-
-  buildPhase = args.buildPhase or ''
-    runHook preBuild
-
-    runHook renameImports
-
-    buildGoDir() {
-      local d; local cmd;
-      cmd="$1"
-      d="$2"
-      . $TMPDIR/buildFlagsArray
-      echo "$d" | grep -q "\(/_\|examples\|Godeps\)" && return 0
-      [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
-      local OUT
-      if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" -v $d 2>&1)"; then
-        if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
-          echo "$OUT" >&2
-          return 1
-        fi
-      fi
-      if [ -n "$OUT" ]; then
-        echo "$OUT" >&2
-      fi
-      return 0
-    }
-
-    getGoDirs() {
-      local type;
-      type="$1"
-      if [ -n "$subPackages" ]; then
-        echo "$subPackages" | sed "s,\(^\| \),\1$goPackagePath/,g"
-      else
-        pushd "$NIX_BUILD_TOP/go/src" >/dev/null
-        find "$goPackagePath" -type f -name \*$type.go -exec dirname {} \; | grep -v "/vendor/" | sort | uniq
-        popd >/dev/null
-      fi
-    }
-
-    if (( "''${NIX_DEBUG:-0}" >= 1 )); then
-      buildFlagsArray+=(-x)
-    fi
-
-    if [ ''${#buildFlagsArray[@]} -ne 0 ]; then
-      declare -p buildFlagsArray > $TMPDIR/buildFlagsArray
-    else
-      touch $TMPDIR/buildFlagsArray
-    fi
-    export -f buildGoDir # parallel needs to see the function
-    if [ -z "$enableParallelBuilding" ]; then
-        export NIX_BUILD_CORES=1
-    fi
-    getGoDirs "" | parallel -j $NIX_BUILD_CORES buildGoDir install
-
-    runHook postBuild
-  '';
-
-  checkPhase = args.checkPhase or ''
-    runHook preCheck
-
-    getGoDirs test | parallel -j $NIX_BUILD_CORES buildGoDir test
-
-    runHook postCheck
-  '';
-
-  installPhase = args.installPhase or ''
-    runHook preInstall
-
-    mkdir -p $bin
-    dir="$NIX_BUILD_TOP/go/bin"
-    [ -e "$dir" ] && cp -r $dir $bin
-
-    runHook postInstall
-  '';
-
-  preFixup = preFixup + ''
-    find $bin/bin -type f -exec ${removeExpr removeReferences} '{}' + || true
-  '';
-
-  # Disable go cache, which is not reused in nix anyway
-  GOCACHE = "off";
-
-  shellHook = ''
-    d=$(mktemp -d "--suffix=-$name")
-  '' + toString (map (dep: ''
-     mkdir -p "$d/src/$(dirname "${dep.goPackagePath}")"
-     ln -s "${dep.src}" "$d/src/${dep.goPackagePath}"
-  ''
-  ) goPath) + ''
-    export GOPATH=${lib.concatStringsSep ":" ( ["$d"] ++ ["$GOPATH"] ++ ["$PWD"] ++ extraSrcPaths)}
-  '' + shellHook;
-
-  disallowedReferences = lib.optional (!allowGoReference) go
-    ++ lib.optional (!dontRenameImports) govers;
-
-  passthru = passthru //
-    { inherit go; } //
-    lib.optionalAttrs (goPackageAliases != []) { inherit goPackageAliases; };
-
-  enableParallelBuilding = enableParallelBuilding;
-
-  # I prefer to call this dev but propagatedBuildInputs expects $out to exist
-  outputs = args.outputs or [ "bin" "out" ];
-
-  meta = {
-    # Add default meta information
-    homepage = "https://${goPackagePath}";
-    platforms = go.meta.platforms or lib.platforms.all;
-  } // meta // {
-    # add an extra maintainer to every package
-    maintainers = (meta.maintainers or []) ++
-                  [ lib.maintainers.ehmry lib.maintainers.lethalman ];
-  };
-})
+in buildGoPackage


### PR DESCRIPTION
###### Motivation for this change

This allows, eg, patches that require extraSrcs to be applied to Go packages. It's similar to `overridePythonAttrs`, and to the `overrideRustAttrs` function I propose in https://github.com/NixOS/nixpkgs/pull/46842.

Example:

```nix
hub.overrideGoAttrs (oldAttrs: {
  patches = [
    (fetchpatch {
      url = https://github.com/alyssais/hub/commit/e23a9027669e179a93437ff731b0e43691bb272d.patch;
      sha256 = "19i3sy06vqdmrqvngq8wxnwksa9h65kc4bwjmsn0pwj71asvvhp3";
    })
  ];
  extraSrcs = [
    {
      goPackagePath = "github.com/keybase/go-keychain";
      src = fetchFromGitHub {
        owner = "keybase";
        repo = "go-keychain";
        rev = "15d3657f24fc7e290714ab795239c5bb33b091ea";
        sha256 = "1357drs3pdkz92whdlrh8f6k905rb5dshvq4amajn393vwgpm2bw";
      };
    }
  ];
})
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

