### PR TITLE
lib/systems: use correct config for armv7l-hf-multiplatform

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -28,7 +28,7 @@ rec {
   };
 
   armv7l-hf-multiplatform = rec {
-    config = "armv7a-unknown-linux-gnueabihf";
+    config = "armv7l-unknown-linux-gnueabihf";
     platform = platforms.armv7l-hf-multiplatform;
   };
 


### PR DESCRIPTION
###### Motivation for this change

Elaborating `lib.systems.example.armv7l-hf-multiplatform` results in unexpected values for some of the fields, breaking cross-compilation of certain packages. In particular `linux_hardkernel_4_14` fails because it uses `meta.platforms` to restrict the host system to `armv7l-linux` and `hostPlatform.system` has `armv7a-linux` instead.

This command reproduces the problem:
```
# nix-build '<nixpkgs>' --arg crossSystem '(import <nixpkgs/lib>).systems.examples.armv7l-hf-multiplatform' -A linuxPackages_hardkernel_4_14.kernel
error: Package ‘linux-4.14.69-148’ in /elided/nixpkgs/pkgs/os-specific/linux/kernel/manual-config.nix:237 is not supported on ‘armv7a-unknown-linux-gnueabihf’, refusing to evaluate.
```

Before this PR:
```
> s = lib.systems.elaborate lib.systems.examples.armv7l-hf-multiplatform
> s.config
"armv7a-unknown-linux-gnueabihf"
> s.parsed.cpu.name
"armv7a"
> s.system
"armv7a-linux" # Should be armv7l-linux
```

The simple fix seems to be to change `config` to `armv7l-unknown-linux-gnueabihf` as is done by this PR, but I'm not confident that this is the correct fix.

I don't really know what the difference between the two triplets is, and why it was chosen in the first place. a02be2bd85b37ed8b257e969d9439357844baa24 seems like it could have introduced this problem, but before that commit `system` was `arm-linux`, which is still wrong. Going further back, 171c7f0e63b0f92c71c73b756cbbd91b8ddce444 changed `config` from `armv7l-unknown-linux-gnueabi` to `arm-linux-gnueabihf`, but the cross compilation infrastructure has changed so much since then that I'm not sure what implications that had.

After this PR:
```
> s = lib.systems.elaborate lib.systems.examples.armv7l-hf-multiplatform
> s.config
"armv7l-unknown-linux-gnueabihf"
> s.parsed.cpu.name
"armv7l"
> s.system
"armv7l-linux"
```

I have tested this only on cross-compiled kernels, which build correctly. I'm afraid it could break packages that use `parsed.cpu.name`.

cc @Ericson2314 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

