### PR TITLE
fbv: init at 1.0b

### DIFF
--- a/pkgs/tools/graphics/fbv/default.nix
+++ b/pkgs/tools/graphics/fbv/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, getopt, libjpeg, libpng12, libungif }:
+
+stdenv.mkDerivation rec {
+  name = "fbv-1.0b";
+
+  src = fetchurl {
+    url = "http://s-tech.elsat.net.pl/fbv/${name}.tar.gz";
+    sha256 = "0g5b550vk11l639y8p5sx1v1i6ihgqk0x1hd0ri1bc2yzpdbjmcv";
+  };
+
+  buildInputs = [ getopt libjpeg libpng12 libungif ];
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    mkdir -p $out/{bin,man/man1}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "View pictures on a linux framebuffer device";
+    homepage = http://s-tech.elsat.net.pl/fbv/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2588,6 +2588,8 @@ with pkgs;
 
   feedgnuplot = callPackage ../tools/graphics/feedgnuplot { };
 
+  fbv = callPackage ../tools/graphics/fbv { };
+
   fim = callPackage ../tools/graphics/fim { };
 
   flac123 = callPackage ../applications/audio/flac123 { };


### PR DESCRIPTION
###### Motivation for this change

We use this to show a logo on appliances.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

