### PR TITLE
nixos/syncthing: move configuration to condigDir

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -97,6 +97,16 @@
        start org.nixos.nix-daemon</command>.
       </para>
      </listitem>
+     <listitem>
+      <para>
+        The Syncthing state and configuration data has been moved from
+        <varname>services.syncthing.dataDir</varname> to the newly defined
+        <varname>services.syncthing.configDir</varname>, which default to
+        <literal>/var/lib/syncthing/.config/syncthing</literal>.
+        This change makes possible to share synced directories using ACLs
+        without Syncthing resetting the permission on every start.
+      </para>
+     </listitem>
     </itemizedlist>
    </listitem>
    <listitem>

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -63,8 +63,20 @@ in {
         type = types.path;
         default = "/var/lib/syncthing";
         description = ''
+          Path where synced directories will exist.
+        '';
+      };
+
+      configDir = mkOption {
+        type = types.path;
+        description = ''
           Path where the settings and keys will exist.
         '';
+        default =
+          let
+            nixos = config.system.stateVersion;
+            cond  = versionAtLeast nixos "19.03";
+          in cfg.dataDir + (optionalString cond "/.config/syncthing");
       };
 
       openDefaultPorts = mkOption {
@@ -144,7 +156,7 @@ in {
             ${cfg.package}/bin/syncthing \
               -no-browser \
               -gui-address=${cfg.guiAddress} \
-              -home=${cfg.dataDir}
+              -home=${cfg.configDir}
           '';
         };
       };


### PR DESCRIPTION
###### Motivation for this change
Fix #47513 

###### Things done
- [x] Tested using a NixOS VM
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

