### PR TITLE
firejail: override files should be in /etc/firejail

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -37,6 +37,14 @@ stdenv.mkDerivation {
     sed -e "s@/etc/@$out/etc/@g" -e "/chmod u+s/d" -i Makefile
   '';
 
+  # We need to set the directory for the .local override files back to
+  # /etc/firejail so we can actually override them
+  postInstall = ''
+    sed -E -e 's@^include (.*)(/firejail/.*.local)$@include /etc\2@g' -i $out/etc/firejail/*.profile
+  '';
+
+  enableParallelBuilding = true;
+
   meta = {
     inherit (s) version;
     description = ''Namespace-based sandboxing tool for Linux'';


### PR DESCRIPTION
###### Motivation for this change

All the profiles are correctly loaded from $out/etc/firejail but the .local files used for overrides should still be in /etc/firejail.

Would be nice if #45469 could be adjusted to also support writing ```/etc/firejail```... (hint hint @dotlambda)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
