### PR TITLE
gnupg1compat: fix compatibility with gnupg20

### DIFF
--- a/pkgs/tools/security/gnupg/20.nix
+++ b/pkgs/tools/security/gnupg/20.nix
@@ -12,7 +12,8 @@ with stdenv.lib;
 assert guiSupport -> pinentry != null;
 
 stdenv.mkDerivation rec {
-  name = "gnupg-2.0.30";
+  name = "gnupg-${version}";
+  version = "2.0.30";
 
   src = fetchurl {
     url = "mirror://gnupg/gnupg/${name}.tar.bz2";


### PR DESCRIPTION
###### Motivation for this change

Presently, gnupg1compat only works with gnupg22. Without this change, the error

```
error: attribute 'version' missing, at .../nixpkgs/pkgs/tools/security/gnupg/1compat.nix:4:26
```

is emitted when evaluating

```
pkgs.gnupg1compat.override { gnupg = pkgs.gnupg20; }'
```

Even with that done, `1compat` after e34ce9d1c551fb43742aada6bb43ccb1a52e64a1 no longer actually created `gpg->gpg2` or `gpgv->gpgv2` symlinks at all, making it effectively a noop (and thus ineffective for the `gnupg20` package, which -- unlike `gnupg22` -- was not modified in the aforementioned commit to create `gpg` binaries itself).

The symlink-creation behavior is thus reintroduced, but if-and-only-if actually needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

