### PR TITLE
dateutils: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/tools/misc/dateutils/default.nix
+++ b/pkgs/tools/misc/dateutils/default.nix
@@ -1,13 +1,19 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, autoreconfHook, tzdata }:
 
 stdenv.mkDerivation rec {
-  version = "0.4.4";
+  version = "0.4.5";
   name = "dateutils-${version}";
 
   src = fetchurl {
     url = "https://bitbucket.org/hroptatyr/dateutils/downloads/${name}.tar.xz";
-    sha256 = "0ky8177is4swgxfqczc78d7yjc13w626k515qw517086n7xjxk59";
+    sha256 = "1pnbc186mnvmyb5rndm0ym50sjihsy6m6crz62xxsjbxggza1mhn";
   };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ tzdata ]; # needed for datezone
+  enableParallelBuilding = true;
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "A bunch of tools that revolve around fiddling with dates and times in the command line";


### PR DESCRIPTION
###### Motivation for this change

datezone needs TZdata
\+ enabling parallel building
\+ run the tests suite

Follow-up to #47811

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

