### PR TITLE
mint: 0.2.1 -> 0.3.1

### DIFF
--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -1,9 +1,9 @@
 # Updating the dependencies for this package:
 #
-#   wget https://github.com/mint-lang/mint/blob/0.2.1/shard.lock
+#   wget https://raw.githubusercontent.com/mint-lang/mint/0.3.1/shard.lock
 #   nix-shell -p crystal libyaml --run 'crystal run crystal2nix.cr'
 #
-{stdenv, lib, fetchFromGitHub, crystal, zlib, openssl, duktape, which }:
+{stdenv, lib, fetchFromGitHub, crystal, zlib, openssl, duktape, which, libyaml }:
 let
   crystalPackages = lib.mapAttrs (name: src:
     stdenv.mkDerivation {
@@ -33,17 +33,16 @@ let
   };
 in
 stdenv.mkDerivation rec {
-  version = "0.2.1";
+  version = "0.3.1";
   name = "mint-${version}";
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
     rev = version;
-    sha256 = "0r8hv2j5yz0rlvrbpnybihj44562pkmsssa8f0hjs45m1ifvf4b1";
+    sha256 = "1f49ax045zdjj0ypc2j4ms9gx80rl63qcsfzm3r0k0lcavfp57zr";
   };
 
-  nativeBuildInputs = [ which ];
-  buildInputs = [ crystal zlib openssl duktape ];
+  nativeBuildInputs = [ which crystal zlib openssl duktape libyaml ];
 
   buildPhase = ''
     mkdir -p $out/bin tmp

--- a/pkgs/development/compilers/mint/shards.nix
+++ b/pkgs/development/compilers/mint/shards.nix
@@ -8,8 +8,8 @@
   ameba = {
     owner = "veelenga";
     repo = "ameba";
-    rev = "v0.7.0";
-    sha256 = "01h0a1ba5l254r04mgkqhjdfn21cs0q7fmvk4gj35cj5lpr2bp17";
+    rev = "v0.8.0";
+    sha256 = "0i9vc5xy05kzxgjid2rnvc7ksvxm9gba25qqi6939q2m1s07qjka";
   };
   baked_file_system = {
     owner = "schovi";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

