### PR TITLE
hugo: helpers/content.go: call rst2html directly to render content

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchpatch }:
 
 buildGoPackage rec {
   name = "hugo-${version}";
@@ -12,6 +12,13 @@ buildGoPackage rec {
     rev    = "v${version}";
     sha256 = "0n27vyg66jfx4lwswsmdlybly8c9gy5rk7yhy7wzs3rwzlqv1jzj";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/gohugoio/hugo/commit/b137ad4dbd6d14d0a9af68c044aaee61f2c87fe5.diff";
+      sha256 = "0w1gpg11idqywqcpwzvx4xabn02kk8y4jmyz4h67mc3yh2dhq3ll";
+    })
+  ];
 
   goDeps = ./deps.nix;
 


### PR DESCRIPTION
###### Motivation for this change

Hugo launches rst2html by calling Python interpreter and passing it the path of rst2html file.
This doesn't work on NixOS because the real rst2html is actually wrapped behind a bash script which is responsible for correctly setting the env and then exec-ing the real rst2html.

The problem is that rst2html is actually a bash script and not a Python script. Hence, Python fails to launch it with SyntaxError.

This patch ensures that rst2html is called directly so the shebang work correctly.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).