### PR TITLE
thunderbird: fix build with rustc that supports `aarch64-fuchsia`

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, pkgconfig, gtk2, pango, perl, python, zip, libIDL
+{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, gtk2, pango, perl, python, zip, libIDL
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
 , freetype, fontconfig, file, nspr, nss, libnotify
 , yasm, libGLU_combined, sqlite, unzip
@@ -30,6 +30,14 @@ in stdenv.mkDerivation rec {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
     sha512 = "1933csh6swcx1z35lbxfkxlln36mx2mny28rzxz53r480wcvar8zcj77gwb06hzn6j5cvqls7qd5n6a7x43sp7w9ykkf4kf9gmlccya";
   };
+
+  patches = [
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1479540
+    (fetchpatch {
+      url = "https://hg.mozilla.org/mozilla-central/raw-diff/36f4ba2fb6f5/build/moz.configure/init.configure";
+      sha256 = "0aml7mnwrcfcqr79wbw2rgxl58i1hxglx7c73ipydnizvydqyq7w";
+    })
+  ];
 
   # from firefox, but without sound libraries
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

Thunderbird is broken! See [upstream report][] for details.

[upstream report]: https://bugzilla.mozilla.org/show_bug.cgi?id=1479540

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

