### PR TITLE
renoise: add mpg123 to runtime deps

### DIFF
--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib, releasePath ? null }:
+{ stdenv, fetchurl, libX11, libXext, libXcursor, libXrandr, libjack2, alsaLib,
+  mpg123, makeWrapper, releasePath ? null }:
 
 with stdenv.lib;
 
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
         releasePath
     else throw "Platform is not supported by Renoise";
 
-  buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
+  buildInputs = [ makeWrapper libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
 
   installPhase = ''
     cp -r Resources $out
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
     ln -s $out/renoise $out/bin/renoise
 
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) --set-rpath $out/lib $out/renoise
+    wrapProgram "$out/renoise" --prefix LD_LIBRARY_PATH : "${mpg123}/lib"
   '';
 
   meta = {

--- a/pkgs/applications/audio/renoise/default.nix
+++ b/pkgs/applications/audio/renoise/default.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation rec {
         releasePath
     else throw "Platform is not supported by Renoise";
 
-  buildInputs = [ makeWrapper libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ libX11 libXext libXcursor libXrandr alsaLib libjack2 ];
 
   installPhase = ''
     cp -r Resources $out
@@ -62,7 +63,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Modern tracker-based DAW";
-    homepage = http://www.renoise.com/;
+    homepage = https://www.renoise.com/;
     license = licenses.unfree;
     maintainers = [];
     platforms = [ "i686-linux" "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change

Renoise cannot read/use MP3 samples unless mpg123 is available to it.
It's an optional dependency and maybe there's a better way to provide this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

