### PR TITLE
nixos/display-managers/startx: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -732,6 +732,7 @@
   ./services/x11/display-managers/lightdm.nix
   ./services/x11/display-managers/sddm.nix
   ./services/x11/display-managers/slim.nix
+  ./services/x11/display-managers/startx.nix
   ./services/x11/display-managers/xpra.nix
   ./services/x11/fractalart.nix
   ./services/x11/hardware/libinput.nix

--- a/nixos/modules/services/x11/display-managers/startx.nix
+++ b/nixos/modules/services/x11/display-managers/startx.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.xserver.displayManager.startx;
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+    services.xserver.displayManager.startx = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable the dummy "startx" pseudo-display manager,
+          which allows users to start X manually via the "startx" command
+          from a vt shell. The X server runs under the user's id, not as root.
+          The user must provide a ~/.xinintrc file containing session startup
+          commands, see startx(1). This is not autmatically generated
+          from the desktopManager and windowManager settings.
+        '';
+      };
+    };
+  };
+
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    services.xserver = {
+      exportConfiguration = true;
+      displayManager.job.execCmd = "";
+      displayManager.lightdm.enable = lib.mkForce false;
+    };
+    systemd.services.display-manager.enable = false;
+    environment.systemPackages =  with pkgs; [ xorg.xinit ];
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

This defines the `startx` dummy display manager that allows running X as a normal user.
The X server is started manually from a VT using `startx`.  It is possible to start multiple X sessions from different VTs.

Session startup commands must be provided by the user in `~/.xinitrc`, which is NOT automatically generated. This lack of integration with the `desktopManager` and `windowManager` settings and other NixOS options is intentional, to keep it simple and give users full control over their X session, independent of system-wide settings. 

Here's how I use it with my minimal dwm desktop:
```
  services.xserver = {
    enable = true;
    displayManager.startx.enable = true;
    desktopManager.default = "none";
    desktopManager.xterm.enable = false;
    windowManager.dwm.enable = true;  # as a convenient way to install the dwm package
  };
```

A minimal `~/.xinitrc` without any extra initialisations may look like:
```
exec dwm
```

###### Things done

- [x] writing this on a NixOS system using it.

---

