### PR TITLE
[18.03] fscrypt: 0.2.3 -> 0.2.4 (security, CVE-2018-6558)

### DIFF
--- a/pkgs/os-specific/linux/fscrypt/default.nix
+++ b/pkgs/os-specific/linux/fscrypt/default.nix
@@ -4,7 +4,7 @@
 
 buildGoPackage rec {
   name = "fscrypt-${version}";
-  version = "0.2.3";
+  version = "0.2.4";
 
   goPackagePath = "github.com/google/fscrypt";
 
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "google";
     repo = "fscrypt";
     rev = "v${version}";
-    sha256 = "126bbxim4nj56kplvyv528i88mfray50r2rc6ysblkmaw6x0fd9c";
+    sha256 = "10gbyqzgi30as1crvqbb4rc5p8zzbzk1q5j080h1gnz56qzwivr8";
   };
 
   buildInputs = [ pam ];

--- a/pkgs/os-specific/linux/fscrypt/default.nix
+++ b/pkgs/os-specific/linux/fscrypt/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, pam }:
+{ stdenv, buildGo110Package, fetchFromGitHub, pam }:
 
 # Don't use this for anything important yet!
 
-buildGoPackage rec {
+buildGo110Package rec {
   name = "fscrypt-${version}";
   version = "0.2.4";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

