### PR TITLE
libxcb: 1.13 -> 1.13.1

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1136,11 +1136,11 @@ let
   }) // {inherit ;};
 
   libxcb = (mkDerivation "libxcb" {
-    name = "libxcb-1.13";
+    name = "libxcb-1.13.1";
     builder = ./builder.sh;
     src = fetchurl {
-      url = http://xcb.freedesktop.org/dist/libxcb-1.13.tar.bz2;
-      sha256 = "1ahxhmdqp4bhb90zmc275rmf5wixqra4bnw9pqnzyl1w3598g30q";
+      url = http://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2;
+      sha256 = "1i27lvrcsygims1pddpl5c4qqs6z715lm12ax0n3vx0igapvg7x8";
     };
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ libxslt libpthreadstubs python libXau xcbproto libXdmcp ];

--- a/pkgs/servers/x11/xorg/extra.list
+++ b/pkgs/servers/x11/xorg/extra.list
@@ -1,5 +1,5 @@
 http://xcb.freedesktop.org/dist/libpthread-stubs-0.4.tar.bz2
-http://xcb.freedesktop.org/dist/libxcb-1.13.tar.bz2
+http://xcb.freedesktop.org/dist/libxcb-1.13.1.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-proto-1.13.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-0.4.0.tar.bz2
 http://xcb.freedesktop.org/dist/xcb-util-cursor-0.1.3.tar.bz2


### PR DESCRIPTION
https://lists.freedesktop.org/archives/xcb/2018-September/011155.html
(cherry picked from commit b043a056a2cc6a4ab129ab1ce2bf7d4aa7d2ea69)



Bugfix, see announcement linked above.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---