### PR TITLE
opensm: 3.3.20 -> 3.3.21

### DIFF
--- a/pkgs/tools/networking/opensm/default.nix
+++ b/pkgs/tools/networking/opensm/default.nix
@@ -1,13 +1,14 @@
-{ stdenv, fetchgit, autoconf, automake, libtool, bison, flex, rdma-core }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, flex, rdma-core }:
 
 stdenv.mkDerivation rec {
   name = "opensm-${version}";
-  version = "3.3.20";
+  version = "3.3.21";
 
-  src = fetchgit {
-    url = git://git.openfabrics.org/~halr/opensm.git;
-    rev = name;
-    sha256 = "1hlrn5z32yd4w8bj4z6bsfv84pk178s4rnppbabyjqv1rg3c58wl";
+  src = fetchFromGitHub {
+    owner = "linux-rdma";
+    repo = "opensm";
+    rev = "${version}";
+    sha256 = "0iikw28vslxq3baq9qmmw08yay7l524wciz7dv7km09ylcbx23b7";
   };
 
   nativeBuildInputs = [ autoconf automake libtool bison flex ];
@@ -15,6 +16,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ rdma-core ];
 
   preConfigure = "bash ./autogen.sh";
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Infiniband subnet manager";

--- a/pkgs/tools/networking/opensm/default.nix
+++ b/pkgs/tools/networking/opensm/default.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ rdma-core ];
 
-  preConfigure = "bash ./autogen.sh";
+  preConfigure = ''
+    patchShebangs ./autogen.sh
+    ./autogen.sh
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
Old git source repository was dead. Switched to GitHub. Update to new version.

CC @aij 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

