### PR TITLE
pythonPackages.eradicate: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/eradicate/default.nix
+++ b/pkgs/development/python-modules/eradicate/default.nix
@@ -1,0 +1,19 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "eradicate";
+  version = "0.2.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "092zmck919bn6sl31ixrzhn88g9nvhwzmwzpq8dzgn6c8k2h3bzr";
+  };
+
+  meta = with lib; {
+    description = "eradicate removes commented-out code from Python files.";
+    homepage = https://github.com/myint/eradicate;
+    license = [ licenses.mit ];
+
+    maintainers = [ maintainers.mmlb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -300,6 +300,8 @@ in {
 
   diff-match-patch = callPackage ../development/python-modules/diff-match-patch { };
 
+  eradicate = callPackage ../development/python-modules/eradicate {  };
+
   fido2 = callPackage ../development/python-modules/fido2 {  };
 
   fire = callPackage ../development/python-modules/fire { };


### PR DESCRIPTION
###### Motivation for this change
This is a new dependency of pylama, which I intend to PR with the upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

