### PR TITLE
zn_poly: 0.9 -> 0.9.1

### DIFF
--- a/pkgs/development/libraries/science/math/zn_poly/default.nix
+++ b/pkgs/development/libraries/science/math/zn_poly/default.nix
@@ -1,17 +1,25 @@
 { stdenv
-, fetchurl
+, lib
+, fetchFromGitLab
+, fetchpatch
 , gmp
 , python2
+, tune ? false # tune to hardware, impure
 }:
 
 stdenv.mkDerivation rec {
-  version = "0.9";
+  version = "0.9.1";
   pname = "zn_poly";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "http://web.maths.unsw.edu.au/~davidharvey/code/zn_poly/releases/zn_poly-${version}.tar.gz";
-    sha256 = "1kxl25av7i3v68k32hw5bayrfcvmahmqvs97mlh9g238gj4qb851";
+  # sage has picked up the maintenance (bug fixes and building, not development)
+  # from the original, now unmaintained project which can be found at
+  # http://web.maths.unsw.edu.au/~davidharvey/code/zn_poly/
+  src = fetchFromGitLab {
+    owner = "sagemath";
+    repo = "zn_poly";
+    rev = version;
+    sha256 = "0ra5vy585bqq7g3317iw6fp44iqgqvds3j0l1va6mswimypq4vxb";
   };
 
   buildInputs = [
@@ -22,27 +30,42 @@ stdenv.mkDerivation rec {
     python2 # needed by ./configure to create the makefile
   ];
 
-  libname = "libzn_poly${stdenv.targetPlatform.extensions.sharedLibrary}";
+  # name of library file ("libzn_poly.so")
+  libbasename = "libzn_poly";
+  libext = "${stdenv.targetPlatform.extensions.sharedLibrary}";
 
   makeFlags = [ "CC=cc" ];
 
   # Tuning (either autotuning or with hand-written paramters) is possible
   # but not implemented here.
   # It seems buggy anyways (see homepage).
-  buildFlags = [ "all" libname ];
+  buildFlags = [ "all" "${libbasename}${libext}" ];
 
+  configureFlags = lib.optionals (!tune) [
+    "--disable-tuning"
+  ];
+
+  patches = [
+    # fix format-security by not passing variables directly to printf
+    # https://gitlab.com/sagemath/zn_poly/merge_requests/1
+    (fetchpatch {
+      name = "format-security.patch";
+      url = "https://gitlab.com/timokau/zn_poly/commit/1950900a80ec898d342b8bcafa148c8027649766.patch";
+      sha256 = "1gks9chvsfpc6sg5h3nqqfia4cgvph7jmj9dw67k7dk7kv9y0rk1";
+    })
+  ];
 
   # `make install` fails to install some header files and the lib file.
   installPhase = ''
     mkdir -p "$out/include/zn_poly"
     mkdir -p "$out/lib"
-    cp "${libname}" "$out/lib"
+    cp "${libbasename}"*"${libext}" "$out/lib"
     cp include/*.h "$out/include/zn_poly"
   '';
 
   doCheck = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://web.maths.unsw.edu.au/~davidharvey/code/zn_poly/;
     description = "Polynomial arithmetic over Z/nZ";
     license = with licenses; [ gpl3 ];


### PR DESCRIPTION
###### Motivation for this change

Sage has taken over maintenance since the original author no longer
maintains the project.

The upgrade integrates various patches from sage. It also enables tuning by default, which now has to be disabled explicitly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

