### PR TITLE
WIP emby: 3.5.2.0 -> 3.5.3.0 and migration from mono to dotnet

### DIFF
--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -32,14 +32,14 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -dm 755 "$out/lib/emby-server"
-    cp -r * "$out/lib/emby-server"
+    install -dm 755 "$out/opt/emby-server"
+    cp -r * "$out/opt/emby-server"
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/emby \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         sqlite
       ]}" \
-      --add-flags "$out/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
+      --add-flags "$out/opt/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
   meta =  with stdenv.lib; {

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -36,6 +36,9 @@ stdenv.mkDerivation rec {
     cp -r * "$out/usr/lib/emby-server"
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/emby \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
+        sqlite
+      ]}" \
       --add-flags "$out/usr/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 

--- a/pkgs/servers/emby/default.nix
+++ b/pkgs/servers/emby/default.nix
@@ -32,14 +32,14 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -dm 755 "$out/usr/lib/emby-server"
-    cp -r * "$out/usr/lib/emby-server"
+    install -dm 755 "$out/lib/emby-server"
+    cp -r * "$out/lib/emby-server"
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/emby \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
         sqlite
       ]}" \
-      --add-flags "$out/usr/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
+      --add-flags "$out/lib/emby-server/EmbyServer.dll -programdata /var/lib/emby/ProgramData-Server -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
   '';
 
   meta =  with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Fixes #47658

This release is not available as a mono build, so I tried to make it work with dotnet

## Current situation

By launching it manually it seems to be working as it is

### Fixed

I didn't manage to make it work yet, if you have any suggestion please make a comment.

Execution of `bin/emby` for now:
```
System.DllNotFoundException: Unable to load shared library 'sqlite3' or one of its dependencies.
```

Previously this was fixed by editing the file `SQLitePCLRaw.provider.sqlite3.dll.config`, but it is not present anymore and creating it doesn't have any effects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

