### PR TITLE
backport tor-browser-bundle-bin minor update

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -103,7 +103,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "8.0.1";
+  version = "8.0.2";
 
   lang = "en-US";
 
@@ -113,7 +113,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "05k914066pk11qxbwr77g6v20cfc8h9mh9yc3bpsfy35p8sypv8c";
+      sha256 = "1vajphnl53bhp0bnq8shljvnnq4k2wpvfrfclmxklp97lqvfl9vz";
     };
 
     "i686-linux" = fetchurl {
@@ -121,7 +121,7 @@ let
         "https://github.com/TheTorProject/gettorbrowser/releases/download/v${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://dist.torproject.org/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "1w2apsiimy6d5vpql37j5bmf8y8xhx4irryd5ad3vqqsr0x5wla7";
+      sha256 = "157yd8n53w79xx58xf5v983a50xq1s0c09cr7qfd5cxgs7zrwh34";
     };
   };
 in


### PR DESCRIPTION
tor-browser-bundle-bin: 8.0.1 -> 8.0.2

Update to latest version due to security updates and 8.0.1 not being
available on the mirrors anymore.

Release notes: https://blog.torproject.org/new-release-tor-browser-802

(cherry picked from commit 248ed3575c41866c657d0aa2f4a70ebb7a2c079a)

###### Motivation for this change

reason: The binary dist-file of tor-browser-bundle-bin-8.0.2 is gone
from the mirrors, making the derivation for v8.0.1 fail.
This is just a minor version bump.

###### Things done

cherry-picked version-bump commit from master

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

