### PR TITLE
taskell: init at 1.3.2

### DIFF
--- a/pkgs/applications/misc/taskell/default.nix
+++ b/pkgs/applications/misc/taskell/default.nix
@@ -1,0 +1,59 @@
+{ haskell, lib, haskellPackages, fetchFromGitHub }:
+
+let
+  version = "1.3.2";
+  sha256  = "0cyysvkl8m1ldlprmw9mpvch3r244nl25yv74dwcykga3g5mw4aa";
+
+in (haskellPackages.mkDerivation {
+  pname = "taskell";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "smallhadroncollider";
+    repo = "taskell";
+    rev = version;
+    inherit sha256;
+  };
+
+  postPatch = ''${haskellPackages.hpack}/bin/hpack'';
+
+  # basically justStaticExecutables; TODO: use justStaticExecutables
+  enableSharedExecutables = false;
+  enableLibraryProfiling = false;
+  isExecutable = true;
+  doHaddock = false;
+  postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
+
+  # copied from packages.yaml
+  libraryHaskellDepends = with haskellPackages; [
+    classy-prelude
+    # base <=5
+    aeson
+    brick
+    # bytestring
+    config-ini
+    # containers
+    # directory
+    file-embed
+    http-conduit
+    http-client
+    http-types
+    lens
+    # mtl
+    # template-haskell
+    # text
+    time
+    vty
+  ];
+
+  executableHaskellDepends = [];
+
+  testHaskellDepends = with haskellPackages; [
+    tasty
+    tasty-discover
+    tasty-expected-failure
+    tasty-hunit
+  ];
+
+  license = lib.licenses.bsd3;
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1537,7 +1537,7 @@ with pkgs;
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
     conf = config.riot-web.conf or null;
   };
-  
+
   roundcube = callPackage ../servers/roundcube { };
 
   rsbep = callPackage ../tools/backup/rsbep { };
@@ -18877,6 +18877,8 @@ with pkgs;
 
   teamspeak_client = libsForQt5.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };
+
+  taskell = callPackage ../applications/misc/taskell { };
 
   taskjuggler = callPackage ../applications/misc/taskjuggler { };
 


### PR DESCRIPTION
@Profpatsch please ACK this, as you're in the git trailers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

