### PR TITLE
rxvt_unicode: fixes annoying locale mismatch bug

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/wrapper.nix
+++ b/pkgs/applications/misc/rxvt_unicode/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, rxvt_unicode, makeWrapper, plugins }:
+{ symlinkJoin, rxvt_unicode, makeWrapper, glibcLocales, plugins }:
 
 let
   rxvt_name = builtins.parseDrvName rxvt_unicode.name;
@@ -8,12 +8,14 @@ in symlinkJoin {
 
   paths = [ rxvt_unicode ] ++ plugins;
 
-  buildInputs = [ makeWrapper ];
+  buildInputs = [ makeWrapper glibcLocales ];
 
   postBuild = ''
     wrapProgram $out/bin/urxvt \
+      --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive \
       --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
     wrapProgram $out/bin/urxvtd \
+      --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive \
       --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

We've been here before: if the package is build with a different glibclocale version than the default on the system it is run on, it results in bad behaviour. (Especially annoying for non-nixos systems).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

