### PR TITLE
gdal: add libxml2 to build

### DIFF
--- a/pkgs/development/libraries/gdal/default.nix
+++ b/pkgs/development/libraries/gdal/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, fetchpatch, unzip, libjpeg, libtiff, zlib
 , postgresql, mysql, libgeotiff, pythonPackages, proj, geos, openssl
 , libpng, sqlite, libspatialite, poppler, hdf4, qhull, giflib, expat
-, libiconv
+, libiconv, libxml2
 , netcdfSupport ? true, netcdf, hdf5, curl
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ unzip libjpeg libtiff libpng proj openssl sqlite
-    libspatialite poppler hdf4 qhull giflib expat ]
+    libspatialite poppler hdf4 qhull giflib expat libxml2 ]
   ++ (with pythonPackages; [ python numpy wrapPython ])
   ++ stdenv.lib.optional stdenv.isDarwin libiconv
   ++ stdenv.lib.optionals netcdfSupport [ netcdf hdf5 curl ];
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     "--with-proj=${proj}" # optional
     "--with-geos=${geos}/bin/geos-config"# optional
     "--with-hdf4=${hdf4.dev}" # optional
+    "--with-xml2=${libxml2.dev}/bin/xml2-config" # optional
     (if netcdfSupport then "--with-netcdf=${netcdf}" else "")
   ];
 


### PR DESCRIPTION
###### Motivation for this change

gdal appears to already pull in libxml2 as a transitive dependency (via libspatialite), but it is never enabled in the build. This leads to certain functionality being disabled, like the ability to read OpenStreetMap XML files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

