### PR TITLE
xcodeenv.buildApp: inherit meta

### DIFF
--- a/pkgs/development/mobile/xcodeenv/build-app.nix
+++ b/pkgs/development/mobile/xcodeenv/build-app.nix
@@ -20,6 +20,7 @@
 , bundleId ? null
 , version ? null
 , title ? null
+, meta ? {}
 }:
 
 assert release -> codeSignIdentity != null && certificateFile != null && certificatePassword != null && provisioningProfile != null && signMethod != null;
@@ -49,6 +50,7 @@ in
 stdenv.mkDerivation {
   name = stdenv.lib.replaceChars [" "] [""] name;
   inherit src;
+  inherit meta;
   buildInputs = [ xcodewrapper ];
   buildPhase = ''
     ${stdenv.lib.optionalString release ''


### PR DESCRIPTION
###### Motivation for this change

Without `inherit meta;` there was no easy way for XCode packages to
set meta information of the final derivation.

For example,
```nix
{stdenv, xcodeenv}:
xcodeenv.buildApp {
  name = "example";
  meta = with stdenv.lib; {
    homepage = http://example.com;
  };
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
