### PR TITLE
gramps: added support for recommended packages.

### DIFF
--- a/pkgs/applications/misc/gramps/default.nix
+++ b/pkgs/applications/misc/gramps/default.nix
@@ -1,7 +1,9 @@
 { stdenv, fetchFromGitHub, gtk3, pythonPackages, intltool, gnome3,
   pango, gobjectIntrospection, wrapGAppsHook,
 # Optional packages:
- enableOSM ? true, osm-gps-map
+ enableOSM ? true, osm-gps-map,
+ enableGraphviz ? true, graphviz,
+ enableGhostscript ? true, ghostscript
  }:
 
 let
@@ -14,6 +16,11 @@ in buildPythonApplication rec {
   buildInputs = [ intltool gtk3 gobjectIntrospection pango gnome3.gexiv2 ] 
     # Map support
     ++ stdenv.lib.optional enableOSM osm-gps-map
+    # Graphviz support
+    ++ stdenv.lib.optional enableGraphviz graphviz
+    # Ghostscript support
+    ++ stdenv.lib.optional enableGhostscript ghostscript
+    
   ;
 
   src = fetchFromGitHub {


### PR DESCRIPTION
###### Motivation for this change
The GRAMPS readme indicates there are a number of recommended packages (graphviz, ghostscript,
PyICU and osm-gps-map which was already supported).  These default to true.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

