### PR TITLE
cups-googlecloudprint: init at 20160502

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -250,7 +250,7 @@ in
       drivers = mkOption {
         type = types.listOf types.path;
         default = [];
-        example = literalExample "[ pkgs.gutenprint pkgs.hplip pkgs.splix ]";
+        example = literalExample "with pkgs; [ gutenprint hplip splix cups-googlecloudprint ]";
         description = ''
           CUPS drivers to use. Drivers provided by CUPS, cups-filters,
           Ghostscript and Samba are added unconditionally. If this list contains

--- a/pkgs/misc/cups/drivers/googlecloudprint/default.nix
+++ b/pkgs/misc/cups/drivers/googlecloudprint/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, lib, fetchFromGitHub, python2, python2Packages, file, makeWrapper, cups }:
+
+# Setup instructions can be found at https://github.com/simoncadman/CUPS-Cloud-Print#configuration
+# So the nix version is something like:
+# nix run nixpkgs.cups-googlecloudprint -c sudo setupcloudprint
+# nix run nixpkgs.cups-googlecloudprint -c sudo listcloudprinters
+
+let pythonEnv = python2.buildEnv.override {
+  extraLibs = with python2Packages; [
+    six
+    httplib2
+    pycups
+  ];
+};
+
+in stdenv.mkDerivation rec {
+  name    = "cups-googlecloudprint-${version}";
+  version = "20160502";
+
+  src = fetchFromGitHub {
+    owner  = "simoncadman";
+    repo   = "CUPS-Cloud-Print";
+    rev    = version;
+    sha256 = "0760i12w7jrhq7fsgyz3yqla5cvpjb45n6m2jz96wsy3p3xf6dzz";
+  };
+
+  buildInputs = [ cups makeWrapper ];
+
+  cupsgroup = "nonexistantgroup";
+  NOPERMS = 1;
+
+  postConfigure = ''
+    substituteInPlace Makefile --replace "${cups}" "$out"
+  '';
+
+  postInstall = ''
+    pushd "$out"
+    for s in lib/cups/backend/gcp lib/cups/driver/cupscloudprint
+    do
+      echo "Wrapping $s..."
+      wrapProgram "$out/$s" --set PATH "${lib.makeBinPath [pythonEnv file]}" --prefix PYTHONPATH : "$out/share/cloudprint-cups"
+    done
+
+    mkdir bin
+
+    for s in share/cloudprint-cups/*.py
+    do
+      if [ -x "$s" ] # Only wrapping those Python scripts marked as executable
+      then
+        o="bin/$(echo $s | sed 's,share/cloudprint-cups/\(.*\).py,\1,')"
+        echo "Wrapping $o -> $s..."
+        makeWrapper "$out/$s" "$o" --set PATH "${lib.makeBinPath [pythonEnv file]}" --prefix PYTHONPATH : "$out/share/cloudprint-cups"
+      fi
+    done
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Google Cloud Print driver for CUPS, allows printing to printers hosted on Google Cloud Print";
+    homepage    = http://ccp.niftiestsoftware.com;
+    platforms   = platforms.linux;
+    license     = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21606,6 +21606,8 @@ with pkgs;
 
   cups-brother-hl1110 = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1110 { };
 
+  cups-googlecloudprint = callPackage ../misc/cups/drivers/googlecloudprint { };
+
   # this driver ships with pre-compiled 32-bit binary libraries
   cnijfilter_2_80 = pkgsi686Linux.callPackage ../misc/cups/drivers/cnijfilter_2_80 { };
 


### PR DESCRIPTION
###### Motivation for this change

Add support for Google Cloud Print in CUPS, using https://github.com/simoncadman/CUPS-Cloud-Print / https://www.niftiestsoftware.com/cups-cloud-print/

cc @samueldr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

