### PR TITLE
initrd.network: support predictable interface names 

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -121,6 +121,8 @@ in rec {
         (all nixos.tests.predictable-interface-names.unpredictable)
         (all nixos.tests.predictable-interface-names.predictableNetworkd)
         (all nixos.tests.predictable-interface-names.unpredictableNetworkd)
+        (all nixos.tests.predictable-interface-names.predictableInitrdNetwork)
+        (all nixos.tests.predictable-interface-names.unpredictableInitrdNetwork)
         (all nixos.tests.printing)
         (all nixos.tests.proxy)
         (all nixos.tests.sddm.default)

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -2,11 +2,14 @@
 
 let
   inherit (import ../lib/testing.nix { inherit system; }) makeTest pkgs;
-in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
-  name = pkgs.lib.optionalString (!predictable) "un" + "predictable"
-       + pkgs.lib.optionalString withNetworkd "Networkd";
+  inherit (pkgs) lib;
+in lib.listToAttrs (map ({ predictable, withNetworkd ? false, withInitrdNetwork ? false }: rec {
+  name = lib.optionalString (!predictable) "un" + "predictable"
+       + lib.optionalString withNetworkd "Networkd"
+       + lib.optionalString withInitrdNetwork "InitrdNetwork";
+
   value = makeTest {
-    name = "${if predictable then "" else "un"}predictableInterfaceNames${if withNetworkd then "-with-networkd" else ""}";
+    name = builtins.replaceStrings ["predictable"] ["predictableInterfaceNames"] name;
     meta = {};
 
     machine = { lib, ... }: {
@@ -14,6 +17,14 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
       networking.usePredictableInterfaceNames = lib.mkForce predictable;
       networking.useNetworkd = withNetworkd;
       networking.dhcpcd.enable = !withNetworkd;
+      boot.initrd.network.enable = withInitrdNetwork;
+
+      # Ensure initrd DHCP works with predictable names.
+      # Use the same method as in tests/initrd-network.nix
+      boot.initrd.network.postCommands = lib.mkIf (predictable && !withNetworkd && withInitrdNetwork) ''
+        ip addr | grep 10.0.2.15 || exit 1
+        ping -c1 10.0.2.2 || exit 1
+      '';
     };
 
     testScript = ''
@@ -22,4 +33,13 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
       $machine->fail("ip link show ${if predictable then "eth0" else "ens3"}");
     '';
   };
-}) [[true false] [true false]])
+}) [
+  { predictable = true; }
+  { predictable = false; }
+
+  { withNetworkd = true; predictable = true; }
+  { withNetworkd = true; predictable = false; }
+
+  { withInitrdNetwork = true; predictable = true; }
+  { withInitrdNetwork = true; predictable = false; }
+])

--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -10,6 +10,7 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
     meta = {};
 
     machine = { lib, ... }: {
+      imports = [ ../modules/profiles/minimal.nix ];
       networking.usePredictableInterfaceNames = lib.mkForce predictable;
       networking.useNetworkd = withNetworkd;
       networking.dhcpcd.enable = !withNetworkd;


### PR DESCRIPTION
#### Copy of main commit msg:
When `initrd.network.enable` and `networking.usePredictableInterfaceNames`
are enabled, apply predictable interface naming in initrd.

This also fixes a bug:
Previously, setting `initrd.network.enable` effectively disabled option
`networking.usePredictableInterfaceNames`.
Reason: Interfaces brought up in initrd are not renamed by udev in boot
stage 2. So the unpredictable names assigned in initrd remained
unchanged after booting.

Implementation notes:
udhcpc uses eth0 as the default interface.
When predictable names are enabled, use the lexicographically
first Ethernet interface (en*) instead.

##### Things done:
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))


