### PR TITLE
texlive: generate MkIV caches

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -235,6 +235,19 @@ in buildEnv {
         ln -s -t . ../texmf/doc/"$d"/*
       )
     done
+  '' +
+  # MkIV uses its own lookup mechanism and we need to initialize
+  # caches for it. Unsetting TEXMFCNF is needed to let mtxrun
+  # determine it from kpathsea so that the config path is given with
+  # "selfautodir:" as it will be in runtime. This is important because
+  # the cache is identified by a hash of this path.
+  ''
+    if [[ -e "$out/bin/mtxrun" ]]; then
+      (
+        unset TEXMFCNF
+        mtxrun --generate
+      )
+    fi
   ''
     + bin.cleanBrokenLinks
   ;


### PR DESCRIPTION
Documentation:
http://www.pragma-ade.com/general/manuals/tools-mkiv.pdf

Fixes: #19279
Closes: #47370

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

