### PR TITLE
dockerTools: Use nix instead of nixUnstable

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -10,7 +10,7 @@
   lib,
   pkgs,
   pigz,
-  nixUnstable,
+  nix,
   perl,
   runCommand,
   rsync,
@@ -262,7 +262,7 @@ rec {
     '';
 
   nixRegistration = contents: runCommand "nix-registration" {
-    buildInputs = [ nixUnstable perl ];
+    buildInputs = [ nix perl ];
     # For obtaining the closure of `contents'.
     exportReferencesGraph =
       let contentsList = if builtins.isList contents then contents else [ contents ];
@@ -803,7 +803,7 @@ rec {
         echo "         be better to only have one layer that contains a nix store."
         # This requires Nix 1.12 or higher
         export NIX_REMOTE=local?root=$PWD
-        ${nixUnstable}/bin/nix-store --load-db < ${nixRegistration contents}/db.dump
+        ${nix}/bin/nix-store --load-db < ${nixRegistration contents}/db.dump
 
         # We fill the store in order to run the 'verify' command that
         # generates hash and size of output paths.
@@ -814,7 +814,7 @@ rec {
         storePaths=$(cat ${nixRegistration contents}/storePaths)
         echo "Copying everything to /nix/store (will take a while)..."
         cp -prd $storePaths nix/store/
-        ${nixUnstable}/bin/nix-store --verify --check-contents
+        ${nix}/bin/nix-store --verify --check-contents
 
         mkdir -p nix/var/nix/gcroots/docker/
         for i in ${lib.concatStringsSep " " contents}; do


### PR DESCRIPTION
###### Motivation for this change
I believe the usage of `nixUnstable` is an oversight since the original 2.x bump.
This should probably be backported to 18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

