### PR TITLE
steamPackages.steam: add udev rules and update to 1.0.0.56

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -413,11 +413,8 @@ packageOverrides = pkgs: {
     in your <filename>/etc/nixos/configuration.nix</filename>. You'll also need
 <programlisting>hardware.pulseaudio.support32Bit = true;</programlisting>
     if you are using PulseAudio - this will enable 32bit ALSA apps integration.
-    To use the Steam controller, you need to add
-<programlisting>services.udev.extraRules = ''
-    SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0666"
-    KERNEL=="uinput", MODE="0660", GROUP="users", OPTIONS+="static_node=uinput"
-  '';</programlisting>
+    To use the Steam controller or other Steam supported controllers such as the DualShock 4 or Nintendo Switch Pro, you need to add
+<programlisting>hardware.steam-hardware.enable = true;</programlisting>
     to your configuration.
    </para>
   </section>

--- a/nixos/modules/hardware/steam-hardware.nix
+++ b/nixos/modules/hardware/steam-hardware.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.hardware.steam-hardware;
+
+in
+
+{
+  options.hardware.steam-hardware = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable udev rules for Steam hardware such as the Steam Controller, other supported controllers and the HTC Vive";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [
+      pkgs.steamPackages.steam
+    ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,6 +46,7 @@
   ./hardware/opengl.nix
   ./hardware/pcmcia.nix
   ./hardware/raid/hpsa.nix
+  ./hardware/steam-hardware.nix
   ./hardware/usb-wwan.nix
   ./hardware/onlykey.nix
   ./hardware/video/amdgpu.nix

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -25,6 +25,8 @@ in stdenv.mkDerivation rec {
       EOF
       chmod +x $out/bin/steamdeps
     ''}
+    install -d $out/lib/udev/rules.d
+    install -m644 lib/udev/rules.d/*.rules $out/lib/udev/rules.d
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -2,14 +2,14 @@
 
 let
   traceLog = "/tmp/steam-trace-dependencies.log";
-  version = "1.0.0.51";
+  version = "1.0.0.56";
 
 in stdenv.mkDerivation rec {
   name = "steam-original-${version}";
 
   src = fetchurl {
     url = "http://repo.steampowered.com/steam/pool/steam/s/steam/steam_${version}.tar.gz";
-    sha256 = "1ghrfznm9rckm8v87zvh7hx820r5pp7sq575wxwq0fncbyq6sxmz";
+    sha256 = "01jgp909biqf4rr56kb08jkl7g5xql6r2g4ch6lc71njgcsbn5fs";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];


### PR DESCRIPTION
###### Motivation for this change
Fixes #47314 
Close #47447

Hello @Mic92 I did your suggestion

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

