### PR TITLE
Add roccat-tools and libgaminggear dependency

### DIFF
--- a/pkgs/development/libraries/libgaminggear/default.nix
+++ b/pkgs/development/libraries/libgaminggear/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, cmake, pkgconfig, gettext
+, gtk2, libcanberra, libnotify, pcre, sqlite, xorg
+}:
+
+stdenv.mkDerivation rec {
+  name = "libgaminggear-${version}";
+  version = "0.15.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/libgaminggear/${name}.tar.bz2";
+    sha256 = "0jf5i1iv8j842imgiixbhwcr6qcwa93m27lzr6gb01ri5v35kggz";
+  };
+
+  outputs = [ "dev" "out" "bin" ];
+
+  nativeBuildInputs = [ cmake pkgconfig gettext ];
+
+  propagatedBuildInputs = [
+    gtk2 libcanberra libnotify pcre sqlite xorg.libXdmcp xorg.libpthreadstubs
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DINSTALL_CMAKE_MODULESDIR=lib/cmake"
+    "-DINSTALL_PKGCONFIGDIR=lib/pkgconfig"
+    "-DINSTALL_LIBDIR=lib"
+  ];
+
+  postFixup = ''
+    moveToOutput bin "$bin"
+  '';
+
+  meta = {
+    description = "Provides functionality for gaming input devices";
+    homepage = https://sourceforge.net/projects/libgaminggear/;
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchurl, cmake, pkgconfig, gettext
+, dbus, dbus_glib, libgaminggear, libgudev, lua
+}:
+
+stdenv.mkDerivation rec {
+  name = "roccat-tools-${version}";
+  version = "5.7.0";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/roccat/${name}.tar.bz2";
+    sha256 = "15gxplcm62167xhk65k8v6gg3j6jr0c5a64wlz72y1vfq0ai7qm6";
+  };
+
+  postPatch = ''
+    sed -i -re 's,/(etc/xdg),\1,' roccateventhandler/CMakeLists.txt
+
+    sed -i -e '/roccat_profile_dir(void).*{/,/}/ {
+      /return/c \
+        return g_build_path("/", g_get_user_data_dir(), "roccat", NULL);
+    }' libroccat/roccat_helper.c
+  '';
+
+  nativeBuildInputs = [ cmake pkgconfig gettext ];
+  buildInputs = [ dbus dbus_glib libgaminggear libgudev lua ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-DUDEVDIR=\${out}/lib/udev/rules.d"
+    "-DCMAKE_MODULE_PATH=${libgaminggear.dev}/lib/cmake"
+    "-DWITH_LUA=${lua.luaversion}"
+    "-DLIBDIR=lib"
+  ];
+
+  meta = {
+    description = "Tools to configure ROCCAT devices";
+    homepage = http://roccat.sourceforge.net/;
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3781,6 +3781,8 @@ with pkgs;
 
   libfann = callPackage ../development/libraries/libfann { };
 
+  libgaminggear = callPackage ../development/libraries/libgaminggear { };
+
   libipfix = callPackage ../development/libraries/libipfix { };
 
   libircclient = callPackage ../development/libraries/libircclient { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14661,6 +14661,8 @@ with pkgs;
     payload = "${linux_riscv}/vmlinux";
   };
 
+  roccat-tools = callPackage ../os-specific/linux/roccat-tools { };
+
   rtkit = callPackage ../os-specific/linux/rtkit { };
 
   rt5677-firmware = callPackage ../os-specific/linux/firmware/rt5677 { };


### PR DESCRIPTION
I had this package along with `libgaminggear` laying around since [June 2016](https://gist.github.com/aszlig/3a01c0c23254a68c2be4c6df59e26862) and basically just did the setup for the ROCCAT device once and never touched it again since then. However, I got requests from other users who might need this, so I decided to finally upstream it along with using the latest versions.

The change here should be non-controversal and it's mainly here to check with ofborg for possible other platforms that `libgaminggear` might work on, because I only have access to x86 machines at the moment.