### PR TITLE
nixos/host-sink: init task module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -962,6 +962,7 @@
   ./tasks/filesystems/vfat.nix
   ./tasks/filesystems/xfs.nix
   ./tasks/filesystems/zfs.nix
+  ./tasks/host-sink.nix
   ./tasks/lvm.nix
   ./tasks/network-interfaces.nix
   ./tasks/network-interfaces-systemd.nix

--- a/nixos/modules/tasks/host-sink.nix
+++ b/nixos/modules/tasks/host-sink.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.networking.hostSink;
+
+  sources = [
+    https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+    https://mirror1.malwaredomains.com/files/justdomains
+    http://sysctl.org/cameleon/hosts
+    https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist
+    https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
+    https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
+    https://hosts-file.net/ad_servers.txt
+    http://winhelp2002.mvps.org/hosts.txt
+  ];
+
+  sinkParser = pkgs.writeText "sinkholes.awk" ''
+    BEGIN { sinkhole="" }
+
+    !/^#/ && $1 ~ /^0.0.0.0||^127.0.0.1/ && $2 ~ !/localhost/ {
+        if (NF == 2) { sinkhole = sinkhole "\n" $2 }
+    }
+
+    END { print sinkhole }
+  '';
+
+  hostFmt = pkgs.writeText "hosts.awk" ''
+    // { print "0.0.0.0 " $1 }
+  '';
+  unboundFmt = pkgs.writeText "unbound-localdata.awk" ''
+    // { print "local-data: \"" $1 " A 0.0.0.0\"" }
+  '';
+
+  upstreams = map builtins.fetchurl sources;
+
+  inputHosts = pkgs.stdenv.mkDerivation {
+    name = "host-blacklists";
+    phases = [ "installPhase" ];
+    installPhase = ''
+       for up in ${lib.concatStringsSep " " upstreams};do
+         awk -f ${sinkParser} $up >> allHosts
+       done
+       sed -i -e '/^$/d' -e 's/\r$//g' allHosts
+       mkdir -p $out
+       awk -f ${hostFmt} allHosts | sort -u > $out/hosts
+       awk -f ${unboundFmt} allHosts | sort -u > $out/unbound-localdata.conf
+    '';
+  };
+
+in
+
+{
+
+  options.networking.hostSink.enable =
+    mkEnableOption "Tracker and Ad host sinkhole";
+
+  config = mkIf cfg.enable {
+
+    networking.extraHosts =
+      builtins.readFile (inputHosts + "/hosts");
+
+    services.unbound.extraConfig = mkIf (services.unbound.enable)
+      builtins.readFile (inputHosts + "/unbound-localdata.conf");
+
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

This appends known ads- and tracker hosts to the `/etc/hosts` and if `services.unbound.enable` to its extra config as local-data A entries. I'm personally a bit ambivalent to this change since it:

  1. Is nice to get rid of known bad hosts.
  2. It uses shaless `builtins.fetchurl`, with the problems that entails, to retrieve the upstream hosts lists in order to avoid pounding this module with shachanges.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

