### PR TITLE
onestepback: 0.98 -> 0.991

### DIFF
--- a/pkgs/misc/themes/onestepback/default.nix
+++ b/pkgs/misc/themes/onestepback/default.nix
@@ -1,23 +1,37 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchurl, unzip }:
 
-let
-  version = "0.98";
-
-in fetchzip {
+stdenv.mkDerivation rec {
   name = "onestepback-${version}";
+  version = "0.991";
 
-  url = "http://www.vide.memoire.free.fr/perso/OneStepBack/OneStepBack-v${version}.zip";
+  srcs = [
+    (fetchurl {
+      url = "http://www.vide.memoire.free.fr/perso/OneStepBack/OneStepBack-v${version}.zip";
+      sha256 = "1jfgcgzbb6ra9qs3zcp6ij0hfldzg3m0yjw6l6vf4kq1mdby1ghm";
+    })
+    (fetchurl {
+      url = "http://www.vide.memoire.free.fr/perso/OneStepBack/OneStepBack-grey-brown-green-blue-v${version}.zip";
+      sha256 = "0i006h1asbpfdzajws0dvk9acplvcympzgxq5v3n8hmizd6yyh77";
+    })
+    (fetchurl {
+      url = "http://www.vide.memoire.free.fr/perso/OneStepBack/OneStepBack-green-brown-v${version}.zip";
+      sha256 = "16p002lak6425gcskny4hzws8x9dgsm6j3a1r08y11rsz7d2hnmy";
+    })
+  ];
 
-  postFetch = ''
-    mkdir -p $out/share/themes
-    unzip $downloadedFile -x OneStepBack/LICENSE -d $out/share/themes
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p  $out/share/themes
+    cp -a OneStepBack* $out/share/themes/
+    rm $out/share/themes/*/{LICENSE,README*}
   '';
-
-  sha256 = "0sjacvx7020lzc89r5310w83wclw96gzzczy3mss54ldkgmnd0mr";
 
   meta = with stdenv.lib; {
     description = "Gtk theme inspired by the NextStep look";
-    homepage = https://www.opendesktop.org/p/1013663/;
+    homepage = http://www.vide.memoire.free.fr/perso/OneStepBack;
     license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
###### Motivation for this change

- Update to version 0.991
- Add color variants of the theme
- Change home page

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).