### PR TITLE
Fix `nload` output corrupting a few seconds after starting

### DIFF
--- a/pkgs/applications/networking/nload/default.nix
+++ b/pkgs/applications/networking/nload/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ncurses }:
+{ stdenv, fetchurl, fetchpatch, ncurses }:
 
 stdenv.mkDerivation rec {
   version = "0.7.4";
@@ -8,6 +8,19 @@ stdenv.mkDerivation rec {
     url = "http://www.roland-riegel.de/nload/${name}.tar.gz";
     sha256 = "1rb9skch2kgqzigf19x8bzk211jdfjfdkrcvaqyj89jy2pkm3h61";
   };
+
+  patches = [
+    # Fixes an ugly bug of graphs scrolling to the side, corrupting the view.
+    # There is an upstream fix, but not a new upstream release that includes it.
+    # Other distributions like Gentoo also patch this as a result; see:
+    #   https://github.com/rolandriegel/nload/issues/3#issuecomment-427579143
+    # TODO Remove when https://github.com/rolandriegel/nload/issues/3 is merged and available
+    (fetchpatch {
+      url = "https://github.com/rolandriegel/nload/commit/8a93886e0fb33a81b8fe32e88ee106a581fedd34.patch";
+      name = "nload-0.7.4-Eliminate-flicker-on-some-terminals.patch";
+      sha256 = "10yppy5l50wzpcvagsqkbyf1rcan6aj30am4rw8hmkgnbidf4zbq";
+    })
+  ];
 
   buildInputs = [ ncurses ];
 


### PR DESCRIPTION
See https://github.com/rolandriegel/nload/issues/3


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'll let CI test the build for me (since I use this in an overlay).

I have tested the effectiveness of the patch itself on NixOS.