### PR TITLE
uhub: re-enable sqlite plugin / fix aarch64 build

### DIFF
--- a/pkgs/servers/uhub/default.nix
+++ b/pkgs/servers/uhub/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, cmake, openssl, sqlite, pkgconfig, systemd
+{ stdenv, fetchpatch, fetchFromGitHub, cmake, openssl, sqlite, pkgconfig, systemd
 , tlsSupport ? false }:
 
 assert tlsSupport -> openssl != null;
@@ -31,9 +31,14 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./plugin-dir.patch
+    # fix aarch64 build: https://github.com/janvidar/uhub/issues/46
+    (fetchpatch {
+      url = "https://github.com/janvidar/uhub/pull/47.patch";
+      sha256 = "07yik6za89ar5bxm7m2183i7f6hfbawbxvd4vs02n1zr2fgfxmiq";
+    })
 
     # Fixed compilation on systemd > 210
-    (fetchurl {
+    (fetchpatch {
       url = "https://github.com/janvidar/uhub/commit/70f2a43f676cdda5961950a8d9a21e12d34993f8.diff";
       sha256 = "1jp8fvw6f9jh0sdjml9mahkk6p6b96p6rzg2y601mnnbcdj8y8xp";
     })

--- a/pkgs/servers/uhub/default.nix
+++ b/pkgs/servers/uhub/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     "mod_welcome"
     "mod_logging"
     "mod_auth_simple"
+    "mod_auth_sqlite"
     "mod_chat_history"
     "mod_chat_only"
     "mod_topic"

--- a/pkgs/servers/uhub/default.nix
+++ b/pkgs/servers/uhub/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, openssl, sqlite, pkgconfig, systemd
+{ stdenv, fetchurl, fetchFromGitHub, cmake, openssl, sqlite, pkgconfig, systemd
 , tlsSupport ? false }:
 
 assert tlsSupport -> openssl != null;
@@ -7,9 +7,11 @@ stdenv.mkDerivation rec {
   name = "uhub-${version}";
   version = "0.5.0";
 
-  src = fetchurl {
-    url = "https://www.extatic.org/downloads/uhub/uhub-${version}-src.tar.bz2";
-    sha256 = "1xcqjz20lxikzn96f4f69mqyl9y985h9g0gyc9f7ckj18q22b5j5";
+  src = fetchFromGitHub {
+    owner = "janvidar";
+    repo = "uhub";
+    rev = version;
+    sha256 = "0zdbxfvw7apmfhqgsfkfp4pn9iflzwdn0zwvzymm5inswfc00pxg";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/uhub/plugin-dir.patch
+++ b/pkgs/servers/uhub/plugin-dir.patch
@@ -7,7 +7,7 @@
 -	install( TARGETS mod_example mod_welcome mod_logging mod_auth_simple mod_auth_sqlite mod_chat_history mod_chat_history_sqlite mod_chat_only mod_topic mod_no_guest_downloads DESTINATION /usr/lib/uhub/ OPTIONAL )
 -	install( FILES ${CMAKE_SOURCE_DIR}/doc/uhub.conf ${CMAKE_SOURCE_DIR}/doc/plugins.conf ${CMAKE_SOURCE_DIR}/doc/rules.txt ${CMAKE_SOURCE_DIR}/doc/motd.txt DESTINATION /etc/uhub OPTIONAL )
 +
-+    set( PLUGINS mod_example mod_welcome mod_logging mod_auth_simple mod_chat_history mod_chat_only mod_topic mod_no_guest_downloads )
++    set( PLUGINS mod_example mod_welcome mod_logging mod_auth_simple mod_auth_sqlite mod_chat_history mod_chat_only mod_topic mod_no_guest_downloads )
 +
 +    foreach( PLUGIN ${PLUGINS} )
 +        install( TARGETS ${PLUGIN} DESTINATION $ENV{${PLUGIN}} OPTIONAL )


### PR DESCRIPTION
###### Motivation for this change

This PR re-enables the sqlite authentication plugin for uhub. It was disabled because of a failed build, but this seems to have been solved.
Additionally it fixes the build of uhub for aarch64

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

