### PR TITLE
haskell: fix x509-system on mojave

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -131,8 +131,16 @@ self: super: builtins.intersectAttrs super {
   x509-system = if pkgs.stdenv.hostPlatform.isDarwin && !pkgs.stdenv.cc.nativeLibc
     then let inherit (pkgs.darwin) security_tool;
       in pkgs.lib.overrideDerivation (addBuildDepend super.x509-system security_tool) (drv: {
+        # darwin.security_tool is broken in Mojave (#45042)
+
+        # We will use the system provided security for now.
+        # Beware this WILL break in sandboxes!
+
+        # TODO(matthewbauer): If someone really needs this to work in sandboxes,
+        # I think we can add a propagatedImpureHost dep here, but I’m hoping to
+        # get a proper fix available soonish.
         postPatch = (drv.postPatch or "") + ''
-          substituteInPlace System/X509/MacOS.hs --replace security ${security_tool}/bin/security
+          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
         '';
       })
     else super.x509-system;


### PR DESCRIPTION
darwin.security_tool is currently broken in Mojave. See issue #45042
for more info. Our security_tool stuff comes from 10.9 so I suspect
that it needs an update.

Here I am putting in a hack to get things working again. This uses the
system provided security binary at /usr/bin/security to avoid the
issue in Haskell’s x509-system package. Unfortunately, this will break
with the sandbox. I am also working on a proper fix, but this requires
updating lots of Apple stuff (and also copumpkin’s new CF). You can
follow the progress on this branch:

  https://github.com/matthewbauer/nixpkgs/tree/xcode-security

This commit should be backported to release-18.03 and release-18.09.

/cc @copumpkin @lnl7 @pikajude
