### PR TITLE
exempi: patch CVE-2018-12648, enable tests

### DIFF
--- a/pkgs/development/libraries/exempi/default.nix
+++ b/pkgs/development/libraries/exempi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, expat, zlib, boost, libiconv, darwin }:
+{ stdenv, fetchurl, fetchpatch, expat, zlib, boost, libiconv, darwin }:
 
 stdenv.mkDerivation rec {
   name = "exempi-2.4.5";
@@ -8,12 +8,25 @@ stdenv.mkDerivation rec {
     sha256 = "07i29xmg8bqriviaf4vi1mwha4lrw85kfla29cfym14fp3z8aqa0";
   };
 
+  patches = [
+    # CVE-2018-12648
+    # https://gitlab.freedesktop.org/libopenraw/exempi/issues/9
+    # remove with exempi > 2.4.5
+    (fetchpatch {
+      name = "CVE-2018-12648.patch";
+      url = https://gitlab.freedesktop.org/libopenraw/exempi/commit/8ed2f034705fd2d032c81383eee8208fd4eee0ac.patch;
+      sha256 = "1nh8irk5p26868875wq5n8g92xp4crfb8fdd8gyna76ldyzqqx9q";
+    })
+  ];
+
   configureFlags = [
     "--with-boost=${boost.dev}"
   ];
 
   buildInputs = [ expat zlib boost ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.CoreServices ];
+
+  doCheck = stdenv.isLinux;
 
   meta = with stdenv.lib; {
     homepage = https://libopenraw.freedesktop.org/wiki/Exempi/;


### PR DESCRIPTION
###### Motivation for this change

cc https://github.com/NixOS/nixpkgs/issues/47122
please backport on release-18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

