### PR TITLE
google-chrome, treewide: fix patchelf usages to not crash constantly, patchelf as native

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -26,7 +26,7 @@ with stdenv; lib.makeOverridable mkDerivation rec {
     '';
   };
 
-  buildInputs = [ makeWrapper patchelf p7zip unzip ];
+  nativeBuildInputs = [ makeWrapper patchelf p7zip unzip ];
 
   patchPhase = ''
       get_file_size() {

--- a/pkgs/applications/misc/ipmiview/default.nix
+++ b/pkgs/applications/misc/ipmiview/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wp22wm7smlsb25x0cck4p660cycfczxj381930crd1qrf68mw4h";
   };
 
-   buildInputs = [ patchelf makeWrapper ];
+   nativeBuildInputs = [ patchelf makeWrapper ];
 
    buildPhase = with xorg; ''
      patchelf --set-rpath "${stdenv.lib.makeLibraryPath [ libX11 libXext libXrender libXtst libXi ]}" ./jre/lib/amd64/xawt/libmawt.so

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -71,9 +71,8 @@ in stdenv.mkDerivation rec {
 
   src = chromium.upstream-info.binary;
 
+  nativeBuildInputs = [ patchelf makeWrapper ];
   buildInputs = [
-    patchelf makeWrapper
-
     # needed for GSETTINGS_SCHEMAS_PATH
     gsettings-desktop-schemas glib gtk
 

--- a/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bluejeans/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
       sha256 = "0sbv742pzqd2cxn3kq10lfi16jah486i9kyrmi8l1rpb9fhyw2m1";
     };
 
-  buildInputs = [ patchelf rpmextract ];
+  nativeBuildInputs = [ patchelf rpmextract ];
 
   libPath =
     stdenv.lib.makeLibraryPath

--- a/pkgs/applications/networking/mailreaders/inboxer/default.nix
+++ b/pkgs/applications/networking/mailreaders/inboxer/default.nix
@@ -22,7 +22,8 @@ stdenv.mkDerivation rec {
   unpackPhase = ''
     ar p $src data.tar.xz | tar xJ
   '';
-  buildInputs = [ binutils patchelf makeWrapper ];
+  nativeBuildInputs = [ patchelf makeWrapper ];
+  buildInputs = [ binutils ];
 
   preFixup = with stdenv.lib; let
     lpath = makeLibraryPath [

--- a/pkgs/applications/networking/spideroak/default.nix
+++ b/pkgs/applications/networking/spideroak/default.nix
@@ -57,7 +57,7 @@ in stdenv.mkDerivation {
     sed -i 's/^Exec=.*/Exec=spideroak/' $out/share/applications/SpiderOakONE.desktop
   '';
 
-  buildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [ patchelf makeWrapper ];
 
   meta = {
     homepage = https://spideroak.com;

--- a/pkgs/applications/science/logic/tptp/default.nix
+++ b/pkgs/applications/science/logic/tptp/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0slqbqv4y43wz6wnh72s4n540ssapah0d12mndi0c7xr04kf2v2d";
   };
 
-  buildInputs = [ tcsh yap perl patchelf ];
+  nativeBuildInputs = [ patchelf ];
+  buildInputs = [ tcsh yap perl ];
 
   installPhase = ''
     sharedir=$out/share/tptp

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -32,12 +32,12 @@ in stdenv.mkDerivation {
 
   outputs = [ "out" "modsrc" ];
 
-  nativeBuildInputs = [ pkgconfig which docbook_xsl docbook_xml_dtd_43 ];
+  nativeBuildInputs = [ pkgconfig which docbook_xsl docbook_xml_dtd_43 patchelfUnstable ];
 
   buildInputs =
     [ iasl dev86 libxslt libxml2 xproto libX11 libXext libXcursor libIDL
       libcap glib lvm2 alsaLib curl libvpx pam xorriso makeself perl
-      libXmu libpng patchelfUnstable python ]
+      libXmu libpng python ]
     ++ optional javaBindings jdk
     ++ optional pythonBindings python # Python is needed even when not building bindings
     ++ optional pulseSupport libpulseaudio

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -36,7 +36,8 @@ stdenv.mkDerivation {
 
   NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  buildInputs = [ patchelf cdrkit makeWrapper dbus ] ++ kernel.moduleBuildDependencies;
+  nativeBuildInputs = [ patchelf makeWrapper ];
+  buildInputs = [ cdrkit dbus ] ++ kernel.moduleBuildDependencies;
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/development/compilers/gcc-arm-embedded/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
     sha256 = sha256;
   };
 
-  buildInputs = [ bzip2 patchelf ];
+  nativeBuildInputs = [ bzip2 patchelf ];
 
   dontPatchELF = true;
 

--- a/pkgs/development/compilers/mentor/default.nix
+++ b/pkgs/development/compilers/mentor/default.nix
@@ -10,7 +10,7 @@ let
     stdenv.mkDerivation rec {
       inherit name src;
 
-      buildInputs = [ patchelf ];
+      nativeBuildInputs = [ patchelf ];
 
       buildCommand = ''
         # Unpack tarball

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -38,7 +38,8 @@ stdenv.mkDerivation rec {
 
   sourceRoot = name;
 
-  buildInputs = [ gmp ] ++ stdenv.lib.optional stdenv.isLinux patchelf;
+  buildInputs = [ gmp ];
+  nativeBuildInputs = stdenv.lib.optional stdenv.isLinux patchelf;
 
   makeFlags = [ "all-no-docs" ];
 

--- a/pkgs/development/compilers/opendylan/bin.nix
+++ b/pkgs/development/compilers/opendylan/bin.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     }
     else throw "platform ${stdenv.hostPlatform.system} not supported.";
 
-  buildInputs = [ patchelf boehmgc gnused makeWrapper ];
+  nativeBuildInputs = [ patchelf boehmgc gnused makeWrapper ];
 
   buildCommand = ''
     mkdir -p "$out"

--- a/pkgs/development/libraries/scmccid/default.nix
+++ b/pkgs/development/libraries/scmccid/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     })
     else throw "Architecture not supported";
 
-  buildInputs = [ patchelf ];
+  nativeBuildInputs = [ patchelf ];
 
   installPhase = ''
     RPATH=${libusb.out}/lib:${stdenv.cc.libc.out}/lib

--- a/pkgs/games/openarena/default.nix
+++ b/pkgs/games/openarena/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0jmc1cmdz1rcvqc9ilzib1kilpwap6v0d331l6q53wsibdzsz3ss";
   };
 
-  buildInputs = [ pkgs.unzip patchelf makeWrapper];
+  nativeBuildInputs = [ pkgs.unzip patchelf makeWrapper];
 
   installPhase = let
     gameDir = "$out/openarena-$version";

--- a/pkgs/games/planetaryannihilation/default.nix
+++ b/pkgs/games/planetaryannihilation/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     inherit (config.planetary_annihilation) url sha256;
   };
 
-  buildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [ patchelf makeWrapper ];
  
   installPhase = ''
     mkdir -p $out/{bin,lib}

--- a/pkgs/games/ue4demos/default.nix
+++ b/pkgs/games/ue4demos/default.nix
@@ -5,7 +5,7 @@ let
     stdenv.mkDerivation rec {
       inherit name src;
 
-      buildInputs = [ unzip patchelf ];
+      nativeBuildInputs = [ unzip patchelf ];
 
       rtdeps = stdenv.lib.makeLibraryPath
         [ xorg.libXxf86vm xorg.libXext openal ]

--- a/pkgs/misc/cups/drivers/samsung/4.00.39/default.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.00.39/default.nix
@@ -26,7 +26,8 @@ in stdenv.mkDerivation rec {
     sha256 = "144b4xggbzjfq7ga5nza7nra2cf6qn63z5ls7ba1jybkx1vm369k";
   };
 
-  buildInputs = [ cups' gcc ghostscript glibc patchelf ];
+  nativeBuildInputs = [ patchelf ];
+  buildInputs = [ cups' gcc ghostscript glibc ];
 
   inherit gcc ghostscript glibc;
   cups = cups';

--- a/pkgs/misc/drivers/epkowa/default.nix
+++ b/pkgs/misc/drivers/epkowa/default.nix
@@ -30,7 +30,7 @@ let plugins = {
     version = "1.0.1";
     pluginVersion = "2.1.2-1";
 
-    buildInputs = [ patchelf rpm ];
+    nativeBuildInputs = [ patchelf rpm ];
     src = fetchurl {
       url = "https://download2.ebz.epson.net/iscan/plugin/gt-x770/rpm/x64/iscan-gt-x770-bundle-${version}.x64.rpm.tar.gz";
       sha256 = "0m9c60rszzdvq1pqfzygzzrjycm1giy465lj29108j7hsnfcv56r";

--- a/pkgs/tools/security/gorilla-bin/default.nix
+++ b/pkgs/tools/security/gorilla-bin/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "19ir6x4c01825hpx2wbbcxkk70ymwbw4j03v8b2xc13ayylwzx0r";
   };
 
-  buildInputs = [ patchelf makeWrapper ];
+  nativeBuildInputs = [ patchelf makeWrapper ];
   phases = [ "unpackPhase" "installPhase" ];
 
   unpackCmd = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16865,7 +16865,7 @@ with pkgs;
 
   googleearth = callPackage ../applications/misc/googleearth { };
 
-  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
+  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; patchelf = patchelfUnstable; };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
 


### PR DESCRIPTION
Tired of seeing build logs telling me patchelf segfaults 20 times or
unfriendly assertion failure messages, neither of which are reasonable state of "normal".


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested virtualbox, google-chrome, and a number of the expressions modified but not all.