### PR TITLE
bubblewrap: drop maintainership

### DIFF
--- a/pkgs/tools/admin/bubblewrap/default.nix
+++ b/pkgs/tools/admin/bubblewrap/default.nix
@@ -15,6 +15,6 @@ stdenv.mkDerivation rec {
     description = "Unprivileged sandboxing tool";
     homepage = https://github.com/projectatomic/bubblewrap;
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ konimex ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Since I can no longer maintain and oversee this package, I hereby drop my own maintainership for this package.

However, since to my understanding (after reading CONTRIBUTING.md and the manual) a package *must* have at least a maintainer, I'm not sure what to do. So I opened this PR in hope for someone to see this and decide to take the helm.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

