### PR TITLE
buildRustPackage: install binaries to bin and libraries to lib correctly

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -94,7 +94,9 @@ in stdenv.mkDerivation (args // {
   installPhase = args.installPhase or ''
     runHook preInstall
     mkdir -p $out/bin
-    find target/release -maxdepth 1 -executable -type f -exec cp "{}" $out/bin \;
+    mkdir -p $out/lib
+    find target/release -maxdepth 1 -type f -executable ! \( -name "*.so.*" -o -name "*.so" -o -name "*.a" -o -name "*.dylib" \) | xargs -r -n 1 cp -t $out/bin
+    find target/release -maxdepth 1 -name "*.so.*" -o -name "*.so" -o -name "*.a" -o -name "*.dylib" | xargs -r -n 1 cp -t $out/lib
     runHook postInstall
   '';
 

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -93,10 +93,11 @@ in stdenv.mkDerivation (args // {
 
   installPhase = args.installPhase or ''
     runHook preInstall
-    mkdir -p $out/bin
-    mkdir -p $out/lib
-    find target/release -maxdepth 1 -type f -executable ! \( -name "*.so.*" -o -name "*.so" -o -name "*.a" -o -name "*.dylib" \) | xargs -r -n 1 cp -t $out/bin
-    find target/release -maxdepth 1 -name "*.so.*" -o -name "*.so" -o -name "*.a" -o -name "*.dylib" | xargs -r -n 1 cp -t $out/lib
+    mkdir -p $out/bin $out/lib
+    find target/release -maxdepth 1 -type f -executable ! \( -regex ".*.\(so.[0-9]\|so\|a\|dylib\)" \) -print0 | xargs -r -0 cp -t $out/bin
+    find target/release -maxdepth 1 -regex ".*.\(so.[0-9]\|so\|a\|dylib\)" -print0 | xargs -r -0 cp -t $out/lib
+    rmdir $out/bin 2>/dev/null || true
+    rmdir $out/lib 2>/dev/null || true
     runHook postInstall
   '';
 

--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -94,10 +94,9 @@ in stdenv.mkDerivation (args // {
   installPhase = args.installPhase or ''
     runHook preInstall
     mkdir -p $out/bin $out/lib
-    find target/release -maxdepth 1 -type f -executable ! \( -regex ".*.\(so.[0-9]\|so\|a\|dylib\)" \) -print0 | xargs -r -0 cp -t $out/bin
-    find target/release -maxdepth 1 -regex ".*.\(so.[0-9]\|so\|a\|dylib\)" -print0 | xargs -r -0 cp -t $out/lib
-    rmdir $out/bin 2>/dev/null || true
-    rmdir $out/lib 2>/dev/null || true
+    find target/release -maxdepth 1 -type f -executable ! \( -regex ".*.\(so.[0-9.]+\|so\|a\|dylib\)" \) -print0 | xargs -r -0 cp -t $out/bin
+    find target/release -maxdepth 1 -regex ".*.\(so.[0-9.]+\|so\|a\|dylib\)" -print0 | xargs -r -0 cp -t $out/lib
+    rmdir --ignore-fail-on-non-empty $out/lib $out/bin
     runHook postInstall
   '';
 


### PR DESCRIPTION
###### Motivation for this change

See here: https://github.com/NixOS/nixpkgs/pull/47556

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

