### PR TITLE
Upgrade FreeCAD to qt5, maybe fix seg fault

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, coin3d, xercesc, ode, eigen, qt4, opencascade, gts
+{ stdenv, fetchurl, cmake, coin3d, xercesc, ode, eigen, qt5, opencascade, gts
 , hdf5, vtk, medfile, zlib, python27Packages, swig, gfortran, fetchpatch
 , soqt, libf2c, makeWrapper, makeDesktopItem
 , mpi ? null }:
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
     sha256 = "1yv6abdzlpn4wxy315943xwrnbywxqfgkjib37qwfvbb8y9p60df";
   };
 
-  buildInputs = [ cmake coin3d xercesc ode eigen qt4 opencascade gts
+  buildInputs = [ cmake coin3d xercesc ode eigen qt5.qtbase opencascade gts
     zlib  swig gfortran soqt libf2c makeWrapper  mpi vtk hdf5 medfile
   ] ++ (with pythonPackages; [
     matplotlib pycollada pyside pysideShiboken pysideTools pivy python boost


### PR DESCRIPTION
See #42790


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---