### PR TITLE
drone: 0.8.5 -> 0.8.6

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "drone.io-${version}";
-  version = "0.8.5-20180329-${stdenv.lib.strings.substring 0 7 revision}";
-  revision = "81103a98208b0bfc76be5b07194f359fbc80183b";
+  version = "0.8.6-20180727-${stdenv.lib.strings.substring 0 7 revision}";
+  revision = "c48150767c2700d35dcc29b110a81c8b5969175e";
   goPackagePath = "github.com/drone/drone";
 
   # These dependencies pulled (in `drone` buildprocess) via Makefile,
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner = "drone";
     repo = "drone";
     rev = revision;
-    sha256 = "1890bwhxr62adv261v4kn1azhq7qvcj2zpll68i9nsvjib8a52bq";
+    sha256 = "0miq2012nivvr1ysi3aa2xrr5ak3mf0l3drybyc83iycy0kp4bda";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Bump to latest release of `drone`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

