### PR TITLE
linux_rpi, rasperrypifw, raspberrypi-tools: update to latest versions

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "raspberrypi-firmware-${version}";
-  version = "1.20180817";
+  version = "1.20180919";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    sha256 = "0cjlgs7y0x7wjvbz6046017yb9r9wkjrxksvlnc6i9mgdjcryqqm";
+    sha256 = "0aw5fzz7kr18cc4phdn81g45swkpaf4022sgi72pq2q6zzqnrdg4";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/firmware/raspberrypi/tools.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/tools.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "raspberrypi-tools-${version}";
-  version = "2018-02-05";
+  version = "2018-10-03";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "userland";
-    rev = "a343dcad1dae4e93f4bfb99496697e207f91027e";
-    sha256 = "1z4qrwjb7x3a45mx978q8vyhnx068sgzhymm4z0ayhckji4ngal1";
+    rev = "de4a7f2e3c391e2d3bc76af31864270e7802d9ac";
+    sha256 = "0w96xa98ngdk9m6wv185w8waa7wm2hkn2bhxz52zd477hchzrxlg";
   };
 
   patches = [ ./tools-dont-install-sysv-init-scripts.patch ];

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, buildPackages, fetchFromGitHub, perl, buildLinux, ... } @ args:
 
 let
-  modDirVersion = "4.14.62";
-  tag = "1.20180817";
+  modDirVersion = "4.14.70";
+  tag = "1.20180919";
 in
 lib.overrideDerivation (buildLinux (args // rec {
   version = "${modDirVersion}-${tag}";
@@ -12,7 +12,7 @@ lib.overrideDerivation (buildLinux (args // rec {
     owner = "raspberrypi";
     repo = "linux";
     rev = "raspberrypi-kernel_${tag}-1";
-    sha256 = "17k7c9hcp834qmlpllag8jc6xhym9wkr5lck1vr0y2wlcxccwnaz";
+    sha256 = "1zjvzk6rhrn3ngc012gjq3v7lxn8hy89ljb7fqwld5g7py9lkf0b";
   };
 
   defconfig = {


### PR DESCRIPTION
###### Motivation for this change

I ran into a hardware video encoding regression with the update to raspberrypifw 1.20180817. I updated these packages to the latest versions in the hopes that it would fix it. Unfortunately it did not, but I thought I might as well submit these updates upstream anyway.

I have tested these updates on a Raspberry Pi 3.

cc @dezgeg 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

