### PR TITLE
pythonPackages.pythondaemon: rename to pythonPackages.python-daemon

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -670,7 +670,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "035w8gqql36zlan0xjrzz9j4lh9hs0qrsgnbyw07qs7lnkvbdv9x";
   };
 
-  propagatedBuildInputs = with python3Packages; [ tornado_4 pythondaemon ];
+  propagatedBuildInputs = with python3Packages; [ tornado_4 python-daemon ];
 
   meta = with lib; {
     ...

--- a/pkgs/applications/networking/cluster/luigi/default.nix
+++ b/pkgs/applications/networking/cluster/luigi/default.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
     sed -i 's/<2.2.0//' setup.py
   '';
 
-  propagatedBuildInputs = with python3Packages; [ tornado_4 pythondaemon ];
+  propagatedBuildInputs = with python3Packages; [ tornado_4 python-daemon ];
 
   # Requires tox, hadoop, and google cloud
   doCheck = false;

--- a/pkgs/development/python-modules/coilmq/default.nix
+++ b/pkgs/development/python-modules/coilmq/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi
-, stompclient, pythondaemon, redis, pid, pytest, six, click, coverage
+, stompclient, python-daemon, redis, pid, pytest, six, click, coverage
 , sqlalchemy }:
 
 buildPythonPackage rec {
@@ -11,7 +11,7 @@ buildPythonPackage rec {
     sha256 = "4cbfeb5ed2459df14902c1380157be6267702b1271682924cd316ccad8a29d1d";
   };
 
-  propagatedBuildInputs = [ stompclient pythondaemon redis pid ];
+  propagatedBuildInputs = [ stompclient python-daemon redis pid ];
   buildInputs = [ pytest six click coverage sqlalchemy ];
 
   # The teste data is not included in the distribution

--- a/pkgs/development/python-modules/libagent/default.nix
+++ b/pkgs/development/python-modules/libagent/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchPypi, buildPythonPackage, ed25519, ecdsa , semver, mnemonic,
   unidecode, mock, pytest , backports-shutil-which, ConfigArgParse,
-  pythondaemon, pymsgbox }:
+  python-daemon, pymsgbox }:
 
 buildPythonPackage rec {
   pname = "libagent";
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ unidecode backports-shutil-which ConfigArgParse
-    pythondaemon pymsgbox ecdsa ed25519 mnemonic semver ];
+    python-daemon pymsgbox ecdsa ed25519 mnemonic semver ];
 
   checkInputs = [ mock pytest ];
 

--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi, nose, dnspython
-,  chardet, lmtpd, pythondaemon, six, jinja2, mock }:
+,  chardet, lmtpd, python-daemon, six, jinja2, mock }:
 
 buildPythonPackage rec {
   pname = "salmon-mail";
@@ -11,7 +11,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ nose jinja2 mock ];
-  propagatedBuildInputs = [ chardet dnspython lmtpd pythondaemon six ];
+  propagatedBuildInputs = [ chardet dnspython lmtpd python-daemon six ];
 
   # The tests use salmon executable installed by salmon itself so we need to add
   # that to PATH

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12197,7 +12197,7 @@ in {
       };
     in if isPy3k then py3 else py2;
 
-  pythondaemon = callPackage ../development/python-modules/python-daemon { };
+  python-daemon = callPackage ../development/python-modules/python-daemon { };
 
   sympy = callPackage ../development/python-modules/sympy { };
 


### PR DESCRIPTION
This commit renames the pythondaemon module to match its module name, github
name, and pypi name, which makes it easier to find and reference. In order to
avoid breaking any external users, I've left an alias with a deprecated warning.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

