### PR TITLE
sierra-gtk-theme: 2018-09-14 -> 2018-10-01

### DIFF
--- a/pkgs/misc/themes/sierra/default.nix
+++ b/pkgs/misc/themes/sierra/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "sierra-gtk-theme-${version}";
-  version = "2018-09-14";
+  version = "2018-10-01";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = "sierra-gtk-theme";
-    rev = "4c07f9e4978ab2d87ce0f8d4a5d60da21784172c";
-    sha256 = "0mp5v462wbjq157hfnqzd8sw374mc611kpk92is2c3qhvj5qb6qd";
+    rev = version;
+    sha256 = "10rjk2lyhlkhhfx6f6r0cykbkxa2jhri4wirc3h2wbzzsx7ch3ix";
   };
 
   nativeBuildInputs = [ libxml2 ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [2018-10-01](https://github.com/vinceliuice/Sierra-gtk-theme/releases/tag/2018-10-01).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).