### PR TITLE
pythonPackages.py-cpuinfo: Fix darwin build

### DIFF
--- a/pkgs/development/python-modules/py-cpuinfo/default.nix
+++ b/pkgs/development/python-modules/py-cpuinfo/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchFromGitHub
 , buildPythonPackage
+, pytest
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,16 @@ buildPythonPackage rec {
      rev = "v${version}";
      sha256 = "1pp561lj80jnvr2038nrzhmks2akxsbdqxvfrqa6n340x81981lm";
   };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest -k "not TestActual"
+    runHook postCheck
+  '';
 
   meta = {
     description = "Get CPU info with pure Python 2 & 3";


### PR DESCRIPTION
###### Motivation for this change
This should fix the darwin build of py-cpuinfo.
I couldn't figure out why the test doesn't run on darwin, but I tested the resulting `cpuinfo` script and it seems do work outside of the build environment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

