### PR TITLE
terraform-providers.matchbox: init at 0.2.2

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/data.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/data.nix
@@ -609,6 +609,13 @@
       version = "1.8.1";
       sha256  = "0y6n7mvv1f3jqsxlvf68iq85k69fj7a333203vkvc83dba84aqki";
     };
+  matchbox =
+    {
+      owner   = "coreos";
+      repo    = "terraform-provider-matchbox";
+      version = "0.2.2";
+      sha256  = "07lzslbl41i3h84bpsmxhvchm5kqk87yzin2yvpbq0m3m7r2f547";
+    };
   nixos =
     {
       owner   = "tweag";

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.txt
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.txt
@@ -9,5 +9,8 @@
 # include all terraform-providers
 terraform-providers terraform-provider- terraform-provider-\\(azure-classic\\|scaffolding\\|google-beta\\)
 
+# include terraform-provider-matchbox
+coreos/terraform-provider-matchbox
+
 # include terraform-provider-nixos
 tweag/terraform-provider-nixos


### PR DESCRIPTION
###### Motivation for this change
This adds the [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @zimbatm 