### PR TITLE
maintainers/maintainer-list.nix: add PGP/GPG fingerprints

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1,21 +1,27 @@
 /* List of NixOS maintainers.
 
     handle = {
+      # Required
       name = "Real name";
       email = "address@example.org";
+
+      # Optional
       github = "GithubUsername";
     };
 
-  where `name` is your real name, `email` is your maintainer email
-  address and `github` is your GitHub handle (as it appears in the
-  URL of your profile page, `https://github.com/<userhandle>`).
- address
-  The only required fields are `name` and `email`.
+  where
+
+  - `handle` is the handle you are going to use in nixpkgs expressions,
+  - `name` is your real name,
+  - `email` is your maintainer email address, and
+  - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`).
+
+  `handle == github` is strongly preffered whenever `github` is an acceptable attribute name and is short and convenient.
+
   More fields may be added in the future.
 
   Please keep the list alphabetically sorted.
-  See `../maintainers/scripts/check-maintainer-github-handles.sh`
-  for an example on how to work with this data.
+  See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
   */
 {
   "1000101" = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7,6 +7,10 @@
 
       # Optional
       github = "GithubUsername";
+      keys = [{
+        longkeyid = "rsa2048/0x0123456789ABCDEF";
+        fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
+      }];
     };
 
   where
@@ -14,9 +18,19 @@
   - `handle` is the handle you are going to use in nixpkgs expressions,
   - `name` is your, preferably real, name,
   - `email` is your maintainer email address, and
-  - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`).
+  - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
+  - `keys` is a list of your PGP/GPG key IDs and fingerprints.
 
   `handle == github` is strongly preffered whenever `github` is an acceptable attribute name and is short and convenient.
+
+  Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
+
+  To get the required PGP/GPG values for a key run
+  ```shell
+  gpg --keyid-format 0xlong --fingerprint <email> | head -n 2
+  ```
+
+  !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
 
   More fields may be added in the future.
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3119,6 +3119,10 @@
     email = "oxij@oxij.org";
     github = "oxij";
     name = "Jan Malakhovski";
+    keys = [{
+      longkeyid = "rsa2048/0x0E6CA66E5C557AA8";
+      fingerprint = "514B B966 B46E 3565 0508  86E8 0E6C A66E 5C55 7AA8";
+    }];
   };
   oyren = {
     email = "m.scheuren@oyra.eu";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2,7 +2,7 @@
 
     handle = {
       # Required
-      name = "Real name";
+      name = "Your name";
       email = "address@example.org";
 
       # Optional
@@ -12,7 +12,7 @@
   where
 
   - `handle` is the handle you are going to use in nixpkgs expressions,
-  - `name` is your real name,
+  - `name` is your, preferably real, name,
   - `email` is your maintainer email address, and
   - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`).
 


### PR DESCRIPTION
###### Motivation for this change

A first tiny step towards https://github.com/NixOS/rfcs/pull/34

###### Things done

- [X] It evaluates.