### PR TITLE
pythonPackages.dpath: init at 1.4.2

### DIFF
--- a/pkgs/development/python-modules/dpath/default.nix
+++ b/pkgs/development/python-modules/dpath/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchPypi, buildPythonPackage
+, mock, nose
+}:
+
+buildPythonPackage rec {
+  pname = "dpath";
+  version = "1.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gr7816pnzbyh9h1ia0qz0q1f9zfzacwb8dc36js8hw8x14myqqg";
+  };
+
+  checkInputs = [ mock nose ];
+  checkPhase = ''
+    nosetests
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/akesterson/dpath-python;
+    license = [ licenses.mit ];
+    description = "A python library for accessing and searching dictionaries via /slashed/paths ala xpath";
+    maintainers = [ maintainers.mmlb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1482,6 +1482,8 @@ in {
 
   dopy = callPackage ../development/python-modules/dopy { };
 
+  dpath = callPackage ../development/python-modules/dpath { };
+
   dpkt = callPackage ../development/python-modules/dpkt {};
 
   urllib3 = callPackage ../development/python-modules/urllib3 {};


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

