### PR TITLE
stern: init at 1.8.0

### DIFF
--- a/pkgs/applications/networking/cluster/stern/default.nix
+++ b/pkgs/applications/networking/cluster/stern/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "stern-${version}";
+  version = "1.8.0";
+
+  goPackagePath = "github.com/wercker/stern";
+
+  src = fetchFromGitHub {
+    owner = "wercker";
+    repo = "stern";
+    rev = "${version}";
+    sha256 = "14ccgb41ca2gym7wab0q02ap8g94nhfaihs41qky4wnsfv6j1zc8";
+  };
+
+  goDeps = ./deps.nix;
+
+   meta = with lib; {
+      description      = "Multi pod and container log tailing for Kubernetes";
+      homepage         = "https://github.com/wercker/stern";
+      license          = licenses.asl20;
+      maintainers      = with maintainers; [ mbode ];
+      platforms        = platforms.unix;
+    };
+}

--- a/pkgs/applications/networking/cluster/stern/deps.nix
+++ b/pkgs/applications/networking/cluster/stern/deps.nix
@@ -1,0 +1,345 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://code.googlesource.com/gocloud";
+      rev =  "97efc2c9ffd9fe8ef47f7f3203dc60bbca547374";
+      sha256 = "1zf8imq0hgba13rbn260pqf2qd41cg3i4wzzq2i0li3lxnjglkv1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/Azure/go-autorest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Azure/go-autorest";
+      rev =  "1ff28809256a84bb6966640ff3d0371af82ccba4";
+      sha256 = "0sxvj2j1833bqwxvhq3wq3jgq73rnb81pnzvl0x3y1m0hzpaf2zv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "2d684516a8861da43017284349b7e303e809ac21";
+      sha256 = "1fcfmz4wji3gqmmsdx493r7d101s58hwjalqps6hy25nva5pvmfs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev =  "73d445a93680fa1a78ae23a5839bad48f32ba1ee";
+      sha256 = "0pg53ky4sy3sp9j4n7vgf1p3gw4nbckwqfldcmmi9rf13kjh0mr7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev =  "c0656edd0d9eab7c66d1eb0c568f9039345796f7";
+      sha256 = "0b943dhx571lhgcs3rqzy0092mi2x5mwy2kl7g8rryhy3r5rzrz9";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev =  "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev =  "b4deda0973fb4c70b50d226b1af49f3da59f5265";
+      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev =  "4030bb1f1f0c35b30ca7009e9ebd06849dd45306";
+      sha256 = "0ba430m9fbnagacp57krgidsyrgp3ycw5r7dj71brgp5r52g82p6";
+    };
+  }
+  {
+    goPackagePath  = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev =  "24818f796faf91cd76ec7bddd72458fbced7a6c1";
+      sha256 = "0cq90m2lgalrdfrwwyycrrmn785rgnxa3l3vp9yxkvnv88bymmlm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/googleapis/gnostic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gnostic";
+      rev =  "0c5108395e2debce0d731cf0287ddf7242066aba";
+      sha256 = "0jf3cp5clli88gpjf24r6wxbkvngnc1kf59d4cgjczsn2wasvsfc";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gregjones/httpcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gregjones/httpcache";
+      rev =  "787624de3eb7bd915c329cba748687a3b22666a6";
+      sha256 = "1zqlg9pkj7r6fqw7wv3ywvbz3bh0hvzifs2scgcraj812q5189w5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/imdario/mergo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/imdario/mergo";
+      rev =  "6633656539c1639d9d78127b7d47c622b5d7b6dc";
+      sha256 = "1fffbq1l17i0gynmvcxypl7d9h4v81g5vlimiph5bfgf4sp4db7g";
+    };
+  }
+  {
+    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+    };
+  }
+  {
+    goPackagePath  = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev =  "0ac74bba4a81211b28e32ef260c0f16ae41f1377";
+      sha256 = "07aa3jz9rmhn3cfv06z9549kfpsx4i85qbi3j7q60z2pvasjxqv5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev =  "b8bc1bf767474819792c23f32d8286a45736f1c6";
+      sha256 = "13ry4lylalkh4g2vny9cxwvryslzyzwp9r92z0b10idhdq3wad1q";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev =  "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev =  "05fbef0ca5da472bbf96c9322b84a53edc03c9fd";
+      sha256 = "1jc7xba9v3scsc8fg5nb9g6lrxxgiaaykx8q817arq9b737y90gm";
+    };
+  }
+  {
+    goPackagePath  = "github.com/petar/GoLLRB";
+    fetch = {
+      type = "git";
+      url = "https://github.com/petar/GoLLRB";
+      rev =  "53be0d36a84c2a886ca057d34b6aa4468df9ccb4";
+      sha256 = "01xp3lcamqkvl91jg6ly202gdsgf64j39rkrcqxi6v4pbrcv7hz0";
+    };
+  }
+  {
+    goPackagePath  = "github.com/peterbourgon/diskv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/peterbourgon/diskv";
+      rev =  "5f041e8faa004a95c88a202771f4cc3e991971e6";
+      sha256 = "1mxpa5aad08x30qcbffzk80g9540wvbca4blc1r2qyzl65b8929b";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "816c9085562cd7ee03e7f8188a1cfd942858cded";
+      sha256 = "1ws5crb7c70wdicavl6qr4g03nn6m92zd6wwp9n2ygz5c8rmxh8k";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev =  "a114f312e075f65bf30d6d9a1430113f857e543b";
+      sha256 = "10lmi5ni06yijxg02fcic5b7ycjkia12yma4a4lz8a56j30wykx1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev =  "3ebe029320b2676d667ae88da602a5f854788a8a";
+      sha256 = "11yxs0wqy70wj106fkz8r923yg4ncnc2mbw33v48zmlg4a1rasgp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/v2pro/plz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/v2pro/plz";
+      rev =  "10fc95fad3224a032229e59f6e7023137d82b526";
+      sha256 = "0p04pjrz55zn6dbi6l0705prjmhqnmvsvrxzc74hl12wi6r35drp";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "49796115aa4b964c318aad4f3084fdb41e9aa067";
+      sha256 = "0pcq2drkzsw585xi6rda8imd7a139prrmvgmv8nz0zgzk6g4dy59";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "1c05540f6879653db88113bc4a2b70aec4bd491f";
+      sha256 = "0h8yqb0vcqgllgydrf9d3rzp83w8wlr8f0nm6r1rwf2qg30pq1pd";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev =  "a6bd8cefa1811bd24b86f8902872e4e8225f74c4";
+      sha256 = "151in8qcf5y97ziavl6b03vgw4r87zqx5kg4vjhjszjbh60cfswp";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "e4b3c5e9061176387e7cea65e4dc5853801f3fb7";
+      sha256 = "1ijx254fycsnr16m24k7lqvkmdkkrqxsl9mr1kz4mf61a8n0arf9";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev =  "f51c12702a4d776e4c1fa9b0fabab841babae631";
+      sha256 = "07wc6g2fvafkr6djsscm0jpbpl4135khhb6kpyx1953hi5d1jvyy";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06";
+      sha256 = "1iabxnqgxvvn1239i6fvfl375vlbvhfrc03m1x2rvalmx4d6w9c7";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/inf.v0";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-inf/inf";
+      rev =  "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4";
+      sha256 = "0rf3vwyb8aqnac9x9d6ax7z5526c45a16yjm2pvkijr6qgqz8b82";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-yaml/yaml";
+      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/api";
+      rev =  "8be2a0b24ed0dac9cfc1ac2d987ea16cfcdbecb6";
+      sha256 = "1dpmd59jlkxgrp5aaf8420344c6nq4kjlc1avgcp7690yrzc50v6";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/apimachinery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/apimachinery";
+      rev =  "594fc14b6f143d963ea2c8132e09e73fe244b6c9";
+      sha256 = "0xykhpmjgagyb0ac4y0ps4v1s9bd2b1sc0simh48c41a9fk3yvr7";
+    };
+  }
+  {
+    goPackagePath  = "k8s.io/client-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kubernetes/client-go";
+      rev =  "739dd8f9d4801eb23e2bc43423c0b4acaaded29a";
+      sha256 = "15psjmb14rz4kwysim9vfbbylx0khkw29b195rziv1vk202lh28k";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22115,6 +22115,8 @@ with pkgs;
 
   steamcontroller = callPackage ../misc/drivers/steamcontroller { };
 
+  stern = callPackage ../applications/networking/cluster/stern { };
+
   streamripper = callPackage ../applications/audio/streamripper { };
 
   sqsh = callPackage ../development/tools/sqsh { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

