### PR TITLE
Fix local path to release notes in error message

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@ if ! builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.
 
     For more information, please see the NixOS release notes at
     https://nixos.org/nixos/manual or locally at
-    ${toString ./doc/manual/release-notes}.
+    ${toString ./nixos/doc/manual/release-notes}.
 
     If you need further help, see https://nixos.org/nixos/support.html
   ''


### PR DESCRIPTION
The error message when produced when Nix is too old refers the user to a local
copy of the NixOS release notes, but the provided path is incorrect.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

