### PR TITLE
FIL-plugins: init at 0.3.0

### DIFF
--- a/pkgs/applications/audio/FIL-plugins/default.nix
+++ b/pkgs/applications/audio/FIL-plugins/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchurl, ladspaH
+}:
+
+stdenv.mkDerivation rec {
+  name = "FIL-plugins-${version}";
+  version = "0.3.0";
+  src = fetchurl {
+    url = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${name}.tar.bz2";
+    sha256 = "1scfv9j7jrp50r565haa4rvxn1vk2ss86xssl5qgcr8r45qz42qw";
+  };
+
+  buildInputs = [ ladspaH ];
+
+  patchPhase = ''
+    sed -i 's@/usr/bin/install@install@g' Makefile
+    sed -i 's@/bin/rm@rm@g' Makefile
+    sed -i 's@/usr/lib/ladspa@$(out)/lib/ladspa@g' Makefile
+  '';
+
+  preInstall="mkdir -p $out/lib/ladspa";
+
+  meta = {
+    description = ''a four-band parametric equaliser, which has the nice property of being stable even while parameters are being changed'';
+    longDescription = ''
+      Each section has an active/bypass switch, frequency, bandwidth and gain controls.
+      There is also a global bypass switch and gain control.
+      The 2nd order resonant filters are implemented using a Mitra-Regalia style lattice filter.
+      All switches and controls are internally smoothed, so they can be used 'live' whithout any clicks or zipper noises.
+      This should make this plugin a good candidate for use in systems that allow automation of plugin control ports, such as Ardour, or for stage use.
+    '';
+    version = "${version}";
+    homepage = http://kokkinizita.linuxaudio.org/linuxaudio/ladspa/index.html;
+    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = [ stdenv.lib.maintainers.magnetophon ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16424,6 +16424,8 @@ with pkgs;
 
   fig2dev = callPackage ../applications/graphics/fig2dev { };
 
+  FIL-plugins = callPackage ../applications/audio/FIL-plugins { };
+
   flacon = callPackage ../applications/audio/flacon { };
 
   flexget = callPackage ../applications/networking/flexget { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

