### PR TITLE
eteroj.lv2: init at 0.4.0

### DIFF
--- a/pkgs/applications/audio/eteroj.lv2/default.nix
+++ b/pkgs/applications/audio/eteroj.lv2/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libuv, lv2 }:
+
+stdenv.mkDerivation rec {
+  pname = "eteroj.lv2";
+  version = "0.4.0";
+  name = "${pname}-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "OpenMusicKontrollers";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0lzdk7hlz3vqgshrfpj0izjad1fmsnzk2vxqrry70xgz8xglvnmn";
+  };
+
+  buildInputs = [ libuv lv2 ];
+  nativeBuildInputs = [ cmake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "OSC injection/ejection from/to UDP/TCP/Serial for LV2";
+    homepage = https://open-music-kontrollers.ch/lv2/eteroj;
+    license = licenses.artistic2;
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16375,6 +16375,8 @@ with pkgs;
 
   eterm = callPackage ../applications/misc/eterm { };
 
+  eteroj.lv2 = libsForQt5.callPackage ../applications/audio/eteroj.lv2 { };
+
   etherape = callPackage ../applications/networking/sniffers/etherape { };
 
   evilvte = callPackage ../applications/misc/evilvte {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

