### PR TITLE
fix broken packages from #47709

### DIFF
--- a/pkgs/games/ja2-stracciatella/default.nix
+++ b/pkgs/games/ja2-stracciatella/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     ./remove-rust-buildstep.patch
   ];
   preConfigure = ''
-    sed -i -e 's|rust-stracciatella|${libstracciatella}/bin/libstracciatella.so|g' CMakeLists.txt
+    sed -i -e 's|rust-stracciatella|${libstracciatella}/lib/libstracciatella.so|g' CMakeLists.txt
     cmakeFlagsArray+=("-DEXTRA_DATA_DIR=$out/share/ja2")
   '';
 

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -41,7 +41,7 @@ in pythonPackages.buildPythonApplication rec {
 
   preBuild = ''
     mkdir -p rust/target/release
-    ln -s ${native}/bin/libvdirsyncer_rustext* rust/target/release/
+    ln -s ${native}/lib/libvdirsyncer_rustext* rust/target/release/
   '';
 
   LC_ALL = "en_US.utf8";


### PR DESCRIPTION
###### Things done

I had a quick look at a [Hydra evaluation](https://hydra.nixos.org/eval/1482163) of #47709 and fixed two packages that were broken by it:

- `vdirsyncer`
- `ja2-stracciatella`

This goes to `staging`, as IIRC the commits of #47709 are still there.

This should be backported to `release-18.09`, as the commits in question are already there.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

