### PR TITLE
cpplint: init at 1.3.0

### DIFF
--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -1,0 +1,29 @@
+{ lib, pythonPackages, fetchFromGitHub }:
+
+pythonPackages.buildPythonApplication rec {
+  pname = "cpplint";
+  version = "1.3.0";
+
+  # Fetch from github instead of pypi, since the test cases are not in the pypi archive
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "107v7bp35kxbv9v7wl79h7115z1m4b48rhasp0cnivql1grd277i";
+  };
+
+  postPatch = ''
+    patchShebangs cpplint_unittest.py
+  '';
+
+  checkPhase = ''
+    ./cpplint_unittest.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/cpplint/cpplint;
+    description = "Static code checker for C++";
+    maintainers = [ maintainers.bhipple ];
+    license = [ licenses.bsd3 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8264,6 +8264,8 @@ with pkgs;
 
   cppcheck = callPackage ../development/tools/analysis/cppcheck { };
 
+  cpplint = callPackage ../development/tools/analysis/cpplint { };
+
   cquery = callPackage ../development/tools/misc/cquery {
     llvmPackages = llvmPackages_6;
   };


### PR DESCRIPTION
Static analyzer for C++ code. Licensed under a very permissive, generic Google license.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

