### PR TITLE
aws-rotate-key: 1.0.0 -> 1.0.3

### DIFF
--- a/pkgs/tools/admin/aws-rotate-key/default.nix
+++ b/pkgs/tools/admin/aws-rotate-key/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "aws-rotate-key-${version}";
-  version = "1.0.0";
+  version = "1.0.3";
 
   goPackagePath = "github.com/Fullscreen/aws-rotate-key";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "Fullscreen";
     repo = "aws-rotate-key";
-    sha256 = "13q7rns65cj8b4i0s75dbswijpra9z74b462zribwfjdm29by5k1";
+    sha256 = "15na7flc0vp14amaq3116a5glqlb4ydvdlzv0q7mwl73pc38zxn3";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

