### PR TITLE
[18.09] flatpak: 0.99.3 -> 1.0.2 (cherry-picked from master)

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-x"
     "--disable-static"
-    "--enable-remote-desktop"
+    # "--enable-remote-desktop"
     "--enable-shape"
     "--enable-sm"
     "--enable-startup-notification"

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -1,26 +1,31 @@
 { stdenv, fetchurl, autoreconfHook, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43, docbook_xsl, which, libxml2
-, gobjectIntrospection, gtk-doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc
+, gobjectIntrospection, gtk-doc, intltool, libxslt, pkgconfig, xmlto, appstream-glib, substituteAll, glibcLocales, yacc, xdg-dbus-proxy, p11-kit
 , bubblewrap, bzip2, dbus, glib, gpgme, json-glib, libarchive, libcap, libseccomp, coreutils, python2, hicolor-icon-theme
 , libsoup, lzma, ostree, polkit, python3, systemd, xorg, valgrind, glib-networking, makeWrapper, gnome3 }:
 
 let
-  version = "0.99.3";
+  version = "1.0.2";
   desktop_schemas = gnome3.gsettings-desktop-schemas;
 in stdenv.mkDerivation rec {
   name = "flatpak-${version}";
 
+  # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [ "out" "man" "doc" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${version}/${name}.tar.xz";
-    sha256 = "0wd6ix1qyz8wmjkfrmr6j99gwywqs7ak1ilsn1ljp72g2z449ayk";
+    sha256 = "0d0nnymb4p3njc24j0p6f74x7cdfi7jac714gxzzz5y5lrd651gn";
   };
 
   patches = [
     (substituteAll {
       src = ./fix-test-paths.patch;
-      inherit coreutils python2 glibcLocales;
+      inherit coreutils glibcLocales;
       hicolorIconTheme = hicolor-icon-theme;
+    })
+    (substituteAll {
+      src = ./fix-paths.patch;
+      p11 = p11-kit;
     })
     # patch taken from gtk_doc
     ./respect-xml-catalog-files-var.patch
@@ -30,7 +35,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook libxml2 docbook_xml_dtd_412 docbook_xml_dtd_42 docbook_xml_dtd_43 docbook_xsl which gobjectIntrospection
     gtk-doc intltool libxslt pkgconfig xmlto appstream-glib yacc makeWrapper
-  ] ++ stdenv.lib.optionals doCheck checkInputs;
+  ];
 
   buildInputs = [
     bubblewrap bzip2 dbus glib gpgme json-glib libarchive libcap libseccomp
@@ -45,6 +50,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-system-bubblewrap=${bubblewrap}/bin/bwrap"
+    "--with-system-dbus-proxy=${xdg-dbus-proxy}/bin/xdg-dbus-proxy"
     "--localstatedir=/var"
     "--enable-installed-tests"
   ];

