### PR TITLE
rapidcheck: init at unstable-2018-09-27

### DIFF
--- a/pkgs/development/libraries/rapidcheck/default.nix
+++ b/pkgs/development/libraries/rapidcheck/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, cmake, fetchFromGitHub }:
+
+stdenv.mkDerivation rec{
+  name = "rapidcheck-${version}";
+  version = "unstable-2018-09-27";
+
+  src = fetchFromGitHub {
+    owner = "emil-e";
+    repo  = "rapidcheck";
+    rev   = "de54478fa35c0d9cea14ec0c5c9dfae906da524c";
+    sha256 = "0n8l0mlq9xqmpkgcj5xicicd1my2cfwxg25zdy8347dqkl1ppgbs";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  postInstall = ''
+    cp ../extras/boost_test/include/rapidcheck/boost_test.h $out/include/rapidcheck
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A C++ framework for property based testing inspired by QuickCheck";
+    inherit (src.meta) homepage;
+    maintainers = with maintainers; [ jb55 ];
+    license = licenses.bsd2;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11958,6 +11958,8 @@ with pkgs;
 
   rabbitmq-java-client = callPackage ../development/libraries/rabbitmq-java-client {};
 
+  rapidcheck = callPackage ../development/libraries/rapidcheck {};
+
   rapidjson = callPackage ../development/libraries/rapidjson {};
 
   raul = callPackage ../development/libraries/audio/raul { };


### PR DESCRIPTION
rapidcheck is a C++ property-based testing framework inspired by QuickCheck

Signed-off-by: William Casarin <jb55@jb55.com>

###### Motivation for this change

Needed it for testing property based tests recently added to Bitcoin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

