### PR TITLE
ocamlPackages_latest.ocaml: 4.07.0 -> 4.07.1

### DIFF
--- a/pkgs/development/compilers/ocaml/4.07.nix
+++ b/pkgs/development/compilers/ocaml/4.07.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "07";
-  patch_version = "0";
-  sha256 = "03wzkzv6w4rdiiva20g5amz0n4x75swpjl8d80468p6zm8hgfnzl";
+  patch_version = "1";
+  sha256 = "1f07hgj5k45cylj1q3k5mk8yi02cwzx849b1fwnwia8xlcfqpr6z";
 
   # If the executable is stripped it does not work
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

Bugfix release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

