### PR TITLE
nixos/bitlbee: add pam option

### DIFF
--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation rec {
     ++ optional enableLibPurple pidgin;
 
   configureFlags = [
-    "--gcov=1"
     "--otr=1"
     "--ssl=gnutls"
     "--pidfile=/var/lib/bitlbee/bitlbee.pid"

--- a/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee/default.nix
@@ -1,5 +1,7 @@
-{ fetchurl, stdenv, gnutls, glib, pkgconfig, check, libotr, python,
-enableLibPurple ? false, pidgin ? null }:
+{ fetchurl, stdenv, gnutls, glib, pkgconfig, check, libotr, python
+, enableLibPurple ? false, pidgin ? null
+, enablePam ? false, pam ? null
+}:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -13,18 +15,23 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ] ++ optional doCheck check;
 
   buildInputs = [ gnutls glib libotr python ]
-    ++ optional enableLibPurple pidgin;
+    ++ optional enableLibPurple pidgin
+    ++ optional enablePam pam;
 
   configureFlags = [
     "--otr=1"
     "--ssl=gnutls"
     "--pidfile=/var/lib/bitlbee/bitlbee.pid"
-  ]
-  ++ optional enableLibPurple "--purple=1";
+  ] ++ optional enableLibPurple "--purple=1"
+    ++ optional enablePam "--pam=1";
 
   installTargets = [ "install" "install-dev" ];
 
   doCheck = !enableLibPurple; # Checks fail with libpurple for some reason
+  checkPhase = ''
+    # check flags set VERBOSE=y which breaks the build due overriding a command
+    make check
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

