### PR TITLE
libimagequant: init at 2.12.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2442,6 +2442,11 @@
     github = "ma27";
     name = "Maximilian Bosch";
   };
+  ma9e = {
+    email = "sean@lfo.team";
+    github = "ma9e";
+    name = "Sean Haugh";
+  };
   madjar = {
     email = "georges.dubus@compiletoi.net";
     github = "madjar";

--- a/pkgs/development/libraries/libimagequant/default.nix
+++ b/pkgs/development/libraries/libimagequant/default.nix
@@ -24,5 +24,6 @@ in
       longDescription = "Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images.";
       license = lib.licenses.gpl3Plus;
       platforms = lib.platforms.unix;
+      maintainers = with lib.maintainers; [ ma9e ];
     };
   }

--- a/pkgs/development/libraries/libimagequant/default.nix
+++ b/pkgs/development/libraries/libimagequant/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, unzip }:
+
+with stdenv;
+
+let
+  version = "2.12.1";
+in
+  mkDerivation {
+    name = "libimagequant-${version}";
+    src = fetchFromGitHub {
+      owner = "ImageOptim";
+      repo = "libimagequant";
+      rev = "${version}";
+      sha256 = "0r7zgsnhqci2rjilh9bzw43miwp669k6b7q16hdjzrq4nr0xpvbl";
+    };
+
+    preConfigure = ''
+      patchShebangs ./configure
+    '';
+
+    meta = {
+      homepage = https://pngquant.org/lib/;
+      description = "Image quantization library";
+      longDescription = "Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images.";
+      license = lib.licenses.gpl3Plus;
+      platforms = lib.platforms.unix;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10735,6 +10735,8 @@ with pkgs;
 
   libiec61883 = callPackage ../development/libraries/libiec61883 { };
 
+  libimagequant = callPackage ../development/libraries/libimagequant {};
+
   libinfinity = callPackage ../development/libraries/libinfinity { };
 
   libinput = callPackage ../development/libraries/libinput {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

