### PR TITLE
brigand: init at 1.3.0

### DIFF
--- a/pkgs/development/libraries/brigand/default.nix
+++ b/pkgs/development/libraries/brigand/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  name = "brigand-${version}";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "edouarda";
+    repo = "brigand";
+    rev = "4db9f665b4ece31b51aaf35b499b2c8e5811efa3";
+    sha256 = "14b8r3s24zq0l3addy3irzxs5cyqn3763y5s310lmzzswgj1v7r4";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Instant compile time C++ 11 metaprogramming library";
+    longDescription = ''
+      Brigand is a light-weight, fully functional, instant-compile time C++ 11 meta-programming library.
+      Everything you were doing with Boost.MPL can be done with Brigand. And if that's not the case, open an issue!'';
+    homepage = https://github.com/edouarda/brigand;
+    license = licenses.boost;
+    maintainers = with maintainers; [ pmiddend ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -961,6 +961,8 @@ with pkgs;
 
   brasero = callPackage ../tools/cd-dvd/brasero/wrapper.nix { };
 
+  brigand = callPackage ../development/libraries/brigand { };
+
   brltty = callPackage ../tools/misc/brltty {
     alsaSupport = (!stdenv.isDarwin);
     systemdSupport = stdenv.isLinux;


### PR DESCRIPTION
###### Motivation for this change

I actually wanted to update fcppt, but this needs brigand now, so first let's introduce this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

