### PR TITLE
docs: lib/options.nix function documentation

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -8,7 +8,31 @@ with lib.strings;
 
 rec {
 
+  # Returns true when the given argument is an option
+  #
+  # Examples:
+  #   isOption 1             // => false
+  #   isOption (mkOption {}) // => true
   isOption = lib.isType "option";
+
+  # Creates an Option attribute set. mkOption accepts an attribute set with the following keys:
+  #
+  #  default:     Default value used when no definition is given in the configuration.
+  #  defaultText: Textual representation of the default, for in the manual.
+  #  example:     Example value used in the manual.
+  #  description: String describing the option.
+  #  type:        Option type, providing type-checking and value merging.
+  #  apply:       Function that converts the option value to something else.
+  #  internal:    Whether the option is for NixOS developers only.
+  #  visible:     Whether the option shows up in the manual.
+  #  readOnly:    Whether the option can be set only once
+  #  options:     Obsolete, used by types.optionSet.
+  #
+  # All keys default to `null` when not given.
+  #
+  # Examples:
+  #   mkOption { }  // => { _type = "option"; }
+  #   mkOption { defaultText = "foo"; } // => { _type = "option"; defaultText = "foo"; }
   mkOption =
     { default ? null # Default value used when no definition is given in the configuration.
     , defaultText ? null # Textual representation of the default, for in the manual.
@@ -24,6 +48,10 @@ rec {
     } @ attrs:
     attrs // { _type = "option"; };
 
+  # Creates a Option attribute set for a boolean value option i.e an option to be toggled on or off:
+  #
+  # Examples:
+  #   mkEnableOption "foo" // => { _type = "option"; default = false; description = "Whether to enable foo."; example = true; type = { ... }; }
   mkEnableOption = name: mkOption {
     default = false;
     example = true;
@@ -74,7 +102,18 @@ rec {
       else
         val) (head defs).value defs;
 
+  # Extracts values of all "value" keys of the given list
+  #
+  # Examples:
+  #   getValues [ { value = 1; } { value = 2; } ] // => [ 1 2 ]
+  #   getValues [ ]                               // => [ ]
   getValues = map (x: x.value);
+
+  # Extracts values of all "file" keys of the given list
+  #
+  # Examples:
+  #   getFiles [ { file = "file1"; } { file = "file2"; } ] // => [ "file1" "file2" ]
+  #   getFiles [ ]                                         // => [ ]
   getFiles = map (x: x.file);
 
   # Generate documentation template from the list of option declaration like


### PR DESCRIPTION
###### Motivation for this change

This documentation was written 11 months ago by @gilligan during the NixCon 2017 hackathon. I've rebased it so it can be of use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

