### PR TITLE
Bitcoin: 0.16.3 -> 0.17.0

### DIFF
--- a/pkgs/applications/altcoins/bitcoin.nix
+++ b/pkgs/applications/altcoins/bitcoin.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec{
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "0.16.3";
+  version = "0.17.0";
 
   src = fetchurl {
     urls = [ "https://bitcoincore.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
              "https://bitcoin.org/bin/bitcoin-core-${version}/bitcoin-${version}.tar.gz"
            ];
-    sha256 = "060223dzzk2izfzhxwlzzd0fhbgglvbgps2nyc4zz767vybysvl3";
+    sha256 = "0pkq28d2dj22qrxyyg9kh0whmhj7ghyabnhyqldbljv4a7l3kvwq";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change
Updating to latest Bitcoin release.

I've also fixed `doCheck` to work with `bitcoin-qt` and enabled it by default, which partly reverts https://github.com/NixOS/nixpkgs/pull/47258.

Sorry @dtzWill, but I prefer checks to be enabled for Bitcoin.  We are not necessarily using the same compiler flags nor the exact build dependencies that upstream is using when they release Bitcoin, so having checks it place could be useful in catching critical errors from being introduced by our slightly adhoc build process.  Bitcoin is especially critical software in that software errors could cause people to permanently lose funds; we want to do everything we can to guard against that happening.

However, `doCheck` is now a parameter to the derivation, which should make it easy to override for anyone who wants to disable the checks.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@jb55 Would you like to review?