### PR TITLE
dbmate: init at 1.4.1

### DIFF
--- a/pkgs/development/tools/database/dbmate/default.nix
+++ b/pkgs/development/tools/database/dbmate/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "dbmate-${version}";
+  version = "1.4.1";
+
+  goPackagePath = "github.com/amacneil/dbmate";
+
+  src = fetchFromGitHub {
+    owner = "amacneil";
+    repo = "dbmate";
+    rev = "v${version}";
+    sha256 = "0s3l51kmpsaikixq1yxryrgglzk4kfrjagcpf1i2bkq4wc5gyv5d";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Database migration tool";
+    homepage = https://dbmate.readthedocs.io;
+    license = licenses.mit;
+    maintainers = [ maintainers.manveru ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/database/dbmate/deps.nix
+++ b/pkgs/development/tools/database/dbmate/deps.nix
@@ -1,0 +1,84 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev =  "2cc627ac8defc45d65066ae98f898166f580f9a4";
+      sha256 = "0n589y9ak2m6glaqmqlggrfv2hghy5i2906r123svf92ci4r9sww";
+    };
+  }
+  {
+    goPackagePath  = "github.com/joho/godotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/joho/godotenv";
+      rev =  "a79fa1e548e2c689c241d10173efd51e5d689d5b";
+      sha256 = "09610yqswxa02905mp9cqgsm50r76saagzddc55sqav4ad04j6qm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev =  "19c8e9ad00952ce0c64489b60e8df88bb16dd514";
+      sha256 = "0lm79ja5id7phf1jwf1vs987azaxis0q7qr69px0r6gqiva0q0vz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev =  "6c771bb9887719704b210e87e934f08be014bdb1";
+      sha256 = "0x6s7hy3ab3qw6dfl81y7ighjva5j4rrzvqhppf1qwz5alpfmpdm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev =  "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c";
+      sha256 = "178xyfgsbs40jq406aqj0r67ik1b81gdc28z45nbcw6hfhz82rvl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev =  "cfb38830724cc34fedffe9a2a29fb54fa9169cd1";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "150dc57a1b433e64154302bdc40b6bb8aefa313a";
+      sha256 = "0w3knznv39k8bm85ri62f83czcrxknql7dv6p9hk1a5jx3xljgxq";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6439,6 +6439,8 @@ with pkgs;
 
   crystal = callPackage ../development/compilers/crystal { };
 
+  dbmate = callPackage ../development/tools/database/dbmate { };
+
   devpi-client = callPackage ../development/tools/devpi-client {};
 
   devpi-server = callPackage ../development/tools/devpi-server {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

