### PR TITLE
omegat: init at 4.1.5.2

### DIFF
--- a/pkgs/applications/misc/omegat.nix
+++ b/pkgs/applications/misc/omegat.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, unzip, jdk, makeWrapper}:
+
+stdenv.mkDerivation rec {
+  version = "4.1.5.2";
+  name = "omegat";
+
+  src = fetchurl {  # their zip has repeated files or something, so no fetchzip
+    url = mirror://sourceforge/project/omegat/OmegaT%20-%20Latest/OmegaT%204.1.5%20update%202/OmegaT_4.1.5_02_Beta_Without_JRE.zip;
+    sha256 = "1mdnsvjgsccpd5xwpqzgva5jjp8yd1akq9aqpild4v6k70lqql2b";
+  };
+
+  buildInputs = [ unzip makeWrapper ];
+
+  unpackCmd = "unzip -o $curSrc";  # tries to go interactive without -o
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r lib docs images plugins scripts *.txt *.html OmegaT.jar $out/
+
+    cat > $out/bin/omegat <<EOF
+    #! $SHELL -e
+    CLASSPATH="$out/lib"
+    exec ${jdk}/bin/java -jar -Xmx1024M $out/OmegaT.jar "\$@"
+    EOF
+    chmod +x $out/bin/omegat
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The free computer aided translation (CAT) tool for professionals";
+    longDescription = ''
+      OmegaT is a free and open source multiplatform Computer Assisted Translation
+      tool with fuzzy matching, translation memory, keyword search, glossaries, and
+      translation leveraging into updated projects.
+    '';
+    homepage = http://www.omegat.org/;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ t184256 ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18021,6 +18021,8 @@ with pkgs;
 
   ogmtools = callPackage ../applications/video/ogmtools { };
 
+  omegat = callPackage ../applications/misc/omegat.nix { };
+
   omxplayer = callPackage ../applications/video/omxplayer { };
 
   openbox = callPackage ../applications/window-managers/openbox { };


### PR DESCRIPTION
OmegaT is a Computer-Assisted Translation tool written in Java.
This derivation doesn't build it from source, but rather downloads
a 'Cross-platform without JRE' zip file.
I took the liberty of shorting the upstream version naming of
"4.1.5 update 2 Beta" to a more concise "4.1.5.2".

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

