### PR TITLE
pythonPackages.histbook: init at 1.2.3

### DIFF
--- a/pkgs/development/python-modules/histbook/default.nix
+++ b/pkgs/development/python-modules/histbook/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi, numpy, pandas }:
+
+buildPythonPackage rec {
+  pname = "histbook";
+  version = "1.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12d5l4c5pxwac5hzcfif51j87qjljm0w9nd0c8pnhj7q2snap4x4";
+  };
+
+  propagatedBuildInputs = [ numpy pandas ];
+
+  meta = with lib; {
+    homepage = https://github.com/scikit-hep/histbook;
+    description = "Versatile, high-performance histogram toolkit for Numpy";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -326,6 +326,8 @@ in {
 
   habanero = callPackage ../development/python-modules/habanero { };
 
+  histbook = callPackage ../development/python-modules/histbook { };
+
   httpsig = callPackage ../development/python-modules/httpsig { };
 
   i3ipc = callPackage ../development/python-modules/i3ipc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

