### PR TITLE
adapta-gtk-theme: 3.94.0.132 -> 3.95.0.1

### DIFF
--- a/pkgs/misc/themes/adapta/default.nix
+++ b/pkgs/misc/themes/adapta/default.nix
@@ -1,14 +1,30 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, parallel, sassc, inkscape, libxml2, glib, gdk_pixbuf, librsvg, gtk-engine-murrine, gnome3 }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, parallel, sassc, inkscape
+, libxml2, glib, gdk_pixbuf, librsvg, gtk-engine-murrine, gnome3
+, enableGnome ? true
+, enableCinnamon ? true
+, enableFlashback ? true
+, enableXfce ? true
+, enableMate ? true
+, enableOpenbox ? true
+, enableGtkNext ? false
+, enablePlank ? false
+, enableTelegram ? false
+, enableTweetdeck ? false
+, withSelectionColor ? null # Primary color for 'selected-items' (Default: #3F51B5 = Indigo500)
+, withAccentColor ? null # Secondary color for notifications and OSDs (Default: #7986CB = Indigo300)
+, withSuggestionColor ? null # Secondary color for 'suggested' buttons (Default: #673AB7 = DPurple500)
+, withDestructionColor ? null # Tertiary color for 'destructive' buttons (Default: #F44336 = Red500)
+}:
 
 stdenv.mkDerivation rec {
   name = "adapta-gtk-theme-${version}";
-  version = "3.94.0.149";
+  version = "3.95.0.1";
 
   src = fetchFromGitHub {
     owner = "adapta-project";
     repo = "adapta-gtk-theme";
     rev = version;
-    sha256 = "1rb07yv4iz4yp6cnigzy690mw3w6fcf7szlcbbna6wnjaf1rbf2i";
+    sha256 = "0hc3ar55wjg51qf8c7h0nix0lyqs16mk1d4hhxyv102zq4l5fz97";
   };
 
   preferLocalBuild = true;
@@ -33,11 +49,24 @@ stdenv.mkDerivation rec {
 
   postPatch = "patchShebangs .";
 
-  configureFlags = [
-    "--disable-gtk_legacy"
-    "--disable-gtk_next"
-    "--disable-unity"
-  ];
+  configureFlags =
+    let
+      inherit (stdenv.lib) enableFeature optional;
+      withOptional = feat: value: optional (value != null) "--with-${feat}=${value}";
+    in [
+      "--enable-parallel"
+      (enableFeature enableGnome "gnome")
+      (enableFeature enableCinnamon "cinnamon")
+      (enableFeature enableFlashback "flashback")
+      (enableFeature enableXfce "xfce")
+      (enableFeature enableMate "mate")
+      (enableFeature enableOpenbox "openbox")
+      (enableFeature enableGtkNext "gtk_next")
+    ]
+    ++ (withOptional "selection_color" withSelectionColor)
+    ++ (withOptional "accent_color" withAccentColor)
+    ++ (withOptional "suggestion_color" withSuggestionColor)
+    ++ (withOptional "destruction_color" withDestructionColor);
 
   meta = with stdenv.lib; {
     description = "An adaptive Gtk+ theme based on Material Design Guidelines";


### PR DESCRIPTION
###### Motivation for this change

Update to the latest Adapta release.

Add override flags for all knobs that can be tweaked by Adapta's configuration scripts.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

