### PR TITLE
Collecting systemd units execution times in NixOS tests

### DIFF
--- a/nixos/lib/test-driver/Machine.pm
+++ b/nixos/lib/test-driver/Machine.pm
@@ -396,6 +396,16 @@ sub systemctl {
     return $self->execute("systemctl $q");
 }
 
+sub systemdAnalyzeBlame {
+    my ($self) = @_;
+    my ($status, $lines) = $self->execute("systemd-analyze blame");
+    return undef if $status != 0;
+    foreach my $line (split /\n/ ,$lines) {
+        $line =~ s/\s*//;
+        $self->log($line);
+    }
+}
+
 # Fail if the given systemd unit is not in the "active" state.
 sub requireActiveUnit {
     my ($self, $unit) = @_;

--- a/nixos/lib/test-driver/test-driver.pl
+++ b/nixos/lib/test-driver/test-driver.pl
@@ -122,6 +122,13 @@ sub runTests {
         $term->WriteHistory;
     }
 
+    $log->nest("collecting systemd units exection time", sub {
+        foreach my $vm (values %vms) {
+            next unless $vm->isUp();
+            $vm->systemdAnalyzeBlame();
+        }
+    });
+
     # Copy the kernel coverage data for each machine, if the kernel
     # has been compiled with coverage instrumentation.
     $log->nest("collecting coverage data", sub {


### PR DESCRIPTION
At the end of the NixOS test, exection times of all systemd units
are collected. This is implemented by using the `systemd-analyze
blame` command.

A new section is added to the log.html file. This section contains,
for each VM, the list of running units ordered by time to init.

###### Motivation for this change
This is to know why some of my tests are too slow:/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

