### PR TITLE
nvie/vim-flake8: init at 2018-09-21

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2088,6 +2088,16 @@
     };
   };
 
+  vim-flake8 = buildVimPluginFrom2Nix {
+    name = "vim-flake8-2018-09-21";
+    src = fetchFromGitHub {
+      owner = "nvie";
+      repo = "vim-flake8";
+      rev = "d50b3715ef386e4d998ff85dad6392110536478d";
+      sha256 = "135374sr4ymyslc9j8qgf4qbhijc3lm8jl9mhhzq1k0ndsz4w3k3";
+    };
+  };
+
   vim-ft-diff_fold = buildVimPluginFrom2Nix {
     name = "vim-ft-diff_fold-2013-02-10";
     src = fetchFromGitHub {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -194,6 +194,7 @@ neutaaaaan/iosvkem
 nixprime/cpsm
 NLKNguyen/papercolor-theme
 noc7c9/vim-iced-coffee-script
+nvie/vim-flake8
 osyo-manga/shabadou.vim
 osyo-manga/vim-anzu
 osyo-manga/vim-textobj-multiblock


### PR DESCRIPTION
###### Motivation for this change

nvie/vim-flake8 is a useful vim plugin (it introduces flake8 integration for vim)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

