### PR TITLE
howl: init at 0.5.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3120,6 +3120,11 @@
     github = "oyren";
     name = "Moritz Scheuren";
   };
+  pacien = {
+    email = "b4gx3q.nixpkgs@pacien.net";
+    github = "pacien";
+    name = "Pacien Tran-Girard";
+  };
   paholg = {
     email = "paho@paholg.com";
     github = "paholg";

--- a/pkgs/applications/editors/howl/default.nix
+++ b/pkgs/applications/editors/howl/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchurl, makeWrapper, pkgconfig, gtk3, librsvg }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  name = "howl-${version}";
+  version = "0.5.3";
+
+  # Use the release tarball containing pre-downloaded dependencies sources
+  src = fetchurl {
+    url = "https://github.com/howl-editor/howl/releases/download/0.5.3/howl-0.5.3.tgz";
+    sha256 = "0gnc8vr5h8mwapbcqc1zr9la62rb633awyqgy8q7pwjpiy85a03v";
+  };
+
+  sourceRoot = "./howl-${version}/src";
+
+  # The Makefile uses "/usr/local" if not explicitly overridden
+  installFlags = [ "PREFIX=$(out)" ];
+
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
+  buildInputs = [ gtk3 librsvg ];
+  enableParallelBuilding = true;
+
+  # Required for the program to properly load its SVG assets
+  postInstall = ''
+    wrapProgram $out/bin/howl \
+      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+  '';
+
+  meta = {
+    homepage = https://howl.io/;
+    description = "A general purpose, fast and lightweight editor with a keyboard-centric minimalistic user interface";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pacien ];
+
+    # LuaJIT and Howl builds fail for x86_64-darwin and aarch64-linux respectively
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17022,6 +17022,8 @@ with pkgs;
     gtk = gtk3;
   };
 
+  howl = callPackage ../applications/editors/howl { };
+
   ht = callPackage ../applications/editors/ht { };
 
   hubstaff = callPackage ../applications/misc/hubstaff { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds a new package for the Howl text editors and registers myself as a maintainer.

The package builds on my NixOS machine and the programs runs fine.

Since the introduction of this new package should not break anything, could this be back-ported to `release-18.03` and `release-18.09`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

