### PR TITLE
gmic_krita_qt: Init at 2.3.6

### DIFF
--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -19,15 +19,15 @@ in stdenv.mkDerivation rec {
 
   srcs = [
     (fetchFromGitHub {
+      owner = "dtschump";
+      repo = "gmic";
+      rev = "3e9600c5c99cca3b389099909fc3a231e0a69d8e";
+      sha256 = "1yg9ri3n07drv8gz4x0mn39ryi801ibl26jaza47m19ma893m8fi";})
+    (fetchFromGitHub {
       owner = "c-koi";
       repo = "gmic-qt";
       rev = "9e992cff2db418032b849458f5c9443267c7162c";
       sha256= "0j9wqlq67dwzir36yg58xy5lbblwizvgcvlmzcv9d6l901d5ayf3";})
-    (fetchFromGitHub {
-      owner ="dtschump";
-      repo = "gmic";
-      rev = "3e9600c5c99cca3b389099909fc3a231e0a69d8e";
-      sha256 = "1yg9ri3n07drv8gz4x0mn39ryi801ibl26jaza47m19ma893m8fi";})
   ];
 
   sourceRoot = "gmic-${gmic-version}";
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     fftw zlib libjpeg libtiff libpng opencv openexr graphicsmagick
-  ] ++ stdenv.lib.optionals withGimpPlugin [ gimp gimp.gtk ];
+  ];
 
   #cmakeFlags = [
   #  "-DBUILD_LIB_STATIC=OFF"

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchurl, fetchFromGitHub, cmake, ninja, pkgconfig, qt5
+, opencv, openexr, graphicsmagick, fftw, zlib, libjpeg, libtiff, libpng
+, withGimpPlugin ? true, gimp ? null}:
+
+assert withGimpPlugin -> gimp != null;
+
+let
+  version = "2.3.6";
+
+  gmic-version = "2.3.6";
+
+  # CMakeLists.txt is missing from the tarball and Makefile is terrible
+  #CMakeLists = fetchurl {
+  #  url = "https://github.com/dtschump/gmic/raw/v.${version}/CMakeLists.txt";
+  #  sha256 = "0lv5jrg98cpbk13fl4xm7l4sk1axfz054q570bpi741w815d7cpg";
+  #};
+in stdenv.mkDerivation rec {
+  name = "gmic-qt-${version}";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "c-koi";
+      repo = "gmic-qt";
+      rev = "9e992cff2db418032b849458f5c9443267c7162c";
+      sha256= "0j9wqlq67dwzir36yg58xy5lbblwizvgcvlmzcv9d6l901d5ayf3";})
+    (fetchFromGitHub {
+      owner ="dtschump";
+      repo = "gmic";
+      rev = "3e9600c5c99cca3b389099909fc3a231e0a69d8e";
+      sha256 = "1yg9ri3n07drv8gz4x0mn39ryi801ibl26jaza47m19ma893m8fi";})
+  ];
+
+  sourceRoot = "gmic-${gmic-version}";
+
+  #src = fetchgit {
+  #  url = "https://gmic.eu/files/source/gmic_${version}.tar.gz";
+  #  sha256 = "0zqfj2ym5nn3ff93xh2wf9ayxqlznabbdi00xw4lm7vw3iwkzqnc";
+  #};
+
+  nativeBuildInputs = [ qt5.qmake ];
+
+  buildInputs = [
+    fftw zlib libjpeg libtiff libpng opencv openexr graphicsmagick
+  ] ++ stdenv.lib.optionals withGimpPlugin [ gimp gimp.gtk ];
+
+  #cmakeFlags = [
+  #  "-DBUILD_LIB_STATIC=OFF"
+  #  "-DBUILD_PLUGIN=${if withGimpPlugin then "ON" else "OFF"}"
+  #  "-DENABLE_DYNAMIC_LINKING=ON"
+  #] ++ stdenv.lib.optional withGimpPlugin "-DPLUGIN_INSTALL_PREFIX=${placeholder "gimpPlugin"}/${gimp.targetPluginDir}";
+
+  #postPatch = ''
+  #  cp ${CMakeLists} CMakeLists.txt
+  #'';
+
+  buildPhase = ''
+    make -C src CImg.h gmic_stdlib.h;
+    cd ../qmic-qt;
+    mkdir build;
+    qmake HOST=krita ..;
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin;
+    install -Dm755 "gmic-qt/gmic_krita_qt" "$out/gmic_krita_qt"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Krita plugin for the G'MIC image processing framework";
+    homepage = http://gmic.eu/;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, cmake, ninja, pkgconfig, qt5
 , opencv, openexr, graphicsmagick, fftw, zlib, libjpeg, libtiff, libpng
