### PR TITLE
google-chrome: use default patchelf, "fixes" nacl_helper crashing.

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16895,7 +16895,7 @@ with pkgs;
 
   googleearth = callPackage ../applications/misc/googleearth { };
 
-  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; patchelf = patchelfUnstable; };
+  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
 


### PR DESCRIPTION
I'm not sure what the problem is, precisely, but even so
this was preventing use of things like cast'ing--
not that I'm entirely clear on what that would be the case either :/.

Err on caution and let's go back to what the situation was before
and fix it properly when we better understand the issue.



* I'm seeing "nacl_helper" crashing and it didn't before
  * other than journalctl logs (and coredumpctl) browser seems to work
    with only noticed difference being inability to cast to my
    chromecast.
* If you attempt to run the 'nacl_helper' binary produced before/after
  this change the one patched by unstable crashes while the other
  spams your console since it's not really meant to be run that way :P.

Sorry for the churn, as far as regressions go it was subtle and
took me some time to even really be sure what caused it xD.

Wouldn't mind someone checking if they at least see the crashing
desribed above (no clue if my chromecast is just being moody)
to give some confidence this is a step (back? forward? ONWARD!)
in the right direction.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---