### PR TITLE
gnome3.gnome-session: update glib reference

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      # FIXME: glib binaries shouldn't be in .dev!
-      gsettings = "${glib.dev}/bin/gsettings";
+      gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
     })
   ];


### PR DESCRIPTION
###### Motivation for this change

Found this one when working on gnome-3.30. Left over from https://github.com/NixOS/nixpkgs/pull/38486 where `gsettings` moved from glib's `dev` output to `bin`.

~Should be backported to 18.09.~

cc @jtojnar 
