### PR TITLE
antibody: 3.6.1 -> 3.7.0

### DIFF
--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "antibody-${version}";
-  version = "3.6.1";
+  version = "3.7.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/getantibody/antibody";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner  = "getantibody";
     repo   = "antibody";
-    sha256 = "1xlaf3440hs1ffa23ja0fc185sj0rxjv0808ib8li3rq2qfkd0k8";
+    sha256 = "1c7f0b1lgl4pm3cs39kr6dgr19lfykjhamg74k5ryrizag0j68l5";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change
An update

###### Notes
There are no changes to `deps.nix` just to clarify since I see that can be a common oversight.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

