### PR TITLE
arc-theme: fix `config.allowAliases = false` evaluation

### DIFF
--- a/pkgs/misc/themes/arc/default.nix
+++ b/pkgs/misc/themes/arc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, sassc, autoreconfHook, pkgconfig, gtk3
-, gnome-themes-standard, gtk-engine-murrine, optipng, inkscape}:
+, gnome-themes-extra, gtk-engine-murrine, optipng, inkscape}:
 
 let
   pname = "arc-theme";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig sassc optipng inkscape ];
   buildInputs = [ gtk3 ];
 
-  propagatedUserEnvPkgs = [ gnome-themes-standard gtk-engine-murrine ];
+  propagatedUserEnvPkgs = [ gnome-themes-extra gtk-engine-murrine ];
 
   postPatch = ''
     find . -name render-assets.sh |


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

