### PR TITLE
steamPackages.steam: 1.0.0.51 -> 1.0.0.56

### DIFF
--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -2,14 +2,14 @@
 
 let
   traceLog = "/tmp/steam-trace-dependencies.log";
-  version = "1.0.0.51";
+  version = "1.0.0.56";
 
 in stdenv.mkDerivation rec {
   name = "steam-original-${version}";
 
   src = fetchurl {
     url = "http://repo.steampowered.com/steam/pool/steam/s/steam/steam_${version}.tar.gz";
-    sha256 = "1ghrfznm9rckm8v87zvh7hx820r5pp7sq575wxwq0fncbyq6sxmz";
+    sha256 = "01jgp909biqf4rr56kb08jkl7g5xql6r2g4ch6lc71njgcsbn5fs";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];


### PR DESCRIPTION
###### Motivation for this change

This update include udev rules needed for HTC vive and more supported controller
The udev rules are included in the package by this PR #47455 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

