### PR TITLE
go-symbols: unstable-2017-02-06 -> unstable-2018-05-23

### DIFF
--- a/pkgs/development/tools/go-symbols/default.nix
+++ b/pkgs/development/tools/go-symbols/default.nix
@@ -1,17 +1,18 @@
-{ stdenv, buildGoPackage, fetchgit }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "go-symbols-${version}";
-  version = "unstable-2017-02-06";
-  rev = "5a7f75904fb552189036c640d04cd6afef664836";
+  version = "unstable-2018-05-23";
+  rev = "953befd75e223f514580fcb698aead0dd6ad3421";
 
   goPackagePath = "github.com/acroca/go-symbols";
   goDeps = ./deps.nix;
 
-  src = fetchgit {
+  src = fetchFromGitHub {
     inherit rev;
-    url = "https://github.com/acroca/go-symbols";
-    sha256 = "0qh2jjhwwk48gi8yii0z031bah11anxfz81nwflsiww7n426a8bb";
+    owner = "acroca";
+    repo = "go-symbols";
+    sha256 = "0dwf7w3zypv5brk68n7siakz222jwnhrhkzvwk1iwdffk79gqp3x";
   };
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Update go-symbols to latest master

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

