### PR TITLE
nixos/prometheus-snmp-exporter: fix command line argument format

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/snmp.nix
@@ -60,10 +60,10 @@ in
       DynamicUser = true;
       ExecStart = ''
         ${pkgs.prometheus-snmp-exporter.bin}/bin/snmp_exporter \
-          -config.file ${configFile} \
-          -log.format ${cfg.logFormat} \
-          -log.level ${cfg.logLevel} \
-          -web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          --config.file=${configFile} \
+          --log.format=${cfg.logFormat} \
+          --log.level=${cfg.logLevel} \
+          --web.listen-address=${cfg.listenAddress}:${toString cfg.port} \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';
     };


### PR DESCRIPTION
###### Motivation for this change

No longer works after upgrading to NixOS 18.09, so should be backported.

```
snmp_exporter[847]: snmp_exporter: error: unknown short flag '-c', try --help
systemd[1]: prometheus-snmp-exporter.service: Main process exited, code=exited, status=1/FAILURE
```

The argument format changed:

```
$ nix run -f channel:nixos-18.03 prometheus-snmp-exporter -c snmp_exporter --help
Usage of snmp_exporter:
  -config.file string
    	Path to configuration file. (default "snmp.yml")
  -log.format value
    	Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true" (default "logger:stderr")
  -log.level value
    	Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] (default "info")
  -version
    	Print version information.
  -web.listen-address string
    	Address to listen on for web interface and telemetry. (default ":9116")
```

```
$ nix run -f channel:nixos-18.09 prometheus-snmp-exporter -c snmp_exporter --help
usage: snmp_exporter [<flags>]

Flags:
  -h, --help                    Show context-sensitive help (also try --help-long and --help-man).
      --config.file="snmp.yml"  Path to configuration file.
      --web.listen-address=":9116"
                                Address to listen on for web interface and telemetry.
      --log.level="info"        Only log messages with the given severity or above. Valid levels: [debug, info, warn,
                                error, fatal]
      --log.format="logger:stderr"
                                Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or
                                "logger:stdout?json=true"
      --version                 Show application version.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

