### PR TITLE
feedgnuplot: 1.49 -> 1.51

### DIFF
--- a/pkgs/tools/graphics/feedgnuplot/default.nix
+++ b/pkgs/tools/graphics/feedgnuplot/default.nix
@@ -10,13 +10,13 @@ in
 
 buildPerlPackage rec {
   name = "feedgnuplot-${version}";
-  version = "1.49";
+  version = "1.51";
 
   src = fetchFromGitHub {
     owner = "dkogan";
     repo = "feedgnuplot";
     rev = "v${version}";
-    sha256 = "1bjnx36rsxlj845w9apvdjpza8vd9rbs3dlmgvky6yznrwa6sm02";
+    sha256 = "0npk2l032cnmibjj5zf3ii09mpxciqn32lx6g5bal91bkxwn7r5i";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

