### PR TITLE
konqueror: init at 18.08

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -129,6 +129,7 @@ let
       kontact = callPackage ./kontact.nix {};
       kontactinterface = callPackage ./kontactinterface.nix {};
       konquest = callPackage ./konquest.nix {};
+      konqueror = callPackage ./konqueror.nix {};
       korganizer = callPackage ./korganizer.nix {};
       kpimtextedit = callPackage ./kpimtextedit.nix {};
       ksmtp = callPackage ./ksmtp {};

--- a/pkgs/applications/kde/konqueror.nix
+++ b/pkgs/applications/kde/konqueror.nix
@@ -1,0 +1,20 @@
+{ lib
+, mkDerivation
+, extra-cmake-modules, kdoctools
+, kdelibs4support, kcmutils, khtml, kdesu
+, qtwebkit, qtwebengine, qtx11extras, qtscript, qtwayland
+}:
+
+mkDerivation {
+  name = "konqueror";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kdelibs4support kcmutils khtml kdesu
+    qtwebkit qtwebengine qtx11extras qtscript qtwayland
+  ];
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = with lib.maintainers; [ ];
+  };
+}
+


### PR DESCRIPTION
###### Motivation for this change
It looks like `konqueror` isn't packaged?

NOTE: I need some help testing this. It doesn't seem to always have the correct DPI, and is missing icons, but that may just be because of other local changes or my DE/WM setup at the moment. (I'm changing things up and not sure Qt apps are working correctly right now).

So if someone else can test and let me know, that would be helpful.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [sorta] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

