### PR TITLE
i3lock-fancy: unstable-2017-12-14 -> unstable-2018-08-27

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -1,39 +1,43 @@
-{ stdenv, fetchFromGitHub, coreutils, scrot, imagemagick, gawk
-, i3lock-color, getopt, fontconfig
+{ stdenv, fetchFromGitHub, makeWrapper
+, coreutils, scrot, imagemagick, gawk, i3lock-color, getopt, fontconfig
 }:
 
 stdenv.mkDerivation rec {
-  rev = "3734fba160166006521e513f5734eb76ac6aa48f";
-  name = "i3lock-fancy-unstable-2017-12-14_rev${builtins.substring 0 7 rev}";
+  name = "i3lock-fancy-unstable-${version}";
+  version = "2018-08-27";
+
   src = fetchFromGitHub {
     owner = "meskarune";
     repo = "i3lock-fancy";
-    inherit rev;
-    sha256 = "1bg4xds2hmbq8rp6azbdqvgp1aaq5y1bp05cfwqqm6y3sjw7ywzl";
+    rev = "f2e9bdd1d27e761f0dca75b89329865545351d70";
+    sha256 = "14h0364xbv60shypxyp62ldx0v4bc47zhybiaxlpb9db934rxg8b";
   };
+
+  nativeBuildInputs = [ makeWrapper ];
+
   patchPhase = ''
-    sed -i -e "s|(mktemp)|(${coreutils}/bin/mktemp)|" lock
-    sed -i -e "s|'rm -f |'${coreutils}/bin/rm -f |" lock
-    sed -i -e "s|scrot -z |${scrot}/bin/scrot -z |" lock
-    sed -i -e "s|convert |${imagemagick.out}/bin/convert |" lock
-    sed -i -e "s|awk -F|${gawk}/bin/awk -F|" lock
-    sed -i -e "s| awk | ${gawk}/bin/awk |" lock
-    sed -i -e "s|i3lock -i |${i3lock-color}/bin/i3lock-color -i |" lock
-    sed -i -e 's|icon="$scriptpath/icons/lockdark.png"|icon="'$out'/share/i3lock-fancy/icons/lockdark.png"|' lock
-    sed -i -e 's|icon="$scriptpath/icons/lock.png"|icon="'$out'/share/i3lock-fancy/icons/lock.png"|' lock
-    sed -i -e "s|getopt |${getopt}/bin/getopt |" lock
-    sed -i -e "s|fc-match |${fontconfig.bin}/bin/fc-match |" lock
-    sed -i -e "s|shot=(import -window root)|shot=(${scrot}/bin/scrot -z)|" lock
+    substituteInPlace i3lock-fancy --replace "i3lock -i" "i3lock-color -i"
+    substituteInPlace i3lock-fancy --replace "shot=(import -window root)" "shot=(scrot -z)"
+    substituteInPlace i3lock-fancy --replace "/usr/share/i3lock-fancy/icons/" "$out/share/i3lock-fancy/icons/"
   '';
+
+  dontBuild = true;
+
   installPhase = ''
-    mkdir -p $out/bin $out/share/i3lock-fancy/icons
-    cp lock $out/bin/i3lock-fancy
-    cp icons/lock*.png $out/share/i3lock-fancy/icons
+    install -Dm755 i3lock-fancy          -t "$out/bin"
+    install -Dm644 icons/*               -t "$out/share/i3lock-fancy/icons"
+    install -Dm644 doc/i3lock-fancy.1    -t "$out/share/man/man1"
+    install -Dm644 LICENSE               -t "$out/share/licenses/i3lock-fancy"
   '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/i3lock-fancy" --prefix PATH : ${stdenv.lib.makeBinPath [coreutils scrot imagemagick gawk i3lock-color getopt fontconfig]}
+  '';
+
   meta = with stdenv.lib; {
-    description = "i3lock is a bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text.";
+    description = "A bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text";
     homepage = https://github.com/meskarune/i3lock-fancy;
-    maintainers = with maintainers; [ garbas ];
+    maintainers = with maintainers; [ garbas jqueiroz ];
     license = licenses.mit;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
- Updates package to a more recent version
- Man pages are now installed

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

