### PR TITLE
Rust build-support: enabling cross-compilation of Rust code

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -36,9 +36,9 @@
       green="$(printf '\033[0;32m')" #set green
       boldgreen="$(printf '\033[0;1;32m')" #set bold, and set green.
     fi
-
     ${echo_build_heading colors}
     ${noisily colors verbose}
+
     build_lib() {
        lib_src=$1
        echo_build_heading $lib_src ${libName}

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -4,7 +4,7 @@
 # This can be useful for deploying packages with NixOps, and to share
 # binary dependencies between projects.
 
-{ lib, stdenv, defaultCrateOverrides, fetchCrate, ncurses, rustc, binutils, gcc }:
+{ lib, stdenv, defaultCrateOverrides, fetchCrate, ncurses, rustc }:
 
 let
     # This doesn't appear to be officially documented anywhere yet.

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -4,7 +4,7 @@
 # This can be useful for deploying packages with NixOps, and to share
 # binary dependencies between projects.
 
-{ lib, stdenv, defaultCrateOverrides, fetchCrate, ncurses, rustc  }:
+{ lib, stdenv, defaultCrateOverrides, fetchCrate, ncurses, rustc, binutils, gcc }:
 
 let
     # This doesn't appear to be officially documented anywhere yet.
@@ -86,7 +86,8 @@ stdenv.mkDerivation (rec {
       else
         fetchCrate { inherit (crate) crateName version sha256; };
     name = "rust_${crate.crateName}-${crate.version}";
-    buildInputs = [ rust ncurses ] ++ (crate.buildInputs or []) ++ buildInputs_;
+    depsBuildBuild = [ rust stdenv.cc ];
+    buildInputs = (crate.buildInputs or []) ++ buildInputs_;
     dependencies =
       builtins.map
         (dep: dep.override { rust = rust; release = release; verbose = verbose; crateOverrides = crateOverrides; })


### PR DESCRIPTION
###### Motivation for this change

The Rust build-support in Nixpkgs was lacking cross-compilation support, mostly because 'rustc' was not using the proper linker. Another issue is the difference in platform names (for instance ARMv7) between Gnu and Rust.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

