### PR TITLE
dart: 1.24.3 -> 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3858,6 +3858,11 @@
     github = "solson";
     name = "Scott Olson";
   };
+  sorixelle = {
+    email = "srxl@protonmail.com";
+    github = "Sorixelle";
+    name = "Ruby Juric";
+  };
   sorki = {
     email = "srk@48.io";
     github = "sorki";

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, version ? "1.24.3" }:
+{ stdenv, fetchurl, unzip, version ? "2.0.0" }:
 
 let
 
@@ -24,6 +24,14 @@ let
     "1.24.3-i686-linux" = fetchurl {
       url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
       sha256 = "d67b8f8f9186e7d460320e6bce25ab343c014b6af4b2f61369ee83755d4da528";
+    };
+    "2.0.0-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "4014a1e8755d2d32cc1573b731a4a53acdf6dfca3e26ee437f63fe768501d336";
+    };
+    "2.0.0-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "3164a9de70bf11ab5b20af0d51c8b3303f2dce584604dce33bea0040bdc0bbba";
     };
     "2.0.0-dev.26.0-x86_64-linux" = fetchurl {
       url = "${dev}/${version}/sdk/dartsdk-linux-x64-release.zip";
@@ -70,5 +78,6 @@ stdenv.mkDerivation {
       mixins, abstract classes, reified generics, and optional typing.
     '';
     license = stdenv.lib.licenses.bsd3;
+    maintainers = [ stdenv.lib.maintainers.sorixelle ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update Dart to the latest stable version (2.0.0) from 1.24.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

