### PR TITLE
Add 4 companion apps for applications/audio/fldigi

### DIFF
--- a/pkgs/applications/misc/fllog/default.nix
+++ b/pkgs/applications/misc/fllog/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchurl
+, fltk13
+, libjpeg
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.2.5";
+  pname = "fllog";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/fldigi/${name}.tar.gz";
+    sha256 = "042j1g035338vfbl4i9laai8af8iakavar05xn2m4p7ww6x76zzl";
+  };
+
+  buildInputs = [
+    fltk13
+    libjpeg
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  meta = {
+    description = "Digital modem log program";
+    homepage = https://sourceforge.net/projects/fldigi/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ dysinger ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/flmsg/default.nix
+++ b/pkgs/applications/misc/flmsg/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchurl
+, fltk13
+, libjpeg
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  version = "4.0.7";
+  pname = "flmsg";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/fldigi/${name}.tar.gz";
+    sha256 = "1kdlwhxsw02pas9d0kakkq2713wj1m4q881f6am5aq4x8n01f4xw";
+  };
+
+  buildInputs = [
+    fltk13
+    libjpeg
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  meta = {
+    description = "Digital modem message program";
+    homepage = https://sourceforge.net/projects/fldigi/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ dysinger ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/flrig/default.nix
+++ b/pkgs/applications/misc/flrig/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchurl
+, fltk13
+, libjpeg
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.3.40";
+  pname = "flrig";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/fldigi/${name}.tar.gz";
+    sha256 = "1wr7bb2577gha7y3a8m5w60m4xdv8m0199cj2c6349sgbds373w9";
+  };
+
+  buildInputs = [
+    fltk13
+    libjpeg
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  meta = {
+    description = "Digital modem rig control program";
+    homepage = https://sourceforge.net/projects/fldigi/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ dysinger ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/flwrap/default.nix
+++ b/pkgs/applications/misc/flwrap/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchurl
+, fltk13
+, libjpeg
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  version = "1.3.5";
+  pname = "flwrap";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/fldigi/${name}.tar.gz";
+    sha256 = "0qqivqkkravcg7j45740xfky2q3k7czqpkj6y364qff424q2pppg";
+  };
+
+  buildInputs = [
+    fltk13
+    libjpeg
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  meta = {
+    description = "Digital modem file transfer program";
+    homepage = https://sourceforge.net/projects/fldigi/;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = with stdenv.lib.maintainers; [ dysinger ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16431,6 +16431,8 @@ with pkgs;
   flink = callPackage ../applications/networking/cluster/flink { };
   flink_1_5 = flink.override { version = "1.5"; };
 
+  flmsg = callPackage ../applications/misc/flmsg { };
+
   fluidsynth = callPackage ../applications/audio/fluidsynth {
      inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio CoreMIDI CoreServices;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16433,6 +16433,8 @@ with pkgs;
 
   flmsg = callPackage ../applications/misc/flmsg { };
 
+  flwrap = callPackage ../applications/misc/flwrap { };
+
   fluidsynth = callPackage ../applications/audio/fluidsynth {
      inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio CoreMIDI CoreServices;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16431,6 +16431,8 @@ with pkgs;
   flink = callPackage ../applications/networking/cluster/flink { };
   flink_1_5 = flink.override { version = "1.5"; };
 
+  fllog = callPackage ../applications/misc/fllog { };
+
   flmsg = callPackage ../applications/misc/flmsg { };
 
   flrig = callPackage ../applications/misc/flrig { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16433,6 +16433,8 @@ with pkgs;
 
   flmsg = callPackage ../applications/misc/flmsg { };
 
+  flrig = callPackage ../applications/misc/flrig { };
+
   flwrap = callPackage ../applications/misc/flwrap { };
 
   fluidsynth = callPackage ../applications/audio/fluidsynth {


### PR DESCRIPTION
###### Motivation for this change

There are many companion apps to 'fldigi' missing from nixpkgs. http://www.w1hkj.com/

This app is not really "audio" but rather is a digital communication platform primarily used for ham radio. The companion apps are external to fldigi but integrate into fldigi in the preferences.

![2018-10-02-091644_1920x1080_scrot](https://user-images.githubusercontent.com/447/46371572-6034de80-c624-11e8-8acb-507233aa926c.png)

Side comment: nixpkgs really needs a "ham radio" section in the package tree (not unlike applications/science). There are a ton of ham radio apps. Debian even has a dedicated distro/flavor for hams. Some of the existing ham apps are in "misc" and some in "audio" right now on nixpkgs. Just for now I put these fldigi apps in "misc" along side WSJTX because they are definitely not 'audio' apps.

This is my first P/R to nixpkgs so please tell me all things I need to do to correctly get this finished. I see a big checklist below but all I've done is create the packages and use them on my nixos machine for a few days. They work on Nixos and aren't complicated packages. I imagine they'd work anywhere that fldigi works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

