### PR TITLE
gomodifytags: unstable-2017-12-14 -> unstable-2018-09-14

### DIFF
--- a/pkgs/development/tools/gomodifytags/default.nix
+++ b/pkgs/development/tools/gomodifytags/default.nix
@@ -1,16 +1,17 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "gomodifytags-${version}";
-  version = "unstable-2017-12-14";
-  rev = "20644152db4fe0ac406d81f3848e8a15f0cdeefa";
+  name = "gomodifytags-unstable-${version}";
+  version = "2018-09-14";
+  rev = "141225bf62b6e5c9c0c9554a2e993e8c30aebb1d";
 
   goPackagePath = "github.com/fatih/gomodifytags";
 
-  src = fetchgit {
+  src = fetchFromGitHub {
     inherit rev;
-    url = "https://github.com/fatih/gomodifytags";
-    sha256 = "0k0ly3mmm9zcaxwlzdbvdxr2gn7kvcqzk1bb7blgq7fkkzpp7i1q";
+    owner = "fatih";
+    repo = "gomodifytags";
+    sha256 = "16qbp594l90qpvf388wlv0kf6wvqj1vz2mqq0g3qcz6dkrc4cjqa";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update gomodifytags to latest master

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

