### PR TITLE
pythonPackages.fastpbkdf2: init at 0.2

### DIFF
--- a/pkgs/development/python-modules/fastpbkdf2/default.nix
+++ b/pkgs/development/python-modules/fastpbkdf2/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, buildPythonPackage
+, openssl, pytest, cffi, six }:
+
+buildPythonPackage rec {
+  pname = "fastpbkdf2";
+  version = "0.2";
+
+  # Fetching from GitHub as tests are missing in PyPI
+  src = fetchFromGitHub {
+    owner  = "Ayrx";
+    repo   = "python-fastpbkdf2";
+    rev    = "v${version}";
+    sha256 = "1hvvlk3j28i6nswb6gy3mq7278nq0mgfnpxh1rv6jvi7xhd7qmlc";
+  };
+
+  buildInputs = [ openssl ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ cffi six ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Ayrx/python-fastpbkdf2;
+    description = "Python bindings for fastpbkdf2";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ jqueiroz ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -326,6 +326,8 @@ in {
 
   eradicate = callPackage ../development/python-modules/eradicate {  };
 
+  fastpbkdf2 = callPackage ../development/python-modules/fastpbkdf2 {  };
+
   fido2 = callPackage ../development/python-modules/fido2 {  };
 
   filterpy = callPackage ../development/python-modules/filterpy { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

