### PR TITLE
nixos/xserver: add option to install custom xkb layouts

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -125,10 +125,12 @@
    You will need to reboot after enabling this driver to prevent a clash with
    other kernel modules.
   </para>
+  <note>
   <para>
-   Note: for recent AMD GPUs you most likely want to keep either the defaults
+   For recent AMD GPUs you most likely want to keep either the defaults
    or <literal>"amdgpu"</literal> (both free).
   </para>
+  </note>
  </simplesect>
  <simplesect xml:id="sec-x11-touchpads">
   <title>Touchpads</title>

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -157,4 +157,134 @@
    versions.
   </para>
  </simplesect>
+ <simplesect xml:id="custom-xkb-layouts">
+  <title>Custom XKB layouts</title>
+  <para>
+   It is possible to install custom
+   <link xlink:href="https://en.wikipedia.org/wiki/X_keyboard_extension">
+    XKB
+   </link>
+   keyboard layouts using the option
+   <option>
+    <link linkend="opt-services.xserver.extraLayouts">
+     services.xserver.extraLayouts
+    </link>
+   </option>.
+   As a first example, we are going to create a layout based on the basic US
+   layout, with an additional layer to type some greek symbols by pressing the
+   right-alt key.
+  </para>
+  <para>
+   To do this we are going to create a <literal>us-greek</literal> file
+   with a <literal>xkb_symbols</literal> section.
+  </para>
+<programlisting>
+xkb_symbols &quot;us-greek&quot;
+{
+  include &quot;us(basic)&quot;            // includes the base US keys
+  include &quot;level3(ralt_switch)&quot;  // configures right alt as a third level switch
+
+  key &lt;LatA&gt; { [ a, A, Greek_alpha ] };
+  key &lt;LatB&gt; { [ b, B, Greek_beta  ] };
+  key &lt;LatG&gt; { [ g, G, Greek_gamma ] };
+  key &lt;LatD&gt; { [ d, D, Greek_delta ] };
+  key &lt;LatZ&gt; { [ z, Z, Greek_zeta  ] };
+};
+</programlisting>
+  <para>
+   To install the layout, the filepath, a description and the list of
+   languages must be given:
+  </para>
+<programlisting>
+<xref linkend="opt-services.xserver.extraLayouts"/>.us-greek = {
+  description = "US layout with alt-gr greek";
+  languages   = [ "eng" ];
+  symbolsFile = /path/to/us-greek;
+}
+</programlisting>
+  <note>
+  <para>
+   The name should match the one given to the
+   <literal>xkb_symbols</literal> block.
+  </para>
+  </note>
+  <para>
+   The layout should now be installed and ready to use: try it by
+   running <literal>setxkbmap us-greek</literal> and type
+   <literal>&lt;alt&gt;+a</literal>. To change the default the usual
+   <option>
+    <link linkend="opt-services.xserver.layout">
+     services.xserver.layout
+    </link>
+   </option>
+   option can still be used.
+  </para>
+  <para>
+   A layout can have several other components besides
+   <literal>xkb_symbols</literal>, for example we will define new
+   keycodes for some multimedia key and bind these to some symbol.
+  </para>
+  <para>
+   Use the <emphasis>xev</emphasis> utility from
+   <literal>pkgs.xorg.xev</literal> to find the codes of the keys of
+   interest, then create a <literal>media-key</literal> file to hold
+   the keycodes definitions
+  </para>
+<programlisting>
+xkb_keycodes &quot;media&quot;
+{
+ &lt;volUp&gt;   = 123;
+ &lt;volDown&gt; = 456;
+}
+</programlisting>
+  <para>
+    Now use the newly define keycodes in <literal>media-sym</literal>:
+  </para>
+<programlisting>
+xkb_symbols &quot;media&quot;
+{
+ key.type = &quot;ONE_LEVEL&quot;;
+ key &lt;volUp&gt;   { [ XF86AudioLowerVolume ] };
+ key &lt;volDown&gt; { [ XF86AudioRaiseVolume ] };
+}
+</programlisting>
+  <para>
+    As before, to install the layout do
+  </para>
+<programlisting>
+<xref linkend="opt-services.xserver.extraLayouts"/>.media = {
+  description  = "Multimedia keys remapping";
+  languages    = [ "eng" ];
+  symbolsFile  = /path/to/media-key;
+  keycodesFile = /path/to/media-sym;
+};
+</programlisting>
+  <note>
+  <para>
+   The function <literal>pkgs.writeText &lt;filename&gt; &lt;content&gt;
+   </literal> can be useful if you prefer to keep the layout definitions
+   inside the NixOS configuration.
+  </para>
+  </note>
+  <para>
+    Unfortunately, the Xorg server does not (currently) support setting a
+    keymap directly but relies instead on XKB rules to select the matching
+    components (keycodes, types, ...) of a layout. This means that components
+    other than symbols won't be loaded by default. As a workaround, you
+    can set the keymap using <literal>setxkbmap</literal> at the start of the
+    session with:
+  </para>
+<programlisting>
+<xref linkend="opt-services.xserver.displayManager.sessionCommands"/> = "setxkbmap -keycodes media";
+</programlisting>
+  <para>
+   To learn how to write layouts take a look at the XKB
+  <link xlink:href="https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Enhancing.html#Defining_New_Layouts">
+   documentation
+  </link>. More example layouts can also be found
+  <link xlink:href="https://wiki.archlinux.org/index.php/X_KeyBoard_extension#Basic_examples">
+   here
+  </link>.
+  </para>
+</simplesect>
 </chapter>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -811,6 +811,7 @@
   ./services/web-servers/uwsgi.nix
   ./services/web-servers/varnish/default.nix
   ./services/web-servers/zope2.nix
