### PR TITLE
Document make-channel.nix

### DIFF
--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -1,3 +1,7 @@
+/* Build a channel tarball. These contain, in addition to the nixpkgs
+ * expressions themselves, files that indicate the version of nixpkgs
+ * that they represent. This only seems to be used by Travis.
+ */
 { pkgs, nixpkgs, version, versionSuffix }:
 
 pkgs.releaseTools.makeSourceTarball {

--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -1,6 +1,6 @@
 /* Build a channel tarball. These contain, in addition to the nixpkgs
  * expressions themselves, files that indicate the version of nixpkgs
- * that they represent. This only seems to be used by Travis.
+ * that they represent.
  */
 { pkgs, nixpkgs, version, versionSuffix }:
 


### PR DESCRIPTION
###### Motivation for this change

This documentation was written 11 months ago by @lheckemann during the NixCon 2017 hackathon. I've rebased it so it can be of use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

