### PR TITLE
eolie: 0.9.37 -> 0.9.41

### DIFF
--- a/pkgs/applications/networking/browsers/eolie/default.nix
+++ b/pkgs/applications/networking/browsers/eolie/default.nix
@@ -5,7 +5,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   name = "eolie-${version}";
-  version = "0.9.37";
+  version = "0.9.41";
 
   format = "other";
   doCheck = false;
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec {
     url = "https://gitlab.gnome.org/World/eolie";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    sha256 = "0la458zgh943wmgbzr9fpq78c0n11a2wm7rmks7ispk0719f6lxz";
+    sha256 = "0qrbgyzhvh96d7h2rcz04m7am6av30pcvb3fwlrjx0c402rslsx8";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

