### PR TITLE
sourcetrail: init at 2018.3.55

### DIFF
--- a/pkgs/development/tools/sourcetrail/default.nix
+++ b/pkgs/development/tools/sourcetrail/default.nix
@@ -1,0 +1,75 @@
+{ stdenv, fetchurl, autoPatchelfHook
+, icu, zlib, expat, dbus, libheimdal, openssl}:
+
+stdenv.mkDerivation rec {
+  name = "sourcetrail-${version}";
+  version = "2018.3.55";
+
+  src = fetchurl {
+    name = "sourtrail.tar.gz";
+    url = "https://www.sourcetrail.com/downloads/${version}/linux/64bit";
+    sha256 = "6f5fbbecc221e7165ecbf1c4d208e302dade4feea9d43eb3265521efc0a376e2";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ zlib expat dbus stdenv.cc.cc openssl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/opt
+
+    mv -v setup/share $out
+    mv -v data/gui/icon/logo_1024_1024.png $out/share/icons/sourcetrail.png
+    mv -v data/gui/icon/project_256_256.png $out/share/icons/project-sourcetrail.png
+
+    mkdir -p $out/share/sourcetrail/doc
+    mv -v README EULA.txt $out/share/sourcetrail/doc
+    mv -v plugin $out/share/sourcetrail
+
+    cp -rv . $out/opt
+
+    rm $out/opt/lib/libssl.so
+    rm $out/opt/lib/platforms/{libqeglfs.so,libqwebgl.so}
+    ln -s ${openssl}/lib/libssl.so $out/opt/lib/libssl.so
+
+    substituteInPlace \
+      $out/share/applications/sourcetrail.desktop \
+      --replace /usr/bin/ $out/bin/
+
+    cat <<EOF > $out/bin/sourcetrail
+      #! ${stdenv.shell} -e
+
+      # XXX: Sourcetrail somehow copies the initial config files into the home
+      # directory without write permissions. We currently just copy them
+      # ourselves to work around this problem.
+      setup_config() {
+        local src dst
+
+        [ ! -d ~/.config/sourcetrail ] && mkdir -p ~/.config/sourcetrail
+        for src in $out/opt/data/fallback/*; do
+          dst=~/.config/sourcetrail/"\$(basename "\$src")"
+          if [ ! -e "\$dst" ]; then
+            cp -r "\$src" "\$dst"
+          fi
+        done
+
+        chmod -R u+w ~/.config/sourcetrail
+      }
+
+      [ -d "\$HOME" ] && setup_config
+      exec "$out/opt/Sourcetrail.sh" "\$@"
+    EOF
+    chmod +x $out/bin/sourcetrail
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://www.sourcetrail.com;
+    description = "A cross-platform source explorer for C/C++ and Java";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ midchildan ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18930,6 +18930,8 @@ with pkgs;
     apiKey = config.libspotify.apiKey or null;
   };
 
+  sourcetrail = callPackage ../development/tools/sourcetrail { };
+
   spotifywm = callPackage ../applications/audio/spotifywm { };
 
   squeezelite = callPackage ../applications/audio/squeezelite { };


### PR DESCRIPTION
###### Motivation for this change
Sourcetrail is a cross referencer for C/C++/Java

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

