### PR TITLE
theme-obsidian2: fix theme name in index.theme

### DIFF
--- a/pkgs/misc/themes/obsidian2/default.nix
+++ b/pkgs/misc/themes/obsidian2/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
 
+  postPatch = ''
+    sed -i -e 's|Obsidian-2-Local|Obsidian-2|' Obsidian-2/index.theme
+  '';
+
   installPhase = ''
     mkdir -p $out/share/themes
     cp -a Obsidian-2 $out/share/themes


### PR DESCRIPTION
###### Motivation for this change

Remove the suffix `-Local` from the theme name in file `index.theme`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).