### PR TITLE
arrow-cpp: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/darwin.patch
+++ b/pkgs/development/libraries/arrow-cpp/darwin.patch
@@ -1,0 +1,11 @@
+diff --git a/cmake_modules/FindPythonLibsNew.cmake b/cmake_modules/FindPythonLibsNew.cmake
+--- a/cmake_modules/FindPythonLibsNew.cmake
++++ b/cmake_modules/FindPythonLibsNew.cmake
+@@ -117,6 +117,7 @@ list(GET _PYTHON_VALUES 6 PYTHON_SIZEOF_VOID_P)
+ list(GET _PYTHON_VALUES 7 PYTHON_LIBRARY_SUFFIX)
+ list(GET _PYTHON_VALUES 8 PYTHON_LIBRARY_PATH)
+ list(GET _PYTHON_VALUES 9 PYTHON_OTHER_LIBS)
++string(REPLACE "-lncurses" "" PYTHON_OTHER_LIBS "${PYTHON_OTHER_LIBS}")
+ 
+ # Make sure the Python has the same pointer-size as the chosen compiler
+ # Skip the check on OS X, it doesn't consistently have CMAKE_SIZEOF_VOID_P defined

--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -2,14 +2,17 @@
 
 stdenv.mkDerivation rec {
   name = "arrow-cpp-${version}";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchurl {
     url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "16l91fixb5dgx3v6xc73ipn1w1hjgbmijyvs81j7ywzpna2cdcdy";
+    sha256 = "0bc4krapz1kzdm16npzmgdz7zvg9lip6rnqbwph8vfn7zji0fcll";
   };
 
   sourceRoot = "apache-arrow-${version}/cpp";
+
+  # patch to fix python-test
+  patches = [ ./darwin.patch ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost python.pkgs.python python.pkgs.numpy ];

--- a/pkgs/development/libraries/parquet-cpp/api.patch
+++ b/pkgs/development/libraries/parquet-cpp/api.patch
@@ -1,0 +1,12 @@
+diff --git a/src/parquet/arrow/reader.cc b/src/parquet/arrow/reader.cc
+--- a/src/parquet/arrow/reader.cc
++++ b/src/parquet/arrow/reader.cc
+@@ -1421,7 +1421,7 @@ Status StructImpl::DefLevelsToNullArray(std::shared_ptr<Buffer>* null_bitmap_out
+   const int16_t* def_levels_data;
+   size_t def_levels_length;
+   RETURN_NOT_OK(GetDefLevels(&def_levels_data, &def_levels_length));
+-  RETURN_NOT_OK(AllocateEmptyBitmap(pool_, def_levels_length, &null_bitmap));
++  RETURN_NOT_OK(GetEmptyBitmap(pool_, def_levels_length, &null_bitmap));
+   uint8_t* null_bitmap_ptr = null_bitmap->mutable_data();
+   for (size_t i = 0; i < def_levels_length; i++) {
+     if (def_levels_data[i] < struct_def_level_) {

--- a/pkgs/development/libraries/parquet-cpp/default.nix
+++ b/pkgs/development/libraries/parquet-cpp/default.nix
@@ -2,12 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "parquet-cpp-${version}";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchurl {
     url = "https://github.com/apache/parquet-cpp/archive/apache-${name}.tar.gz";
-    sha256 = "1kn7pjzi5san5f05qbl8l8znqsa3f9cq9bflfr4s2jfwr7k9p2aj";
+    sha256 = "19nwqahc0igr0jfprbf2m86rmzz6zicw4z7b8z832wbsyc904wli";
   };
+
+  patches = [ ./api.patch ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost ];

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, python, isPy3k, fetchurl, arrow-cpp, cmake, cython, futures, numpy, pandas, pytest, pytestrunner, parquet-cpp, pkgconfig, setuptools_scm, six }:
+{ lib, buildPythonPackage, python, isPy3k, fetchurl, arrow-cpp, cmake, cython, futures, JPype1, numpy, pandas, pytest, pytestrunner, parquet-cpp, pkgconfig, setuptools_scm, six }:
 
 let
   _arrow-cpp = arrow-cpp.override { inherit python;};
@@ -7,18 +7,14 @@ in
 
 buildPythonPackage rec {
   pname = "pyarrow";
-  version = "0.9.0";
 
-  src = fetchurl {
-    url = "mirror://apache/arrow/arrow-${version}/apache-arrow-${version}.tar.gz";
-    sha256 = "16l91fixb5dgx3v6xc73ipn1w1hjgbmijyvs81j7ywzpna2cdcdy";
-  };
+  inherit (_arrow-cpp) version src;
 
   sourceRoot = "apache-arrow-${version}/python";
 
   nativeBuildInputs = [ cmake cython pkgconfig setuptools_scm ];
   propagatedBuildInputs = [ numpy six ] ++ lib.optionals (!isPy3k) [ futures ];
-  checkInputs = [ pandas pytest pytestrunner ];
+  checkInputs = [ pandas pytest pytestrunner JPype1 ];
 
   PYARROW_BUILD_TYPE = "release";
   PYARROW_CMAKE_OPTIONS = "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib;${PARQUET_HOME}/lib";


### PR DESCRIPTION
pythonPackages.pyarrow: 0.9.0 -> 0.10.0
parquet: 1.4.0 -> 1.5.0

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
