### PR TITLE
nixos/munin: move from /var/run to /run

### DIFF
--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -5,8 +5,8 @@
 
 # TODO: support fastcgi
 # http://munin-monitoring.org/wiki/CgiHowto2
-# spawn-fcgi -s /var/run/munin/fastcgi-graph.sock -U www-data   -u munin -g munin /usr/lib/munin/cgi/munin-cgi-graph
-# spawn-fcgi -s /var/run/munin/fastcgi-html.sock  -U www-data   -u munin -g munin /usr/lib/munin/cgi/munin-cgi-html
+# spawn-fcgi -s /run/munin/fastcgi-graph.sock -U www-data   -u munin -g munin /usr/lib/munin/cgi/munin-cgi-graph
+# spawn-fcgi -s /run/munin/fastcgi-html.sock  -U www-data   -u munin -g munin /usr/lib/munin/cgi/munin-cgi-html
 # https://paste.sh/vofcctHP#-KbDSXVeWoifYncZmLfZzgum
 # nginx http://munin.readthedocs.org/en/latest/example/webserver/nginx.html
 
@@ -22,7 +22,7 @@ let
       dbdir     /var/lib/munin
       htmldir   /var/www/munin
       logdir    /var/log/munin
-      rundir    /var/run/munin
+      rundir    /run/munin
 
       ${cronCfg.extraGlobalConfig}
 
@@ -170,7 +170,7 @@ in
       wantedBy = [ "multi-user.target" ];
       path = with pkgs; [ munin smartmontools "/run/current-system/sw" "/run/wrappers" ];
       environment.MUNIN_LIBDIR = "${pkgs.munin}/lib";
-      environment.MUNIN_PLUGSTATE = "/var/run/munin";
+      environment.MUNIN_PLUGSTATE = "/run/munin";
       environment.MUNIN_LOGDIR = "/var/log/munin";
       preStart = ''
         echo "updating munin plugins..."
@@ -188,7 +188,7 @@ in
     };
 
     # munin_stats plugin breaks as of 2.0.33 when this doesn't exist
-    systemd.tmpfiles.rules = [ "d /var/run/munin 0755 munin munin -" ];
+    systemd.tmpfiles.rules = [ "d /run/munin 0755 munin munin -" ];
 
   }) (mkIf cronCfg.enable {
 
@@ -210,7 +210,7 @@ in
     };
 
     systemd.tmpfiles.rules = [
-      "d /var/run/munin 0755 munin munin -"
+      "d /run/munin 0755 munin munin -"
       "d /var/log/munin 0755 munin munin -"
       "d /var/www/munin 0755 munin munin -"
       "d /var/lib/munin 0755 munin munin -"


### PR DESCRIPTION
as using /var/run now emits a warning by systemd's tmpfiles.d.
As /var/run is already a symlink to /run, this can't break anything, and
data does not need to be migrated.

###### Motivation for this change
Without this patch, systemd-tmpfiles shows this error when munin is enabled:
```
[/etc/tmpfiles.d/nixos.conf:8] Line references path below legacy directory /var/run/, updating /var/run/munin → /run/munin; please update the tmpfiles.d/ drop-in file accordingly.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

