### PR TITLE
envsubst: init at 1.1.0

### DIFF
--- a/pkgs/tools/misc/envsubst/default.nix
+++ b/pkgs/tools/misc/envsubst/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "envsubst-${version}";
+  version = "1.1.0";
+
+  goPackagePath = "github.com/a8m/envsubst";
+  src = fetchFromGitHub {
+    owner = "a8m";
+    repo = "envsubst";
+    rev = "v${version}";
+    sha256 = "1d6nipagjn40n6iw1p3r489l2km5xjd5db9gbh1vc5sxc617l7yk";
+  };
+
+  meta = with lib; {
+    description = "Environment variables substitution for Go";
+    homepage = https://github.com/a8m/envsubst;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ nicknovitski ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1284,6 +1284,8 @@ with pkgs;
 
   envconsul = callPackage ../tools/system/envconsul { };
 
+  envsubst = callPackage ../tools/misc/envsubst { };
+
   eschalot = callPackage ../tools/security/eschalot { };
 
   esptool = callPackage ../tools/misc/esptool { };


### PR DESCRIPTION
The `envsubst` command in the `gettext` package is missing a feature: sometimes, you want it to fail if the document refers to an unset variable, to detect certain typos and incorrect invocations.  This tool is a go implementation of envsubst with that and a few other features.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- ~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- ~[ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- ~[ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---