+  ./services/x11/extra-layouts.nix
   ./services/x11/colord.nix
   ./services/x11/compton.nix
   ./services/x11/unclutter.nix

--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -1,0 +1,165 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  layouts = config.services.xserver.extraLayouts;
+
+  layoutOpts = {
+    options = {
+      description = mkOption {
+        type = types.str;
+        description = "A short description of the layout.";
+      };
+
+      languages = mkOption {
+        type = types.listOf types.str;
+        description =
+        ''
+          A list of languages provided by the layout.
+          (Use ISO 639-2 codes, for example: "eng" for english)
+        '';
+      };
+
+      compatFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          The path to the xkb compat file.
+          This file sets the compatibility state, used to preserve
+          compatibility with xkb-unaware programs.
+          It must contain a <literal>xkb_compat "name" { ... }</literal> block.
+        '';
+      };
+
+      geometryFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          The path to the xkb geometry file.
+          This (completely optional) file describes the physical layout of
+          keyboard, which maybe be used by programs to depict it.
+          It must contain a <literal>xkb_geometry "name" { ... }</literal> block.
+        '';
+      };
+
+      keycodesFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          The path to the xkb keycodes file.
+          This file specifies the range and the interpretation of the raw
+          keycodes sent by the keyboard.
+          It must contain a <literal>xkb_keycodes "name" { ... }</literal> block.
+        '';
+      };
+
+      symbolsFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          The path to the xkb symbols file.
+          This is the most important file: it defines which symbol or action
+          maps to each key and must contain a
+          <literal>xkb_symbols "name" { ... }</literal> block.
+        '';
+      };
+
+      typesFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          The path to the xkb types file.
+          This file specifies the key types that can be associated with
+          the various keyboard keys.
+          It must contain a <literal>xkb_types "name" { ... }</literal> block.
+        '';
+      };
+
+    };
+  };
+
+in
+
+{
+
+  ###### interface
+
+  options.services.xserver = {
+    extraLayouts = mkOption {
+      type = types.attrsOf (types.submodule layoutOpts);
+      default = {};
+      example = literalExample
+      ''
+        {
+          mine = {
+            description = "My custom xkb layout.";
+            languages = [ "eng" ];
+            symbolsFile = /path/to/my/layout;
+          };
+        }
+      '';
+      description = ''
+        Extra custom layouts that will be included in the xkb configuration.
+        Information on how to create a new layout can be found here:
+        <link xlink:href="https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Enhancing.html#Defining_New_Layouts"></link>.
+        For more examples see
+        <link xlink:href="https://wiki.archlinux.org/index.php/X_KeyBoard_extension#Basic_examples"></link>
+      '';
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf (layouts != { }) {
+
+    # We don't override xkeyboard_config directly to
+    # reduce the amount of packages to be recompiled.
+    # Only the following packages are necessary to set
+    # a custom layout anyway:
+    nixpkgs.overlays = lib.singleton (self: super: {
+
+      xkb_patched = self.xorg.xkeyboardconfig_custom {
+        layouts = config.services.xserver.extraLayouts;
+      };
+
+      xorg = super.xorg // {
+        xorgserver = super.xorg.xorgserver.overrideAttrs (old: {
+          configureFlags = old.configureFlags ++ [
+            "--with-xkb-bin-directory=${self.xorg.xkbcomp}/bin"
+            "--with-xkb-path=${self.xkb_patched}/share/X11/xkb"
+          ];
+        });
+
+        setxkbmap = super.xorg.setxkbmap.overrideAttrs (old: {
+          postInstall =
+            ''
+              mkdir -p $out/share
+              ln -sfn ${self.xkb_patched}/etc/X11 $out/share/X11
+            '';
+        });
+
+        xkbcomp = super.xorg.xkbcomp.overrideAttrs (old: {
+          configureFlags = "--with-xkb-config-root=${self.xkb_patched}/share/X11/xkb";
+        });
+
+      };
+
+      ckbcomp = super.ckbcomp.override {
+        xkeyboard_config = self.xkb_patched;
+      };
+
+      xkbvalidate = super.xkbvalidate.override {
+        libxkbcommon = self.libxkbcommon.override {
+          xkeyboard_config = self.xkb_patched;
+        };
+      };
+
+    });
+
+    services.xserver.xkbDir = "${pkgs.xkb_patched}/etc/X11/xkb";
+
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change
I have found no way to add a custom keyboard layout to xkb declaratively from nixos configuration.
I wrote this module based on a blog [post](http://stesie.github.io/2018/09/nixos-custom-keyboard-layout-revisited) and it's working as intended so far. See also #31138.

The usage is as follows:
``` 
  services.xserver = {  
    layout = "rn";
    extraLayouts.rn = {
      description = "US with alt-gr, greek, math and other simbols";
      languages = [ "eng" "ita" ];
      filepath = /home/rnhmjoj/.config/xkb/symbols/rn;
    };
  };
```

It works by patching various packages so I'm not sure if this is acceptable.

###### Things done
- [x] Test in a NixOS VM
- [x] Test more than one layout
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

