### PR TITLE
gixy: 0.1.9 -> 0.1.20

### DIFF
--- a/pkgs/tools/admin/gixy/default.nix
+++ b/pkgs/tools/admin/gixy/default.nix
@@ -2,7 +2,7 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "gixy";
-  version = "0.1.9";
+  version = "0.1.20";
 
   # package is only compatible with python 2.7 and 3.5+
   disabled = with python.pkgs; !(pythonAtLeast "3.5" || isPy27);
@@ -12,7 +12,7 @@ python.pkgs.buildPythonApplication rec {
     owner = "yandex";
     repo = "gixy";
     rev = "v${version}";
-    sha256 = "11aps8a8xg1nlw36jgrmnaf38imfz2rj67wnlalrrsqb616xipcv";
+    sha256 = "14arz3fjidb8z37m08xcpih1391varj8s0v3gri79z3qb4zq5k6b";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
[latest release](https://github.com/yandex/gixy/releases/tag/v0.1.20)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---