### PR TITLE
gnulib: add a symlink from bin/gnulib-tool to gnulib-tool

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out; mv * $out/
     ln -s $out/lib $out/include
+    mkdir -p $out/bin
+    ln -s $out/gnulib-tool $out/bin/
   '';
 
   meta = {


### PR DESCRIPTION
This makes gnulib-tool available in the user's path after installing gnulib.

###### Motivation for this change
After installing gnulib, I would like to be able to run gnulib-tool to import gnulib packages into projects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

