### PR TITLE
jetbrains: add libnotify to wrapper to enable notifications

### DIFF
--- a/pkgs/applications/editors/jetbrains/common.nix
+++ b/pkgs/applications/editors/jetbrains/common.nix
@@ -1,5 +1,5 @@
 { stdenv, makeDesktopItem, makeWrapper, patchelf, p7zip
-, coreutils, gnugrep, which, git, unzip, libsecret
+, coreutils, gnugrep, which, git, unzip, libsecret, libnotify
 }:
 
 { name, product, version, src, wmClass, jdk, meta }:
@@ -67,6 +67,7 @@ with stdenv; lib.makeOverridable mkDerivation rec {
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         # Some internals want libstdc++.so.6
         stdenv.cc.cc.lib libsecret
+        libnotify
       ]}" \
       --set JDK_HOME "$jdk" \
       --set ${hiName}_JDK "$jdk" \


### PR DESCRIPTION
###### Motivation for this change

System notifications weren't available in the corresponding menu. Also, the log showed:

```
ntellij.ui.SystemNotifications - Unable to load library 'libnotify.so.4': Native library (linux-x86-64/libnotify.so.4) not found in resource path (/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/bootstrap.jar:/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/extensions.jar:/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/util.jar:/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/jdom.jar:/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/log4j.jar:/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/trove4j.jar:/nix/store/qqsvlbrn6k6drb9bhd85zx1jv2fgp147-idea-community-2018.2.2/idea-community-2018.2.2/lib/jna.jar:/nix/store/llz3210kc2fmidfizx68k0hl8qzb5nzp-jetbrainsjdk-152b1248.6/lib/tools.jar)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

