### PR TITLE
bento4: init at 1.5.1-624

### DIFF
--- a/pkgs/tools/video/bento4/default.nix
+++ b/pkgs/tools/video/bento4/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub
+, cmake
+}:
+stdenv.mkDerivation rec {
+  name = "bento4-${version}";
+  version = "1.5.1-624";
+
+  src = fetchFromGitHub {
+    owner = "axiomatic-systems";
+    repo = "Bento4";
+    rev = "v${version}";
+    sha256 = "1cq6vhrq3n3lc1n454slbc66qdyqam2srxgdhfpyfxbq5c4y06nf";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  installPhase = ''
+    mkdir -p $out/{lib,bin}
+    find -iname '*.so' -exec mv --target-directory="$out/lib" {} \;
+    find -maxdepth 1 -executable -type f -exec mv --target-directory="$out/bin" {} \;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Full-featured MP4 format and MPEG DASH library and tools";
+    homepage = http://bento4.com;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ makefu ];
+    broken = stdenv.isAarch64;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1664,6 +1664,8 @@ with pkgs;
     pythonPackages = python3Packages;
   };
 
+  bento4 = callPackage ../tools/video/bento4 { };
+
   bepasty = callPackage ../tools/misc/bepasty { };
 
   bettercap = callPackage ../tools/security/bettercap { };


### PR DESCRIPTION
###### Motivation for this change

adds the bento4 package with tools for working with MPEG DASH 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

