### PR TITLE
Add pkgs.nixosTest

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -1,4 +1,13 @@
-{ system, pkgs, minimal ? false, config ? {} }:
+{ system
+, # Use a minimal kernel?
+  minimal ? false
+, # Ignored
+  config ? null
+  # Nixpkgs, for qemu, lib and more
+, pkgs
+, # NixOS configuration to add to the VMs
+  extraConfigurations ? []
+}:
 
 with pkgs.lib;
 with import ../lib/qemu-flags.nix { inherit pkgs; };
@@ -28,7 +37,8 @@ rec {
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
-        ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
+        ] ++ optional minimal ../modules/testing/minimal-kernel.nix
+          ++ extraConfigurations;
       extraArgs = { inherit nodes; };
     };
 

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -1,6 +1,13 @@
-{ system, pkgs, minimal ? false, config ? {} }:
+{ system
+, pkgs
+  # Use a minimal kernel?
+, minimal ? false
+  # Ignored
+, config ? null
+  # Modules to add to each VM
+, extraConfigurations ? [] }:
 
-with import ./build-vms.nix { inherit system pkgs minimal config; };
+with import ./build-vms.nix { inherit system pkgs minimal extraConfigurations; };
 with pkgs;
 
 let

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -30,5 +30,7 @@ with pkgs;
 
   cross = callPackage ./cross {};
 
+  nixos-functions = callPackage ./nixos-functions {};
+
   patch-shebangs = callPackage ./patch-shebangs {};
 }

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -1,3 +1,14 @@
+/*
+
+This file is a test that makes sure that the `pkgs.nixos` and
+`pkgs.nixosTest` functions work. It's far from a perfect test suite,
+but better than not checking them at all on hydra.
+
+To run this test:
+
+    nixpkgs$ nix-build -A tests.nixos-functions
+
+ */
 { pkgs, lib, stdenv, ... }:
 
 lib.optionalAttrs stdenv.hostPlatform.isLinux (

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -1,0 +1,32 @@
+{ pkgs, lib, stdenv, ... }:
+
+lib.optionalAttrs stdenv.hostPlatform.isLinux (
+  pkgs.recurseIntoAttrs {
+
+    nixos-test = (pkgs.nixos {
+      boot.loader.grub.enable = false;
+      fileSystems."/".device = "/dev/null";
+    }).toplevel;
+
+    nixosTest-test = let
+      # extend pkgs with an extra overlay to make sure pkgs is passed along properly to machines.
+      altPkgs = pkgs.extend (self: super: {
+        # To test pkgs in machine
+        hello_s9e8ghsi = self.hello;
+        # To test lib in test
+        lib = super.lib // { testSubject_dohra8w = "nixosTest"; };
+        # To test pkgs in test
+        dash-test_ny3dseg = "-test";
+       });
+    in altPkgs.nixosTest ({ lib, pkgs, ... }: {
+      name = "${lib.testSubject_dohra8w}${pkgs.dash-test_ny3dseg}"; # These would fail if it's the wrong pkgs or lib
+      machine = { pkgs, ... }: {
+        environment.systemPackages = [ pkgs.hello_s9e8ghsi ];
+      };
+      testScript = ''
+        $machine->succeed("hello");
+      '';
+    });
+
+  }
+)

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -8,20 +8,10 @@ lib.optionalAttrs stdenv.hostPlatform.isLinux (
       fileSystems."/".device = "/dev/null";
     }).toplevel;
 
