### PR TITLE
tinyemu: init at 2018-09-23

### DIFF
--- a/pkgs/applications/virtualization/tinyemu/default.nix
+++ b/pkgs/applications/virtualization/tinyemu/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, openssl, curl, SDL }:
+
+stdenv.mkDerivation rec {
+  name = "tinyemu-${version}";
+  version = "2018-09-23";
+  src = fetchurl {
+    url = "https://bellard.org/tinyemu/${name}.tar.gz";
+    sha256 = "0d6payyqf4lpvmmzvlpq1i8wpbg4sf3h6llsw0xnqdgq3m9dan4v";
+  };
+  buildInputs = [ openssl curl SDL ];
+  makeFlags = [ "DESTDIR=$(out)" "bindir=/bin" ];
+  preInstall = ''
+    mkdir -p "$out/bin"
+  '';
+  meta = {
+    homepage = https://bellard.org/tinyemu/;
+    description = "A system emulator for the RISC-V and x86 architectures";
+    longDescription = "TinyEMU is a system emulator for the RISC-V and x86 architectures. Its purpose is to be small and simple while being complete.";
+    license = with stdenv.lib.licenses; [ mit bsd2 ];
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ jhhuh ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5597,6 +5597,8 @@ with pkgs;
 
   tiny8086 = callPackage ../applications/virtualization/8086tiny { };
 
+  tinyemu = callPackage ../applications/virtualization/tinyemu { };
+
   tinyproxy = callPackage ../tools/networking/tinyproxy {};
 
   tio = callPackage ../tools/misc/tio { };


### PR DESCRIPTION
###### Motivation for this change

To add Fabrice Bellard's new shiny (and also tiny) risc-v emulator.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

