### PR TITLE
light: 1.1.2 -> 1.2, use new udev support instead of setuid wrapper.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -107,7 +107,7 @@
    </listitem>
    <listitem>
      <para>
-       The <literal>light</literal> module no longer use setuids binary, but
+       The <literal>light</literal> module no longer uses setuid binaries, but
        udev rules. As a consequence users of that module have to belong to the
        <literal>video</literal> group in order to use the executable
        (i.e. <literal>users.users.yourusername.extraGroups = ["video"];</literal>).

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -105,6 +105,14 @@
      <varname>rabbitmq-server</varname>.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       The <literal>light</literal> module no longer use setuids binary, but
+       udev rules. As a consequence users of that module have to belong to the
+       <literal>video</literal> group in order to use the executable
+       (i.e. <literal>users.users.yourusername.extraGroups = ["video"];</literal>).
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/programs/light.nix
+++ b/nixos/modules/programs/light.nix
@@ -13,7 +13,7 @@ in
         default = false;
         type = types.bool;
         description = ''
-          Whether to install Light backlight control with setuid wrapper.
+          Whether to install Light backlight control command and udev rules.
         '';
       };
     };
@@ -21,6 +21,6 @@ in
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.light ];
-    security.wrappers.light.source = "${pkgs.light.out}/bin/light";
+    services.udev.packages = [ pkgs.light ];
   };
 }

--- a/nixos/modules/programs/light.nix
+++ b/nixos/modules/programs/light.nix
@@ -13,7 +13,8 @@ in
         default = false;
         type = types.bool;
         description = ''
-          Whether to install Light backlight control command and udev rules.
+          Whether to install Light backlight control command
+          and udev rules granting access to members of the "video" group.
         '';
       };
     };

--- a/pkgs/os-specific/linux/light/default.nix
+++ b/pkgs/os-specific/linux/light/default.nix
@@ -1,26 +1,31 @@
-{ stdenv, fetchFromGitHub, help2man }:
+{ stdenv, fetchFromGitHub, autoreconfHook, coreutils }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.2";
+  version = "1.2";
   name = "light-${version}";
   src = fetchFromGitHub {
     owner = "haikarainen";
     repo = "light";
-    rev = version;
-    sha256 = "0c934gxav9cgdf94li6dp0rfqmpday9d33vdn9xb2mfp4war9n4w";
+    rev = "v${version}";
+    sha256 = "1h286va0r1xgxlnxfaaarrj3qhxmjjsivfn3khwm0wq1mhkfihra";
   };
 
-  buildInputs = [ help2man ];
+  configureFlags = [ "--with-udev" ];
 
-  installPhase = "mkdir -p $out/bin; cp light $out/bin/";
+  nativeBuildInputs = [ autoreconfHook ];
 
-  preFixup = "make man; mkdir -p $out/man/man1; mv light.1.gz $out/man/man1";
+  # ensure udev rules can find the commands used
+  postPatch = ''
+    substituteInPlace 90-backlight.rules \
+      --replace '/bin/chgrp' '${coreutils}/bin/chgrp' \
+      --replace '/bin/chmod' '${coreutils}/bin/chmod'
+  '';
 
   meta = {
     description = "GNU/Linux application to control backlights";
     homepage = https://haikarainen.github.io/light/;
     license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ puffnfresh ];
+    maintainers = with stdenv.lib.maintainers; [ puffnfresh dtzWill ];
     platforms = stdenv.lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---