### PR TITLE
fceux: adding optional gtk ui

### DIFF
--- a/pkgs/misc/emulators/fceux/default.nix
+++ b/pkgs/misc/emulators/fceux/default.nix
@@ -1,6 +1,12 @@
-{stdenv, fetchurl, scons, zlib, SDL, lua5_1, pkgconfig}:
+{ stdenv, fetchurl, scons, zlib, SDL, lua5_1, pkgconfig
+  , enableGtk ? false, gtk2 ? null
+}:
 
-stdenv.mkDerivation {
+assert enableGtk -> gtk2 != null;
+
+let
+  bool2str = bval: if bval then "true" else "false";
+in stdenv.mkDerivation {
   name = "fceux-2.2.3";
 
   src = fetchurl {
@@ -10,7 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    scons zlib SDL lua5_1
+    scons zlib SDL lua5_1 enableGtk gtk2
   ];
 
   phases = "unpackPhase buildPhase";
@@ -24,7 +30,7 @@ stdenv.mkDerivation {
     export CC="gcc"
     export CXX="g++"
     mkdir -p "$out" "$out/share/applications" "$out/share/pixmaps"
-    scons --prefix="$out" OPENGL=false GTK=false CREATE_AVI=false LOGO=false install
+    scons --prefix="$out" OPENGL=false GTK=${bool2str enableGtk} CREATE_AVI=false LOGO=false install
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Allow users to enable fceux's gtk2 UI - maybe this should be the default, as fceux seems difficult to use without it.

Before merging this, I hope someone can show if I'm actually able to use it correctly .. This seems like it should be pretty basic. Here's a script I'm trying to use with nix-shell to enable gtk:

```nix
with import ((builtins.getEnv "HOME") + "/workspace/nixpkgs") { }; # or:
# with import <nixpkgs> {};
let fceuxLocal = pkgs.fceux.override{enableGtk=true; gtk2=pkgs.gtk2;};
in stdenv.mkDerivation {
  name = "fceuxEnv";
  buildInputs = [ fceuxLocal ];
  src = null;
}
```

Attempt to use this ends in the following failure:

```
these derivations will be built:
  /nix/store/1d1c6r0i9vd3f5ykxvwbgr7ddfvxvxfx-fceux-2.2.3.drv
building '/nix/store/1d1c6r0i9vd3f5ykxvwbgr7ddfvxvxfx-fceux-2.2.3.drv'...
build input 1 does not exist
builder for '/nix/store/1d1c6r0i9vd3f5ykxvwbgr7ddfvxvxfx-fceux-2.2.3.drv' failed with exit code 1
error: build of '/nix/store/1d1c6r0i9vd3f5ykxvwbgr7ddfvxvxfx-fceux-2.2.3.drv' failed
```

It seems I've correctly specified my local nixpkgs in the nix-shell expression though.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

