### PR TITLE
gcalcli: use python3 i/o python2 so we can drop our overrides

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -1,38 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, python2
+{ stdenv, lib, fetchFromGitHub, python3
 , libnotify ? null }:
 
-let
-  py = python2.override {
-    packageOverrides = self: super: {
-      google_api_python_client = super.google_api_python_client.overridePythonAttrs (oldAttrs: rec {
-        version = "1.5.1";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "1ggxk094vqr4ia6yq7qcpa74b4x5cjd5mj74rq0xx9wp2jkrxmig";
-        };
-      });
+with python3.pkgs;
 
-      oauth2client = super.oauth2client.overridePythonAttrs (oldAttrs: rec {
-        version = "1.4.12";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "0phfk6s8bgpap5xihdk1xv2lakdk1pb3rg6hp2wsg94hxcxnrakl";
-        };
-      });
-
-      uritemplate = super.uritemplate.overridePythonAttrs (oldAttrs: rec {
-        version = "0.6";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "1zapwg406vkwsirnzc6mwq9fac4az8brm6d9bp5xpgkyxc5263m3";
-        };
-        # there are no checks in this version
-        doCheck = false;
-      });
-    };
-  };
-
-in with py.pkgs; buildPythonApplication rec {
+buildPythonApplication rec {
   version = "4.0.0a4";
   name = "gcalcli-${version}";
 
@@ -45,7 +16,6 @@ in with py.pkgs; buildPythonApplication rec {
 
   propagatedBuildInputs = [
     dateutil gflags httplib2 parsedatetime six vobject
-    # overridden
     google_api_python_client oauth2client uritemplate
   ] ++ lib.optional (!isPy3k) futures;
 
@@ -59,8 +29,8 @@ in with py.pkgs; buildPythonApplication rec {
   doCheck = false;
 
   meta = with lib; {
-    homepage = https://github.com/insanum/gcalcli;
     description = "CLI for Google Calendar";
+    homepage = https://github.com/insanum/gcalcli;
     license = licenses.mit;
     maintainers = with maintainers; [ nocoolnametom ];
     inherit version;


### PR DESCRIPTION
###### Motivation for this change

use python3 i/o python2 so we can drop our overrides

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

