### PR TITLE
hol_light: 2017-07-06 -> 2018-09-30

### DIFF
--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -1,32 +1,37 @@
-{ stdenv, fetchFromGitHub, fetchpatch, ocaml, camlp5 }:
+{ stdenv, fetchFromGitHub, ocaml, num, camlp5 }:
 
 let
-  start_script = ''
-    #!/bin/sh
-    cd "$out/lib/hol_light"
-    exec ${ocaml}/bin/ocaml -I \`${camlp5}/bin/camlp5 -where\` -init make.ml
-  '';
+  load_num =
+    if num == null then "" else
+      ''
+        -I ${num}/lib/ocaml/${ocaml.version}/site-lib/num \
+        -I ${num}/lib/ocaml/${ocaml.version}/site-lib/top-num \
+        -I ${num}/lib/ocaml/${ocaml.version}/site-lib/stublibs \
+      '';
+
+  start_script =
+    ''
+      #!/bin/sh
+      cd $out/lib/hol_light
+      exec ${ocaml}/bin/ocaml \
+        -I \`${camlp5}/bin/camlp5 -where\` \
+        ${load_num} \
+        -init make.ml
+    '';
 in
 
 stdenv.mkDerivation {
-  name     = "hol_light-2017-07-06";
+  name     = "hol_light-2018-09-30";
 
   src = fetchFromGitHub {
     owner  = "jrh13";
     repo   = "hol-light";
-    rev    = "0ad8cbdb4de08a38dac600f352555e8454499faa";
-    sha256 = "0px9hl1b0mkyqv84j0si1zdq4066ffdrhzp27p2iah9l8ynbvpaq";
+    rev    = "27e09dd27834de46e917057710e9d8ded51a4c9f";
+    sha256 = "1p0rm08wnc2lsrh3xzhlq3zdhzqcv1lbqnkwx3aybrqhbg1ixc1d";
   };
 
   buildInputs = [ ocaml camlp5 ];
-
-  patches = [ (fetchpatch {
-      url = https://github.com/girving/hol-light/commit/f80524bad61fd6f6facaa42153b2e29d1eab4658.patch;
-      sha256 = "1563wp597vakhmsgg8940dpirzzfvvxqp75x3dnx20rvmi2n2xw0";
-    })
-  ];
-
-  postPatch = "cp pa_j_3.1x_{6,7}.xx.ml";
+  propagatedBuildInputs = [ num ];
 
   installPhase = ''
     mkdir -p "$out/lib/hol_light" "$out/bin"

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1041,6 +1041,7 @@ let
     };
 
     hol_light = callPackage ../applications/science/logic/hol_light {
+      inherit num;
       camlp5 = camlp5_strict;
     };
 


### PR DESCRIPTION
Also, handle compatibility with newer versions of OCaml (depend on num
library as needed).

###### Motivation for this change

- Update HOL Light to the latest distributed version.
- Make HOL Light work with recent versions of OCaml (including the current default version).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@vbgl, @thoughtpolice: you are welcome to revise these changes and contribute improvements.
