### PR TITLE
gremlin-console: init at 3.3.3

### DIFF
--- a/pkgs/applications/misc/gremlin-console/default.nix
+++ b/pkgs/applications/misc/gremlin-console/default.nix
@@ -1,0 +1,29 @@
+{ pkgs, fetchzip, stdenv, makeWrapper, openjdk }:
+
+stdenv.mkDerivation rec {
+  name = "gremlin-console-${version}";
+  version = "3.3.4";
+  src = fetchzip {
+    url = "http://www-eu.apache.org/dist/tinkerpop/${version}/apache-tinkerpop-gremlin-console-${version}-bin.zip";
+    sha256 = "14xr0yqklmm4jvj1hnkj89lj83zzs2l1375ni0jbf12gy31jlb2w";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/opt
+    cp -r ext lib $out/opt/
+    install -D bin/gremlin.sh $out/opt/bin/gremlin-console
+    makeWrapper $out/opt/bin/gremlin-console $out/bin/gremlin-console \
+      --prefix PATH ":" "${openjdk}/bin/" \
+      --set CLASSPATH "$out/opt/lib/"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://tinkerpop.apache.org/;
+    description = "Console of the Apache TinkerPop graph computing framework";
+    license = licenses.asl20;
+    maintainers = [ maintainers.lewo ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -726,6 +726,8 @@ with pkgs;
    SDL = SDL_sixel;
   };
 
+  gremlin-console = callPackage ../applications/misc/gremlin-console { };
+
   gcsfuse = callPackage ../tools/filesystems/gcsfuse { };
 
   glyr = callPackage ../tools/audio/glyr { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

