### PR TITLE
pythonPackages.pystemd: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/pystemd/default.nix
+++ b/pkgs/development/python-modules/pystemd/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi, mock, pytest, six, systemd }:
+
+buildPythonPackage rec {
+  pname = "pystemd";
+  version = "0.5.0";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "000001hxv25vwcsvc0avg42v89c7qcjdpw6dr8419prmcb9186i5";
+  };
+
+  buildInputs = [ systemd ];
+  propagatedBuildInputs = [ six ];
+
+  checkInputs = [ pytest mock ];
+  checkPhase = "pytest tests";
+
+  meta = with stdenv.lib; {
+    description = "A thin Cython-based wrapper on top of libsystemd, focused on exposing the dbus API via sd-bus in an automated and easy to consume way.";
+    homepage = https://github.com/facebookincubator/pystemd/;
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9805,6 +9805,8 @@ in {
 
   python-pushover = callPackage ../development/python-modules/pushover {};
 
+  pystemd = callPackage ../development/python-modules/pystemd { systemd = pkgs.systemd; };
+
   mongodict = buildPythonPackage rec {
     name = "mongodict-${version}";
     version = "0.3.1";


### PR DESCRIPTION
###### Motivation for this change
This adds pystemd, a thin Cython-based wrapper on top of libsystemd, focused on exposing the dbus API via sd-bus in an automated and easy to consume way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Please backport to 18.09 as well.
