### PR TITLE
nvtop: use version-independent libnvidia-ml.so symlink

### DIFF
--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
-    "-DNVML_LIBRARIES=${nvidia_x11}/lib/libnvidia-ml.so.390.67"
+    "-DNVML_LIBRARIES=${nvidia_x11}/lib/libnvidia-ml.so"
     "-DCMAKE_BUILD_TYPE=Release"
   ];
 


### PR DESCRIPTION
###### Motivation for this change
When I originally packaged nvtop, I referenced the management library directly. In the meantime the version and therefore the filename have changed, which breaks the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---