### PR TITLE
ocamlPackages.ezxmlm: init at 1.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/ezxmlm/default.nix
+++ b/pkgs/development/ocaml-modules/ezxmlm/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib, dune, xmlm }:
+
+stdenv.mkDerivation rec {
+  version = "1.0.2";
+  name = "ocaml${ocaml.version}-ezxmlm-${version}";
+
+  src = fetchFromGitHub {
+    owner = "avsm";
+    repo = "ezxmlm";
+    rev = "v${version}";
+    sha256 = "1dgr61f0hymywikn67inq908x5adrzl3fjx3v14l9k46x7kkacl9";
+  };
+
+  propagatedBuildInputs = [ xmlm ];
+
+  buildInputs = [ ocaml findlib dune ];
+
+  buildFlags = "build";
+
+  inherit (dune) installPhase;
+
+  meta = with stdenv.lib; {
+    description = "Combinators to use with xmlm for parsing and selection";
+    longDescription = ''
+      An "easy" interface on top of the xmlm library. This version provides
+      more convenient (but far less flexible) input and output functions
+      that go to and from [string] values. This avoids the need to write signal
+      code, which is useful for quick scripts that manipulate XML.
+
+      More advanced users should go straight to the Xmlm library and use it
+      directly, rather than be saddled with the Ezxmlm interface. Since the
+      types in this library are more specific than Xmlm, it should interoperate
+      just fine with it if you decide to switch over.
+    '';
+    maintainers = [ maintainers.carlosdagos ];
+    inherit (src.meta) homepage;
+    inherit (ocaml.meta) platforms;
+    license = licenses.isc;
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -252,6 +252,8 @@ let
 
     ezjsonm = callPackage ../development/ocaml-modules/ezjsonm { };
 
+    ezxmlm = callPackage ../development/ocaml-modules/ezxmlm { };
+
     facile = callPackage ../development/ocaml-modules/facile { };
 
     faillib = callPackage ../development/ocaml-modules/faillib { };


### PR DESCRIPTION
###### Motivation for this change

Nice library to have :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

