### PR TITLE
gcc-arm-embedded: 6-2017-q2-update -> 7-2018-q2-update

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3304,6 +3304,11 @@
     github = "proglodyte";
     name = "Proglodyte";
   };
+  prusnak = {
+    email = "stick@gk2.sk";
+    github = "prusnak";
+    name = "Pavol Rusnak";
+  };
   pshendry = {
     email = "paul@pshendry.com";
     github = "pshendry";

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchurl, ncurses5, python27 }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "gcc-arm-embedded-${version}";
+  version = "7-2018-q2-update";
+  subdir = "7-2018q2";
+
+  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
+
+  src = fetchurl { url=urlString; sha256="0sgysp3hfpgrkcbfiwkp0a7ymqs02khfbrjabm52b5z61sgi05xv"; };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf $f > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4/M7, Cortex-R4/R5/R7/R8)";
+    homepage = https://developer.arm.com/open-source/gnu-toolchain/gnu-rm;
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "blacksphere";
     repo = "blackmagic";
-    rev = "d3a8f27fdbf952194e8fc5ce9b2fc9bcef7c545c";
-    sha256 = "0c3l7cfqag3g7zrfn4mmikkx7076hb1r856ybhhdh0f6zji2j6jx";
+    rev = "29386aee140e5e99a958727358f60980418b4c88";
+    sha256 = "05x19y80mixk6blpnfpfngy5d41jpjvdqgjzkmhv1qc03bhyhc82";
     fetchSubmodules = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6744,7 +6744,8 @@ with pkgs;
     ncurses = pkgsi686Linux.ncurses5;
   };
   gcc-arm-embedded-6 = callPackage ../development/compilers/gcc-arm-embedded/6 {};
-  gcc-arm-embedded = gcc-arm-embedded-6;
+  gcc-arm-embedded-7 = callPackage ../development/compilers/gcc-arm-embedded/7 {};
+  gcc-arm-embedded = gcc-arm-embedded-7;
 
   gforth = callPackage ../development/compilers/gforth {};
 


### PR DESCRIPTION
###### Motivation for this change

gcc-arm-embedded was not updated since mid-2017, this update brings the package to the latest possible version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

