### PR TITLE
plantuml: 1.2018.10 -> 1.2018.11

### DIFF
--- a/pkgs/tools/misc/plantuml/default.nix
+++ b/pkgs/tools/misc/plantuml/default.nix
@@ -1,37 +1,34 @@
-{ stdenv, fetchurl, jre, graphviz }:
+{ stdenv, fetchurl, makeWrapper, jre, graphviz }:
 
 stdenv.mkDerivation rec {
-  version = "1.2018.10";
+  version = "1.2018.11";
   name = "plantuml-${version}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/plantuml/${version}/plantuml.${version}.jar";
-    sha256 = "19s3zrfri388nfykcs67sfk0dhmiw0rcv0dvj1j4c0fkyhl41bjs";
+    sha256 = "006bpxz6zsjypxscxbnz3b7icg47bfwcq1v7rvijflchw12hq9nm";
   };
 
-  # It's only a .jar file and a shell wrapper
-  phases = [ "installPhase" ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  installPhase = ''
-    mkdir -p "$out/bin"
-    mkdir -p "$out/lib"
+  buildCommand = ''
+    install -Dm644 $src $out/lib/plantuml.jar
 
-    cp "$src" "$out/lib/plantuml.jar"
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/plantuml \
+      --argv0 plantuml \
+      --set GRAPHVIZ_DOT ${graphviz}/bin/dot \
+      --add-flags "-jar $out/lib/plantuml.jar"
 
-    cat > "$out/bin/plantuml" << EOF
-    #!${stdenv.shell}
-    export GRAPHVIZ_DOT="${graphviz}/bin/dot"
-    exec "${jre}/bin/java" -jar "$out/lib/plantuml.jar" "\$@"
-    EOF
-    chmod a+x "$out/bin/plantuml"
+    $out/bin/plantuml -help
   '';
 
   meta = with stdenv.lib; {
     description = "Draw UML diagrams using a simple and human readable text description";
     homepage = http://plantuml.sourceforge.net/;
-    # "java -jar plantuml.jar -license" says GPLv3 or later
+    # "plantuml -license" says GPLv3 or later
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.bjornfor ];
+    maintainers = with maintainers; [ bjornfor ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Instead of manually hacking together a wrapper script, just use ```makeWrapper``` instead.

Cc: @bjornfor 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

