### PR TITLE
gnome3.mutter: fix crash on startup with nvidia drivers

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, stdenv, pkgconfig, gnome3, intltool, gobjectIntrospection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
-, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
+, pipewire, libgudev, libwacom, xwayland, autoreconfHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "mutter-${version}";
@@ -15,6 +15,14 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript { packageName = "mutter"; attrPath = "gnome3.mutter"; };
   };
+
+  patches = [
+    # https://gitlab.gnome.org/GNOME/mutter/merge_requests/172
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/mutter/commit/62660bbd.patch;
+      sha256 = "1qq8vxlqnyrqh94dc0dh1aj1dsbyw6bwv3x46q5vsscbbxbiv9wk";
+    })
+  ];
 
   configureFlags = [
     "--with-x"


### PR DESCRIPTION
###### Motivation for this change

Tracking down why my desktop is crashing after upgrade to 18.09. I don't know if this is the actual cause, but it's a fix that applies to the current version of mutter (3.28.3), and is currently absent from the `gnome3.mutter` package.

- upstream bug report: [mutter#223]
- upstream fix: [mutter#172]

[mutter#172]: https://gitlab.gnome.org/GNOME/mutter/merge_requests/172
[mutter#223]: https://gitlab.gnome.org/GNOME/mutter/issues/223

While we're here, are there any other patches that were backported by Ubuntu that are important? https://bugs.launchpad.net/ubuntu/+source/mutter/+bug/1767956/comments/8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

