### PR TITLE
modules/kexec: fix typo in kexec

### DIFF
--- a/nixos/modules/system/boot/kexec.nix
+++ b/nixos/modules/system/boot/kexec.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, ... }:
 
 {
-  config = lib.mkIf (lib.any (lib.meta.platformMatch pkgs.stdenv.hostPlatform) pkgs.kexectools.meta.platform) {
+  config = lib.mkIf (lib.any (lib.meta.platformMatch pkgs.stdenv.hostPlatform) pkgs.kexectools.meta.platforms) {
     environment.systemPackages = [ pkgs.kexectools ];
 
     systemd.services."prepare-kexec" =


### PR DESCRIPTION
fix typo introduced in https://github.com/NixOS/nixpkgs/commit/599c4df46a90c7415a6cc0689f0b23d22e7fdb67
@dezgeg 