### PR TITLE
tambura: init at 1.0

### DIFF
--- a/pkgs/applications/audio/tambura/default.nix
+++ b/pkgs/applications/audio/tambura/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, faust2jaqt, faust2lv2 }:
+stdenv.mkDerivation rec {
+  pname = "Tambura";
+  name = "${pname}-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "olilarkin";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "1w80cmiyzca1wirf5gypg3hcix1ky777id8wnd3k92mn1jf4a24y";
+  };
+
+  buildInputs = [ faust2jaqt faust2lv2 ];
+
+  buildPhase = ''
+    faust2jaqt -vec -time -t 99999 ${pname}.dsp
+    faust2lv2 -vec -time -gui -t 99999 ${pname}.dsp
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${pname} $out/bin/
+    mkdir -p $out/lib/lv2
+    cp -r ${pname}.lv2/ $out/lib/lv2
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A FAUST patch inspired by the Indian Tambura/Tanpura - a four string drone instrument, known for its unique rich harmonic timbre";
+    homepage = https://github.com/olilarkin/Tambura;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18929,6 +18929,8 @@ with pkgs;
     gconf = gnome2.GConf;
   };
 
+  tambura = callPackage ../applications/audio/tambura { };
+
   teamspeak_client = libsForQt5.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

