### PR TITLE
sewer: init at 0.6.0

### DIFF
--- a/pkgs/tools/admin/sewer/default.nix
+++ b/pkgs/tools/admin/sewer/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sewer";
+  version = "0.6.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "180slmc2zk4mvjqp25ks0j8kd63ai4y77ds5icm7qd7av865rryp";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ pyopenssl requests tldextract ];
+
+  postPatch = ''
+    # The README has non-ascii characters which makes setup.py crash.
+    sed -i 's/[\d128-\d255]//g' README.md
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/komuw/sewer;
+    description = "ACME client";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kevincox ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5214,6 +5214,8 @@ with pkgs;
 
   seqdiag = with python3Packages; toPythonApplication seqdiag;
 
+  sewer = callPackage ../tools/admin/sewer { };
+
   screenfetch = callPackage ../tools/misc/screenfetch { };
 
   sg3_utils = callPackage ../tools/system/sg3_utils { };


### PR DESCRIPTION
sewer is an ACME client which supports DNS challenges with support for
various DNS servers.

###### Motivation for this change

Provide this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

