### PR TITLE
pythonPackages.mypy_extensions: use typing from stdlib on >=3.5

### DIFF
--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage, typing, isPy3k }:
+{ stdenv, fetchPypi, buildPythonPackage, typing, pythonOlder }:
 
 buildPythonPackage rec {
   pname = "mypy_extensions";
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     sha256 = "04h8brrbbx151dfa2cvvlnxgmb5wa00mhd2z7nd20s8kyibfkq1p";
   };
 
-  propagatedBuildInputs = [ typing ];
+  propagatedBuildInputs = if pythonOlder "3.5" then [ typing ] else [ ];
 
   meta = with stdenv.lib; {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";


### PR DESCRIPTION
It's not necessary to depend on the "typing" backport since it's in
the standard library; I also observed serious breakage in anything
using the typing module (including) when the backport was in the
closure on >=3.5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

