### PR TITLE
pythonPackages.pvlib: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "pvlib";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1897v9qq97nk5n0hfm9089yz8pffd42795mnhcyq48g9bsyap1xi";
+    sha256 = "1j2p6w41hv7k604jbcpxvs5f04y8dsfdvd3d202l60ks0fc0agyj";
   };
 
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change

Update Python package pvlib.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

