### PR TITLE
[WIP] services.nextcloud: add port option

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -71,6 +71,13 @@ in {
     };
 
     nginx.enable = mkEnableOption "nginx vhost management";
+    nginx.port = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      description = ''
+        Port for nginx to listen on.
+      '';
+    };
 
     webfinger = mkOption {
       type = types.bool;
@@ -365,6 +372,7 @@ in {
         enable = true;
         virtualHosts = {
           "${cfg.hostName}" = {
+            listen = if cfg.nginx.port != null then [ { addr = "*"; port = cfg.nginx.port; } ] else [];
             root = pkgs.nextcloud;
             locations = {
               "= /robots.txt" = {


### PR DESCRIPTION
###### Motivation for this change
i'd rather have all services run on different ports and then add a single nginx in-front of those.

works for me, but there is probably a nicer way. any hints are welcome.