### PR TITLE
mhwaveedit: 1.4.23 -> 1.4.24

### DIFF
--- a/pkgs/applications/audio/mhwaveedit/default.nix
+++ b/pkgs/applications/audio/mhwaveedit/default.nix
@@ -1,23 +1,24 @@
-{ stdenv, fetchurl, makeWrapper, SDL, alsaLib, autoreconfHook, gtk2, libjack2, ladspaH
+{ stdenv, fetchFromGitHub, makeWrapper, SDL, alsaLib, autoreconfHook, gtk2, libjack2, ladspaH
 , ladspaPlugins, libsamplerate, libsndfile, pkgconfig, libpulseaudio, lame
 , vorbis-tools }:
 
-stdenv.mkDerivation  rec {
+stdenv.mkDerivation rec {
   name = "mhwaveedit-${version}";
-  version = "1.4.23";
+  version = "1.4.24";
 
-  src = fetchurl {
-    url = "https://github.com/magnush/mhwaveedit/archive/v${version}.tar.gz";
-    sha256 = "1lvd54d8kpxwl4gihhznx1b5skhibz4vfxi9k2kwqg808jfgz37l";
+  src = fetchFromGitHub {
+    owner = "magnush";
+    repo = "mhwaveedit";
+    rev = "v${version}";
+    sha256 = "037pbq23kh8hsih994x2sv483imglwcrqrx6m8visq9c46fi0j1y";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkgconfig ];
 
   preAutoreconf = "(cd docgen && sh gendocs.sh)";
 
   buildInputs = [
-     SDL alsaLib gtk2 libjack2 ladspaH libsamplerate libsndfile
-     pkgconfig libpulseaudio makeWrapper
+    SDL alsaLib gtk2 libjack2 ladspaH libsamplerate libsndfile libpulseaudio
   ];
 
   configureFlags = [ "--with-default-ladspa-path=${ladspaPlugins}/lib/ladspa" ];
@@ -30,7 +31,7 @@ stdenv.mkDerivation  rec {
 
   meta = with stdenv.lib; {
     description = "Graphical program for editing, playing and recording sound files";
-    homepage = https://gna.org/projects/mhwaveedit;
+    homepage = https://github.com/magnush/mhwaveedit;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];


### PR DESCRIPTION
###### Motivation for this change

Package refresh
\+ moved pkgconfig and makeWrapper to nativeBuildInputs
\+ fixed fetcher
\+ fixed meta.homepage since Gna.org forge is closed

Follow-up to #32205

It builds and runs on NixOS 18.09-beta
cc @cillianderoiste for review

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

