### PR TITLE
simple-websocket-server: Init at 20180414

### DIFF
--- a/pkgs/development/python-modules/simple-websocket-server/default.nix
+++ b/pkgs/development/python-modules/simple-websocket-server/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "simple-websocket-server";
+  version = "20180414";
+  src = fetchFromGitHub {
+    owner = "dpallot";
+    repo = "simple-websocket-server";
+    rev = "34e6def93502943d426fb8bb01c6901341dd4fe6";
+    sha256 = "19rcpdx4vxg9is1cpyh9m9br5clyzrpb7gyfqsl0g3im04m098n5";
+  };
+
+  doCheck = false; # no tests
+
+  meta = with stdenv.lib; {
+    description = "A python based websocket server that is simple and easy to use";
+    homepage = https://github.com/dpallot/simple-websocket-server/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ rvolosatovs ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4295,6 +4295,8 @@ in {
 
   schema = callPackage ../development/python-modules/schema {};
 
+  simple-websocket-server = callPackage ../development/python-modules/simple-websocket-server {};
+
   stem = callPackage ../development/python-modules/stem { };
 
   svg-path = callPackage ../development/python-modules/svg-path { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