--- a/pkgs/development/libraries/flatpak/fix-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-paths.patch
@@ -1,0 +1,20 @@
+--- a/session-helper/flatpak-session-helper.c
++++ b/session-helper/flatpak-session-helper.c
+@@ -624,7 +624,7 @@
+   g_auto(GStrv) stdout_lines = NULL;
+   int i;
+   char *p11_argv[] = {
+-    "p11-kit", "server",
++    "@p11@/bin/p11-kit", "server",
+     /* We explicitly request --sh here, because we then fail on earlier versions that doesn't support
+      * this flag. This is good, because those earlier versions did not properly daemonize and caused
+      * the spawn_sync to hang forever, waiting for the pipe to close.
+@@ -770,7 +770,7 @@
+       exit (1);
+     }
+ 
+-  if (g_find_program_in_path ("p11-kit"))
++  if (TRUE)
+     start_p11_kit_server (flatpak_dir);
+   else
+     g_debug ("p11-kit not found");

--- a/pkgs/development/libraries/flatpak/fix-test-paths.patch
+++ b/pkgs/development/libraries/flatpak/fix-test-paths.patch
@@ -1,6 +1,6 @@
 --- a/tests/libtest.sh
 +++ b/tests/libtest.sh
-@@ -315,7 +315,7 @@
+@@ -296,7 +296,7 @@
          # running installed-tests: assume we know what we're doing
          :
      elif ! "$FLATPAK_BWRAP" --unshare-ipc --unshare-net --unshare-pid \
@@ -9,16 +9,7 @@
          sed -e 's/^/# /' < bwrap-result
          echo "1..0 # SKIP Cannot run bwrap"
          exit 0
-@@ -323,7 +323,7 @@
- }
- 
- skip_without_python2 () {
--    if ! test -f /usr/bin/python2 || ! /usr/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
-+    if ! test -f @python2@/bin/python2 || ! @python2@/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
-         echo "1..0 # SKIP this test requires /usr/bin/python2 (2.7) support"
-         exit 0
-     fi
-@@ -335,12 +335,12 @@
+@@ -309,12 +309,12 @@
  export DBUS_SESSION_BUS_ADDRESS="$(cat dbus-session-bus-address)"
  DBUS_SESSION_BUS_PID="$(cat dbus-session-bus-pid)"
  
@@ -43,7 +34,7 @@
  mkdir -p ${DIR}/usr/bin
  mkdir -p ${DIR}/usr/lib
  ln -s ../lib ${DIR}/usr/lib64
-@@ -35,73 +36,27 @@
+@@ -35,48 +36,27 @@
  else
      cp `which ldconfig` ${DIR}/usr/bin
  fi
@@ -73,31 +64,6 @@
  for i in $@; do
 -    I=`which $i`
 -    add_bin $I
--    if test $i == python2; then
--        mkdir -p ${DIR}/usr/lib/python2.7/lib-dynload
--        # This is a hardcoded minimal set of modules we need in the current tests.
--        # Pretty hacky stuff. Add modules as needed.
--        PYDIR=/usr/lib/python2.7
--        if test -d /usr/lib64/python2.7; then PYDIR=/usr/lib64/python2.7; fi
--        for py in site os stat posixpath genericpath warnings \
--                       linecache types UserDict abc _abcoll \
--                       _weakrefset copy_reg traceback sysconfig \
--                       re sre_compile sre_parse sre_constants \
--                       _sysconfigdata ; do
--            cp ${PYDIR}/$py.py ${DIR}/usr/lib/python2.7
--        done
--        # These might not exist, depending how Python was configured; and the
--        # part after ${so} might be "module" or ".x86_64-linux-gnu" or
--        # something else
--        for so in _locale strop ; do
--            cp ${PYDIR}/lib-dynload/${so}*.so ${DIR}/usr/lib/python2.7/lib-dynload || :
--        done
--        for plat in $( cd ${PYDIR} && echo plat-* ); do
--            test -e ${PYDIR}/${plat} || continue
--            mkdir -p ${DIR}/usr/lib/python2.7/${plat}
--            cp ${PYDIR}/${plat}/*.py ${DIR}/usr/lib/python2.7/${plat}/
--        done
--    fi
 -done
 -for i in `cat $BINS`; do
 -    echo Adding binary $i 1>&2

--- a/pkgs/development/libraries/flatpak/use-flatpak-from-path.patch
+++ b/pkgs/development/libraries/flatpak/use-flatpak-from-path.patch
@@ -1,6 +1,6 @@
 --- a/common/flatpak-dir.c
 +++ b/common/flatpak-dir.c
-@@ -5467,7 +5467,7 @@ export_desktop_file (const char   *app,
+@@ -5758,7 +5758,7 @@ export_desktop_file (const char   *app,
  
        new_exec = g_string_new ("");
        g_string_append_printf (new_exec,
@@ -9,7 +9,7 @@
                                escaped_branch,
                                escaped_arch);
  
-@@ -6644,8 +6644,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
+@@ -6935,8 +6935,8 @@ flatpak_dir_deploy (FlatpakDir          *self,
                                         error))
          return FALSE;
  

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchFromGitHub, meson, ninja, pkgconfig, doxygen, graphviz, valgrind
-, glib, dbus, gst_all_1, v4l_utils, alsaLib, ffmpeg, libjack2, udev, libva, xorg
+, glib, dbus, gst_all_1, libv4l, alsaLib, ffmpeg, libjack2, udev, libva, xorg
 , sbc, SDL2, makeFontsConf, freefont_ttf
 }:
 
 let
-  version = "0.1.9";
+  version = "0.2.3";
 
   fontsConf = makeFontsConf {
     fontDirectories = [ freefont_ttf ];
@@ -16,22 +16,22 @@ in stdenv.mkDerivation rec {
     owner = "PipeWire";
     repo = "pipewire";
     rev = version;
-    sha256 = "0r9mgwbggnnijhdz49fnv0qdka364xn1h8yml2jakyqpfrm3i2nm";
+    sha256 = "1y04brfi5bv4y0hdyqzrcbayr674njf6a5hiwjfv2yi6lazkqv1k";
   };
 
-  outputs = [ "out" "dev" "doc" ];
+  outputs = [ "out" "lib" "dev" "doc" ];
 
   nativeBuildInputs = [
     meson ninja pkgconfig doxygen graphviz valgrind
   ];
   buildInputs = [
-    glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer v4l_utils
+    glib dbus gst_all_1.gst-plugins-base gst_all_1.gstreamer libv4l
     alsaLib ffmpeg libjack2 udev libva xorg.libX11 sbc SDL2
   ];
 
   mesonFlags = [
-    "-Denable_docs=true"
-    "-Denable_gstreamer=true"
+    "-Ddocs=true"
+    "-Dgstreamer=true"
   ];
 
   PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "lib/systemd/user";

--- a/pkgs/development/libraries/xdg-dbus-proxy/default.nix
+++ b/pkgs/development/libraries/xdg-dbus-proxy/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, pkgconfig, glib }:
+
+let
+  version = "0.1.0";
+in stdenv.mkDerivation rec {
+  name = "xdg-dbus-proxy-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/flatpak/xdg-dbus-proxy/releases/download/${version}/${name}.tar.xz";
+    sha256 = "055wli36lvdannp6qqwbvd78353n61wn9kp8y3dchh39wq7x7vwy";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ glib ];
+
+  meta = with stdenv.lib; {
+    description = "DBus proxy for Flatpak and others";
+    homepage = https://flatpak.org/;
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libxml2, xdg-desktop-portal, gtk3, glib }:
 
 let
-  version = "0.99";
+  version = "1.0.2";
 in stdenv.mkDerivation rec {
   name = "xdg-desktop-portal-gtk-${version}";
 
@@ -9,7 +9,7 @@ in stdenv.mkDerivation rec {
     owner = "flatpak";
     repo = "xdg-desktop-portal-gtk";
     rev = version;
-    sha256 = "0jnmrl55gpvz06hy0832kcby4y84f0a1hiali6qy1lcmyqhm3v59";
+    sha256 = "06dzh3vzq5nw3r89kb1qi3r2z8wjh9zmzc0hfnva4vnx7mwgm7ax";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig libxml2 xdg-desktop-portal ];

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libxml2, glib, pipewire, fuse }:
 
 let
-  version = "0.99";
+  version = "1.0.2";
 in stdenv.mkDerivation rec {
   name = "xdg-desktop-portal-${version}";
 
@@ -11,7 +11,7 @@ in stdenv.mkDerivation rec {
     owner = "flatpak";
     repo = "xdg-desktop-portal";
     rev = version;
-    sha256 = "05garhdxylphrizyaqnz4sfpp28fd00v877q7cf1gyhpk1sr8i83";
+    sha256 = "1vl0150gz20x106di9yfa6l3zjw0nd2lr44rkq2147n2a254p79p";
   };
 
   patches = [

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -29,6 +29,7 @@
 , libcap
 , libdwarf
 , libsoup
+, libyaml
 , ostree
 , patch
 , rpm
@@ -72,6 +73,7 @@ in stdenv.mkDerivation rec {
     libdwarf
     libsoup
     libxml2
+    libyaml
     ostree
   ];
 

--- a/pkgs/tools/misc/ostree/default.nix
+++ b/pkgs/tools/misc/ostree/default.nix
@@ -4,13 +4,13 @@
 }:
 
 let
-  version = "2018.6";
+  version = "2018.8";
 
   libglnx-src = fetchFromGitHub {
     owner = "GNOME";
     repo = "libglnx";
-    rev = "e1a78cf2f5351d5394ccfb79f3f5a7b4917f73f3";
-    sha256 = "10kzyjbrmr98i65hlz8jc1v5bijyqwwfp6qqjbd5g3y0n520iaxc";
+    rev = "470af8763ff7b99bec950a6ae0a957c1dcfc8edd";
+    sha256 = "1fwik38i6w3r6pn4qkizradcqp1m83n7ljh9jg0y3p3kvrbfxh15";
   };
 
   bsdiff-src = fetchFromGitHub {
@@ -28,7 +28,7 @@ in stdenv.mkDerivation {
     rev = "v${version}";
     owner = "ostreedev";
     repo = "ostree";
-    sha256 = "0kk04pznk6m6fqdz609m2zcnkalcw9q8fsx8wm42k6dhf6cw7l3g";
+    sha256 = "0i7b7hvlv8m44k39fr5389wskf810vda8s7ivy2whj1nan5951yx";
   };
 
   patches = [
@@ -67,6 +67,8 @@ in stdenv.mkDerivation {
   preConfigure = ''
     env NOCONFIGURE=1 ./autogen.sh
   '';
+
+  enableParallelBuilding = true;
 
   configureFlags = [
     "--with-systemdsystemunitdir=$(out)/lib/systemd/system"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19389,6 +19389,8 @@ with pkgs;
 
   xdaliclock = callPackage ../tools/misc/xdaliclock {};
 
+  xdg-dbus-proxy = callPackage ../development/libraries/xdg-dbus-proxy { };
+
   xdg-desktop-portal = callPackage ../development/libraries/xdg-desktop-portal { };
 
   xdg-desktop-portal-gtk = callPackage ../development/libraries/xdg-desktop-portal-gtk { };


### PR DESCRIPTION
###### Motivation for this change

Update Flatpak to the first stable version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

