### PR TITLE
rtl-sdr: 0.5.4 -> 0.6.0

### DIFF
--- a/pkgs/applications/misc/rtl-sdr/default.nix
+++ b/pkgs/applications/misc/rtl-sdr/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "rtl-sdr-${version}";
-  version = "0.5.4";
+  version = "0.6.0";
 
   src = fetchgit {
     url = "git://git.osmocom.org/rtl-sdr.git";
-    rev = "refs/tags/v${version}";
-    sha256 = "0c56a9dhlqgs6y15ns0mn4r5giz0x6y7x151jcq755f711pc3y01";
+    rev = "refs/tags/${version}";
+    sha256 = "0lmvsnb4xw4hmz6zs0z5ilsah5hjz29g1s0050n59fllskqr3b8k";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Update to version. 

CC @bjornfor 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

