### PR TITLE
wire-desktop: 3.2.2840 -> 3.3.2872

### DIFF
--- a/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/wire-desktop/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, fetchurl, dpkg, makeDesktopItem, gnome2, gtk2, atk, cairo, pango, gdk_pixbuf, glib
+{ stdenv, fetchurl, dpkg, makeDesktopItem, gnome2, gtk2, atk, cairo, pango, gdk_pixbuf, glib
 , freetype, fontconfig, dbus, libnotify, libX11, xorg, libXi, libXcursor, libXdamage
 , libXrandr, libXcomposite, libXext, libXfixes, libXrender, libXtst, libXScrnSaver
-, nss, nspr, alsaLib, cups, expat, udev, xdg_utils, hunspell
+, nss, nspr, alsaLib, cups, expat, udev, xdg_utils, hunspell, pulseaudio, pciutils
 }:
 let
-  rpath = lib.makeLibraryPath [
+  rpath = stdenv.lib.makeLibraryPath [
     alsaLib
     atk
     cairo
@@ -17,7 +17,6 @@ let
     glib
     gnome2.GConf
     gtk2
-    pango
     hunspell
     libnotify
     libX11
@@ -33,13 +32,16 @@ let
     libXtst
     nspr
     nss
+    pango
+    pciutils
+    pulseaudio
     stdenv.cc.cc
     udev
     xdg_utils
     xorg.libxcb
   ];
 
-  version = "3.2.2840";
+  version = "3.3.2872";
 
   plat = {
     "i686-linux" = "i386";
@@ -47,8 +49,8 @@ let
   }.${stdenv.hostPlatform.system};
 
   sha256 = {
-    "i686-linux" = "071ddh2d8wmiybwafwyb97962zj358l0fq7g2r44231653sgybvq";
-    "x86_64-linux" = "0qp9ms94smnm7k47b0n0jdzvnm1b7gj25hyinsfc6lghrb6jqw3r";
+    "i686-linux" = "16dw4ycajxviqrf4i32rkrhg1j1mdkmk252y8vjwr18xlyn958qb";
+    "x86_64-linux" = "04ysk91h2izyb41b243zki4j08bis9yzjq2va9bakp1lv6ywm8pw";
   }.${stdenv.hostPlatform.system};
 
 in
@@ -74,31 +76,31 @@ in
     nativeBuildInputs = [ dpkg ];
     unpackPhase = "dpkg-deb -x $src .";
     installPhase = ''
-      mkdir -p $out
-      cp -R opt $out
-      cp -R usr/share $out/share
+      mkdir -p "$out"
+      cp -R "opt" "$out"
+      cp -R "usr/share" "$out/share"
 
-      chmod -R g-w $out
+      chmod -R g-w "$out"
 
-      # Patch signal
+      # Patch wire-desktop
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-               --set-rpath "${rpath}:$out/opt/wire-desktop" \
-               "$out/opt/wire-desktop/wire-desktop"
+               --set-rpath "${rpath}:$out/opt/Wire" \
+               "$out/opt/Wire/wire-desktop"
 
       # Symlink to bin
-      mkdir -p $out/bin
-      ln -s "$out/opt/wire-desktop/wire-desktop" $out/bin/wire-desktop
+      mkdir -p "$out/bin"
+      ln -s "$out/opt/Wire/wire-desktop" "$out/bin/wire-desktop"
 
       # Desktop file
-      mkdir -p $out/share/applications
-      cp ${desktopItem}/share/applications/* $out/share/applications
+      mkdir -p "$out/share/applications"
+      cp ${desktopItem}/share/applications/* "$out/share/applications"
     '';
 
-    meta = {
+    meta = with stdenv.lib; {
       description = "A modern, secure messenger";
       homepage    = https://wire.com/;
-      license     = lib.licenses.gpl3;
-      maintainers = with lib.maintainers; [ worldofpeace ];
-      platforms = [ "i686-linux" "x86_64-linux" ];
+      license     = licenses.gpl3;
+      maintainers = with maintainers; [ worldofpeace ];
+      platforms   = [ "i686-linux" "x86_64-linux" ];
     };
   }


### PR DESCRIPTION
###### Motivation for this change
An update.

[Release Notes](https://medium.com/wire-news/wire-for-linux-3-3-2872-f1463ae7c238)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

