### PR TITLE
pasystray: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "pasystray-${version}";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "christophgysin";
     repo = "pasystray";
     rev = name;
-    sha256 = "0k13s7pmz5ks3kli8pwhzd47hcjwv46gd2fgk7i4fbkfwf3z279h";
+    sha256 = "0cc9hjyw4gr4ip4lw74pzb1l9sxs3ffhf0xn0m1fhmyfbjyixwkh";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
https://github.com/christophgysin/pasystray/releases/tag/pasystray-0.7.0

Release notes say this updates pasystray to 0.7.0.

I would hope so! :D


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Running it right now, all day! :)