### PR TITLE
linux kernel: increase build timeout from 2 to 4 hrs

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -247,7 +247,7 @@ let
           maintainers.thoughtpolice
         ];
         platforms = platforms.linux;
-        timeout = 7200; # 2 hours
+        timeout = 14400; # 4 hours
       } // extraMeta;
     };
 in


### PR DESCRIPTION
###### Motivation for this change

We've recently seen a many kernel build timeouts on hydra like this: https://hydra.nixos.org/eval/1481520?filter=linuxPackage  so let's increase the timeout.
We'll see if 4 hours are sufficient (hey, it's a lot faster than chromium builds :smile:)

Please backport to 18.09, ZHF #45960. 

###### Things done

- [x] noop, just increased timeout

---
cc @vcunat @samueldr @thoughtpolice 

