### PR TITLE
jsonnet: skip building the website

### DIFF
--- a/pkgs/development/compilers/jsonnet/default.nix
+++ b/pkgs/development/compilers/jsonnet/default.nix
@@ -1,12 +1,8 @@
-{ stdenv, lib, fetchFromGitHub, emscripten
-, enableJsonnetJs ? !stdenv.isDarwin
-}:
+{ stdenv, lib, fetchFromGitHub }:
 
-let version = "0.11.2"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "jsonnet-${version}";
-  version = version;
+  version = "0.11.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
@@ -15,19 +11,18 @@ stdenv.mkDerivation {
     sha256 = "05rl5i4g36k2ikxv4sw726mha1qf5bb66wiqpi0s09wj9azm7vym";
   };
 
-  buildInputs = if enableJsonnetJs then [ emscripten ] else [ ];
-
   enableParallelBuilding = true;
 
-  makeFlags = [''EM_CACHE=$(TMPDIR)/.em_cache''] ++
-    (if enableJsonnetJs then ["all"] else ["jsonnet" "libjsonnet.so" "libjsonnet++.so"]);
+  makeFlags = [
+    "jsonnet"
+    "libjsonnet.so"
+  ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib $out/share/
+    mkdir -p $out/bin $out/lib $out/include
     cp jsonnet $out/bin/
     cp libjsonnet*.so $out/lib/
-    cp -a doc $out/share/doc
-    cp -a include $out/include
+    cp -a include/*.h $out/include/
   '';
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10108,9 +10108,7 @@ with pkgs;
 
   jsoncpp = callPackage ../development/libraries/jsoncpp { };
 
-  jsonnet = callPackage ../development/compilers/jsonnet {
-    emscripten = emscripten.override {python=python2;};
-  };
+  jsonnet = callPackage ../development/compilers/jsonnet { };
 
   jsonrpc-glib = callPackage ../development/libraries/jsonrpc-glib { };
 


### PR DESCRIPTION
###### Motivation for this change

The emscripten build of jsonnet is only used in the interactive demo found on jsonnet.org, and I don't think we need to include the whole website in our package.  This reduces the transitive closure from
~100mb to ~32mb, and the build duration from ~8 minutes to ~20 seconds on my machine.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

followup from #47939