### PR TITLE
build GTK icon caches for some packages

### DIFF
--- a/pkgs/data/icons/maia-icon-theme/default.nix
+++ b/pkgs/data/icons/maia-icon-theme/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchFromGitHub, cmake, extra-cmake-modules, gtk3, kdeFrameworks }:
+{ stdenv, fetchFromGitLab, cmake, extra-cmake-modules, gtk3, kdeFrameworks, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "maia-icon-theme-${version}";
-  version = "2016-09-16";
+  version = "2018-02-24";
 
-  src = fetchFromGitHub {
-    owner = "manjaro";
-    repo = "artwork-maia";
-    rev = "f6718cd9c383adb77af54b694c47efa4d581f5b5";
-    sha256 = "0f9l3k9abgg8islzddrxgbxaw6vbai5bvz5qi1v2fzir7ykx7bgj";
+  src = fetchFromGitLab {
+    domain = "gitlab.manjaro.org";
+    group = "artwork";
+    owner = "themes";
+    repo = "maia";
+    rev = "b61312cc80cb9d12b0d8a55b3e61668eb6b77d2d";
+    sha256 = "1g98snlh96z4sqw9sfd7fxgamh45pcj3lh1kcmng7mirvrcn2pam";
   };
 
   nativeBuildInputs = [
@@ -19,10 +21,20 @@ stdenv.mkDerivation rec {
     kdeFrameworks.kwindowsystem
   ];
 
+  buildInputs = [
+    hicolor-icon-theme
+  ];
+
+  postFixup = ''
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+  '';
+
   meta = with stdenv.lib; {
     description = "Icons based on Breeze and Super Flat Remix";
-    homepage = https://github.com/manjaro/artwork-maia;
-    license = licenses.free; # https://github.com/manjaro/artwork-maia/issues/27
+    homepage = https://gitlab.manjaro.org/artwork/themes/maia;
+    license = licenses.lgpl3;
     maintainers = with maintainers; [ mounium ];
     platforms = platforms.all;
   };

--- a/pkgs/data/icons/paper-icon-theme/default.nix
+++ b/pkgs/data/icons/paper-icon-theme/default.nix
@@ -18,6 +18,11 @@ stdenv.mkDerivation rec {
     patchShebangs meson/post_install.py
   '';
 
+  postInstall = ''
+    # The cache for Paper-Mono-Dark is missing
+    gtk-update-icon-cache "$out"/share/icons/Paper-Mono-Dark;
+  '';
+
   meta = with stdenv.lib; {
     description = "Modern icon theme designed around bold colours and simple geometric shapes";
     homepage = https://snwh.org/paper;

--- a/pkgs/desktops/enlightenment/efl.nix
+++ b/pkgs/desktops/enlightenment/efl.nix
@@ -3,7 +3,7 @@
 , libsndfile, xorg, libdrm, libxkbcommon, udev, utillinux, bullet, luajit
 , python27Packages, openjpeg, doxygen, expat, harfbuzz, jbig2dec, librsvg
 , dbus, alsaLib, poppler, ghostscript, libraw, libspectre, xineLib, libwebp
-, curl, libinput, systemd, mesa_noglu, writeText
+, curl, libinput, systemd, mesa_noglu, writeText, gtk3
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "0a5907h896pvpix7a6idc2fspzy6d78xrzf84k8y9fyvnd14nxs4";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig gtk3 ];
 
   buildInputs = [ openssl zlib lz4 freetype fontconfig SDL libGL mesa_noglu
     giflib libpng libtiff glib gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
@@ -71,6 +71,9 @@ stdenv.mkDerivation rec {
     modules=$(for i in "$out/include/"*/; do printf ' -I''${includedir}/'`basename $i`; done)
     substituteInPlace "$out/lib/pkgconfig/efl.pc" --replace 'Cflags: -I''${includedir}/efl-1' \
       'Cflags: -I''${includedir}/eina-1/eina'"$modules"
+
+    # build icon cache
+    gtk-update-icon-cache "$out"/share/icons/Enlightenment-X
   '';
 
   # EFL applications depend on libcurl, although it is linked at

--- a/pkgs/desktops/gnome-3/core/gnome-themes-extra/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-themes-extra/default.nix
@@ -21,6 +21,10 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool ];
   buildInputs = [ gtk3 librsvg pango atk gtk2 gdk_pixbuf gnome3.defaultIconTheme ];
 
+  postFixup = ''
+    gtk-update-icon-cache "$out"/share/icons/HighContrast
+  '';
+
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     maintainers = gnome3.maintainers;

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, mate, hicolor-icon-theme }:
+{ stdenv, fetchurl, autoreconfHook, gtk3, mate, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-faenza-${version}";
@@ -9,10 +9,16 @@ stdenv.mkDerivation rec {
     sha256 = "000vr9cnbl2qlysf2gyg1lsjirqdzmwrnh6d3hyrsfc0r2vh4wna";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook gtk3 ];
 
   buildInputs = [ mate.mate-icon-theme hicolor-icon-theme ];
-  
+
+  postInstall = ''
+    for theme in "$out"/share/icons/*; do
+      gtk-update-icon-cache "$theme"
+    done
+  '';
+
   meta = {
     description = "Faenza icon theme from MATE";
     homepage = http://mate-desktop.org;

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, intltool, mate, gtk2, gtk_engines,
-  gtk-engine-murrine, gdk_pixbuf, librsvg }:
+{ stdenv, fetchurl, pkgconfig, intltool, mate, gtk2, gtk3,
+  gtk_engines, gtk-engine-murrine, gdk_pixbuf, librsvg }:
 
 stdenv.mkDerivation rec {
   name = "mate-themes-${version}";
@@ -10,11 +10,15 @@ stdenv.mkDerivation rec {
     sha256 = "0538bw8qismp16ymxbjk0ww7yjw1ch5v3f3d4vib3770xvgmmcfm";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig intltool gtk3 ];
 
   buildInputs = [ mate.mate-icon-theme gtk2 gtk_engines gdk_pixbuf librsvg ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  postInstall = ''
+    gtk-update-icon-cache "$out"/share/icons/ContrastHigh
+  '';
 
   meta = {
     description = "A set of themes from MATE";


### PR DESCRIPTION
###### Motivation for this change

- maia-icon-theme: 2016-09-16 -> 2018-02-24
- paper-icon-theme: build GTK icon cache for Paper-Mono-Dark
- efl: build GTK icon cache
- gnome-themes-extra: build GTK icon cache
- mate-icon-theme-faenza: build GTK icon cache
- mate-themes: build GTK icon cache

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

