### PR TITLE
nixos/doc: Actually fix partitioning instructions.

### DIFF
--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -115,10 +115,17 @@
      </listitem>
      <listitem>
       <para>
-       Add a <emphasis>swap</emphasis> partition. The size required will vary
-       according to needs, here a 8GiB one is created. The space left in front
-       (512MiB) will be used by the boot partition.
-<screen language="commands"># parted /dev/sda -- mkpart primary linux-swap 512MiB 8.5GiB</screen>
+       Add the <emphasis>root</emphasis> partition. This will fill the disk
+       except for the end part, where the swap will live, and the space left in
+       front (512MiB) which will be used by the boot partition.
+<screen language="commands"># parted /dev/sda -- mkpart primary 512MiB -8GiB</screen>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Next, add a <emphasis>swap</emphasis> partition. The size required will
+       vary according to needs, here a 8GiB one is created.
+<screen language="commands"># parted /dev/sda -- mkpart primary linux-swap -8GiB 100%</screen>
        <note>
         <para>
          The swap partition size rules are no different than for other Linux
@@ -129,18 +136,11 @@
      </listitem>
      <listitem>
       <para>
-       Next, add the <emphasis>root</emphasis> partition. This will fill the
-       remainder ending part of the disk.
-<screen language="commands"># parted /dev/sda -- mkpart primary 8.5GiB -1MiB</screen>
-      </para>
-     </listitem>
-     <listitem>
-      <para>
        Finally, the <emphasis>boot</emphasis> partition. NixOS by default uses
        the ESP (EFI system partition) as its <emphasis>/boot</emphasis>
        partition. It uses the initially reserved 512MiB at the start of the
        disk.
-<screen language="commands"># parted /dev/sda -- mkpart ESP fat32 1M 512MiB
+<screen language="commands"># parted /dev/sda -- mkpart ESP fat32 1MiB 512MiB
 # parted /dev/sda -- set 3 boot on</screen>
       </para>
      </listitem>
@@ -177,22 +177,22 @@
      </listitem>
      <listitem>
       <para>
-       Add a <emphasis>swap</emphasis> partition. The size required will vary
-       according to needs, here a 8GiB one is created.
-<screen language="commands"># parted /dev/sda -- mkpart primary linux-swap 1M 8GiB</screen>
+       Add the <emphasis>root</emphasis> partition. This will fill the the disk
+       except for the end part, where the swap will live.
+<screen language="commands"># parted /dev/sda -- mkpart primary 1MiB -8GiB</screen>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Finally, add a <emphasis>swap</emphasis> partition. The size required
+       will vary according to needs, here a 8GiB one is created.
+<screen language="commands"># parted /dev/sda -- mkpart primary linux-swap -8GiB 100%</screen>
        <note>
         <para>
          The swap partition size rules are no different than for other Linux
          distributions.
         </para>
        </note>
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Finally, add the <emphasis>root</emphasis> partition. This will fill the
-       remainder of the disk.
-<screen language="commands"># parted /dev/sda -- mkpart primary 8GiB -1s</screen>
       </para>
      </listitem>
     </orderedlist>
@@ -486,17 +486,17 @@ $ nix-env -i w3m</screen>
    <title>Example partition schemes for NixOS on <filename>/dev/sda</filename> (MBR)</title>
 <screen language="commands">
 # parted /dev/sda -- mklabel msdos
-# parted /dev/sda -- mkpart primary linux-swap 1M 8GiB
-# parted /dev/sda -- mkpart primary 8GiB -1s</screen>
+# parted /dev/sda -- mkpart primary 1MiB -8GiB
+# parted /dev/sda -- mkpart primary linux-swap -8GiB 100%</screen>
   </example>
 
   <example xml:id="ex-partition-scheme-UEFI">
    <title>Example partition schemes for NixOS on <filename>/dev/sda</filename> (UEFI)</title>
 <screen language="commands">
 # parted /dev/sda -- mklabel gpt
-# parted /dev/sda -- mkpart primary linux-swap 512MiB 8.5GiB
-# parted /dev/sda -- mkpart primary 8.5GiB -1MiB
-# parted /dev/sda -- mkpart ESP fat32 1M 512MiB
+# parted /dev/sda -- mkpart primary 512MiB -8GiB
+# parted /dev/sda -- mkpart primary linux-swap -8GiB 100%
+# parted /dev/sda -- mkpart ESP fat32 1MiB 512MiB
 # parted /dev/sda -- set 3 boot on</screen>
   </example>
 


### PR DESCRIPTION
The previous tentative to the fix got the order mixed up a bit. This
new fix has been re-verified to get them in the good order as per the
instructions in the following chapters.

* * *

First of all: sorry. Next: it's *hard* trying to write something like that when you automatically fix the wrong inputs in your head! I was not seeing "/dev/sda1", but "the root partition".

The issue was pointed out to me in private by a friend trying NixOS and following the instructions.

This'll need to be backported.

* * *

The instructions are verified on qemu with a 100GiB disk.

Now, take a moment and check where the guide wants to create the root filesystem and swap:

 * `# mkfs.ext4 -L nixos /dev/sda1`
 * `# mkswap -L swap /dev/sda2`

I am verifying that in the next output the vda1 and vda2 partitions are sized as expected.

###### MBR

```
[root@nixos:~]# parted /dev/vda -- mklabel msdos
Information: You may need to update /etc/fstab.

[root@nixos:~]# parted /dev/vda -- mkpart primary 1MiB -8GiB
Information: You may need to update /etc/fstab.

                                                                          
[root@nixos:~]# parted /dev/vda -- mkpart primary linux-swap -8GiB -1s
Information: You may need to update /etc/fstab.

[root@nixos:~]# fdisk -l /dev/vda
Disk /dev/vda: 100 GiB, 107374182400 bytes, 209715200 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x0cadb97f

Device     Boot     Start       End   Sectors Size Id Type
/dev/vda1            2048 192937983 192935936  92G 83 Linux
/dev/vda2       192937984 209715199  16777216   8G 82 Linux swap / Solaris
```

###### GPT

```
[root@nixos:~]# parted /dev/vda -- mklabel gpt
Information: You may need to update /etc/fstab.

                                                                          
[root@nixos:~]# parted /dev/vda -- mkpart primary 512MiB -8GiB
Information: You may need to update /etc/fstab.

                                                                          
[root@nixos:~]# parted /dev/vda -- mkpart primary linux-swap -8GiB -1MiB
Information: You may need to update /etc/fstab.

                                                                          
[root@nixos:~]# parted /dev/vda -- mkpart ESP fat32 1MiB 512MiB
Information: You may need to update /etc/fstab.

                                                                          
[root@nixos:~]# parted /dev/vda -- set 3 boot on
Information: You may need to update /etc/fstab.

                                                                          
[root@nixos:~]# fdisk -l /dev/vda
Disk /dev/vda: 100 GiB, 107374182400 bytes, 209715200 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 5860F00D-3FE1-4945-8FB4-0C76A1DB23B3

Device         Start       End   Sectors  Size Type
/dev/vda1    1048576 192937983 191889408 91.5G Linux filesystem
/dev/vda2  192937984 209713151  16775168    8G Linux swap
/dev/vda3       2048   1048575   1046528  511M EFI System

Partition table entries are not in disk order.
```

* * *

###### What was done

 * ✔️ `make format` on the installing.xml file
 * ✔️ building the documentation
 * ✔️ **[Rendered here](https://stuff.samueldr.com/tmp-manual/index.html#sec-installation-partitioning)**