### PR TITLE
nixos/tests/nix-ssh-serve.nix: Use stable nix

### DIFF
--- a/nixos/tests/nix-ssh-serve.nix
+++ b/nixos/tests/nix-ssh-serve.nix
@@ -14,8 +14,8 @@ in
              keys = [ snakeOilPublicKey ];
              protocol = "ssh-ng";
            };
-         server.nix.package = pkgs.nixUnstable;
-         client.nix.package = pkgs.nixUnstable;
+         server.nix.package = pkgs.nix;
+         client.nix.package = pkgs.nix;
        };
      testScript = ''
        startAll;


### PR DESCRIPTION
###### Motivation for this change
Stable Nix supports ssh-ng since 2.x.
Should be backported to 18.09


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

