### PR TITLE
virtualbox: remove useless patchelfUnstable build input

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -11,7 +11,6 @@
 , enableHardening ? false
 , headless ? false
 , enable32bitGuests ? true
-, patchelfUnstable # needed until 0.10 is released
 }:
 
 with stdenv.lib;
@@ -37,7 +36,7 @@ in stdenv.mkDerivation {
   buildInputs =
     [ iasl dev86 libxslt libxml2 xproto libX11 libXext libXcursor libIDL
       libcap glib lvm2 alsaLib curl libvpx pam xorriso makeself perl
-      libXmu libpng patchelfUnstable python ]
+      libXmu libpng python ]
     ++ optional javaBindings jdk
     ++ optional pythonBindings python # Python is needed even when not building bindings
     ++ optional pulseSupport libpulseaudio


### PR DESCRIPTION
###### Motivation for this change
It wasn't used at all because stdenv puts regular `patchelf` in `PATH` before it, see discussion in #45449

###### Things done

- [x] this should be a no-op rebuild

---

cc @dtzWill 