### PR TITLE
scribusUnstable: init at 2018-10-13

### DIFF
--- a/pkgs/applications/office/scribus/unstable.nix
+++ b/pkgs/applications/office/scribus/unstable.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchsvn, makeWrapper, pkgconfig, cmake, qtbase, cairo, pixman,
+boost, cups, fontconfig, freetype, hunspell, libjpeg, libtiff, libxml2, lcms2,
+podofo, poppler, poppler_data, python2, harfbuzz, qtimageformats, qttools }:
+
+let
+  pythonEnv = python2.withPackages(ps: [ps.tkinter ps.pillow]);
+  revision = "22730";
+in 
+stdenv.mkDerivation rec {
+  name = "scribus-unstable-${version}";
+  version = "2018-10-13";
+
+  src = fetchsvn {
+    url = "svn://scribus.net/trunk/Scribus";
+    rev = revision;
+    sha256 = "1nlg4qva0fach8fi07r1pakjjlijishpwzlgpnxyaz7r31yjaw63";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    makeWrapper pkgconfig cmake qtbase cairo pixman boost cups fontconfig
+    freetype hunspell libjpeg libtiff libxml2 lcms2 podofo poppler
+    poppler_data pythonEnv harfbuzz qtimageformats qttools
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/scribus \
+      --prefix QT_PLUGIN_PATH : "${qtbase}/${qtbase.qtPluginPrefix}"
+  '';
+
+  meta = {
+    maintainers = [ stdenv.lib.maintainers.erictapen ];
+    platforms = stdenv.lib.platforms.linux;
+    description = "Desktop Publishing (DTP) and Layout program for Linux";
+    homepage = http://www.scribus.net;
+    license = stdenv.lib.licenses.gpl2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18698,6 +18698,8 @@ with pkgs;
     inherit (gnome2) libart_lgpl;
   };
 
+  scribusUnstable = libsForQt5.callPackage ../applications/office/scribus/unstable.nix { };
+
   seafile-client = libsForQt5.callPackage ../applications/networking/seafile-client { };
 
   seeks = callPackage ../tools/networking/p2p/seeks {


### PR DESCRIPTION
###### Motivation for this change

For more than [three years](https://wiki.scribus.net/canvas/1.5.0_Release), Scribus 1.5 has been around as the next major release. E.g. in [Debian](https://packages.debian.org/jessie/scribus-ng), this appears to be available as `scribus-ng`. In general, I'd recommend people learning Scribus to take the 1.5 version.

###### Things done

Packaged Scribus from the most recent svn commit. I'd rather packaged the `1.5.4` release, but they had some compile failure und I failed to cherry-pick the fix. As soon as `1.5.5` comes out, I'd switch to the release to have a definite version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

