### PR TITLE
menumaker: init at 0.99.10

### DIFF
--- a/pkgs/applications/misc/menumaker/default.nix
+++ b/pkgs/applications/misc/menumaker/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pythonPackages }:
+
+pythonPackages.buildPythonApplication rec {
+  name = "menumaker-${version}";
+  version = "0.99.10";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/menumaker/${name}.tar.gz";
+    sha256 = "1mm4cvg3kphkkd8nwrhcg6d9nm5ar7mgc0wf6fxk6zck1l7xn8ky";
+  };
+
+  format = "other";
+
+  meta = with stdenv.lib; {
+    description = "Heuristics-driven menu generator for several window managers";
+    homepage = http://menumaker.sourceforge.net;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17540,6 +17540,8 @@ with pkgs;
     gconf = pkgs.gnome2.GConf;
   };
 
+  menumaker = callPackage ../applications/misc/menumaker { };
+
   mercurial = callPackage ../applications/version-management/mercurial {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
     guiSupport = false; # use mercurialFull to get hgk GUI


### PR DESCRIPTION
###### Motivation for this change

Add [menumaker](http://menumaker.sourceforge.net/) .

MenuMaker is a menu generation utility for X window managers on *NIX systems. It is capable of finding lots of installed programs and generating a root menu consistent across all supported X window managers, so one will get (almost) the same menu no matter what window manager is used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).