### PR TITLE
doc: Update section about imperative containers

### DIFF
--- a/nixos/doc/manual/administration/imperative-containers.xml
+++ b/nixos/doc/manual/administration/imperative-containers.xml
@@ -73,8 +73,7 @@ Linux foo 3.4.82 #1-NixOS SMP Thu Mar 20 14:44:05 UTC 2014 x86_64 GNU/Linux
  </para>
 
  <para>
-  There are several ways to change the configuration of the container. First,
-  on the host, you can edit
+  To change the configuration of the container, you can edit
   <literal>/var/lib/container/<replaceable>name</replaceable>/etc/nixos/configuration.nix</literal>,
   and run
 <screen>
@@ -87,21 +86,22 @@ Linux foo 3.4.82 #1-NixOS SMP Thu Mar 20 14:44:05 UTC 2014 x86_64 GNU/Linux
   <xref linkend="opt-services.httpd.enable"/> = true;
   <xref linkend="opt-services.httpd.adminAddr"/> = "foo@example.org";
   <xref linkend="opt-networking.firewall.allowedTCPPorts"/> = [ 80 ];
-'
+  '
+
+  <para>
+    Note that in previous versions of NixOS (17.09 and earlier) one could
+    also use all nix-related commands (like <command>nixos-rebuild switch</command>) 
+    from inside the container. However, since the release of Nix 2.0 this
+    is not supported anymore. Supporting Nix commands inside the
+    container might be possible again in future versions. See
+    <link xlink:ref="https://github.com/NixOS/nixpkgs/issues/40355">the github issue</link> for tracking progress on this issue.
+  </para>
 
 # curl http://$(nixos-container show-ip foo)/
 &lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">…
 </screen>
   However, note that this will overwrite the container’s
   <filename>/etc/nixos/configuration.nix</filename>.
- </para>
-
- <para>
-  Alternatively, you can change the configuration from within the container
-  itself by running <command>nixos-rebuild switch</command> inside the
-  container. Note that the container by default does not have a copy of the
-  NixOS channel, so you should run <command>nix-channel --update</command>
-  first.
  </para>
 
  <para>


### PR DESCRIPTION
Nix commands inside the container have been broken since 18.03,
and no fix is yet in sight.  Lets remove from the documentation
that this is a usecase that we support, as it doesn't seem
likely that this will be fixed before 18.09 either.

See #40355

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

