### PR TITLE
NDISWrapper

### DIFF
--- a/pkgs/os-specific/linux/ndiswrapper/default.nix
+++ b/pkgs/os-specific/linux/ndiswrapper/default.nix
@@ -1,16 +1,20 @@
-{ stdenv, fetchurl, kernel, perl, kmod }:
-
+{ stdenv, fetchFromGitHub, kernel, perl, kmod, libelf }:
+let
+  version = "1.62-pre";
+in
 stdenv.mkDerivation {
-  name = "ndiswrapper-1.59-${kernel.version}";
+  name = "ndiswrapper-${version}-${kernel.version}";
+  inherit version;
 
   hardeningDisable = [ "pic" ];
 
   patches = [ ./no-sbin.patch ];
 
-  # need at least .config and include 
+  # need at least .config and include
   kernel = kernel.dev;
 
   buildPhase = "
+    cd ndiswrapper
     echo make KBUILD=$(echo \$kernel/lib/modules/*/build);
     echo -n $kernel/lib/modules/*/build > kbuild_path
     export PATH=${kmod}/sbin:$PATH
@@ -26,18 +30,20 @@ stdenv.mkDerivation {
     patchShebangs $out/sbin
   '';
 
-  # should we use unstable? 
-  src = fetchurl {
-    url = mirror://sourceforge/ndiswrapper/ndiswrapper-1.59.tar.gz;
-    sha256 = "1g6lynccyg4m7gd7vhy44pypsn8ifmibq6rqgvc672pwngzx79b6";
+  # should we use unstable?
+  src = fetchFromGitHub {
+    owner = "pgiri";
+    repo = "ndiswrapper";
+    rev = "f4d16afb29ab04408d02e38d4ea1148807778e21";
+    sha256 = "0iaw0vhchmqf1yh14v4a6whnbg4sx1hag8a4hrsh4fzgw9fx0ij4";
   };
 
-  buildInputs = [ perl ];
+  buildInputs = [ perl libelf ];
 
-  meta = { 
+  meta = {
     description = "Ndis driver wrapper for the Linux kernel";
     homepage = https://sourceforge.net/projects/ndiswrapper;
     license = "GPL";
-    broken = true;
+    platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }

--- a/pkgs/os-specific/linux/ndiswrapper/no-sbin.patch
+++ b/pkgs/os-specific/linux/ndiswrapper/no-sbin.patch
@@ -1,7 +1,8 @@
-diff -Naur ndiswrapper-1.59-orig/driver/Makefile ndiswrapper-1.59/driver/Makefile
---- ndiswrapper-1.59-orig/driver/Makefile	2013-11-28 14:42:35.000000000 -0500
-+++ ndiswrapper-1.59/driver/Makefile	2014-01-04 18:31:43.242377375 -0500
-@@ -191,7 +191,7 @@
+diff --git a/ndiswrapper/driver/Makefile b/ndiswrapper/driver/Makefile
+index bf42f7bc..ad23aa2d 100644
+--- a/ndiswrapper/driver/Makefile
++++ b/ndiswrapper/driver/Makefile
+@@ -191,7 +191,7 @@ clean:
  	rm -rf .tmp_versions
  
  install: config_check $(MODULE)


### PR DESCRIPTION
###### Motivation for this change

NDISWrapper was updated to support newer kernels, located at https://github.com/pigiri/ndiswrapper.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

