### PR TITLE
patch-shebangs: use isScript to safely check for shebang start

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -19,9 +19,8 @@ patchShebangs() {
     local newInterpreterLine
 
     find "$dir" -type f -perm -0100 | while read f; do
-        if [ "$(head -1 "$f" | head -c+2)" != '#!' ]; then
-            # missing shebang => not a script
-            continue
+        if ! isScript "$f"; then
+          continue
         fi
 
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -19,9 +19,7 @@ patchShebangs() {
     local newInterpreterLine
 
     find "$dir" -type f -perm -0100 | while read f; do
-        if ! isScript "$f"; then
-          continue
-        fi
+        isScript "$f" || continue
 
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
         read -r oldPath arg0 args <<< "$oldInterpreterLine"

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -18,7 +18,10 @@ patchShebangs() {
     local oldInterpreterLine
     local newInterpreterLine
 
-    find "$dir" -type f -perm -0100 | while read f; do
+    [ -e "$dir" ] || return 0
+
+    local f
+    while IFS= read -r -d $'\0' f; do
         isScript "$f" || continue
 
         oldInterpreterLine=$(head -1 "$f" | tail -c+3)
@@ -58,7 +61,7 @@ patchShebangs() {
                 rm "$f.timestamp"
             fi
         fi
-    done
+    done < <(find "$dir" -type f -perm -0100 -print0)
 
     stopNest
 }


### PR DESCRIPTION
Fixes commonly encountered errors about broken pipes or null-bytes in
command-substitution.



Fixing another source of errors in logs produced by our setup-hooks.

Have yet to push through full rebuild but using the modified setuphook
selectively in cases of my own showed the errors no longer occurring
and shebangs were fixed where found.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---