### PR TITLE
csa: init at 0.5.100810

### DIFF
--- a/pkgs/applications/audio/csa/default.nix
+++ b/pkgs/applications/audio/csa/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "csa-${version}";
+  version = "0.5.100810";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/csa/${name}.tar.gz";
+    sha256 = "1syg81dzdil0dyx1mlx1n7if3qsf2iz243p2zv34a1acfqm509r3";
+  };
+
+  # after running either cellular leveler mono or stereo, the other stops working,
+  # so we remove one of them:
+  postInstall = "rm $out/lib/ladspa/celllm_3890.*";
+
+  meta = with stdenv.lib; {
+    homepage = https://sourceforge.net/projects/csa/;
+    description = "A group of LADSPA Audio plugins for FM broadcast and more";
+    longDescription = ''
+      CSA means : Contrôle Signal Audio.
+      It contains the following plugins:
+      Emphazised Limiter, Cellular Leveler, Simple right/left amplifier. Blind Peak Meter.
+    '';
+    license = licenses.gpl3;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1537,7 +1537,7 @@ with pkgs;
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
     conf = config.riot-web.conf or null;
   };
-  
+
   roundcube = callPackage ../servers/roundcube { };
 
   rsbep = callPackage ../tools/backup/rsbep { };
@@ -15843,6 +15843,8 @@ with pkgs;
   coriander = callPackage ../applications/video/coriander {
     inherit (gnome2) libgnomeui GConf;
   };
+
+  csa = callPackage ../applications/audio/csa { };
 
   csound = callPackage ../applications/audio/csound { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

