### PR TITLE
notmuch-bower: 2017-09-27 -> 0.8.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch-bower/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "notmuch-bower-${version}";
-  version = "2017-09-27";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "wangp";
     repo = "bower";
-    rev = "e4918ed581984bf2813f51f007a0aaaa7fa0da7f";
-    sha256 = "13np5yharjik1pp23cfgffi0g0ikl6pl5sqqyy0ki7gk7gyy913i";
+    rev = version;
+    sha256 = "0rdjip6jq7qlfn640ci81m9vfgcn4q5vaj72zp3bria8m55a56rf";
   };
 
   nativeBuildInputs = [ gawk mercury pandoc ];


### PR DESCRIPTION
0.8.1 was released Mar 31, 2018, so lets move this up to stable.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---