### PR TITLE
ghcjs-*: Expose the version of GHC used

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -42,6 +42,7 @@ let
     targetPrefix = "";
     inherit bootGhcjs;
     inherit (bootGhcjs) version;
+    ghcVersion = bootPkgs.ghc.version;
     isGhcjs = true;
 
     enableShared = true;

--- a/pkgs/development/compilers/ghcjs/base.nix
+++ b/pkgs/development/compilers/ghcjs/base.nix
@@ -133,6 +133,7 @@ in mkDerivation (rec {
   '';
   passthru = {
     inherit bootPkgs;
+    ghcVersion = ghc.version;
     isCross = true;
     isGhcjs = true;
     inherit nodejs ghcjsBoot;


### PR DESCRIPTION
###### Motivation for this change

This is more meaningful than the GHCJS version for most tasks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @ElvishJerricco 
