### PR TITLE
pwsafe: 0.99BETA -> 1.06BETA

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -1,25 +1,31 @@
-{ stdenv, fetchFromGitHub, wxGTK, libuuid, xercesc, zip , libXt, libXtst
-, libXi, xextproto, gettext, perl, pkgconfig, libyubikey, yubikey-personalization
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, zip, gettext, perl
+, wxGTK31, libXi, libXt, libXtst, xercesc, xextproto
+, libqrencode, libuuid, libyubikey, yubikey-personalization
 }:
 
 stdenv.mkDerivation rec {
-  name = "pwsafe-${version}";
-  version = "0.99";
+  pname = "pwsafe";
+  version = "1.06";
+  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
-    owner = "pwsafe";
-    repo = "pwsafe";
+    owner = "${pname}";
+    repo = "${pname}";
     rev = "${version}BETA";
-    sha256 = "1bkimz4g9v9kfjkqr3dqddh4jps7anzc1hgmirmmhwpac0xdp60g";
+    sha256 = "1q3xi7i4r3nmz3hc79lx8l15sr1nqhwbi3lrnfqr356nv6aaf03y";
   };
 
-  makefile = "Makefile.linux";
-  makeFlags = "YBPERS_LIBPATH=${yubikey-personalization}/lib";
-
-  buildFlags = "unicoderelease";
-  buildInputs = [ wxGTK libuuid gettext perl zip
-                  xercesc libXt libXtst libXi xextproto
-                  pkgconfig libyubikey yubikey-personalization ];
+  nativeBuildInputs = [ cmake pkgconfig zip ];
+  buildInputs = [
+    gettext perl libqrencode libuuid
+    libXi libXt libXtst wxGTK31 xercesc xextproto
+    libyubikey yubikey-personalization
+  ];
+  cmakeFlags = [
+    "-DNO_GTEST=ON"
+    "-DCMAKE_CXX_FLAGS=-I${yubikey-personalization}/include/ykpers-1"
+  ];
+  enableParallelBuilding = true;
 
   postPatch = ''
     # Fix perl scripts used during the build.
@@ -40,31 +46,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  installPhase = ''
-    mkdir -p $out/bin \
-             $out/share/applications \
-             $out/share/pwsafe/xml \
-             $out/share/icons/hicolor/48x48/apps \
-             $out/share/doc/passwordsafe/help \
-             $out/share/man/man1 \
-             $out/share/locale
-
-    (cd help && make -f Makefile.linux)
-    cp help/help*.zip $out/share/doc/passwordsafe/help
-
-    (cd src/ui/wxWidgets/I18N && make mos)
-    cp -dr src/ui/wxWidgets/I18N/mos/* $out/share/locale/
-    # */
-
-    cp README.txt docs/ReleaseNotes.txt docs/ChangeLog.txt \
-      LICENSE install/copyright $out/share/doc/passwordsafe
-
-    cp src/ui/wxWidgets/GCCUnicodeRelease/pwsafe $out/bin/
-    cp install/graphics/pwsafe.png $out/share/icons/hicolor/48x48/apps
-    cp docs/pwsafe.1 $out/share/man/man1
-    cp xml/* $out/share/pwsafe/xml
-    #  */
-  '';
+  installFlags = [ "PREFIX=$(out)" ];
 
   meta = with stdenv.lib; {
     description = "A password database utility";
@@ -77,8 +59,8 @@ stdenv.mkDerivation rec {
       username/password combinations that you use.
     '';
 
-    homepage = http://passwordsafe.sourceforge.net/;
-    maintainers = with maintainers; [ pjones ];
+    homepage = https://pwsafe.org/;
+    maintainers = with maintainers; [ c0bw3b pjones ];
     platforms = platforms.linux;
     license = licenses.artistic2;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4314,9 +4314,7 @@ with pkgs;
 
   pulsemixer = callPackage ../tools/audio/pulsemixer { };
 
-  pwsafe = callPackage ../applications/misc/pwsafe {
-    wxGTK = wxGTK30;
-  };
+  pwsafe = callPackage ../applications/misc/pwsafe { };
 
   niff = callPackage ../tools/package-management/niff { };
 


### PR DESCRIPTION
###### Motivation for this change

Package update
\+ build using _cmake_ as upstream recommend
\+ use newer wxWidgets
\+ update homepage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

