### PR TITLE
black: 18.6b4 -> 18.9b0

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "black";
-  version = "18.6b4";
+  version = "18.9b0";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0i4sfqgz6w15vd50kbhi7g7rifgqlf8yfr8y78rypd56q64qn592";
+    sha256 = "1992ramdwv8sg4mbl5ajirwj5i4a48zjgsycib0fnbaliyiajc70";
   };
 
   checkInputs =  [ pytest glibcLocales ];

--- a/pkgs/development/python-modules/pyls-black/default.nix
+++ b/pkgs/development/python-modules/pyls-black/default.nix
@@ -19,6 +19,9 @@ buildPythonPackage rec {
     pytest
   '';
 
+  # Enable when https://github.com/rupert/pyls-black/pull/6 is merged.
+  doCheck = false;
+
   checkInputs = [ pytest ];
 
   propagatedBuildInputs = [ black toml python-language-server ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

