### PR TITLE
ghc-8.2.2: Oops, added adjacent patch the one I wanted

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2.nix
+++ b/pkgs/development/compilers/ghc/8.2.2.nix
@@ -110,8 +110,8 @@ stdenv.mkDerivation (rec {
       stripLen = 1;
     })
     (fetchpatch {
-      url = "https://git.haskell.org/hsc2hs.git/patch/d1e191766742e9166a90656c94a7cf3bd73444df";
-      sha256 = "0q25n0k0sbgji6qvalx5j3lmw80j2k0d2k87k4v4y7xqc4ihpi12";
+      url = "https://git.haskell.org/hsc2hs.git/patch/598303cbffcd230635fbce28ce4105d177fdf76a";
+      sha256 = "0hqcg434qbh1bz1pk85cap2q4v9i8bs6x65yzq4spz6xk3zq6af7";
       extraPrefix = "utils/hsc2hs/";
       stripLen = 1;
     })


### PR DESCRIPTION
###### Motivation for this change

We need the one that changed the cabal file, not the one that changes the Travis job!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

