### PR TITLE
dhcp: fix build with sandbox=false

### DIFF
--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, perl, file, nettools, iputils, iproute, makeWrapper
-, coreutils, gnused, openldap ? null
+, zlib, coreutils, gnused, openldap ? null
 }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
       ./set-hostname.patch
     ];
 
-  buildInputs = [ perl makeWrapper openldap ];
+  buildInputs = [ perl makeWrapper zlib openldap ];
 
   configureFlags = [
     "--enable-failover"


### PR DESCRIPTION
###### Motivation for this change

It builds on Hydra (https://hydra.nixos.org/build/82170551) but on Nix on Debian ```./configure``` is unable to find ```zlib``` and the build fails.
