### PR TITLE
kbd: Renamed norwegian dvorak keymap to dvorak-no.

### DIFF
--- a/pkgs/os-specific/linux/kbd/default.nix
+++ b/pkgs/os-specific/linux/kbd/default.nix
@@ -25,6 +25,19 @@ stdenv.mkDerivation rec {
       # Add Neo keymap subdirectory
       sed -i -e 's,^KEYMAPSUBDIRS *= *,&i386/neo ,' data/Makefile.am
 
+      # Renaming keymaps with name clashes, because loadkeys just picks
+      # the first keymap it sees. The clashing names lead to e.g.
+      # "loadkeys no" defaulting to a norwegian dvorak map instead of
+      # the much more common qwerty one.
+      pushd data/keymaps/i386
+      mv qwertz/cz{,-qwertz}.map
+      mv olpc/es{,-olpc}.map
+      mv olpc/pt{,-olpc}.map
+      mv dvorak/{no.map,dvorak-no.map}
+      mv fgGIod/trf{,-fgGIod}.map
+      mv colemak/{en-latin9,colemak}.map
+      popd
+
       # Fix the path to gzip/bzip2.
       substituteInPlace src/libkeymap/findfile.c \
         --replace gzip ${gzip}/bin/gzip \


### PR DESCRIPTION
This brings it in line with all the other dvorak map names, and keeps
it from hogging the "no" name from the qwery map.

###### Motivation for this change
Issue  #47877; would get dvorak instead of qwerty keymap for "no" map.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

