### PR TITLE
systemd-wait: init at 0.1+2018-10-05

### DIFF
--- a/pkgs/os-specific/linux/systemd-wait/default.nix
+++ b/pkgs/os-specific/linux/systemd-wait/default.nix
@@ -1,0 +1,25 @@
+{ python3Packages, fetchFromGitHub, lib }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "systemd-wait";
+  version = "0.1+2018-10-05";
+
+  src = fetchFromGitHub {
+    owner = "Stebalien";
+    repo = pname;
+    rev = "bbb58dd4584cc08ad20c3888edb7628f28aee3c7";
+    sha256 = "1l8rd0wzf3m7fk0g1c8wc0csdisdfac0filhixpgp0ck9ignayq5";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    dbus-python pygobject3
+  ];
+
+  meta = {
+    homepage = https://github.com/Stebalien/systemd-wait;
+    license = lib.licenses.gpl3;
+    description = "Wait for a systemd unit to enter a specific state";
+    maintainers = [ lib.maintainers.benley ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1539,7 +1539,7 @@ with pkgs;
   riot-web = callPackage ../applications/networking/instant-messengers/riot/riot-web.nix {
     conf = config.riot-web.conf or null;
   };
-  
+
   roundcube = callPackage ../servers/roundcube { };
 
   rsbep = callPackage ../tools/backup/rsbep { };
@@ -14745,6 +14745,8 @@ with pkgs;
         cp "${pkgs.lvm2}/lib/systemd/system-generators/"* $out/lib/systemd/system-generators
       '';
   }));
+
+  systemd-wait = callPackages ../os-specific/linux/systemd-wait { };
 
   sysvinit = callPackage ../os-specific/linux/sysvinit { };
 


### PR DESCRIPTION
###### Motivation for this change
This will be useful when we want to use systemd units to run graphical login sessions: `systemd-wait --user window-manager.service inactive` at the end of an xsession script ought to work great.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---