### PR TITLE
zig: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -1,29 +1,22 @@
-{ stdenv, fetchFromGitHub, cmake, llvmPackages, libxml2 }:
+{ stdenv, fetchFromGitHub, cmake, llvmPackages, libxml2, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.2.0";
+  version = "0.3.0";
   name = "zig-${version}";
 
   src = fetchFromGitHub {
-    owner = "zig-lang";
+    owner = "ziglang";
     repo = "zig";
     rev = "${version}";
-    sha256 = "0lym28z9mj6hfiq78x1fsd8y89h8xyfc1jgqyazi1g9r72427n07";
+    sha256 = "089ywagxjjh7gxv8h8yg7jpmryzjf7n4m5irhdkhp2966d03kyxm";
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmPackages.clang-unwrapped llvmPackages.llvm libxml2 ];
+  buildInputs = [ llvmPackages.clang-unwrapped llvmPackages.llvm libxml2 zlib ];
 
   cmakeFlags = [
-    "-DZIG_LIBC_INCLUDE_DIR=${stdenv.cc.libc_dev}/include"
-    "-DZIG_LIBC_LIB_DIR=${stdenv.cc.libc}/lib"
     "-DCMAKE_BUILD_TYPE=Release"
-    "-DZIG_EACH_LIB_RPATH=On"
   ];
-
-  preConfigure = ''
-    cmakeFlags="$cmakeFlags -DZIG_LIBC_STATIC_LIB_DIR=$(dirname $(cc -print-file-name=crtbegin.o)) -DZIG_DYNAMIC_LINKER=$(cc -print-file-name=ld-linux-x86-64.so.2)"
-  '';
 
   meta = with stdenv.lib; {
     description = "Programming languaged designed for robustness, optimality, and clarity";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12679,7 +12679,7 @@ with pkgs;
   zmqpp = callPackage ../development/libraries/zmqpp { };
 
   zig = callPackage ../development/compilers/zig {
-    llvmPackages = llvmPackages_6;
+    llvmPackages = llvmPackages_7;
   };
 
   zimlib = callPackage ../development/libraries/zimlib { };


### PR DESCRIPTION
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

