### PR TITLE
st: remove unused build inputs, drop wrapper

### DIFF
--- a/pkgs/applications/misc/st/default.nix
+++ b/pkgs/applications/misc/st/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, writeText, makeWrapper, libX11, ncurses, libXext
-, libXft, fontconfig, dmenu, conf ? null, patches ? [], extraLibs ? []}:
+{ stdenv, fetchurl, pkgconfig, writeText, libX11, ncurses
+, libXft, conf ? null, patches ? [], extraLibs ? []}:
 
 with stdenv.lib;
 
@@ -16,12 +16,11 @@ stdenv.mkDerivation rec {
   configFile = optionalString (conf!=null) (writeText "config.def.h" conf);
   preBuild = optionalString (conf!=null) "cp ${configFile} config.def.h";
 
-  nativeBuildInputs = [ pkgconfig makeWrapper ];
-  buildInputs = [ libX11 ncurses libXext libXft fontconfig ] ++ extraLibs;
+  nativeBuildInputs = [ pkgconfig ncurses ];
+  buildInputs = [ libX11 libXft ] ++ extraLibs;
 
   installPhase = ''
     TERMINFO=$out/share/terminfo make install PREFIX=$out
-    wrapProgram "$out/bin/st" --prefix PATH : "${dmenu}/bin"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change
cleanup:

- remove unused buildInputs
- ncurses belongs in nativeBuildInputs (tic to compile terminfo)
- drop dmenu wrapper, st doesn't use dmenu at all

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @andsild 