### PR TITLE
jetbrains.idea-community: add IntelliJ keyword to the longDescription

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -130,7 +130,8 @@ let
         longDescription = ''
           IDE for Java SE, Groovy & Scala development Powerful
           environment for building Google Android apps Integration
-          with JUnit, TestNG, popular SCMs, Ant & Maven.
+          with JUnit, TestNG, popular SCMs, Ant & Maven. Also known
+          as IntelliJ.
         '';
         maintainers = with maintainers; [ edwtjo ];
         platforms = platforms.linux;


### PR DESCRIPTION
This should make it easier to find the package under the name
IntelliJ in eg. [1]

If possible, please backport :)

[1] https://nixos.org/nixos/packages.html#intellij

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

