### PR TITLE
Fix NetworkManager patches with fetchpatch and updated hashes

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, substituteAll, intltool, pkgconfig, dbus-glib, gnome3
-, systemd, libuuid, polkit, gnutls, ppp, dhcp, iptables
+{ stdenv, fetchurl, fetchpatch, substituteAll, intltool, pkgconfig, dbus-glib
+, gnome3, systemd, libuuid, polkit, gnutls, ppp, dhcp, iptables
 , libgcrypt, dnsmasq, bluez5, readline
 , gobjectIntrospection, modemmanager, openresolv, libndp, newt, libsoup
 , ethtool, gnused, coreutils, file, inetutils, kmod, jansson, libxslt
@@ -67,13 +67,13 @@ in stdenv.mkDerivation rec {
 
   patches = [
     # https://bugzilla.gnome.org/show_bug.cgi?id=796751
-    (fetchurl {
+    (fetchpatch {
       url = https://bugzilla.gnome.org/attachment.cgi?id=372953;
-      sha256 = "1crjplyiiipkhjjlifrv6hhvxinlcxd6irp9ijbc7jij31g44i0a";
+      sha256 = "0xg7bzs6dvkbv2qp67i7mi1c5yrmfd471xgmlkn15b33pqkzy3mc";
     })
-    (fetchurl {
+    (fetchpatch {
       url = https://gitlab.freedesktop.org/NetworkManager/NetworkManager/commit/0a3755c1799d3a4dc1875d4c59c7c568a64c8456.patch;
-      sha256 = "af1717f7c6fdd6dadb4082dd847f4bbc42cf1574833299f3e47024e785533f2e";
+      sha256 = "0r7338q3za7mf419a244vi65b1q497rg84avijybmv6w4x6p1ksd";
     })
     (substituteAll {
       src = ./fix-paths.patch;


### PR DESCRIPTION
###### Motivation for this change

Had someone on IRC who couldn't `nixos-rebuild` because the second patch here had changed hashes. Looks like there's some irrelevant version number gitlab is appending to the patch file. Using `fetchpatch` should prevent this from being an issue in the future if I understand correctly.

Sidenote, while I was testing this out, I found I could download the results of the old expression from https://cache.nixos.org by running `nix-build -A networkmanager.patches`. (EDIT: IRC user couldn't because they had `substituters = http://nixos-arm.dezgeg.me/channel`). However it's been pointed out to me that `fetchurl` is supposed to enable `preferLocalBuild`, which is supposed to prevent this. Is this a bug in Nix?

Sidenote 2, is there a particular reason this derivation doesn't have `enableParallelBuilding = true`? It's quite a slow build without that, for my 32 thread machine :P

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

