### PR TITLE
gopkgs: unstable-2017-12-29 -> 2.0.1

### DIFF
--- a/pkgs/development/tools/gopkgs/default.nix
+++ b/pkgs/development/tools/gopkgs/default.nix
@@ -2,17 +2,16 @@
 
 buildGoPackage rec {
   name = "gopkgs-${version}";
-  version = "unstable-2017-12-29";
-  rev = "b2ea2ecd37740e6ce0e020317d90c729aab4dc6d";
+  version = "2.0.1";
 
   goPackagePath = "github.com/uudashr/gopkgs";
   goDeps = ./deps.nix;
 
   src = fetchFromGitHub {
-    inherit rev;
+    rev = "v${version}";
     owner = "uudashr";
     repo = "gopkgs";
-    sha256 = "1hwzxrf2h8xjbbx6l86mjpjh4csxxsy17zkh8h3qzncyfnsnczzg";
+    sha256 = "03zfwkmzwx2knkghky3irb2r78lbc1ccszjcg9y445b4pbqkn6w4";
   };
 
   meta = {

--- a/pkgs/development/tools/gopkgs/deps.nix
+++ b/pkgs/development/tools/gopkgs/deps.nix
@@ -1,11 +1,21 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
 [
   {
-    goPackagePath = "github.com/MichaelTJones/walk";
+    goPackagePath  = "github.com/karrick/godirwalk";
     fetch = {
       type = "git";
-      url = "https://github.com/MichaelTJones/walk";
-      rev = "4748e29d5718c2df4028a6543edf86fd8cc0f881";
-      sha256 = "03bc3cql3w8cx05xlnzxsff59c6679rcpx4njzk86k00blkkizv7";
+      url = "https://github.com/karrick/godirwalk";
+      rev =  "5cc8b3875be6c21825a1b54d3029ed415c93c4f7";
+      sha256 = "02nlyr0sa0lj1f27fsrxlspcsrx7fs60qwr33l5r6yq52axcikcd";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

Bump gopkgs to latest release (and thus remove unstable)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

