### PR TITLE
treewide: Use fetchFromGitHub instead of fetchurl

### DIFF
--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "moonlight-embedded-${version}";
-  version = "2.4.6";
+  version = "2.4.7";
 
   src = fetchFromGitHub {
     owner = "irtimmer";
     repo = "moonlight-embedded";
     rev = "v${version}";
-    sha256 = "0vs6rjmz8058s9lscagiif6pcizwfrvfpk9rxxgacfi0xisfgmf1";
+    sha256 = "0ihgb0kh4rhbgn55s25rfbs8063zqvcyqn137jn3nsc0is1595a9";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/moonlight-embedded/default.nix
+++ b/pkgs/applications/misc/moonlight-embedded/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, perl
+{ stdenv, fetchFromGitHub, cmake, perl
 , alsaLib, libevdev, libopus, udev, SDL2
 , ffmpeg, pkgconfig, xorg, libvdpau, libpulseaudio, libcec
 , curl, expat, avahi, enet, libuuid
@@ -8,11 +8,12 @@ stdenv.mkDerivation rec {
   name = "moonlight-embedded-${version}";
   version = "2.4.6";
 
-  # fetchgit used to ensure submodules are available
-  src = fetchgit {
-    url = "git://github.com/irtimmer/moonlight-embedded";
-    rev = "refs/tags/v${version}";
+  src = fetchFromGitHub {
+    owner = "irtimmer";
+    repo = "moonlight-embedded";
+    rev = "v${version}";
     sha256 = "0vs6rjmz8058s9lscagiif6pcizwfrvfpk9rxxgacfi0xisfgmf1";
+    fetchSubmodules = true;
   };
 
   outputs = [ "out" "man" ];

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
@@ -1,6 +1,6 @@
 { stable, version, sha256Hash, archPatchesRevision, archPatchesHash }:
 
-{ mkDerivation, lib, fetchgit, fetchsvn
+{ mkDerivation, lib, fetchFromGitHub, fetchsvn
 , pkgconfig, pythonPackages, cmake, wrapGAppsHook
 , qtbase, qtimageformats, gtk3, libappindicator-gtk3, libnotify, xdg_utils
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
@@ -13,8 +13,9 @@ mkDerivation rec {
   inherit version;
 
   # Telegram-Desktop with submodules
-  src = fetchgit {
-    url = "git://github.com/telegramdesktop/tdesktop";
+  src = fetchFromGitHub {
+    owner = "telegramdesktop";
+    repo = "tdesktop";
     rev = "v${version}";
     sha256 = sha256Hash;
     fetchSubmodules = true;

--- a/pkgs/development/libraries/science/biology/mirtk/default.nix
+++ b/pkgs/development/libraries/science/biology/mirtk/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, lib, gtest, fetchgit, cmake, boost, eigen, python, vtk, zlib }:
+{ stdenv, lib, gtest, fetchFromGitHub, cmake, boost, eigen, python, vtk, zlib }:
 
 stdenv.mkDerivation rec {
   version = "2.0.0";
   name = "mirtk-${version}";
 
-  # uses submodules so can't use fetchFromGitHub
-  src = fetchgit {
-    url = "https://github.com/BioMedIA/MIRTK.git";
+  src = fetchFromGitHub {
+    owner = "BioMedIA";
+    repo = "MIRTK";
     rev = "v${version}";
     sha256 = "0i2v97m66ir5myvi5b123r7zcagwy551b73s984gk7lksl5yiqxk";
+    fetchSubmodules = true;
   };
 
   cmakeFlags = "-DWITH_VTK=ON -DBUILD_ALL_MODULES=ON -DBUILD_TESTING=ON";

--- a/pkgs/os-specific/linux/reptyr/default.nix
+++ b/pkgs/os-specific/linux/reptyr/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   version = "0.6.2";
   name = "reptyr-${version}";
-  src = fetchurl {
-    url = "https://github.com/nelhage/reptyr/archive/reptyr-${version}.tar.gz";
-    sha256 = "07pfl0rkgm8m3f3jy8r9l2yvnhf8lgllpsk3mh57mhzdxq8fagf7";
+  src = fetchFromGitHub {
+    owner = "nelhage";
+    repo = "reptyr";
+    rev = "reptyr-${version}";
+    sha256 = "0yfy1p0mz05xg5gzp52vilfz0yl1sjjsvwn0z073mnr4wyam7fg8";
   };
 
   # Avoid a glibc >= 2.25 deprecation warning that gets fatal via -Werror.

--- a/pkgs/tools/misc/i3minator/default.nix
+++ b/pkgs/tools/misc/i3minator/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, pythonPackages, glibcLocales }:
+{ stdenv, fetchFromGitHub, pythonPackages, glibcLocales }:
 
 pythonPackages.buildPythonApplication rec {
   name = "i3minator-${version}";
   version = "0.0.4";
 
-  src = fetchurl {
-    url = "https://github.com/carlesso/i3minator/archive/${version}.tar.gz";
-    sha256 = "11dn062788kwfs8k2ry4v8zr2gn40r6lsw770s9g2gvhl5n469dw";
+  src = fetchFromGitHub {
+    owner = "carlesso";
+    repo = "i3minator";
+    rev = version;
+    sha256 = "07dic5d2m0zw0psginpl43xn0mpxw7wilj49d02knz69f7c416lm";
   };
 
   LC_ALL = "en_US.UTF-8";

--- a/pkgs/tools/misc/sutils/default.nix
+++ b/pkgs/tools/misc/sutils/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, alsaLib }:
 
 stdenv.mkDerivation rec {
-   version = "0.1";
+   version = "0.2";
    name = "sutils-${version}";
 
    src = fetchFromGitHub {
      owner = "baskerville";
      repo = "sutils";
      rev = version;
-     sha256 = "0rvkc1y7rpw62d00n37pwfzvpvbbhzm6jvr2sb195l2dw53ya8d6";
+     sha256 = "0i2g6a6xdaq3w613dhq7mnsz4ymwqn6kvkyan5kgy49mzq97va6j";
    };
 
    hardeningDisable = [ "format" ];
+
+   buildInputs = [ alsaLib ];
 
    prePatch = ''sed -i "s@/usr/local@$out@" Makefile'';
 

--- a/pkgs/tools/misc/sutils/default.nix
+++ b/pkgs/tools/misc/sutils/default.nix
@@ -1,11 +1,14 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-   name = "sutils-0.1";
+   version = "0.1";
+   name = "sutils-${version}";
 
-   src = fetchurl {
-     url = "https://github.com/baskerville/sutils/archive/0.1.tar.gz";
-     sha256 = "0xqk42vl82chy458d64fj68a4md4bxaip8n3xw9skxz0a1sgvks8";
+   src = fetchFromGitHub {
+     owner = "baskerville";
+     repo = "sutils";
+     rev = version;
+     sha256 = "0rvkc1y7rpw62d00n37pwfzvpvbbhzm6jvr2sb195l2dw53ya8d6";
    };
 
    hardeningDisable = [ "format" ];

--- a/pkgs/tools/networking/pingtcp/default.nix
+++ b/pkgs/tools/networking/pingtcp/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchgit, cmake }:
+{ stdenv, fetchFromGitHub, cmake }:
 
 stdenv.mkDerivation rec {
   name = "pingtcp-${version}";
   version = "0.0.3";
 
-  # This project uses git submodules, which fetchFromGitHub doesn't support:
-  src = fetchgit {
+  src = fetchFromGitHub {
+    owner = "LanetNetwork";
+    repo = "pingtcp";
     sha256 = "1cv84n30y03s1b83apxxyn2jv5ss1pywsahrfrpkb6zcgzzrcqn8";
     rev = "refs/tags/v${version}";
-    url = "https://github.com/LanetNetwork/pingtcp.git";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake
+{ stdenv, fetchFromGitHub, cmake
 , libsodium, mbedtls, libev, c-ares, pcre
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, libxslt
 }:
@@ -8,11 +8,12 @@ stdenv.mkDerivation rec {
   version = "3.2.0";
 
   # Git tag includes CMake build files which are much more convenient.
-  # fetchgit because submodules.
-  src = fetchgit {
-    url = "https://github.com/shadowsocks/shadowsocks-libev";
+  src = fetchFromGitHub {
+    owner = "shadowsocks";
+    repo = "shadowsocks-libev";
     rev = "refs/tags/v${version}";
     sha256 = "0i9vz5b2c2bkdl2k9kqzvqyrlpdl94lf7k7rzxds8hn2kk0jizhb";
+    fetchSubmodules = true;
   };
 
   buildInputs = [ libsodium mbedtls libev c-ares pcre ];

--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -1,5 +1,5 @@
 { stdenv
-, fetchgit
+, fetchFromGitHub
 , cmake
 , sqlite
 , botan2
@@ -14,11 +14,12 @@ stdenv.mkDerivation rec {
   name = "neopg-${version}";
   version = "0.0.4";
 
-  # no fetchFromGitHub, as repo contains submodules
-  src = fetchgit {
-    url = "https://github.com/das-labor/neopg.git";
+  src = fetchFromGitHub {
+    owner = "das-labor";
+    repo = "neopg";
     rev = "v${version}";
     sha256 = "0hhkl326ff6f76k8pwggpzmivbm13fz497nlyy6ybn5bmi9xfblm";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   name = "neopg-${version}";
-  version = "0.0.4";
+  version = "0.0.5";
 
   src = fetchFromGitHub {
     owner = "das-labor";
     repo = "neopg";
     rev = "v${version}";
-    sha256 = "0hhkl326ff6f76k8pwggpzmivbm13fz497nlyy6ybn5bmi9xfblm";
+    sha256 = "1ky3pwg6w8kyaa9iksfx6rryva87mbj1h3yi2mrzp2h7jhrfffpp";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, makeWrapper, bash-completion, cmake, fetchgit, hidapi, libusb1, pkgconfig
+{ stdenv, makeWrapper, bash-completion, cmake, fetchFromGitHub, hidapi, libusb1, pkgconfig
 , qtbase, qttranslations, qtsvg }:
 
 stdenv.mkDerivation rec {
   name = "nitrokey-app-${version}";
   version = "1.3.1";
 
-  # We use fetchgit instead of fetchFromGitHub because of necessary git submodules
-  src = fetchgit {
-    url = "https://github.com/Nitrokey/nitrokey-app.git";
+  src = fetchFromGitHub {
+    owner = "Nitrokey";
+    repo = "nitrokey-app";
     rev = "v${version}";
     sha256 = "0zf2f7g5scqd5xfzvmmpvfc7d1w66rf22av0qv6s37875c61j9r9";
+    fetchSubmodules = true;
   };
 
   postPatch = ''

--- a/pkgs/tools/security/nitrokey-app/default.nix
+++ b/pkgs/tools/security/nitrokey-app/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "nitrokey-app-${version}";
-  version = "1.3.1";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-app";
     rev = "v${version}";
-    sha256 = "0zf2f7g5scqd5xfzvmmpvfc7d1w66rf22av0qv6s37875c61j9r9";
+    sha256 = "193kzlz3qn9il56h78faiqkgv749hdils1nn1iw6g3wphgx5fjs2";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/system/bootchart/default.nix
+++ b/pkgs/tools/system/bootchart/default.nix
@@ -1,14 +1,14 @@
 {stdenv, fetchFromGitHub, pkgconfig, glib, gtk2, python2Packages }:
 
 stdenv.mkDerivation rec {
-  version = "0.14.7";
+  version = "0.14.8";
   name = "bootchart-${version}";
 
   src = fetchFromGitHub {
     owner = "mmeeks";
     repo = "bootchart";
     rev = version;
-    sha256 = "178p7z5npx2ksqx477454n1l5560ncbpjh65j9dr001wmwzqzh5q";
+    sha256 = "12ja2hp6f49416zfjdx0kjfmlkh9wl9b7wz7gk372kps4gjnypqx";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/tools/system/bootchart/default.nix
+++ b/pkgs/tools/system/bootchart/default.nix
@@ -1,12 +1,14 @@
-{stdenv, fetchurl, pkgconfig, glib, gtk2, python2Packages }:
+{stdenv, fetchFromGitHub, pkgconfig, glib, gtk2, python2Packages }:
 
 stdenv.mkDerivation rec {
   version = "0.14.7";
   name = "bootchart-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/mmeeks/bootchart/archive/${version}.tar.gz";
-    sha256 = "1abn4amsyys6vwn7csxsxny94n24ycca3xhqxqcmdc4j0dzn3kmb";
+  src = fetchFromGitHub {
+    owner = "mmeeks";
+    repo = "bootchart";
+    rev = version;
+    sha256 = "178p7z5npx2ksqx477454n1l5560ncbpjh65j9dr001wmwzqzh5q";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
As per #32997, replaced a few calls of `fetchurl` by `fetchFromGitHub`.
Replaced `fetchgit` by `fetchFromGitHub` where, according to the comments, submodule support was needed but not present. See also https://github.com/NixOS/nixpkgs/pull/27327#issuecomment-314874995 for a discussion whether to prefer `fetchgit` for GitHub.
Also updated the affected packages sutils, bootchart, moonlight-embedded, neopg and nitrokey-app to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).