### PR TITLE
 thunderbird,  thunderbird-bin: 60.0 -> 60.2.1 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "60.0";
+  version = "60.2.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ar/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ar/thunderbird-60.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "fd37e00c8b50d1dc932295288ad2865358da2f37f5b170a3a7f75d929e78486165a24f1967defcb4032546a7f712cd6887c7cf47257a4a08685df85f9ecf81bd";
+      sha512 = "026d4f74378ab0c94e14689161187793ec614a3c492a20d41401714d3a51a5478d060d0a6072a48e20dca88e7d0f4853efc293d36999ddfea431de466dcf94d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ast/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ast/thunderbird-60.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "64a14f40678a64def00597eb1bd7cc0c9759b56da4e72bfe24c3d4e50ef92414bb18346b8ecc9c0a834a063a2a2fe7920b72c2ce59c7cb7ba67442f7e8842b13";
+      sha512 = "a9156cd525d072711a78f7c45261d50e9057f1f797fe0847c0b52ebdcb42a9f283432da036c870209aedc37183b2fd4df12527e128f46a06d5eb289bdb11d379";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/be/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/be/thunderbird-60.2.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "6368f3693f0f54f4768d27a4b9f82015d4c789180db3d8ea5302053e2ff8d7bc5e50388b00b7b1d534c0145718255c84d43977361f5d8cff5f432a8336436e9c";
+      sha512 = "d75dc81e7ed655e5bc539362b4ea212ef47bed496c483a6401c8cc52fe2aa7c89f12024ef5364e8e44826c5df2a7cc0eae01a55cbfb22c78b7d29744e05c2389";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/bg/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/bg/thunderbird-60.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "b881105b39f5a3d66cf77105fb555af692477b387a4fe2c13c9c398968baa705cdf3753665b0e6d28bd8fdb21bc75e439672402dbe1185a9f8289b8236f505ef";
+      sha512 = "4302c20cec5239d3cffd1c5756537059f98eb19ebe6332ce255ddeb555f8f07b6ce03c18ccfd2adc7b1a51c954a0ef3dfbd98ca2a5238cf510d4abea48d10df9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/br/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/br/thunderbird-60.2.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "c45a3dfb8ae5564071c2e59a623263f995a83f9ac20c84345be47935a337b863be3d334b2e0f40767842e9a53cbb1eb00dd87645cb0b8a737efce15cd81b9336";
+      sha512 = "c22bd6606886c50fd782f1646f03917d9988a76020fc5e1a210e39a771980badcea965332ddc80f6f08fd062be4f08a499cbf7ea3585c78cb7089d40b40b92af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ca/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ca/thunderbird-60.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "aec05cd7e9a5f529408bca9691ef68bb384b23b9cd464c9342336b96da0afe20473121128861c20d55bc3c4f5c33f779fe892681270d5b26df6b64aa27c13511";
+      sha512 = "7827c61dcc0294b85db7709029021daf52148a9d00b1d06c3a05f2e3591ca1e9e75a84bed3ac01da3a7f4af7bb2842b7574ec519849c8a5cde30600f0d237c85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/cs/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/cs/thunderbird-60.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "e0286e388a1b9a273043bfbcfd2bdf9675bede43d6b3f364882a9f7a9bee1fccd76e5ada76aae309f961c3e0bcae6373cb40457a53d48a9ff37c9fb53245f889";
+      sha512 = "dd51fee0d4e2c87e841c1e13aeff54c49e375bb95ed69f539320815cb551d57853032d42346516627024f88ba77154a8f1aeba651f3e90b5d5ef206dfeb23c5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/cy/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/cy/thunderbird-60.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "7f5f28836084132f044b3fcda749dec03fa6234a04eff73a8001f804c98be8df57eba564e864bf09a9938818bb86003d9fcf54cacba2d1efad7a330381e08b0a";
+      sha512 = "29c32c26fc56d1fe7ae47fc93d121b8591e75f0d42b25ef3e1f9d98f3bfa66bdce551d96c8f98f553bca6425173da43f9e9a13f3f006db1259f1b69a68abb7cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/da/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/da/thunderbird-60.2.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "1b9b63abe185fc91ee2e0dea054bc5e94941bc2cdd59cd85c9997ef9d49eed0c93827265847a480845901af8b37e3547c9301896beb538aef724945bca2ed2b9";
+      sha512 = "f57484cf06388193dbf3e6ec9c8c631829e6e0914dd785fa81b007bcd9789cdffc777d6f5df5939a1e125f66f9cd2a04d0b4a9dac5250aa615c7033bffb70d97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/de/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/de/thunderbird-60.2.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "e499f327ed9f4536b7bd9659879b28a2282a6a2b9aeb4514b3a70f774d76427283379293d09e95271e54f7c68ab07beaa60e867936b9de8c09b600914d3e4156";
+      sha512 = "d12857d40c23f3817809e09e1edf9cf1131939d2aa5e830da2e9a13b4971096f33691deed0a29188510c2f84aeaa2a7ab704f54ced3c79885ea7b883cbd88f49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/dsb/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/dsb/thunderbird-60.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "d862020f5ae7c50560ba4c58d67af4c0e54622f826934b90887efcff5ae1c97126bbce0bd42f7e1c1215258b92db6a012b184a2106f4beed0d7e8c79b84bae54";
+      sha512 = "c65ce176520eaafe2afe54cf3ff6266bdeaef437c29f82e5580f286c31bb97881fe9724435995b5debd14306332ce2d379e45a30350296473f140d8caaeaee6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/el/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/el/thunderbird-60.2.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "88b98d3558400370b48f1e133147b8ba57fbb240ad6db1bbd79d7e0266c4a2814fc9cad5521ea8c0296b14857bd09cb4e8e0d86f625fc53d621008729f31e002";
+      sha512 = "8aad41efc6bae79e6e5f238ad6209f0cec7ff3ed0f82a4ef22a0e1e12c3ffb2577ff105983b1f1892591e1b2a58f2d8bb8d9ea51051ec930649dfa954341b219";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/en-GB/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/en-GB/thunderbird-60.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "02f1eecc4aff0a8691cdf131736c34fa93035d821a645c97213be41a95b4ff00d244411344089e56c24267984bc91d294f1250b1fd7e8c966ee9de9983794427";
+      sha512 = "b75eab236a8749a185083c33b8f28492d903ee84b2b5a9aa3659e04eae7bc72cc93493a6cafa39ca29ebd0c065301e1091d21a23836b41bc4a5b60f4e61f6668";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/en-US/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/en-US/thunderbird-60.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "87be28d46f22885c730e89c0a945ed307b23da11e331a5911b21353a53536587f8e95658de591d44a9bdf617dc3d50099f537bebe85680dbf1b3f25c7f18fdfb";
+      sha512 = "71308c1d6691894ef60144f7bc119709491eaa3af400197e4fec61f25231266b085e925fe1163d6de8d3d1f3ce34475a299968e9405341a9881c512fbd6e4362";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/es-AR/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/es-AR/thunderbird-60.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "4d1651de4d4b3d5324ae5b07581634fc82399a2b0f9793d53797224d2f6b1205389bd0672b1c671fb956191312549b446c317ff98f187e1a7248aba901bd2499";
+      sha512 = "061f0ea13b7c213ef2020aa2cf9ebee51b6b72f0de9b65ccb095f7e67152f5325d6806af90b5f600b7498d8cbd18916079e81914affd29308e04de0c7535939e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/es-ES/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/es-ES/thunderbird-60.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "6abc82968464377cb2c05bc09b1bc978af65d9423dcba78e73e8d0817a2dcc1dde89711acb1d5fd9e3539cd33c6e3813e6b00297f3a23ff1c4250771b40c8522";
+      sha512 = "39c7b2806400cd57cd3e778d57f174a45eaa6e15bf1975d7e82f082d31d965e13a43ef130952e00300df9a13470c780c60f0ec9b398210b183593492d30c158a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/et/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/et/thunderbird-60.2.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "9e4bba499f39ee7a87676627fe3ec6da2dcba6a55e39aec897953abf00ad08216550d0fe94804a5426e2894970ad2db3f391dd09ae2768580ea05ac6a77ddbb1";
+      sha512 = "29b0399f7d896b09bb74b9ab78d10686061052493b880f72ee31c00db7cc226e3fe04e9519ff23e139c9644045bf9d6a45a8570d105a9675cbbbc310a930370f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/eu/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/eu/thunderbird-60.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "66aaf66011117c2f9e675f22a68317552ed7673c05dd56266e4a8719e853629648de3d88fd44448ac1d9674b0cdf6cbe48925328f633c1bc23cb5a7f005468ac";
+      sha512 = "d53ced6a20ff89966888d9241fe483d0a6a5586ae8da4a6d9584f6298a8c254a06e2e1e4527536e38c42f92cc14b778cc8264f402efa6abbaba6ca52486c5e06";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/fi/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/fi/thunderbird-60.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "8c61206e100182080859c45736d973975ae5e1055fc2df170828dc0715e04be5468ba815995be9d60530ba9600e187aed965a1d94f9887337789c8219e2cca6b";
+      sha512 = "2fdf8b87cee0829e78d130ebf87b5d4bf62266abf17475d349440f7dca043ff7e1c14feef1f69b630cc81afb42bca52440643d0e2f833ce0a61f19e1c1f25721";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/fr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/fr/thunderbird-60.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "1583081060580dc72d864ca88ae8f114a22db4d4f3177532a4345471bac6ca3a85397b5bd82cc32f85dbfdc4992f788dd15a4dfa9d6fa7b154d3921c0c23fa29";
+      sha512 = "288f8346cf90dd666cbb082f1761ad8fdd77a33e43bcca1cfa58c1f84c86bd6c3f7cd6d1d4effdb9ed77c6a50d07b8e5ef3505dc2e2098dc3c38ec32e7fa99c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/fy-NL/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/fy-NL/thunderbird-60.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "59deb0b3e32dc2dbcce96aed6558dee899e290a469ded997bd2b7b6b2832f5f7c358d44f128cc1fac2327e3c19c43400424dccf4a0478bcbfeae3401fbc93882";
+      sha512 = "836a74aaf424a93304e12a412f0104ed5d577bd10ad1beceed1b78f2dac65d096103e9999298e25cdb8fea9d616fb4f814ad8c3bca84aeaff0cdcdc38b8763e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ga-IE/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ga-IE/thunderbird-60.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "8bba0addc0d9d1000ddaed0702b5db0d797f3ac9fff0f04e645d6fb3747f961c2570ee058e53d4084e3c02cbb8490c2a32781517c57bf7971b8f1d4db0fe871d";
+      sha512 = "8c680f783e26193a26c507491b82128b123ed89e73dba328391d18264c5780ad88b9f077d4d12868dab6968f4be7e8f1c0dbe397196b556a5af31c07c1b1072e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/gd/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/gd/thunderbird-60.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "8e8f5df3aee5f1dbc1e6fd8c761b5d968dd35b9e29a8c04e013a7de08091f65cc2573109f0bfe201048f90a578ea84f1bb05826d7bd8e9fb7dd9110b45623034";
+      sha512 = "e5b092f6b1b79b93225c0cae4022bde8452598d8c36b9e5ebd8fb4b9449d265df048526c30a1207b9ebeb7a5ad421ae77085306dbeb9d1d5b9c34decb98da1af";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/gl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/gl/thunderbird-60.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "56a56179eddff5da07ce124f17ed08a6a033d7c2c3d139fd5b00afdb86f0c54215525c40f9c6c108384adeafdcc6f8dab87d72b07d88bd38e0c43c89aac4db0a";
+      sha512 = "ec235f57cdc56a66885f2d8098ab9ce80ab3fb87fb30b4c5cc97cde874ae321e326b3ce4fc9e69a6c7f0e61e43cbfb28c0392349151b25ee25a2503e13bf5c3a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/he/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/he/thunderbird-60.2.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "6880b7ab22b3e642d10edce67458fe30935c87dad60f32ac32b443473e5a208a4df0645b2a18ef26d5ce40053b3a9119eb432e640afca8421c4e93815b28bdf9";
+      sha512 = "fc9f1ef3dd117b6b4198a09997e3e4095036dddcbf50a32b94a36f53ec886bfdb33debaa2c69b68c14ba7af945c1a35891b11fe9ae8602c11842d381bdf0286b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/hr/thunderbird-60.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "14b22f95559f1c9addf04d51dcf857c3cd59f3612743970bf9cbfc99c84a3d0fcb898be7e83858c0848e341039493a5aba4189d24941362327f4ef9982dd739e";
+      sha512 = "4d548d121cc8111711ff7a35383ffe859cdd99a692b255dc71d52cb4cfa90614a5415a58f000ce447209c998b03fa545608333a53c5230fe01527aa882eea295";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hsb/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/hsb/thunderbird-60.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "5bbddd6bb288cc03015707bd2ed3ef38ff20c7b93b08907e1b90cd8a22725786a293fedb142f99e18e0cf66fa14529097399e95fd157c434414c8fd61c0ba70b";
+      sha512 = "2f98ebdaa190aeebbe60fe20d6246d027425c3d5408abfefcbd50857ba800e9fc53b0177f54cf8b710a013bfc59e4a58b237991058a123cd2f8f0e1f4afaa1b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hu/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/hu/thunderbird-60.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "4f751f64b1417022f6c1487e1f3d92edc0ea1cd603850a9f64b35a71a652be1e51dfa17babb66e3447bc5a8bb2693c6e2dae89a736dc2f070b4b6a9500cf9299";
+      sha512 = "b54703d9b7eb868a771538c0f5ffb0e881efd9137ed29b684dc149e77b3f9a675d0b59feac21c8b1f54c35545b9a2ea2274bcb485ce583102a406e916c3c25f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/hy-AM/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/hy-AM/thunderbird-60.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "c932b56abf6801bfb6ff90978343aea12f67f006ea71882fa7bbb469dd750371330c47581f48aec3ecfca9cfa51f7edfb2aed6a3da874041c2087b5c5ff60abc";
+      sha512 = "f3e3918538df95e6a278bd680d019b39c5382078c79eece57f23810aeadd43fd61810967aa384f222f6d21d5d815cf3bd7520a7d31e44b3d2e6c024ff6b46a47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/id/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/id/thunderbird-60.2.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "d8a61bb0c1c308d7ef89a9f938fd1c738ce8e66cebfdf4a236636e3c9469705c1012d19c3d3cf8837bdabefed01c744692aec2d749c7ec0adb472bc125e54cdf";
+      sha512 = "3b1956f69a4b82a900dca97f90b29d7cb685c79e6d6063b58bd8de629fd604dca58d058c8b0855ae46daf9517edb1451c40f669cc98e986ada02e317b131b19c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/is/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/is/thunderbird-60.2.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "1fe98420d0ceda881b50e4dfff667de59b960c1d8a23b5f88140c076fa5bfc8cc01b636a3b9bd46987f87a30ba6cb510eeaeadbf83ada954a5681c3da68cf7a5";
+      sha512 = "fa5e7574bd73c1d85d300b151a5d1c7852fb035ca5e4599b675008170074736045ee034169108eafe6171371ee94b84003922088e8e0dc4b1c05ba7837499c4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/it/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/it/thunderbird-60.2.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "79190716416c48bfaf486470a5f31ef881bce0b97e4c780126581a38ff39e6a14ae12487779ed219e55afa2467139b652f54e989b91f4d438685d1fb174f920d";
+      sha512 = "a2bd51df6adf2caf4bb22edd02b3b70d94abb1d3ce22731a3188c718161b492f860be1cdd94c39c4a64e6ccbbbe80092310448ff08d671d870ec565b36466b33";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ja/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ja/thunderbird-60.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "c8c9d6a31664df4e7ad9668a73197da100f5c0b9bcd7bc500638f1d1c26e123a91cd370cd574185f0a2700c44564df7a048b6942265294c2326c8d0ae02f8c73";
+      sha512 = "b065494dbefeb8ed79b40b255bc8551dca4f0606c204f00d7c0cc0534fa1aeff45d0b7fa80454fe8ae8803b002600d3e332f7b3138894005922aac48cbdf9ef3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/kab/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/kab/thunderbird-60.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "d76f7178edaee6d16045e332ecac4dd31d7eaa3e8688c24cc48cde48df7df9b1bf9bbc0d76a95e8c35923fe1fb743792bcadf8d3f705f76a8acc7d714b8b0bad";
+      sha512 = "a22017107f11151f2b383d11d6a6b8aa45571c3c4def1ce422fa4b108b546273a362279889c60bf5b01dff73b497879d881b0f8960be97ad92526ceb0ae16488";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/kk/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/kk/thunderbird-60.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "f3d13ee3665e6345ea8295d616d227ade4be5af166af08b0a2094ae27a69eb82955933967f734e111930d802270f8c5ace57a9f16bc56b920ad9a3081f82acbb";
+      sha512 = "9d9abbd85a6bda636aacf361dafa05b7f64dff8a7cebe81d2ff9b6d5eca9c800753cfbd3e9dd66ca17edea0bdf8b656d242f47e53f5aab364b14a88d2917da0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ko/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ko/thunderbird-60.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "9ff20db6d945938868b5b9833519a93011d33804f5514f0f347814137f9f8e96b427658f1f086867c0b272ef8fa5c22e92b8093950b534f3ac0224f84bbf2779";
+      sha512 = "083b33b6b50af83380e2976fffcfe9d4fa3fc64199bd6895606392842888ac66734deff738788dbbe449ee7c7a1e06608caa25320c12b1d49885825f7dd8a500";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/lt/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/lt/thunderbird-60.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "cc0309a724a2b21bd6426af53e5ca6b8168f2e3f1293c16aba954c1484defd0a227a1d93c4d92e946d5327d5ce58fcc37f6848d180426e3cd9673de483676713";
+      sha512 = "33c16ff80c9cea364bf2d4a501d3d7f04eb6a04c70785d99e0d8d5fa2272acfdaeeb09b45e618ea1c08b9da083f7fdbbfd571eb84699d0d93718e103810983aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ms/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ms/thunderbird-60.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "59351da7225877be43a1e651afd089facd47675497d8f2c0d6bc1c8a2234058ef9362b30309d65b074c8b98faf19b9d4cf80e83cfec2f8e438fc0a7c6d60f899";
+      sha512 = "92368bcdf6157b7fbcaad6f5abd40a6dfea2c12d3aaa6eb58a2cc118621ee8df50f34f506aa124413264a44cedadd1755e5dd827f4ad6df069fab9d6cf3b08ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/nb-NO/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/nb-NO/thunderbird-60.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "94c5f139cda0a90bc575f32f6121441dd198455482a89d052227777759f912f26aa53d74a6232e3a78ecf1cd3062cadfb3c7f30e349dd59bb8797825dce825a4";
+      sha512 = "d06ccb94bbe15947b8cc1d685e6ab8f8001e717e104cd1af6799a02c47ac79ce8e1b5315feb6ea3683f9d89b72202e1e2e41a0226f994931304880535a25e2dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/nl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/nl/thunderbird-60.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "f1fd359ab66f349643191efc5f112a4512acfb64cf088b963068e54688c34b4244a8b0d31135200a706122ed797e2d2b09237e96c1076bbf086d660b80d44dbb";
+      sha512 = "2650806011a205cf6dfb1756c270a6a8ec33dc36cfa67d85bbf70264bd306a2b98edf973eac001ac79657fc624f2c56d39c24e7ada9b53b6aaf5825d701c4df5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/nn-NO/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/nn-NO/thunderbird-60.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "819c02852685cdebf0b3c3b86ab4261ac13ae6067f0a9c3610214d4cab05f3a913da58527be7d3fd2d06fbe9de13481c34c679b317fe0659383b31ac1fd19bec";
+      sha512 = "bd58db3533496758873a273d988f9b53f2d201a176b936b549ca543bd3e612e0898c83a42f761885a9b9ac58f5a3dfd38e93e9f807afed02717dc6b47f574c5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/pl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/pl/thunderbird-60.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "e384e19a68ab56c16266d59abb6b22ad5b7bfef649c2a7537a5822753f856a6e90604e057a7a43b744487294475be6afca2b8484911044422fbf06d01df31e5c";
+      sha512 = "3d2961721fb1d70b4a40b447ff4364039159115b096eb75aff418db20709e102bbf3f752e04bbbc735506b2b4d45554d38b1d217459efa7405676908831fe4f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/pt-BR/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/pt-BR/thunderbird-60.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "edf352970e3292c9f3eb17caf8de07edb924d14500c3dfc6d1864adebcfc174d1639b2d0ca5b4006cd952f9922e09fd220ef50c7ee3f15920d554dbae22eaff4";
+      sha512 = "3610306eeb52cc29ea739b1d5140bf0e4cec8536aed99278a82ea0847a592975e5a9fd23d4763032d3a178a9a830e5a8c87bbe6b0be7765a4f961c00fab05f6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/pt-PT/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/pt-PT/thunderbird-60.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "2d91620bce2051d6c30a3b16f21f7c97b99e3ac4a239e22b582b37ce7e6ef4b6861d66e56e7e7f58cd71cd25fcddb5e161e66248d87fc9984e755f229dbd54b1";
+      sha512 = "30ad1102cd1abdf091cee8971ecd537ee7727e0ff3ef31bc535f830c3c50f8598330b98ab5acd5b1c22d9b4a245f9952b7f6ea0e8ca373c58aaf57f4ae78d554";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/rm/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/rm/thunderbird-60.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "0ee05046cef873313eea34cb5bc002f9231f015415ba97c23b06e7ed0ef9996e7cb77beab89cc1e312fc74122cbac179af430153b2426d885acef8fb7d1126b1";
+      sha512 = "8581718d7ef1b0e3c6ffbc2dd38f9a183577d80613a79bfdeed4aefdaddb6fe060429c76ac0ecf4c18a4a445499a444f5b0315ec32f3da00ebdd2d1a3e70d262";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ro/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ro/thunderbird-60.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "c53a2bdfbda8cda335d2a9fe03476090034ebfdbd8a8eb345a9fa5d3c0f1422a0e1c2d95bb5a0b75cf84f8338679068436cc90c857a3547f297f3294d5028b70";
+      sha512 = "e9393e95ef620474fa40188bcc3deb110b21c58eedeb2791cd7d17d0621f45f345fe219eaeaf4a5d71d80e303ad23b5d8ab93c8b5f7d085c3eead902ce239e5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/ru/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/ru/thunderbird-60.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "ffc6c2729291d8d1c7f32cca8933d3d8adbd54e278940ccd7cb844778b8a55123af0bcc9d435480077551de49d1c2200250209311579d2a34a5609a336eb32b3";
+      sha512 = "dfa9aba3a85bc6f3264849b54d8f6ef14a5cbfcab2eec6f71b5130eaad6b7d8dfdfa2b9572f965fc19b51f80868183008e441961ee0072a1500eef183111f1c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/si/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/si/thunderbird-60.2.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "9f708d01d6a6492d10ff058bd2425172bb90ff9c2827cf88a4307de0df20c6cdac9d8c135daddbca132fc55e89c68924fddfe9ca8cb49d77ca6c874283c49a8d";
+      sha512 = "b669455b70def2b7a8e08cf8f7c77db857ef0062b4f791a91ad636e7fcd0eba0aaa5199bbe49d7895a6872370e8cd442e142d017ec6855327d0f555129fa2d68";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sk/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/sk/thunderbird-60.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "44e3dd85654dd91ac9b0bd1f1d7f6f74341e3f39be8f01b028353d3425938825877b8f8b0c296ebf269cc5b1e78dbdde18bc49153ada0065dbc1de3079096ad8";
+      sha512 = "0719f9073db07793a4f061cf430b3aff539ec3e124ae2a7b6596ca5505e0d0ba96d1af1a3e1dfeebc55601be1ea7a173c5c89657036606b0fdf92c07a35efc7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/sl/thunderbird-60.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "2d77bebf1e3a6466fdddf32f21cbb5d28e46f4b70fbd07eec701559a0accb6f78ed9ed8a3b969d0eb3e249907208ffe8ab096e6bb035bdfb8c91e268ba228992";
+      sha512 = "66d8ab801f86a5a6a68d5fb48ebb255c3348fe7a0e9eee975fee7c939712cf5cc3bcec084c853600235f8f9774c4bfe66507fae856bc4c9a88d170bc3d6d4e6a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sq/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/sq/thunderbird-60.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "f705fad8b3a3ec5f760f28205caeb19986cd90084c8db0d921569553aa3cef668443e30594a82a32cb684e4cb2444057d04355b39a2dc02ac2dfc0ad5273bd68";
+      sha512 = "eeb3d2396f8de38cbd9495a82c766183e1640bb05c48dcb4accf770c4c00fb4823be55c5cab6561dbd2dc413316f383265cdae9e0809da1150b9afde678bf4aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/sr/thunderbird-60.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "37dd80ec39ea566e66d8ace889bdf0353ec63682356472a1d0352f556814bee38793a263b285c65e9a68e62b782caf064d7b530b503e1222a490ad81798b2a76";
+      sha512 = "e251e7c1970e68849bfaa6bd9a34894e9b710c7adba1cd54ea063274e7f07735795879a01b4dde2256eb612539d3fd433507fc9c586a28ec803cd636194ca12f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/sv-SE/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/sv-SE/thunderbird-60.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "3685b1788f7da31032b5b16a974af87d729a05aad8f906f6692d7dd688684c6f745fe766a1c5baaaaecac4d1b417d3e91d78ca082a41704a6f9caff29b64d842";
+      sha512 = "c6d2d165eaa2e46adc9131cbc4aa203308852ee80ccbdc226def37be9505c4e2649e70b668ce38d061dbfebc284e0d604db1094418a02092f189ddd3e7317419";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/tr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/tr/thunderbird-60.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "3b1de9eb1371ac686c1d28253bab5b5a3c5ee3b91739bd9e272ed496266fbad01fafe5015f257cd0dc6ef553d47d674bf13e5a53444d030f50572c929d0b3c75";
+      sha512 = "d23cb1cac7becb82cedb768376e200108e08814e55c8308492cc65a687d5d9aa5fd38ae742c39572ead41b2d2c3e03dbf2222f88fb0b94ceba6183d6b8a4d0e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/uk/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/uk/thunderbird-60.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "0cbd6f8ad5f0bf49e62efeed2d52b3c22ec0dc4701d84771465f3650ca2ca2736acb1e9d83fead6ecba4dbbd64eb883bd9cce9ece31b5e1ec28da4a410db196c";
+      sha512 = "7385c719fb86a3c6d64c5d6ed8bea81cb7366cf1cdc97858dd177fb1435f24f3d3d257c60a319dd2db82da1274b9a2e14b73d3eaf20684ca955a0bd7b7b7e3a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/vi/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/vi/thunderbird-60.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "0e0440d0640b7c50aea0a6a6983779524007897dee8996fbf898d110881920041c99891ba282cdd5bd02060d4f8606e57bf9ebd25531ef9cdb87659aa1150e55";
+      sha512 = "369be97c79232b58ce2a096814d63c3ee805e2fca8ba40566ddace637c5d9d3686c06e8e0a158ce38395d7056dcc85416251b73ae7b50bdeb79c26fd65044200";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/zh-CN/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/zh-CN/thunderbird-60.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "3fd66874bbb9853da447cd4a4495f848d1ead3a1ef1ceca36590082f4ccec8985280d25f42a643b52f955290a4b9649709909080db8b6a592a943ee1ba4bbb44";
+      sha512 = "934d49874ab0811ad2959de1c43c94e5c94ac52e45dca2e8a6c91ca32c033bbf7c076ab46fbaff5c1f508301d0635b3ada957f09d9f591647d202d09484940c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-x86_64/zh-TW/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-x86_64/zh-TW/thunderbird-60.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "8e716f938a146a14c9f5ad8d99da463a6b5ea8d1705c26a575a4e34de89e1e9a36e1a288f60bd67b87a2560fae7646dd9157c4d60e9a35f7e977d20d55756f0c";
+      sha512 = "50253f13fe918a1f9b066fc9c8b3245aea8fc79502ff7b5130150cf207da080b569fe0aabc5c19cfd77fb79eebe9a9d48f103d6748ea2070bd06476c0bb90e4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ar/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ar/thunderbird-60.2.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "2076cd84255a8ad52521a752b8444cafd3490932b69a3ec632d8815a5215d08d4efcbebb888f76b26232eb6edd66c4b9ce2233107de32603d6a7a37b87f3595e";
+      sha512 = "3f0da183490797d4046272a85c9584e95f5b0c66edb94ec4e84906f78f009f8558e4e2c4fcf03f83e8d857aebc13febea3305eb02c6c63ac32474749bd28046b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ast/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ast/thunderbird-60.2.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "a070d8bf3771ae9a9e09f40888b3c7cf391eef4966bbf437f547eb8a914290d2da918e7a824558aa5a506ce1941fc95ad738bb9ba56cc7418004da6658c42344";
+      sha512 = "e3e0e9d7b30b7a790c681c650e4da123246bb9fc5005dd382f5eb85f3bee9b2e3f79f5a9688f4b5e25da1c1bcb09721ae8c7cce32309e0c554a992fbf1b418ef";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/be/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/be/thunderbird-60.2.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "f9c92aec1316decc523e8bb9136004ef74e184f2213c1ae92541416c36c9f3aa1a8adbe9f875b25120597026dd948a1ca68a9e1074643088d2698f8483a04762";
+      sha512 = "ad8c3794452cf734234421b2e7b0e90553f2012e62c1d7ea887610f74aec4af5d60b1ef37765d9cdef93c23367135fdfee800df0f7bcb59cac1761356877e3e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/bg/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/bg/thunderbird-60.2.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "a576991acf9129ab9a365e80b90fca7aef01e66ce3d06dffb8ecdc0ae3d8dc2902470a99a0293a87c9f112fd13658b71a86e6fb045fa7cefb7773de1cdbbe31c";
+      sha512 = "30076e64f51084059186998f36014047ec53f0ec9d9ea2589808c20793403b777f484569eed31d4ecbfd5dec890e1cd219bf071102140d1b4f5ed401225a411d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/br/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/br/thunderbird-60.2.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "d63edb38305e2ee76df5c05dda275ee45ba419bfc6776d007fa39dec36d202158f7eacff9611aee44d3681b0db5b200a6706e8034fffcf1ca7d575787240a5ff";
+      sha512 = "9bf11610fdac1278c66bbe7123269e3ebe4e24b619f8b1ee89769460656825c3a170ad730f5297ca5dc1181833ce833b3a812306d5a6339fb80408992eb9f89e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ca/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ca/thunderbird-60.2.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "d5ae9f8478c638fb50af671dbd12e95b338333e87b31a7cd42d99e8deb200ec23841ac9b93b0ab26b39306067203d8645976cb99292e3a028149ca549c9d43c0";
+      sha512 = "95a643963817f5105c76d195c1b3ce4def01e0e5262c730a9cf1ee247512e562d16d56e53968d0078cef12514b9294f30ab59f93e4e25c068553d8ed9633dc59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/cs/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/cs/thunderbird-60.2.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "9284fd6b7757c4ba331f2d2e713c247f7fbdecb7724c1d66df1d1f0c81e3803dea4cee6fc4a905020b00ec5b281a4c959eb56ef401af5b8ec5cbf05252d7ab66";
+      sha512 = "a20498a81b5f3a70a0995552875eb8eb2635b1d8d3508540368f6ec9938493927050a17cdbc944e9f0712622666d13ca6e15088cacdfd687de21b83bad7d7b48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/cy/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/cy/thunderbird-60.2.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "182e1c8878e53af87b5b83fe00ba5a8fa7c72ee35002e843d3e1cbbcebb1d2e82c37e90a44c411b238b9c843be6594aa75d34deaa576d213c23af4e2e8b0fe23";
+      sha512 = "9a7ffb9eb9c3d561ba328e43daf232ca2261a30430a17d49010e283f7ae1e190475e3b0c87ab931e26ba6713eb1cd079a1f6f6ac1cd5cf5e991dcee940eae041";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/da/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/da/thunderbird-60.2.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "10f22a40283a4202c0e6612a27022ffdd3d2c45727cd170ebeaab6678f59f624c6d2520ddf2c9540e98030c6813760b5d56c70882caada0166985f3206fef4c7";
+      sha512 = "186a96ba0ade51ac1ef53aeb02b2c140f0b1da048d24dc41f97497ec1b37afeba5226cebcd1b1f0226391f20f972aa385f41220844897bf1cf8ed8f64fd895b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/de/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/de/thunderbird-60.2.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "42709aa4778e93ebd61ff44d027eb0445028f036c735943d71ad355870d03da6dabb763367123156922aa56fe66d6968ba9c93e7b9a8b58197624f984c36437b";
+      sha512 = "68aaa7c30f119407f5a7adfcde55865f06841ca60b7819bc4966b16df12af87e32f24d631e483341a171e712979e90d9086fe43a1b1cdd92a512e178d6374ae8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/dsb/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/dsb/thunderbird-60.2.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "6b82976526b862c9cae1a056b04f36c6d6cbc4ca91308a1f02a808d88272326c10f34cc77aef00b6f6c1863de42ed9a03328a667e4a0b985ecf837765557f982";
+      sha512 = "0bb90eec8123035e1833b746ac3ad1558ef01fe4647c94706a4988d1c8ed53b01f8621f3ac2aeffda640a8e6fd05cb71b3edca369a7b445608a8eae5dc12dc9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/el/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/el/thunderbird-60.2.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "4314dc7d8fcffa4c4f498d41657332bc476d79f934b4f46181fac4b6cd93d3161271fcd0575f07139186d502c5b833b53ff26d2f8728c9a73765e551963c45d6";
+      sha512 = "8f2072017f5edf494c091e712e26b253ae4809fbb81d1ee22063ad02f2cbde06f04d9873c61691245ddd249c489c4b3f58230ca12cb390abee8375114331121d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/en-GB/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/en-GB/thunderbird-60.2.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "0840f23683c8c109ac802415b4216f778d6e1c2487e0e8d179def2a3b56308a7d9888c46a96d8d509f99fa4aa296213e2772bf1e74a97330c5e2bea97dce7c70";
+      sha512 = "8a91106d035033e9a358f99d1b28cebad978586bf2e363b0856333583e6b1fbee191f3a8518efab85c188fa60c8c5d3d4452fffdd8b5f3a7998e213d5e6eaf05";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/en-US/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/en-US/thunderbird-60.2.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "baf0334ba9803cdb79e1a05a6745f6a87575d52bf86f6169b664903608236eda8ba8965481a58b660fb1edb567c681211f328c3f0b9b298e267b5e572b41f642";
+      sha512 = "e104e90333fd9ad786cd59cb323a2a87a532b242aa7e6127ba38df00b9d747278cafda32b359258c9e6ade5a945c4a227ad81595e30717b1a06e314c511e975b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/es-AR/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/es-AR/thunderbird-60.2.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "c7a7ba5a547cbb7b839191b14a0a78835935cf589f82d3ee28e144032e0d94d9209348a45502b7e2da67314427b23d88fabf61db1ea78e55dda9bd1ef97abe9f";
+      sha512 = "a7cfeb77ce146102b8583fa086536c58760ff30b69c8f9373be2277815ed57c1132ffdd04edf782ab8224f2ef231ae4c2c581dc13c174db6ff382a72975279b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/es-ES/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/es-ES/thunderbird-60.2.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "ae3c7211dea682e133f960a147169e0a7b615a0fd4ad2fd28fed3976a395f16ebbe1184c872746e2872a09466ca84646cfdddd270ecb3567725dab24201297d9";
+      sha512 = "7700206c19f5b8a434e323cd3f64df90696b04790620e6e20d23519dc92a8f3abcdcd8799d7d3843968e78cd8a6cf282924f3ebe442eebd40282fc035e096c0c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/et/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/et/thunderbird-60.2.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "e08db3e430bc90b5af7fa5d979d694d38de1bcfbb89d68613f5b3abc2abe135ca19071890fcaa5e08e2c42d7486a113345ec24ce5555d963ef2c072a3f4b77ff";
+      sha512 = "14768d992308cee0fcb30d8c676d89f8e30bebc86f4fb4087c06d38afc41df418666446c65e995e74c67a6a6214c05338fd9471e02d5d5101e438b414c9873e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/eu/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/eu/thunderbird-60.2.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "f3e5ab6e80ef67fb7b05e08dcaab138475f4feede719939a055c0c548a719902a1bd9b7c18c4a76d5e7173f5a01a319c56579c41059a1888fd29bd43f78666ca";
+      sha512 = "b8a33488d452443ee7393d77db68760b96d3f868050f49521a76b522fcddb7f4a573be06810c091e8b02d76b681c393554c01fc6800e420f9adf4c3e42bdb436";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/fi/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/fi/thunderbird-60.2.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "b034c2fc5f633e4cc5b9f3258d7073439e805371833e7dccea9e8a7c9bc52ea7bb862642eb32bc02cacf2f114ff9b379edc22eb0df52ce676db52f67a3d48672";
+      sha512 = "670db16b381e68e2f6faa353d91120a787ce360143d72c4a9041a4684688314e3dc466b2beb9166b76a822f8d96348b41bb32410678d711e39947c932424f295";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/fr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/fr/thunderbird-60.2.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "bdc4222ef8f15ec73297b0b1382e2e6da638d103e70c0a00adb5f3aff3b4944be1149f4099cde60e7e0daab273775959110e2354834641f6c85ddcc3f1b8303f";
+      sha512 = "b3474043fb1b3a6fd1d396d6b0490d8db71c135846e4ef74d22e80abf41ab4ca1faf346c9928424e13ef9c12d6cad19f389b4cd38c45385688b5b4587bcc0a0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/fy-NL/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/fy-NL/thunderbird-60.2.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "d4ccbbed8cd929c385369c7df9b9d031e4e06600cf8d08449d9e60844aad2ccafbb6517327882cecf1e25786a573e2878f15d841851cf30c72646eea7cd028d9";
+      sha512 = "41b9f80ae6e8ce765d8fb057bd49af032532cee9d5f2c4b17a4d3833fbe8ace4c7ed4336433273e59f98a1b4cadef1ed49f77a95eca868a39e76e7454d7bf91a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ga-IE/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ga-IE/thunderbird-60.2.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "c89c2ff0a5c06ce0df29300ac2e1ba034b39b021487ddf86e870138dd165459a71dc250a066df1622e4ebec1813b1c315eaeadaad5da6afa522ca2208222f1d7";
+      sha512 = "f89277340c6deb07e73fd7a7227fa216960c89269e9d4ada0f8a6863ee60ba004317beb207a1128930fb8c28477963bb66ffb0a76e86dfcc371579672b0eb26f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/gd/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/gd/thunderbird-60.2.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "5f1ab74c7492a6a52b1ddbd38f7b9f85f59bd911cf8a64084d1eb35715f0b9cd45a7650dcfa9771679ac6255eed99dafc0becb8b3e32e315e7d186e118b56afb";
+      sha512 = "d3ac6c868fb504b71823b5a3139155f6f441839c33f10cf73d8e0bafab5e7d9f7bfae3b884b41fee1ced4c10565321bd13900575855d42f70958e569e7756743";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/gl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/gl/thunderbird-60.2.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "690915f4e182b5ecab32675aa03616a2f51f7a4e795991cdfece82f63f074e2d8057d6e87ebf9f74dcc5acd149b1dc844517bee19de3d959a493cb64b51e6158";
+      sha512 = "88f41447654685280aef548951609cb0ce7054a67c632a66892d1707d6d3dad3fe037dcea6ac8222080c0fc2f19d77f622506e82b6ea93114462b131fd4de308";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/he/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/he/thunderbird-60.2.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "ea589ef7a9b4897beb23b4595c830fa14e7021472dbab815fb15325e99cf858a28b7265d43df0629d2196c1563a769f36beae1ca048fa3c006cd97d54e923ecf";
+      sha512 = "faa622a8b7fb3c5ba4156cfb6ab4414c0a56a820a1593b555e817c3edcefc59fede6b681a0c6722cb540c81ccc425bb27d2895ff84f5ce2e61eaa7b37114be42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/hr/thunderbird-60.2.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "e5b8e4cf40819c9b83339520e832773e3161c9c38c802ca37fe512616f128163bcc2d1e7a40ea6e0bb754973a782f141ed044c4be3a0cb7a39685326a1c3a8e5";
+      sha512 = "74321b6e6833014d60b698d7f83337c846452fc1e2148634150f192425607595795036e13d55ea0366c4d3e7c998c9c3766f50abebd606dd2ce7c3e6fbbf4963";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hsb/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/hsb/thunderbird-60.2.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "81382e35b825b65f95508cf04bdeb1a8709f2cd7b408f3dc068cb75d4c5ec31bdbead8807008c78599bc11043f77437013242f9969333c46e10d9ba4a8e563cc";
+      sha512 = "5964563cc323a606dd33019888ac483bda47f0da073e3d64ba329521cb7a192ae9014cdd2d44e48091d2f3f0219dab11a60497842e42e37a7b3be9415843fd76";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hu/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/hu/thunderbird-60.2.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "190794f6fa1ffdbfc2b8516cf0c954a9abf8408aa04c1d9c51e1a601f8a1d3d8fc32e2ca9644bcd1e11e8cfc47982c55995b2daadbbbafcc713b4c6f5c8aa63e";
+      sha512 = "20ed810d74584d9c79b0dad65c50ab8422f841aa2e4974dcdef249aaf4901315c79ee1f071c4d03cd83fbb973eae35fa730aa0db88fb46617454ad5a4371f107";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/hy-AM/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/hy-AM/thunderbird-60.2.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "a6cc1ebcf284fb7b4fa0873768713dc569efdb39982f37131499434577ab5515448caaa5fac776987bc008074ac6c04eb29e2f60e21626b06dac2dfd17ee09c5";
+      sha512 = "90973c56fb46c3c150efad6cfd48d24916983302dc459f386c5fa11ebeb4b32d7b7d4a35e8b3e0ff7358b4af9c13e112d01eb30abc069dfaa8ef8aa3af043955";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/id/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/id/thunderbird-60.2.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "4333f727d2e310bb24e6f266b748d757683523d6c3414c68169bc1a7852edad8d76bc3021aea01bc08e7d95c5fe4da16281306236cb6eca6f3e339cd5cc11fa0";
+      sha512 = "9838d3e9a9fd30e03885f4195a951e285230a33757672c54c60edeecfedd220e6a8951d9bbfad34688ab0d16fe38507b3f8524d1ff3a987482cf761d67a17dc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/is/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/is/thunderbird-60.2.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "f26d7117241a090de6675e3a336b5b0c9b5462acc80248d6e41bf43f8c990a761ce36e6d0a4620a1733d06f5bf7cd8511c88f686b9ae0806f23f5a852be3c0d2";
+      sha512 = "b951f6db2e2a70a6bf43e5cc7ce203d59b9062aad44bae3634db03dfe202aac723bb8b2283deeace96e8401c772f43aa985b76259de538f62dd970e285b09a42";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/it/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/it/thunderbird-60.2.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "33dfd7890b6c156b907e40c5442795c8549053362d65272bd08a5ddaeda61783ec914d8c917a7b9731885aff766011b9a667307ee01cac79614eb84133bc8675";
+      sha512 = "389ec0d921b42e4238ce13546df6bdd1256381e95aea9e9e18e46524feeb4837b2be534fa452a4cae51d3fb060e059dbdffe7f26f017adc4f88aebea19f656ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ja/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ja/thunderbird-60.2.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "4ed858b1a1411472bc2029ce1396b78a00f25cabfc2232f6e3daf0acfe91898df769c2397f908db52759c32efc25a79d9d39efa99891a68e2b7d5b7c13820a23";
+      sha512 = "d012b6339c6e18aa49c4f6a4db40aae3315128b89938bbc64fee94a90db8cbd65b27bda9742a7a761c52fa974d9b5ab5e1d98ab485123c33be318d216ea8628e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/kab/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/kab/thunderbird-60.2.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "61e8b05c0c952eb493fb5f35b7ce6ee1da586a7a4d25f27224f36b7afae75a0f217717f5afac17b43f763b2f6403f4c50ed01c1d1dc6dd084d24f8821566b552";
+      sha512 = "06b05f5d4c97008706eca67eb9b513b35122716a3083bdf3f3fb97cf0a6f1606c97a097a5c979657234562e505203f66bba483879fc2070c97514000326cdc23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/kk/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/kk/thunderbird-60.2.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "507ad5d46263ada1fb9b3d05f2c6d1a00b76f5d25fe9459edafcb2793070b6771ff52b338bc9963c1810a46740ea1e22ed330a5b935bfef72437b572f0214e67";
+      sha512 = "0ea99590b068925f137a63bfad3a0cce2e380f80388a94910836e7f517f0375d43f6f1325c6660eab13a97d1b9685102cef921f99135504abe70650ba7de9697";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ko/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ko/thunderbird-60.2.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "2550ae6cd5e8ee1fb6fc0b3fd974c1028edf8b292da72b57d6e27fe2e600d6418c6f4ca2c9d5535cbf1f1c67b20713cfef5732beae79ceebe328f44a73023b69";
+      sha512 = "e89d27c4cae745c902f61d9534b6582e2af3806714e596dffac1a0d49416a0ab4eca76d9810853c759312c192679b2aae4a6cdb289c5b5d1f472450757c71ccb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/lt/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/lt/thunderbird-60.2.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "29e47bd8306507fd65d27892863b9cd0b58cff4d2035f7c0d3df8cfb98ddc890e922c0e54e0177b255b6bda70116a72fa630494b7ead05683f928c1a3f6bfed3";
+      sha512 = "3f86701c031aa174ffaacb532f198f7911045a855f8526e8a47ed26695e86bd40d1d83140cdab123e40a9759317724296f4ec7d788781b767590f0135b0c79c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ms/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ms/thunderbird-60.2.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "fec173bea9f579e605ea3b40510f26d0cd94ae96ca465f2b6b829eb710fd3154ce6b997c3951b12165491b8d57af8371517a23ec73615b3b53e463b6077efe96";
+      sha512 = "d44ddf44d0c0b5190f3b282be2e3f98dbd28a584727970ceb8b3569672634ae476b85c4dda4659d1a58d8ae36adb9db1c5a4d341f9f1f7d861af64287e546316";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/nb-NO/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/nb-NO/thunderbird-60.2.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "1f15c20580104e6bbfcf07d234ac987e2d35eadeff5437369f62b34acb8b47dd646c365c31e2c5601c675a413cc0d2d73fff6f4a663436b426331d373725aee5";
+      sha512 = "d0455dbd94fddabbd474037325c792e3e30fc4aba419d04f0425bdd33db17a1532c955a992b1bf3ffe2c16f440c6ed5c15a5ca6e259c74a5ee1e3f84f457de5e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/nl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/nl/thunderbird-60.2.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "5f1b20753423ed3882625309ad91e3a6c0931984b502e395cd56d5701eaa6612ba547d996c608b5d87f521989900eb4f02a419036b4f1c9312f9d763bf68e89d";
+      sha512 = "b4c24a1b73078a9196178d5ff0f386502afc451f0108321bb45641b30bbbe8225ffd54e00b883515b4849bc76ad8c4dfce525ae5e2aea378ffc31ffa5867dca1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/nn-NO/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/nn-NO/thunderbird-60.2.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "2a7964d792058c973940cb99add2862f61e66e6ce0cf6988c6b0395274b8791a09f81730a403748962b56be8a183c5d8e063cc8b7e93e166a1d508c8f274ad16";
+      sha512 = "56ee8a0911a7a7034f18f246d1a607733842846f31d9715611b1e3df5aeb5b70f4d13e4af6785be53ba75a79e845066ffc7ce2aaa8d7319dc92d6ff04a2a5901";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/pl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/pl/thunderbird-60.2.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "49e372e264e902eac027db402d5e53683efcdf67faa41696113f7e963dabb85e6fbb8f58759460bb3fefc67ad52100a1d204884dcbafc39ab08e46059f72124e";
+      sha512 = "256331ad82a25c162681e4cc79f5f1c1127b09672e8bb663968950fcfbeeeadce26acb9ecbe10322552ec7d11e80612fab8582906380880e90ae6caa84be6cd3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/pt-BR/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/pt-BR/thunderbird-60.2.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "201398c2c58e55b9d311f87d445727a0a3c455167febe23a597ec97fe80ca189aff3557d8ac0e1957443251af184542d071229664f0a78de2faf31dcf337d951";
+      sha512 = "67c7d28061ce5d1f2062092c308be8f88f7a718be637d359c400e56a772e5ff3722bbe3388b5673262dd12373b9728e6e58afbf9a713dabce5d3172532a8257e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/pt-PT/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/pt-PT/thunderbird-60.2.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "88ba0c8dc4665305c85e00a0f50ff4247abf1a5925436d717c082c4934a6df41f9d45c45ac458598167bfae8633e3fa2c12f938e32480b956b2a61527c677af2";
+      sha512 = "ce818347a10f580eaeb7f97d343a73149db571527ab207e3eef9108aca7309222e0ed7bda41d523d6e371abd6518d3cccfdc760d28eab692e23746b30940b556";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/rm/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/rm/thunderbird-60.2.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "f121ad8ca5ee662a9b815d547352b21f7cf46bbabcf12f21617f857821e8a2b303a915fb1b3b3676684a0e79b30c9d97ba34a9223794616b4fd79f85f562d264";
+      sha512 = "c2cf9e67ebc7aeeb8642fc2f32d721f4c9656456d9fc7d04df31672b9c6b07352d87f25d58d75267d9a8388dbaca238d605373559dca4bc238b02bc7a27dd837";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ro/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ro/thunderbird-60.2.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "a0bff4872cb8186eb187fb7b366a5469cb2f8bbc5c42296195a104432b91e99b4729515d4808651f61faa585979966be903453a75524001b619350b66a6f2349";
+      sha512 = "f567baa16a96617e01753136f74744cc72c147ef59e40861292048fafb37745e0f8654d355c5e60752a4b86236b378fc15d09f656998a920ab970c6f7ca6e4cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/ru/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/ru/thunderbird-60.2.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "e5eb22490436cb0c1456af5f7019b2b1b77dbdc4b68fb9d0d693a8502acde51027a90335ea4adb1b030cb4557ffdcefc8caec423110fbdc40f0c30bd269e1e45";
+      sha512 = "e28699b8884f7859323870987fe425af0a8408152a3d373007b634aea1868ab1de483830c07da7efa1fd49c96b5be6c52f5bef91c21c8de0533216be57644fc6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/si/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/si/thunderbird-60.2.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "830965b9d551665e84646e865e66aeabe6082308278669fce95e005643ba5807a0fc17ec294043f5ce908676a53b88ac64d9234b56571dbbb22b5a5de66aefac";
+      sha512 = "e8ea29c2b77398611b79cebd674983f9458d07b4866597fa2bc35ce6d78bf81daebe4311e93604e4e5a391e632eaa9f6601eb75d022ef1b2dfc225b9cc61b0c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sk/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/sk/thunderbird-60.2.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "40fca2d6bc9d2dea9df6ad7c153bcffcd30687c0fcce17b78583501dda379994ad706f28003248ed2cb62b0a3f0d510c203b7d4eca2f071be6f2d670f7f04c76";
+      sha512 = "587f54eb86b0d0069433e14dce5f24e07ebc355f35f22eaba3ee0982e257782fe4ce5799ee0f7c733fa5a571935d2404ff950acf25b9be61dced6250d76611bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sl/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/sl/thunderbird-60.2.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "0881ee4832639fe79201260f8c0c755bd2d4bdac7ce5a422a37b9798901815b5b7ee1eefda9d3f82c1d49fbd0c6174ffa3aa5cc850aa260af7133d60b0685ad3";
+      sha512 = "196a31e47578bcf064b42c3d3ed1ac3b623a54b5694fab72e1177257d68c13013352228a09ec8dd4fc53d91a0e8036b2b7c815432fdd35c624852cd74f98541c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sq/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/sq/thunderbird-60.2.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "df1d0639030a33ecd4e0e336aff064dc87daf423ce7c8a6a0279f1a92d3cec4406ff0054eec1c911812f0ec6074308c8e66180e1adf919d366a8b6f138a6ef36";
+      sha512 = "5a2b966e7119853fd98e976e555831058aa0c8cfdc463dcc79ca698aa4bb5d9b43b5fa2e6cb60a51cfee987c360c651de509463002aeb9c4e1fbe58b6fa4dd08";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/sr/thunderbird-60.2.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "ce264e4a8b5bc11396832533c1dfcfe43b601d4b4e8dad3d3b03c285732ab6b5fba50b90e28dfd883468cdab06e4f726d46478aa8b9e2b3a244c515288fef0bc";
+      sha512 = "62666fe7d94f3486d1d5df1cf479bd21a13b9bdc9a4f24fa1f280a838c008d28a2fd6e78ac445ea6ce126fc54b60151e3c4f9b3820e231c8593fa83aab1076fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/sv-SE/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/sv-SE/thunderbird-60.2.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "da5e8ee2e9fc35a605481f7351b0391d8ca056ce7f152a5e46b3b91b539f5e35b1ecb0067cd8fdd26f249393d45e22e61d318c9687d66b52accb59e8b3283e13";
+      sha512 = "b8f75bfdb3ad9ffa768a5ef4cdfed93004232d9d4f301b0e5b9ce56fd47d34efc779fafcb67c0b848a83ed59c1fa4bb17dbdb583599a99b78186489099159d92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/tr/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/tr/thunderbird-60.2.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "546c6ed7113af0c52aaa69630561637789381a5e97f2edea3415d14a88edc25124a64427c3a1e1a75e8c4019468aed0ebf4d6ff56ecf26ed1c64eee6b69ee777";
+      sha512 = "b72e4c0d1564248927e1f2d8922651e3f7e37e99de77dc548508d4c0c1951e0e59b461cad18cf0dca0145d7465fe7bac93ecb4841c18db2b57822b0014b2f83e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/uk/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/uk/thunderbird-60.2.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "ce3386e90c77fae05c79d4e30abb723fba507e4655bee6667edca9de048c8854184af5c8775b10f2b7560dc9e6e95bbe7b8db79a345e590211cb56ad313f288a";
+      sha512 = "7287cb6fce1c1482e0adf00598139b0e9e97371171a14b15ea42652c5890fb1c7de0aa213220444c68c5fe33a43f242f0475b5836deebcfe5fc6b52e21c195e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/vi/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/vi/thunderbird-60.2.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "9bce245422e162e017198782778995ecc1ac1e2760ca91864605e3002042576a9c53519f085f6159e1654a4dff7dddc19f9fd1dda0a9f4cb9b616baeba8845d5";
+      sha512 = "07886cd20ea43fbac59055d5cf34776fd38616477f8c55f4af78031034f8198ef57d716b365ee7a08f267fef0e3b50ba188dd31b1ba1508545b85fd7001f4326";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/zh-CN/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/zh-CN/thunderbird-60.2.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "db756f120fc2ecfa3478cf07935b12414f79f746a96b0e30f75496f2cb8a7d880b9f3017b12122f0cdc0f64d10ae738da9c026aa9c533dbdaa6e0f38e5a71ee7";
+      sha512 = "d34dde5c5f063d8d79a0aa032f54602570426bcce920810d1fc3c8e842827fdbb0b8b9dfa3e4049bf37de4c98356f7e87942bfdd3f7483bb6e3dc7ddd2ebd246";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.0/linux-i686/zh-TW/thunderbird-60.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.2.1/linux-i686/zh-TW/thunderbird-60.2.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "b589e9f472681bc9ddb5909197db2acf8b54e610998d00df4731c6a1403c5b865334aef2e072b3c7ac0694175f0e7cda6864809fc6079f95681b508267d90a59";
+      sha512 = "e8de34531211a60099e677dd619e9e75883f0d5a935df4807b0075dc3d8c57c97dc364eef629896aa46066d290f7138ed67e002fe0cadf7e86b0c77cf99f080f";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, pkgconfig, gtk2, pango, perl, python, zip, libIDL
-, libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
+{ lib, stdenv, fetchurl, pkgconfig, gtk2, pango, perl, python, zip, fetchpatch
+, libIDL, libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
 , freetype, fontconfig, file, nspr, nss, libnotify
 , yasm, libGLU_combined, sqlite, unzip
 , hunspell, libevent, libstartup_notification
@@ -24,11 +24,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "60.0";
+  version = "60.2.1";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "1933csh6swcx1z35lbxfkxlln36mx2mny28rzxz53r480wcvar8zcj77gwb06hzn6j5cvqls7qd5n6a7x43sp7w9ykkf4kf9gmlccya";
+    sha512 = "018l9pq03nzlirpaf285qpwvb8s4msam8n91d15lzc1bc1caq9zcy2dnrnvn5av3jlapm9ckz028iar66nhqxi2kkqbmiaq0v4s6kfp";
   };
 
   # from firefox, but without sound libraries
@@ -46,6 +46,16 @@ in stdenv.mkDerivation rec {
 
   # from firefox + m4 + wrapperTool
   nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python wrapperTool cargo rustc ];
+
+  # https://bugzilla.mozilla.org/show_bug.cgi?format=default&id=1479540
+  # https://hg.mozilla.org/releases/mozilla-release/rev/bc651d3d910c
+  patches = [
+    (fetchpatch {
+      name = "bc651d3d910c.patch";
+      url = "https://hg.mozilla.org/releases/mozilla-release/raw-rev/bc651d3d910c";
+      sha256 = "0iybkadsgsf6a3pq3jh8z1p110vmpkih8i35jfj8micdkhxzi89g";
+    })
+  ];
 
   configureFlags =
     [ # from firefox, but without sound libraries (alsa, libvpx, pulseaudio)


### PR DESCRIPTION
###### Motivation for this change

https://www.thunderbird.net/en-US/thunderbird/60.2.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

