### PR TITLE
jsonnet: fix on darwin

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, emscripten }:
+{ stdenv, lib, fetchFromGitHub, emscripten
+, enableJsonnetJs ? !stdenv.isDarwin
+}:
 
 let version = "0.11.2"; in
 
@@ -13,16 +15,17 @@ stdenv.mkDerivation {
     sha256 = "05rl5i4g36k2ikxv4sw726mha1qf5bb66wiqpi0s09wj9azm7vym";
   };
 
-  buildInputs = [ emscripten ];
+  buildInputs = if enableJsonnetJs then [ emscripten ] else [ ];
 
   enableParallelBuilding = true;
 
-  makeFlags = [''EM_CACHE=$(TMPDIR)/.em_cache'' ''all''];
+  makeFlags = [''EM_CACHE=$(TMPDIR)/.em_cache''] ++
+    (if enableJsonnetJs then ["all"] else ["jsonnet" "libjsonnet.so" "libjsonnet++.so"]);
 
   installPhase = ''
     mkdir -p $out/bin $out/lib $out/share/
     cp jsonnet $out/bin/
-    cp libjsonnet.so $out/lib/
+    cp libjsonnet*.so $out/lib/
     cp -a doc $out/share/doc
     cp -a include $out/include
   '';


### PR DESCRIPTION
Build on darwin fails when using emscripten to build the js
library. Disabling this is unsatisfying, but gets the jsonnet binary
building again.

###### Motivation for this change

Build fails on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@benley 
FYI, initial error on darwin is this (the missing tmpfile thing is not the true error, I think):
```
INFO:root:generating system library: libcxx.a... (this will be cached in "/private/var/folders/vc/gx_wbycj2nlbt3yzw5gt520xdjznbj/T/nix-build-jsonnet-0.11.2.drv-1/.em_cache/asmjs/libcxx.a" for subsequent builds)
INFO:root: - ok
INFO:root:generating system library: libcxxabi.bc... (this will be cached in "/private/var/folders/vc/gx_wbycj2nlbt3yzw5gt520xdjznbj/T/nix-build-jsonnet-0.11.2.drv-1/.em_cache/asmjs/libcxxabi.bc" for subsequent builds)
/nix/store/s4wfflah5il55qv0svbhsz7f4yk99sya-emscripten-1.37.36/share/emscripten/system/lib/libcxxabi/src/cxa_aux_runtime.cpp:22:1: error: unknown type name 'LIBCXXABI_NORETURN'
LIBCXXABI_NORETURN
^
```

was trying to follow http://www.omniprog.info/clang_build_libcxx.html but could not make it work, so just ended up disabling emscripten / js build on darwin. May be the same issue as seen here: https://github.com/bakape/meguca/issues/767
