### PR TITLE
dbeaver: 5.2.0 -> 5.2.1 (18.09)

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   name = "dbeaver-ce-${version}";
-  version = "5.2.0";
+  version = "5.2.1";
 
   desktopItem = makeDesktopItem {
     name = "dbeaver";
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://dbeaver.io/files/${version}/dbeaver-ce-${version}-linux.gtk.x86_64.tar.gz";
-    sha256 = "13j2qc4g24d2gmkxj9zpqrcbai9aq8rassrq3c9mp9ir6sf4q0jf";
+    sha256 = "0zm320cdpypv2s58gcg89mdkir9xpz1824dscfqkmahx89g1ma81";
   };
 
   installPhase = ''


### PR DESCRIPTION
(cherry picked from commit 2012860e7ef0511eb013e8c98ad3044abbb9185e)

###### Motivation for this change

 * [Updates dbeaver 5.2.0](https://dbeaver.io/2018/09/09/dbeaver-5-2/).

This cherry-picks #47951 

###### Things done

- ✔️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ✔️ NixOS
- ✔️ Tested execution of all binary files (usually in `./result/bin/`)
- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

> *As a side note, #34182 is still open and I will still gladly accept any help in figuring out how to build this using the source release.*