### PR TITLE
wmfocus: init at 1.0.2

### DIFF
--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, rustPlatform,
+  xorg, python3, pkgconfig, glib, cmake, cairo, libxkbcommon }:
+let
+  pname = "wmfocus";
+  version = "1.0.2";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
+  name = "${pname}-${version}";
+
+  buildInputs = [python3 pkgconfig glib xorg.libX11 cmake cairo xorg.libX11];
+  nativeBuildInputs = [libxkbcommon xorg.libxcb xorg.xcbutilkeysyms];
+
+  # For now, this is the only available featureset. This is also why the file is
+  # in the i3 folder, even though it might be useful for more than just i3
+  # users.
+  cargoBuildFlags = ["--features i3"];
+
+  src = fetchFromGitHub {
+    owner = "svenstaro";
+    repo = pname;
+    rev = version;
+    sha256 = "14yxg2jiqx7gng677sbmvv0a0msb9wpvp3qh8h3nkq0vi17ds668";
+  };
+
+  cargoSha256 = "0lwzw8gf970ybblaxxkwn3pxrncxp0hhvykffbzirs7fic4fnvsg";
+
+  meta = with stdenv.lib; {
+    description = ''
+      Tool that allows you to rapidly choose a specific window directly
+      without having to use the mouse or directional keyboard navigation.
+    '';
+    maintainers = with maintainers; [ synthetica ];
+    platforms = platforms.linux;
+    license = licenses.mit;
+    homepage = https://github.com/svenstaro/wmfocus;
+  };
+}

--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, rustPlatform,
-  xorg, python3, pkgconfig, glib, cmake, cairo, libxkbcommon }:
+  xorg, python3, pkgconfig, cairo, libxkbcommon }:
 let
   pname = "wmfocus";
   version = "1.0.2";
@@ -8,8 +8,8 @@ rustPlatform.buildRustPackage {
   inherit pname version;
   name = "${pname}-${version}";
 
-  buildInputs = [python3 pkgconfig glib xorg.libX11 cmake cairo xorg.libX11];
-  nativeBuildInputs = [libxkbcommon xorg.libxcb xorg.xcbutilkeysyms];
+  nativeBuildInputs = [ python3 pkgconfig ];
+  buildInputs = [ cairo libxkbcommon xorg.xcbutilkeysyms ];
 
   # For now, this is the only available featureset. This is also why the file is
   # in the i3 folder, even though it might be useful for more than just i3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17045,6 +17045,8 @@ with pkgs;
 
   i3-wk-switch = callPackage ../applications/window-managers/i3/wk-switch.nix { };
 
+  wmfocus = callPackage ../applications/window-managers/i3/wmfocus.nix { };
+
   i810switch = callPackage ../os-specific/linux/i810switch { };
 
   icewm = callPackage ../applications/window-managers/icewm {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

