### PR TITLE
woeusb: add p7zip to runtime deps enable extra feature

### DIFF
--- a/pkgs/tools/misc/woeusb/default.nix
+++ b/pkgs/tools/misc/woeusb/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     # should be patched with a less useless default PATH, but for now
     # we add everything we need manually.
     wrapProgram "$out/bin/woeusb" \
-      --set PATH '${stdenv.lib.makeBinPath [ coreutils dosfstools findutils gawk gnugrep grub2_light ncurses ntfs3g parted utillinux wget ]}'
+      --set PATH '${stdenv.lib.makeBinPath [ coreutils dosfstools findutils gawk gnugrep grub2_light ncurses ntfs3g parted utillinux wget p7zip ]}'
   '';
 
   doInstallCheck = true;

--- a/pkgs/tools/misc/woeusb/default.nix
+++ b/pkgs/tools/misc/woeusb/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, makeWrapper
-, coreutils, dosfstools, findutils, gawk, gnugrep, grub2_light, ncurses, ntfs3g, parted, utillinux, wget
+, coreutils, dosfstools, findutils, gawk, gnugrep, grub2_light, ncurses, ntfs3g, parted, p7zip, utillinux, wget
 , wxGTK30 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1h2msp45slcd2s5jgw7ma9r7pl7schrvifw3kp53skxfpyax4j35";
   };
 
-  buildInputs = [ wxGTK30 autoreconfHook makeWrapper ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper ];
+  buildInputs = [ wxGTK30 ];
 
   postPatch = ''
     # Emulate version smudge filter (see .gitattributes, .gitconfig).


### PR DESCRIPTION
WoeUSB depends on presence of '7z` binary in the path to execute an extra step. 
As Windows 7's installation media doesn't place the required EFI bootloaders
in the right location, WoeUSB extracts them from the system image manually
using '7z' binary which it checks with 'command -v 7z'.

See related code at:
https://github.com/slacka/WoeUSB/blob/aea4f91783d60fe092605cf26b996d1ba593f976/src/woeusb#L1530

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

