### PR TITLE
tetra-gtk-theme: init at 1.6

### DIFF
--- a/pkgs/misc/themes/tetra/default.nix
+++ b/pkgs/misc/themes/tetra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, gtk3, sassc, optipng, inkscape, which }:
+{ stdenv, fetchFromGitHub, gtk3, sassc }:
 
 let
   pname = "tetra-gtk-theme";
@@ -20,14 +20,15 @@ stdenv.mkDerivation rec {
     export HOME="$NIX_BUILD_ROOT"
   '';
 
-  nativeBuildInputs = [ sassc optipng inkscape which ];
+  nativeBuildInputs = [ sassc ];
   buildInputs = [ gtk3 ];
 
   postPatch = "patchShebangs .";
 
-  buildPhase = "./render-assets.sh";
-
-  installPhase = "./install.sh -d $out";
+  installPhase = ''
+    mkdir -p $out/share/themes
+    ./install.sh -d $out/share/themes
+  '';
 
   meta = with stdenv.lib; {
     description = "Adwaita-based gtk+ theme with design influence from elementary OS and Vertex gtk+ theme.";

--- a/pkgs/misc/themes/tetra/default.nix
+++ b/pkgs/misc/themes/tetra/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, gtk3, sassc, optipng, inkscape, which }:
+
+let
+  pname = "tetra-gtk-theme";
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  version = "0.1.6";
+
+  src = fetchFromGitHub {
+    owner  = "hrdwrrsk";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0jdgj7ac9842cgrjnzdqlf1f3hlf9v7xk377pvqcz2lwcr1dfaxz";
+  };
+
+  preBuild = ''
+    # Shut up inkscape's warnings
+    export HOME="$NIX_BUILD_ROOT"
+  '';
+
+  nativeBuildInputs = [ sassc optipng inkscape which ];
+  buildInputs = [ gtk3 ];
+
+  postPatch = "patchShebangs .";
+
+  buildPhase = "./render-assets.sh";
+
+  installPhase = "./install.sh -d $out";
+
+  meta = with stdenv.lib; {
+    description = "Adwaita-based gtk+ theme with design influence from elementary OS and Vertex gtk+ theme.";
+    homepage    = https://github.com/hrdwrrsk/tetra-gtk-theme;
+    license     = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22157,6 +22157,8 @@ with pkgs;
 
   tetex = callPackage ../tools/typesetting/tex/tetex { libpng = libpng12; };
 
+  tetra-gtk-theme = callPackage ../misc/themes/tetra { };
+
   tewi-font = callPackage ../data/fonts/tewi  {};
 
   texFunctions = callPackage ../tools/typesetting/tex/nix pkgs;


### PR DESCRIPTION
Looked like I might want it, thought others might find it interesting as well.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---