### PR TITLE
libcanberra: fix darwin build

### DIFF
--- a/pkgs/development/libraries/libcanberra/default.nix
+++ b/pkgs/development/libraries/libcanberra/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig, libtool
 , gtk ? null
 , libpulseaudio, gst_all_1, libvorbis, libcap
+, CoreServices
 , withAlsa ? stdenv.isLinux, alsaLib }:
 
 stdenv.mkDerivation rec {
@@ -15,6 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libpulseaudio libvorbis gtk
   ] ++ (with gst_all_1; [ gstreamer gst-plugins-base ])
+    ++ lib.optional stdenv.isDarwin CoreServices
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional withAlsa alsaLib;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10242,7 +10242,9 @@ with pkgs;
     inherit (xorg) libX11 libXext;
   };
 
-  libcanberra = callPackage ../development/libraries/libcanberra { };
+  libcanberra = callPackage ../development/libraries/libcanberra {
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+  };
   libcanberra-gtk3 = pkgs.libcanberra.override {
     gtk = gtk3;
   };


### PR DESCRIPTION
###### Motivation for this change
This should fix the darwin build of libcanberra. Please backport to 18.09. (#45961)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

