### PR TITLE
cozy-audiobooks: init at 0.6.3

### DIFF
--- a/pkgs/applications/audio/cozy-audiobooks/default.nix
+++ b/pkgs/applications/audio/cozy-audiobooks/default.nix
@@ -1,0 +1,85 @@
+{ stdenv, fetchFromGitHub
+, ninja
+, boost
+, meson
+, pkgconfig
+, wrapGAppsHook
+, appstream-glib
+, desktop-file-utils
+, gtk3
+, gst_all_1
+, gobjectIntrospection
+, python3Packages
+, file
+, cairo
+, sqlite
+, gettext
+, gnome3
+}:
+
+python3Packages.buildPythonApplication rec {
+
+  format = "other"; # no setup.py
+
+  name = "cozy-${version}";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "geigi";
+    repo = "cozy";
+    rev = version;
+    sha256 = "0xs6vzvmx0nvybpjqlrngggv2x8b2ky073slh760iirs1p0dclbc";
+  };
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig
+    wrapGAppsHook
+    appstream-glib
+    desktop-file-utils
+    gobjectIntrospection
+  ];
+
+  buildInputs = [
+    gtk3
+    cairo
+    gettext
+    gnome3.defaultIconTheme
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-good
+    gst-plugins-ugly
+    gst-plugins-base
+  ]);
+
+  propagatedBuildInputs = with python3Packages; [
+    gst-python
+    pygobject3
+    dbus-python
+    mutagen
+    peewee
+    magic
+  ];
+
+  postPatch = ''
+    chmod +x data/meson_post_install.py
+    patchShebangs data/meson_post_install.py
+    substituteInPlace cozy/magic/magic.py --replace "ctypes.util.find_library('magic')" "'${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}'"
+  '';
+
+  checkPhase = ''
+    ninja test
+  '';
+
+  postInstall = ''
+    ln -s $out/bin/com.github.geigi.cozy $out/bin/cozy
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+       A modern audio book player for Linux using GTK+ 3
+    '';
+    homepage = https://cozy.geigi.de/;
+    maintainers = [ maintainers.makefu ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/development/python-modules/peewee/default.nix
+++ b/pkgs/development/python-modules/peewee/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, buildPythonPackage, fetchFromGitHub
+, sqlite
+, cython
+, apsw
+, flask
+, withPostgres ? false, psycopg2
+, withMysql ? false, mysql-connector
+}:
+
+buildPythonPackage rec {
+
+  pname = "peewee";
+  version = "3.7.1";
+
+  # pypi release does not provide tests
+  src = fetchFromGitHub {
+    owner = "coleifer";
+    repo = pname;
+    rev = version;
+    sha256 = "0chn8mknzvkmcmysy2291hanf0vg3sfzqgfc5hqx1nnrd6qkiq8r";
+  };
+
+
+  checkInputs = [ flask ];
+
+  checkPhase = ''
+    rm -r playhouse # avoid using the folder in the cwd
+    python runtests.py
+  '';
+
+  buildInputs = [
+    sqlite
+    cython # compile speedups
+  ];
+
+  propagatedBuildInputs = [
+    apsw # sqlite performance improvement
+  ] ++ (lib.optional withPostgres psycopg2)
+    ++ (lib.optional withMysql mysql-connector);
+
+  meta = with stdenv.lib;{
+    description = "a small, expressive orm";
+    homepage    = http://peewee-orm.com;
+    license     = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -653,6 +653,8 @@ with pkgs;
 
   chkcrontab = callPackage ../tools/admin/chkcrontab { };
 
+  cozy = callPackage ../applications/audio/cozy-audiobooks { };
+
   djmount = callPackage ../tools/filesystems/djmount { };
 
   dgsh = callPackage ../shells/dgsh { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3666,6 +3666,8 @@ in {
     };
   };
 
+  peewee =  callPackage ../development/python-modules/peewee { };
+
   peppercorn = buildPythonPackage rec {
     name = "peppercorn-0.5";
 


### PR DESCRIPTION
###### Motivation for this change

add the cozy-audiobook package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

