### PR TITLE
khard: fixup zsh autocompletion

### DIFF
--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -41,7 +41,7 @@ in with python.pkgs; buildPythonApplication rec {
   ];
 
   postInstall = ''
-    install -D misc/zsh/_khard $out/share/zsh/site-functions/
+    install -D misc/zsh/_khard $out/share/zsh/site-functions/_khard
   '';
 
   # Fails; but there are no tests anyway.


### PR DESCRIPTION
I introduced an error in https://github.com/NixOS/nixpkgs/pull/46515:
```
/build/khard-0.12.2
install: target '/nix/store/f8awiqmsici77awywp64j3prr29ij9lk-python3.6-khard-0.12.2/share/zsh/site-functions/' is not a directory: No such file or directory
note: keeping build directory '/tmp/nix-build-python3.6-khard-0.12.2.drv-0'
```
`install -D` will create the folders until the last component excluded so I needed to add the filename for it to create the `site-functions/` folder. 

I had tested it and clearly remembers completion working. I must have messed up somewhere sorry for the inconvenience.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

