### PR TITLE
i3lock-color: 2.11-c -> 2.12.c

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-color.nix
+++ b/pkgs/applications/window-managers/i3/lock-color.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libxcb,
   xcbutilkeysyms , xcbutilimage, pam, libX11, libev, cairo, libxkbcommon,
-  libxkbfile, libjpeg_turbo
+  libxkbfile, libjpeg_turbo, xcbutilxrm
 }:
 
 stdenv.mkDerivation rec {
-  version = "2.11-c";
+  version = "2.12.c";
   name = "i3lock-color-${version}";
 
   src = fetchFromGitHub {
     owner = "PandorasFox";
     repo = "i3lock-color";
     rev = version;
-    sha256 = "1myq9fazkwd776agrnj27bm5nwskvss9v9a5qb77n037dv8d0rdw";
+    sha256 = "08fhnchf187b73h52xgzb86g6byzxz085zs9galsvl687g5zxk34";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libxcb xcbutilkeysyms xcbutilimage pam libX11
-    libev cairo libxkbcommon libxkbfile libjpeg_turbo ];
+    libev cairo libxkbcommon libxkbfile libjpeg_turbo xcbutilxrm ];
 
   makeFlags = "all";
   preInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Note the change in naming scheme, this is intentional
(https://github.com/PandorasFox/i3lock-color/issues/92)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

