### PR TITLE
gen-oath-safe: 2017-06-30 -> 0.11.0

### DIFF
--- a/pkgs/tools/security/gen-oath-safe/default.nix
+++ b/pkgs/tools/security/gen-oath-safe/default.nix
@@ -1,12 +1,13 @@
 { coreutils, fetchFromGitHub, libcaca, makeWrapper, python, openssl, qrencode, stdenv, yubikey-manager }:
 
-stdenv.mkDerivation {
-  name = "gen-oath-safe-2017-01-23";
+stdenv.mkDerivation rec {
+  name = "gen-oath-safe-${version}";
+  version = "0.11.0";
   src = fetchFromGitHub {
     owner = "mcepl";
     repo = "gen-oath-safe";
-    rev = "fb53841";
-    sha256 = "0018kqmhg0861r5xkbis2a1rx49gyn0dxcyj05wap5ms7zz69m0m";
+    rev = version;
+    sha256 = "1914z0jgj7lni0nf3hslkjgkv87mhxdr92cmhmbzhpjgjgr23ydp";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

follow official releases of gen-oath-safe, prepares auto-update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

