### PR TITLE
gcc-arm-embedded: 6-2017-q2-update -> 7-2018-q2-update

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3264,6 +3264,11 @@
     github = "proglodyte";
     name = "Proglodyte";
   };
+  prusnak = {
+    email = "stick@gk2.sk";
+    github = "prusnak";
+    name = "Pavol Rusnak";
+  };
   pshendry = {
     email = "paul@pshendry.com";
     github = "pshendry";

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchurl, ncurses5, python27 }:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  name = "gcc-arm-embedded-${version}";
+  version = "7-2018-q2-update";
+  subdir = "7-2018q2";
+
+  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
+
+  src = fetchurl { url=urlString; sha256="0sgysp3hfpgrkcbfiwkp0a7ymqs02khfbrjabm52b5z61sgi05xv"; };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r * $out
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  preFixup = ''
+    find $out -type f | while read f; do
+      patchelf $f > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ "$out" stdenv.cc.cc ncurses5 python27 ]} "$f" || true
+    done
+  '';
+
+  meta = {
+    description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors (Cortex-M0/M0+/M3/M4/M7, Cortex-R4/R5/R7/R8)";
+    homepage = https://developer.arm.com/open-source/gnu-toolchain/gnu-rm;
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    maintainers = with maintainers; [ prusnak ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "blacksphere";
     repo = "blackmagic";
-    rev = "d3a8f27fdbf952194e8fc5ce9b2fc9bcef7c545c";
-    sha256 = "0c3l7cfqag3g7zrfn4mmikkx7076hb1r856ybhhdh0f6zji2j6jx";
+    rev = "29386aee140e5e99a958727358f60980418b4c88";
+    sha256 = "05x19y80mixk6blpnfpfngy5d41jpjvdqgjzkmhv1qc03bhyhc82";
     fetchSubmodules = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6697,6 +6697,7 @@ with pkgs;
     ncurses = pkgsi686Linux.ncurses5;
   };
   gcc-arm-embedded-6 = callPackage ../development/compilers/gcc-arm-embedded/6 {};
+  gcc-arm-embedded-7 = callPackage ../development/compilers/gcc-arm-embedded/7 {};
   gcc-arm-embedded = gcc-arm-embedded-6;
 
   gforth = callPackage ../development/compilers/gforth {};


### PR DESCRIPTION
(+ update blackmagic to latest commit which includes gcc7 fixes)

(cherry picked from commit b3531b9719f37de1c25c40192399b34dba4e0494)

###### Motivation for this change

We just updated gcc-arm-embedded in master to version 7. I think this is the change which should get into 18.09 release too, because otherwise we'll ship a rather old embedded compiler.

As discussed with @mic92 in https://github.com/NixOS/nixpkgs/pull/47542 I am sending a pull request to "release-18.09", where I kept `gcc-arm-embedded = gcc-arm-embedded-6;` as requested, so only a new `gcc-arm-embedded-7` package is added.

If you think we should point `gcc-arm-embedded` to version 7, I'll be happy to amend the commit and return the line `gcc-arm-embedded = gcc-arm-embedded-7;` back.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

