### PR TITLE
nixos/nextcloud : added options to customize the listening address/port

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -70,7 +70,19 @@ in {
       '';
     };
 
-    nginx.enable = mkEnableOption "nginx vhost management";
+    nginx = {
+      enable = mkEnableOption "nginx vhost management";
+      addr = mkOption {
+        type = types.str;
+        default = "[::]";
+        description = "Address listened to by nginx service";
+      };
+      port = mkOption {
+        type = types.int;
+        default = 80;
+        description = "Port listened to by nginx service";
+      };
+    };
 
     webfinger = mkOption {
       type = types.bool;
@@ -366,6 +378,7 @@ in {
         virtualHosts = {
           "${cfg.hostName}" = {
             root = pkgs.nextcloud;
+            listen = [ { addr = "${cfg.nginx.addr}"; port = cfg.nginx.port; } ];
             locations = {
               "= /robots.txt" = {
                 priority = 100;


### PR DESCRIPTION
###### Motivation for this change
I added options to customize the listening address and port

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

