### PR TITLE
stupidterm: 2018-03-10 -> 2018-09-25

### DIFF
--- a/pkgs/applications/misc/stupidterm/default.nix
+++ b/pkgs/applications/misc/stupidterm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, vte, gtk }:
 
 stdenv.mkDerivation rec {
-  name = "stupidterm-2018-03-10";
+  name = "stupidterm-2018-09-25";
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "esmil";
     repo = "stupidterm";
-    rev = "0463519a96c9e4f9ce9fdc99d8e776499346ccba";
-    sha256 = "1vbk53xyjn33myb3fix6y7sxb1x3rndrkk5l9qa60qaw2ivkr965";
+    rev = "d1bc020797330df83d427e361d3620e346a4e792";
+    sha256 = "1yh2vhq3d0qbh0dh2h9yc7s9gkffgkb987vvwz2bdnvlskrjmmdj";
   };
 
   makeFlags = "PKGCONFIG=${pkgconfig}/bin/pkg-config binary=stupidterm";


### PR DESCRIPTION
###### Motivation for this change
Diff: https://github.com/esmil/stupidterm/compare/0463519a96c9e4f9ce9fdc99d8e776499346ccba..d1bc020797330df83d427e361d3620e346a4e792

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

