### PR TITLE
lib.makeOverridable: Propagate function arguments

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -68,16 +68,17 @@ rec {
     let
       ff = f origArgs;
       overrideWith = newArgs: origArgs // (if lib.isFunction newArgs then newArgs origArgs else newArgs);
+      override = lib.setFunctionArgs (newArgs: makeOverridable f (overrideWith newArgs)) (lib.functionArgs f);
     in
       if builtins.isAttrs ff then (ff // {
-        override = newArgs: makeOverridable f (overrideWith newArgs);
+        inherit override;
         overrideDerivation = fdrv:
           makeOverridable (args: overrideDerivation (f args) fdrv) origArgs;
         ${if ff ? overrideAttrs then "overrideAttrs" else null} = fdrv:
           makeOverridable (args: (f args).overrideAttrs fdrv) origArgs;
       })
       else if lib.isFunction ff then {
-        override = newArgs: makeOverridable f (overrideWith newArgs);
+        inherit override;
         __functor = self: ff;
         overrideDerivation = throw "overrideDerivation not yet supported for functors";
       }

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, symlinkJoin, gimp, makeWrapper, gimpPlugins, plugins ? null}:
 
 let
-allPlugins = lib.filter (pkg: builtins.isAttrs pkg && pkg.type == "derivation" && !pkg.meta.broken or false) (lib.attrValues gimpPlugins);
+allPlugins = lib.filter (pkg: lib.isDerivation pkg && !pkg.meta.broken or false) (lib.attrValues gimpPlugins);
 selectedPlugins = if plugins == null then allPlugins else plugins;
 extraArgs = map (x: x.wrapArgs or "") selectedPlugins;
 versionBranch = stdenv.lib.versions.majorMinor gimp.version;


### PR DESCRIPTION
Previously when using `.override` of overridable derivations, it was
impossible to know which arguments it accepts, because the function
argument aren't propagated:


```nix
lib.functionArgs pkgs.hello.override
-> { }

pkgs.hello.override { foo = 0; }
-> # error: anonymous function at /nixpkgs/pkgs/applications/misc/hello/default.nix:1:1 called with unexpected argument 'foo', at /nixpkgs/lib/customisation.nix:69:12

pkgs.hello.override { stdenv = pkgs.gccStdenv; }
-> { name = "hello-2.10"; ... }
```

With this change, lib.functionArgs works according to intuition:

```nix
lib.functionArgs pkgs.hello.override
-> { fetchurl = false; stdenv = false; }
```

Note that builtins.functionArgs does not work with this:

```nix
builtins.functionArgs pkgs.hello.override
-> # error: 'functionArgs' requires a function, at (string):1:21
```

This is due to how `lib.setFunctionArgs` is implemented: It actually
creates an attribute set with an attribute `__functor` for the function
and `__functionArgs` for the arguments. Nix can pretend such attributes to
be functions when they have `__functor`, but `builtins.functionArgs` doesn't
automatically use `__functionArgs`. That's why `lib.functionArgs` needs to
be used, which checks for the `__functionArgs` attribute.

Ping @Profpatsch @cleverca22 @nbp @shlevy 

###### Motivation for this change
@unode asked on IRC whether it was possible to get available `.override` arguments. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

