### PR TITLE
treewide: fix evaluation problems

### DIFF
--- a/pkgs/applications/editors/flpsed/default.nix
+++ b/pkgs/applications/editors/flpsed/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fltk13, ghostscript, xlibs }:
+{ stdenv, fetchurl, fltk13, ghostscript }:
 
 stdenv.mkDerivation rec {
   name = "flpsed-${version}";

--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, cmake, pkgconfig, gettext
-, dbus, dbus_glib, libgaminggear, libgudev, lua
+, dbus, dbus-glib, libgaminggear, libgudev, lua
 }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ cmake pkgconfig gettext ];
-  buildInputs = [ dbus dbus_glib libgaminggear libgudev lua ];
+  buildInputs = [ dbus dbus-glib libgaminggear libgudev lua ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22155,11 +22155,6 @@ with pkgs;
     callPackage ../applications/networking/cluster/terraform-providers {}
   );
 
-  terraform-provider-libvirt = callPackage ../applications/networking/cluster/terraform-provider-libvirt {};
-
-  terraform-provider-ibm = callPackage ../applications/networking/cluster/terraform-provider-ibm {};
-
-
   terraform-inventory = callPackage ../applications/networking/cluster/terraform-inventory {};
 
   terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape {};


### PR DESCRIPTION
Some are related to setting `allowAliases = false;`
