### PR TITLE
unoconv: fix reference to libreoffice

### DIFF
--- a/pkgs/tools/text/unoconv/default.nix
+++ b/pkgs/tools/text/unoconv/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python3, libreoffice, asciidoc, makeWrapper
+{ stdenv, fetchurl, python3, libreoffice-unwrapped, asciidoc, makeWrapper
 # whether to install odt2pdf/odt2doc/... symlinks to unoconv
 , installSymlinks ? true
 }:
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     sed -i "s|/usr/bin/env python.*|${python3}/bin/${python3.executable}|" "$out/bin/unoconv"
-    wrapProgram "$out/bin/unoconv" --set UNO_PATH "${libreoffice}/lib/libreoffice/program/"
+    wrapProgram "$out/bin/unoconv" --set UNO_PATH "${libreoffice-unwrapped}/lib/libreoffice/program/"
   '' + (if installSymlinks then ''
     make install-links prefix="$out"
   '' else "");


### PR DESCRIPTION
###### Motivation for this change

Fixes #43489. cc @Radvendii.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