-, curl, krita, gdk_pixbuf, cairo
-, fetchgit, withGimpPlugin ? true, gimp }:
+, curl, krita
+, fetchgit }:
 
 let
   version = "2.3.6";
@@ -60,15 +60,15 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    qt5.qtbase qt5.qttools gimp gdk_pixbuf fftw zlib libjpeg libtiff libpng
-    opencv openexr graphicsmagick curl cairo krita
+    qt5.qtbase qt5.qttools fftw zlib libjpeg libtiff libpng
+    opencv openexr graphicsmagick curl krita
   ];
 
   cmakeFlags = [ "-DGMIC_QT_HOST=krita" ];
 
   installPhase = ''
     mkdir -p $out/bin;
-    install -Dm755 gmic-qt/gmic_krita_qt "$out/gmic_krita_qt"
+    install -Dm755 gmic_krita_qt "$out/bin/gmic_krita_qt"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -6,8 +6,6 @@
 let
   version = "2.3.6";
 
-  gmic-version = "2.3.6";
-
 in stdenv.mkDerivation rec {
   name = "gmic-qt-${version}";
 
@@ -51,10 +49,13 @@ in stdenv.mkDerivation rec {
     chmod -R +w gmic gmic_qt
     ln -s ${CImg} CImg
 
+    cd gmic_qt
+  '';
+
+  preConfigure = ''
     cp ${gmic_stdlib} gmic/src/gmic_stdlib.h
 
     make -C gmic/src CImg.h gmic_stdlib.h
-    cd gmic_qt
   '';
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -31,14 +31,14 @@ in stdenv.mkDerivation rec {
   gmic = fetchFromGitHub {
     owner = "dtschump";
     repo = "gmic";
-    rev = "b9a6876684f40852ca39300c9d7e7d676cb81b14";
+    rev = "v.${version}";
     sha256 = "0f69r460lyfb021m7bs8s4rxa3png51cbp1izywsy3sprjd1s57p";
   };
 
   gmic_qt = fetchFromGitHub {
     owner = "c-koi";
     repo = "gmic-qt";
-    rev = "9e992cff2db418032b849458f5c9443267c7162c";
+    rev = "v.${version}";
     sha256= "0j9wqlq67dwzir36yg58xy5lbblwizvgcvlmzcv9d6l901d5ayf3";
   };
 

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -49,12 +49,12 @@ in stdenv.mkDerivation rec {
     chmod -R +w gmic gmic_qt
     ln -s ${CImg} CImg
 
+    cp ${gmic_stdlib} gmic/src/gmic_stdlib.h
+
     cd gmic_qt
   '';
 
   preConfigure = ''
-    cp ${gmic_stdlib} gmic/src/gmic_stdlib.h
-
     make -C gmic/src CImg.h gmic_stdlib.h
   '';
 

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -55,7 +55,7 @@ in stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    make -C gmic/src CImg.h gmic_stdlib.h
+    make -C ../gmic/src CImg.h gmic_stdlib.h
   '';
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, fetchFromGitHub, cmake, ninja, pkgconfig, qt5
 , opencv, openexr, graphicsmagick, fftw, zlib, libjpeg, libtiff, libpng
-, curl, krita
+, curl, krita, gdk_pixbuf, cairo
 , fetchgit, withGimpPlugin ? true, gimp }:
 
 let
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     chmod -R +w gmic gmic_qt
     ln -s ${CImg} CImg
 
-    cp ${gmic_stdlib} gmic/gmic_stdlib.h
+    cp ${gmic_stdlib} gmic/src/gmic_stdlib.h
 
     make -C gmic/src CImg.h gmic_stdlib.h
     cd gmic_qt
@@ -60,10 +60,11 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    qt5.qtbase qt5.qttools gimp fftw zlib libjpeg libtiff libpng opencv openexr graphicsmagick curl krita
+    qt5.qtbase qt5.qttools gimp gdk_pixbuf fftw zlib libjpeg libtiff libpng
+    opencv openexr graphicsmagick curl cairo krita
   ];
 
-  qmakeFlags = [ "HOST=krita" ];
+  cmakeFlags = [ "-DGMIC_QT_HOST=krita" ];
 
   installPhase = ''
     mkdir -p $out/bin;

--- a/pkgs/tools/graphics/gmic-qt/default.nix
+++ b/pkgs/tools/graphics/gmic-qt/default.nix
@@ -24,6 +24,7 @@ in stdenv.mkDerivation rec {
 
   gmic_stdlib = fetchurl {
     name = "gmic_stdlib.h";
+    # Version should e in sync with gmic. Basically the version string without dots
     url = "http://gmic.eu/gmic_stdlib236.h";
     sha256 = "0q5g87dsn9byd2qqsa9xrsggfb9qv055s3l2gc0jrcvpx2qbza4q";
   };

--- a/pkgs/tools/graphics/gmic_krita_qt/default.nix
+++ b/pkgs/tools/graphics/gmic_krita_qt/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     owner = "dtschump";
     repo = "gmic";
     rev = "v.${version}";
-    sha256 = "0f69r460lyfb021m7bs8s4rxa3png51cbp1izywsy3sprjd1s57p";
+    sha256 = "1yg9ri3n07drv8gz4x0mn39ryi801ibl26jaza47m19ma893m8fi";
   };
 
   gmic_qt = fetchFromGitHub {

--- a/pkgs/tools/graphics/gmic_krita_qt/default.nix
+++ b/pkgs/tools/graphics/gmic_krita_qt/default.nix
@@ -18,8 +18,8 @@ in stdenv.mkDerivation rec {
 
   CImg = fetchgit {
     url = "https://framagit.org/dtschump/CImg";
-    rev = "c523f0026f3b03831c0778335fe7c7661bf9a719";
-    sha256 = "13ja8immpjkm2xskddc920axq2rp4hc2sr5ghgvgy1rshc3lp8i8";
+    rev = "90f5657d8eab7b549ef945103ef680e747385805";
+    sha256 = "1af3dwqq18dkw0lz2gvnlw8y0kc1cw01hnc72rf3pg2wyjcp0pvc";
   };
 
   gmic_stdlib = fetchurl {

--- a/pkgs/tools/graphics/gmic_krita_qt/default.nix
+++ b/pkgs/tools/graphics/gmic_krita_qt/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, fetchFromGitHub, cmake, ninja, pkgconfig, qt5
+{ stdenv, fetchurl, fetchFromGitHub, cmake, ninja, pkgconfig
 , opencv, openexr, graphicsmagick, fftw, zlib, libjpeg, libtiff, libpng
-, curl, krita
+, curl, krita, qtbase, qttools
 , fetchgit }:
 
 let
   version = "2.3.6";
 
 in stdenv.mkDerivation rec {
-  name = "gmic-qt-${version}";
+  name = "gmic_krita_qt-${version}";
 
   gmic-community = fetchFromGitHub {
     owner = "dtschump";
@@ -62,7 +62,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    qt5.qtbase qt5.qttools fftw zlib libjpeg libtiff libpng
+    qtbase qttools fftw zlib libjpeg libtiff libpng
     opencv openexr graphicsmagick curl krita
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1370,7 +1370,7 @@ with pkgs;
 
   gmic = callPackage ../tools/graphics/gmic { };
 
-  gmic-qt = callPackage ../tools/graphics/gmic-qt { };
+  gmic_krita_qt = libsForQt5.callPackage ../tools/graphics/gmic_krita_qt { };
 
   goa = callPackage ../development/tools/goa {
     buildGoPackage = buildGo110Package;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1370,6 +1370,8 @@ with pkgs;
 
   gmic = callPackage ../tools/graphics/gmic { };
 
+  gmic-qt = callPackage ../tools/graphics/gmic-qt { };
+
   goa = callPackage ../development/tools/goa {
     buildGoPackage = buildGo110Package;
   };


### PR DESCRIPTION
###### Motivation for this change

This tool has been missing in the toolbox.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

