### PR TITLE
qpdf: Drop CVE-2018-9918.patch

### DIFF
--- a/pkgs/development/libraries/qpdf/default.nix
+++ b/pkgs/development/libraries/qpdf/default.nix
@@ -14,14 +14,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib libjpeg ];
 
-  patches = [
-    (fetchpatch {
-      name = "CVE-2018-9918.patch";
-      url = "https://github.com/qpdf/qpdf/commit/b4d6cf6836ce025ba1811b7bbec52680c7204223";
-      sha256 = "0mdqa9w1p6cmli6976v4wi0sw9r4p5prkj7lzfd1877wk11c9c73";
-    })
-  ];
-
   postPatch = ''
     patchShebangs qpdf/fix-qdf
   '';


### PR DESCRIPTION
###### Motivation for this change

This patch has been merged upstream in 8.2.1, as pointed out in #47899.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

