### PR TITLE
libreoffice-fresh: 6.1.1.2 -> 6.1.2.1

### DIFF
--- a/pkgs/applications/office/libreoffice/default-primary-src.nix
+++ b/pkgs/applications/office/libreoffice/default-primary-src.nix
@@ -3,8 +3,8 @@
 rec {
   major = "6";
   minor = "1";
-  patch = "1";
-  tweak = "2";
+  patch = "2";
+  tweak = "1";
 
   subdir = "${major}.${minor}.${patch}";
 
@@ -12,6 +12,6 @@ rec {
 
   src = fetchurl {
     url = "https://download.documentfoundation.org/libreoffice/src/${subdir}/libreoffice-${version}.tar.xz";
-    sha256 = "228166908a3404cbb8e6e662f44b1af8644c0589b2309fadce89dcef112fd09d";
+    sha256 = "650c57b60f880db28e49e584f42018da9e714865dfa94fbb8391de15b58a3f91";
   };
 }

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -48,14 +48,14 @@ let
 
     translations = fetchSrc {
       name = "translations";
-      sha256 = "2933d0898fbc8ea32cb39b773cf49c5f7da165f75a33522ff91c88d7bd0c7440";
+      sha256 = "33e13d07e9328cdbccbd019ab2491f74f5bb897707886c074791080881544bcc";
     };
 
     # TODO: dictionaries
 
     help = fetchSrc {
       name = "help";
-      sha256 = "41e1af094f2ca5a9ab88894c2dceca2d91e6c28568d7f002f56c647e973cc595";
+      sha256 = "dffee97ffce5b4979140aa56fa333608e7b004bfc2451245bab33ed97fc4c205";
     };
 
   };

--- a/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
+++ b/pkgs/applications/office/libreoffice/libreoffice-srcs.nix
@@ -658,11 +658,11 @@
     md5name = "cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824-openldap-2.4.45.tgz";
   }
   {
-    name = "openssl-1.0.2o.tar.gz";
-    url = "http://dev-www.libreoffice.org/src/openssl-1.0.2o.tar.gz";
-    sha256 = "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d";
+    name = "openssl-1.0.2p.tar.gz";
+    url = "http://dev-www.libreoffice.org/src/openssl-1.0.2p.tar.gz";
+    sha256 = "50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00";
     md5 = "";
-    md5name = "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d-openssl-1.0.2o.tar.gz";
+    md5name = "50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00-openssl-1.0.2p.tar.gz";
   }
   {
     name = "liborcus-0.13.4.tar.gz";


### PR DESCRIPTION
Bump.  Feel free to squash if you'd like :).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---