### PR TITLE
pythonPackages.flask-jwt-extended: init at 3.13.1

### DIFF
--- a/pkgs/development/python-modules/flask-jwt-extended/default.nix
+++ b/pkgs/development/python-modules/flask-jwt-extended/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildPythonPackage, fetchPypi, flask, pyjwt, werkzeug, pytest }:
+
+buildPythonPackage rec {
+  pname = "Flask-JWT-Extended";
+  version = "3.13.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10qz3ljr2kpd93al2km6iijxp23z33kvvwd0y5bc840f86b4mra8";
+  };
+
+  propagatedBuildInputs = [ flask pyjwt werkzeug ];
+  checkInputs = [ pytest ];
+
+  checkPhase = ''
+    pytest tests/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "JWT extension for Flask";
+    homepage = https://flask-jwt-extended.readthedocs.io/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ gerschtli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5278,6 +5278,8 @@ in {
 
   flask_elastic = callPackage ../development/python-modules/flask-elastic { };
 
+  flask-jwt-extended = callPackage ../development/python-modules/flask-jwt-extended { };
+
   flask-limiter = callPackage ../development/python-modules/flask-limiter { };
 
   flask_login = callPackage ../development/python-modules/flask-login { };


### PR DESCRIPTION
###### Motivation for this change

Adds `pythonPackages.flask-jwt-extended` at 3.13.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

