### PR TITLE
Unifi updates

### DIFF
--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -54,8 +54,8 @@ in rec {
   };
 
   unifiTesting = generic {
-    version = "5.9.22";
-    suffix  = "-d2a4718971";
-    sha256  = "1xxpvvn0815snag4bmmsdm8zh0cb2qjrhnvlkgn8i478ja1r3n54";
+    version = "5.9.29";
+    suffix  = "-04b5d20997";
+    sha256  = "0djdjh7lwaa5nvhvz2yh6dn07iad5nq4jpab7rc909sljl6wvwvx";
   };
 }

--- a/pkgs/servers/unifi/default.nix
+++ b/pkgs/servers/unifi/default.nix
@@ -49,8 +49,8 @@ in rec {
   };
 
   unifiStable = generic {
-    version = "5.8.28";
-    sha256  = "1zyc6n54dwqy9diyqnzlwypgnj3hqcv0lfx47s4rkq3kbm49nwnl";
+    version = "5.8.30";
+    sha256  = "051cx1y51xmhvd3s8zbmknrcjdi46mj4yf1rlnngzr77rj77sqvi";
   };
 
   unifiTesting = generic {


### PR DESCRIPTION
###### Motivation for this change

Update all unifi packages to the latest available version.

I did not test if the unifiTesting package is working correctly. I only made sure it builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

