### PR TITLE
spotifywm-unstable: init at 2016-11-28

### DIFF
--- a/pkgs/applications/audio/spotifywm/default.nix
+++ b/pkgs/applications/audio/spotifywm/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, spotify, xorg }:
+stdenv.mkDerivation rec {
+  name = "spotifywm-unstable-${version}";
+  version = "2016-11-28";
+
+  src = fetchFromGitHub {
+    owner  = "dasJ";
+    repo   = "spotifywm";
+    rev    = "91dd5532ffb7a398d775abe94fe7781904ab406f";
+    sha256 = "01z088i83410bpx1vbp7c6cq01r431v55l7340x3izp53lnpp379";
+  };
+
+  buildInputs = [ xorg.libX11 ];
+
+  propagatedBuildInputs = [ spotify ];
+
+  installPhase = ''
+    echo "#!${stdenv.shell}" > spotifywm
+    echo "LD_PRELOAD="$out/lib/spotifywm.so" ${spotify}/bin/spotify \$*" >> spotifywm
+    install -Dm644 spotifywm.so $out/lib/spotifywm.so
+    install -Dm755 spotifywm $out/bin/spotifywm
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dasJ/spotifywm;
+    description = "Wrapper around Spotify that correctly sets class name before opening the window";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jqueiroz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18826,6 +18826,8 @@ with pkgs;
     apiKey = config.libspotify.apiKey or null;
   };
 
+  spotifywm = callPackage ../applications/audio/spotifywm { };
+
   squeezelite = callPackage ../applications/audio/squeezelite { };
 
   ltunify = callPackage ../tools/misc/ltunify { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

