### PR TITLE
kubectx: 0.5.1 -> 0.6.1

### DIFF
--- a/pkgs/development/tools/kubectx/default.nix
+++ b/pkgs/development/tools/kubectx/default.nix
@@ -4,13 +4,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubectx";
-  version = "0.5.1";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "ahmetb";
     repo = "${name}";
     rev = "v${version}";
-    sha256 = "1bmmaj5fffx4hy55l6x4vl5gr9rp2yhg4vs5b9sya9rjvdkamdx5";
+    sha256 = "1507g8sm73mqfsxl3fabmj37pk9l4jddsdi4qlpf0ixhk3z1lfkg";
   };
 
   buildInputs = [ makeWrapper ];
@@ -20,8 +20,23 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
+    mkdir -p $out/share/zsh/site-functions
+    mkdir -p $out/share/bash-completion/completions
+    mkdir -p $out/share/fish/vendor_completions.d
+
     cp kubectx $out/bin
     cp kubens $out/bin
+
+    # Provide ZSH completions
+    cp completion/kubectx.zsh $out/share/zsh/site-functions/_kubectx
+    cp completion/kubens.zsh $out/share/zsh/site-functions/_kubens
+
+    # Provide BASH completions
+    cp completion/kubectx.bash $out/share/bash-completion/completions/kubectx
+    cp completion/kubens.bash $out/share/bash-completion/completions/kubens
+
+    # Provide FISH completions
+    cp completion/*.fish $out/share/fish/vendor_completions.d/
 
     for f in $out/bin/*; do
       wrapProgram $f --prefix PATH : ${makeBinPath [ kubectl ]}


### PR DESCRIPTION
Also provides shell completions for zsh, bash and fish

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

