### PR TITLE
brave: init at 0.24.0

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -1,0 +1,108 @@
+{ stdenv, lib, fetchurl,
+  dpkg,
+  alsaLib,
+  at-spi2-atk,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk_pixbuf,
+  glib,
+  gnome2,
+  gtk3,
+  libuuid,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXrandr,
+  libXrender,
+  libXScrnSaver,
+  libXtst,
+  nspr,
+  nss,
+  pango,
+  udev,
+  xorg,
+  zlib
+}:
+
+let rpath = lib.makeLibraryPath [
+    alsaLib
+    at-spi2-atk
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gtk3
+    libuuid
+    libX11
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXScrnSaver
+    libXtst
+    nspr
+    nss
+    pango
+    udev
+    xorg.libxcb
+    zlib
+];
+
+
+in stdenv.mkDerivation rec {
+    name = "brave";
+    version = "0.25.2";
+
+    src = fetchurl {
+        url = "https://github.com/brave/browser-laptop/releases/download/v${version}dev/brave_${version}_amd64.deb";
+        sha256 = "1r3rsa6szps7mvvpqyw0mg16zn36x451dxq4nmn2l5ds5cp1f017";
+    };
+
+    phases = [ "unpackPhase" "installPhase" ];
+
+    nativeBuildInputs = [ dpkg ];
+
+    unpackPhase = "dpkg-deb -x $src .";
+
+    installPhase = ''
+        mkdir -p $out
+
+        cp -R usr/* $out
+
+        patchelf \
+            --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+            --set-rpath "${rpath}" $out/bin/brave
+    '';
+
+    meta = with stdenv.lib; {
+        homepage = "https://brave.com/";
+        description = "Privacy-oriented browser for Desktop and Laptop computers";
+        longDescription = ''
+          Brave browser blocks the ads and trackers that slow you down,
+          chew up your bandwidth, and invade your privacy. Brave lets you
+          contribute to your favorite creators automatically.
+        '';
+        license = licenses.mpl20;
+        maintainers = [ maintainers.uskudnik ];
+        platforms = [ "x86_64-linux" ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15738,6 +15738,8 @@ with pkgs;
 
   brackets = callPackage ../applications/editors/brackets { gconf = gnome2.GConf; };
 
+  brave = callPackage ../applications/networking/browsers/brave { };
+
   notmuch-bower = callPackage ../applications/networking/mailreaders/notmuch-bower { };
 
   bristol = callPackage ../applications/audio/bristol { };


### PR DESCRIPTION
###### Motivation for this change
Add [brave](https://brave.com/) browser

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I just started using it as browser "on the side" but most of the stuff seems to work (e.g tor in private mode, youtube).