### PR TITLE
redoflacs: init at 0.30.20150202

### DIFF
--- a/pkgs/applications/audio/redoflacs/default.nix
+++ b/pkgs/applications/audio/redoflacs/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, makeWrapper
+, flac, sox }:
+
+stdenv.mkDerivation rec {
+  name = "redoflacs-${version}";
+  version = "0.30.20150202";
+
+  src = fetchFromGitHub {
+    owner  = "sirjaren";
+    repo   = "redoflacs";
+    rev    = "86c6f5becca0909dcb2a0cb9ed747a575d7a4735";
+    sha256 = "1gzlmh4vnf2fl0x8ig2n1f76082ngldsv85i27dv15y2m1kffw2j";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin redoflacs
+    install -Dm644 -t $out/share/doc/redoflacs LICENSE *.md
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/redoflacs \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ flac sox ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Parallel BASH commandline FLAC compressor, verifier, organizer, analyzer, and retagger";
+    homepage    = src.meta.homepage;
+    license     = licenses.gpl2;
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16629,6 +16629,8 @@ with pkgs;
 
   flac = callPackage ../applications/audio/flac { };
 
+  redoflacs = callPackage ../applications/audio/redoflacs { };
+
   flameshot = libsForQt5.callPackage ../tools/misc/flameshot { };
 
   flashplayer = callPackage ../applications/networking/browsers/mozilla-plugins/flashplayer {


### PR DESCRIPTION
###### Motivation for this change

FLAC recompressor

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

