### PR TITLE
notmuch: use test-database in checkPhase

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/default.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/default.nix
@@ -89,6 +89,14 @@ stdenv.mkDerivation rec {
     install_name_tool -change "$badname" "$goodname" "$prg"
   '';
 
+  preCheck = let
+    test-database = fetchurl {
+      url = "https://notmuchmail.org/releases/test-databases/database-v1.tar.xz";
+      sha256 = "1lk91s00y4qy4pjh8638b5lfkgwyl282g1m27srsf7qfn58y16a2";
+    };
+  in ''
+    ln -s ${test-database} test/test-databases/database-v1.tar.xz
+  '';
   doCheck = !stdenv.isDarwin && (versionAtLeast gmime.version "3.0");
   checkTarget = "test V=1";
 


### PR DESCRIPTION
###### Motivation for this change

for running all tests, notmuch requires a database file, which can be downloaded at https://notmuchmail.org/releases/test-databases/

See test/README in notmuch sources for further info.

###### Things done

In preFixup, fetchurl the file and link it in the corresponding directory. This results in a log diff like this:

```diff
 T530-upgrade: Testing database upgrade
- missing prerequisites: database-v1.tar.xz - fetch with 'make download-test-databases'
- SKIP   all tests in T530-upgrade
+ PASS   database checksum
+ PASS   folder: search does not work with old database version
+ PASS   path: search does not work with old database version
+ PASS   pre upgrade dump
+ PASS   database upgrade from format version 1
+ PASS   tag backup matches pre-upgrade dump
+ PASS   folder: no longer matches in the middle of path
+ PASS   folder: search
+ PASS   top level folder: search
+ PASS   path: search
+ PASS   top level path: search
+ PASS   recursive path: search
```

As `test/test-databases/database-v1.tar.xz.sha256` in notmuch sources contains the sha256 of the fetched file, I'd expect the download to be stable between notmuch releases.

Pinging notmuch maintainers @chaoflow @flokli @garbas @the-kenny 

This could be (easily) backported.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

