### PR TITLE
csv2svn: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/applications/version-management/cvs2svn/default.nix
+++ b/pkgs/applications/version-management/cvs2svn/default.nix
@@ -1,29 +1,33 @@
-{stdenv, lib, fetchurl, python2, cvs, makeWrapper}:
+{ lib, fetchurl, makeWrapper
+, python2Packages
+, cvs, subversion, git, bazaar
+}:
 
-stdenv.mkDerivation rec {
-  name = "cvs2svn-2.4.0";
+python2Packages.buildPythonApplication  rec {
+  name = "cvs2svn-${version}";
+  version = "2.5.0";
 
   src = fetchurl {
-    url = "http://cvs2svn.tigris.org/files/documents/1462/49237/${name}.tar.gz";
-    sha256 = "05piyrcp81a1jgjm66xhq7h1sscx42ccjqaw30h40dxlwz1pyrx6";
+    url = "http://cvs2svn.tigris.org/files/documents/1462/49543/${name}.tar.gz";
+    sha256 = "1ska0z15sjhyfi860rjazz9ya1gxbf5c0h8dfqwz88h7fccd22b4";
   };
 
-  buildInputs = [python2 makeWrapper];
+  buildInputs = [ makeWrapper ];
 
-  dontBuild = true;
-  installPhase = ''
-    python ./setup.py install --prefix=$out
+  checkInputs = [ subversion git bazaar ];
+
+  checkPhase = "python run-tests.py";
+
+  doCheck = false; # Couldn't find node 'transaction...' in expected output tree
+
+  postInstall = ''
     for i in bzr svn git; do
       wrapProgram $out/bin/cvs2$i \
-          --prefix PATH : "${lib.makeBinPath [ cvs ]}" \
-          --set PYTHONPATH "$(toPythonPath $out):$PYTHONPATH"
+          --prefix PATH : "${lib.makeBinPath [ cvs ]}"
     done
   '';
 
-  /* !!! maybe we should absolutise the program names in
-     $out/lib/python2.4/site-packages/cvs2svn_lib/config.py. */
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A tool to convert CVS repositories to Subversion repositories";
     homepage = http://cvs2svn.tigris.org/;
     maintainers = [ maintainers.makefu ];


### PR DESCRIPTION
###### Motivation for this change
update csv2svn to the latest version.
use buildPythonApplication instead of manual setup.py call

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

