### PR TITLE
vndr: 20171005 -> unstable-2018-06-23

### DIFF
--- a/pkgs/development/tools/vndr/default.nix
+++ b/pkgs/development/tools/vndr/default.nix
@@ -1,9 +1,9 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "vndr-${version}";
-  version = "20171005-${lib.strings.substring 0 7 rev}";
-  rev = "b57c5799efd5ed743f347a025482babf01ba963e";
+  name = "vndr-unstable-${version}";
+  version = "2018-06-23";
+  rev = "81cb8916aad3c8d06193f008dba3e16f82851f52";
 
   goPackagePath = "github.com/LK4D4/vndr";
   excludedPackages = "test";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "LK4D4";
     repo = "vndr";
-    sha256 = "15mmy4a06jgzvlbjbmd89f0xx695x8wg7jqi76kiz495i6figk2v";
+    sha256 = "0c0k0cic35d1141az72gbf8r0vm9zaq4xi8v1sqpxhlzf28m297l";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update vndr to latest commit (and change version scheme to be the same as other `go` unstable packages)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