-    nixosTest-test = let
-      # extend pkgs with an extra overlay to make sure pkgs is passed along properly to machines.
-      altPkgs = pkgs.extend (self: super: {
-        # To test pkgs in machine
-        hello_s9e8ghsi = self.hello;
-        # To test lib in test
-        lib = super.lib // { testSubject_dohra8w = "nixosTest"; };
-        # To test pkgs in test
-        dash-test_ny3dseg = "-test";
-       });
-    in altPkgs.nixosTest ({ lib, pkgs, ... }: {
-      name = "${lib.testSubject_dohra8w}${pkgs.dash-test_ny3dseg}"; # These would fail if it's the wrong pkgs or lib
+    nixosTest-test = pkgs.nixosTest ({ lib, pkgs, ... }: {
+      name = "nixosTest-test";
       machine = { pkgs, ... }: {
-        environment.systemPackages = [ pkgs.hello_s9e8ghsi ];
+        environment.systemPackages = [ pkgs.hello ];
       };
       testScript = ''
         $machine->succeed("hello");

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22245,10 +22245,14 @@ with pkgs;
 
 
   /*
-   * Run a NixOS VM network test.
+   * Run a NixOS VM network test using this evaluation of Nixpkgs.
    *
-   * This is equivalent to `import ./make-test.nix` from the NixOS manual
-   * For details see https://nixos.org/nixos/manual/index.html#sec-nixos-tests
+   * It is mostly equivalent to `import ./make-test.nix` from the
+   * NixOS manual[1], except that your `pkgs` will be used instead of
+   * letting NixOS invoke Nixpkgs again. If a test machine needs to
+   * set NixOS options under `nixpkgs`, it must set only the
+   * `nixpkgs.pkgs` option. For the details, see the Nixpkgs
+   * `pkgs.nixos` documentation.
    *
    * Parameter:
    *   A NixOS VM test network, or path to it. Example:
@@ -22264,8 +22268,8 @@ with pkgs;
    * Result:
    *   A derivation that runs the VM test.
    *
-   * For the interaction between Nixpkgs and NixOS configuration
-   * consult the pkgs.nixos function documentation.
+   * [1]: For writing NixOS tests, see
+   *      https://nixos.org/nixos/manual/index.html#sec-nixos-tests
    */
   nixosTest =
     let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22243,6 +22243,57 @@ with pkgs;
                 );
     }).config.system.build;
 
+
+  /*
+   * Run a NixOS VM network test.
+   *
+   * This is equivalent to  import ./make-test.nix  from the NixOS manual
+   * For details see https://nixos.org/nixos/manual/index.html#sec-nixos-tests
+   *
+   * Parameter:
+   *   A NixOS VM test network, or path to it. Example:
+   *
+   *      { lib, ... }:
+   *      { name = "my-test";
+   *        nodes = {
+   *          machine-1 = someNixOSConfiguration;
+   *          machine-2 = ...;
+   *        }
+   *      }
+   *
+   * Result:
+   *   A derivation that runs the VM test.
+   *
+   * For the interaction between Nixpkgs and NixOS configuration
+   * consult the pkgs.nixos function documentation.
+   */
+  nixosTest =
+    let
+      /* The nixos/lib/testing.nix module, preapplied with arguments that
+       * make sense for this evaluation of Nixpkgs.
+       */
+      nixosTesting =
+        (import ../../nixos/lib/testing.nix {
+          inherit (pkgs.stdenv.hostPlatform) system;
+          inherit pkgs;
+          extraConfigurations = [(
+            { lib, ... }: {
+              config.nixpkgs.pkgs = lib.mkDefault pkgs;
+            }
+          )];
+        });
+    in
+      test:
+        let
+          loadedTest = if builtins.typeOf test == "path"
+                       then import test
+                       else test;
+          calledTest = if pkgs.lib.isFunction loadedTest
+                       then callPackage loadedTest {}
+                       else loadedTest;
+        in
+          nixosTesting.makeTest calledTest;
+
   nixui = callPackage ../tools/package-management/nixui { node_webkit = nwjs_0_12; };
 
   nixdoc = callPackage ../tools/nix/nixdoc {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22247,7 +22247,7 @@ with pkgs;
   /*
    * Run a NixOS VM network test.
    *
-   * This is equivalent to  import ./make-test.nix  from the NixOS manual
+   * This is equivalent to `import ./make-test.nix` from the NixOS manual
    * For details see https://nixos.org/nixos/manual/index.html#sec-nixos-tests
    *
    * Parameter:


### PR DESCRIPTION
###### Motivation for this change

This makes writing NixOS tests easier and faster for project that use Nixpkgs, because it reuses the applied `pkgs`.

(The fast aspect was available since `config.nixpkgs.pkgs` but its use is unlikely to have spread much)

This now also includes a test for `pkgs.nixos`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

