### PR TITLE
borgbackup: patch bug that allowed for exceeding quotas

### DIFF
--- a/pkgs/tools/backup/borg/default.nix
+++ b/pkgs/tools/backup/borg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3Packages, acl, libb2, lz4, zstd, openssl, openssh }:
+{ stdenv, fetchpatch, python3Packages, acl, libb2, lz4, zstd, openssl, openssh }:
 
 python3Packages.buildPythonApplication rec {
   pname = "borgbackup";
@@ -8,6 +8,15 @@ python3Packages.buildPythonApplication rec {
     inherit pname version;
     sha256 = "f7b51a132e9edfbe1cacb4f478b28caf3622d79fffcb369bdae9f92d8c8a7fdc";
   };
+
+  patches = [
+    # Workarounds for https://github.com/borgbackup/borg/issues/4093
+    # Can be deleted when 1.1.8 comes out
+    (fetchpatch {
+      url = "https://github.com/borgbackup/borg/commit/975cc33206e0e3644626fb7204c34d2157715b61.patch";
+      sha256 = "0b7apaixpa7bk0sy7g5ycm98cjpkg5gkwcgm7m37xj35lzxdlxhc";
+    })
+  ];
 
   nativeBuildInputs = with python3Packages; [
     # For building documentation:


### PR DESCRIPTION
See also https://github.com/borgbackup/borg/issues/4093 for this.

Should get backported to `nixos-18.09` imo.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

