### PR TITLE
elm-format: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -107,26 +107,10 @@ let
 
 
             /*
-            This is not a core Elm package, and it's hosted on GitHub.
-            To update, run:
-
-                cabal2nix --jailbreak --revision refs/tags/foo http://github.com/avh4/elm-format > packages/elm-format.nix
-
-            where foo is a tag for a new version, for example "0.8.0".
+            The elm-format expression is updated via a script in the https://github.com/avh4/elm-format repo:
+            `pacakge/nix/build.sh`
             */
-            elm-format = overrideCabal (self.callPackage ./packages/elm-format.nix {  }) (drv: {
-              # https://github.com/avh4/elm-format/issues/529
-              patchPhase = ''
-                cat >Setup.hs <<EOF
-                import Distribution.Simple
-                main = defaultMain
-                EOF
-
-                sed -i '/Build_elm_format/d' elm-format.cabal
-                sed -i 's/Build_elm_format.gitDescribe/""/' src/ElmFormat/Version.hs
-                sed -i '/Build_elm_format/d' src/ElmFormat/Version.hs
-              '';
-            });
+            elm-format = self.callPackage ./packages/elm-format.nix {};
           };
       in elmPkgs // {
         inherit elmPkgs;
@@ -134,6 +118,7 @@ let
 
         # Needed for elm-format
         indents = self.callPackage ./packages/indents.nix {};
+        tasty-quickcheck = self.callPackage ./packages/tasty-quickcheck.nix {};
       };
   };
 in hsPkgs.elmPkgs

--- a/pkgs/development/compilers/elm/packages/elm-format.nix
+++ b/pkgs/development/compilers/elm/packages/elm-format.nix
@@ -1,17 +1,21 @@
-{ mkDerivation, ansi-terminal, ansi-wl-pprint, base, binary
-, bytestring, Cabal, cmark, containers, directory, fetchgit
-, filepath, free, HUnit, indents, json, mtl, optparse-applicative
-, parsec, process, QuickCheck, quickcheck-io, split, stdenv, tasty
-, tasty-golden, tasty-hunit, tasty-quickcheck, text
+{ mkDerivation, fetchgit, ansi-terminal, ansi-wl-pprint, base, binary
+, bytestring, Cabal, cmark, containers, directory, filepath, free
+, HUnit, indents, json, mtl, optparse-applicative, parsec, process
+, QuickCheck, quickcheck-io, split, stdenv, tasty, tasty-golden
+, tasty-hunit, tasty-quickcheck, text
 }:
 mkDerivation {
   pname = "elm-format";
-  version = "0.8.0";
+  version = "0.8.1";
   src = fetchgit {
     url = "http://github.com/avh4/elm-format";
-    sha256 = "1w79xvsyq98vfz3jb4sv8433vdh6pcg8s7yh54lcxzr1p08yhsb6";
-    rev = "f19ac28046d7e83ff95f845849c033cc616f1bd6";
+    sha256 = "0p1dy1m6illsl7i04zsv5jqw7i4znv7pfpdfm53zy0k7mq0fk09j";
+    rev = "89694e858664329e3cbdaeb71b15c4456fd739ff";
   };
+  postPatch = ''
+    sed -i "s|desc <-.*||" ./Setup.hs
+    sed -i "s|gitDescribe = .*|gitDescribe = \\\\\"0.8.1\\\\\"\"|" ./Setup.hs
+  '';
   isLibrary = true;
   isExecutable = true;
   setupHaskellDepends = [ base Cabal directory filepath process ];
@@ -26,8 +30,6 @@ mkDerivation {
     split tasty tasty-golden tasty-hunit tasty-quickcheck text
   ];
   doHaddock = false;
-  jailbreak = true;
-  doCheck = false;
   homepage = "http://elm-lang.org";
   description = "A source code formatter for Elm";
   license = stdenv.lib.licenses.bsd3;

--- a/pkgs/development/compilers/elm/packages/tasty-quickcheck.nix
+++ b/pkgs/development/compilers/elm/packages/tasty-quickcheck.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, pcre-light, QuickCheck, random, stdenv
+, tagged, tasty, tasty-hunit
+}:
+mkDerivation {
+  pname = "tasty-quickcheck";
+  version = "0.9.2";
+  sha256 = "c5920adeab6e283d5e3ab45f3c80a1b011bedfbe4a3246a52606da2e1da95873";
+  libraryHaskellDepends = [ base QuickCheck random tagged tasty ];
+  testHaskellDepends = [ base pcre-light tasty tasty-hunit ];
+  doCheck = false;
+  homepage = "https://github.com/feuerbach/tasty";
+  description = "QuickCheck support for the Tasty test framework";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/development/compilers/elm/update.sh
+++ b/pkgs/development/compilers/elm/update.sh
@@ -1,3 +1,1 @@
 cabal2nix https://github.com/elm/compiler --revision  32059a289d27e303fa1665e9ada0a52eb688f302 > packages/elm.nix
-cabal2nix --no-check cabal://indents-0.3.3 > packages/indents.nix
-cabal2nix --no-haddock --no-check --jailbreak --revision refs/tags/0.8.0 http://github.com/avh4/elm-format > packages/elm-format.nix


### PR DESCRIPTION
###### Motivation for this change

New official release of elm-format: https://github.com/avh4/elm-format/releases/tag/0.8.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

