### PR TITLE
openssh: fix tunnel forwarding broken in 7.7p1

### DIFF
--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
 
   patches =
     [
+      ./fix-tunnel-forwarding-broken-in-7.7p1.patch
+
       ./locale_archive.patch
       ./fix-host-key-algorithms-plus.patch
 

--- a/pkgs/tools/networking/openssh/fix-tunnel-forwarding-broken-in-7.7p1.patch
+++ b/pkgs/tools/networking/openssh/fix-tunnel-forwarding-broken-in-7.7p1.patch
@@ -1,0 +1,23 @@
+diff --git a/openbsd-compat/port-net.c b/openbsd-compat/port-net.c
+index 7050629c3..bb535626f 100644
+--- a/openbsd-compat/port-net.c
++++ b/openbsd-compat/port-net.c
+@@ -185,7 +185,7 @@ sys_tun_open(int tun, int mode, char **ifname)
+ 	else
+ 		debug("%s: %s mode %d fd %d", __func__, ifr.ifr_name, mode, fd);
+ 
+-	if (ifname != NULL && (*ifname = strdup(ifr.ifr_name)))
++	if (ifname != NULL && (*ifname = strdup(ifr.ifr_name)) == NULL)
+ 		goto failed;
+ 
+ 	return (fd);
+@@ -272,7 +272,7 @@ sys_tun_open(int tun, int mode, char **ifname)
+ 			goto failed;
+ 	}
+ 
+-	if (ifname != NULL && (*ifname = strdup(ifr.ifr_name)))
++	if (ifname != NULL && (*ifname = strdup(ifr.ifr_name)) == NULL)
+ 		goto failed;
+ 
+ 	close(sock);
+


### PR DESCRIPTION
Uses an upstream patch from https://github.com/openssh/openssh-portable/commit/b81b2d120e9c8a83489e241620843687758925ad

Fixes #48016.

###### Motivation for this change

This should un-break NixOps' encrypted links which are currently broken in 18.09.

###### Things done

I tested the package by installing it with `nix-env -i openssh -f <my-nixpkgs-dir>`, device tunneling works after this. I could not complete `nixos-rebuild switch` because it ate all 6GB of my free disk space (probably wanted to rebuild half the world due to git dependency; it would take too long anyway).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

