### PR TITLE
Update metadata to reflect uncompyle6 and xdis relicensing to GPL (v3 and v2 respectively)

### DIFF
--- a/pkgs/development/python-modules/uncompyle6/default.nix
+++ b/pkgs/development/python-modules/uncompyle6/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python cross-version byte-code deparser";
     homepage = https://github.com/rocky/python-uncompyle6/;
-    license = licenses.mit;
+    license = licenses.gpl3;
   };
 
 }

--- a/pkgs/development/python-modules/xdis/default.nix
+++ b/pkgs/development/python-modules/xdis/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "Python cross-version byte-code disassembler and marshal routines";
     homepage = https://github.com/rocky/python-xdis/;
-    license = licenses.mit;
+    license = licenses.gpl2;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

Significant bugfixes to uncompyle6 between 2.8 and 3.2; able to correctly handle a wider range of bytecode.

xdis and spark_parser are part of the dependency chain; analysis via nox appears to indicate that they aren't used elsewhere.

Note that upstream moved to GPLv3 for uncompyle6 and GPLv2 for xdis within this span of releases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

