### PR TITLE
ocamlPackages.odoc: fix resolution of odoc.css

### DIFF
--- a/pkgs/development/ocaml-modules/odoc/default.nix
+++ b/pkgs/development/ocaml-modules/odoc/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ bos doc-ock-html doc-ock-xml ];
 
+  configurePhase = "ocaml bin/set-etc bin/odoc_etc.ml $out/etc/odoc";
+
   inherit (dune) installPhase;
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Fix call to `odoc css -o …`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

