### PR TITLE
snipes: init at 20180930

### DIFF
--- a/pkgs/games/snipes/default.nix
+++ b/pkgs/games/snipes/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, fetchurl, SDL2, SDL2_ttf }:
+
+let
+  font = fetchurl {
+    url    = "http://kingbird.myphotos.cc/ee22d44076adb8a34d8e20df4be3730a/SnipesConsole.ttf";
+    sha256 = "06n8gq18js0bv4svx84ljzhs9zmi81wy0zqcqj3b4g0rsrkr20a7";
+  };
+
+in stdenv.mkDerivation rec {
+  name = "snipes-${version}";
+  version = "20180930";
+
+  src = fetchFromGitHub {
+    owner  = "Davidebyzero";
+    repo   = "Snipes";
+    rev    = "343e14104b7848eb1f882401888e685b7918ef9f";
+    sha256 = "1rl70d5miak34warbwfv27z11vln4lvf7maqqc78z0gdc5zivdv2";
+  };
+
+  postPatch = ''
+    substitute config-sample.h config.h \
+      --replace SnipesConsole.ttf $out/share/snipes/SnipesConsole.ttf
+  '';
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ SDL2 SDL2_ttf ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin snipes
+    install -Dm644 -t $out/share/doc/snipes *.md
+    install -Dm644 ${font} $out/share/snipes/SnipesConsole.ttf
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Modern port of the classic 1982 text-mode game Snipes";
+    homepage    = https://www.vogons.org/viewtopic.php?f=7&t=49073;
+    license     = licenses.free; # This reverse-engineered source code is released with the original authors' permission.
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1512,6 +1512,8 @@ with pkgs;
 
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
+  snipes = callPackage ../games/snipes { };
+
   socklog = callPackage ../tools/system/socklog { };
 
   staccato = callPackage ../tools/text/staccato { };
@@ -1537,7 +1539,7 @@ with pkgs;
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
     conf = config.riot-web.conf or null;
   };
-  
+
   roundcube = callPackage ../servers/roundcube { };
 
   rsbep = callPackage ../tools/backup/rsbep { };


### PR DESCRIPTION
###### Motivation for this change

A true classic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

