### PR TITLE
ranger: syntax highlight previews by default

### DIFF
--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3Packages, file, less
+{ stdenv, lib, fetchFromGitHub, python3Packages, file, less, highlight
 , imagePreviewSupport ? true, w3m ? null}:
 
 with stdenv.lib;
@@ -24,6 +24,11 @@ python3Packages.buildPythonApplication rec {
   '';
 
   preConfigure = ''
+    ${lib.optionalString (highlight != null) ''
+      sed -i -e 's|^\s*highlight\b|${highlight}/bin/highlight|' \
+        ranger/data/scope.sh
+    ''}
+
     substituteInPlace ranger/data/scope.sh \
       --replace "/bin/echo" "echo"
 
@@ -46,7 +51,7 @@ python3Packages.buildPythonApplication rec {
       --replace "set preview_images false" "set preview_images true"
   '';
 
-  meta =  with stdenv.lib; {
+  meta =  with lib; {
     description = "File manager with minimalistic curses interface";
     homepage = http://ranger.github.io/;
     license = licenses.gpl3;

--- a/pkgs/applications/misc/ranger/default.nix
+++ b/pkgs/applications/misc/ranger/default.nix
@@ -36,7 +36,7 @@ python3Packages.buildPythonApplication rec {
 
     # give file previews out of the box
     substituteInPlace ranger/config/rc.conf \
-      --replace "set preview_script ~/.config/ranger/scope.sh" "set preview_script $out/share/doc/ranger/config/scope.sh"
+      --replace "#set preview_script ~/.config/ranger/scope.sh" "set preview_script $out/share/doc/ranger/config/scope.sh"
   '' + optionalString imagePreviewSupport ''
     substituteInPlace ranger/ext/img_display.py \
       --replace /usr/lib/w3m ${w3m}/libexec/w3m


### PR DESCRIPTION
This also fixes out-of-the-box previews. I'm guessing this became commented out by default at some point.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---