### PR TITLE
nixos/matomo: introduce services.matomo.package option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -117,7 +117,11 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+     The <option>services.matomo</option> module gained the option
+     <option>services.matomo.package</option> which determines the used
+     Matomo version.
+    </para>
    </listitem>
   </itemizedlist>
  </section>


### PR DESCRIPTION
for e.g. being able to use an updated matomo from unstable or custom sources.

###### Motivation for this change
During 18.03's lifetime, I had several maintainership issues with Matomo releasing new versions that are not strictly security-relveant, but were still of crucial importance to a limited set of people.
The most prominent example was the GDPR update: If GDPR did not apply to you, you might would not want to risk the stability of your system, but for users in/targeting Europe, the update was crucial to be allowed to still operate a Matomo instance.

This option should allow me to be more strict on what's required for stable, as users really needing the update could easily get it from unstable with this option. The service definition itself is very unlikely to break with Matomo new releases, so this should just work.

Can we still get this into 18.09, at least eventually? I know I'm late, but this should not be able to break anything and help maintaining a stable Matomo during 18.09's lifetime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

