### PR TITLE
ifdnfc: init at 2016-03-01

### DIFF
--- a/pkgs/tools/security/ifdnfc/default.nix
+++ b/pkgs/tools/security/ifdnfc/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub , pkgconfig
+, pcsclite
+, autoreconfHook
+, libnfc
+}:
+
+stdenv.mkDerivation rec {
+  name = "ifdnfc-${version}";
+  version = "2016-03-01";
+
+  src = fetchFromGitHub {
+    owner = "nfc-tools";
+    repo = "ifdnfc";
+    rev = "0e48e8e";
+    sha256 = "1cxnvhhlcbm8h49rlw5racspb85fmwqqhd3gzzpzy68vrs0b37vg";
+  };
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
+  buildInputs = [ pcsclite libnfc ];
+
+  configureFlags = [ "--prefix=$(out)" ];
+  makeFlags = [ "DESTDIR=/" "usbdropdir=$(out)/pcsc/drivers" ];
+
+  meta = with stdenv.lib; {
+    description = "PC/SC IFD Handler based on libnfc";
+    longDescription =
+    '' libnfc Interface Plugin to be used in <code>services.pcscd.plugins</code>.
+       It provides support for all readers which are not supported by ccid but by libnfc.
+
+       For activating your reader you need to run
+       <code>ifdnfc-activate yes<code> with this package in your
+       <code>environment.systemPackages</code>
+
+       To use your reader you may need to blacklist your reader kernel modules:
+       <code>boot.blacklistedKernelModules = [ "pn533" "pn533_usb" "nfc" ];</code>
+
+       Supports the pn533 smart-card reader chip which is for example used in
+       the SCM SCL3711.
+    '';
+    homepage = https://github.com/nfc-tools/ifdnfc;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ makefu ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4627,6 +4627,7 @@ with pkgs;
   pcsc-cyberjack = callPackage ../tools/security/pcsc-cyberjack { };
 
   pcsc-scm-scl011 = callPackage ../tools/security/pcsc-scm-scl011 { };
+  ifdnfc = callPackage ../tools/security/ifdnfc { };
 
   pdd = python3Packages.callPackage ../tools/misc/pdd { };
 


### PR DESCRIPTION
###### Motivation for this change

this package enables support for my NFC reader for pcsc-lite, an SCM SCL3711.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [NA] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

