### PR TITLE
EmptyEpsilon: fix version numbering

### DIFF
--- a/pkgs/games/empty-epsilon/default.nix
+++ b/pkgs/games/empty-epsilon/default.nix
@@ -2,9 +2,9 @@
 
 let
 
-  major = "2018"
-  minor = "02"
-  patch = "15"
+  major = "2018";
+  minor = "02";
+  patch = "15";
 
   version = "${major}.${minor}.${patch}";
 

--- a/pkgs/games/empty-epsilon/default.nix
+++ b/pkgs/games/empty-epsilon/default.nix
@@ -2,7 +2,11 @@
 
 let
 
-  version = "2018.02.15";
+  major = "2018"
+  minor = "02"
+  patch = "15"
+
+  version = "${major}.${minor}.${patch}";
 
   serious-proton = stdenv.mkDerivation rec {
     name = "serious-proton-${version}";
@@ -46,6 +50,10 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DSERIOUS_PROTON_DIR=${serious-proton.src}"
+    "-DCPACK_PACKAGE_VERSION=${version}"
+    "-DCPACK_PACKAGE_VERSION_MAJOR=${major}"
+    "-DCPACK_PACKAGE_VERSION_MINOR=${minor}"
+    "-DCPACK_PACKAGE_VERSION_PATCH=${patch}"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

Previous scheme produced incompatible versions for multiplayer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

