### PR TITLE
Trezor GPG agent

### DIFF
--- a/nixos/modules/programs/gnupg.nix
+++ b/nixos/modules/programs/gnupg.nix
@@ -61,6 +61,27 @@ in
         Enables GnuPG network certificate management daemon with socket-activation for every user session.
       '';
     };
+
+    trezor-agent.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable the Trezor GnuPG agent service, which allows you to use your
+        Trezor as a GnuPG agent for signing and decrypting.
+      '';
+    };
+
+    trezor-agent.configPath = mkOption {
+      type = types.string;
+      default = "/var/empty";
+      example = "/home/alice/.gnupg/trezor";
+      description = ''
+        The GNUPGHOME path for your Trezor GnuPG config. See
+        https://github.com/romanz/trezor-agent/blob/master/doc/README-GPG.md on
+        how to set this up.
+      '';
+    };
+
   };
 
   config = mkIf cfg.agent.enable {
@@ -107,6 +128,19 @@ in
         message = "You can't use ssh-agent and GnuPG agent with SSH support enabled at the same time!";
       }
     ];
-  };
+  } // (mkIf cfg.trezor-agent.enable  {
+    systemd.user.services.trezor-agent = {
+      description = "Trezor GnuPG Agent";
+
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.gnupg ];
+
+      environment = {
+        GNUPGHOME=cfg.trezor-agent.configPath;
+      };
+
+      serviceConfig.ExecStart = "${pkgs.trezor-agent}/bin/trezor-gpg-agent";
+    };
+  });
 
 }

--- a/pkgs/tools/security/trezor-agent/default.nix
+++ b/pkgs/tools/security/trezor-agent/default.nix
@@ -1,0 +1,35 @@
+{ buildPythonPackage, qtbase, stdenv, fetchFromGitHub,
+  trezor, libagent, lib, pinentry
+}:
+
+buildPythonPackage rec {
+  name = "${pname}-${version}";
+  pname = "trezor_agent";
+  version = "0.12.0";
+
+  src = "${fetchFromGitHub {
+    repo = "trezor-agent";
+    owner = "romanz";
+    rev = "7f9aa2b1477aaf411ae5dba382f0e7681d9925c9";
+    sha256 = "1jsijl7ik8q71g1idg182yvqkcg1iggpg6wspj9r2c5hzq2n2qjz";
+  }}/agents/trezor";
+
+  propagatedBuildInputs = [ trezor libagent ];
+
+  postFixup = ''
+    # fix for qt pinentry in non-tty environments such as systemd services
+    wrapProgram $out/bin/trezor-gpg-agent \
+      --set QT_QPA_PLATFORM_PLUGIN_PATH "${qtbase.bin}/lib/qt-*/plugins/platforms/" \
+      --prefix PATH : ${lib.makeBinPath [ pinentry ]}
+
+    wrapProgram $out/bin/trezor-gpg \
+      --prefix PATH : ${lib.makeBinPath [ pinentry ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Using Trezor as hardware SSH agent";
+    homepage = https://github.com/romanz/trezor-agent;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ jb55 np ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6215,6 +6215,11 @@ in
 
   trezord = callPackage ../servers/trezord { };
 
+  trezor-agent = callPackage ../tools/security/trezor-agent {
+    inherit (python3Packages) trezor libagent buildPythonPackage;
+    inherit (qt5) qtbase;
+  };
+
   tthsum = callPackage ../applications/misc/tthsum { };
 
   chaps = callPackage ../tools/security/chaps { };


### PR DESCRIPTION
###### Motivation for this change

This is a continuation of #32773 /cc @fpletz @FRidh 

See the commits for why I've moved it out of python modules.

This patchset adds a systemd user service that provides a Trezor GPG agent. This allows you to use your Trezor for signing and encrypting things.

range-diff: v1 -> v2

```diff
 1:  1e63ead03d5 < -:  ----------- trezor-agent: 0.9.0 -> 0.9.2
 2:  939215154c6 < -:  ----------- trezor-agent: support qt pinentry on non-ttys
 -:  ----------- > 1:  09558b61be6 trezor-agent: 0.9.0 -> 0.12.0
 3:  971112bd12d ! 2:  c35222cbb30 trezor-agent: system service for trezor-gpg-agent
@@ -4,6 +4,8 @@
 
     Allows you to use your Trezor as a GnuPG agent
 
+    Signed-off-by: William Casarin <jb55@jb55.com>
+
 diff --git a/nixos/modules/programs/gnupg.nix b/nixos/modules/programs/gnupg.nix
 --- a/nixos/modules/programs/gnupg.nix
 +++ b/nixos/modules/programs/gnupg.nix
@@ -27,8 +29,8 @@
 +      example = "/home/alice/.gnupg/trezor";
 +      description = ''
 +        The GNUPGHOME path for your Trezor GnuPG config. See
-+        https://github.com/romanz/trezor-agent/blob/master/README-GPG.md on how
-+        to set this up.
++        https://github.com/romanz/trezor-agent/blob/master/doc/README-GPG.md on
++        how to set this up.
 +      '';
 +    };
 +
@@ -51,7 +53,7 @@
 +        GNUPGHOME=cfg.trezor-agent.configPath;
 +      };
 +
-+      serviceConfig.ExecStart = "${pkgs.python27Packages.trezor_agent}/bin/trezor-gpg-agent";
++      serviceConfig.ExecStart = "${pkgs.trezor-agent}/bin/trezor-gpg-agent";
 +    };
 +  });
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

