### PR TITLE
 firefox,  firefox-bin: 62.0.2 -> 62.0.3,  firefox-esr: 60.2.1esr -> 60.2.2esr [Critical security fixes]

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "62.0.2";
+  version = "62.0.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ach/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ach/firefox-62.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "30660e1377c125ec195006d84ba5ae356c8b53b21865675ac7649ffadd169e578ab91d0107f18f26530788ae66aacb7edeec1c507bccb456e1aa89bac95351dd";
+      sha512 = "bcf519e0080aca1cf232ec327ea65973e71230dd60204bc1fef3284dd94fa123f4a60421b647a3f64352829b1ef3b0e0b689a1fa7a06f6b1848c5acb1d33b917";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/af/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/af/firefox-62.0.3.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "81e3d9b33af731c9a79bdac678c84d2f30de0b77b6d90d4adaa7da11383e360444f85bf7465add562048d13692cce88b3fb1bd63beac30a6d490f6b75eb9be26";
+      sha512 = "5b145ab068216846169303dd75ad3b5a40e82129234cee35cd7a559cde0dcbc6abb1d6ce50680b9a8180828db82f3c23d62e9dc46015a88b0a3c75eb164c17df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/an/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/an/firefox-62.0.3.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "42d3118c2bba77aed919a1675538f52230841ec6c8398e2b9964631100c22c70335fc80f8757a916aef7c0ebabccc5356ca323901061d1bd0e5ad4eb0a10b483";
+      sha512 = "92a7b8eda43a1d6323e058d285e5b599b14ff8a7275d8e900d9ad8d5dc8160ddbfeb8134b877cbd078b3e3ce9919c2906f4cf7f9224f807f6c0ebf0c6e906be3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ar/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ar/firefox-62.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "c6a5a647e17b8b4fb4e20a32c2e492c6102cb899acf5af2d3af3af3cd122d989bfa452638d038b9b7c8c0bbade604f6caa11f42cbde5a3260fb13e44080cd720";
+      sha512 = "2592b6808abd04054ab6d71b8f44d94eb040c92f53c755b2258e4a10a3c8cd80241dedc2e57924e9410717cc8943947248b27c753c6223aa57352b0a08cd64dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/as/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/as/firefox-62.0.3.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "c1664a83e3dbd7b3041449ab4f7b9b41b038425c126572d380bf9c5d1d7318264a8ba798d670156ba91625de0865ed0b6e4e38bbd2ea700a118b64bbeea95b25";
+      sha512 = "224c3d09c1122f2444d2bc75833d6db60a7cbdacc819d16d40a3d5e6537e275a5720f1b6d4616ed318868683b99547d03aedc21175781eab0b32ec8c6be87495";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ast/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ast/firefox-62.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "31c15cde2d9a0f93fa742c41032e8b6e06ad24a5e6126c953e70c0addc5d1a74c5b5d06088002b4c1516a1f75b2e3e82d9d04c0a624db781bde2d3e8182062f3";
+      sha512 = "26b316efd6d4d238726e5a1fef3a6ad00af3f42cd45846598e4562b9c5b2d35af3372e283efd30713464c440715de82ce49ce3d73569ff528d90ec479264110b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/az/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/az/firefox-62.0.3.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "8d3f949c325bd5efb9619e96f8d8688324d113ac7add21b1d3290c160bba1e2193f923a54d3ce295e75b2ea0a59ab9c718e117374a46963ef69c53f3ceaa1957";
+      sha512 = "29935c406c955692a469762a9c53762d6a8f7ccd4555b53c31283f4767db2547a17819f7e55aafd011b3570c30839e350dfe74a52d322047647ddaae58b23919";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/be/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/be/firefox-62.0.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "7cb5fd02ba28c54acb1c73320f794165c0debf35a35c5e15602ccb7677b879ef41c910deb4668c0f160663b7a6afa43f30492fc23691406848e6adde7fcd0b02";
+      sha512 = "e4a438ff8a9100126f0fac456bd6aa7d0713bf2e22e7ce6490c4f3ec5643087b668bb5d8d867c9466a289a964f957ce958dd9545ada53b207bf026f3f8200373";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bg/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/bg/firefox-62.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "c6484b8b19941e135d2dd983085325d9f5bef118105879b0f830762ec1899096146a454397510286a902d175f9ad4eb3e849fdce38844535bc8a92bcaa478862";
+      sha512 = "3b17536b1bd6cbb94548b7b2b0d05ced711ef116acc4687309c3392f77ec0b51cb4814efbeee26ceb51328a4ae5b5ee1c4d8e69e57c2580be8cb1989bb082cba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bn-BD/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/bn-BD/firefox-62.0.3.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "4526b294ea939f88c92a3275ea17fe16932b410b0114af03d9f3db892cf6ed1a9d0ae0a6e0a651a0599aaee9bf53c69273b8d0286b94656635b3357ee2ab021a";
+      sha512 = "d9969a8d0fda1bc4d108f0c24e934235186420734df1be38db9608e303d7928b45007b40857681d0b29826bc26628b3b86388c81925059ebb23b6ccbeb80f375";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bn-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/bn-IN/firefox-62.0.3.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "3a17f78a48c7657d7ed834f4c05b523d661c5a692e27751e48ed8ea6f580cee21295b025a2474bca10fdc803ade0acef0ff0f0ce40de992a1fd072ca70a1062e";
+      sha512 = "7e449679b8bece1eed95ca5e3bfbe1a303d9dfa8bd4b9e53d14f99198e01a4dc4367112de48ad50b61c3cc54eaaba8caf143c36336da3c86c2815828ca5a2a80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/br/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/br/firefox-62.0.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "7932c59f390580c3a9f333fe40ddb9aace2c7d35703ec022468c503b4e58604fff777fb86e44cfcb84186845e8da26f55a7d0584d09982e88ee08e2b205f289e";
+      sha512 = "328deff7045bfa2187c19a66ca03a0c8f25e266eb6ea9c19715c201702245a0c338458254297974aa18466350231dc800f20b72c552f4633d5eea176f45adf80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/bs/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/bs/firefox-62.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "509b1d013a5ef5bf5f5a8167685a7232ee400202c1bfda37eab1ad8965cf0d7a6ae2988163be050b5d37741bb405df5b28aa937c82e086708cd6d943b5215ede";
+      sha512 = "20f85e5ca5f7a7be5079778b426e252c98112550849fb6e16e3b0d52a15570e638c8a664976a9252891a2254be59fe436dcda0d65b1f9ad5cdbe0cc5636cb93f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ca/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ca/firefox-62.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "75b918bb00c9039228b8881ac8fef4dbd36521b80651dc2d6b1ad1f6701ca39f3527b244c88d9e97ba1ac0a6e12ea7b6a3c40f9b95c0c2167e7c175b5d9ce37e";
+      sha512 = "7abd7b7220c6a5b1cbb4c8f9ee6c55d15682bba5bc1e1356a038f9b1ae7ec351c57ef4dd19a02f8216f6789342d5d91cf76a00ecf13e71c8fad0f1fbc315e775";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/cak/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/cak/firefox-62.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "8803b41c4651174e4999804071b27d7cbf47497a8a5b83488654d0586fd6245d5d517c03e64e8e75ccc0991b2be47cb0ee95143d08828027e627409fe6c55cd6";
+      sha512 = "2a8070bcd971261d994ae2ded0366b9e07961e1b98aa76c117d1e949a8f9990a22ba461ebda223b76f33c7ca94e1862a888b000642a4f874b8b92d2b5f470736";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/cs/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/cs/firefox-62.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "182cd25579ad04713852e0343e0d9604f42772a4c6ad06da512a8286314451f7b90c667c2f199afd1a1162c8ff6d1320abfc87207602182a3cb32196916189d1";
+      sha512 = "8beb5c0ee3a0b2a556b455e41887dda126a0892df50aba4e283f0db819c99c4601427370c70c09d176f1a6ee8d629e1ec5f8b803d51b9444237e56c7a273cc0a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/cy/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/cy/firefox-62.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "c65fff984a351cc67dba5574e7d2b3291de4e6c78f7659a6020d70f09cdb3bc951696ba88b778df4057633e9e06013799af58f5f2d0a052bdc22e7c98aaec278";
+      sha512 = "ec1a4fb0c8f753454aea88fdcfb3a340d0328d9c059653d9390a71841098573d667c2329c0c8dc88a2fc52eedfd8dbc584df2fe44fff273f8aeec8a3f1eaa0f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/da/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/da/firefox-62.0.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "e9fa596fb6c825fd3c2b1d5f42ad1c192db42ee046ad2f348733a979135d41bf2b0efbcd8ac2fb68e0337890ac3131a3454425425ef727225786ab0cb51f4d9a";
+      sha512 = "79532e1cf94447797d9d816cdc342fe0f8c37915494ff000bbc7148c2d42a1adeb7226887d51999774b6068f62d71bbb54b0951bc606003a91df12e9f24e7691";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/de/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/de/firefox-62.0.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "7a4c786b18299378c4d8b797e99385e35ad501912f05c02bad311665be6d52a6435a3fa04c7a8ae8a562af654aa3cf17eb497fc9691fbd0b2cf46a67f5967353";
+      sha512 = "5f0d10736912f6ad4bd38538601ceb8db10cf97dd414446366218ccb03ae010037114d688409cd724e194126524bdd442f71b1cf646f1f3ac46499afecc082d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/dsb/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/dsb/firefox-62.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "52ae2b79d9106fb304b4b3b945ac9960614efdc7780406e87bbe1dc15effc049e8cbb91c8f4f2dcd1966ed0085e3574e3e1a4234d933fa587e05901875234344";
+      sha512 = "2cafc29c75b055e4c21e12fe2b2ca3c974ad53fed43c8b082e09323bd1854ae7179da13c7d33edf41f783fe0016053d52292bafbccdcff79cc69d8ffedf01ab9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/el/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/el/firefox-62.0.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "956d5d36ec255ec122c09edda12a2242bbbb03793385fa9c417fbb8037fb19506298a31bed94eb39e825e4fcb66184901b3580ced8812cbc44f8a4d8ba339d19";
+      sha512 = "b1246b56eb0d61d5ac874383ee279d3c9dfe559127052c4d4403ab0009d702a76711d05f1ebb781f972d9cbe6cee9a6b3c1aea9cb74866e497f2569480a2cbf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-CA/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/en-CA/firefox-62.0.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "6a93cedce6724a19ea663e70ef9d57d27c144c1250c438ff15cd8d36c3d92b8a95c9e3f81fb53862b550d0765a8f0b7bdc14d6d9929a41f18357e0d0cfae732e";
+      sha512 = "8d344a08fce1be002b5710031250aa0f13d237bd38386cb31d5f6a75cc29ee17dffd01e1375e4a26b1a136d268db6ebaa591fc23789b3fbd7771f42a6bb59979";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-GB/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/en-GB/firefox-62.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "c3f825196d8f1d1284644ebf07f08a7626086c869408603d50ded5b0eeaa98bb9f874c7df38bbbf3083dbb4a1ae8afa8e4c90ed35a83fd99bec78cf3813dd92e";
+      sha512 = "88899808190f9013eba157345adc740fbd1889fd1ac963209cf093e9bd9f1e9b3f35126e85c5d3a1590e02ff1da8c09fa390ec519bc0ab01bab7c37d9b5d4bed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-US/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/en-US/firefox-62.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "f19a938af6bfe6499bb4e4337ece1cc0918fe56b361ced0f131f010652b2849d98e48a7cd06277580cc87843454c7bdfe816b65c99189e1ba749aaa64059a6ef";
+      sha512 = "577cdf1e1c4845e0b22c174833b0e20375443121e429a57d16f1f0e3af86533a6c27d35d8451ab25b3f7ba10ee9385d0f497866b50d4f37a81f9663137aa3395";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/en-ZA/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/en-ZA/firefox-62.0.3.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "0214fbf75843617b0623eea8c8ea2ef46d23d739f63a74ff47fc87ff16817d9110862696f92ba614167386bc51c5e94a9627d0dcdd22c19c20bac4a24543c126";
+      sha512 = "ee679b5bab64492bd069cd9b3b7509db7a5296a019d8712afd12a5b6ffeb1911fc4daaf63483b895b79652f67f9095b66be780a2b0dce3e7b9b57fb5fcda316a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/eo/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/eo/firefox-62.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "7da531166d26dfa3cd1edc327eecd583e10c8a2c41d007daba41e6f28e42159e1c43be5759061891c74ab0157ca3d4ce58b8a6a7d879ad4ce4c50586341b460e";
+      sha512 = "32e54f1a83e4b3cf8f7296fad200abedafb5c7d4bd409c7acd2806944a241b6923794a33a7999754e4d2010f2788ea3a3d08ee72a9354713b6cc2ee1dc73a665";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-AR/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/es-AR/firefox-62.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "e5bc4003ec881a41a28b6847dc9d90c81dec5ba9d103111922fdcc718713c67027f5b04a9d608d4e8b20a656abd94e0c5c8d5819135e8884d84eeb952b855590";
+      sha512 = "ce740d773ecc016eb89e9fe4370e199294f8c51c4f5f74bbe7f09a5ac060b374d23e80fd8a27b63c6149bcaec2b93d58a892ba7f53c08628c141b406838e2d58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-CL/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/es-CL/firefox-62.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "c5360481d7a86bddb87805672dedab22735e484e3a048e5e57e9265034ac40d0e5586bedab617da1cb54a4b7c1d3b4e18bd5f0cc0c8b8d3563df54b7ad506b23";
+      sha512 = "9ea5c06200091975c98587627ca371bb492cef91ec200a52409b4b30092aeeda64360913b8950ce56031aef34e66364bea71bb071df5549736dc0900ac54f7f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-ES/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/es-ES/firefox-62.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "8977a46f5946da99c4e3f30e3451110adf7993ad5a64f5dee09016932ee55a63ebca9126f7c3196191e658aa39465701db347068bdc6e6acc85d061873ccf226";
+      sha512 = "df71790d420798b17e64aaeb007f7f8585037d48b7c8933f5760b75385c945ef16e815c84b5872cfef8a2ebafd3293cbb4910befc4844b166f16774947a9b32b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/es-MX/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/es-MX/firefox-62.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "2bb3eeb2bef0f7c72c9bd95093e4c80b69e6f56ec41d0d4b3c54d2f8d7496884394583fb77e9f5e985ff6dedeb94711d4732baaaf5947e26e1f7b13f3024470b";
+      sha512 = "02e0948d3f4855a9c9e502627cf5d199364c0f0a7ee7f4314d69c9977f8504e43c3dc1cb8e80c9aa6bb6f4d75609108f6aafa8c9acdac31aedb908b5df26e1a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/et/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/et/firefox-62.0.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "cad31e57d54d5e533f5c999b2009d29c22c9469b7b620499df7f433d0e86f14ba336665a9d9917a48f55d9a57e30be70dd461e8e2159092d5c2c1435e842603f";
+      sha512 = "776bed6ba54f1ac29836681a99ec673741dd439501b7859a68c1d6645693f566fb3dbaf2e827cb23d3ab993ff4ca290008de7256aa28cc6e29625eda4048db27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/eu/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/eu/firefox-62.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "6cfd46bc362a9dca327651ad9219979e321c8ec8ebef21fed64617e7c5540804ce0a16514848faff8e3a3018a454e8b90fac627054b92cb96f5fe8046326db50";
+      sha512 = "7e95ac325fd4726def5aed67ee110693dbeb7953aa5672913c18cb1b91f8a884500e6096a5100e89d9266c28ede9d677be91fb00227944d379a946938ffc752e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fa/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/fa/firefox-62.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "cfcd0562561478bf2d14ea6b2d87c081d86c5c6d30bd7c2c1eea673e2a82f875a2f954955fdac959ba96ce5fe8461c82137bd3c6313eefb3fb24bd4993692c29";
+      sha512 = "6cc8d99ddd690f7dac9da19d23666e655aa65a576cf912b195ec3f83ece9b5a6677d656a1d187930897adfc021ee3d16e3113a8d8454fb9b4a9f878c615b49ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ff/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ff/firefox-62.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "ffda297f92bfa0a76d613e7c54a71d376c2264570ee8d9f2bbed9faacded01cc8ea9fb171ae14f4d349702d91896899299bfd6b2cb66e9ded933bc6e34e63033";
+      sha512 = "026976b48352d2c292d27b0df8f17f75f2bbdc0822d89b722bd1e58d9189ce35c925da6de287f0f89e18ac9f64134a1bf5dbd3b6da609da823686acfcea5b05b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fi/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/fi/firefox-62.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "be791b05d114f2d49c23714898f240aeaf9593aae6b7d06a85fb3e6dbe9116ee19d5089aff137e1c0fc56873c172a73937e15b19eb76db15122019649dd83a58";
+      sha512 = "8d7621858ba33c340248df277f3822c120b4beea5cfb9811afd61b85fc2b5dfdb100c475d0b291c9bedeffae4ba52bea653d925571af8c68bafae6c997beba74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/fr/firefox-62.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "1f167a7df26ee83671a7c3dea3bcccaa7797da0253110eafa3de5a17b7e19d1710966ac3a82bb0e7bee3d7287a6b39f59b9152672618dbad5d782e297ea6587e";
+      sha512 = "23f73a32cfa388bc21c1e202886d83a36c21a8b4fd83f7001ce72a911be800d9dd2d49e21cdd9d9cf48a82121d4684802dcaa7d97b3bb47b762ec4c95be49011";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/fy-NL/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/fy-NL/firefox-62.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "ed9ee111ba5b451b5fa730bc0f8e14046ad7613d542a7695f68e28d9fddb279770e3663d8b9964617d803f073c7f02dc036e4cc6ce3a17b69ba5fba782831da0";
+      sha512 = "2d3c4d546d1d8f03ab407c2bf481e23bb4bf191b84e9e0da533b2b00a0c8f7cea7c5730fcadd777b909c9515981e61a1fef25fd1037d75bdab15901a877c9fb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ga-IE/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ga-IE/firefox-62.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "073b104cebd63452fecff3949195ebeb794dde2d4c2defb44f62f4493165f5dcac20320da8229bd7c3e5410b840bb51b4699d77fdc886974848745e066ccec16";
+      sha512 = "7f52631104ef48631d2d2d5434a50d1f62447b314329e9571915bf16b246c9910a8875500077474303806edc05993d79c72b60a2b6f3a64389446609092320d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gd/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/gd/firefox-62.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "307262bb8874fc6115051608bf4a79e51fb08910de7d3df44a6bb3bbde64d3a76aa88361f10b811a2af9a05518d7ba42b6f2e078d5db32f0118cd08f8a3ec7fb";
+      sha512 = "98b9275029ad64dbebebeb697ccfeb1dfd2b0d51e437899a8417292f2a14421a5a83f07164cd4158250aa08d5e45bbe4c97e1fc7ebf3fa02cf42d7dac740aa0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/gl/firefox-62.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "dbecb09308a701aaf13d278b208fb3b9e7631c8fc07b9b3fc99c27a4035ea7fd75da810063913449c2746933c63cf7a5175d4d5a17aa808f6bd8d19bf0692f0e";
+      sha512 = "6abd8e3d990983094880056924fa60c14efb6c133f05ef129294c7cd83725df1e32a85bc08ddffc22f3e3d4414744345f67ca5f055af74a93a0eaf8838f38f8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gn/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/gn/firefox-62.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "f62e0a0cb6794f6fc36c85f98952ccd313676d4389b12a054461789e30effd3effb6fc729bbdfd83674c2691d03aa219ddccfcb6eb74426ff49bd4a458ff7ca9";
+      sha512 = "043471a8b62dc300f1c719ea33a6c8b3690f38876697cf57625e26bf1d66ec2a4b6f952c836359da19f9b346851c3fc20525fad32596c9e91b9f5b23ca1672d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/gu-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/gu-IN/firefox-62.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "b0624b04a3a20a48358027aeac449c52198139a3e9dbf0bc035a06c22fae3bcb44f34a07ad88a14a44e87dc16a3393688ce8d45d5070264d1ce63b2c183aceb1";
+      sha512 = "ae849a0f9350fd0382e859ae9fde0217d73014c3fb7a7974b635b3bb2f7d62087c7b40c62707ff64eabd37ca700faa0f392e737b1ace15494d44fd6a87599b69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/he/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/he/firefox-62.0.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "7b3f4478100b6122c22fc50a944dc86e46b3d2d73893209be748c001461968a21500562b2eb18a40669d13068618ca3093ada082470833085b78f4083064767f";
+      sha512 = "49a350f95858916d73aa71be60bc3f162bee24556c06524ccc5d10eb7658e91affe4c8945d92c7c6958eb7c8bb3879211d6096a1912bc4b50a9e35b465ddd219";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hi-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/hi-IN/firefox-62.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "13d42b552bca18e0020b891f6b3a563b66dd86b3e5fb9b5badae88ecf5a37b5febd5b9c927807f7996b81ddfcd4ef076553fc82655eb05c8a04a920f2a64ca71";
+      sha512 = "a55d2647fa5ffe06fc479675676700edf460c7d7600fe18ae468fc3e13a8cb3cc025dd64bff244b61724ee213835a64c71e51e2d59a0ac2eaaca0a29a692dfaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/hr/firefox-62.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "5bf92b1abd156019935c8728435101fcee9973ea413cca05760322dce94b62fed9f7271699610e00e812f0c7d320cbc966bf03fd5250b9dbf9bb2ac2a5f96466";
+      sha512 = "6d961a7936c46dbdeb4d66a6ba91414a158593120a58f9f454ae77839cfedd5af2dc9d3dde02bd2d36e21f946b5ff9de0727abf44c2ea78f6e618cb84242892a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hsb/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/hsb/firefox-62.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "777ef75daae66a138f4013ff19fccaf7236700a8c2a46e6f0f811065326c7f4fb7dcb284ee9bac2dc3461b45cb8239015ff24731a691a85a199519398c03e53b";
+      sha512 = "eba4e20491a61d9de7a25373bec43fac62b9ac3b461be5e593117ff4d31884acee63c2c6bbb56cc7eeef67bd36b7d3bfc748169fd7fc49877efdf7656813ee5d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hu/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/hu/firefox-62.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "800f1cecd46b4adfaf1ed20878d422191709801e148aef5e827c4cc3b9fbd46ecb475dd3c4b412a39ae2b05d4af2be8ec7d75515e2b98b1e07aef74fe49c4d70";
+      sha512 = "d78c29d57143a3aa443ff79718afcc9c7ddd72b8f9fa3dfebcd6c19279947685a7560fbc4ba2de42589cdf4d9a71de94e335fd6641ce284fc60418e483895b97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/hy-AM/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/hy-AM/firefox-62.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "910fe027a761480a4673207733fb5a78c0106249806f5c5347bb602de6853ba4299f2b13c896a088368eef036bef38962a487b4b3d6957f765f39eb06bedfebb";
+      sha512 = "e7239c2f90870322c16e9af03da9156d8d36b6ef5b71053006f78f94af9da068e81521eb155abfa74195a83a63f7181cafba270c9bda2d4bea63f9cedf9aabef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ia/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ia/firefox-62.0.3.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "4138b14e0cdb6f6760e5892bbdfea3c244460cf2c922e737a1af568b1df5aa0076cdebc836688cfd74d97ac859cb8fd71ba52752f5db1b28e8827ca59123756f";
+      sha512 = "e614f2a89feb9b2555d2d3de019c1c6b74b6891eb4e9b7d9e055444ec923689442e6c7ec8f2d8605236e0556c79827a031a870989635234439e678eaf1846e39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/id/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/id/firefox-62.0.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "463f2d340b7c439ee64ee6429021062cf05b2fd4f32226723bff37a67c5f25566ba5d6815a5e604d82df97b426b677b3158b2f8a565762a340cfa7425ea097ff";
+      sha512 = "2e5e40dbe997459c14432f80d50075029ef79d1fbcf64fffa527bfffbd5c348ad84a2f2909045ddf98f2b268c26a20b1bec0c00ca753e64782a0e7dda972727a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/is/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/is/firefox-62.0.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "ec264aad9cfe095119f7f52f3391d376dc1864c24eb133bd51bde3349afc92c3cd1bcd0673b1fe95fa03ad36f869e0a6ee9835e97e922bd949228954779c075c";
+      sha512 = "77875a40aa36692f594ee0e714ad9cffcca0d036669f10dc31ce8492c1b372a885642b9a3f9cb85ab94833cd7accd425ea673535fbbcb93d3255ae74711b0ccf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/it/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/it/firefox-62.0.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "c81ee4ff685fae9108b07235931b9d0347ca46e3063211764fd1762e2ef9b5e4e337001304a14309c97593543859800d7dab9fbeb21a18af1b84a2b2b6c6d5cf";
+      sha512 = "6e737a1911bc5a97c6bc3ccdf33d72b5b964b2e155672ae583268393b3d9ec785765d55a0cbbdb0deb4fd4bd8bbd2bdd0849ed27ab782116f3d09293f441f40f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ja/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ja/firefox-62.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "2f0ac4bbf507d3c306dc30dbfb94cb3bf8d907431f9a5c6b863505012cc4b077e22144af3658dca60e056d287273129f4742c72cf78f800162347e64d2b887f7";
+      sha512 = "eb69cae70ef52c96b21f74fcf339ae031c4dde08817b211b4deed493d0ed63c87b28cea1d67123fc2f36ec4ff375f8d8a4f6eb07f0e55be87e1ae74d001dff77";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ka/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ka/firefox-62.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "4a85a9f34e69abb29d63ef8cae372f225d246a5065a26d03d99a22d137085609e6ef5adc03df70fd7fe1057731472808f510fde2a40926418fb98cdf8dd452ad";
+      sha512 = "87c7a6872de8829615834706fc76f1eb093c57f9c7866a45a4a43f2974288f05d7a98a3b563b65b2464e649c8a34972a9d779b6386bd904283db907981064f58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/kab/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/kab/firefox-62.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "7b03433b9c79203feb40705469c6788b8df08505ec2e92c704570e0cc5b8066d2b305a68a4c7a61f81e07cb6ea7ea12c059b00e8c11870bc44be54406e8a224b";
+      sha512 = "c65d155fcc48d9b57590bc09ccea6303b85c1a7bffb8ab6783e39408ea271c341f558ca6800eae145baef263af54ed19b882b0aa39ed75b38bfa8a4f5b3842a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/kk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/kk/firefox-62.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "51c141c62e3251101a5b110573c26547533fb2a8bb2019cee63734ffe4ef2c4d1b4b6e5e540d88e0237721ec7d0d88c26bf5c179630f685c037e3f9eaa0a6f02";
+      sha512 = "2858283a1721fffac6af65505c26d3c761331df82a7a17d5e107d3b9151cb08e448cf7d80eb3bef29068b9a4d0bc2f268207f86e0afa692a50b8c9e6623bf835";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/km/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/km/firefox-62.0.3.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "113303e05d1ea54c38ddcb0476873214696f38b17aeae64381a7bc00bd59d3ec551540125190c0a48e9e85abc4de9ab232bda0a6dacd1bf7584b7d09c9be67ad";
+      sha512 = "fb77850dbdbd2078ca6b7933fd630550d52ddc57615a789265756b460840cf6389dbe138be82136612762f48fcc8da2f8aecf94c3ffbf8962b6c1dd6f60cf52f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/kn/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/kn/firefox-62.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "3dc579341533e0d9b82919aea3dddae1ad247f9a994d52d26699bd371c8910ae5b417e76be04002af53eb3caf5a6c2323261e48dccb8b4ffa63b27fe80272681";
+      sha512 = "cea7b6c2c1c82b6d5ab14bbcd9345325c826600bb1c736ac898358e9a5d96f0e58eefdbc03190a51d21b4e3ecdc477e6b2e88f493e3a787219dab6970cc3eb40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ko/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ko/firefox-62.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "4269f0f945c360e8385dd83d3a62450825a9e74c349dd74a9f8f18e683a83526113ed315e5e363dfe00706b59bad92739e6b08c004e27608addcbf599b7da21e";
+      sha512 = "1f8b2af8a153d1b166ca62cdbb652e255653e8ecca33eb10d81b71007f5f6d3645cb33613f3def21f6384137ddd54697a880f9acf77908ab0b800a88b4420813";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/lij/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/lij/firefox-62.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "ee26793ff03184b9221f7cfc88bb351f27ce01a04fbf74681f355e2a0c6b4330eded098a4ecabc3215e3c6b78fd2d09090275a4793c845b3c6debab962e2999c";
+      sha512 = "0806dce8a381741d7df769e87061c15df57b6839fe3230be30936be5406939d79502602b02202654d78fa45f284e33aaa88c1d62b4cead4230e7368737105761";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/lt/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/lt/firefox-62.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "2f7b98d182b4aea92f8e370107d56f647e16a11a1966c2e2e47b8b4ce2b45d9b9742d09c19478c200cd7fe42889ec4c2498304626fefa7531e987ad134e3c05b";
+      sha512 = "5184b3525d094e80bb16acbacd9e8323f83f25a3a1652d82f0bad6a78f6750081140a6c007a4c2fad8c2955fad2aea07577642341dbef01bde1f7c06947a87c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/lv/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/lv/firefox-62.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "7c31be85ff6b3295636f50b9c7491fa467b2cba1e5ffe9c7ef997c3674d8cd801e14ab8fc9bc2d1ab75d2a379aa590109530c1ac81599f26b747a43cb557cfa9";
+      sha512 = "49f878a62d140a6667a76e89b129f28cef1a56e02212aaadf6eaceed2c776e54f4ad23bbe58c6e013a16c29bf81c06ef942451c726b7372a20391cf75e08b1ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/mai/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/mai/firefox-62.0.3.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "e365c3e4a9d2ccb80871c1530ae1e372d4ac1a809cb2c72f82c682161dab6d7707591194a72481a312760a7819fba0e5dc9ae3f80308b7a9c45af66d97e47230";
+      sha512 = "4b24b433fd5c695960476fff3ad678e094bab5d81f9e7cd2d1c6a3c56075f0bdbd4f24f6c6009e0ac5b5a4a25a7e72b2d566fca0f08e6cbada8131b9b5700be4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/mk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/mk/firefox-62.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "e28b9564ce368a8e68c27436e967cd5ad5adbff1b78b50bad64f7646cee32a28f2dfbeaf0bd049d7057ffef59ce709765cedc85ea139b84cb6b02d95c743cb81";
+      sha512 = "2c500c446c3ba9aa6735df3fca9673e056d04b8d8a059ed50bcb4cd7b5819fb224e12fffde3d33d5658adab93eb9f53c296bb422556264eb3bdc08e4a386e238";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ml/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ml/firefox-62.0.3.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "50ce7dc0445a37d125fddfb51951d455b91bec19f807df262bcba0734a7cf855d455e965144e1d8da4692c4013861f62cb683e364e33e85f4962c99097b74838";
+      sha512 = "3e743c899e60cea9010c28355f0b1d3f5f34da6c4865f7c284edfa81ae835bb8ba21e378c3aef36310cdecffcb1be3cc0d06b9e7c9ce2ff15482db3bfee93bcc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/mr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/mr/firefox-62.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "defcaaf5c589d0a11104f06890f986ea3cb627db499c2bcd1fc39162402b09f8c1be3fd05ca33571dadae9e8d127d1d67dc5f08804f670e8f8db45b33ead6234";
+      sha512 = "53864ac115e5f84f50b4f33103d549942b4c19286bdb4c236a794239bd9f40bceded9272c43aa808405eabc2a75ad36d2e643caaf30732a57bfa7d2de4c908a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ms/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ms/firefox-62.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "2f36fd10942b2a700b6901efafe2fc14e8a7cd97d41241a070f87edf4d1ebed63bcb1d202b1c557426bdd8fd96639ac263ffcf0c96ecad9196916cc69c9e3e90";
+      sha512 = "8820b20add1fcfe14f30a4b54428008cf770feb321b0e9aa27a0896c94bfca84aa1b4d3c4c7acaa30ea5a615c94259837bc9539c0b96f6702a3a5b093842dcde";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/my/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/my/firefox-62.0.3.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "71001dd61027cd3acbb12f555a19ac3534c547b2d9b2c964a6bdb656524429ccb25b6c601422ec7f8af9e7d6319319e4bdf0db15df3f3833611d72d3d9eba410";
+      sha512 = "6a34963674a7448a2454e2b84cd732cf679b65db568f165d13c699651efaf1ca4804b0602181a9dbb301aad7e5dd39646b19fb3dc73469792d82f02220a7d9c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/nb-NO/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/nb-NO/firefox-62.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "2bbb7a4cd756757c0559294a487c972ab0c6bc6df005c948a24978a35f51c369b66269dcf6fa96795525758ae66e24670fe8ef7fa0f5b05b7d81bff79f2cb762";
+      sha512 = "cffe42d175570493c853044e0bf774155e1b7020d4d26aec7e578a6bc5cbaad057c125d30c7fe92f818bd9b2c982c775f19ac5535f606346b46bab095dd99b18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ne-NP/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ne-NP/firefox-62.0.3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "4bd51046dd55004e6a08dd0fc646344f91d7d830249fa8a33284f4c66bd5f11b1913920119593e45d9488db1b9d7aad1a74b296226633d94a02c0c705f527a60";
+      sha512 = "72ae1ef7e071b665abb92dd07add0b4023cefb64aeed09638768152a0c15d7370686849199771e7f19272b5df8042f72f76bb02e57f9a304c6dc930d49c2d04b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/nl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/nl/firefox-62.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "408bf232f3c1e592a929ff2364b52af899aba1a7542e6199366a7bb0369ec14bf3c44964851a6dfb37ece8e9ffb342ce7448c11013c3013bb0d4e1d67a43e2ca";
+      sha512 = "b290a26a41a6fa0b0d1d89076aa5beec4a250ad2ff053e83c19108164c95c78ccb50ad1fdc6e1091605bfdb1a829d108fdd4528747309682fbe472b1332ab741";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/nn-NO/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/nn-NO/firefox-62.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "450239e4d62d03151b0ff093e04e4cd5cffafeaa91da7374390d31c5944366bdfd0361e6e59b162352418436f7bdb1ebdfbe959107efd14f0015de0e873cd5e1";
+      sha512 = "9f4ea82b06102744696c1c842cec65250e4361c6e37607ef5cb8e03abb31bf97ac8032de7120f369362199d4aaae1274563a09f61f04dec07d50aa94358e13b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/oc/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/oc/firefox-62.0.3.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "a7c00d91430494659a4a2285ae9505329e18a10985757a50f9543d46b6ddcb740cbc440e31a1718ba4b830661bed56a0054c5309b04bbd8029abc691b59f0c08";
+      sha512 = "e75d1a8c0af6424f7cb7575797c70b230919d840086f4bfef850febe36b863d9663d0dd45c6488528794f7f7356e0042c21dbac8e607689989d55b51cc64f3d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/or/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/or/firefox-62.0.3.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "e0ed4fc73fcffd0c59f87b6ed8d1ba4ebf8526acc79ab5a2fdbd689c1329d185bf9717cd34f0921d9ae2028a18bb12d485a0cfdd20dffb3e2a9b33969df943b6";
+      sha512 = "563dc60168a9e686c6058117ec12ab84f55836ff442f606f0a7ae6af663cf73228956c8d12141a0dce0a80d75386623002ede2fdf89c07b6a00379c08d00b544";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pa-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/pa-IN/firefox-62.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "8106baacbc84b053eed0527ef78f9ba4bdc94f0679c0d887d72bf19ef5c6a7950b6d8e9a35d493b51de031ef2e4720d03abb9677355a65b2a539c9e73a4ab633";
+      sha512 = "2fca31b8ec096191733a1a7ee6ecca37b3ce2acec56be01e23556f68ca7e6d3cc56fd1ff0a3dec7b2bb090d28606d545690f567d6432e25e8b335d7b238fd601";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/pl/firefox-62.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "9295362613e98387d10160af9f779a03c8318797e98daf39a514d70618eeffa53066113198257c6cbf1373fbcde33cef525c917c85fc3e838df5f918868e10b0";
+      sha512 = "0c2f125b0aca823fb2a99567ede66e18ce9ebe1dfb649f9d6ef5bb4683c61813d9f9efe94c2224dc7ad441fe0f2b3136a3d090ac1335246ea4c4304229c106a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pt-BR/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/pt-BR/firefox-62.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "d5bb188822c7b8e5ecba035585621685cd1b334950b8480d73b1841f871325236f9a13a3a4f0098d11588c0085c20fac7525a57cf83687a29d15f05cf9d9cbd2";
+      sha512 = "15563039e10ae5a6464ed0d20c0afab6d6a3bb5e54bea507db87fa03c48be22d7f325af22f776d052e49b9ebf9659c36ad77e92a22f884a0c443e3d49462b003";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/pt-PT/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/pt-PT/firefox-62.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "ee2f8aa32c2e20bb69ee291f3bd4ea931d5b2ab863f6f650bce92d35b331234491b93296803f5ede49ce49027b805241db44989bf48ee6d68722d262625b1fe1";
+      sha512 = "93eb9f47254a1119074e462c892698de6339bf68ecb3c1f3d4ccc9c97758ee3a0ce54cc026b8084b50283f7ad7960245efa9f345761ec8a50b4363ec52d86aee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/rm/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/rm/firefox-62.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "60605882860f1e1b805f8cb74539c421e45438aff07e79d6b3b1db3546d38950059665ca443d84617ddc9a4a3c104940d885f294932390170b3bc6c2eedd0529";
+      sha512 = "96295dfe17a2e066f838add7f3002e6307d1ef7e0212c0c3bc543bf7e3ae3be9da5a49bc6850b3c4b5f5bf46e112bc690824e528eb90f15864d43c7ab55d0eaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ro/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ro/firefox-62.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "850063575dd69270903a031748e665cb8363105057f1e170e43f264b3a9b228976fc901f7e3749cee22e3d9489b3357240198dc3f22e20de5b9581729e8c601c";
+      sha512 = "2782b44a49d116e8d15c0df9de710f432195a56cb46934e3d5659e9c91a190dfa49289cac64c738323fc2399058dd9e3bf607fb01d52cc9ee671499c4c29e10c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ru/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ru/firefox-62.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "8491c625171c0bf7c88c3f3a053e5f49a7c56b9dfc7c0ea7c381bfcb7505ffdce6a1079d15c73ce6a4edc5f89125e849e8b5fe8d464a4440d4413dcf6666a0e8";
+      sha512 = "fec5ece757f19a19e5dd4d92a073c8e1fbde56757e12e038a7247edef11e4fc9daf27264b560ea9bf8f37008432df4d306f8209baf826c537360ed8c6ffbb538";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/si/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/si/firefox-62.0.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "bde4eaf6879cb40967ebc872738f5ac6b931f6a1a633886e35985fda76de4ea4c0a4ebc7e68585dab34f7f453cd54977bc84fbcca636d53d6c5eddfad6d13bde";
+      sha512 = "cceac95143d3444e6b4a589d6685ef6740ece81b4ea26c0b31b4253a117b4ee239468d404bdd9caec9543e645e9e985304eb8a354000796e2124d71e23b74921";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/sk/firefox-62.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "776ea025a2e087a7d8717c3b63e8a203f13ae7e44812e0bcbef8075aad1166f80cb6977970d88f68720772668cca982662c2172f1bfca02732a79daf45974112";
+      sha512 = "1e4b31480a5c75bdd350cc17b159e2e14fcb53ba39215d565510ed54cd7d12d4e9d6901b1ed0909140e03e31f7c1005ba8e1a48a3a2f6d91bca1e51490cb30d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/sl/firefox-62.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "1bc1a53815d287acef056c981bf306b1ae7cc36d4c8acd3bf556f3a2f44e6af2c05bede49f04bf7fd591cc5f0be40dba10b38c5b64379c673705b57ac0853d79";
+      sha512 = "6ce2f2c338ac8481224518bfaae55ff66e8005ef40ca7a13cec294e1b797723b6c3874f96b6c2e4fb78ae526232ad267cfa407b8952d454fa5f4eb40bbcd19a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/son/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/son/firefox-62.0.3.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "ba3f5377ad15c8586c7e826ffe8c614ba71f49c9867caeb1fbddf9ffa86d513f299fcf39d750c7e91db88ba17533097d38def63c8614aca743946d2a3b0b0484";
+      sha512 = "24ad351629771a6f3ad8d381508bad99094ae441f6ffaff9ec19d8018fc711ab852a42b9d1d0f447e8a4da79c1fc177ee9368940f15b1e89344dc7beff49946f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sq/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/sq/firefox-62.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "c3f35991e3ff9410c4829491acc4a7f7cdd61f9104778c168adf3e1d359d5d0c8cb57ef552aeed669f80098c546a72f7adaa09cac4f486dacf78bd381f5fad76";
+      sha512 = "d8c80ea61e545f29a8a2b0bb4ee2be81650c131123693f1d6955d00364d67c4bd78ee6c85903d84d62c2405bc0df4f45f08301d1a13c30f6f33cb24ce4e9d7c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/sr/firefox-62.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "df6bdface285322457f676d74703084cb677c6c429992a87dfb933bb3da25eff374dd2894f13c37616268266e3934a55cd61f3f6239a487595282ada58bf69ea";
+      sha512 = "c9455bec9df85347e6aff71b252f57f4859bbb8f378d274010ce402da0ba6931d9bb0a6d0f2dfdd4d87700ac68b039ada9fe7f673f5fbc7d95aeff738980e68f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/sv-SE/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/sv-SE/firefox-62.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "a48a11e4b1e1bea955ddd73c77e7f5e1a7d03435b29659f7b610a089b604cdfed57893420d0c1827198efea6365a52ed236a8296646a980fabb6007b865a78e6";
+      sha512 = "7b80caa0fafdd82fe1d0e1909656f894515439fe21f6c41a05455a06c89afcd72fed37c846c8168e874da47598d1eb87c676637ed9047943d0483322acb027ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ta/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ta/firefox-62.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "e01845b225c5516ecfc25afde98e9691b9afedf27405207cb91e655a9b48edb416786a2cb99ad73df37da41cb22c58958165836e5e6b1018c6c9f788f2b9337f";
+      sha512 = "47a13f1bb090ea5271aea1add660f765e330b351ea6c77edacb380c74d5dd1939428b98ddd4f4cceaed38af9ca99f6f499298289f44c5f5d7c78c9ee3fceb9d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/te/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/te/firefox-62.0.3.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "95b795fd6f995527d85fa83b122bfd9a2c091c792c879f7f4611dde63b4ddaf0502d3ae0ee33002363da359d1931d008c01e40611eea61f1ff66aafac2844f52";
+      sha512 = "7d0c21a749be9d7bdca8a7b6baae2044335244ce35932d913575cfba1eb63b4cc2a41ab79a5e19b6d3ef0607eaccb0e6303f57cfa9d44fa21deca86a34b52843";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/th/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/th/firefox-62.0.3.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "9ad3d99c9479155e20559ee1c8ef276a69b591be2cb96700075ca19352f033d9063d9f9b57ea9fbcab5db9bf46e1cb03c9b001e6254b6b0bee5547f8c91fb59c";
+      sha512 = "d02a77da738db455e419fb2bc519650d911b4612e5d5e282c54100e719d8b119b5e3119cb458f652ae532128ca64afad1153cf4b3434bffecf2cdbdd67cfc029";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/tr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/tr/firefox-62.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "90fca950893500868edc6ae1c0aee417cbbee7b7a0f48e0f10421b3d7ba495a56e090543ffd097949c9bebe69784cb8fb03b559156863f9dee940aa867421135";
+      sha512 = "87ec0311160aac012e601ed753599019b499b08e73f256d78c68a695ed6c1ecab53095ff16b007a4be08ffe54feb0dcdf31e7465271a3f48928abbcc5b80d5ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/uk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/uk/firefox-62.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "18942b931cf09b03973a10e390ac15c6e5bfd1f730953b782b7929943838be19bf4a61f157b33979f1a8e13042f1f4facb08ab205b7825d285b9e96c0ac897b4";
+      sha512 = "d80c098d00c9681220c9ababf0f62b69607ab6b71ba34d177941332450ec51a5b9120e0c3e629e0eaef91c64beb9b10aaafce2fd094f931cb976a99266d63a10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/ur/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/ur/firefox-62.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "7f16c4810467469385a88346f5ee3fac4d3d95342c6a6d37e0df7880f0b08896d0e39e77091eb0262a66ed7fa15c3151f244eb47ce4ea774ad21797b5da502ac";
+      sha512 = "98d1553710997d61efa48c7d84fbad2fba5d730d0259b9213811b7a5f47ef1e4ca8940f4e17708e8dfb7949b4fd908bf80dd5e9faaa86b3e3d2c3a07b3a3d7e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/uz/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/uz/firefox-62.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "8266d638c74a78fa26c939c1ba7a6abd05ede85a9e349135f1934a6e3df27e3f6172026486738cea28e50689b84c29c0dbc63cc8779faa11a6ae55b4f367c23d";
+      sha512 = "7a6074c2d7f1d40c41a5969fb33839df065fb398e7161ca7bf4d6aabf22a87deaeec7d623f0d36f992f8907d696c5aa53136cdee33bb623dfed94cc402b1fc46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/vi/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/vi/firefox-62.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "787e570afae27cb668d6f4b9b6e8b3097f02148c2e2974efd1c58e406354724def031f04fc69c0ed10a04ce5833cbf7bb2ae8fd77ef068f8f17bf2118d1305c5";
+      sha512 = "013c9210066a5b72f9640a5d7d647312391daeadf757e5b13484a035d5bffe2405f80d4fd750e7afe81990daf14baa49c6c4d77cce7e1a60a3483340aa115524";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/xh/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/xh/firefox-62.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "805df0dcc24a7d77afca47335b31cbdfd0d0df51145c9cedfdaba4d865aae71697eee14e446351e6fd8db950e3264ed788f66d683356d4fbbab17ea9d7c2c452";
+      sha512 = "b104815968385980a7bb297d83fea2dba4ec18bd853ecb70ac7065f30e0fcf5fd3708376f8202840d71c2d9e6bb3c48dcfa866594d334dc7a5ae3cbf3b83c888";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/zh-CN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/zh-CN/firefox-62.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "cb251f942c31cc0c30c46bab04f658567b16f379068e7bc946970ed512e2de08c6e3511990b722541756e95261dcdf96b03cb247072f0b230f66ba7afdb038f1";
+      sha512 = "7961e947a3c34343c54d06e62e522f503375d83c8fda6648197b1408ec0916e54dadf6da982650c99d4b7215889eba015b5f1c8e5ddc0a48b9aa6c0925286540";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-x86_64/zh-TW/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-x86_64/zh-TW/firefox-62.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "afa5847337657cee3ec28896a089bfc0fc2b25750d6dc271bb83740ea5170e2f926fdf3158b0b136eabe0d2d6b4b81db1ecfabcd8c2049164af54cd796e9a7c2";
+      sha512 = "e09fdc1b84093c49fa8918310fc2a44b0285247548941bb5150a5a64ebff12c1ceacd6e8e397137da14ca6d8336bb2411dac9f4d1126c266da679d1214ba6974";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ach/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ach/firefox-62.0.3.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "99781074276e530b9ceaf2cdb8f902673ceeba3df515a6c2c2ece3fb3dfa84e6f3d494a3a69346a3f9fef20d11f7bac0361eb80968ec7b9e76b603f8b001749b";
+      sha512 = "f0544809f924d264af750456abd6331af1b4116710ee9149604bbc11745070a76d84cb50f4810307a078e8ae4d2966b6771c318243215a3eef8ad957b8127414";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/af/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/af/firefox-62.0.3.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "bd9c6fe306a8802b22860cad8cb452b6591c0227e12ffc4a33db1a88b811d06725348e5f128d624240b9666393cef35b30f5bc7d12e41a046bb318dd346f63f2";
+      sha512 = "3c96ed1cb9408d888478fdce554d577930d2d365d10dba7c3fb7ce93db8032df25ccfad1f055ae849dfc63428afb9935dde013ffdc737f364704d4b693d9d751";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/an/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/an/firefox-62.0.3.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "289c00b7bf464fb6d86cdbf24274514dca98dc47e78389125287792e8f77708090c120aeb5ebaf4688e16857c5fc6b78fc1eb6f0a7efd7afb62c22fee325e78d";
+      sha512 = "87038254a3f4a6e200b5de6b6269adc0eca198e9f2739bb810f00fb028f746a989b50b5433fe3577bf63250893b69b45bc7a5184d2a6c050818e86213b1b64be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ar/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ar/firefox-62.0.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "412cdcb82e2d60e2f37658001638bbe50cdd3a7db1e9bb4cb0e2fab49b878fe64b62ef019e499c3a960bca3510266a0afb3fb4c57cc5a8b6bff22aca772e643f";
+      sha512 = "a7f2231f026fa90f53952bb9cc7c36663226c87afc6629466fe1d15e379048bb9e464876b0d8c79382536bed850c2f806c1e8b06fbbbaa1c02551f778767ca89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/as/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/as/firefox-62.0.3.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "8068c78be22e42f9174cd6f9e1e7dedff527a00865f722c6dd9062c6f5cce2b83693d0938ae5f56197f72f5af71bbb485b0970b632ca5dfec9190214558fea2a";
+      sha512 = "9a101cbb2d9b689d05b976035e524f2026154508a3c18a9f1e238e600be0924d36573a951ef3a54a28e62311f661008f66ca8438d40e985357e537bfb7b71d33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ast/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ast/firefox-62.0.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "37ab6ad2899b3b115bd2b59f6be121e2d340c27eb745f698fd2942ab6424c0840273ddb4afeaf1083d9f458408b939270d971676e9b08e1f0fa409bca69f3e84";
+      sha512 = "3305cd08c09726e04ee0d3a3f0228092e596641d1f80e5703c869ce5d3588fb37bec2d80a2db5690e5fee5517c8745f13e9bf723627a03b499e59c7672ce932e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/az/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/az/firefox-62.0.3.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "5724ae7680d7e88061a4cc45706590d519a5bd769b204d06ee0e8e6e86f706b312b665354d22314853af0a73b073acf68be8b7c3ae9dadb87984e1222722b4a8";
+      sha512 = "138b35496601a577752dc1362dab7a5c8dc8b3a78b0c252748dbd15b1bb1013e304aff8d8ef1a9f5138e4e26dee74149c7f66eef752fb77ea75a6dfb8d388895";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/be/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/be/firefox-62.0.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "6249b41382a1d2cdac2d9c9d235697a70bac76d0dfb341d3db41c0f329cce868ef66df6d2f249b4e22a1daf737d5ea3b7f2cad36a2d30b1dcd649fc1476218a5";
+      sha512 = "7f6608f932f96bd84f57902482b691aca966814f1475bbb0479356c792a16e4698a289f944d7462db71e77552f368df1dad3181280e3d0e07a5261ad90c2bf63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bg/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/bg/firefox-62.0.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "a769ead4a10d4168d64ac9c2391c0cfcc5e0dc33f4521d6df73c5b53087e3aa073096af09adc49c901489e60af9839ac888483d63f7e9bcb1de2588236cba75a";
+      sha512 = "c284d6ddc03c3bcaf82756a8f9909e12ca193b9b2a21096f84383c71e1dd5ca7369a4eb6c02876ce741ee38e6418e45fec2ad4936e7c6d48ef270ea45ada462d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bn-BD/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/bn-BD/firefox-62.0.3.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "0761e32fd88fdea9c87686411ed87affa8875f2047ff9b1b1ec11376583001c9c9b421b2b27cedfe883cc5cd233d4d3a932aba74e50cbd74aea63a6aaeb64c8a";
+      sha512 = "eb9b3e070e6a2882a6b43d2a0fa7792f2b8700df9f64ca70e6f616e6237e0cb15c5d5a642db8f7b236c7cb2f4392dbc553072c544e81e0223c8f4d6d85c36be1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bn-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/bn-IN/firefox-62.0.3.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "1868b2d7d6f32936c6072998afd1ebfc232158940e5270bf483c6c29a8a30682f0ba729161e9b0aeef7d839c9e9209739380a20b8b118c49112bd71caba03ec9";
+      sha512 = "73c4c67bb9f4fbc47509c53820319456c614a74dabe8ba14d05b365a3ba9429d1d9ad9ebbc6d1edc7bf18f4a387ed9dd92850478268f2eea3541929558f14e6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/br/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/br/firefox-62.0.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "43d1691d6b1d9aafaee55be50bf8c4934b75c0501c811314d12e1156c2b68cd58914362e167ed50fdf5267a0d7a2db9730c68bf318d492bacb8c33eee7bdd12e";
+      sha512 = "78921d68f06c26f029f29fea01a15c5dd54f55f59150e08d38e05f640612355a494f72d88c0e80bbb2ea6f54ec26b3a5716c3249f1118202843c4ab1ef05f891";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/bs/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/bs/firefox-62.0.3.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "aeac8dc018ed59e2aeb68b63c1a1d6281e543975844e3ce5b7f22991968bf0e05f40cdf1ad3bf434cf9de774363b0ffa6f96d1c0b457f0372d4d1d943c0a40bd";
+      sha512 = "643d5ebb610d3e83a6ed85a3239a8631c150a86925ddfaf5a4adc87d0a8add022a5e35ed20fafe5e6f1a6835b3ec105ae1734cac6552d79d95b83bd34c1e73ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ca/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ca/firefox-62.0.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "10b6c40701b7cb8f2543e97a61335f426b210273d46d542034bcefd7d23c95124cada1d1df85c3b5e33d25e8680678b18815ed0c8ed58936061f670b0abf1d87";
+      sha512 = "ceb8f81f3fde233be921da104d993546b1200ee348b19340f43dc697685b87c80a4377d406dc72080701614896f7b1cdcc27f364a89a92e433639603e08a6611";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/cak/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/cak/firefox-62.0.3.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "029cfee850c3ba5ac408b6db45d66dd9849db392097dcedc64d637756ffba893770a93915eaded6302f6e667f072949fe6decfdd918be292abb9ab8d1300c2fb";
+      sha512 = "04f5dbdcfcfc2b996a912130335ed855612e5fd2f27bd4cc615a369be2fc2dad14ba43511dfb2bf47a9fde3d28b8b5913cefbbf34b89383eb36bfdcdb96cfb3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/cs/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/cs/firefox-62.0.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "ce919ca42a629f171df4faacabc18fc3db0faf2d38f04912720ba697612215e0c26f650781a535b5e956dca912fd47d1d9b9528910b8e9b7a18841c411e25623";
+      sha512 = "b82cfd9dc6b57e0bd147f508a38bf41bedbf8fd9c6725434fcbdc8871cf6f683898ff0507e0e2fc202077d234096cea252acce56e6faaca738e60512b3b9e1d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/cy/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/cy/firefox-62.0.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "727827fa6b47cdec5048f40005872f021cc506d7c72a7f1a6bef9f736612341fe3cc6127b3bf005f63620f17b180a00c3fa0f799f63e685111119f9661d9ca7c";
+      sha512 = "8f9d4ea520c99d3595d8ebfbb8732e1bbb73b7d39ab707e0a3f86d3cb928231e1b7d84c7ef017d9f685a2d2893c0b486f27cd4a704f05cd7518465452010df97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/da/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/da/firefox-62.0.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "e795a7aaa38c28733a8864928229d91d752d6f0fe108bc5a3350b34e783155c3be14a5c0261eea26642097db2a583a34553d746d6040704f34de82953952f21a";
+      sha512 = "28ad6674fdb830d07837b826ead67503a943b7cb2330655b75ae7bdb5f348458f19af37ab775d820a0f0131a6f7d5dda52bdabdedb5b0deccc1605912e46b9c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/de/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/de/firefox-62.0.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "56185cb92f9a246140b58119cbbb6a128905c8e244a7ed8917613a65fe8f87a542b103afe69f1fa542e47efca18c8666e669c266e9c107661b800c5e3b4ebb75";
+      sha512 = "b94ebbfaa81bea44e452d0ae69c3069bf100178c82bc28b3d2841ee14dfb4bc2c55b99d325fa4d8049afad93e674d24160f6bdc235e329e9575b49842c731d5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/dsb/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/dsb/firefox-62.0.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "ff30865cf3135f466d67143487ad34a50b73c11000419b2caec1c232d4efc805cee5cbd282bd1e0b9ccaf03ccc95e08ac4d1baed93abde27b45b0f2af5d71fbe";
+      sha512 = "c292abb164b948ba76b13548c44fb41033ec9d394b3d3d710dadb72f666c56d16fa7d72dc5c3aa4543b81ccfd2ff76bd5e94cefaf88f537bfa7c8b16b9290f71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/el/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/el/firefox-62.0.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "e22d89c822843db26e05834c088e5d687c6d315a870ef2457f13126bd740135016ebacf83b9fae131128b4fcf62b474a68fcb1fa12098aec22f199a5871e63b6";
+      sha512 = "35e01baea98785db080f801b911023c6ef3d5bc6c61d8e3a5e8ea1ecf7e51153e4f2646db7a8fd32dd1f778e1804cd2065efc28e8d79e8475105d9f12c9b0a7a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-CA/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/en-CA/firefox-62.0.3.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "0f462a6900bf92513c40f28a9fd2ecb0fb3a69678b2b0091e6495b89b9a2fbe6c805e48b2e55fe274996ff7a15c32294d02a3e025b97505f920069cd71b23341";
+      sha512 = "ccf68a4f05f4c5b0dbaec25c69fe66eb9d1c23f3ad21e6fa2be14704fd5227fbfbac8d46dbd036a6e17f0e94b58a4fecbe91520da45d56a2901074bcd7031516";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-GB/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/en-GB/firefox-62.0.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "dd7a7fc0b05877f1e1f297b123075695c97247e2641311ff646b953e002278e2e16187682226eb46034cf3959880b2d17d74314ff7dcc654b1963beca6785410";
+      sha512 = "49eda2efa176054adc5579ec26a9da92df9903c16d989d761b8b566568740b135f851e5c2b983512b644e80074171895431b3c1689708dda9d86c757dd7d2599";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-US/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/en-US/firefox-62.0.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "bdb45cca1c207502ae5f76fe10e4b73d3f7e6079913bc9a6216e9325b8c70fac37d14e32b4e5ef6acadd73c301c3ca1aa2d72a5d44acc0b6cb0c22b481de2e46";
+      sha512 = "08e3ca5f859a531b2895a5442734112de9c450bc8bdc2eea9a8fe3231f3b97b8a243cfb408311c56c1703dce63fc2f5201026719fa01b9c76061a204d59942d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/en-ZA/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/en-ZA/firefox-62.0.3.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "351ab5114b25daf11ff2ce1aa377e6c16a7adf9807a7609c97e04f30911f8680da727c6dd1d3067e028978d3f6f793351d99f500374372dc22b11ca760e4d36a";
+      sha512 = "7629e33144c955d015a17bbed4d1e570ae74045511c6ea1db9131b711ac58c67e76748e22ecfaee5b594651f7c736cb0d6d87697ba9dca46705e5328bdfbdb2f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/eo/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/eo/firefox-62.0.3.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "1ec40261c42db667f1680361e4e7f12db271f5fbe6d213d44d0722e692a93421bb92d73193f87f42e43df40700cfddc7913454d6a64f5e15fb78f08d7a5a3c0f";
+      sha512 = "13430d5a4462e8e00467f0d39d2ad03ac684e0cdebb21901cd0ee4f2411794794cf5024ec51d915e3917660de6077d6dfc08aef30fe6c342f5b8588f07883f33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-AR/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/es-AR/firefox-62.0.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "00cc8c232fb4b7b2c56aeed098719d60deb26abacb38f8a7ffd9117c8d8875c838fc702413a6d8584f862b35843262e2bd31074bfbbc7cefa6f62247d8a16abe";
+      sha512 = "44ca9daf57afbf9dccbb158712e9218d87db4254855838604250b8a4254fed7adadc266e3e1fd49d23b34ba0176dfe5f25fca42dd5fd6d1c322c857337de35b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-CL/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/es-CL/firefox-62.0.3.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "70da97fd43b84b5475e707780c215f73b05a423577f6ccb67a31e01370842319d40c6d691c99da138db881d6c5de8f73c1bea8287fb9ba1cd3647bc74ff8125b";
+      sha512 = "09e43c14a99c54ae123364ceea46ba7b1b38e30da8d15bdb734b873a63e37b6b4292edb6f8ec4ee731e97bd12194ea76ec35e710d29ebbdfcf7fb41b1997934e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-ES/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/es-ES/firefox-62.0.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "76b717e852c1aa2f3801a5460a8f0d51256486d5bb688b30cb85abaa30eb8a441cb28391988ef8ac4fdd1a430e0c09a2c298c8738f7a76e6a18742bc2a4f3998";
+      sha512 = "cc1f5b4e421813c9b044c50f66a28f9204196f9ba2574ae537dc3040d04ffb6eafcdca971536387cf2d79c4c35de5ae3a5335f4796aed878aa5ba817dd7bb308";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/es-MX/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/es-MX/firefox-62.0.3.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "e4e7f734ba533a0daf56d9c99881c0c1c758ba6e492e8e62b67944fc3a6c42c82df7e4d01a27fe797077708d49c810a51bb05d3fa4f2cf91fb63548f82e25322";
+      sha512 = "5ca49c92ea11127ed80fc48c5699ef541287bb6f53ea7ac96df990e7a82854cf8bfa8c61f21d0bea2fa245a3b0ded7aa7b3afb662b1639c421525900f8e7d688";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/et/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/et/firefox-62.0.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "6b832c2b71b0e42db5a2292d90f1545ab545845f30b09baf277bd48597975e426cb98442fc16b7053d5c573d50d42e37e89cc49d7f325835aa5582262333fc4e";
+      sha512 = "074986b9e80ccf1dea362bc7a28f7e44d2fcb9c19878a8456e63b64bb1e0abad293b6dceb6672bae200cff1aac1c774cc99faeb7ce52d7e6a4b3a154dccdf4ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/eu/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/eu/firefox-62.0.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "5bc67a8afec07f48c99ad331257236cb2fdde7fa23afadeb3de8c270d78e93bf855702bf82781c9c90eb5a4a0b9966d83bcc6d8f357ff5ef2bc265378200d674";
+      sha512 = "b823fa6c5aeced11c6e0878e11cba561a18893e531c28e9d7713e449905225ce8aed35e1240876976c4335e958e6a68d5e39037fdc59e9f0e900d5d822236c89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fa/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/fa/firefox-62.0.3.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "43d16efdabc3eb39e3aa924387040f6e92c80333087369b754065c34403d202f0881c993bf667322f8ddf303a8e066c4203b2a4daebaf68ce5b95a8c1cf80844";
+      sha512 = "e842e26e5095f008fee36f7b84a9932cc9ab868e9145d92f8069d2f7f24017ecf538db7d0525f7233bc7cae8a2709fa2da8bade077e864cc05c1813ba4a1ff57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ff/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ff/firefox-62.0.3.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "86837496c81d9f1209719d46aa396d17eca17a13f111ad0ac3b94f1d3f9bc60ddf8d8b10018e41100e091996d820975db897abb470fc85e0d87a0ff742a67b34";
+      sha512 = "0eb63c6a996dd29ade92ce88f2f9065da63737cea459d8b2e7c79356b51b43eddcb639af9efa85476f500885a249b77347964982ac297cb22adc501590dbb8f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fi/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/fi/firefox-62.0.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "baae77ef1bfc59c87eb72c3ad6f8524dbdf5fda9502abccf297c3b3f6e1033002d9b4e5b341c9fe101bbdbc93dbac768bd962ac9378088c9c567ec5d71ff00d4";
+      sha512 = "db4da21885411214805a45bf4279776144c3270845a6dba20da95a54ddc5cf3205132ce2762ee997895b7a6f83e2f31cc618c17668df4d4211646a1e3b24edf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/fr/firefox-62.0.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "60fc885a6b5703a88dbbb60bed41296e2a1bf73405eba33a82e5f916ac0b22972377aec321c2b13d7007dbd94fdfcd24d43fc8f0acee37fcc9e23543c5a65f67";
+      sha512 = "12f3fbcd0f085f4547a4406b25d83858425a4653ea9bb2bd5700e21687c2d2ec8e1a032f76a242edd72be99813cabea3332c18921f16c54edd8c430a017e4948";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/fy-NL/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/fy-NL/firefox-62.0.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "945c2b7241e0faa83e1dfa1f36a3dc86cefb03d3c48191f2ae6b3dfe8384ae848440731d69363197f724da3c32988e20c0bbfa3adbc52e7eb99018b7ef8c4510";
+      sha512 = "033bc2ffed09faa76e67258bed77597bdebbe20eb0a8c17765c7f3261e9abb7cec558aeb8dc913344e4d0179b85928ad49c71979eb6f20c6a092fb7d68b9b8a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ga-IE/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ga-IE/firefox-62.0.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "6b3ffd73216ce3879b26211a3dd26db393eba8f0ec3f35b6626bea3847a614d6624f1fd6fcedd5ac00e5bb08c9465b8ae63fd4105a79acf86bc357dd331d44c7";
+      sha512 = "5481287ee60e87e9f71baebe196254f30f6fd793be8b07e4c216bbb9af3d81c321f0cdf77d4459ef6e50c3fbcd7ea6929eaff38bdda2f8ec18acaf44495f7b9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gd/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/gd/firefox-62.0.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "cdea3ed1ffd14d02d6489983832cf11f87b1f17bc73539e4b27f7a76f267b491ddd3163a80ef9a953e3c79fe184631a32be842474427d9792b2d525df8006ffd";
+      sha512 = "5ab61163854e8255e8cfef5ed8674f6de79cd084839c65b5e2758530135acea5dc159f7001f3ee26f9bbc6d931bf1fd0fbe360a3a570add9560493a8b7e18629";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/gl/firefox-62.0.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "b098ab10e0fda3fe67a04bf3040112e08ae1e94e30d65a076fa0e1f4d4e30e1be99e9578e06650f2fcddc6cc6b57309afbbda71008af67ad97caf9eacc7dd550";
+      sha512 = "ce59c0e9cef75ad9b762d9d8c31f5c3606c047736ef20fca91a12376ee15bd67a46016d0d84da7303af61e78f1ebb6be0d99f343dd2cced01cdbcac536b0fb87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gn/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/gn/firefox-62.0.3.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "a83c0134556894a375ba91137d9513322a876299edd0347eead0869aebb4b04003dca12594cb276e3a521452d4b6ebbabc6be8f79040514f26f6827f55c15d3c";
+      sha512 = "c73b5e5b2ea49fc13f2acf0397d0f98d0178f25ee2ee303fc0647ee4f939eaa465d329affb2e3a41eb6a0d46f413918b01cb7e01b3776f42712d81472e1cb325";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/gu-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/gu-IN/firefox-62.0.3.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "d313657b11f3fecbb0ef26a0c5a2d4b9ead411f2a3c55bbb4bca3ea3a6d861ee54ed1950e9bd5b14b24b9fa569c7c67b73807353331af60e3cd942b570430a76";
+      sha512 = "3a98d619ddfaaa94d0696d05b940d82d12c6696c98dc4356190a6c6a45a602abe14e84888a2282f6b685f26d8954e3efbbd0778b594ac63ed629e922d91549dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/he/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/he/firefox-62.0.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "a05a94f0634f1a857eab463825c97ebf2fa1b5315c44082095d6fb674884b77375968ebd39df05fe6f0f3892b87d9f1313532ea022012cb411eb32a43e1d01f7";
+      sha512 = "9e5fd865c107b2b9daf9ebac3ffc1d0c41b35e5d2b10c930e2cbb1da4aabe1040d4c522940b63e42c2cb2dc0923b851dd6a8ad9fd65da73026d9bf2d44dcd238";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hi-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/hi-IN/firefox-62.0.3.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "e4cc460637c6aefab1b323ac5a13674f9f95eaf5cf0bfc2020869a196fd13f1708814b33c938981017fc27cdaaf57e75591ce2917cc66e5f97b3c8f22d3d44ab";
+      sha512 = "0d625b2ba90172d4e42e17ed7daf1b030ddbaa4327f9d321c67beb0c71e20572705bc54b9ac709fce67384dc6d188fb6832ff7d6e85c79acba8c975cf06455c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/hr/firefox-62.0.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "74c11421c3815b5772cd9a5f74e1c48d914d335babcffbca984187b72dc7a5db0609e7b31915f58d358a12c52a0db204ff191c78af28609c1e68d002a32f313a";
+      sha512 = "317c6fe9bb37418cfa8fe2d48d5afde58a3e5c192d2feef515865ad4669d65010ff5ca0f82efe22003f9ca763cb132798e1c86216f3ef2875178d367b894d651";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hsb/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/hsb/firefox-62.0.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "8b399983719f73f65d2db17af40065faaab4793ab32ab1596e79b6f844d43fe4bf3386343b50a244480bb9f724defc795a6479703cfdce305dba0321e4b5fc09";
+      sha512 = "298dd184b47db389e1b40872dec2c40814c063ef6eda8582fa6fbef647b6f91e11d49026806aa7b5f735ddd02dd48128adf8c5f9bfe17f4b9bc9e6c01ceb302c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hu/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/hu/firefox-62.0.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "a5443cc52bcc5881a7297f2f200418e2a9791835f705d472bb657caceb0bb59f8dc1a7c424b196c2a66bf1f0c042d092a55c5b0d04a085dea702e11e433ed98e";
+      sha512 = "53df50c2e877dab2bf1d7ee40312f77bfac977ba3a041f98c350c1b9d188b539d409f460134f0e79d07c6a3d53fe063e53b1451fd84e7a817b98d6f5b2564717";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/hy-AM/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/hy-AM/firefox-62.0.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "ea3e471c41d3e17c99c5b819ab8c3de8759a275d1ee1af66f133f835ebb6be9c7aeb52ae8b6f79d849e489e0c8f79f69d557d101efe681b27ff38b4e8b306b54";
+      sha512 = "eec4295b544ccf4ddd46176e3b391b42c04d2ebba73edbde24a6cd0043c31d5f06e7a1e6cb03d7ed02327a07f2aaecce7d8c55f09156f413ae3e8f2c18f08649";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ia/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ia/firefox-62.0.3.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "8bd09d0a8bfefc1a73b3a256a2e5be976b88998055299485c6270afc7ee7805a90e6ea9de144bd5ee8d3e40c079adac1dc29e9beb6d7ca376514fbac902f8de2";
+      sha512 = "b9bafd5b616722d5e0b19abe9e2080ede9c0e3d2e971cc1c00f0e3d2678489e5e4268837341fa7eed34e2076c69880e7ec726814729ede4731fc1336f4b5269f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/id/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/id/firefox-62.0.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "c19859ab8b24aa239b0fc91930d8fb581850e631a9aa9033a98aea0287055d2a02ca6ae154ea23e37fd407a00999af1b5f7ce0854865b4b19a8462ccc3838cf5";
+      sha512 = "07a271e3c9b479018de9184b32bb5a164d3ac2ce5431bf714f3b53ff7bf5c324e6e9413b514748b6ef84e2e57b66145ae775b5116e88d1b695f5c9dd001ad530";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/is/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/is/firefox-62.0.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "68fc21b8b3aefe39bc6e87e8d90fb2652f2125af45520e7f91eef12615aff81d0c6237f3fbacce99259761f0f45c7b49aecb59894f161faa8760184271b2fbbb";
+      sha512 = "f101472751e16e29c2928e3d19acd25afeca20abf7f943be14297e6e03762f67edab1ba59db5e22b8ffeac398208083f91ad97772905fe3436e7daac6d554fcf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/it/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/it/firefox-62.0.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "8c8866bff0ea8c2e70a82798253334feca4d96d2e79d37d479f8bf2b5580912565ce08bc47777ff9340ceb4e5677d01eda6cb1d28f25274bab400086493e4610";
+      sha512 = "dfa7a5f9cc4c53f392d061b8bc9491dc541deecb6ef5bc7386a2bda353a8980dfbbccbd16b5a2c167cd523b4f52a9993403bd44ab05b38e03b9b0308a61da261";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ja/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ja/firefox-62.0.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "56e1bd61de818e9271d483bdbeac7c8a95e00a1a2acee2ad7d7e5779b0bba452170d8e0fa6463b0f978ee3c3df720bf338367b8b1f041e5000054268cf267af6";
+      sha512 = "b84f5317b7917be27d1d93d39b0b3ce0143396642d3f5c2a41a656f16074b31aaa549690bfba0675b3ec8cc2ada383929745ed2823ae6afa399bb7407557ca24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ka/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ka/firefox-62.0.3.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "de329fbe61b7563aaa2e62b1dad827445809df6f675518d7d19d9483acd6e23fc502f6abeabc13ed7c5eb2cc5b26a6ad0f0dd431c733f25a68a0ae7e2ee9923b";
+      sha512 = "5d56a8f8cfa5132c3cd5cc3c1bbc56cf3c076eabbf21f98747c493c3b64076c8506150262ad65cb62880e31cc37ad7a9ab5728094a8d8e1f704fcea145c3a049";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/kab/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/kab/firefox-62.0.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "f739aa9432ce0bd8bea4917f590b076c0d88643aa595be951dfec27872d534fa3926a7ed8d82527e95a70689d365c1219d164cda79e06b7418b90652bd2b7cc7";
+      sha512 = "d86d69559d9e7eec6bb111fe05ffb380ba49c2f47a957e6eac8470f81213a544ca44ae685456e22644b08958c54ffe5f815b0812bd045514d1f70a08a5fe9790";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/kk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/kk/firefox-62.0.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "131b3ab83b953130cda7c9c388bf096edf90c424f86d1b6f4221b3601829a2ae0b7cc073a9336d7e4af588e497fb5df7731cca80a8413edf40a2f605927ba410";
+      sha512 = "0cab56f34acb5df1b9a83c48f1a1d2f41c68e79c7896ee4da8ba11bd44e3477214e59697c9e9efec802f633171177ed2653e3184c000d145b7d73089a33930d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/km/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/km/firefox-62.0.3.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "6b0f4a83a746630b87b5a6c933f9aa65d6dbdb2e686af870562800aaa683371a23fbe79f31dcb0ef6ed397f556df83e1e30f83cb493921631e6ac1c8cbcd37f8";
+      sha512 = "4fe39d6a89138111c2e98d1f449adaf474d3011a966c4e17627f9793d599eeef04cc1081c6cac85df235d8854db6b57de1548834abcf3a96baabb30c797e9073";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/kn/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/kn/firefox-62.0.3.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "e4042bb8884ecf46396e9e45a70b57c22b0ef76dd6d452ee0609382e87669e6163c1d86845aa904e13894e750eb2f35d1c9a2b7987aa6e7d3fcd5eaad38d8199";
+      sha512 = "563dca7d5874717937747a1771a9ff32d2012205e2da9274f4cff76ae29782d92d7a20eec8c792564d3a4929458cc5c2722fa38d8b08edcc879dc9ea184c67b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ko/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ko/firefox-62.0.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "02d30f4b2cc7285506239adfea681c780d0e16c1719c6cb68c908c54388e565bf98f1a3a3d98449b0e55b2cdda00627ad6c6f3e63fc9ad10f8c96b2df6138620";
+      sha512 = "69d10aa7d2b91197bb9062ea5bcf1b89e08cd474003e4d9c203f9f4c7df14dac5b991a15c74fad38843d2534ecc5b08878536ca45c2b80e83ec4c8f6168c5acb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/lij/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/lij/firefox-62.0.3.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "3cf57550bc091d756c5a2bb707aabf78cfab1660e1486c9276de5ad37cbae91be24f2170f5b20560ecf7f53d21217bd738b4e4277504d6f8934d3fe1ca5fcb1f";
+      sha512 = "01bb7b7bea7e528e2fb4ad910e591642539e68a8a3771be2b2d28c3f1b54e95d74394f3d9411d8ae9bd13f991ac4dc788e98cbc8532a552fd70e83b6b3cae38b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/lt/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/lt/firefox-62.0.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "606f27cc78c5ee0ea3a61f6110611ecc10c35af63cb9e7c5fa1d3d0ca7a74ac8cd81fec30c1ffe5573c27e0a7f5f04ed82105b8cf26b7c22d648ea217cb57e83";
+      sha512 = "0bb6582347ccdf31dee98a09577380f7a66e8b3222127fb222000d64cb09c4d0ab19d4084d98be2b47ecccfaed51793c1b4fa263634f61eed059da27da0e42bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/lv/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/lv/firefox-62.0.3.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "ab028d6f31a966ffee99cbcd5263b18cae94c6e0a6e3e055d2c86354849b68120d870a142678184a32f816c7e5803d221f3230b895c6ec71dda20a6540101c50";
+      sha512 = "3357a5fdf0e41b88e13c24c37243bb8bcefe75134df4944f286364d4f926efb9188e66a91ead78c7d9228275b394a8375ff9f24ac83489c987b42e34132d9224";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/mai/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/mai/firefox-62.0.3.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "faebf74c8a194f3dfe33addea35965b11f3f9e0c2b4bac4f9e4056c2248df24c26bc9e5a5696fe3f8c2e30e2172dae03fddcffef09bf7837fb6dd9fb6a1b3075";
+      sha512 = "172783f25dacda040e65ac980d6f3d33125cb6721c2c3568255a27f494e6d80beae3d61783171448caaca89358735a4c3b64dd9be47ca5c904d5727a3e0ab419";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/mk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/mk/firefox-62.0.3.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "dddef2e42aef03d11327ae2bc186c0dfd25e81b11845b319848e7c7253c101d32b2801548f6444f4ca01a91c365cb2bc6067e765490f3b876d149899a9edbf3e";
+      sha512 = "8f3b31e48b1b423df1cdca1c240db88978f8d03a7409727842339096f5c1c6099e87c2fe1d6a122a6874c080b61ae59bcba1303479d80b944b4cc8d938eb7a00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ml/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ml/firefox-62.0.3.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "0157abf3d8dbd54f50f6a17d796fba6c66e0270649b8dea1674a696a036d2a59f5841bda55d8b326d90266a198ec0dea3a65753b09fffa583b104c976ab75cd1";
+      sha512 = "dec1bae8329c9f8498fa9d95547abb2c2ec737df03b63ab44600b5132fe6037454070ab3bdb2ec0be1de48bb97c014d985fdc8530b97803c4202793a14e5e6d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/mr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/mr/firefox-62.0.3.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "9c6aa7a0a943b8f62f6888effeb65c6c3f36aac3353ff54011eeba06ff2bb0b66ead6b75d1107ffc358184df927cb2dc7cd3bca183fc54879427baf74cb8e570";
+      sha512 = "1e876518b8c73eea6aa4f51384e6ba9d7dfa983e7ea878bbc26becc248e2badd4647f3a44d273e33a742e5b6f99ed5ad364d621eff314c830612e0971ff268cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ms/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ms/firefox-62.0.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "b7a723f79a18db5b3d886c39e76a65975c2f6229022c62cab7d7e38c840206d9004c81da1783f4bf0cc373438518f1367f4a34e3764ea9919568ed4c8725c94a";
+      sha512 = "3c72bd0536ada586d31d02cb0b59184889a064d09cf30f73bcb93417064fc6e7905fe084c554d249d0a29cc6ef6c57dfddde7d97d658c14958861397455f267f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/my/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/my/firefox-62.0.3.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "5538fa15d3ff02409bf9145d384e1c8e28a182239a682aa5beba671c09a0b813b56af6482476d57084af6a5895ad21af1f6ead71ecf23ea817780aedbd33661b";
+      sha512 = "1118b4d8caf8dc2b4a4aa6ee01805bef409e9238e38182ad8561bd8cd1885c22e2462b7baa00355aadbd103279ac0aa008299beca0157356f49773040916c3bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/nb-NO/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/nb-NO/firefox-62.0.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "8349c51a6b01301de6b0e0e37b665f44bd83abe9f771bc086c3f369534b6d4efc692441a46576b2335afda93cd8dbeff60ce17936e205e3c7212a2ef1b2844ce";
+      sha512 = "b0243d6642d51e9a81d58951e9251cf586080a7c90849adefef1678c856a34c0cac710752efa4f3cf1f9d099461968d0a15327d9610bf1792e451bfb38296c56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ne-NP/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ne-NP/firefox-62.0.3.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "f16911685a7d233a8957780c5526be9e94c07f73b259dad09855b8c21bdba1756ca70ee71dd7b732ac56555135d749584986bf4501adb056373ded74f96e265d";
+      sha512 = "668498eb589927f92fc53806111c47b7b130d08c53c8a3d997edab4efe52ac7aa1388dedaf976fe46cc45603249b99922b803f32b5306888df194bf4d6547aa9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/nl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/nl/firefox-62.0.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "07e271170d05cb87cee9361efe8fee2007ca032b462ce68c562406fde581f4baab96c2ccea66cf92b8e72aba4647e7bb8271ec50e3adcfff6b787699b687a23c";
+      sha512 = "c6db81626bfb20724faadc34e113eba0cc3da7e251d1ea9e859ea4b1c82e2d8ecdc01ae3b60c12eab5b071e62c3cfb85a28cddb43573a9da39d3a07cbe78b7ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/nn-NO/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/nn-NO/firefox-62.0.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "eaace3b808dbc919d05a9701e7af2bdb241d57cb0356e4eb60b4706def37372a16b7767540947efaa91d5a3f338785187f83caf8bfa5bffe5f4f92aa3bec13d0";
+      sha512 = "dcac12899163fac3d191104542f1d834a2406388f69faa78b871106408772a0cf01f73caf267cda6731e557cb872c341d6ddcaa1be9c972007e7a3cd9c0781a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/oc/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/oc/firefox-62.0.3.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "aeaab0fc9ba77aae2c0ddd92d7096c167a99335b3d795f232a24e685d49b53678bed59b6e873ce1c7667f76d1527bf685b910bb51b8defc539999500eac14d5a";
+      sha512 = "1318631847b588dcf4662a3a82a80fb8bd1eac1fe1e78cd4bb5b1bb8990bc7c2adceef1dc057df1ff54cfb195a05612fc5957ddf22bf8355341d6744e1938df6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/or/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/or/firefox-62.0.3.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "92b82c7bca322a9bfb6e6df61c9f2b6d82cf39c67848f2905dd372a627eb0379d235982e5634577825ad72794fd1d49b2e591ad5347977dac9a745d1167f7467";
+      sha512 = "6d9a2af2ab431eaa6205958239e33d336f11ff789ee2cd62b90533153ce41b9e17ce3c8204d679c8949c1edbbf493efbc96d009b463e5ac96b3200ab8ab7d707";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pa-IN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/pa-IN/firefox-62.0.3.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "2aec320ba120dd3632fa95599a9934ce133544e7b0d15a74236fb20435ab0a9ad44d6515f82897e7badeeeae19eb80d6b68fec4d000d63772d4e5ccd1f11d1eb";
+      sha512 = "e7a0b4ff68c428d0028eb098dc0f1da82e14de691ae77d2d94e32465ef50c8af70dc9abe21f92db4606ce4a42d443b181e11bf2157363faad874b07f9c0e0110";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/pl/firefox-62.0.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "b62565b94eaae3ee225f2bbc8981f493594f48d40e8e8d83564a6d4ac6a4194c952663f9db52d7694993f08f714463b7607d659790236a727cbf803b084eb73e";
+      sha512 = "780886f9fa3136ea6d3981e2b63124e3c625acc971c144978840e254e1fb77da5e65fbc7b6b7edc6a363e5f24fbb09bfe16bcd89d3171e6e92efe18a58946e54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pt-BR/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/pt-BR/firefox-62.0.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "2b218b66feb456a86919b395d1cdc40aa73de6ebbca3bc4135c54d5dc1ac993bfaf169bc7b0d2d770aa6f4565e71ead1fa2aaab02dc7362a9f4e5a896dae2c2d";
+      sha512 = "d922b1294bb2aea2019034e7af38b9f01cc7aac316a223ddc54137219f01fa1a6d34b23830d82dc9ce816024532cf0535d2753a55b36e952da1f867e487924d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/pt-PT/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/pt-PT/firefox-62.0.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "d89122b993083bee798279c72a2d6296a5b966f7ac30269edcfe17a2036db648cd3e1e77eaf5f2479afc3c6831657267b22f2507176d62ee08dfaf4c100e074c";
+      sha512 = "86760623c1aa85efb05fe66929f1668fc6c7b2f631b77c9c93d1b12a23c6409345caebc25a70a6891f480dff2112966f283e3658e08951a49bac700de754c975";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/rm/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/rm/firefox-62.0.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "4ecba1d3bc6b3bbbc3ca974afa86e9b6e7664a0dd23605ea34349bbf822fc2098e7dd394f132b43e2e4127eeec36ec820710391671405b14c414d966540b63e3";
+      sha512 = "b66f542b8ce0e878fb9ad599233adc136a20e09f1b77a82050273e16903b56b6f3f8f94a33fdc7a2a1ff0eae94d20cccd4ec6ade8c2ddaabad3c32547303d5ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ro/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ro/firefox-62.0.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "97e8ebd7bc491bd320106765408bdd88542bd932c3c1b43a373aa5679f20e2a0aa12b48182454ec36812dbf4044364850cfe3e6878bec670ee46e8971e9293cc";
+      sha512 = "393fdf5d1ffe51694b50f5027243d19c2f1d5d25daf9ad88f14f21ce3bc3e0d5bece8cce2f3192d263e873a8e55e1fdd6ec22ce014c43c71ae9fe9833a7b0df9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ru/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ru/firefox-62.0.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "f8f433e0d2970d028a01f1039951f1e725cae8e263bed9f0dff64387913ae269558f037d672a65d32614408cdd3267ddd65677dbcf212188c531d04960266535";
+      sha512 = "a1af73215c8e3151e45e8a0a7b1c4eee51301065b3a724f904005f41101018eb11313319c1b8206432c4958d5a415575baebc64ff782b4e3b993b71d4a66e829";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/si/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/si/firefox-62.0.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "11620e27c01dd91114d5e2080b430876282316ce6d527100305806314b4e7fccc38f2e93165f3e544cd3ef63b03aeaf738d6079201a0f7ae3f867b2e0b28239f";
+      sha512 = "ee3a7b6b1e9a5b10661390b7f1d1fa61ef9589d59e4f869ef8ff6c4a1719fb15014e2abcd8472769c4a17b3f74ab7ae2671f3f79ad94a1d3d875f2fbdd03eb8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/sk/firefox-62.0.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "0a43e8fdc1c3f2bc63b6bacc15f9e3f3527302d0d7f0f0e0cc9498bab7728cca944fddf886c33ab67c60bcd9bafa051db97c8e8a77e781d6869a4bdb8096f4b1";
+      sha512 = "478eefc7afb725496e3a17615c8458d29e44dc200dfb4534c32cd15d3c45ec15ddf9f5b1fcaad312e00d693a06d9bcd116038177d9844273a64f81b531b6e676";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sl/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/sl/firefox-62.0.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "343a22feab53142ff585985fbaa8a037dbe9c3d3c2c073361f8d4af3b74272a47e5df2053ea91b333bf0da15334b9512c0513726ae80176838774020a7c7c639";
+      sha512 = "f07fae5f52528899ef3dc680ecc551311496125d9c10c2117e35d0ac8af387d99236ac9a3f921a9ad2e40102d70df91fcb43526ccb8910d5ded1379a42bf5914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/son/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/son/firefox-62.0.3.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "bb9c9c4bc82550b6d83c3b9995a1ca3afadc9fb5b27a5de4503682d29428ed7751895d1225a3b5ba8472d539c9efca957522187e4119e4e134f46b37da2f43e6";
+      sha512 = "f20dbcdea88828cdaa4d9bc2e8ffd2792e06929495b0268814808f842c1bb9ccd87f86df16b005af989edd3c470d53ef6254288664ea192d15620ed10ef2682d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sq/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/sq/firefox-62.0.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "97b2c394f71e9bda6fa679353c579a01f40a4fb5b588bc177329d6fbfcff0d126e2db072c868eafd6078c26f9190f1a2d4c65f887754af4d25eb9c128d807030";
+      sha512 = "9a548ee02d1290c112ac3a72be6cf96163cb67448a8a5ae00a88e3e115f907945899cfb5a5edbf3e37a13c16550ebe7b6f67f94c05be6659c168a5e0043adc04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/sr/firefox-62.0.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "84024816cfd48076ef5ddbe0af392ab5ae0bcb8a02cc0ee1f6d0dafdf5673d9dfee377e83f0a9508c11593d8f4db682ad400c336a1c37591c25864c9299939f9";
+      sha512 = "ff081635cf761293ca77ce7d3574e0a1b6a57d7dfd5649089e9554c27b85de544a39b2973205e293152a33d69137ae373110a884f6427dd58788c5832caa7773";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/sv-SE/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/sv-SE/firefox-62.0.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "b630b627b038b16ae1b97f669e79afccba95e66a93dc3b7358e26960ae836f1f3663a49394b7a9be9906871a2301824c6b1f78f1f38943b54e4631f9beb90407";
+      sha512 = "28686a08fc1c4cc63a084cbfa094e6f1b8ace446a5746f3892ea37d1b916806a15641875ef08c850c316059078a116a2060294f754e722d84d1fdc2817ed7618";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ta/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ta/firefox-62.0.3.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "1306d444c620f558894ea81512944e1d07dfe706306206d1638c2e86ae5a2dba4e02b5927e4c9250df3cbc607d15da15bf2cb1c9e1ff74332354ae883c6bcc42";
+      sha512 = "43b3db7262fc43b19f66cc586af56a404b6b0feaa98d31b53766deaa8d4f5314279dd6aaee5e3373f8c1bb9f4c152e2ae6d7aa5b9e4b1123a5dec7b42c6b68ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/te/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/te/firefox-62.0.3.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "3b0e1d6fea01ac99e315419365afdee54c107dd33ad577b19fcd9a59de1a176f34497e607fc7466217ddef5a6c442a62f1dd41cdb137651c0274274cb9357171";
+      sha512 = "05936a5de6d723edf72c1155aa0f18c9a6eb5275dac4f4de58fe93cfd9a814e7ef349fa6c630d043d6b39ca5dab6fe5f3c92c45c36d5b515b4748bff6493063f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/th/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/th/firefox-62.0.3.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "7bcb0d7e17d397a7b114172234f3306f9faa28e7d9f8bb2db1399b58c28bd36ce4e478686c3ec98c76793cc75bbb974a316599b3a7c38fb034e852100ffa13e3";
+      sha512 = "5ececcf6b3404f1010b48956bb2423907261f7d544a695e775900e1a3cbc09e71b008b94118ee39651ff6469cf8c456afc5ab9c9fdf0b9fa4a9c41f76e16788b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/tr/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/tr/firefox-62.0.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "5c543b8bf79fdcb605b6d763688ca5bcd1e61b0e2088441e1d6d6dd4f0823f9f3d2075f39776d582bb468dc41ef39f7d562c7ebb6d5e4f084c3c1aaf1e61de8e";
+      sha512 = "29cc67dc15acf77589fe72d0e28591b5f4403de5cdfc6cfa7cd9f16ccf7315ed19c2d38872b5c76c1f4a78b2688e9401417b6e6ccba1985c27becb54baba4d22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/uk/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/uk/firefox-62.0.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "2fe636a02d0adc75d00f67620fcfaba902d16b5d828c2c9770560300c33cd0a8a8bd7208f146943cd62ac0aa8e3be784ff8549de78eb4f247783e1cfc823dd1c";
+      sha512 = "e7814a55b835051c8d02b74e4343739241ea60d69b8060a496f60b6b323b81d8628541d346281e0080d83d9ef4183640c907c144743d3d444499c887c34709ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/ur/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/ur/firefox-62.0.3.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "c84e1bf737b3a4b93f77098a087bd7ae598364d6a15110d3032bab4ee8aab6d1a64ce3ec4ef17b197b920e334f1e57a7a093581b8ac3b1ecab85d9cbb2da2c50";
+      sha512 = "e6323528d7a916473a62edd9565ed8d67832e3298fba51c7aca32f9d0c2d401ac74d2df5770962e191f7fc79fbbe6f22ae242475075423a23f09c8f11c26afa9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/uz/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/uz/firefox-62.0.3.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "cee9849825181c517a82c6f6cb07920767ff2c02d54b87c8e509e60bef3adff260f282882b9495b6034fa61b11e2cf831e3adc3ed3928ff32792a62084cf115b";
+      sha512 = "759e63deb63e59166d137e109f81ecd57a314aa045eb97a54ae82fe04a418bc3ac73c83bb663d65fc1b66233ed49e43ba7ba5a8db1bce5138fc6b65b7377b230";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/vi/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/vi/firefox-62.0.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "a0eddaf392addf41017108ded0d32418175ab5ff7cddf74e3224929da93bc84cf07312671f16aa5652ecdc315707a4301c69b856be709f4298861298541a065f";
+      sha512 = "cdd1e2fb71043fa628bc9653a1be4c7a4d64779383b25d2b1812ea7af2eea3711cc2777c09be1acaf2fcba9c931cd212c99bde69d067d331a294825b89c2addb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/xh/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/xh/firefox-62.0.3.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "50741d2ff1b7f1d9cf503af66ec61a2d19600ad7240db837392440b2943c6d96a7b8d5538ca24f0d528cbe9fbaede7964c9f8404474f95a1c022e193fa91f81e";
+      sha512 = "97eb405cc8379cd803af5db55166b9db1e489c5a0e29fc316cdeeb49e2c2beca2ba87f7f01e9117dd22639d0cbfddc26ca90aa4187a522462a1b42126bee89a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/zh-CN/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/zh-CN/firefox-62.0.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "103be3f37fa7a92c00d6465f93bedffc31527939bd85df0c742c04ac75f9ddec4018a368a2ff29730f5a055459b018c64afa344df255638ec3c26bb295e1a31a";
+      sha512 = "7559ae148ce548d2b766be291667e7f04d9c28bca0de467cb36f37772736d2f44cb3724e0bf0c95bdd11ac2a84ab07238e14902d6f8f23280796505cf5b9e471";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.2/linux-i686/zh-TW/firefox-62.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/62.0.3/linux-i686/zh-TW/firefox-62.0.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "0ac22e595f2d87f75b586eabab07470f9eec16026a45902fb40c19fd2cbf93f2f88241900a13703edb89290953127c689bacbc0eccd560822e43bc07a97e3ddf";
+      sha512 = "95829dba29e96497f047e2f03a4bcbe36d61c0a36637087e56300f889f9b191c7b6c4ce936604283145f4a8be8ee4b129fefdeba7efd201cd0a647a0016ebde1";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -20,10 +20,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    version = "62.0.2";
+    version = "62.0.3";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "0j5q1aa7jhq4pydaywp8ymibc319wv3gw2q15qp14i069qk3fpn33zb5z86lhb6z864f88ikx3zxv6phqs96qvzj25yqbh7nxmzwhvv";
+      sha512 = "0kvb664s47bmmdq2ppjsnyqy8yaiig1xj81r25s36c3i8igfq3zxvws10k2dlmmmrwyc5k4g9i9imgkxj7r3xwwqxc72dl429wvfys8";
     };
 
     patches = nixpkgsPatches ++ [

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -70,10 +70,10 @@ rec {
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    version = "60.2.1esr";
+    version = "60.2.2esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "2mklws09haki91w3js2i5pv8g3z5ck4blnzxvdbk5qllqlv465hn7rvns78hbcbids55mqx50fsn0161la73v25zs04bf8xdhbkcpsm";
+      sha512 = "2h2naaxx4lv90bjpcrsma4sdhl4mvsisx3zi09vakjwv2lad91gy41cmcpqprpcbsmlvpqf8yiv52ah4d02a8d9335xhw2ajw6asjc1";
     };
 
     patches = nixpkgsPatches ++ [


### PR DESCRIPTION
###### Motivation for this change

- Critical security fixes

https://www.mozilla.org/en-US/firefox/62.0.3/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2018-24/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

