### PR TITLE
ghostscript: 9.24 -> 9.25

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -9,9 +9,8 @@ assert x11Support -> xlibsWrapper != null;
 assert cupsSupport -> cups != null;
 let
   version = "9.${ver_min}";
-  ver_min = "24";
-  # ghostscript*.tar.xz in https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9xx/SHA512SUMS
-  sha512 = "dcbeeb5d3dd5ccaf949dc4be68363c50b1d35e647be4790a50b1bbf5f259f1d9181f705be27bfca708c4d270f945ff4b24e3db10b57800c1ee0ea7a40931c547";
+  ver_min = "25";
+  sha512 = "18pcqzva7pq2a9mmqf9pq8x4winb6qmzni49vq2qx50k60rwyv1kdmixik3ym2bpj5p1j8g0vb47w7w2cf4lba5q583ylpd8rshn73s";
 
   fonts = stdenv.mkDerivation {
     name = "ghostscript-fonts";


### PR DESCRIPTION
Backport of #47934 from `master` to `release-18.09` (merged with #47903 and #47946). Please backport to 18.03 as well.

###### Changelog
> Highlights in this release include:

> This release fixes problems with argument handling, some unintended results of the security fixes to the SAFER file access restrictions (specifically accessing ICC profile files), and some additional security issues over the recent 9.24 release.

CVE-2018-16802
CVE-2018-17183

> Note: The ps2epsi utility does not, and cannot call Ghostscript with the -dSAFER command line option. It should never be called with input from untrusted sources.
> 
> Security issues have been the primary focus of this release, including solving several (well publicised) real and potential exploits.
> PLEASE NOTE: We strongly urge users to upgrade to this latest release to avoid these issues.
> 
> As well as Ghostscript itself, jbig2dec has had a significant amount of work improving its robustness in the face of out specification files.
> 
> IMPORTANT: We are in the process of forking LittleCMS. LCMS2 is not thread safe, and cannot be made thread safe without breaking the ABI. Our fork will be thread safe, and include performance enhancements (these changes have all be been offered and rejected upstream). We will maintain compatibility between Ghostscript and LCMS2 for a time, but not in perpetuity. Our fork will be available as its own package separately from Ghostscript (and MuPDF).
> 
> The usual round of bug fixes, compatibility changes, and incremental improvements.

(cherry picked from commit 5b77b0d2f1eda9a42fe188eafb499230741e7925)

cc @xeji 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

