### PR TITLE
simutrans: Fix hash of pak128

### DIFF
--- a/pkgs/games/simutrans/default.nix
+++ b/pkgs/games/simutrans/default.nix
@@ -39,7 +39,7 @@ let
 
     pak128 = {
       srcPath = "pak128%20for%20ST%20120.2.2%20%282.7%2C%20minor%20changes%29/pak128";
-      sha256 = "1x6g6yfv1hvjyh3ciccly1i2k2n2b63dw694gdg4j90a543rmclg";
+      sha256 = "0z01y7r0rz7q79vr17bbnkgcbjjrimphy1dwb1pgbiv4klz7j5xw";
     };
     "pak128.britain" = {
       srcPath = "pak128.Britain%20for%20120-1/pak128.Britain.1.17-120-1";


### PR DESCRIPTION
###### Motivation for this change

It seems that https://github.com/NixOS/nixpkgs/commit/9b934a4b699bf2f9bc3d9584102619ff3c96a366 updated the expression for simutrans, but when `nix-env -iA nixos.simutrans`, it tells me:

```
fixed-output derivation produced path '/nix/store/b68pr406fns3b29zfnv6ihimmq6bgkmr-pak128.zip' with sha256 hash '0z01y7r0rz7q79vr17bbnkgcbjjrimphy1dwb1pgbiv4klz7j5xw' instead of the expected hash '1x6g6yfv1hvjyh3ciccly1i2k2n2b63dw694gdg4j90a543rmclg'
```

So I'm updating this hash here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

